### PR TITLE
Update gmtdefaults description

### DIFF
--- a/doc/rst/source/gmtdefaults.rst
+++ b/doc/rst/source/gmtdefaults.rst
@@ -23,13 +23,14 @@ Description
 **-D** is used. There are three ways to change some of the settings: (1)
 Use the command :doc:`gmtset`, (2) in classic mode you may use any text editor to edit the file
 :doc:`gmt.conf` in your home, ~/.gmt or current directory (if you do not
-have this file, run :doc:`gmtset` **-D** to get one with the system default
-settings), or (3) override any parameter by specifying one
+have this file, run :doc:`gmtdefaults` **-D** > gmt.conf to get one with the 
+system default settings), or (3) override any parameter by specifying one
 or more **-**\ **-PARAMETER**\ =\ *VALUE* statements on the command line of any
 GMT command (**PARAMETER** and *VALUE* are any combination listed
-below). The first two options are permanent changes until explicitly
-changed back, while the last option is ephemeral and only applies to the
-single GMT command that received the override. GMT can provide
+below). In classic mode, the first two options are permanent changes until 
+explicitly changed back, while the last option is ephemeral and only applies to 
+the single GMT command that received the override. In modern mode, changes made using
+`gmtset` stay in effect for the duration of the current session. GMT can provide
 default values in US or SI units. This choice is determined at compile time.
 
 Required Arguments

--- a/doc/rst/source/gmtdefaults.rst
+++ b/doc/rst/source/gmtdefaults.rst
@@ -30,7 +30,7 @@ GMT command (**PARAMETER** and *VALUE* are any combination listed
 below). In classic mode, the first two options are permanent changes until 
 explicitly changed back, while the last option is ephemeral and only applies to 
 the single GMT command that received the override. In modern mode, changes made using
-`gmtset` stay in effect for the duration of the current session. GMT can provide
+:doc:`gmtset` stay in effect for the duration of the current session. GMT can provide
 default values in US or SI units. This choice is determined at compile time.
 
 Required Arguments


### PR DESCRIPTION
**Description of proposed changes**

Updates gmtdefaults documentation to create gmt.conf using gmtdefaults rather then gmtset. Also specifies that gmtset changes settings for the duration of the current session in modern modern mode.

I could not find an similar example in the docs to determine whether "gmtdefaults -D > gmt.conf" should be formatted as in-line code or not. Please let me know if I should change that. 


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #4585 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
