### PR TITLE
Update sighandler code for Apple Silicon M1 architecture

### DIFF
--- a/src/gmt_common_sighandler.c
+++ b/src/gmt_common_sighandler.c
@@ -58,6 +58,8 @@ void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 # if __DARWIN_UNIX03
 #  ifdef __x86_64__
 #   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__rip)
+#  elif __arm64__	/* Apple Silicon, e.g. M1 */
+#   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__pc)
 #  else
 #   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__eip)
 #  endif


### PR DESCRIPTION
The fix suggested in #4567 worked. Closes #4567.