### PR TITLE
Minor corrections to debug page

### DIFF
--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -126,7 +126,7 @@ Debug PyGMT in Xcode on macOS
 ------------------------------
 
 **Note**: Tested with Xcode 12.0.  Install PyGMT following the official instructions at https://www.pygmt.org/dev/install.
-If you already have the dev version then you may just need to `cd` into your pygmt dir and call git pull:
+If you already have the dev version then you may just need to run `conda activate pygmt` and `cd` into your pygmt dir and call git pull:
 
 #. Add conda-forge channel and activate virtual environment (optional)::
 
@@ -146,7 +146,7 @@ If you already have the dev version then you may just need to `cd` into your pyg
    directory created by xcodebuild so that PyGMT can find the GMT library, and set $GMT_SHAREDIR to point to the full path that
    contains the share directory.
 
-#. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
+#. Open Xcode, select scheme "libgmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
 
 #. Type python in the terminal to get a python console, attach the process id or name to Xcode (menu item Debug->Attach to Process by PID or Name),
@@ -171,7 +171,7 @@ done you can proceed to installing the master GMT.jl:
 
 #. When done, end package install mode by hitting backspace.
 
-#. Open Xcode, select scheme "gmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
+#. Open Xcode, select scheme "libgmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
 
 #. Attach the Julia process id or name in Xcode (menu item Debug->Attach to Process by PID or Name), and run GMT.jl


### PR DESCRIPTION
Best to select the libgmt scheme since gmt.c is not involved in these situations.  Also, clarify that if you already have installed pyGMT then you just need to git pull, activate, and cd to directory.
