### PR TITLE
Better check for earthtide and block* grid output selections

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12371,7 +12371,7 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 	unsigned int output_pos = 0, input_pos = 0, mod_pos;
 	int family = GMT_NOTSET;	/* -1, or one of GMT_IS_DATASET, GMT_IS_GRID, GMT_IS_PALETTE, GMT_IS_IMAGE */
 	int geometry = GMT_NOTSET;	/* -1, or one of GMT_IS_NONE, GMT_IS_TEXT, GMT_IS_POINT, GMT_IS_LINE, GMT_IS_POLY, GMT_IS_SURFACE */
-	int sdir, k, n_in_added = 0, n_to_add, e, n_pre_arg, n_per_family[GMT_N_FAMILIES];
+	int sdir, k = 0, n_in_added = 0, n_to_add, e, n_pre_arg, n_per_family[GMT_N_FAMILIES];
 	bool deactivate_output = false, deactivate_input = false, strip_colon = false, strip = false, is_grdmath = false;
 	size_t n_alloc, len;
 	const char *keys = NULL;	/* This module's option keys */
@@ -12479,14 +12479,12 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 		if (opt->arg[0]) {
 			for (k = 1, len = 0; len < strlen (opt->arg); len++) if (opt->arg[len] == ',') k++;
 		}
