### PR TITLE
Ensure xyz2grd -Z??a can handle NaNs

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -1218,7 +1218,8 @@ GMT_LOCAL int gmtio_a_read (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *
 	while ((--p != line) && strchr (" \t,\r\n", (int)*p));
 	*(p + 1) = '\0';
 	/* Convert whatever it is to double */
-	gmt_scanf (GMT, line, gmt_M_type (GMT, GMT_IN, GMT_Z), d);
+	if (gmt_scanf (GMT, line, gmt_M_type (GMT, GMT_IN, GMT_Z), d) == GMT_IS_NAN)
+		*d = GMT->session.d_NaN;
 	return (GMT_OK);
 }
 


### PR DESCRIPTION
_gmt_scanf_ correctly returned **GMT_IS_NAN** when encountering the "NaN", but it was not acted on by _gmtio_a_read_.  This is a particular case where the regular GMT i/o machinery gets redirected for reading single items (i.e., the flavors of **-Z**) and the ascii-reading function did not do what was needed when NaN was encountered.
Closes #4572.
