### PR TITLE
Sequential auto-colors for polygon fills or line pens in plot and plot3d

### DIFF
--- a/doc/rst/source/explain_-l_full.rst_
+++ b/doc/rst/source/explain_-l_full.rst_
@@ -28,4 +28,7 @@
     just subdivides the available width among the specified columns.
     The upper-case modifiers reflect legend codes described in :doc:`legend`, which provide more details and
     customization.  If **legend** is not called explicitly we will call it implicitly when finishing the plot
-    via :doc:`end`.
+    via :doc:`end`.  **Note**: If auto-coloring is used for pens or fills and **-l** is set then *label* may
+    contain a C-format for integers (e.g., %3.3d) or just # and we will use the sequence number
+    with the format to build the label entries.  Alternatively, give a list of comma-separated labels, or give
+    no label if your segment headers contain label settings.

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -89,6 +89,9 @@ COLOR Parameters
     **COLOR_NAN**
         Color used for the non-defined areas of images (i.e., where z = NaN) [127.5].
 
+    **COLOR_SET**
+        Default comma-separated list of colors (or a CPT name) for automatic, sequential color assignments [categorical].
+
 .. _DIR Parameters:
 
 DIR Parameters

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -90,7 +90,8 @@ COLOR Parameters
         Color used for the non-defined areas of images (i.e., where z = NaN) [127.5].
 
     **COLOR_SET**
-        Default comma-separated list of colors (or a CPT name) for automatic, sequential color assignments [categorical].
+        Default comma-separated list of colors (or a *categorical* CPT name) for automatic,
+        sequential color assignments [categorical].
 
 .. _DIR Parameters:
 

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -91,7 +91,7 @@ COLOR Parameters
 
     **COLOR_SET**
         Default comma-separated list of colors (or a *categorical* CPT name) for automatic,