-		else
-			k = 1;	/* -A means -Az */
-		if ((opt = GMT_Find_Option (API, 'G', *head))) {	/* This is a problem */
-			if (!strcmp(opt->arg, "")) {
-				GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
-				return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
-			}
+		else if ((opt = GMT_Find_Option (API, 'G', *head)) && opt->arg[0] == '\0') {	/* This is a problem */
+			GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
+			return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
 		}
+		else	/* -A with no args means -Az */
+			k = 1;
 		while (k) {	/* Add -G? option k times */
 			new_ptr = GMT_Make_Option (API, 'G', "?");	/* Create new output grid option(s) with filename "?" */
 			*head = GMT_Append_Option (API, new_ptr, *head);
@@ -12499,16 +12497,12 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 		if ((opt = GMT_Find_Option (API, 'C', *head))) {	/* Determine how many output grids are requested */
 			for (k = 1, len = 0; len < strlen (opt->arg); len++) if (opt->arg[len] == ',') k++;
 		}
-		else
-			k = 1;	/* Default is the Gz grid */
-		if ((opt = GMT_Find_Option(API, 'G', *head))) {	/* This is a problem unless -G actually sent in a file name */
-			if (!strcmp(opt->arg, "")) {
-				GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
-				return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
-			}
-			else
-				return GMT_NOERROR;
+		else if ((opt = GMT_Find_Option(API, 'G', *head)) && opt->arg[0] == '\0') {	/* This is a problem unless -G actually sent in a file name */
+			GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
+			return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
 		}
+		else 	/* Default is the -Gz grid */
+			k = 1;
 		while (k) {	/* Add -G? option k times */
 			new_ptr = GMT_Make_Option (API, 'G', "?");	/* Create new output grid option(s) with filename "?" */
 			*head = GMT_Append_Option (API, new_ptr, *head);

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12481,11 +12481,11 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 			for (k = 1, len = 0; len < strlen (opt->arg); len++) if (opt->arg[len] == ',') k++;
 		}
 		if ((opt = GMT_Find_Option (API, 'G', *head))) {	/* This is a problem unless -G actually sent in a file name */
-			if (opt->arg[0] == '\0') {	/* This is a problem unless -G actually sent in a file name, in which case no -G? should be added */
+			if (opt->arg[0] == '\0') {	/* Cannot just give -G here */
 				GMT_Report (API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
-				return_null (NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
+				return_null (NULL, GMT_NOT_A_VALID_OPTION);
 			}
-			else	/* Gave an argument, no need to add -G? */
+			else	/* Gave a (presumably) file argument, no need to add -G? */
 				k = 0;
 		}
 		else	/* No -A or -G; default is to just add the z grid via -G?  */
@@ -12505,11 +12505,11 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 			for (k = 1, len = 0; len < strlen (opt->arg); len++) if (opt->arg[len] == ',') k++;
 		}
 		if ((opt = GMT_Find_Option(API, 'G', *head))) {	/* This is a problem unless -G actually sent in a file name */
-			if (opt->arg[0] == '\0') {	/* This is a problem unless -G actually sent in a file name, in which case no -G? should be added */
+			if (opt->arg[0] == '\0') {	/* Cannot just give -G here */
 				GMT_Report (API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G (with no argument) when called externally\n", module);
-				return_null (NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
+				return_null (NULL, GMT_NOT_A_VALID_OPTION);
 			}
-			else	/* Gave an argument, no need to add -G? */
+			else	/* Gave a (presumably) file argument, no need to add -G? */
 				k = 0;
 		}
 		else if (k == 0) 	/* No -C or -G; default is to just add the -Gz grid via -G? */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12483,7 +12483,7 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 			GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
 			return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
 		}
-		else	/* -A with no args means -Az */
+		else	/* -A with no args means just add the z grid */
 			k = 1;
 		while (k) {	/* Add -G? option k times */
 			new_ptr = GMT_Make_Option (API, 'G', "?");	/* Create new output grid option(s) with filename "?" */
@@ -12501,7 +12501,7 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 			GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
 			return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
 		}
-		else 	/* Default is the -Gz grid */
+		else 	/* Default is to just add the -Gz grid */
 			k = 1;
 		while (k) {	/* Add -G? option k times */
 			new_ptr = GMT_Make_Option (API, 'G', "?");	/* Create new output grid option(s) with filename "?" */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12475,48 +12475,51 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 	}
 	/* 1j. Check if this is a blockm* module using -A to set n output grids */
 	else if (!strncmp (module, "block", 5U) && (opt = GMT_Find_Option (API, 'A', *head))) {
-		/* Determine how many output grids are requested */
-		if (opt->arg[0]) {
+		/* Below, k is the number of under=the-hood -G? options we must add for returning grids to externals */
+		k = 0;	/* Make sure we initialize this first */
+		if (opt->arg[0]) {	/* Gave -A: Determine how many output grids are requested */
 			for (k = 1, len = 0; len < strlen (opt->arg); len++) if (opt->arg[len] == ',') k++;
 		}
-		else if ((opt = GMT_Find_Option (API, 'G', *head))) {	/* This is a problem */
-			if (opt->arg[0] == '\0') {	/* This is a problem */
-				GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
-				return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
+		if ((opt = GMT_Find_Option (API, 'G', *head))) {	/* This is a problem unless -G actually sent in a file name */
+			if (opt->arg[0] == '\0') {	/* This is a problem unless -G actually sent in a file name, in which case no -G? should be added */
+				GMT_Report (API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
+				return_null (NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
 			}
-			else
+			else	/* Gave an argument, no need to add -G? */
 				k = 0;
 		}
-		else	/* No -A with no args or -G means just add the z grid */
+		else	/* No -A or -G; default is to just add the z grid via -G?  */
 			k = 1;
 		while (k) {	/* Add -G? option k times */
 			new_ptr = GMT_Make_Option (API, 'G', "?");	/* Create new output grid option(s) with filename "?" */
 			*head = GMT_Append_Option (API, new_ptr, *head);
 			k--;
 		}
-		deactivate_output = true;	/* Turn off implicit table output since only secondary -G -G -G is in effect */
+		deactivate_output = true;	/* Turn off implicit table output since only secondary -G output(s) is in effect */
 	}
 	/* 1k. Check if this is the earthtide module requesting output grids */
 	else if (!strncmp (module, "earthtide", 9U) && !GMT_Find_Option (API, 'L', *head) && !GMT_Find_Option (API, 'S', *head)) {
-		if ((opt = GMT_Find_Option (API, 'C', *head))) {	/* Determine how many output grids are requested */
+		/* Below, k is the number of under=the-hood -G? options we must add for returning grids to externals */
+		k = 0;	/* Make sure we initialize this first */
+		if ((opt = GMT_Find_Option (API, 'C', *head))) {	/* Gave -C: Determine how many output grids are requested */
 			for (k = 1, len = 0; len < strlen (opt->arg); len++) if (opt->arg[len] == ',') k++;
 		}
-		else if ((opt = GMT_Find_Option(API, 'G', *head))) {	/* This is a problem unless -G actually sent in a file name */
-			if (opt->arg[0] == '\0') {	/* This is a problem unless -G actually sent in a file name */
-				GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
-				return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
+		if ((opt = GMT_Find_Option(API, 'G', *head))) {	/* This is a problem unless -G actually sent in a file name */
+			if (opt->arg[0] == '\0') {	/* This is a problem unless -G actually sent in a file name, in which case no -G? should be added */
+				GMT_Report (API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G (with no argument) when called externally\n", module);
+				return_null (NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
 			}
-			else
+			else	/* Gave an argument, no need to add -G? */
 				k = 0;
 		}
-		else 	/* No -C or -G; default is to just add the -Gz grid */
+		else if (k == 0) 	/* No -C or -G; default is to just add the -Gz grid via -G? */
 			k = 1;
 		while (k) {	/* Add -G? option k times */
 			new_ptr = GMT_Make_Option (API, 'G', "?");	/* Create new output grid option(s) with filename "?" */
 			*head = GMT_Append_Option (API, new_ptr, *head);
 			k--;
 		}
-		deactivate_output = true;	/* Turn off implicit table output since only secondary -G -G -G is in effect */
+		deactivate_output = true;	/* Turn off implicit table output since only secondary -G output(s) is in effect */
 	}
 	/* 1l. Check if this is makecpt using -E or -S with no args */
 	else if (!strncmp (module, "makecpt", 7U)) {

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12479,11 +12479,15 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 		if (opt->arg[0]) {
 			for (k = 1, len = 0; len < strlen (opt->arg); len++) if (opt->arg[len] == ',') k++;
 		}
-		else if ((opt = GMT_Find_Option (API, 'G', *head)) && opt->arg[0] == '\0') {	/* This is a problem */
-			GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
-			return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
+		else if ((opt = GMT_Find_Option (API, 'G', *head))) {	/* This is a problem */
+			if (opt->arg[0] == '\0') {	/* This is a problem */
+				GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
+				return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
+			}
+			else
+				k = 0;
 		}
-		else	/* -A with no args means just add the z grid */
+		else	/* No -A with no args or -G means just add the z grid */
 			k = 1;
 		while (k) {	/* Add -G? option k times */
 			new_ptr = GMT_Make_Option (API, 'G', "?");	/* Create new output grid option(s) with filename "?" */
@@ -12497,11 +12501,15 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 		if ((opt = GMT_Find_Option (API, 'C', *head))) {	/* Determine how many output grids are requested */
 			for (k = 1, len = 0; len < strlen (opt->arg); len++) if (opt->arg[len] == ',') k++;
 		}
-		else if ((opt = GMT_Find_Option(API, 'G', *head)) && opt->arg[0] == '\0') {	/* This is a problem unless -G actually sent in a file name */
-			GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
-			return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
+		else if ((opt = GMT_Find_Option(API, 'G', *head))) {	/* This is a problem unless -G actually sent in a file name */
+			if (opt->arg[0] == '\0') {	/* This is a problem unless -G actually sent in a file name */
+				GMT_Report(API, GMT_MSG_ERROR, "GMT_Encode_Options: %s cannot set -G when called externally\n", module);
+				return_null(NULL, GMT_NOT_A_VALID_OPTION);	/* Too many output objects */
+			}
+			else
+				k = 0;
 		}
-		else 	/* Default is to just add the -Gz grid */
+		else 	/* No -C or -G; default is to just add the -Gz grid */
 			k = 1;
 		while (k) {	/* Add -G? option k times */
 			new_ptr = GMT_Make_Option (API, 'G', "?");	/* Create new output grid option(s) with filename "?" */


### PR DESCRIPTION
This should allow externals to use -Gfile to write directly to file.  Hopefully, @joa-quim can check if this works as expected now.