### PR TITLE
mgd77list: Verify if field names are valid

### DIFF
--- a/src/mgd77/mgd77.c
+++ b/src/mgd77/mgd77.c
@@ -29,6 +29,9 @@
 #define MGD77_CDF_CONVENTION	"CF-1.0"	/* MGD77+ files are CF-1.0 and hence COARDS-compliant */
 #define MGD77_COL_ORDER "#rec\tTZ\tyear\tmonth\tday\thour\tmin\tlat\t\tlon\t\tptc\ttwt\tdepth\tbcc\tbtc\tmtf1\tmtf2\tmag\tmsens\tdiur\tmsd\tgobs\teot\tfaa\tnqc\tid\tsln\tsspn\n"
 
+#define MGD77_NUM_VALID_COLNAMES 51
+char *valid_colnames[] = {"atime", "rtime", "ytime", "year", "month", "day", "hour", "min", "sec", "dmin", "hhmm", "date", "tz", "lon", "lat", "id", "ngdcid", "recno", "dist", "azim", "cc", "vel", "twt", "depth", "mtf1", "mtf2", "mag", "gobs", "faa", "drt", "ptc", "bcc", "btc", "msens", "msd", "diur", "eot", "sln", "sspn", "nqc", "carter", "igrf", "ceot", "ngrav", "weight", "mgd77", "mgd77t", "geo", "all", "allt", "dat"};
+
 struct MGD77_MAG_RF {
 	char *model;        /* Reference field model name */
 	int code;           /* Reference field code       */
@@ -4049,6 +4052,49 @@ void MGD77_Reset (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F) {
 	gmt_M_memset (F->Constraint, MGD77_MAX_COLS, struct MGD77_CONSTRAINT);
 	gmt_M_memset (F->Exact, MGD77_MAX_COLS, struct MGD77_PAIR);
 	gmt_M_memset (F->Bit_test, MGD77_MAX_COLS, struct MGD77_PAIR);
+}
+
+int MGD77_Verify_Columns (struct GMT_CTRL *GMT, char *arg) {
+  /* Scan the -Fstring to check if all the requested fields exist.
+   */
+  
+  char p[GMT_BUFSIZ] = {""}, cstring[GMT_BUFSIZ] = {""};
+  unsigned int i, k, found, pos = 0, n = 0;
+  
+	if (!arg || !arg[0]) return 0;	/* Return when nothing is passed to us */
+    
+  strncpy (cstring, arg, GMT_BUFSIZ-1);
+  if (strchr (cstring, ':')) { /* We just want the fields list */
+    for (i = 0; i < strlen(cstring); i++) {
+      if (cstring[i] == ':') {
+        cstring[i] = '\0';
+        break;
+      }
+    }
+  }
+  
+	while ((gmt_strtok (cstring, ",", &pos, p))) {	/* Until we run out of abbreviations */
+    for (k = 0; k < strlen(p); k++) {
+      if ((p[k] == '>') || (p[k] == '<') || (p[k] == '=') || (p[k] == '|') || (p[k] == '!')) {
+        p[k] = '\0';
+        break;
+      }
+    }
+    found = 0;
+    for (k = 0; k < MGD77_NUM_VALID_COLNAMES; k++) {
+      if (!strcasecmp(p, valid_colnames[k])) {
+        found = 1;
+        break;
+      }
+    }
+    if (!found) {
+      GMT_Report (GMT->parent, GMT_MSG_ERROR, "\"%s\" is not a valid column name.\n", p);      
+      n++;
+    }
+  }
+  
+  return n;
+  
 }
 
 int MGD77_Select_Columns (struct GMT_CTRL *GMT, char *arg, struct MGD77_CONTROL *F, unsigned int option) {

--- a/src/mgd77/mgd77.h
+++ b/src/mgd77/mgd77.h
@@ -507,6 +507,7 @@ EXTERN_MSC int MGD77_Write_Data (struct GMT_CTRL *GMT, char *file, struct MGD77_
 EXTERN_MSC int MGD77_Read_Data_Record (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct MGD77_HEADER *H, double dvals[], char *tvals[]);	/* Read a single data record (selected columns only) */
 EXTERN_MSC int MGD77_Write_Data_Record (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct MGD77_HEADER *H, double dvals[], char *tvals[]);	/* Write a single data record (selected columns only) */
 EXTERN_MSC void MGD77_Free_Dataset (struct GMT_CTRL *GMT, struct MGD77_DATASET **S);								/* Free memory allocated by MGD77_Read_File/MGD77_Read_Data */
+EXTERN_MSC int MGD77_Verify_Columns (struct GMT_CTRL *GMT, char *string);				/* Verify if the -F option only contains valid column names */
 EXTERN_MSC int MGD77_Select_Columns (struct GMT_CTRL *GMT, char *string, struct MGD77_CONTROL *F, unsigned int option);				/* Decode the -F option specifying the desired columns */
 EXTERN_MSC int MGD77_Get_Column (struct GMT_CTRL *GMT, char *word, struct MGD77_CONTROL *F);							/* Get column number from column name (or -1 if not present) */
 EXTERN_MSC int MGD77_Info_from_Abbrev (struct GMT_CTRL *GMT, char *name, struct MGD77_HEADER *H, int *set, int *item);

--- a/src/mgd77/mgd77list.c
+++ b/src/mgd77/mgd77list.c
@@ -712,6 +712,7 @@ static int parse (struct GMT_CTRL *GMT, struct MGD77LIST_CTRL *Ctrl, struct GMT_
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active[Q_C] && Ctrl->Q.min[Q_C] >= Ctrl->Q.max[Q_C], "Option -Qc: Minimum course change equals or exceeds maximum course change!\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active[Q_V] && (Ctrl->Q.min[Q_V] >= Ctrl->Q.max[Q_V] || Ctrl->Q.min[Q_V] < 0.0), "Option -Qv: Minimum velocity equals or exceeds maximum velocity or is negative!\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->D.start > Ctrl->D.stop, "Option -D: Start time exceeds stop time!\n");
+  n_errors += gmt_M_check_condition (GMT, Ctrl->F.active && MGD77_Verify_Columns (GMT, Ctrl->F.flags), "Option F: Invalid column names encountered\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }


### PR DESCRIPTION
**Description of proposed changes**

This is the first step to go to a mgd77list which stay successful when the requested fields (-F option) are missing in the file.

Add the function MGD77_Verify_Columns in mgd77.c to check if all the field names given to the -F option are valid.
Add a call to this function at the end of the parse function of mgd77list.

I wonder if we should not add a special "nan" field if the user wants to make room for further computations...

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