-        sequential color assignments [categorical].
+        sequential color assignments [#0072BD,#D95319,#EDB120,#7E2F8E,#77AC30,#4DBEEE,#A2142F].
 
 .. _DIR Parameters:
 

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -91,7 +91,7 @@ COLOR Parameters
 
     **COLOR_SET**
         Default comma-separated list of colors (or a *categorical* CPT name) for automatic,
-        sequential color assignments [#0072BD,#D95319,#EDB120,#7E2F8E,#77AC30,#4DBEEE,#A2142F].
+        sequential color assignments [*default*, which is #0072BD,#D95319,#EDB120,#7E2F8E,#77AC30,#4DBEEE,#A2142F].
 
 .. _DIR Parameters:
 

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -39,6 +39,7 @@ Synopsis
 [ |SYN_OPT-g| ]
 [ |SYN_OPT-h| ]
 [ |SYN_OPT-i| ]
+[ |SYN_OPT-l| ]
 [ |SYN_OPT-p| ]
 [ |SYN_OPT-qi| ]
 [ |SYN_OPT-tv| ]

--- a/doc/rst/source/plot3d_common.rst_
+++ b/doc/rst/source/plot3d_common.rst_
@@ -88,7 +88,9 @@ Optional Arguments
     Note that the module will search for **-G** and **-W** strings in all the
     segment headers and let any values thus found over-ride the command line settings.
     If **-Z** is set, use **-G+z** to assign fill color via **-C**\ *cpt* and the
-    *z*-values obtained.
+    *z*-values obtained.  Finally, if *fill* = *auto*\ [*-segment*] or *auto=table* then
+    we will cycle through the fill colors implied by :term:`COLOR_SET` and change on a per-segment
+    or per-table basis.  Any *transparency* setting is unchanged.
 
 .. _-I:
 
@@ -154,7 +156,9 @@ Optional Arguments
     **-C**). If instead modifier **+cf** is appended then the color from the cpt
     file is applied to symbol fill.  Use just **+c** for both effects.
     If **-Z** is set, then append **+z** to **-W** to assign pen color via **-C**\ *cpt* and the
-    *z*-values obtained.
+    *z*-values obtained.  Finally, if pen *color* = *auto*\ [*-segment*] or *auto=table* then
+    we will cycle through the pen colors implied by :term:`COLOR_SET` and change on a per-segment
+    or per-table basis.  The *width*, *style*, or *transparency* settings are unchanged.
 
 .. _-X:
 

--- a/doc/rst/source/plot3d_common.rst_
+++ b/doc/rst/source/plot3d_common.rst_
@@ -88,7 +88,7 @@ Optional Arguments
     Note that the module will search for **-G** and **-W** strings in all the
     segment headers and let any values thus found over-ride the command line settings.
     If **-Z** is set, use **-G+z** to assign fill color via **-C**\ *cpt* and the
-    *z*-values obtained.  Finally, if *fill* = *auto*\ [*-segment*] or *auto=table* then
+    *z*-values obtained.  Finally, if *fill* = *auto*\ [*-segment*] or *auto-table* then
     we will cycle through the fill colors implied by :term:`COLOR_SET` and change on a per-segment
     or per-table basis.  Any *transparency* setting is unchanged.
 

--- a/doc/rst/source/plot3d_common.rst_
+++ b/doc/rst/source/plot3d_common.rst_
@@ -194,6 +194,9 @@ Optional Arguments
 
 .. include:: explain_-icols.rst_
 
+.. |Add_-l| unicode:: 0x20 .. just an invisible code
+.. include:: explain_-l.rst_
+
 .. |Add_perspective| unicode:: 0x20 .. just an invisible code
 .. include:: explain_perspective.rst_
 

--- a/doc/rst/source/plot3d_common.rst_
+++ b/doc/rst/source/plot3d_common.rst_
@@ -156,7 +156,7 @@ Optional Arguments
     **-C**). If instead modifier **+cf** is appended then the color from the cpt
     file is applied to symbol fill.  Use just **+c** for both effects.
     If **-Z** is set, then append **+z** to **-W** to assign pen color via **-C**\ *cpt* and the
-    *z*-values obtained.  Finally, if pen *color* = *auto*\ [*-segment*] or *auto=table* then
+    *z*-values obtained.  Finally, if pen *color* = *auto*\ [*-segment*] or *auto-table* then
     we will cycle through the pen colors implied by :term:`COLOR_SET` and change on a per-segment
     or per-table basis.  The *width*, *style*, or *transparency* settings are unchanged.
 

--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -126,7 +126,7 @@ Optional Arguments
     Note that this module will search for **-G** and **-W** strings in all the
     segment headers and let any values thus found over-ride the command line settings.
     If **-Z** is set, use **-G+z** to assign fill color via **-C**\ *cpt* and the
-    *z*-values obtained. Finally, if *fill* = *auto*\ [*-segment*] or *auto=table* then
+    *z*-values obtained. Finally, if *fill* = *auto*\ [*-segment*] or *auto-table* then
     we will cycle through the fill colors implied by :term:`COLOR_SET` and change on a per-segment
     or per-table basis.  Any *transparency* setting is unchanged.
 

--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -126,7 +126,9 @@ Optional Arguments
     Note that this module will search for **-G** and **-W** strings in all the
     segment headers and let any values thus found over-ride the command line settings.
     If **-Z** is set, use **-G+z** to assign fill color via **-C**\ *cpt* and the
-    *z*-values obtained.
+    *z*-values obtained. Finally, if *fill* = *auto*\ [*-segment*] or *auto=table* then
+    we will cycle through the fill colors implied by :term:`COLOR_SET` and change on a per-segment
+    or per-table basis.  Any *transparency* setting is unchanged.
 
 .. _-I:
 
@@ -199,7 +201,9 @@ Optional Arguments
     at the end of the pen specification.
     See the `Vector Attributes`_ for more information.
     If **-Z** is set, then append **+z** to **-W** to assign pen color via **-C**\ *cpt* and the
-    *z*-values obtained.
+    *z*-values obtained.  Finally, if pen *color* = *auto*\ [*-segment*] or *auto=table* then
+    we will cycle through the pen colors implied by :term:`COLOR_SET` and change on a per-segment
+    or per-table basis.  The *width*, *style*, or *transparency* settings are unchanged.
 
 .. _-X:
 

--- a/doc/rst/source/plot_common.rst_
+++ b/doc/rst/source/plot_common.rst_
@@ -201,7 +201,7 @@ Optional Arguments
     at the end of the pen specification.
     See the `Vector Attributes`_ for more information.
     If **-Z** is set, then append **+z** to **-W** to assign pen color via **-C**\ *cpt* and the
-    *z*-values obtained.  Finally, if pen *color* = *auto*\ [*-segment*] or *auto=table* then
+    *z*-values obtained.  Finally, if pen *color* = *auto*\ [*-segment*] or *auto-table* then
     we will cycle through the pen colors implied by :term:`COLOR_SET` and change on a per-segment
     or per-table basis.  The *width*, *style*, or *transparency* settings are unchanged.
 

--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -65,12 +65,14 @@ struct GMT_LEGEND_ITEM {	/* Information about one item in a legend */
 	char pen[3][GMT_LEN32];		/* Pens to use with +d and +v and +p */
 	int draw;			/* 0 no draw, 1 draw horizontal +d, 2 draw vertical +v */
 	int just;			/* Legend placement [TR] */
+	int label_type;			/* 0 if static string, 1 if integer format statement, 2 if list of labels, 3 if nothing (use segment header) */
 	char code;			/* Label justification code (L|C|R) [L] */
 	double size;			/* Fixed symbol size when otherwise cannot set it */
 	double size2;			/* 2nd size (height) for 2-D symbols */
 	double scale;			/* Scale all given sizes, including +s<length> of a line */
 	double width;			/* Override auto-width with a fixed legend width */
 	unsigned int ncols;		/* How many columns to use for symbols */
+	unsigned int ID;		/* ID to use if label contains C-format for integer */
 };
 
 /*! Structure with all information given via the common GMT command-line options -R -J .. */

--- a/src/gmt_common_string.c
+++ b/src/gmt_common_string.c
@@ -251,8 +251,10 @@ char *gmt_strrstr (const char *s, const char *m) {
 
 char *gmt_get_word (char *list, char *sep, unsigned int col) {
 	/* Return word number col in the list with separator sep */
-	char *word = NULL, *trail = NULL, *orig = strdup (list);
+	char *word, *trail, *orig;
 	unsigned int k = 0;
+	if (list == NULL || sep == NULL) return (NULL);
+	orig = strdup (list);
 	trail = orig;
 	while ((word = strsep (&trail, sep)) != NULL && k < col) k++;
 	free (orig);

--- a/src/gmt_common_string.c
+++ b/src/gmt_common_string.c
@@ -26,6 +26,7 @@
  *  gmt_chop                Chops off any CR or LF at end of string
  *  gmt_chop_ext            Chops off the trailing .xxx (file extension)
  *  gmt_get_ext             Returns a pointer to the tailing .xxx (file extension)
+ *  gmt_get_word            Return the specified word entry from a list
  *  gmt_strdup_noquote		Duplicates a string but removes any surrounding single or double quotes
  *  gmt_strstrip            Strip leading and trailing whitespace from string
  *  gmt_strlshift           Left shift a string by n characters
@@ -246,6 +247,16 @@ char *gmt_strrstr (const char *s, const char *m) {
             break;
     }
     return last;
+}
+
+char *gmt_get_word (char *list, char *sep, unsigned int col) {
+	/* Return word number col in the list with separator sep */
+	char *word = NULL, *trail = NULL, *orig = strdup (list);
+	unsigned int k = 0;
+	trail = orig;
+	while ((word = strsep (&trail, sep)) != NULL && k < col) k++;
+	free (orig);
+	return ((k == col) ? strdup (word) : NULL);
 }
 
 unsigned int gmt_get_modifier (const char *string, char modifier, char *token) {

--- a/src/gmt_common_string.h
+++ b/src/gmt_common_string.h
@@ -52,6 +52,7 @@ extern "C" {
 EXTERN_MSC unsigned int gmt_strtok (const char *string, const char *sep, unsigned int *start, char *token);
 EXTERN_MSC void gmt_strtok_m (char *in, char **token, char **remain, char *sep);
 EXTERN_MSC unsigned int gmt_get_modifier (const char *string, char modifier, char *token);
+EXTERN_MSC char *gmt_get_word (char *list, char *sep, unsigned int col);
 EXTERN_MSC void gmt_chop (char *string);
 EXTERN_MSC char *gmt_chop_ext (char *string);
 EXTERN_MSC char *gmt_get_ext (const char *string);

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -241,6 +241,8 @@ enum GMT_enum_basemap {
 #define GMT_CPT_U_ANNOT		2	/* Annotate upper slice boundary */
 #define GMT_CPT_CATEGORICAL_VAL		1	/* Categorical CPT with numerical value */
 #define GMT_CPT_CATEGORICAL_KEY		2	/* Categorical CPT with text key */
+#define GMT_COLOR_AUTO_SEGMENT		-5	/* Flag in rgb for auto-color changing per segment */
+#define GMT_COLOR_AUTO_TABLE		-6	/* Flag in rgb for auto-color changing per table */
 
 /* Default CPT if nothing specified or overruled by remote dataset preferences */
 #define GMT_DEFAULT_CPT_NAME	"turbo"

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -365,7 +365,8 @@ enum GMT_enum_download {
 /*! Various mode for auto-legend pens */
 enum GMT_enum_autolegend {
 	GMT_LEGEND_PEN_D  = 0, GMT_LEGEND_PEN_V  = 1, GMT_LEGEND_PEN_P  = 2,
-	GMT_LEGEND_DRAW_D = 1, GMT_LEGEND_DRAW_V = 2};
+	GMT_LEGEND_DRAW_D = 1, GMT_LEGEND_DRAW_V = 2, GMT_LEGEND_LABEL_FIXED = 0,
+	GMT_LEGEND_LABEL_FORMAT = 1, GMT_LEGEND_LABEL_LIST = 2, GMT_LEGEND_LABEL_HEADER = 3};
 
 /*! Various mode for custom symbols */
 enum GMT_enum_customsymb {

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -241,13 +241,13 @@ enum GMT_enum_basemap {
 #define GMT_CPT_U_ANNOT		2	/* Annotate upper slice boundary */
 #define GMT_CPT_CATEGORICAL_VAL		1	/* Categorical CPT with numerical value */
 #define GMT_CPT_CATEGORICAL_KEY		2	/* Categorical CPT with text key */
-#define GMT_COLOR_AUTO_SEGMENT		-5	/* Flag in rgb for auto-color changing per segment */
-#define GMT_COLOR_AUTO_TABLE		-6	/* Flag in rgb for auto-color changing per table */
+#define GMT_COLOR_AUTO_TABLE		1	/* Flag in rgb for auto-color changing per table */
+#define GMT_COLOR_AUTO_SEGMENT		2	/* Flag in rgb for auto-color changing per segment */
 
 /* Default CPT if nothing specified or overruled by remote dataset preferences */
 #define GMT_DEFAULT_CPT_NAME	"turbo"
 /* Default color list (or cpt) for automatic, sequential color choices */
-#define GMT_DEFAULT_COLOR_SET	"categorical"
+#define GMT_DEFAULT_COLOR_SET	"#0072BD,#D95319,#EDB120,#7E2F8E,#77AC30,#4DBEEE,#A2142F"
 	
 /* CPT extension is pretty fixed */
 #define GMT_CPT_EXTENSION	".cpt"

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -244,6 +244,9 @@ enum GMT_enum_basemap {
 
 /* Default CPT if nothing specified or overruled by remote dataset preferences */
 #define GMT_DEFAULT_CPT_NAME	"turbo"
+/* Default color list (or cpt) for automatic, sequential color choices */
+#define GMT_DEFAULT_COLOR_SET	"categorical"
+	
 /* CPT extension is pretty fixed */
 #define GMT_CPT_EXTENSION	".cpt"
 #define GMT_CPT_EXTENSION_LEN	4U

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -62,6 +62,7 @@ struct GMT_DEFAULTS {
 	unsigned int color_model;		/* 1 = read RGB, 2 = use RGB, 4 = read HSV, 8 = use HSV, 16 = read CMYK, 32 = use CMYK [1+2]
 									 * Add 128 to disallow output of color names */
 	char cpt[GMT_LEN64];			/* Default CPT */
+	char color_set[GMT_LEN256];		/* Default color list (or CPT) for automatic, sequential color choices */
 	double color_patch[3][4];		/* Color of background, foreground, nan [black,white,127.5] */
 	double color_hsv_min_s;			/* For smallest or most negative intensity [1.0] */
 	double color_hsv_max_s;			/* For largest or most positive intensity [0.1] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2988,8 +2988,8 @@ GMT_LOCAL int gmtinit_get_history (struct GMT_CTRL *GMT) {
 				sscanf (value, "%lg %lg", &GMT->current.plot.gridline_spacing[GMT_X], &GMT->current.plot.gridline_spacing[GMT_Y]);
 			else if (option[1] == 'L')	/* Read PS layer */
 				GMT->current.ps.layer = atoi (value);
-			else if (option[1] == 'S')	/* Read next sequential color ID */
-				GMT->current.plot.color_seq_id = atoi (value);
+			else if (option[1] == 'S')	/* Read next sequential color IDs */
+				sscanf (value, "%d %d", &GMT->current.plot.color_seq_id[0], &GMT->current.plot.color_seq_id[1]);
 			continue;
 		}
 		if ((id = gmt_hash_lookup (GMT, option, unique_hashnode, GMT_N_UNIQUE, GMT_N_UNIQUE)) < 0) continue;	/* Quietly skip malformed lines */
@@ -3068,7 +3068,7 @@ GMT_LOCAL int gmtinit_put_history (struct GMT_CTRL *GMT) {
 	if (GMT->current.plot.gridline_spacing[GMT_X] > 0.0 || GMT->current.plot.gridline_spacing[GMT_Y] > 0.0)	/* Save gridline spacing in history */
 		fprintf (fp, "@G\t%g %g\n", GMT->current.plot.gridline_spacing[GMT_X], GMT->current.plot.gridline_spacing[GMT_Y]);
 	if (GMT->current.ps.layer) fprintf (fp, "@L\t%d\n", GMT->current.ps.layer); /* Write PS layer, if non-zero */
-	if (GMT->current.plot.color_seq_id) fprintf (fp, "@S\t%d\n", GMT->current.plot.color_seq_id); /* Write next sequential color, if non-zero */
+	if (GMT->current.plot.color_seq_id[0] && GMT->current.plot.color_seq_id[1]) fprintf (fp, "@S\t%d %d\n", GMT->current.plot.color_seq_id[0], GMT->current.plot.color_seq_id[1]); /* Write next sequential color IDs, if non-zero */
 	fprintf (fp, "END\n");
 
 	/* Close the file */
@@ -12938,7 +12938,7 @@ int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, int row, int col, d
 	else
 		fprintf (fp, "%d %d %g %g %g %g %d %s\n", row, col, gap[XLO], gap[XHI], gap[YLO], gap[YHI], first, L);
 	fclose (fp);
-	if (first) API->GMT->current.plot.color_seq_id = 0;	/* Reset for new panel */
+	if (first) API->GMT->current.plot.color_seq_id[0] = API->GMT->current.plot.color_seq_id[1] = 0;	/* Reset for new panel */
 	API->error = GMT_NOERROR;
 	return GMT_NOERROR;
 }
@@ -14579,7 +14579,8 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 	Ccopy->current.ps.layer = GMT->current.ps.layer;
 	Ccopy->current.ps.active = GMT->current.ps.active;
 	Ccopy->current.ps.initialize = GMT->current.ps.initialize;
-	Ccopy->current.plot.color_seq_id = GMT->current.plot.color_seq_id;
+	Ccopy->current.plot.color_seq_id[0] = GMT->current.plot.color_seq_id[0];
+	Ccopy->current.plot.color_seq_id[1] = GMT->current.plot.color_seq_id[1];
 
 	/* GMT_COMMON */
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2988,6 +2988,8 @@ GMT_LOCAL int gmtinit_get_history (struct GMT_CTRL *GMT) {
 				sscanf (value, "%lg %lg", &GMT->current.plot.gridline_spacing[GMT_X], &GMT->current.plot.gridline_spacing[GMT_Y]);
 			else if (option[1] == 'L')	/* Read PS layer */
 				GMT->current.ps.layer = atoi (value);
+			else if (option[1] == 'S')	/* Read next sequential color ID */
+				GMT->current.plot.color_seq_id = atoi (value);
 			continue;
 		}
 		if ((id = gmt_hash_lookup (GMT, option, unique_hashnode, GMT_N_UNIQUE, GMT_N_UNIQUE)) < 0) continue;	/* Quietly skip malformed lines */
@@ -3066,6 +3068,7 @@ GMT_LOCAL int gmtinit_put_history (struct GMT_CTRL *GMT) {
 	if (GMT->current.plot.gridline_spacing[GMT_X] > 0.0 || GMT->current.plot.gridline_spacing[GMT_Y] > 0.0)	/* Save gridline spacing in history */
 		fprintf (fp, "@G\t%g %g\n", GMT->current.plot.gridline_spacing[GMT_X], GMT->current.plot.gridline_spacing[GMT_Y]);
 	if (GMT->current.ps.layer) fprintf (fp, "@L\t%d\n", GMT->current.ps.layer); /* Write PS layer, if non-zero */
+	if (GMT->current.plot.color_seq_id) fprintf (fp, "@S\t%d\n", GMT->current.plot.color_seq_id); /* Write next sequential color, if non-zero */
 	fprintf (fp, "END\n");
 
 	/* Close the file */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -989,7 +989,7 @@ GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
 	int i = 0;
 	if (!text || !text[0]) {	/* Default is -Xr0 */
 		GMT->current.ps.origin[GMT_X] = GMT->common.X.mode = 'r';
-		GMT->current.setting.map_origin[GMT_X] = 0.0;
+		GMT->common.X.off = GMT->current.setting.map_origin[GMT_X] = 0.0;
 		return (GMT_NOERROR);
 	}
 	switch (text[0]) {
@@ -1021,6 +1021,7 @@ GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
 	}
 	else	/* Allow use of -Xc or -Xf meaning -Xc0 or -Xf0 */
 		GMT->current.setting.map_origin[GMT_X] = 0.0;
+	GMT->common.X.off = GMT->current.setting.map_origin[GMT_X];
 	return (GMT_NOERROR);
 }
 
@@ -1031,7 +1032,7 @@ GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
 	int i = 0;
 	if (!text || !text[0]) {	/* Default is -Yr0 */
 		GMT->current.ps.origin[GMT_Y] = GMT->common.Y.mode = 'r';
-		GMT->current.setting.map_origin[GMT_Y] = 0.0;
+		GMT->common.Y.off = GMT->current.setting.map_origin[GMT_Y] = 0.0;
 		return (GMT_NOERROR);
 	}
 	switch (text[0]) {
@@ -1063,6 +1064,7 @@ GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
 	}
 	else	/* Allow use of -Yc or -Yf meaning -Yc0 or -Yf0 */
 		GMT->current.setting.map_origin[GMT_Y] = 0.0;
+	GMT->common.Y.off = GMT->current.setting.map_origin[GMT_Y];
 	return (GMT_NOERROR);
 }
 
@@ -10253,6 +10255,8 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "COLOR_SET = %s exceeds max name length of %d\n", value, GMT_LEN256);
 				error = true;
 			}
+			else if (!strncmp (value, "default", 7U))	/* Reset to GMT defaults */
+				strncpy (GMT->current.setting.color_set, GMT_DEFAULT_COLOR_SET, GMT_LEN256-1);
 			else if (strchr (value, ',')) {	/* Gave comma-separated list of colors, check that they are all valid */
 				char *word = NULL, *trail = NULL, *orig = strdup (value);
 				trail = orig;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3068,7 +3068,7 @@ GMT_LOCAL int gmtinit_put_history (struct GMT_CTRL *GMT) {
 	if (GMT->current.plot.gridline_spacing[GMT_X] > 0.0 || GMT->current.plot.gridline_spacing[GMT_Y] > 0.0)	/* Save gridline spacing in history */
 		fprintf (fp, "@G\t%g %g\n", GMT->current.plot.gridline_spacing[GMT_X], GMT->current.plot.gridline_spacing[GMT_Y]);
 	if (GMT->current.ps.layer) fprintf (fp, "@L\t%d\n", GMT->current.ps.layer); /* Write PS layer, if non-zero */
-	if (GMT->current.plot.color_seq_id[0] && GMT->current.plot.color_seq_id[1]) fprintf (fp, "@S\t%d %d\n", GMT->current.plot.color_seq_id[0], GMT->current.plot.color_seq_id[1]); /* Write next sequential color IDs, if non-zero */
+	if (GMT->current.plot.color_seq_id[0] || GMT->current.plot.color_seq_id[1]) fprintf (fp, "@S\t%d %d\n", GMT->current.plot.color_seq_id[0], GMT->current.plot.color_seq_id[1]); /* Write next sequential color IDs, if non-zero */
 	fprintf (fp, "END\n");
 
 	/* Close the file */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14578,6 +14578,7 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 	Ccopy->current.ps.layer = GMT->current.ps.layer;
 	Ccopy->current.ps.active = GMT->current.ps.active;
 	Ccopy->current.ps.initialize = GMT->current.ps.initialize;
+	Ccopy->current.plot.color_seq_id = GMT->current.plot.color_seq_id;
 
 	/* GMT_COMMON */
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12938,6 +12938,7 @@ int gmt_set_current_panel (struct GMTAPI_CTRL *API, int fig, int row, int col, d
 	else
 		fprintf (fp, "%d %d %g %g %g %g %d %s\n", row, col, gap[XLO], gap[XHI], gap[YLO], gap[YHI], first, L);
 	fclose (fp);
+	if (first) API->GMT->current.plot.color_seq_id = 0;	/* Reset for new panel */
 	API->error = GMT_NOERROR;
 	return GMT_NOERROR;
 }

--- a/src/gmt_keywords.txt
+++ b/src/gmt_keywords.txt
@@ -5,7 +5,7 @@
 # gmt_keywords.h has quoted parameter names for text comparisons
 # gmt_keycases.h has #define GMT_<parameter> <case> statements
 # Any changes here will likely mean editing gmt_init.c as well,
-# including new entries to GMT5_keywords[].
+# including new entries to GMT_active_keyword[].
 #
 #-------------------------------------------------------
 # COLOR Group:	Color system settings
@@ -19,6 +19,7 @@ COLOR_HSV_MAX_S			# Maximum saturation assigned for most positive intensity valu
 COLOR_HSV_MAX_V			# Maximum value assigned for most positive intensity value
 COLOR_HSV_MIN_S			# Minimum saturation assigned for most positive intensity value
 COLOR_HSV_MIN_V			# Minimum value assigned for most positive intensity value
+COLOR_SET			# Default list of colors (or a cpt) for automatic sequential color choices
 #-------------------------------------------------------
 # DIR Group:	Directories to use
 #-------------------------------------------------------

--- a/src/gmt_macros.h
+++ b/src/gmt_macros.h
@@ -160,8 +160,11 @@
 /* See if no CPT name was given (+u|U modifier may be present but not filename) */
 #define gmt_M_no_cpt_given(arg) (arg == NULL || arg[0] == '\0' || gmt_M_cpt_mod(arg))
 
-/*! Copy two RGB[T] arrays (a = b) */
+/*! Copy two RGB[T] arrays (a = b) including transparency */
 #define gmt_M_rgb_copy(a,b) memcpy (a, b, 4 * sizeof(double))
+
+/*! Copy two RGB[T] arrays (a = b) excluding transparency */
+#define gmt_M_rgb_only_copy(a,b) memcpy (a, b, 3 * sizeof(double))
 
 /*! To compare is two colors are ~ the same */
 #define gmt_M_eq(a,b) (fabs((a)-(b)) < GMT_CONV4_LIMIT)

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -376,6 +376,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double rgb[]);
 EXTERN_MSC double * gmt_duplicate_array (struct GMT_CTRL *GMT, double *array, uint64_t n);
 EXTERN_MSC bool gmt_is_barcolumn (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);
 EXTERN_MSC unsigned int gmt_get_columbar_bands (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -376,6 +376,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC void gmt_init_next_color (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, unsigned int type, double rgb[]);
 EXTERN_MSC double * gmt_duplicate_array (struct GMT_CTRL *GMT, double *array, uint64_t n);
 EXTERN_MSC bool gmt_is_barcolumn (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -376,7 +376,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
-EXTERN_MSC void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double rgb[]);
+EXTERN_MSC void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, unsigned int type, double rgb[]);
 EXTERN_MSC double * gmt_duplicate_array (struct GMT_CTRL *GMT, double *array, uint64_t n);
 EXTERN_MSC bool gmt_is_barcolumn (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);
 EXTERN_MSC unsigned int gmt_get_columbar_bands (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -17361,6 +17361,12 @@ unsigned int gmt_get_columbar_bands (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S)
 	return (n_z);
 }
 
+void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double rgb[]) {
+	/* Cycle through the colors in P and increment sequential ID and only update r,g,b but not alpha */
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Current sequential color pick ID = %u.\n", GMT->current.plot.color_seq_id);
+	gmt_M_rgb_only_copy (rgb, P->data[GMT->current.plot.color_seq_id].rgb_low);
+	GMT->current.plot.color_seq_id = (GMT->current.plot.color_seq_id + 1) % P->n_colors;
+}
 
 #if 0	/* Probably not needed after all */
 char * gmt_add_options (struct GMT_CTRL *GMT, const char *list) {

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6369,20 +6369,7 @@ bool gmt_getrgb (struct GMT_CTRL *GMT, char *line, double rgb[]) {
 	}
 	if (!line[0]) return (false);	/* Nothing to do - accept default action */
 
-	if (strstr (line, "auto")) {	/* Will select sequential colors from a list - flag via -5 */
-		/* Let auto[-segment] be GMT_COLOR_AUTO_SEGMENT and auto-table be GMT_COLOR_AUTO_TABLE */
-		if (strstr (line, "table"))
-			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_TABLE;
-		else
-			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_SEGMENT;
-		return (false);
-	}
-
 	rgb[3] = hsv[3] = cmyk[4] = 0.0;	/* Default is no transparency */
-	if (line[0] == '-') {
-		rgb[0] = rgb[1] = rgb[2] = -1.0;
-		return (false);
-	}
 
 	strncpy (buffer, line, GMT_LEN64-1);	/* Make local copy */
 	if ((t = strstr (buffer, "@")) && strlen (t) > 1) {	/* User requested transparency via @<transparency> */
@@ -6393,6 +6380,21 @@ bool gmt_getrgb (struct GMT_CTRL *GMT, char *line, double rgb[]) {
 			rgb[3] = hsv[3] = cmyk[4] = transparency / 100.0;	/* Transparency is in 0-1 range */
 		t[0] = '\0';	/* Chop off transparency for the rest of this function */
 	}
+
+	if (strstr (buffer, "auto")) {	/* Will select sequential colors from a list - flag via -5 */
+		/* Let auto[-segment] be GMT_COLOR_AUTO_SEGMENT and auto-table be GMT_COLOR_AUTO_TABLE */
+		if (strstr (buffer, "table"))
+			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_TABLE;
+		else
+			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_SEGMENT;
+		return (false);
+	}
+
+	if (buffer[0] == '-') {
+		rgb[0] = rgb[1] = rgb[2] = -1.0;
+		return (false);
+	}
+
 	if (buffer[0] == '#') {	/* #rrggbb */
 		n = sscanf (buffer, "#%2x%2x%2x", (unsigned int *)&irgb[0], (unsigned int *)&irgb[1], (unsigned int *)&irgb[2]);
 		return (n != 3 || gmtsupport_check_irgb (irgb, rgb));

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6365,13 +6365,22 @@ bool gmt_getrgb (struct GMT_CTRL *GMT, char *line, double rgb[]) {
 	if (!line) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No argument given to gmt_getrgb\n");
 		GMT->parent->error = GMT_PARSE_ERROR;
-		return false;
+		return true;
 	}
 	if (!line[0]) return (false);	/* Nothing to do - accept default action */
 
+	if (strstr (line, "auto")) {	/* Will select sequential colors from a list - flag via -5 */
+		/* Let auto[-segment] be GMT_COLOR_AUTO_SEGMENT and auto-table be GMT_COLOR_AUTO_TABLE */
+		if (strstr (line, "table"))
+			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_TABLE;
+		else
+			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_SEGMENT;
+		return (false);
+	}
+
 	rgb[3] = hsv[3] = cmyk[4] = 0.0;	/* Default is no transparency */
 	if (line[0] == '-') {
-		rgb[0] = -1.0; rgb[1] = -1.0; rgb[2] = -1.0;
+		rgb[0] = rgb[1] = rgb[2] = -1.0;
 		return (false);
 	}
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6381,12 +6381,12 @@ bool gmt_getrgb (struct GMT_CTRL *GMT, char *line, double rgb[]) {
 		t[0] = '\0';	/* Chop off transparency for the rest of this function */
 	}
 
-	if (strstr (buffer, "auto")) {	/* Will select sequential colors from a list - flag via -5 */
+	if (strstr (buffer, "auto")) {	/* Will select sequential colors from a list - flag via -5 or -6 */
 		/* Let auto[-segment] be GMT_COLOR_AUTO_SEGMENT and auto-table be GMT_COLOR_AUTO_TABLE */
 		if (strstr (buffer, "table"))
-			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_TABLE;
+			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_TABLE - 7;
 		else
-			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_SEGMENT;
+			rgb[0] = rgb[1] = rgb[2] = GMT_COLOR_AUTO_SEGMENT - 7;
 		return (false);
 	}
 
@@ -17361,11 +17361,13 @@ unsigned int gmt_get_columbar_bands (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S)
 	return (n_z);
 }
 
-void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double rgb[]) {
+void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, unsigned int type, double rgb[]) {
 	/* Cycle through the colors in P and increment sequential ID and only update r,g,b but not alpha */
-	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Current sequential color pick ID = %u.\n", GMT->current.plot.color_seq_id);
-	gmt_M_rgb_only_copy (rgb, P->data[GMT->current.plot.color_seq_id].rgb_low);
-	GMT->current.plot.color_seq_id = (GMT->current.plot.color_seq_id + 1) % P->n_colors;
+	static char *kind[2] = {"table", "segment"};
+	type--;	/* So 1 and 2 becomes 0 and 1 for array indices */ 
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Current %s sequential color pick ID = %u.\n", kind[type], GMT->current.plot.color_seq_id[type]);
+	gmt_M_rgb_only_copy (rgb, P->data[GMT->current.plot.color_seq_id[type]].rgb_low);
+	GMT->current.plot.color_seq_id[type] = (GMT->current.plot.color_seq_id[type] + 1) % P->n_colors;
 }
 
 #if 0	/* Probably not needed after all */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -17361,6 +17361,19 @@ unsigned int gmt_get_columbar_bands (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S)
 	return (n_z);
 }
 
+void gmt_init_next_color (struct GMT_CTRL *GMT) {
+	/*  Reset the sequential color IDs if starting a new plot or we detect overlay shift via -X -Y */
+	bool reset = false;
+	if (!GMT->common.O.active)	/* Start of a new plot means reset counters read from history to 0 0 */
+		reset = true;
+	else if (fabs (GMT->common.X.off) > 0.0 || fabs (GMT->common.Y.off) > 0.0)	/* Overlay but we are moving focus */
+		reset = true;
+	if (reset) {
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reset sequential color pick IDs to 0,0\n");
+		GMT->current.plot.color_seq_id[0] = GMT->current.plot.color_seq_id[1] = 0;
+	}
+}
+
 void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, unsigned int type, double rgb[]) {
 	/* Cycle through the colors in P and increment sequential ID and only update r,g,b but not alpha */
 	static char *kind[2] = {"table", "segment"};

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -347,6 +347,7 @@ struct GMT_PLOT {		/* Holds all plotting-related parameters */
 	bool substitute_pi;		/* true when -R or -B was given with pi and we want to use pi in annotations if possible */
 	unsigned int mode_3D;		/* Determines if we draw fore and/or back 3-D box lines [Default is both] */
 	unsigned int *pen;		/* Pen (PSL_MOVE = up, PSL_DRAW = down) for these points */
+	unsigned int color_seq_id;	/* Next sequential color entry in the auto-CPT list of colors from COLOR_SET */
 	struct GMT_PLOT_CALCLOCK calclock;
 	/* The rest of the struct contains pointers that may point to memory not included by this struct */
 	double *x;			/* Holds the x/y (inches) of a line to be plotted */

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -347,7 +347,7 @@ struct GMT_PLOT {		/* Holds all plotting-related parameters */
 	bool substitute_pi;		/* true when -R or -B was given with pi and we want to use pi in annotations if possible */
 	unsigned int mode_3D;		/* Determines if we draw fore and/or back 3-D box lines [Default is both] */
 	unsigned int *pen;		/* Pen (PSL_MOVE = up, PSL_DRAW = down) for these points */
-	unsigned int color_seq_id;	/* Next sequential color entry in the auto-CPT list of colors from COLOR_SET */
+	unsigned int color_seq_id[2];	/* Next sequential color entries (table,segment) in the auto-CPT list of colors from COLOR_SET */
 	struct GMT_PLOT_CALCLOCK calclock;
 	/* The rest of the struct contains pointers that may point to memory not included by this struct */
 	double *x;			/* Holds the x/y (inches) of a line to be plotted */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -64,7 +64,7 @@ struct PSXY_CTRL {
 	struct PSXY_G {	/* -G<fill>|+z */
 		bool active;
 		bool set_color;
-		int sequential;
+		unsigned int sequential;
 		struct GMT_FILL fill;
 	} G;
 	struct PSXY_I {	/* -I[<intensity>] */
@@ -96,7 +96,7 @@ struct PSXY_CTRL {
 		bool active;
 		bool cpt_effect;
 		bool set_color;
-		int sequential;
+		unsigned int sequential;
 		struct GMT_PEN pen;
 	} W;
 	struct PSXY_Z {	/* -Z<value> */
@@ -794,7 +794,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 				else if (!opt->arg[0] || gmt_getfill (GMT, opt->arg, &Ctrl->G.fill)) {
 					gmt_fill_syntax (GMT, 'G', NULL, " "); n_errors++;
 				}
-				if (Ctrl->G.fill.rgb[0] <= GMT_COLOR_AUTO_SEGMENT) Ctrl->G.sequential = irint (Ctrl->G.fill.rgb[0]);
+				if (Ctrl->G.fill.rgb[0] < -4.0) Ctrl->G.sequential = irint (Ctrl->G.fill.rgb[0]+7.0);
 				break;
 			case 'I':	/* Adjust symbol color via intensity */
 				Ctrl->I.active = true;
@@ -878,7 +878,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 				}
 				if (Ctrl->W.pen.cptmode) Ctrl->W.cpt_effect = true;
 				if (c) c[0] = '+';	/* Restore */
-				if (Ctrl->W.pen.rgb[0] <= GMT_COLOR_AUTO_SEGMENT) Ctrl->W.sequential = irint (Ctrl->W.pen.rgb[0]);
+				if (Ctrl->W.pen.rgb[0] < -4.0) Ctrl->W.sequential = irint (Ctrl->W.pen.rgb[0] + 7.0);
 				break;
 
 			case 'Z':		/* Get value for CPT lookup */
@@ -2166,11 +2166,11 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 				gmt_extract_label (GMT, D->table[tbl]->header[0], S.G.label, NULL);
 
 			if (Ctrl->G.sequential == GMT_COLOR_AUTO_TABLE) {	/* Update sequential fill color per table */
-				gmt_set_next_color (GMT, A, current_fill.rgb);
+				gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_TABLE, current_fill.rgb);
 				gmt_setfill (GMT, &current_fill, outline_setting);
 			}
 			else if (Ctrl->W.sequential == GMT_COLOR_AUTO_TABLE) {	/* Update sequential pen color per table */
-				gmt_set_next_color (GMT, A, current_pen.rgb);
+				gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_TABLE, current_pen.rgb);
 				gmt_setpen (GMT, &current_pen);
 			}
 			for (seg = 0; seg < D->table[tbl]->n_segments; seg++, seg_out++) {	/* For each segment in the table */
@@ -2178,11 +2178,11 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 				L = D->table[tbl]->segment[seg];	/* Set shortcut to current segment */
 
 				if (Ctrl->G.sequential == GMT_COLOR_AUTO_SEGMENT) {	/* Update sequential fill color per segment */
-					gmt_set_next_color (GMT, A, current_fill.rgb);
+					gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_SEGMENT, current_fill.rgb);
 					gmt_setfill (GMT, &current_fill, outline_setting);
 				}
 				else if (Ctrl->W.sequential == GMT_COLOR_AUTO_SEGMENT) {	/* Update sequential pen color per segment */
-					gmt_set_next_color (GMT, A, current_pen.rgb);
+					gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_SEGMENT, current_pen.rgb);
 					gmt_setpen (GMT, &current_pen);
 				}
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -938,15 +938,15 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 
 EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	/* High-level function that implements the psxy task */
-	bool polygon, penset_OK = true, not_line, old_is_world, rgb_from_z = false, decorate_custom = false;
-	bool get_rgb = false, clip_set = false, fill_active, may_intrude_inside = false, seq_legend = false;
-	bool error_x = false, error_y = false, def_err_xy = false, can_update_headpen = true;
-	bool default_outline, outline_active, geovector = false, save_W = false, save_G = false, QR_symbol = false;
-	unsigned int n_needed, n_cols_start = 2, justify, tbl, grid_order, frame_order;
+	bool polygon = false, penset_OK = true, not_line = false, old_is_world = false, rgb_from_z = false;
+	bool get_rgb = false, clip_set = false, fill_active = false, may_intrude_inside = false, seq_legend = false;
+	bool error_x = false, error_y = false, def_err_xy = false, can_update_headpen = true, decorate_custom = false;
+	bool default_outline = false, outline_active = false, geovector = false, save_W = false, save_G = false, QR_symbol = false;
+	unsigned int n_needed = 0, n_cols_start = 2, justify = 0, tbl, grid_order = 0, frame_order = 0;
 	unsigned int n_total_read = 0, j, geometry, icol = 0, tcol_f = 0, tcol_s = 0, n_z = 0, k, kk;
 	unsigned int bcol, ex1, ex2, ex3, change = 0, pos2x, pos2y, save_u = false;
 	unsigned int xy_errors[2], error_type[2] = {EBAR_NONE, EBAR_NONE}, error_cols[5] = {0,1,2,4,5};
-	int error = GMT_NOERROR, outline_setting, seq_n_legends = 0, seq_frequency = 0;
+	int error = GMT_NOERROR, outline_setting = 0, seq_n_legends = 0, seq_frequency = 0;
 
 	char s_args[GMT_BUFSIZ] = {""};
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2117,6 +2117,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			if ((A = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, GMT->current.setting.color_set, NULL)) == NULL) {
 				Return (API->error);
 			}
+			gmt_init_next_color (GMT);
 			if (GMT->common.l.active) {	/* Want auto legend for all the lines or polygons */
 				seq_legend = true;
 				seq_n_legends = A->n_colors;

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -939,14 +939,14 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	/* High-level function that implements the psxy task */
 	bool polygon, penset_OK = true, not_line, old_is_world, rgb_from_z = false, decorate_custom = false;
-	bool get_rgb = false, clip_set = false, fill_active, may_intrude_inside = false;
+	bool get_rgb = false, clip_set = false, fill_active, may_intrude_inside = false, seq_legend = false;
 	bool error_x = false, error_y = false, def_err_xy = false, can_update_headpen = true;
 	bool default_outline, outline_active, geovector = false, save_W = false, save_G = false, QR_symbol = false;
 	unsigned int n_needed, n_cols_start = 2, justify, tbl, grid_order, frame_order;
 	unsigned int n_total_read = 0, j, geometry, icol = 0, tcol_f = 0, tcol_s = 0, n_z = 0, k, kk;
 	unsigned int bcol, ex1, ex2, ex3, change = 0, pos2x, pos2y, save_u = false;
 	unsigned int xy_errors[2], error_type[2] = {EBAR_NONE, EBAR_NONE}, error_cols[5] = {0,1,2,4,5};
-	int error = GMT_NOERROR, outline_setting;
+	int error = GMT_NOERROR, outline_setting, seq_n_legends = 0, seq_frequency = 0;
 
 	char s_args[GMT_BUFSIZ] = {""};
 
@@ -2117,6 +2117,11 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			if ((A = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, GMT->current.setting.color_set, NULL)) == NULL) {
 				Return (API->error);
 			}
+			if (GMT->common.l.active) {	/* Want auto legend for all the lines or polygons */
+				seq_legend = true;
+				seq_n_legends = A->n_colors;
+				seq_frequency = MAX (Ctrl->G.sequential, Ctrl->W.sequential);
+			}
 		}
 
 		if (Zin) {	/* Check that the Z file matches our polygon file */
@@ -2144,7 +2149,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		}
 		if (GMT->current.io.OGR && (GMT->current.io.OGR->geometry == GMT_IS_POLYGON || GMT->current.io.OGR->geometry == GMT_IS_MULTIPOLYGON)) polygon = true;
 
-		if (GMT->common.l.active) {
+		if (!seq_legend && GMT->common.l.active) {
 			if (S.symbol == GMT_SYMBOL_LINE) {
 				if (polygon) {	/* Place a rectangle in the legend */
 					int symbol = S.symbol;
@@ -2177,6 +2182,9 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 
 				L = D->table[tbl]->segment[seg];	/* Set shortcut to current segment */
 
+				if (gmt_segment_BB_outside_map_BB (GMT, L)) continue;
+				if (polygon && gmt_polygon_is_hole (GMT, L)) continue;	/* Holes are handled together with perimeters */
+
 				if (Ctrl->G.sequential == GMT_COLOR_AUTO_SEGMENT) {	/* Update sequential fill color per segment */
 					gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_SEGMENT, current_fill.rgb);
 					gmt_setfill (GMT, &current_fill, outline_setting);
@@ -2186,14 +2194,28 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 					gmt_setpen (GMT, &current_pen);
 				}
 
-				if (gmt_segment_BB_outside_map_BB (GMT, L)) continue;
-				if (polygon && gmt_polygon_is_hole (GMT, L)) continue;	/* Holes are handled together with perimeters */
-
 				SH = gmt_get_DS_hidden (L);
 
+				if (seq_legend && seq_n_legends >= 0 && (seq_frequency == GMT_COLOR_AUTO_SEGMENT || seg == 0)) {
+					if (GMT->common.l.item.label_type == GMT_LEGEND_LABEL_HEADER && L->header)	/* Use a segment label if found in header */
+						gmt_extract_label (GMT, L->header, GMT->common.l.item.label, SH->ogr);
+					if (polygon) {	/* Place a rectangle in the legend */
+						int symbol = S.symbol;
+						S.symbol = PSL_RECT;
+						gmt_add_legend_item (API, &S, Ctrl->G.active, &current_fill, Ctrl->W.active, &current_pen, &(GMT->common.l.item));
+						S.symbol = symbol;
+					}
+					else	/* For specified line, width, color we can do an auto-legend entry under modern mode */
+						gmt_add_legend_item (API, &S, false, NULL, Ctrl->W.active, &current_pen, &(GMT->common.l.item));
+					seq_n_legends--;	/* One less to do */
+					GMT->common.l.item.ID++;	/* Increment the label counter */
+				}
+
 				duplicate = (DH->alloc_mode == GMT_ALLOC_EXTERNALLY && (polygon || gmt_trim_requested (GMT, &current_pen) || GMT->current.map.path_mode == GMT_RESAMPLE_PATH));
-				if (duplicate)	/* Must duplicate externally allocated segment since it needs to be resampled below */
+				if (duplicate) {	/* Must duplicate externally allocated segment since it needs to be resampled below */
 					L = gmt_duplicate_segment (GMT, D->table[tbl]->segment[seg]);
+					SH = gmt_get_DS_hidden (L);
+				}
 
 				resampled = false;
 				if (!polygon && gmt_trim_requested (GMT, &current_pen)) {	/* Needs a haircut */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2165,12 +2165,12 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 				gmt_extract_label (GMT, D->table[tbl]->header[0], S.G.label, NULL);
 
 			if (Ctrl->G.sequential == GMT_COLOR_AUTO_TABLE) {	/* Update sequential fill color per table */
-				gmt_M_rgb_copy (current_fill.rgb, A->data[seq_id].rgb_low);
+				gmt_M_rgb_only_copy (current_fill.rgb, A->data[seq_id].rgb_low);
 				gmt_setfill (GMT, &current_fill, outline_setting);
 				seq_id = (seq_id + 1) % seq_wrap;
 			}
 			else if (Ctrl->W.sequential == GMT_COLOR_AUTO_TABLE) {	/* Update sequential pen olor per table */
-				gmt_M_rgb_copy (current_pen.rgb, A->data[seq_id].rgb_low);
+				gmt_M_rgb_only_copy (current_pen.rgb, A->data[seq_id].rgb_low);
 				gmt_setpen (GMT, &current_pen);
 				seq_id = (seq_id + 1) % seq_wrap;
 			}
@@ -2179,12 +2179,12 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 				L = D->table[tbl]->segment[seg];	/* Set shortcut to current segment */
 
 				if (Ctrl->G.sequential == GMT_COLOR_AUTO_SEGMENT) {	/* Update sequential fill color per table */
-					gmt_M_rgb_copy (current_fill.rgb, A->data[seq_id].rgb_low);
+					gmt_M_rgb_only_copy (current_fill.rgb, A->data[seq_id].rgb_low);
 					gmt_setfill (GMT, &current_fill, outline_setting);
 					seq_id = (seq_id + 1) % seq_wrap;
 				}
 				else if (Ctrl->W.sequential == GMT_COLOR_AUTO_SEGMENT) {	/* Update sequential color per segment */
-					gmt_M_rgb_copy (current_pen.rgb, A->data[seq_id].rgb_low);
+					gmt_M_rgb_only_copy (current_pen.rgb, A->data[seq_id].rgb_low);
 					gmt_setpen (GMT, &current_pen);
 					seq_id = (seq_id + 1) % seq_wrap;
 				}

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -52,7 +52,7 @@ struct PSXYZ_CTRL {
 	struct PSXYZ_G {	/* -G<fill>|+z */
 		bool active;
 		bool set_color;
-		int sequential;
+		unsigned int sequential;
 		struct GMT_FILL fill;
 	} G;
 	struct PSXYZ_I {	/* -I[<intensity>] */
@@ -87,7 +87,7 @@ struct PSXYZ_CTRL {
 		bool active;
 		bool cpt_effect;
 		bool set_color;
-		int sequential;
+		unsigned int sequential;
 		struct GMT_PEN pen;
 	} W;
 	struct PSXYZ_Z {	/* -Z<value> */
@@ -382,7 +382,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSXYZ_CTRL *Ctrl, struct GMT_OPTI
 					gmt_fill_syntax (GMT, 'G', NULL, " ");
 					n_errors++;
 				}
-				if (Ctrl->G.fill.rgb[0] <= GMT_COLOR_AUTO_SEGMENT) Ctrl->G.sequential = irint (Ctrl->G.fill.rgb[0]);
+				if (Ctrl->G.fill.rgb[0] < -4.0) Ctrl->G.sequential = irint (Ctrl->G.fill.rgb[0] + 7.0);
 				break;
 			case 'I':	/* Adjust symbol color via intensity */
 				Ctrl->I.active = true;
@@ -467,7 +467,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSXYZ_CTRL *Ctrl, struct GMT_OPTI
 				}
 				if (Ctrl->W.pen.cptmode) Ctrl->W.cpt_effect = true;
 				if (c) c[0] = '+';	/* Restore */
-				if (Ctrl->W.pen.rgb[0] <= GMT_COLOR_AUTO_SEGMENT) Ctrl->W.sequential = irint (Ctrl->W.pen.rgb[0]);
+				if (Ctrl->W.pen.rgb[0] < -4.0) Ctrl->W.sequential = irint (Ctrl->W.pen.rgb[0] + 7.0);
 				break;
 
 			case 'Z':		/* Get value for CPT lookup */
@@ -1835,11 +1835,11 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			if (D->table[tbl]->n_headers && S.G.label_type == GMT_LABEL_IS_HEADER) gmt_extract_label (GMT, &D->table[tbl]->header[0][1], S.G.label, NULL);	/* Set first header as potential label */
 
 			if (Ctrl->G.sequential == GMT_COLOR_AUTO_TABLE) {	/* Update sequential fill color per table */
-				gmt_set_next_color (GMT, A, current_fill.rgb);
+				gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_TABLE, current_fill.rgb);
 				gmt_setfill (GMT, &current_fill, outline_setting);
 			}
 			else if (Ctrl->W.sequential == GMT_COLOR_AUTO_TABLE) {	/* Update sequential pen color per table */
-				gmt_set_next_color (GMT, A, current_pen.rgb);
+				gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_TABLE, current_pen.rgb);
 				gmt_setpen (GMT, &current_pen);
 			}
 
@@ -1848,11 +1848,11 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 				L = D->table[tbl]->segment[seg];	/* Set shortcut to current segment */
 
 				if (Ctrl->G.sequential == GMT_COLOR_AUTO_SEGMENT) {	/* Update sequential fill color per segment */
-					gmt_set_next_color (GMT, A, current_fill.rgb);
+					gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_SEGMENT, current_fill.rgb);
 					gmt_setfill (GMT, &current_fill, outline_setting);
 				}
 				else if (Ctrl->W.sequential == GMT_COLOR_AUTO_SEGMENT) {	/* Update sequential pen color per segment */
-					gmt_set_next_color (GMT, A, current_pen.rgb);
+					gmt_set_next_color (GMT, A, GMT_COLOR_AUTO_SEGMENT, current_pen.rgb);
 					gmt_setpen (GMT, &current_pen);
 				}
 

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -31,7 +31,7 @@
 #define THIS_MODULE_PURPOSE	"Plot lines, polygons, and symbols in 3-D"
 #define THIS_MODULE_KEYS	"<D{,CC(,T-<,S?(=2,ZD(=,>X}"
 #define THIS_MODULE_NEEDS	"Jd"
-#define THIS_MODULE_OPTIONS "-:>BJKOPRUVXYabdefghipqtxy" GMT_OPT("EHMmc")
+#define THIS_MODULE_OPTIONS "-:>BJKOPRUVXYabdefghilpqtxy" GMT_OPT("EHMmc")
 
 /* Control structure for psxyz */
 
@@ -156,7 +156,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	else
 		GMT_Message (API, GMT_TIME_NONE, "\t%s[-Q] [-S[<symbol>][<size>][/size_y]]\n\t[%s] [%s] [-W[<pen>][<attr>]]\n", API->P_OPT, GMT_U_OPT, GMT_V_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [-Z<value>|<file>[+f|l]] [%s]\n\t[%s] %s[%s] [%s] [%s]\n\t[%s]\n", GMT_X_OPT, GMT_Y_OPT, GMT_a_OPT, GMT_bi_OPT, API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\n", GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_tv_OPT, GMT_colon_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]\n\n", GMT_h_OPT, GMT_i_OPT, GMT_l_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_tv_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -297,7 +297,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +l for just pen color or +f for fill color [Default sets both].\n");
 	GMT_Option (API, "a,bi");
 	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t   Default is the required number of columns.\n");
-	GMT_Option (API, "c,di,e,f,g,h,i,p,qi,t");
+	GMT_Option (API, "c,di,e,f,g,h,i,l,p,qi,t");
 	GMT_Message (API, GMT_TIME_NONE, "\t   For separate transparency for fill and stroke, append /<transp2> as well.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   For plotting symbols with variable transparency read from file, append no value\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   and give the transparency as the last numerical value in the data record.\n");

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -635,11 +635,11 @@ GMT_LOCAL bool psxyz_load_bands (struct GMT_CTRL *GMT, double *in, double *out, 
 
 EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 	/* High-level function that implements the psxyz task */
-	bool polygon, penset_OK = true, not_line, old_is_world, seq_legend = false;
-	bool get_rgb = false, read_symbol, clip_set = false, fill_active, rgb_from_z = false, QR_symbol = false;
-	bool default_outline, outline_active, save_u = false, geovector = false, can_update_headpen = true;
+	bool polygon = false, penset_OK = true, not_line = false, old_is_world = false, seq_legend = false;
+	bool get_rgb = false, read_symbol = false, clip_set = false, fill_active = false, rgb_from_z = false, QR_symbol = false;
+	bool default_outline = false, outline_active = false, save_u = false, geovector = false, can_update_headpen = true;
 	unsigned int k, j, geometry, tbl, pos2x, pos2y, icol = 0, tcol_f = 0, tcol_s = 0, grid_order, frame_order, n_z = 0;
-	unsigned int n_cols_start = 3, justify, v4_outline = 0, v4_status = 0, bcol, ex1, ex2, ex3, change = 0, n_needed;
+	unsigned int n_cols_start = 3, justify, v4_outline = 0, v4_status = 0, bcol, ex1, ex2, ex3, change = 0, n_needed = 0;
 	int error = GMT_NOERROR, seq_n_legends = 0, seq_frequency = 0;
 	uint64_t i, n, n_total_read = 0;
 	size_t n_alloc = 0;
@@ -647,8 +647,8 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 	char s_args[GMT_BUFSIZ] = {""};
 
 	double dim[PSL_MAX_DIMS], rgb[3][4] = {{-1.0, -1.0, -1.0, 0.0}, {-1.0, -1.0, -1.0, 0.0}, {-1.0, -1.0, -1.0, 0.0}};
-	double DX = 0, DY = 0, *xp = NULL, *yp = NULL, *in = NULL, *v4_rgb = NULL;
-	double lux[3] = {0.0, 0.0, 0.0}, tmp, x_1, x_2, y_1, y_2, dx, dy, s, c, zz, zb, length, base, *z_for_cpt = NULL;
+	double DX = 0, DY = 0, *xp = NULL, *yp = NULL, *in = NULL, *v4_rgb = NULL, *z_for_cpt = NULL;
+	double lux[3] = {0.0, 0.0, 0.0}, tmp, x_1, x_2, y_1, y_2, dx, dy, s, c, zz, zb, length, base;
 	double bar_gap, bar_width, bar_step;
 
 	struct GMT_PEN default_pen, current_pen, last_headpen, last_spiderpen;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1798,6 +1798,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			if ((A = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, GMT->current.setting.color_set, NULL)) == NULL) {
 				Return (API->error);
 			}
+			gmt_init_next_color (GMT);
 			if (GMT->common.l.active) {	/* Want auto legend for all the lines or polygons */
 				seq_legend = true;
 				seq_n_legends = A->n_colors;

--- a/test/pslegend/autolegendcolor.ps
+++ b/test/pslegend/autolegendcolor.ps
@@ -1,0 +1,1405 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_3967bf2_2020.12.06 [64-bit] Document from text
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec  6 17:30:30 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/6.46588/0/6.46588 -Jx1i -N -F+jBC+f32p,Helvetica,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.46588000 0.00000000 6.46588000 0.000 6.466 0.000 6.466 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+3880 8159 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+533 F0
+(Test auto­color legends) bc Z
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 3980 TM
+% PostScript produced by:
+%@GMT: gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -lPoly# -BWrtb -Bxaf -Byaf -Xa0i -Ya3.3163i -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 3980 T
+0 A 67 3713 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(a\)) tl Z
+U
+}!
+0 A
+V
+4 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
+O0
+/FO {P}!
+-540 0 0 540 540 0 3 540 540 SP
+/FO {fs os}!
+FO
+{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 1620 1620 SP
+/FO {fs os}!
+FO
+{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 2160 2160 SP
+/FO {fs os}!
+FO
+{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 2700 2700 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 540 M -83 0 D S
+N 0 1620 M -83 0 D S
+N 0 2700 M -83 0 D S
+N 0 3780 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+540 PSL_A0_y MM
+(0) mr Z
+1620 PSL_A0_y MM
+(2) mr Z
+2700 PSL_A0_y MM
+(4) mr Z
+3780 PSL_A0_y MM
+(6) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 1080 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 3240 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+25 W
+N 0 3780 M 0 -3780 D S
+-3780 0 T
+N 0 0 M 3780 0 D S
+0 3780 T
+N 0 0 M 3780 0 D S
+0 -3780 T
+0 setlinecap
+%%EndObject
+0 -3980 TM
+0 A
+FQ
+O0
+0 3980 TM
+% PostScript produced by:
+%@GMT: gmt legend -DjRB+w0i+o0.2c -F+p1p+gwhite -S1 -Xa0i -Ya3.3163i -R-1/6/-1/6 -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_legend_label_width 0 def
+/PSL_legend_string_width 0 def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(Poly 0) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poly 1) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poly 2) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poly 3) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+/PSL_tmp_w 354 def
+/PSL_legend_clear_x 133 def
+/PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
+/PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
+/PSL_legend_box_height 1013 def
+2672 94 T
+PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul neg 0 translate
+V
+17 W
+{1 A} FS
+O1
+0 0 M PSL_legend_box_width 0 D 0 PSL_legend_box_height D PSL_legend_box_width neg 0 D P FO N
+U
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/3.1496/0/3.1496 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000001 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.14960000 0.00000000 3.14960000 0.000 3.150 0.000 3.150 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+4 W
+{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 837 Sr
+{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 617 Sr
+{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 397 Sr
+{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 177 Sr
+U
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/3.1496/0/3.1496 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000002 --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.14960000 0.00000000 3.14960000 0.000 3.150 0.000 3.150 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+421 767 M (Poly 0) bl Z
+421 547 M (Poly 1) bl Z
+421 327 M (Poly 2) bl Z
+421 107 M (Poly 3) bl Z
+%%EndObject
+0 0 TM
+PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate
+-2672 -94 T
+%%EndObject
+0 -3980 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3980 3980 TM
+% PostScript produced by:
+%@GMT: gmt plot p.txt -R-1/6/-1/6 -Gauto@50 '-lPoly X-%2.2d+jBR' -Blrtb -Bxaf -Byaf -Xa3.3163i -Ya3.3163i -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+3980 3980 T
+0 A 67 3713 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(b\)) tl Z
+U
+}!
+0 A
+V
+4 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
+O0
+/FO {P}!
+-540 0 0 540 540 0 3 540 540 SP
+/FO {fs os}!
+FO
+{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 1620 1620 SP
+/FO {fs os}!
+FO
+{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 2160 2160 SP
+/FO {fs os}!
+FO
+{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 2700 2700 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+3780 0 T
+N 0 3780 M 0 -3780 D S
+-3780 0 T
+N 0 0 M 3780 0 D S
+0 3780 T
+N 0 0 M 3780 0 D S
+0 -3780 T
+0 setlinecap
+%%EndObject
+-3980 -3980 TM
+0 A
+FQ
+O0
+3980 3980 TM
+% PostScript produced by:
+%@GMT: gmt legend -DjRB+w0i+o0.2c -F+p1p+gwhite -S1 -Xa3.3163i -Ya3.3163i -R-1/6/-1/6 -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_legend_label_width 0 def
+/PSL_legend_string_width 0 def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(Poly X­00) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poly X­01) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poly X­02) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poly X­03) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+/PSL_tmp_w 354 def
+/PSL_legend_clear_x 133 def
+/PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
+/PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
+/PSL_legend_box_height 1013 def
+2672 94 T
+PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul neg 0 translate
+V
+17 W
+{1 A} FS
+O1
+0 0 M PSL_legend_box_width 0 D 0 PSL_legend_box_height D PSL_legend_box_width neg 0 D P FO N
+U
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/3.1496/0/3.1496 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000001 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.14960000 0.00000000 3.14960000 0.000 3.150 0.000 3.150 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+4 W
+{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 837 Sr
+{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 617 Sr
+{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 397 Sr
+{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 177 Sr
+U
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/3.1496/0/3.1496 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000002 --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.14960000 0.00000000 3.14960000 0.000 3.150 0.000 3.150 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+421 767 M (Poly X­00) bl Z
+421 547 M (Poly X­01) bl Z
+421 327 M (Poly X­02) bl Z
+421 107 M (Poly X­03) bl Z
+%%EndObject
+0 0 TM
+PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate
+-2672 -94 T
+%%EndObject
+-3980 -3980 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot p.txt -R-1/6/-1/6 -Gauto@50 '-lPoly A,Poly B,Poly C,N/A+jBR' -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A 67 3713 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(c\)) tl Z
+U
+}!
+0 A
+V
+4 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
+O0
+/FO {P}!
+-540 0 0 540 540 0 3 540 540 SP
+/FO {fs os}!
+FO
+{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 1620 1620 SP
+/FO {fs os}!
+FO
+{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 2160 2160 SP
+/FO {fs os}!
+FO
+{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 2700 2700 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 540 M -83 0 D S
+N 0 1620 M -83 0 D S
+N 0 2700 M -83 0 D S
+N 0 3780 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+540 PSL_A0_y MM
+(0) mr Z
+1620 PSL_A0_y MM
+(2) mr Z
+2700 PSL_A0_y MM
+(4) mr Z
+3780 PSL_A0_y MM
+(6) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 1080 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 3240 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+25 W
+N 0 3780 M 0 -3780 D S
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 540 0 M 0 -83 D S
+N 1620 0 M 0 -83 D S
+N 2700 0 M 0 -83 D S
+N 3780 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+540 PSL_A0_y MM
+(0) bc Z
+1620 PSL_A0_y MM
+(2) bc Z
+2700 PSL_A0_y MM
+(4) bc Z
+3780 PSL_A0_y MM
+(6) bc Z
+N 0 0 M 0 -42 D S
+N 1080 0 M 0 -42 D S
+N 2160 0 M 0 -42 D S
+N 3240 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+25 W
+N 0 0 M 3780 0 D S
+0 -3780 T
+0 setlinecap
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt legend -DjRB+w0i+o0.2c -F+p1p+gwhite -S1 -Xa0i -Ya0i -R-1/6/-1/6 -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_legend_label_width 0 def
+/PSL_legend_string_width 0 def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(Poly A) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poly B) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poly C) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(N/A) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+/PSL_tmp_w 354 def
+/PSL_legend_clear_x 133 def
+/PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
+/PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
+/PSL_legend_box_height 1013 def
+2672 94 T
+PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul neg 0 translate
+V
+17 W
+{1 A} FS
+O1
+0 0 M PSL_legend_box_width 0 D 0 PSL_legend_box_height D PSL_legend_box_width neg 0 D P FO N
+U
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/3.1496/0/3.1496 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000001 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.14960000 0.00000000 3.14960000 0.000 3.150 0.000 3.150 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+4 W
+{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 837 Sr
+{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 617 Sr
+{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 397 Sr
+{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 177 Sr
+U
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/3.1496/0/3.1496 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000002 --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.14960000 0.00000000 3.14960000 0.000 3.150 0.000 3.150 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+421 767 M (Poly A) bl Z
+421 547 M (Poly B) bl Z
+421 327 M (Poly C) bl Z
+421 107 M (N/A) bl Z
+%%EndObject
+0 0 TM
+PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate
+-2672 -94 T
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3980 0 TM
+% PostScript produced by:
+%@GMT: gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l+jBR -BlrtS -Bxaf -Byaf -Xa3.3163i -Ya0i -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+3980 0 T
+0 A 67 3713 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(d\)) tl Z
+U
+}!
+0 A
+V
+4 W
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
+O0
+/FO {P}!
+-540 0 0 540 540 0 3 540 540 SP
+/FO {fs os}!
+FO
+{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 1620 1620 SP
+/FO {fs os}!
+FO
+{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 2160 2160 SP
+/FO {fs os}!
+FO
+{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-540 0 0 540 540 0 3 2700 2700 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+3780 0 T
+N 0 3780 M 0 -3780 D S
+-3780 0 T
+N 0 0 M 3780 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 540 0 M 0 -83 D S
+N 1620 0 M 0 -83 D S
+N 2700 0 M 0 -83 D S
+N 3780 0 M 0 -83 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg M} def
+/PSL_AH0 0
+200 F0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+540 PSL_A0_y MM
+(0) bc Z
+1620 PSL_A0_y MM
+(2) bc Z
+2700 PSL_A0_y MM
+(4) bc Z
+3780 PSL_A0_y MM
+(6) bc Z
+N 0 0 M 0 -42 D S
+N 1080 0 M 0 -42 D S
+N 2160 0 M 0 -42 D S
+N 3240 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+25 W
+N 0 0 M 3780 0 D S
+0 -3780 T
+0 setlinecap
+%%EndObject
+-3980 0 TM
+0 A
+FQ
+O0
+3980 0 TM
+% PostScript produced by:
+%@GMT: gmt legend -DjRB+w0i+o0.2c -F+p1p+gwhite -S1 -Xa3.3163i -Ya0i -R-1/6/-1/6 -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_legend_label_width 0 def
+/PSL_legend_string_width 0 def
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(First) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(2nd item) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(Poland) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+(My Area) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
+/PSL_tmp_w 354 def
+/PSL_legend_clear_x 133 def
+/PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def
+/PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def
+/PSL_legend_box_height 1013 def
+2672 94 T
+PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul neg 0 translate
+V
+17 W
+{1 A} FS
+O1
+0 0 M PSL_legend_box_width 0 D 0 PSL_legend_box_height D PSL_legend_box_width neg 0 D P FO N
+U
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/3.1496/0/3.1496 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000001 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.14960000 0.00000000 3.14960000 0.000 3.150 0.000 3.150 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+4 W
+{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 837 Sr
+{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 617 Sr
+{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 397 Sr
+{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
+154 236 185 177 Sr
+U
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/3.1496/0/3.1496 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000002 --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.14960000 0.00000000 3.14960000 0.000 3.150 0.000 3.150 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+421 767 M (First) bl Z
+421 547 M (2nd item) bl Z
+421 327 M (Poland) bl Z
+421 107 M (My Area) bl Z
+%%EndObject
+0 0 TM
+PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate
+-2672 -94 T
+%%EndObject
+-3980 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/pslegend/autolegendcolor.sh
+++ b/test/pslegend/autolegendcolor.sh
@@ -22,7 +22,7 @@ cat << EOF > p.txt
 4 5
 EOF
 gmt begin autolegendcolor ps
-  gmt subplot begin 2x2 -R-1/6/-1/6 -Fs8c -SRl -SCb -Blrtb -A -T"Test auto-color legends"
+  gmt subplot begin 2x2 -R-1/6/-1/6 -Fs8c -SRl -SCb -Blrtb -A -T"Test auto-color polygon legends"
     gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l"Poly #"+jBR -c
     gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l"Poly X-%2.2d"+jBR -c
     gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l"Poly A,Poly B,Poly C,N/A"+jBR -c

--- a/test/pslegend/autolegendcolor.sh
+++ b/test/pslegend/autolegendcolor.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+cat << EOF > p.txt
+> -LFirst
+0 0
+1 0
+1 1
+0 1
+> 2 2 -L"2nd item"
+2 2
+3 2
+3 3
+2 3
+> -LPoland
+3 3
+4 3
+4 4
+3 4
+> -L"My Area"
+4 4
+5 4
+5 5
+4 5
+EOF
+gmt begin autolegendcolor ps
+  gmt subplot begin 2x2 -R-1/6/-1/6 -Fs8c -SRl -SCb -Blrtb -A -T"Test auto-color legends"
+    gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l"Poly #"+jBR -c
+    gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l"Poly X-%2.2d"+jBR -c
+    gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l"Poly A,Poly B,Poly C,N/A"+jBR -c
+    gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l+jBR -c
+  gmt subplot end
+gmt end show

--- a/test/pslegend/autolegendcolorL.ps
+++ b/test/pslegend/autolegendcolorL.ps
@@ -5,7 +5,7 @@
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Dec  6 17:33:34 2020
+%%CreationDate: Sun Dec  6 17:35:38 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -671,7 +671,7 @@ O0
 3.32550952342 setmiterlimit
 3880 8159 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
-(Test auto­color polygon legends) bc Z
+(Test auto­color line legends) bc Z
 %%EndObject
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
@@ -679,7 +679,7 @@ FQ
 O0
 0 3980 TM
 % PostScript produced by:
-%@GMT: gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -lPoly# -BWrtb -Bxaf -Byaf -Xa0i -Ya3.3163i -JX15c
+%@GMT: gmt plot p.txt -R-1/6/-1/6 -W3p,auto -lLine# -BWrtb -Bxaf -Byaf -Xa0i -Ya3.3163i -JX15c
 %@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -695,7 +695,8 @@ U
 }!
 0 A
 V
-4 W
+50 W
+-5 A
 clipsave
 0 0 M
 3780 0 D
@@ -703,27 +704,26 @@ clipsave
 -3780 0 D
 P
 PSL_clip N
-{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
-O0
-/FO {P}!
--540 0 0 540 540 0 3 540 540 SP
-/FO {fs os}!
-FO
-{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 1620 1620 SP
-/FO {fs os}!
-FO
-{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 2160 2160 SP
-/FO {fs os}!
-FO
-{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 2700 2700 SP
-/FO {fs os}!
-FO
+1 0 0 C
+540 540 M
+540 0 D
+0 540 D
+S
+0 A
+2160 1620 M
+0 540 D
+-540 0 D
+S
+0 1 1 C
+2160 2160 M
+540 0 D
+-540 540 D
+S
+0 0.392 0 C
+2700 2700 M
+540 540 D
+-540 0 D
+S
 PSL_cliprestore
 U
 25 W
@@ -788,13 +788,13 @@ O0
 /PSL_legend_string_width 0 def
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(Poly 0) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line 0) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poly 1) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line 1) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poly 2) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line 2) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poly 3) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line 3) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 /PSL_tmp_w 354 def
 /PSL_legend_clear_x 133 def
@@ -822,14 +822,16 @@ O0
 3.32550952342 setmiterlimit
 V
 4 W
-{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 837 Sr
-{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 617 Sr
-{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 397 Sr
-{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 177 Sr
+O1
+50 W
+1 0 0 C
+118 185 837 S-
+0 A
+118 185 617 S-
+0 1 1 C
+118 185 397 S-
+0 0.392 0 C
+118 185 177 S-
 U
 %%EndObject
 0 0 TM
@@ -844,10 +846,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-421 767 M (Poly 0) bl Z
-421 547 M (Poly 1) bl Z
-421 327 M (Poly 2) bl Z
-421 107 M (Poly 3) bl Z
+421 767 M (Line 0) bl Z
+421 547 M (Line 1) bl Z
+421 327 M (Line 2) bl Z
+421 107 M (Line 3) bl Z
 %%EndObject
 0 0 TM
 PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate
@@ -860,7 +862,7 @@ FQ
 O0
 3980 3980 TM
 % PostScript produced by:
-%@GMT: gmt plot p.txt -R-1/6/-1/6 -Gauto@50 '-lPoly X-%2.2d+jBR' -Blrtb -Bxaf -Byaf -Xa3.3163i -Ya3.3163i -JX15c
+%@GMT: gmt plot p.txt -R-1/6/-1/6 -W3p,auto '-lLine X-%2.2d+jBR' -Blrtb -Bxaf -Byaf -Xa3.3163i -Ya3.3163i -JX15c
 %@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -876,7 +878,8 @@ U
 }!
 0 A
 V
-4 W
+50 W
+-5 A
 clipsave
 0 0 M
 3780 0 D
@@ -884,27 +887,26 @@ clipsave
 -3780 0 D
 P
 PSL_clip N
-{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
-O0
-/FO {P}!
--540 0 0 540 540 0 3 540 540 SP
-/FO {fs os}!
-FO
-{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 1620 1620 SP
-/FO {fs os}!
-FO
-{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 2160 2160 SP
-/FO {fs os}!
-FO
-{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 2700 2700 SP
-/FO {fs os}!
-FO
+1 0 0 C
+540 540 M
+540 0 D
+0 540 D
+S
+0 A
+2160 1620 M
+0 540 D
+-540 0 D
+S
+0 1 1 C
+2160 2160 M
+540 0 D
+-540 540 D
+S
+0 0.392 0 C
+2700 2700 M
+540 540 D
+-540 0 D
+S
 PSL_cliprestore
 U
 25 W
@@ -937,13 +939,13 @@ O0
 /PSL_legend_string_width 0 def
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(Poly X­00) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line X­00) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poly X­01) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line X­01) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poly X­02) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line X­02) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poly X­03) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line X­03) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 /PSL_tmp_w 354 def
 /PSL_legend_clear_x 133 def
@@ -971,14 +973,16 @@ O0
 3.32550952342 setmiterlimit
 V
 4 W
-{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 837 Sr
-{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 617 Sr
-{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 397 Sr
-{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 177 Sr
+O1
+50 W
+1 0 0 C
+118 185 837 S-
+0 A
+118 185 617 S-
+0 1 1 C
+118 185 397 S-
+0 0.392 0 C
+118 185 177 S-
 U
 %%EndObject
 0 0 TM
@@ -993,10 +997,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-421 767 M (Poly X­00) bl Z
-421 547 M (Poly X­01) bl Z
-421 327 M (Poly X­02) bl Z
-421 107 M (Poly X­03) bl Z
+421 767 M (Line X­00) bl Z
+421 547 M (Line X­01) bl Z
+421 327 M (Line X­02) bl Z
+421 107 M (Line X­03) bl Z
 %%EndObject
 0 0 TM
 PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate
@@ -1009,7 +1013,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot p.txt -R-1/6/-1/6 -Gauto@50 '-lPoly A,Poly B,Poly C,N/A+jBR' -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -JX15c
+%@GMT: gmt plot p.txt -R-1/6/-1/6 -W3p,auto '-lLine A,Line B,Line C,N/A+jBR' -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -JX15c
 %@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -1024,7 +1028,8 @@ U
 }!
 0 A
 V
-4 W
+50 W
+-5 A
 clipsave
 0 0 M
 3780 0 D
@@ -1032,27 +1037,26 @@ clipsave
 -3780 0 D
 P
 PSL_clip N
-{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
-O0
-/FO {P}!
--540 0 0 540 540 0 3 540 540 SP
-/FO {fs os}!
-FO
-{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 1620 1620 SP
-/FO {fs os}!
-FO
-{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 2160 2160 SP
-/FO {fs os}!
-FO
-{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 2700 2700 SP
-/FO {fs os}!
-FO
+1 0 0 C
+540 540 M
+540 0 D
+0 540 D
+S
+0 A
+2160 1620 M
+0 540 D
+-540 0 D
+S
+0 1 1 C
+2160 2160 M
+540 0 D
+-540 540 D
+S
+0 0.392 0 C
+2700 2700 M
+540 540 D
+-540 0 D
+S
 PSL_cliprestore
 U
 25 W
@@ -1146,11 +1150,11 @@ O0
 /PSL_legend_string_width 0 def
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(Poly A) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line A) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poly B) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line B) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poly C) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Line C) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 (N/A) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
@@ -1180,14 +1184,16 @@ O0
 3.32550952342 setmiterlimit
 V
 4 W
-{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 837 Sr
-{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 617 Sr
-{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 397 Sr
-{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 177 Sr
+O1
+50 W
+1 0 0 C
+118 185 837 S-
+0 A
+118 185 617 S-
+0 1 1 C
+118 185 397 S-
+0 0.392 0 C
+118 185 177 S-
 U
 %%EndObject
 0 0 TM
@@ -1202,9 +1208,9 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-421 767 M (Poly A) bl Z
-421 547 M (Poly B) bl Z
-421 327 M (Poly C) bl Z
+421 767 M (Line A) bl Z
+421 547 M (Line B) bl Z
+421 327 M (Line C) bl Z
 421 107 M (N/A) bl Z
 %%EndObject
 0 0 TM
@@ -1218,7 +1224,7 @@ FQ
 O0
 3980 0 TM
 % PostScript produced by:
-%@GMT: gmt plot p.txt -R-1/6/-1/6 -Gauto@50 -l+jBR -BlrtS -Bxaf -Byaf -Xa3.3163i -Ya0i -JX15c
+%@GMT: gmt plot p.txt -R-1/6/-1/6 -W3p,auto -l+jBR -BlrtS -Bxaf -Byaf -Xa3.3163i -Ya0i -JX15c
 %@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -1234,7 +1240,8 @@ U
 }!
 0 A
 V
-4 W
+50 W
+-5 A
 clipsave
 0 0 M
 3780 0 D
@@ -1242,27 +1249,26 @@ clipsave
 -3780 0 D
 P
 PSL_clip N
-{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
-O0
-/FO {P}!
--540 0 0 540 540 0 3 540 540 SP
-/FO {fs os}!
-FO
-{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 1620 1620 SP
-/FO {fs os}!
-FO
-{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 2160 2160 SP
-/FO {fs os}!
-FO
-{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
-/FO {P}!
--540 0 0 540 540 0 3 2700 2700 SP
-/FO {fs os}!
-FO
+1 0 0 C
+540 540 M
+540 0 D
+0 540 D
+S
+0 A
+2160 1620 M
+0 540 D
+-540 0 D
+S
+0 1 1 C
+2160 2160 M
+540 0 D
+-540 540 D
+S
+0 0.392 0 C
+2700 2700 M
+540 540 D
+-540 0 D
+S
 PSL_cliprestore
 U
 25 W
@@ -1330,9 +1336,9 @@ PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reenco
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 (2nd item) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(Poland) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(Curve) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
-(My Area) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
+(My Line) V MU 0 0 M E /PSL_tmp_w edef FP pathbbox N /PSL_tmp_h edef /PSL_tmp_x1 edef /PSL_tmp_d edef /PSL_tmp_x0 edef U
 PSL_tmp_w PSL_legend_label_width gt { /PSL_legend_label_width PSL_tmp_w def } if
 /PSL_tmp_w 354 def
 /PSL_legend_clear_x 133 def
@@ -1360,14 +1366,16 @@ O0
 3.32550952342 setmiterlimit
 V
 4 W
-{0 0.447 0.741 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 837 Sr
-{0.851 0.325 0.098 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 617 Sr
-{0.929 0.694 0.125 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 397 Sr
-{0.494 0.184 0.557 C 0.5 0.5 /Normal PSL_transp} FS
-154 236 185 177 Sr
+O1
+50 W
+1 0 0 C
+118 185 837 S-
+0 A
+118 185 617 S-
+0 1 1 C
+118 185 397 S-
+0 0.392 0 C
+118 185 177 S-
 U
 %%EndObject
 0 0 TM
@@ -1384,8 +1392,8 @@ O0
 3.32550952342 setmiterlimit
 421 767 M (First) bl Z
 421 547 M (2nd item) bl Z
-421 327 M (Poland) bl Z
-421 107 M (My Area) bl Z
+421 327 M (Curve) bl Z
+421 107 M (My Line) bl Z
 %%EndObject
 0 0 TM
 PSL_legend_box_width PSL_legend_box_height sub 2 2 div mul 0 translate

--- a/test/pslegend/autolegendcolorL.sh
+++ b/test/pslegend/autolegendcolorL.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+cat << EOF > p.txt
+> -LFirst
+0 0
+1 0
+1 1
+> 2 2 -L"2nd item"
+3 2
+3 3
+2 3
+> -LCurve
+3 3
+4 3
+3 4
+> -L"My Line"
+4 4
+5 5
+4 5
+EOF
+gmt begin autolegendcolorL ps
+  gmt set COLOR_SET red,black,cyan,darkgreen
+  gmt subplot begin 2x2 -R-1/6/-1/6 -Fs8c -SRl -SCb -Blrtb -A -T"Test auto-color line legends"
+    gmt plot p.txt -R-1/6/-1/6 -W3p,auto -l"Line #"+jBR -c
+    gmt plot p.txt -R-1/6/-1/6 -W3p,auto -l"Line X-%2.2d"+jBR -c
+    gmt plot p.txt -R-1/6/-1/6 -W3p,auto -l"Line A,Line B,Line C,N/A"+jBR -c
+    gmt plot p.txt -R-1/6/-1/6 -W3p,auto -l+jBR -c
+  gmt subplot end
+gmt end show

--- a/test/psxy/autocolorlines.ps
+++ b/test/psxy/autocolorlines.ps
@@ -1,0 +1,3299 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_c4a054d-dirty_2020.12.05 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec  6 11:05:49 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/6.29921/0/7.93323 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.29921000 0.00000000 7.93323000 0.000 6.299 0.000 7.933 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4943 TM
+% PostScript produced by:
+%@GMT: gmt plot /Users/pwessel/.gmt/cache/fz_07.txt -W0.25p,auto -BWENs -Bxaf -Byaf -Xa0i -Ya4.1194i -R-50/0/-10/20 -JM16c
+%@PROJ: merc -50.00000000 0.00000000 -10.00000000 20.00000000 -2782987.270 2782987.270 -1111475.103 2258423.649 +proj=merc +lon_0=-25 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 0 0 M 0 -83 D S
+N 0 4577 M 0 83 D S
+N 1512 0 M 0 -83 D S
+N 1512 4577 M 0 83 D S
+N 3024 0 M 0 -83 D S
+N 3024 4577 M 0 83 D S
+N 4535 0 M 0 -83 D S
+N 4535 4577 M 0 83 D S
+N 6047 0 M 0 -83 D S
+N 6047 4577 M 0 83 D S
+N 7559 0 M 0 -83 D S
+N 7559 4577 M 0 83 D S
+N 0 0 M -83 0 D S
+N 7559 0 M 83 0 D S
+N 0 1509 M -83 0 D S
+N 7559 1509 M 83 0 D S
+N 0 3019 M -83 0 D S
+N 7559 3019 M 83 0 D S
+N 0 4577 M -83 0 D S
+N 7559 4577 M 83 0 D S
+0 4743 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-50°) bc Z
+1512 4743 M (-40°) bc Z
+3024 4743 M (-30°) bc Z
+4535 4743 M (-20°) bc Z
+6047 4743 M (-10°) bc Z
+7559 4743 M (0°) bc Z
+-167 0 M (-10°) mr Z
+7726 0 M (-10°) ml Z
+-167 1509 M (0°) mr Z
+7726 1509 M (0°) ml Z
+-167 3019 M (10°) mr Z
+7726 3019 M (10°) ml Z
+-167 4577 M (20°) mr Z
+7726 4577 M (20°) ml Z
+V
+4 W
+-5 A
+clipsave
+0 0 M
+7559 0 D
+0 4577 D
+-7559 0 D
+P
+PSL_clip N
+0 1 0 C
+4553 4577 M
+93 -23 D
+12 -1 D
+S
+0 0 1 C
+0 3971 M
+60 -21 D
+68 -15 D
+71 -19 D
+74 -11 D
+46 -9 D
+11 0 D
+34 -6 D
+25 -6 D
+71 -6 D
+26 -2 D
+11 1 D
+132 -8 D
+25 -2 D
+89 -6 D
+31 -6 D
+45 -16 D
+44 -7 D
+49 -12 D
+31 -5 D
+39 -12 D
+64 -17 D
+72 -23 D
+70 -16 D
+137 -29 D
+60 -12 D
+66 -8 D
+41 -2 D
+47 -7 D
+59 -2 D
+44 1 D
+49 7 D
+49 9 D
+59 1 D
+34 5 D
+10 3 D
+44 5 D
+49 11 D
+35 2 D
+24 1 D
+35 3 D
+61 2 D
+58 -1 D
+35 -5 D
+45 5 D
+96 -1 D
+12 1 D
+37 -3 D
+125 -19 D
+52 -18 D
+45 -7 D
+33 -7 D
+82 -11 D
+45 -8 D
+93 -10 D
+57 -9 D
+55 -12 D
+47 -2 D
+86 -21 D
+75 -26 D
+84 -19 D
+32 -8 D
+57 -10 D
+89 -28 D
+23 -8 D
+35 -14 D
+137 -30 D
+74 -23 D
+84 -33 D
+45 -9 D
+68 -21 D
+35 -9 D
+33 -7 D
+27 -8 D
+35 -6 D
+10 -4 D
+21 -11 D
+32 -13 D
+32 -7 D
+10 -4 D
+13 -11 D
+S
+1 0 0 C
+0 3584 M
+59 -11 D
+29 -3 D
+39 -11 D
+43 -9 D
+13 -4 D
+38 -16 D
+13 -4 D
+56 -23 D
+37 -11 D
+37 -14 D
+23 -2 D
+11 1 D
+40 -6 D
+72 -13 D
+44 -7 D
+103 -23 D
+40 -6 D
+62 -4 D
+38 1 D
+43 -4 D
+58 1 D
+25 -5 D
+29 -10 D
+26 -3 D
+73 -1 D
+97 -7 D
+136 -8 D
+30 -2 D
+25 1 D
+43 -4 D
+50 -7 D
+36 -8 D
+27 -9 D
+36 -8 D
+35 -11 D
+61 -12 D
+22 -5 D
+11 -1 D
+31 4 D
+25 -4 D
+39 1 D
+66 -4 D
+80 1 D
+38 8 D
+24 3 D
+12 0 D
+65 9 D
+35 11 D
+110 23 D
+33 10 D
+112 17 D
+43 4 D
+57 10 D
+46 -1 D
+39 -7 D
+56 -4 D
+115 -20 D
+38 -6 D
+22 -6 D
+19 -3 D
+S
+0 1 1 C
+0 3527 M
+23 -6 D
+40 -16 D
+58 -18 D
+32 -15 D
+53 -14 D
+24 -10 D
+50 -10 D
+65 -14 D
+75 -14 D
+62 -10 D
+117 -16 D
+115 -9 D
+53 -7 D
+26 0 D
+127 -19 D
+76 -6 D
+98 -12 D
+27 -2 D
+28 -4 D
+50 -2 D
+86 -10 D
+28 -6 D
+27 -9 D
+42 -7 D
+14 -1 D
+62 -14 D
+10 -3 D
+94 -13 D
+28 -6 D
+64 2 D
+84 -7 D
+52 -1 D
+64 -7 D
+23 -1 D
+34 -4 D
+67 -2 D
+49 -1 D
+40 2 D
+54 -3 D
+12 1 D
+33 8 D
+78 25 D
+57 8 D
+36 13 D
+62 14 D
+55 8 D
+21 1 D
+58 -3 D
+34 -4 D
+21 -4 D
+S
+1 0.6 0.933 C
+1217 2965 M
+75 -3 D
+54 -10 D
+62 -3 D
+12 1 D
+70 -6 D
+28 -6 D
+23 -2 D
+11 1 D
+32 -4 D
+S
+1 0.867 0.4 C
+0 3287 M
+66 -13 D
+63 -7 D
+30 -7 D
+93 -17 D
+30 -7 D
+49 -5 D
+40 -11 D
+27 -7 D
+46 -6 D
+42 -8 D
+47 -2 D
+24 -5 D
+60 -1 D
+25 -7 D
+33 -3 D
+11 -3 D
+48 -1 D
+47 -10 D
+24 -2 D
+11 1 D
+22 -1 D
+52 -11 D
+37 -1 D
+68 -9 D
+42 0 D
+39 -6 D
+12 0 D
+23 3 D
+45 -3 D
+11 -2 D
+45 -1 D
+141 -11 D
+32 -7 D
+36 -4 D
+79 -6 D
+38 -4 D
+49 -1 D
+49 -8 D
+108 -2 D
+39 -2 D
+58 2 D
+34 5 D
+64 -3 D
+11 -1 D
+22 1 D
+20 -3 D
+16 4 D
+24 -1 D
+76 -10 D
+79 -19 D
+77 -13 D
+52 -1 D
+57 -7 D
+47 -1 D
+79 5 D
+89 12 D
+108 7 D
+44 7 D
+45 2 D
+35 5 D
+44 1 D
+27 4 D
+51 1 D
+66 4 D
+70 11 D
+69 3 D
+14 -1 D
+14 1 D
+13 -1 D
+132 7 D
+60 -4 D
+58 -8 D
+37 -2 D
+69 5 D
+57 2 D
+51 2 D
+27 -4 D
+12 1 D
+24 -9 D
+10 -1 D
+10 2 D
+10 -4 D
+23 1 D
+23 -3 D
+49 -2 D
+20 -2 D
+S
+0 0.4 0 C
+0 3014 M
+73 10 D
+43 1 D
+15 -1 D
+44 2 D
+94 -8 D
+65 -1 D
+63 -7 D
+52 -7 D
+50 -12 D
+37 -6 D
+48 -8 D
+72 -9 D
+37 -3 D
+24 0 D
+25 -3 D
+46 -17 D
+39 -4 D
+29 -11 D
+112 -21 D
+69 -7 D
+34 -5 D
+52 -3 D
+34 -6 D
+36 2 D
+53 -7 D
+87 -3 D
+114 -16 D
+68 -2 D
+49 -6 D
+55 -10 D
+91 -9 D
+64 1 D
+132 -5 D
+47 -3 D
+74 -10 D
+42 0 D
+28 -3 D
+43 -1 D
+37 -2 D
+69 -1 D
+78 -8 D
+73 -1 D
+11 -1 D
+41 2 D
+86 3 D
+62 7 D
+93 11 D
+96 3 D
+24 2 D
+54 10 D
+39 3 D
+36 6 D
+69 8 D
+60 8 D
+63 5 D
+62 5 D
+45 4 D
+38 6 D
+77 -1 D
+47 5 D
+54 3 D
+24 4 D
+68 -2 D
+61 -1 D
+15 1 D
+130 -5 D
+37 1 D
+104 -6 D
+11 -4 D
+11 -2 D
+13 0 D
+26 5 D
+24 7 D
+76 13 D
+50 3 D
+10 -1 D
+29 11 D
+80 6 D
+26 0 D
+14 3 D
+28 1 D
+43 -6 D
+19 -5 D
+S
+0 0 0.4 C
+1697 2684 M
+75 -2 D
+53 3 D
+49 -3 D
+53 3 D
+52 6 D
+58 -1 D
+56 3 D
+52 3 D
+16 3 D
+S
+0.667 0.333 0.267 C
+2036 2638 M
+59 -1 D
+13 1 D
+110 -1 D
+23 2 D
+34 7 D
+140 10 D
+54 3 D
+35 5 D
+20 1 D
+10 2 D
+S
+0 0.533 0.8 C
+2151 2548 M
+149 -2 D
+25 4 D
+44 -2 D
+46 3 D
+29 6 D
+52 4 D
+38 7 D
+42 2 D
+82 11 D
+12 1 D
+S
+1 0.0667 1 C
+2473 2477 M
+69 -7 D
+47 -2 D
+14 1 D
+42 -1 D
+S
+1 0.933 0.933 C
+1397 2218 M
+23 -11 D
+34 -10 D
+13 -2 D
+47 -15 D
+92 -27 D
+25 -5 D
+37 -9 D
+29 -4 D
+61 -16 D
+25 -4 D
+67 -5 D
+76 -10 D
+86 -3 D
+15 -1 D
+85 2 D
+27 -1 D
+13 1 D
+69 -4 D
+12 0 D
+11 -2 D
+72 2 D
+40 -2 D
+142 9 D
+33 2 D
+78 5 D
+81 6 D
+37 -1 D
+55 6 D
+52 5 D
+102 -4 D
+48 -1 D
+44 3 D
+57 -2 D
+100 6 D
+46 3 D
+53 -1 D
+59 3 D
+111 3 D
+104 6 D
+13 -1 D
+14 1 D
+33 -1 D
+17 1 D
+25 -2 D
+35 2 D
+40 -2 D
+99 2 D
+2 -3 D
+S
+1 0 0.467 C
+4762 2399 M
+34 -11 D
+26 -1 D
+29 1 D
+24 -2 D
+82 15 D
+45 2 D
+79 16 D
+60 9 D
+14 3 D
+52 3 D
+34 8 D
+64 18 D
+26 7 D
+64 28 D
+73 33 D
+10 6 D
+20 8 D
+36 8 D
+23 6 D
+32 5 D
+30 0 D
+51 6 D
+S
+0.533 1 0.6 C
+2744 1678 M
+53 3 D
+24 -3 D
+43 -1 D
+76 -2 D
+12 -1 D
+33 2 D
+82 1 D
+53 -6 D
+51 3 D
+13 2 D
+85 4 D
+25 1 D
+33 -2 D
+20 -4 D
+S
+0.533 0.4 1 C
+1468 1541 M
+7 -7 D
+23 -9 D
+12 -3 D
+43 -1 D
+31 -3 D
+57 -11 D
+40 -1 D
+39 3 D
+53 -2 D
+74 4 D
+42 4 D
+33 2 D
+51 4 D
+49 -3 D
+57 9 D
+76 9 D
+39 7 D
+39 4 D
+42 9 D
+30 9 D
+57 11 D
+36 10 D
+53 6 D
+48 0 D
+60 7 D
+47 -4 D
+11 1 D
+12 -1 D
+51 3 D
+22 -5 D
+13 -1 D
+58 6 D
+44 1 D
+39 9 D
+39 1 D
+44 -8 D
+65 -3 D
+29 -5 D
+108 -2 D
+37 -5 D
+82 -6 D
+28 1 D
+103 -4 D
+37 3 D
+54 9 D
+12 4 D
+86 7 D
+42 1 D
+42 3 D
+24 -1 D
+64 5 D
+25 -1 D
+92 8 D
+14 0 D
+22 2 D
+23 -2 D
+13 1 D
+13 3 D
+43 4 D
+33 6 D
+58 5 D
+79 15 D
+92 9 D
+27 4 D
+40 6 D
+27 5 D
+53 5 D
+41 6 D
+40 3 D
+67 7 D
+48 6 D
+95 20 D
+97 12 D
+69 4 D
+92 10 D
+72 10 D
+45 7 D
+52 12 D
+32 8 D
+12 4 D
+81 13 D
+27 6 D
+25 7 D
+57 10 D
+134 33 D
+49 8 D
+80 20 D
+28 5 D
+77 24 D
+69 21 D
+68 21 D
+41 10 D
+34 12 D
+36 8 D
+37 15 D
+88 24 D
+13 5 D
+50 24 D
+34 19 D
+26 10 D
+S
+0.333 0.533 0.467 C
+1745 1189 M
+36 -2 D
+52 3 D
+75 13 D
+112 5 D
+27 5 D
+37 11 D
+91 14 D
+71 6 D
+61 11 D
+10 0 D
+28 5 D
+18 1 D
+69 10 D
+30 1 D
+32 6 D
+14 1 D
+39 -2 D
+13 2 D
+42 1 D
+11 1 D
+55 -1 D
+15 1 D
+77 -3 D
+75 4 D
+39 0 D
+14 2 D
+40 -1 D
+34 -2 D
+56 1 D
+81 -4 D
+15 -3 D
+43 -2 D
+95 -6 D
+27 3 D
+14 5 D
+28 5 D
+38 1 D
+24 5 D
+24 7 D
+60 10 D
+87 9 D
+11 2 D
+190 12 D
+101 12 D
+64 7 D
+124 7 D
+114 10 D
+62 11 D
+76 8 D
+51 11 D
+65 17 D
+59 11 D
+52 12 D
+71 18 D
+142 29 D
+48 13 D
+12 3 D
+57 23 D
+39 13 D
+111 28 D
+63 12 D
+43 8 D
+38 4 D
+49 11 D
+56 10 D
+28 6 D
+54 11 D
+26 1 D
+146 29 D
+76 9 D
+49 -1 D
+93 10 D
+62 11 D
+39 9 D
+69 8 D
+40 7 D
+15 1 D
+54 11 D
+25 6 D
+49 6 D
+35 11 D
+38 6 D
+51 16 D
+55 12 D
+44 6 D
+89 23 D
+36 8 D
+35 10 D
+26 3 D
+48 10 D
+61 7 D
+39 11 D
+53 11 D
+25 5 D
+35 13 D
+45 19 D
+71 25 D
+39 14 D
+64 16 D
+35 13 D
+40 9 D
+26 6 D
+36 10 D
+34 10 D
+11 5 D
+20 5 D
+33 13 D
+14 1 D
+38 11 D
+35 7 D
+45 15 D
+66 30 D
+70 27 D
+30 14 D
+56 31 D
+4 3 D
+1 0 D S
+0.4 0 0.267 C
+2786 949 M
+53 22 D
+23 12 D
+25 13 D
+35 20 D
+76 24 D
+65 12 D
+47 16 D
+195 47 D
+64 6 D
+108 8 D
+52 1 D
+42 2 D
+84 -4 D
+40 1 D
+40 1 D
+39 -1 D
+96 8 D
+59 -4 D
+44 -5 D
+37 -3 D
+57 -10 D
+59 -2 D
+129 -7 D
+134 6 D
+46 4 D
+74 3 D
+76 11 D
+97 10 D
+49 9 D
+55 12 D
+44 18 D
+48 12 D
+93 11 D
+18 3 D
+97 31 D
+8 4 D
+25 6 D
+31 2 D
+43 10 D
+42 13 D
+142 33 D
+42 7 D
+75 21 D
+13 6 D
+26 9 D
+38 8 D
+59 21 D
+13 3 D
+52 21 D
+52 14 D
+44 8 D
+128 29 D
+12 3 D
+38 0 D
+59 11 D
+91 18 D
+31 9 D
+68 10 D
+23 9 D
+12 7 D
+23 9 D
+36 4 D
+103 27 D
+138 21 D
+36 4 D
+50 11 D
+14 2 D
+16 0 D
+38 8 D
+64 15 D
+58 8 D
+40 7 D
+14 1 D
+71 14 D
+60 15 D
+35 5 D
+34 7 D
+82 8 D
+12 3 D
+25 11 D
+98 31 D
+71 27 D
+60 31 D
+24 16 D
+13 7 D
+25 9 D
+66 32 D
+1 1 D S
+0.867 1 0 C
+2494 675 M
+19 9 D
+73 40 D
+13 8 D
+13 6 D
+50 17 D
+37 13 D
+39 9 D
+94 34 D
+37 15 D
+11 4 D
+38 7 D
+73 21 D
+139 24 D
+68 8 D
+53 5 D
+43 1 D
+40 5 D
+44 8 D
+96 10 D
+164 13 D
+48 2 D
+28 3 D
+91 -4 D
+60 6 D
+52 1 D
+34 -3 D
+17 -3 D
+18 -1 D
+20 1 D
+137 -10 D
+56 -6 D
+55 -2 D
+65 6 D
+54 9 D
+32 1 D
+35 -3 D
+33 1 D
+64 -4 D
+25 -1 D
+26 1 D
+38 5 D
+38 1 D
+46 9 D
+33 1 D
+137 24 D
+45 14 D
+120 26 D
+45 4 D
+44 10 D
+40 9 D
+46 5 D
+49 7 D
+34 4 D
+121 31 D
+22 8 D
+23 5 D
+35 5 D
+51 12 D
+11 2 D
+33 10 D
+74 15 D
+29 1 D
+64 12 D
+55 12 D
+27 9 D
+55 12 D
+76 22 D
+39 14 D
+74 20 D
+26 7 D
+72 19 D
+43 14 D
+113 27 D
+90 23 D
+36 8 D
+23 2 D
+34 8 D
+73 8 D
+96 11 D
+105 22 D
+45 10 D
+49 5 D
+31 6 D
+70 20 D
+33 6 D
+35 13 D
+151 48 D
+13 5 D
+37 8 D
+83 27 D
+37 19 D
+19 9 D
+65 25 D
+39 19 D
+49 18 D
+1 1 D S
+1 0.533 0 C
+2800 0 M
+45 16 D
+29 7 D
+45 15 D
+28 5 D
+80 23 D
+28 5 D
+24 1 D
+79 21 D
+40 14 D
+45 9 D
+53 9 D
+46 6 D
+76 15 D
+63 5 D
+29 6 D
+14 5 D
+59 7 D
+30 6 D
+83 4 D
+14 2 D
+14 0 D
+85 8 D
+49 -1 D
+110 -2 D
+41 5 D
+33 -1 D
+44 3 D
+35 -2 D
+52 3 D
+16 0 D
+30 -2 D
+28 0 D
+36 -4 D
+36 2 D
+80 -7 D
+26 3 D
+42 -1 D
+44 5 D
+14 0 D
+14 2 D
+28 1 D
+12 -1 D
+47 4 D
+11 2 D
+46 4 D
+26 7 D
+40 7 D
+107 4 D
+24 -1 D
+28 3 D
+145 27 D
+79 14 D
+78 17 D
+38 12 D
+40 15 D
+14 3 D
+49 5 D
+56 18 D
+50 13 D
+38 6 D
+25 7 D
+39 7 D
+69 15 D
+35 5 D
+65 20 D
+45 8 D
+45 12 D
+13 5 D
+26 7 D
+25 11 D
+42 11 D
+42 8 D
+40 11 D
+40 6 D
+108 17 D
+51 14 D
+26 2 D
+132 30 D
+47 17 D
+38 8 D
+43 4 D
+126 37 D
+15 4 D
+75 13 D
+29 6 D
+64 18 D
+72 11 D
+92 19 D
+54 7 D
+83 15 D
+47 5 D
+49 10 D
+29 7 D
+59 7 D
+30 6 D
+65 16 D
+46 3 D
+14 0 D
+44 8 D
+30 3 D
+40 9 D
+5 1 D
+0 0 D S
+0.467 0.4 0 C
+5480 225 M
+67 16 D
+14 1 D
+S
+0.733 0 0.6 C
+5477 164 M
+15 6 D
+44 7 D
+23 8 D
+13 -2 D
+S
+0.6 0.467 0.6 C
+5358 0 M
+57 14 D
+23 4 D
+41 12 D
+40 7 D
+65 17 D
+108 29 D
+28 9 D
+26 7 D
+24 9 D
+25 7 D
+46 18 D
+29 7 D
+39 7 D
+23 9 D
+23 4 D
+24 4 D
+14 4 D
+0 -6 D
+S
+0.533 0.667 0 C
+5718 0 M
+12 3 D
+57 20 D
+63 10 D
+55 18 D
+23 4 D
+69 27 D
+S
+0.133 0.2 0.4 C
+6847 0 M
+34 10 D
+41 8 D
+56 17 D
+15 6 D
+32 8 D
+16 2 D
+14 4 D
+86 16 D
+39 10 D
+74 13 D
+54 4 D
+39 10 D
+62 12 D
+76 18 D
+74 17 D
+0 0 D S
+0.133 0.2 0 C
+7211 0 M
+50 13 D
+37 7 D
+57 19 D
+48 17 D
+156 31 D
+0 0 D S
+PSL_cliprestore
+U
+25 W
+0 A
+83 W
+1 A
+N -42 0 M 0 304 D S
+N 7601 0 M 0 304 D S
+0 A
+N -42 304 M 0 303 D S
+N 7601 304 M 0 303 D S
+1 A
+N -42 607 M 0 301 D S
+N 7601 607 M 0 301 D S
+0 A
+N -42 908 M 0 301 D S
+N 7601 908 M 0 301 D S
+1 A
+N -42 1209 M 0 300 D S
+N 7601 1209 M 0 300 D S
+0 A
+N -42 1509 M 0 301 D S
+N 7601 1509 M 0 301 D S
+1 A
+N -42 1810 M 0 301 D S
+N 7601 1810 M 0 301 D S
+0 A
+N -42 2111 M 0 301 D S
+N 7601 2111 M 0 301 D S
+1 A
+N -42 2412 M 0 303 D S
+N 7601 2412 M 0 303 D S
+0 A
+N -42 2715 M 0 304 D S
+N 7601 2715 M 0 304 D S
+1 A
+N -42 3019 M 0 306 D S
+N 7601 3019 M 0 306 D S
+0 A
+N -42 3325 M 0 308 D S
+N 7601 3325 M 0 308 D S
+1 A
+N -42 3633 M 0 311 D S
+N 7601 3633 M 0 311 D S
+0 A
+N -42 3944 M 0 315 D S
+N 7601 3944 M 0 315 D S
+1 A
+N -42 4259 M 0 318 D S
+N 7601 4259 M 0 318 D S
+N 0 -42 M 302 0 D S
+N 0 4618 M 302 0 D S
+0 A
+N 302 -42 M 303 0 D S
+N 302 4618 M 303 0 D S
+1 A
+N 605 -42 M 302 0 D S
+N 605 4618 M 302 0 D S
+0 A
+N 907 -42 M 302 0 D S
+N 907 4618 M 302 0 D S
+1 A
+N 1209 -42 M 303 0 D S
+N 1209 4618 M 303 0 D S
+0 A
+N 1512 -42 M 302 0 D S
+N 1512 4618 M 302 0 D S
+1 A
+N 1814 -42 M 303 0 D S
+N 1814 4618 M 303 0 D S
+0 A
+N 2117 -42 M 302 0 D S
+N 2117 4618 M 302 0 D S
+1 A
+N 2419 -42 M 302 0 D S
+N 2419 4618 M 302 0 D S
+0 A
+N 2721 -42 M 303 0 D S
+N 2721 4618 M 303 0 D S
+1 A
+N 3024 -42 M 302 0 D S
+N 3024 4618 M 302 0 D S
+0 A
+N 3326 -42 M 302 0 D S
+N 3326 4618 M 302 0 D S
+1 A
+N 3628 -42 M 303 0 D S
+N 3628 4618 M 303 0 D S
+0 A
+N 3931 -42 M 302 0 D S
+N 3931 4618 M 302 0 D S
+1 A
+N 4233 -42 M 302 0 D S
+N 4233 4618 M 302 0 D S
+0 A
+N 4535 -42 M 303 0 D S
+N 4535 4618 M 303 0 D S
+1 A
+N 4838 -42 M 302 0 D S
+N 4838 4618 M 302 0 D S
+0 A
+N 5140 -42 M 302 0 D S
+N 5140 4618 M 302 0 D S
+1 A
+N 5442 -42 M 303 0 D S
+N 5442 4618 M 303 0 D S
+0 A
+N 5745 -42 M 302 0 D S
+N 5745 4618 M 302 0 D S
+1 A
+N 6047 -42 M 303 0 D S
+N 6047 4618 M 303 0 D S
+0 A
+N 6350 -42 M 302 0 D S
+N 6350 4618 M 302 0 D S
+1 A
+N 6652 -42 M 302 0 D S
+N 6652 4618 M 302 0 D S
+0 A
+N 6954 -42 M 303 0 D S
+N 6954 4618 M 303 0 D S
+1 A
+N 7257 -42 M 302 0 D S
+N 7257 4618 M 302 0 D S
+0 A
+8 W
+N -83 0 M 7725 0 D S
+N -83 -83 M 7725 0 D S
+N 7559 -83 M 0 4743 D S
+N 7642 -83 M 0 4743 D S
+N 7642 4577 M -7725 0 D S
+N 7642 4660 M -7725 0 D S
+N 0 4660 M 0 -4743 D S
+N -83 4660 M 0 -4743 D S
+%%EndObject
+0 -4943 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot /Users/pwessel/.gmt/cache/fz_07.txt -W0.25p,auto --COLOR_SET=red,green,blue -BWEnS -Bxaf -Byaf -Xa0i -Ya0i -R-50/0/-10/20 -JM16c
+%@PROJ: merc -50.00000000 0.00000000 -10.00000000 20.00000000 -2782987.270 2782987.270 -1111475.103 2258423.649 +proj=merc +lon_0=-25 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 0 0 M 0 -83 D S
+N 0 4577 M 0 83 D S
+N 1512 0 M 0 -83 D S
+N 1512 4577 M 0 83 D S
+N 3024 0 M 0 -83 D S
+N 3024 4577 M 0 83 D S
+N 4535 0 M 0 -83 D S
+N 4535 4577 M 0 83 D S
+N 6047 0 M 0 -83 D S
+N 6047 4577 M 0 83 D S
+N 7559 0 M 0 -83 D S
+N 7559 4577 M 0 83 D S
+N 0 0 M -83 0 D S
+N 7559 0 M 83 0 D S
+N 0 1509 M -83 0 D S
+N 7559 1509 M 83 0 D S
+N 0 3019 M -83 0 D S
+N 7559 3019 M 83 0 D S
+N 0 4577 M -83 0 D S
+N 7559 4577 M 83 0 D S
+0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-50°) tc Z
+1512 -167 M (-40°) tc Z
+3024 -167 M (-30°) tc Z
+4535 -167 M (-20°) tc Z
+6047 -167 M (-10°) tc Z
+7559 -167 M (0°) tc Z
+-167 0 M (-10°) mr Z
+7726 0 M (-10°) ml Z
+-167 1509 M (0°) mr Z
+7726 1509 M (0°) ml Z
+-167 3019 M (10°) mr Z
+7726 3019 M (10°) ml Z
+-167 4577 M (20°) mr Z
+7726 4577 M (20°) ml Z
+V
+4 W
+-5 A
+clipsave
+0 0 M
+7559 0 D
+0 4577 D
+-7559 0 D
+P
+PSL_clip N
+1 0 0 C
+4553 4577 M
+93 -23 D
+12 -1 D
+S
+0 1 0 C
+0 3971 M
+60 -21 D
+68 -15 D
+71 -19 D
+74 -11 D
+46 -9 D
+11 0 D
+34 -6 D
+25 -6 D
+71 -6 D
+26 -2 D
+11 1 D
+132 -8 D
+25 -2 D
+89 -6 D
+31 -6 D
+45 -16 D
+44 -7 D
+49 -12 D
+31 -5 D
+39 -12 D
+64 -17 D
+72 -23 D
+70 -16 D
+137 -29 D
+60 -12 D
+66 -8 D
+41 -2 D
+47 -7 D
+59 -2 D
+44 1 D
+49 7 D
+49 9 D
+59 1 D
+34 5 D
+10 3 D
+44 5 D
+49 11 D
+35 2 D
+24 1 D
+35 3 D
+61 2 D
+58 -1 D
+35 -5 D
+45 5 D
+96 -1 D
+12 1 D
+37 -3 D
+125 -19 D
+52 -18 D
+45 -7 D
+33 -7 D
+82 -11 D
+45 -8 D
+93 -10 D
+57 -9 D
+55 -12 D
+47 -2 D
+86 -21 D
+75 -26 D
+84 -19 D
+32 -8 D
+57 -10 D
+89 -28 D
+23 -8 D
+35 -14 D
+137 -30 D
+74 -23 D
+84 -33 D
+45 -9 D
+68 -21 D
+35 -9 D
+33 -7 D
+27 -8 D
+35 -6 D
+10 -4 D
+21 -11 D
+32 -13 D
+32 -7 D
+10 -4 D
+13 -11 D
+S
+0 0 1 C
+0 3584 M
+59 -11 D
+29 -3 D
+39 -11 D
+43 -9 D
+13 -4 D
+38 -16 D
+13 -4 D
+56 -23 D
+37 -11 D
+37 -14 D
+23 -2 D
+11 1 D
+40 -6 D
+72 -13 D
+44 -7 D
+103 -23 D
+40 -6 D
+62 -4 D
+38 1 D
+43 -4 D
+58 1 D
+25 -5 D
+29 -10 D
+26 -3 D
+73 -1 D
+97 -7 D
+136 -8 D
+30 -2 D
+25 1 D
+43 -4 D
+50 -7 D
+36 -8 D
+27 -9 D
+36 -8 D
+35 -11 D
+61 -12 D
+22 -5 D
+11 -1 D
+31 4 D
+25 -4 D
+39 1 D
+66 -4 D
+80 1 D
+38 8 D
+24 3 D
+12 0 D
+65 9 D
+35 11 D
+110 23 D
+33 10 D
+112 17 D
+43 4 D
+57 10 D
+46 -1 D
+39 -7 D
+56 -4 D
+115 -20 D
+38 -6 D
+22 -6 D
+19 -3 D
+S
+1 0 0 C
+0 3527 M
+23 -6 D
+40 -16 D
+58 -18 D
+32 -15 D
+53 -14 D
+24 -10 D
+50 -10 D
+65 -14 D
+75 -14 D
+62 -10 D
+117 -16 D
+115 -9 D
+53 -7 D
+26 0 D
+127 -19 D
+76 -6 D
+98 -12 D
+27 -2 D
+28 -4 D
+50 -2 D
+86 -10 D
+28 -6 D
+27 -9 D
+42 -7 D
+14 -1 D
+62 -14 D
+10 -3 D
+94 -13 D
+28 -6 D
+64 2 D
+84 -7 D
+52 -1 D
+64 -7 D
+23 -1 D
+34 -4 D
+67 -2 D
+49 -1 D
+40 2 D
+54 -3 D
+12 1 D
+33 8 D
+78 25 D
+57 8 D
+36 13 D
+62 14 D
+55 8 D
+21 1 D
+58 -3 D
+34 -4 D
+21 -4 D
+S
+0 1 0 C
+1217 2965 M
+75 -3 D
+54 -10 D
+62 -3 D
+12 1 D
+70 -6 D
+28 -6 D
+23 -2 D
+11 1 D
+32 -4 D
+S
+0 0 1 C
+0 3287 M
+66 -13 D
+63 -7 D
+30 -7 D
+93 -17 D
+30 -7 D
+49 -5 D
+40 -11 D
+27 -7 D
+46 -6 D
+42 -8 D
+47 -2 D
+24 -5 D
+60 -1 D
+25 -7 D
+33 -3 D
+11 -3 D
+48 -1 D
+47 -10 D
+24 -2 D
+11 1 D
+22 -1 D
+52 -11 D
+37 -1 D
+68 -9 D
+42 0 D
+39 -6 D
+12 0 D
+23 3 D
+45 -3 D
+11 -2 D
+45 -1 D
+141 -11 D
+32 -7 D
+36 -4 D
+79 -6 D
+38 -4 D
+49 -1 D
+49 -8 D
+108 -2 D
+39 -2 D
+58 2 D
+34 5 D
+64 -3 D
+11 -1 D
+22 1 D
+20 -3 D
+16 4 D
+24 -1 D
+76 -10 D
+79 -19 D
+77 -13 D
+52 -1 D
+57 -7 D
+47 -1 D
+79 5 D
+89 12 D
+108 7 D
+44 7 D
+45 2 D
+35 5 D
+44 1 D
+27 4 D
+51 1 D
+66 4 D
+70 11 D
+69 3 D
+14 -1 D
+14 1 D
+13 -1 D
+132 7 D
+60 -4 D
+58 -8 D
+37 -2 D
+69 5 D
+57 2 D
+51 2 D
+27 -4 D
+12 1 D
+24 -9 D
+10 -1 D
+10 2 D
+10 -4 D
+23 1 D
+23 -3 D
+49 -2 D
+20 -2 D
+S
+1 0 0 C
+0 3014 M
+73 10 D
+43 1 D
+15 -1 D
+44 2 D
+94 -8 D
+65 -1 D
+63 -7 D
+52 -7 D
+50 -12 D
+37 -6 D
+48 -8 D
+72 -9 D
+37 -3 D
+24 0 D
+25 -3 D
+46 -17 D
+39 -4 D
+29 -11 D
+112 -21 D
+69 -7 D
+34 -5 D
+52 -3 D
+34 -6 D
+36 2 D
+53 -7 D
+87 -3 D
+114 -16 D
+68 -2 D
+49 -6 D
+55 -10 D
+91 -9 D
+64 1 D
+132 -5 D
+47 -3 D
+74 -10 D
+42 0 D
+28 -3 D
+43 -1 D
+37 -2 D
+69 -1 D
+78 -8 D
+73 -1 D
+11 -1 D
+41 2 D
+86 3 D
+62 7 D
+93 11 D
+96 3 D
+24 2 D
+54 10 D
+39 3 D
+36 6 D
+69 8 D
+60 8 D
+63 5 D
+62 5 D
+45 4 D
+38 6 D
+77 -1 D
+47 5 D
+54 3 D
+24 4 D
+68 -2 D
+61 -1 D
+15 1 D
+130 -5 D
+37 1 D
+104 -6 D
+11 -4 D
+11 -2 D
+13 0 D
+26 5 D
+24 7 D
+76 13 D
+50 3 D
+10 -1 D
+29 11 D
+80 6 D
+26 0 D
+14 3 D
+28 1 D
+43 -6 D
+19 -5 D
+S
+0 1 0 C
+1697 2684 M
+75 -2 D
+53 3 D
+49 -3 D
+53 3 D
+52 6 D
+58 -1 D
+56 3 D
+52 3 D
+16 3 D
+S
+0 0 1 C
+2036 2638 M
+59 -1 D
+13 1 D
+110 -1 D
+23 2 D
+34 7 D
+140 10 D
+54 3 D
+35 5 D
+20 1 D
+10 2 D
+S
+1 0 0 C
+2151 2548 M
+149 -2 D
+25 4 D
+44 -2 D
+46 3 D
+29 6 D
+52 4 D
+38 7 D
+42 2 D
+82 11 D
+12 1 D
+S
+0 1 0 C
+2473 2477 M
+69 -7 D
+47 -2 D
+14 1 D
+42 -1 D
+S
+0 0 1 C
+1397 2218 M
+23 -11 D
+34 -10 D
+13 -2 D
+47 -15 D
+92 -27 D
+25 -5 D
+37 -9 D
+29 -4 D
+61 -16 D
+25 -4 D
+67 -5 D
+76 -10 D
+86 -3 D
+15 -1 D
+85 2 D
+27 -1 D
+13 1 D
+69 -4 D
+12 0 D
+11 -2 D
+72 2 D
+40 -2 D
+142 9 D
+33 2 D
+78 5 D
+81 6 D
+37 -1 D
+55 6 D
+52 5 D
+102 -4 D
+48 -1 D
+44 3 D
+57 -2 D
+100 6 D
+46 3 D
+53 -1 D
+59 3 D
+111 3 D
+104 6 D
+13 -1 D
+14 1 D
+33 -1 D
+17 1 D
+25 -2 D
+35 2 D
+40 -2 D
+99 2 D
+2 -3 D
+S
+1 0 0 C
+4762 2399 M
+34 -11 D
+26 -1 D
+29 1 D
+24 -2 D
+82 15 D
+45 2 D
+79 16 D
+60 9 D
+14 3 D
+52 3 D
+34 8 D
+64 18 D
+26 7 D
+64 28 D
+73 33 D
+10 6 D
+20 8 D
+36 8 D
+23 6 D
+32 5 D
+30 0 D
+51 6 D
+S
+0 1 0 C
+2744 1678 M
+53 3 D
+24 -3 D
+43 -1 D
+76 -2 D
+12 -1 D
+33 2 D
+82 1 D
+53 -6 D
+51 3 D
+13 2 D
+85 4 D
+25 1 D
+33 -2 D
+20 -4 D
+S
+0 0 1 C
+1468 1541 M
+7 -7 D
+23 -9 D
+12 -3 D
+43 -1 D
+31 -3 D
+57 -11 D
+40 -1 D
+39 3 D
+53 -2 D
+74 4 D
+42 4 D
+33 2 D
+51 4 D
+49 -3 D
+57 9 D
+76 9 D
+39 7 D
+39 4 D
+42 9 D
+30 9 D
+57 11 D
+36 10 D
+53 6 D
+48 0 D
+60 7 D
+47 -4 D
+11 1 D
+12 -1 D
+51 3 D
+22 -5 D
+13 -1 D
+58 6 D
+44 1 D
+39 9 D
+39 1 D
+44 -8 D
+65 -3 D
+29 -5 D
+108 -2 D
+37 -5 D
+82 -6 D
+28 1 D
+103 -4 D
+37 3 D
+54 9 D
+12 4 D
+86 7 D
+42 1 D
+42 3 D
+24 -1 D
+64 5 D
+25 -1 D
+92 8 D
+14 0 D
+22 2 D
+23 -2 D
+13 1 D
+13 3 D
+43 4 D
+33 6 D
+58 5 D
+79 15 D
+92 9 D
+27 4 D
+40 6 D
+27 5 D
+53 5 D
+41 6 D
+40 3 D
+67 7 D
+48 6 D
+95 20 D
+97 12 D
+69 4 D
+92 10 D
+72 10 D
+45 7 D
+52 12 D
+32 8 D
+12 4 D
+81 13 D
+27 6 D
+25 7 D
+57 10 D
+134 33 D
+49 8 D
+80 20 D
+28 5 D
+77 24 D
+69 21 D
+68 21 D
+41 10 D
+34 12 D
+36 8 D
+37 15 D
+88 24 D
+13 5 D
+50 24 D
+34 19 D
+26 10 D
+S
+1 0 0 C
+1745 1189 M
+36 -2 D
+52 3 D
+75 13 D
+112 5 D
+27 5 D
+37 11 D
+91 14 D
+71 6 D
+61 11 D
+10 0 D
+28 5 D
+18 1 D
+69 10 D
+30 1 D
+32 6 D
+14 1 D
+39 -2 D
+13 2 D
+42 1 D
+11 1 D
+55 -1 D
+15 1 D
+77 -3 D
+75 4 D
+39 0 D
+14 2 D
+40 -1 D
+34 -2 D
+56 1 D
+81 -4 D
+15 -3 D
+43 -2 D
+95 -6 D
+27 3 D
+14 5 D
+28 5 D
+38 1 D
+24 5 D
+24 7 D
+60 10 D
+87 9 D
+11 2 D
+190 12 D
+101 12 D
+64 7 D
+124 7 D
+114 10 D
+62 11 D
+76 8 D
+51 11 D
+65 17 D
+59 11 D
+52 12 D
+71 18 D
+142 29 D
+48 13 D
+12 3 D
+57 23 D
+39 13 D
+111 28 D
+63 12 D
+43 8 D
+38 4 D
+49 11 D
+56 10 D
+28 6 D
+54 11 D
+26 1 D
+146 29 D
+76 9 D
+49 -1 D
+93 10 D
+62 11 D
+39 9 D
+69 8 D
+40 7 D
+15 1 D
+54 11 D
+25 6 D
+49 6 D
+35 11 D
+38 6 D
+51 16 D
+55 12 D
+44 6 D
+89 23 D
+36 8 D
+35 10 D
+26 3 D
+48 10 D
+61 7 D
+39 11 D
+53 11 D
+25 5 D
+35 13 D
+45 19 D
+71 25 D
+39 14 D
+64 16 D
+35 13 D
+40 9 D
+26 6 D
+36 10 D
+34 10 D
+11 5 D
+20 5 D
+33 13 D
+14 1 D
+38 11 D
+35 7 D
+45 15 D
+66 30 D
+70 27 D
+30 14 D
+56 31 D
+4 3 D
+1 0 D S
+0 1 0 C
+2786 949 M
+53 22 D
+23 12 D
+25 13 D
+35 20 D
+76 24 D
+65 12 D
+47 16 D
+195 47 D
+64 6 D
+108 8 D
+52 1 D
+42 2 D
+84 -4 D
+40 1 D
+40 1 D
+39 -1 D
+96 8 D
+59 -4 D
+44 -5 D
+37 -3 D
+57 -10 D
+59 -2 D
+129 -7 D
+134 6 D
+46 4 D
+74 3 D
+76 11 D
+97 10 D
+49 9 D
+55 12 D
+44 18 D
+48 12 D
+93 11 D
+18 3 D
+97 31 D
+8 4 D
+25 6 D
+31 2 D
+43 10 D
+42 13 D
+142 33 D
+42 7 D
+75 21 D
+13 6 D
+26 9 D
+38 8 D
+59 21 D
+13 3 D
+52 21 D
+52 14 D
+44 8 D
+128 29 D
+12 3 D
+38 0 D
+59 11 D
+91 18 D
+31 9 D
+68 10 D
+23 9 D
+12 7 D
+23 9 D
+36 4 D
+103 27 D
+138 21 D
+36 4 D
+50 11 D
+14 2 D
+16 0 D
+38 8 D
+64 15 D
+58 8 D
+40 7 D
+14 1 D
+71 14 D
+60 15 D
+35 5 D
+34 7 D
+82 8 D
+12 3 D
+25 11 D
+98 31 D
+71 27 D
+60 31 D
+24 16 D
+13 7 D
+25 9 D
+66 32 D
+1 1 D S
+0 0 1 C
+2494 675 M
+19 9 D
+73 40 D
+13 8 D
+13 6 D
+50 17 D
+37 13 D
+39 9 D
+94 34 D
+37 15 D
+11 4 D
+38 7 D
+73 21 D
+139 24 D
+68 8 D
+53 5 D
+43 1 D
+40 5 D
+44 8 D
+96 10 D
+164 13 D
+48 2 D
+28 3 D
+91 -4 D
+60 6 D
+52 1 D
+34 -3 D
+17 -3 D
+18 -1 D
+20 1 D
+137 -10 D
+56 -6 D
+55 -2 D
+65 6 D
+54 9 D
+32 1 D
+35 -3 D
+33 1 D
+64 -4 D
+25 -1 D
+26 1 D
+38 5 D
+38 1 D
+46 9 D
+33 1 D
+137 24 D
+45 14 D
+120 26 D
+45 4 D
+44 10 D
+40 9 D
+46 5 D
+49 7 D
+34 4 D
+121 31 D
+22 8 D
+23 5 D
+35 5 D
+51 12 D
+11 2 D
+33 10 D
+74 15 D
+29 1 D
+64 12 D
+55 12 D
+27 9 D
+55 12 D
+76 22 D
+39 14 D
+74 20 D
+26 7 D
+72 19 D
+43 14 D
+113 27 D
+90 23 D
+36 8 D
+23 2 D
+34 8 D
+73 8 D
+96 11 D
+105 22 D
+45 10 D
+49 5 D
+31 6 D
+70 20 D
+33 6 D
+35 13 D
+151 48 D
+13 5 D
+37 8 D
+83 27 D
+37 19 D
+19 9 D
+65 25 D
+39 19 D
+49 18 D
+1 1 D S
+1 0 0 C
+2800 0 M
+45 16 D
+29 7 D
+45 15 D
+28 5 D
+80 23 D
+28 5 D
+24 1 D
+79 21 D
+40 14 D
+45 9 D
+53 9 D
+46 6 D
+76 15 D
+63 5 D
+29 6 D
+14 5 D
+59 7 D
+30 6 D
+83 4 D
+14 2 D
+14 0 D
+85 8 D
+49 -1 D
+110 -2 D
+41 5 D
+33 -1 D
+44 3 D
+35 -2 D
+52 3 D
+16 0 D
+30 -2 D
+28 0 D
+36 -4 D
+36 2 D
+80 -7 D
+26 3 D
+42 -1 D
+44 5 D
+14 0 D
+14 2 D
+28 1 D
+12 -1 D
+47 4 D
+11 2 D
+46 4 D
+26 7 D
+40 7 D
+107 4 D
+24 -1 D
+28 3 D
+145 27 D
+79 14 D
+78 17 D
+38 12 D
+40 15 D
+14 3 D
+49 5 D
+56 18 D
+50 13 D
+38 6 D
+25 7 D
+39 7 D
+69 15 D
+35 5 D
+65 20 D
+45 8 D
+45 12 D
+13 5 D
+26 7 D
+25 11 D
+42 11 D
+42 8 D
+40 11 D
+40 6 D
+108 17 D
+51 14 D
+26 2 D
+132 30 D
+47 17 D
+38 8 D
+43 4 D
+126 37 D
+15 4 D
+75 13 D
+29 6 D
+64 18 D
+72 11 D
+92 19 D
+54 7 D
+83 15 D
+47 5 D
+49 10 D
+29 7 D
+59 7 D
+30 6 D
+65 16 D
+46 3 D
+14 0 D
+44 8 D
+30 3 D
+40 9 D
+5 1 D
+0 0 D S
+0 1 0 C
+5480 225 M
+67 16 D
+14 1 D
+S
+0 0 1 C
+5477 164 M
+15 6 D
+44 7 D
+23 8 D
+13 -2 D
+S
+1 0 0 C
+5358 0 M
+57 14 D
+23 4 D
+41 12 D
+40 7 D
+65 17 D
+108 29 D
+28 9 D
+26 7 D
+24 9 D
+25 7 D
+46 18 D
+29 7 D
+39 7 D
+23 9 D
+23 4 D
+24 4 D
+14 4 D
+0 -6 D
+S
+0 1 0 C
+5718 0 M
+12 3 D
+57 20 D
+63 10 D
+55 18 D
+23 4 D
+69 27 D
+S
+0 0 1 C
+6847 0 M
+34 10 D
+41 8 D
+56 17 D
+15 6 D
+32 8 D
+16 2 D
+14 4 D
+86 16 D
+39 10 D
+74 13 D
+54 4 D
+39 10 D
+62 12 D
+76 18 D
+74 17 D
+0 0 D S
+1 0 0 C
+7211 0 M
+50 13 D
+37 7 D
+57 19 D
+48 17 D
+156 31 D
+0 0 D S
+PSL_cliprestore
+U
+25 W
+0 A
+83 W
+1 A
+N -42 0 M 0 304 D S
+N 7601 0 M 0 304 D S
+0 A
+N -42 304 M 0 303 D S
+N 7601 304 M 0 303 D S
+1 A
+N -42 607 M 0 301 D S
+N 7601 607 M 0 301 D S
+0 A
+N -42 908 M 0 301 D S
+N 7601 908 M 0 301 D S
+1 A
+N -42 1209 M 0 300 D S
+N 7601 1209 M 0 300 D S
+0 A
+N -42 1509 M 0 301 D S
+N 7601 1509 M 0 301 D S
+1 A
+N -42 1810 M 0 301 D S
+N 7601 1810 M 0 301 D S
+0 A
+N -42 2111 M 0 301 D S
+N 7601 2111 M 0 301 D S
+1 A
+N -42 2412 M 0 303 D S
+N 7601 2412 M 0 303 D S
+0 A
+N -42 2715 M 0 304 D S
+N 7601 2715 M 0 304 D S
+1 A
+N -42 3019 M 0 306 D S
+N 7601 3019 M 0 306 D S
+0 A
+N -42 3325 M 0 308 D S
+N 7601 3325 M 0 308 D S
+1 A
+N -42 3633 M 0 311 D S
+N 7601 3633 M 0 311 D S
+0 A
+N -42 3944 M 0 315 D S
+N 7601 3944 M 0 315 D S
+1 A
+N -42 4259 M 0 318 D S
+N 7601 4259 M 0 318 D S
+N 0 -42 M 302 0 D S
+N 0 4618 M 302 0 D S
+0 A
+N 302 -42 M 303 0 D S
+N 302 4618 M 303 0 D S
+1 A
+N 605 -42 M 302 0 D S
+N 605 4618 M 302 0 D S
+0 A
+N 907 -42 M 302 0 D S
+N 907 4618 M 302 0 D S
+1 A
+N 1209 -42 M 303 0 D S
+N 1209 4618 M 303 0 D S
+0 A
+N 1512 -42 M 302 0 D S
+N 1512 4618 M 302 0 D S
+1 A
+N 1814 -42 M 303 0 D S
+N 1814 4618 M 303 0 D S
+0 A
+N 2117 -42 M 302 0 D S
+N 2117 4618 M 302 0 D S
+1 A
+N 2419 -42 M 302 0 D S
+N 2419 4618 M 302 0 D S
+0 A
+N 2721 -42 M 303 0 D S
+N 2721 4618 M 303 0 D S
+1 A
+N 3024 -42 M 302 0 D S
+N 3024 4618 M 302 0 D S
+0 A
+N 3326 -42 M 302 0 D S
+N 3326 4618 M 302 0 D S
+1 A
+N 3628 -42 M 303 0 D S
+N 3628 4618 M 303 0 D S
+0 A
+N 3931 -42 M 302 0 D S
+N 3931 4618 M 302 0 D S
+1 A
+N 4233 -42 M 302 0 D S
+N 4233 4618 M 302 0 D S
+0 A
+N 4535 -42 M 303 0 D S
+N 4535 4618 M 303 0 D S
+1 A
+N 4838 -42 M 302 0 D S
+N 4838 4618 M 302 0 D S
+0 A
+N 5140 -42 M 302 0 D S
+N 5140 4618 M 302 0 D S
+1 A
+N 5442 -42 M 303 0 D S
+N 5442 4618 M 303 0 D S
+0 A
+N 5745 -42 M 302 0 D S
+N 5745 4618 M 302 0 D S
+1 A
+N 6047 -42 M 303 0 D S
+N 6047 4618 M 303 0 D S
+0 A
+N 6350 -42 M 302 0 D S
+N 6350 4618 M 302 0 D S
+1 A
+N 6652 -42 M 302 0 D S
+N 6652 4618 M 302 0 D S
+0 A
+N 6954 -42 M 303 0 D S
+N 6954 4618 M 303 0 D S
+1 A
+N 7257 -42 M 302 0 D S
+N 7257 4618 M 302 0 D S
+0 A
+8 W
+N -83 0 M 7725 0 D S
+N -83 -83 M 7725 0 D S
+N 7559 -83 M 0 4743 D S
+N 7642 -83 M 0 4743 D S
+N 7642 4577 M -7725 0 D S
+N 7642 4660 M -7725 0 D S
+N 0 4660 M 0 -4743 D S
+N -83 4660 M 0 -4743 D S
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psxy/autocolorlines.ps
+++ b/test/psxy/autocolorlines.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_c4a054d-dirty_2020.12.05 [64-bit] Document from plot
+%%Title: GMT v6.2.0_0f68a93-dirty_2020.12.06 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Dec  6 11:05:49 2020
+%%CreationDate: Sun Dec  6 14:36:06 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -117,39 +117,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -704,22 +704,22 @@ N 0 3019 M -83 0 D S
 N 7559 3019 M 83 0 D S
 N 0 4577 M -83 0 D S
 N 7559 4577 M 83 0 D S
-0 4743 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 4743 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(-50∞) bc Z
-1512 4743 M (-40∞) bc Z
-3024 4743 M (-30∞) bc Z
-4535 4743 M (-20∞) bc Z
-6047 4743 M (-10∞) bc Z
-7559 4743 M (0∞) bc Z
--167 0 M (-10∞) mr Z
-7726 0 M (-10∞) ml Z
--167 1509 M (0∞) mr Z
-7726 1509 M (0∞) ml Z
--167 3019 M (10∞) mr Z
-7726 3019 M (10∞) ml Z
--167 4577 M (20∞) mr Z
-7726 4577 M (20∞) ml Z
+(î50è) bc Z
+1512 4743 M (î40è) bc Z
+3024 4743 M (î30è) bc Z
+4535 4743 M (î20è) bc Z
+6047 4743 M (î10è) bc Z
+7559 4743 M (0è) bc Z
+-167 0 M (î10è) mr Z
+7726 0 M (î10è) ml Z
+-167 1509 M (0è) mr Z
+7726 1509 M (0è) ml Z
+-167 3019 M (10è) mr Z
+7726 3019 M (10è) ml Z
+-167 4577 M (20è) mr Z
+7726 4577 M (20è) ml Z
 V
 4 W
 -5 A
@@ -730,12 +730,12 @@ clipsave
 -7559 0 D
 P
 PSL_clip N
-0 1 0 C
+0 0.447 0.741 C
 4553 4577 M
 93 -23 D
 12 -1 D
 S
-0 0 1 C
+0.851 0.325 0.098 C
 0 3971 M
 60 -21 D
 68 -15 D
@@ -818,7 +818,7 @@ S
 10 -4 D
 13 -11 D
 S
-1 0 0 C
+0.929 0.694 0.125 C
 0 3584 M
 59 -11 D
 29 -3 D
@@ -881,7 +881,7 @@ S
 22 -6 D
 19 -3 D
 S
-0 1 1 C
+0.494 0.184 0.557 C
 0 3527 M
 23 -6 D
 40 -16 D
@@ -934,7 +934,7 @@ S
 34 -4 D
 21 -4 D
 S
-1 0.6 0.933 C
+0.467 0.675 0.188 C
 1217 2965 M
 75 -3 D
 54 -10 D
@@ -946,7 +946,7 @@ S
 11 1 D
 32 -4 D
 S
-1 0.867 0.4 C
+0.302 0.745 0.933 C
 0 3287 M
 66 -13 D
 63 -7 D
@@ -1035,7 +1035,7 @@ S
 49 -2 D
 20 -2 D
 S
-0 0.4 0 C
+0.635 0.0784 0.184 C
 0 3014 M
 73 10 D
 43 1 D
@@ -1121,7 +1121,7 @@ S
 43 -6 D
 19 -5 D
 S
-0 0 0.4 C
+0 0.447 0.741 C
 1697 2684 M
 75 -2 D
 53 3 D
@@ -1133,7 +1133,7 @@ S
 52 3 D
 16 3 D
 S
-0.667 0.333 0.267 C
+0.851 0.325 0.098 C
 2036 2638 M
 59 -1 D
 13 1 D
@@ -1146,7 +1146,7 @@ S
 20 1 D
 10 2 D
 S
-0 0.533 0.8 C
+0.929 0.694 0.125 C
 2151 2548 M
 149 -2 D
 25 4 D
@@ -1159,14 +1159,14 @@ S
 82 11 D
 12 1 D
 S
-1 0.0667 1 C
+0.494 0.184 0.557 C
 2473 2477 M
 69 -7 D
 47 -2 D
 14 1 D
 42 -1 D
 S
-1 0.933 0.933 C
+0.467 0.675 0.188 C
 1397 2218 M
 23 -11 D
 34 -10 D
@@ -1217,7 +1217,7 @@ S
 99 2 D
 2 -3 D
 S
-1 0 0.467 C
+0.302 0.745 0.933 C
 4762 2399 M
 34 -11 D
 26 -1 D
@@ -1242,7 +1242,7 @@ S
 30 0 D
 51 6 D
 S
-0.533 1 0.6 C
+0.635 0.0784 0.184 C
 2744 1678 M
 53 3 D
 24 -3 D
@@ -1259,7 +1259,7 @@ S
 33 -2 D
 20 -4 D
 S
-0.533 0.4 1 C
+0 0.447 0.741 C
 1468 1541 M
 7 -7 D
 23 -9 D
@@ -1362,7 +1362,7 @@ S
 34 19 D
 26 10 D
 S
-0.333 0.533 0.467 C
+0.851 0.325 0.098 C
 1745 1189 M
 36 -2 D
 52 3 D
@@ -1481,7 +1481,7 @@ S
 56 31 D
 4 3 D
 1 0 D S
-0.4 0 0.267 C
+0.929 0.694 0.125 C
 2786 949 M
 53 22 D
 23 12 D
@@ -1571,7 +1571,7 @@ S
 25 9 D
 66 32 D
 1 1 D S
-0.867 1 0 C
+0.494 0.184 0.557 C
 2494 675 M
 19 9 D
 73 40 D
@@ -1669,7 +1669,7 @@ S
 39 19 D
 49 18 D
 1 1 D S
-1 0.533 0 C
+0.467 0.675 0.188 C
 2800 0 M
 45 16 D
 29 7 D
@@ -1774,19 +1774,19 @@ S
 40 9 D
 5 1 D
 0 0 D S
-0.467 0.4 0 C
+0.302 0.745 0.933 C
 5480 225 M
 67 16 D
 14 1 D
 S
-0.733 0 0.6 C
+0.635 0.0784 0.184 C
 5477 164 M
 15 6 D
 44 7 D
 23 8 D
 13 -2 D
 S
-0.6 0.467 0.6 C
+0 0.447 0.741 C
 5358 0 M
 57 14 D
 23 4 D
@@ -1807,7 +1807,7 @@ S
 14 4 D
 0 -6 D
 S
-0.533 0.667 0 C
+0.851 0.325 0.098 C
 5718 0 M
 12 3 D
 57 20 D
@@ -1816,7 +1816,7 @@ S
 23 4 D
 69 27 D
 S
-0.133 0.2 0.4 C
+0.929 0.694 0.125 C
 6847 0 M
 34 10 D
 41 8 D
@@ -1834,7 +1834,7 @@ S
 76 18 D
 74 17 D
 0 0 D S
-0.133 0.2 0 C
+0.494 0.184 0.557 C
 7211 0 M
 50 13 D
 37 7 D
@@ -2012,22 +2012,22 @@ N 0 3019 M -83 0 D S
 N 7559 3019 M 83 0 D S
 N 0 4577 M -83 0 D S
 N 7559 4577 M 83 0 D S
-0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -167 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(-50∞) tc Z
-1512 -167 M (-40∞) tc Z
-3024 -167 M (-30∞) tc Z
-4535 -167 M (-20∞) tc Z
-6047 -167 M (-10∞) tc Z
-7559 -167 M (0∞) tc Z
--167 0 M (-10∞) mr Z
-7726 0 M (-10∞) ml Z
--167 1509 M (0∞) mr Z
-7726 1509 M (0∞) ml Z
--167 3019 M (10∞) mr Z
-7726 3019 M (10∞) ml Z
--167 4577 M (20∞) mr Z
-7726 4577 M (20∞) ml Z
+(î50è) tc Z
+1512 -167 M (î40è) tc Z
+3024 -167 M (î30è) tc Z
+4535 -167 M (î20è) tc Z
+6047 -167 M (î10è) tc Z
+7559 -167 M (0è) tc Z
+-167 0 M (î10è) mr Z
+7726 0 M (î10è) ml Z
+-167 1509 M (0è) mr Z
+7726 1509 M (0è) ml Z
+-167 3019 M (10è) mr Z
+7726 3019 M (10è) ml Z
+-167 4577 M (20è) mr Z
+7726 4577 M (20è) ml Z
 V
 4 W
 -5 A

--- a/test/psxy/autocolorlines.sh
+++ b/test/psxy/autocolorlines.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Test auto-color sequencing via CPT or color list
+
+gmt begin autocolorlines ps
+	gmt subplot begin 2x1 -Fs16c/0 -R-50/0/-10/20 -JM16c -SC -SR -Bwesn
+		gmt plot @fz_07.txt -W0.25p,auto -c
+		gmt plot @fz_07.txt -W0.25p,auto -c --COLOR_SET=red,green,blue
+	gmt subplot end
+gmt end show

--- a/test/psxy/autocolorlines.sh
+++ b/test/psxy/autocolorlines.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Test auto-color sequencing via CPT or color list
+# Test auto-color sequencing of pens via CPT or color list
 
 gmt begin autocolorlines ps
 	gmt subplot begin 2x1 -Fs16c/0 -R-50/0/-10/20 -JM16c -SC -SR -Bwesn

--- a/test/psxy/autocolorpols.ps
+++ b/test/psxy/autocolorpols.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_c4a054d-dirty_2020.12.05 [64-bit] Document from plot
+%%Title: GMT v6.2.0_0f68a93-dirty_2020.12.06 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Dec  6 11:11:23 2020
+%%CreationDate: Sun Dec  6 14:36:06 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -117,39 +117,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -692,28 +692,28 @@ clipsave
 -4724 0 D
 P
 PSL_clip N
-{0 1 0 C} FS
+{0 0.447 0.741 C} FS
 O0
 /FO {P}!
 -675 0 0 675 675 0 3 675 675 SP
 /FO {fs os}!
 FO
-{0 0 1 C} FS
+{0.851 0.325 0.098 C} FS
 /FO {P}!
 -675 0 0 675 675 0 3 1350 1350 SP
 /FO {fs os}!
 FO
-{1 0 0 C} FS
+{0.929 0.694 0.125 C} FS
 /FO {P}!
 -675 0 0 675 675 0 3 2025 2025 SP
 /FO {fs os}!
 FO
-{0 1 1 C} FS
+{0.494 0.184 0.557 C} FS
 /FO {P}!
 -675 0 0 675 675 0 3 2700 2700 SP
 /FO {fs os}!
 FO
-{1 0.6 0.933 C} FS
+{0.467 0.675 0.188 C} FS
 /FO {P}!
 -674 0 0 674 674 0 3 3375 3375 SP
 /FO {fs os}!
@@ -734,7 +734,7 @@ N 0 3375 M -83 0 D S
 N 0 4724 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx
@@ -889,7 +889,7 @@ N 0 3375 M -83 0 D S
 N 0 4724 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx

--- a/test/psxy/autocolorpols.ps
+++ b/test/psxy/autocolorpols.ps
@@ -1,0 +1,993 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_c4a054d-dirty_2020.12.05 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec  6 11:11:23 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/3.93701/0/8.04068 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.93701000 0.00000000 8.04068000 0.000 3.937 0.000 8.041 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4924 TM
+% PostScript produced by:
+%@GMT: gmt plot p.txt -Gauto -BWENb -Bxaf -Byaf -Xa0i -Ya4.1037i -R-1/6/-1/6 -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+V
+4 W
+clipsave
+0 0 M
+4724 0 D
+0 4724 D
+-4724 0 D
+P
+PSL_clip N
+{0 1 0 C} FS
+O0
+/FO {P}!
+-675 0 0 675 675 0 3 675 675 SP
+/FO {fs os}!
+FO
+{0 0 1 C} FS
+/FO {P}!
+-675 0 0 675 675 0 3 1350 1350 SP
+/FO {fs os}!
+FO
+{1 0 0 C} FS
+/FO {P}!
+-675 0 0 675 675 0 3 2025 2025 SP
+/FO {fs os}!
+FO
+{0 1 1 C} FS
+/FO {P}!
+-675 0 0 675 675 0 3 2700 2700 SP
+/FO {fs os}!
+FO
+{1 0.6 0.933 C} FS
+/FO {P}!
+-674 0 0 674 674 0 3 3375 3375 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 675 M -83 0 D S
+N 0 2025 M -83 0 D S
+N 0 3375 M -83 0 D S
+N 0 4724 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+675 PSL_A0_y MM
+(0) mr Z
+2025 PSL_A0_y MM
+(2) mr Z
+3375 PSL_A0_y MM
+(4) mr Z
+4724 PSL_A0_y MM
+(6) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 2700 M -42 0 D S
+N 0 4049 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4724 0 T
+25 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 675 M 83 0 D S
+N 0 2025 M 83 0 D S
+N 0 3375 M 83 0 D S
+N 0 4724 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+675 PSL_A0_y MM
+(0) mr Z
+2025 PSL_A0_y MM
+(2) mr Z
+3375 PSL_A0_y MM
+(4) mr Z
+4724 PSL_A0_y MM
+(6) mr Z
+N 0 0 M 42 0 D S
+N 0 1350 M 42 0 D S
+N 0 2700 M 42 0 D S
+N 0 4049 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-4724 0 T
+25 W
+N 0 0 M 4724 0 D S
+0 4724 T
+N 0 0 M 4724 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 675 0 M 0 83 D S
+N 2025 0 M 0 83 D S
+N 3375 0 M 0 83 D S
+N 4724 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+675 PSL_A0_y MM
+(0) bc Z
+2025 PSL_A0_y MM
+(2) bc Z
+3375 PSL_A0_y MM
+(4) bc Z
+4724 PSL_A0_y MM
+(6) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M 0 42 D S
+N 1350 0 M 0 42 D S
+N 2700 0 M 0 42 D S
+N 4049 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+%%EndObject
+0 -4924 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot p.txt -Gauto@50 --COLOR_SET=red,green,blue -BWEtS -Bxaf -Byaf -Xa0i -Ya0i -R-1/6/-1/6 -JX15c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+V
+4 W
+clipsave
+0 0 M
+4724 0 D
+0 4724 D
+-4724 0 D
+P
+PSL_clip N
+{1 0 0 C 0.5 0.5 /Normal PSL_transp} FS
+O0
+/FO {P}!
+-675 0 0 675 675 0 3 675 675 SP
+/FO {fs os}!
+FO
+{0 1 0 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-675 0 0 675 675 0 3 1350 1350 SP
+/FO {fs os}!
+FO
+{0 0 1 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-675 0 0 675 675 0 3 2025 2025 SP
+/FO {fs os}!
+FO
+{1 0 0 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-675 0 0 675 675 0 3 2700 2700 SP
+/FO {fs os}!
+FO
+{0 1 0 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-674 0 0 674 674 0 3 3375 3375 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 675 M -83 0 D S
+N 0 2025 M -83 0 D S
+N 0 3375 M -83 0 D S
+N 0 4724 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+675 PSL_A0_y MM
+(0) mr Z
+2025 PSL_A0_y MM
+(2) mr Z
+3375 PSL_A0_y MM
+(4) mr Z
+4724 PSL_A0_y MM
+(6) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 2700 M -42 0 D S
+N 0 4049 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4724 0 T
+25 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 675 M 83 0 D S
+N 0 2025 M 83 0 D S
+N 0 3375 M 83 0 D S
+N 0 4724 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+675 PSL_A0_y MM
+(0) mr Z
+2025 PSL_A0_y MM
+(2) mr Z
+3375 PSL_A0_y MM
+(4) mr Z
+4724 PSL_A0_y MM
+(6) mr Z
+N 0 0 M 42 0 D S
+N 0 1350 M 42 0 D S
+N 0 2700 M 42 0 D S
+N 0 4049 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-4724 0 T
+25 W
+N 0 0 M 4724 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 675 0 M 0 -83 D S
+N 2025 0 M 0 -83 D S
+N 3375 0 M 0 -83 D S
+N 4724 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+675 PSL_A0_y MM
+(0) bc Z
+2025 PSL_A0_y MM
+(2) bc Z
+3375 PSL_A0_y MM
+(4) bc Z
+4724 PSL_A0_y MM
+(6) bc Z
+N 0 0 M 0 -42 D S
+N 1350 0 M 0 -42 D S
+N 2700 0 M 0 -42 D S
+N 4049 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4724 T
+25 W
+N 0 0 M 4724 0 D S
+0 -4724 T
+0 setlinecap
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psxy/autocolorpols.sh
+++ b/test/psxy/autocolorpols.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Test auto-color sequencing for fill via CPT or color list
+
+cat << EOF > p.txt
+>
+0 0
+1 0
+1 1
+0 1
+>
+1 1
+2 1
+2 2
+1 2
+>
+2 2
+3 2
+3 3
+2 3
+>
+3 3
+4 3
+4 4
+3 4
+>
+4 4
+5 4
+5 5
+4 5
+EOF
+gmt begin autocolorpols ps
+	gmt subplot begin 2x1 -Fs10c -R-1/6/-1/6 -SC -SR -Blrbt
+		gmt plot p.txt -Gauto -c
+		gmt plot p.txt -Gauto@50 -c --COLOR_SET=red,green,blue
+	gmt subplot end
+gmt end show

--- a/test/psxy/autocolorpolsclassic.ps
+++ b/test/psxy/autocolorpolsclassic.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_a854644_2020.12.06 [64-bit] Document from psxy
+%%Title: GMT v6.2.0_739a732_2020.12.07 [64-bit] Document from psxy
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Dec  6 18:05:47 2020
+%%CreationDate: Mon Dec  7 12:56:42 2020
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -118,39 +118,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -730,7 +730,7 @@ N 0 3375 M -83 0 D S
 N 0 4724 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx
@@ -871,28 +871,28 @@ clipsave
 -4724 0 D
 P
 PSL_clip N
-{0 0 1 C 0.5 0.5 /Normal PSL_transp} FS
+{1 0 0 C 0.5 0.5 /Normal PSL_transp} FS
 O0
 /FO {P}!
 -675 0 0 675 675 0 3 675 675 SP
 /FO {fs os}!
 FO
-{1 0 0 C 0.5 0.5 /Normal PSL_transp} FS
+{0 1 0 C 0.5 0.5 /Normal PSL_transp} FS
 /FO {P}!
 -675 0 0 675 675 0 3 1350 1350 SP
 /FO {fs os}!
 FO
-{0 1 0 C 0.5 0.5 /Normal PSL_transp} FS
+{0 0 1 C 0.5 0.5 /Normal PSL_transp} FS
 /FO {P}!
 -675 0 0 675 675 0 3 2025 2025 SP
 /FO {fs os}!
 FO
-{0 0 1 C 0.5 0.5 /Normal PSL_transp} FS
+{1 0 0 C 0.5 0.5 /Normal PSL_transp} FS
 /FO {P}!
 -675 0 0 675 675 0 3 2700 2700 SP
 /FO {fs os}!
 FO
-{1 0 0 C 0.5 0.5 /Normal PSL_transp} FS
+{0 1 0 C 0.5 0.5 /Normal PSL_transp} FS
 /FO {P}!
 -674 0 0 674 674 0 3 3375 3375 SP
 /FO {fs os}!
@@ -913,7 +913,7 @@ N 0 3375 M -83 0 D S
 N 0 4724 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
 (2) sw mx

--- a/test/psxy/autocolorpolsclassic.ps
+++ b/test/psxy/autocolorpolsclassic.ps
@@ -1,0 +1,1047 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_a854644_2020.12.06 [64-bit] Document from psxy
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec  6 18:05:47 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+2362 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy -R-1/6/-1/6 -JX10c p.txt -Gauto -Baf -P -K -X5c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%GMTBoundingBox: 141.732283465 72 283.464566929 283.464566929
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+V
+4 W
+clipsave
+0 0 M
+4724 0 D
+0 4724 D
+-4724 0 D
+P
+PSL_clip N
+{1 0 0 C} FS
+O0
+/FO {P}!
+-675 0 0 675 675 0 3 675 675 SP
+/FO {fs os}!
+FO
+{0 1 0 C} FS
+/FO {P}!
+-675 0 0 675 675 0 3 1350 1350 SP
+/FO {fs os}!
+FO
+{0 0 1 C} FS
+/FO {P}!
+-675 0 0 675 675 0 3 2025 2025 SP
+/FO {fs os}!
+FO
+{1 0 0 C} FS
+/FO {P}!
+-675 0 0 675 675 0 3 2700 2700 SP
+/FO {fs os}!
+FO
+{0 1 0 C} FS
+/FO {P}!
+-674 0 0 674 674 0 3 3375 3375 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 675 M -83 0 D S
+N 0 2025 M -83 0 D S
+N 0 3375 M -83 0 D S
+N 0 4724 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+675 PSL_A0_y MM
+(0) mr Z
+2025 PSL_A0_y MM
+(2) mr Z
+3375 PSL_A0_y MM
+(4) mr Z
+4724 PSL_A0_y MM
+(6) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 2700 M -42 0 D S
+N 0 4049 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4724 0 T
+25 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 675 M 83 0 D S
+N 0 2025 M 83 0 D S
+N 0 3375 M 83 0 D S
+N 0 4724 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+675 PSL_A0_y MM
+(0) mr Z
+2025 PSL_A0_y MM
+(2) mr Z
+3375 PSL_A0_y MM
+(4) mr Z
+4724 PSL_A0_y MM
+(6) mr Z
+N 0 0 M 42 0 D S
+N 0 1350 M 42 0 D S
+N 0 2700 M 42 0 D S
+N 0 4049 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-4724 0 T
+25 W
+N 0 0 M 4724 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 675 0 M 0 -83 D S
+N 2025 0 M 0 -83 D S
+N 3375 0 M 0 -83 D S
+N 4724 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+675 PSL_A0_y MM
+(0) bc Z
+2025 PSL_A0_y MM
+(2) bc Z
+3375 PSL_A0_y MM
+(4) bc Z
+4724 PSL_A0_y MM
+(6) bc Z
+N 0 0 M 0 -42 D S
+N 1350 0 M 0 -42 D S
+N 2700 0 M 0 -42 D S
+N 4049 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4724 T
+25 W
+N 0 0 M 4724 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 675 0 M 0 83 D S
+N 2025 0 M 0 83 D S
+N 3375 0 M 0 83 D S
+N 4724 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+675 PSL_A0_y MM
+(0) bc Z
+2025 PSL_A0_y MM
+(2) bc Z
+3375 PSL_A0_y MM
+(4) bc Z
+4724 PSL_A0_y MM
+(6) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M 0 42 D S
+N 1350 0 M 0 42 D S
+N 2700 0 M 0 42 D S
+N 4049 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 5669 TM
+
+% PostScript produced by:
+%@GMT: gmt psxy p.txt -R-1/6/-1/6 -JX10c -Gauto@50 -Baf -O -Y12c
+%@PROJ: xy -1.00000000 6.00000000 -1.00000000 6.00000000 -1.000 6.000 -1.000 6.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+V
+4 W
+clipsave
+0 0 M
+4724 0 D
+0 4724 D
+-4724 0 D
+P
+PSL_clip N
+{0 0 1 C 0.5 0.5 /Normal PSL_transp} FS
+O0
+/FO {P}!
+-675 0 0 675 675 0 3 675 675 SP
+/FO {fs os}!
+FO
+{1 0 0 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-675 0 0 675 675 0 3 1350 1350 SP
+/FO {fs os}!
+FO
+{0 1 0 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-675 0 0 675 675 0 3 2025 2025 SP
+/FO {fs os}!
+FO
+{0 0 1 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-675 0 0 675 675 0 3 2700 2700 SP
+/FO {fs os}!
+FO
+{1 0 0 C 0.5 0.5 /Normal PSL_transp} FS
+/FO {P}!
+-674 0 0 674 674 0 3 3375 3375 SP
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 675 M -83 0 D S
+N 0 2025 M -83 0 D S
+N 0 3375 M -83 0 D S
+N 0 4724 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+675 PSL_A0_y MM
+(0) mr Z
+2025 PSL_A0_y MM
+(2) mr Z
+3375 PSL_A0_y MM
+(4) mr Z
+4724 PSL_A0_y MM
+(6) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 1350 M -42 0 D S
+N 0 2700 M -42 0 D S
+N 0 4049 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4724 0 T
+25 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 675 M 83 0 D S
+N 0 2025 M 83 0 D S
+N 0 3375 M 83 0 D S
+N 0 4724 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+675 PSL_A0_y MM
+(0) mr Z
+2025 PSL_A0_y MM
+(2) mr Z
+3375 PSL_A0_y MM
+(4) mr Z
+4724 PSL_A0_y MM
+(6) mr Z
+N 0 0 M 42 0 D S
+N 0 1350 M 42 0 D S
+N 0 2700 M 42 0 D S
+N 0 4049 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-4724 0 T
+25 W
+N 0 0 M 4724 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 675 0 M 0 -83 D S
+N 2025 0 M 0 -83 D S
+N 3375 0 M 0 -83 D S
+N 4724 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+675 PSL_A0_y MM
+(0) bc Z
+2025 PSL_A0_y MM
+(2) bc Z
+3375 PSL_A0_y MM
+(4) bc Z
+4724 PSL_A0_y MM
+(6) bc Z
+N 0 0 M 0 -42 D S
+N 1350 0 M 0 -42 D S
+N 2700 0 M 0 -42 D S
+N 4049 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4724 T
+25 W
+N 0 0 M 4724 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 675 0 M 0 83 D S
+N 2025 0 M 0 83 D S
+N 3375 0 M 0 83 D S
+N 4724 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+675 PSL_A0_y MM
+(0) bc Z
+2025 PSL_A0_y MM
+(2) bc Z
+3375 PSL_A0_y MM
+(4) bc Z
+4724 PSL_A0_y MM
+(6) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M 0 42 D S
+N 1350 0 M 0 42 D S
+N 2700 0 M 0 42 D S
+N 4049 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psxy/autocolorpolsclassic.sh
+++ b/test/psxy/autocolorpolsclassic.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Test auto-color sequencing for fill via CPT or color list [classic mode]
+# Point here is that the color sequence continues from first to second process
+
+cat << EOF > p.txt
+>
+0 0
+1 0
+1 1
+0 1
+>
+1 1
+2 1
+2 2
+1 2
+>
+2 2
+3 2
+3 3
+2 3
+>
+3 3
+4 3
+4 4
+3 4
+>
+4 4
+5 4
+5 5
+4 5
+EOF
+ps=autocolorpolsclassic.ps
+gmt set COLOR_SET red,green,blue
+gmt psxy -R-1/6/-1/6 -JX10c p.txt -Gauto -Baf -P -K -X5c > $ps
+gmt psxy p.txt -R -J -Gauto@50 -Baf -O -Y12c >> $ps

--- a/test/subplot/autocolorline.ps
+++ b/test/subplot/autocolorline.ps
@@ -1,0 +1,2221 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_e6834f4_2020.12.06 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec  6 12:30:35 2020
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      char show
+      0 justy neg G
+      currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {	PSL_CT_reversepath
+	PSL_CT_textline} ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_placetext {PSL_ST_place_label} if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/6.90085/0/9.26305 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.90085000 0.00000000 9.26305000 0.000 6.901 0.000 9.263 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 7809 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa0i -Ya6.5071i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 7809 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(1) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 -7809 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+2959 7809 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa2.4662i -Ya6.5071i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+2959 7809 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(2) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+-2959 -7809 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+5919 7809 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa4.9323i -Ya6.5071i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+5919 7809 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(3) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+-5919 -7809 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 3904 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa0i -Ya3.2536i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 3904 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(4) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 -3904 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+2959 3904 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa2.4662i -Ya3.2536i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+2959 3904 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(5) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+-2959 -3904 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+5919 3904 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa4.9323i -Ya3.2536i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+5919 3904 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(6) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+-5919 -3904 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(7) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+2959 0 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa2.4662i -Ya0i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+2959 0 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(8) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+-2959 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+5919 0 TM
+% PostScript produced by:
+%@GMT: gmt plot lines.txt -W1p,auto -BWenS -Bxaf -Byaf -Xa4.9323i -Ya0i -R0/10/0/8 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 8.00000000 0.000 10.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+5919 0 T
+0 A 67 3240 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(9) tl Z
+U
+}!
+0 A
+V
+17 W
+-5 A
+clipsave
+0 0 M
+2362 0 D
+0 3307 D
+-2362 0 D
+P
+PSL_clip N
+1 0 0 C
+236 413 M
+1890 827 D
+S
+0 1 0 C
+236 827 M
+1890 827 D
+S
+0 0 1 C
+236 1240 M
+1890 827 D
+S
+1 0 0 C
+236 1654 M
+1890 826 D
+S
+0 1 0 C
+236 2067 M
+1890 827 D
+S
+PSL_cliprestore
+U
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 827 M -83 0 D S
+N 0 1654 M -83 0 D S
+N 0 2480 M -83 0 D S
+N 0 3307 M -83 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+827 PSL_A0_y MM
+(2) mr Z
+1654 PSL_A0_y MM
+(4) mr Z
+2480 PSL_A0_y MM
+(6) mr Z
+3307 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 413 M -42 0 D S
+N 0 1240 M -42 0 D S
+N 0 2067 M -42 0 D S
+N 0 2894 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 827 M 83 0 D S
+N 0 1654 M 83 0 D S
+N 0 2480 M 83 0 D S
+N 0 3307 M 83 0 D S
+N 0 413 M 42 0 D S
+N 0 1240 M 42 0 D S
+N 0 2067 M 42 0 D S
+N 0 2894 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 472 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 2362 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+472 PSL_A0_y MM
+(2) bc Z
+945 PSL_A0_y MM
+(4) bc Z
+1417 PSL_A0_y MM
+(6) bc Z
+1890 PSL_A0_y MM
+(8) bc Z
+2362 PSL_A0_y MM
+(10) bc Z
+N 236 0 M 0 -42 D S
+N 709 0 M 0 -42 D S
+N 1181 0 M 0 -42 D S
+N 1654 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 472 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 2362 0 M 0 83 D S
+N 236 0 M 0 42 D S
+N 709 0 M 0 42 D S
+N 1181 0 M 0 42 D S
+N 1654 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3307 T
+0 setlinecap
+%%EndObject
+-5919 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/subplot/autocolorline.sh
+++ b/test/subplot/autocolorline.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Test auto pen color in panels and make sure ID is reset for each panel
+cat << EOF > lines.txt
+>
+1 1
+9 3
+>
+1 2
+9 4
+>
+1 3
+9 5
+>
+1 4
+9 6
+>
+1 5
+9 7
+EOF
+gmt begin autocolorline ps
+  gmt set MAP_FRAME_TYPE plain COLOR_SET=red,green,blue
+  gmt subplot begin 3x3 -Fs5c/7c -A1 -M6p -R0/10/0/8 -BWSen
+    gmt plot lines.txt -W1p,auto -c
+    gmt plot lines.txt -W1p,auto -c
+    gmt plot lines.txt -W1p,auto -c
+    
+    gmt plot lines.txt -W1p,auto -c
+    gmt plot lines.txt -W1p,auto -c
+    gmt plot lines.txt -W1p,auto -c
+    
+    gmt plot lines.txt -W1p,auto -c
+    gmt plot lines.txt -W1p,auto -c
+    gmt plot lines.txt -W1p,auto -c
+  gmt subplot end
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

This PR is the initial implementation of the ideas discussed in #4500.  So far, this has been implemented and should be tested by @joa-quim who requested it:

- A new GMT defaults called **COLOR_SET** [categorical].  It takes either a comma-separated list of colors or the name of a categorical CPT.
- Ability to specify a color fill via **-G** or **-W** by giving the color as _auto_[-_segment_] or _auto-table_ in **plot**.  The first will increment the internal color sequence ID for each input segment while the second will increment the ID for each input table.  In either case we cycle around if we run out of colors.
- If a flavor of auto is selected, the **COLOR_SET** argument is read in as a CPT and we pick colors from it cyclically.
- The initial transparency is kept, so **-G**_auto_@75 retains 75% transparency as the colors cycle.
- This works for both classic and modern mode.

So far, this is restricted to a single process (i.e., the ID starts over at 0).  The plan is to allow auto to be able to continue the ID across several processes (but will be reset at start of each subset panel, for instance.  We will also add a new entry to the auto-legend if **-l** is used.

After building from this branch you can try

`gmt plot @fz_07.txt -R-60/20/-30/30 -JM6i -B -W0.25p,auto -pdf map`

or

`gmt plot @fz_07.txt -R-60/20/-30/30 -JM6i -B -W0.25p,auto -pdf map --COLOR_SET=red,green,blue`

Sorry, I don't have a handy command for **-G**_auto_ but I did test it on some dummy polygons.

Some questions based on this implementation:

1. Should **-G** with no argument mean **-G**_auto_ or is that confusing?
2. If yes, should **-W**_width_,[,_style_] also mean color = auto or is that confusing (e.g., -W0.25p, or -W0.5,,dashed)?
3. I decided to set the color and increment the ID at the top of the loop.  If the segment is entirely outside the region then that color will not show up.  I think this makes sense if you are plotting 6 lines and on one plot segment 4 is outside and not drawn - you don't want segment 5 to now get segment 4's color, right?

Any comments on the current implementation?  I have not touched the docs yet (except for adding **COLOR_SET** to gmt.conf.rst).