### PR TITLE
Let movie check if prefix dir exist and then bail, as docs say we should

### DIFF
--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -266,13 +266,13 @@ build the pre.sh, main.sh, and post.sh scripts on the fly, hence we need to esca
 start with a dollar sign that we need to be written verbatim). At the end of the execution we find 20 grids
 (e.g., such as filter_07.grd), as well as the filter_std.grd file obtained by stacking all the individual
 scripts and computing a standard deviation. The information needed to do all of this is hidden from the user;
-the actual batch scripts that we execute are derived from the user-provided main.sh script and **batch***
+the actual batch scripts that we execute are derived from the user-provided main.sh script and **batch**
 supplies the extra machinery. The **batch** module automatically manages the parallel execution loop over all
 jobs using all available cores and launches new jobs as old ones complete.
 
 As another example, we get a list of all European countries and make a simple coast plot of each of them,
 placing their name in the title and the 2-character ISO code in the upper left corner, then in postflight
-we combine all the individual PDFs into a single file and delete them::
+we combine all the individual PDFs into a single PDF file and delete the individual files::
 
     cat << EOF > pre.sh
     gmt begin
@@ -291,7 +291,7 @@ we combine all the individual PDFs into a single file and delete them::
     EOF
     gmt batch main.sh -Sbpre.sh -Sfpost.sh -Tcountries.txt+w"\t" -Ncountries -V -W -Zs
 
-Here, the postflight script is not even a GMT script; it simply runs gs and deletes what we don't want.
+Here, the postflight script is not even a GMT script; it simply runs gs (Ghostscript) and deletes what we don't want to keep.
 
 See Also
 --------

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -87,6 +87,7 @@ Required Arguments
     Determines the name of the final movie file and a sub-directory with frame images (but see **-W**).
     **Note**: If the subdirectory exist then we exit immediately.  You are therefore required to remove any
     old directory by that name first.  This is done to prevent the accidental loss of valuable data.
+    You can prevent this issue by using **-Z** to delete the directory after a successful run.
 
 .. _-T:
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -9142,7 +9142,7 @@ int gmt_mkdir (const char *path)
 
 	/* Iterate the string */
 	p = (_path[1] == ':') ? _path + 3 : _path + 1;  /* Skip any leading X: drive designators */
-	while (*p) { /* Create intermediate directoreis recursively */
+	while (*p) { /* Create intermediate directories recursively */
 		if (*p == '/' || *p == '\\') {	/* Found start of next directory */
 			sep = *p;	/* What separator did we use? */
 			*p = '\0';	/* Temporarily truncate */

--- a/src/movie.c
+++ b/src/movie.c
@@ -345,6 +345,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, set a custom canvas with dimensions and dots-per-unit manually by\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     providing <width>x<height>x<dpu> (e.g., 15cx10cx50, 6ix6ix100, etc.).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Set the <prefix> used for movie files and directory names.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   The directory cannot already exist; see -Z to remove such directories at the end.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T Set number of frames, create times from <min>/<max>/<inc>[+n] or give file with frame-specific information.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If <min>/<max>/<inc> is used then +n is used to indicate that <inc> is in fact number of frames instead.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If <timefile> does not exist it must be created by the foreground script given via -Sf.\n");
@@ -1325,13 +1326,13 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	}
 	n_data_frames = n_frames;
 
-	if (Ctrl->W.active) {
-		if (Ctrl->W.dir)
+	if (Ctrl->W.active) {	/* Create the working directory under /tmp or a specified directory */
+		if (Ctrl->W.dir)	/* Make a subdirectory under this directory based on N.prefix */
 			strcpy (workdir, Ctrl->W.dir);
-		else 	/* Make one in tempdir based on N.prefix */
+		else	/* Make a subdirectory in the tempdir based on N.prefix */
 			sprintf (workdir, "%s/%s", API->tmp_dir, Ctrl->N.prefix);
 	}
-	else
+	else	/* Create N.prefix locally in the current directory */
 		strcpy (workdir, Ctrl->N.prefix);
 
 	/* Get full path to the current working directory */
@@ -1342,9 +1343,24 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	}
 	gmt_replace_backslash_in_path (topdir);
 
+	{	/* Block to check for existing workdir */
+		struct stat S;
+		int err = stat (workdir, &S);	/* Stat the workdir path (which may not exist) */
+		if (err == 0 && !S_ISDIR (S.st_mode)) {	/* Path already exists, but it is not a directory */
+			GMT_Report (API, GMT_MSG_ERROR, "A file named %s already exist and prevents us from creating a directory by that name; please delete file or adjust -N - exiting.\n", workdir);
+			movie_close_files (Ctrl);
+			Return (GMT_RUNTIME_ERROR);
+		}
+		else if (err == 0 && S_ISDIR (S.st_mode)) {	/* Directory already exists */
+			GMT_Report (API, GMT_MSG_ERROR, "Working directory %s already exist and -Z was not specified - exiting\n", workdir);
+			movie_close_files (Ctrl);
+			Return (GMT_RUNTIME_ERROR);
+		}
+	}
+
 	/* Create a working directory which will house every local file and all subdirectories created */
 	if (gmt_mkdir (workdir)) {
-		GMT_Report (API, GMT_MSG_ERROR, "An old directory named %s exists OR we were unable to create new working directory %s - exiting.\n", workdir, workdir);
+		GMT_Report (API, GMT_MSG_ERROR, "Unable to create new working directory %s - exiting.\n", workdir);
 		movie_close_files (Ctrl);
 		Return (GMT_RUNTIME_ERROR);
 	}
@@ -1357,7 +1373,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	}
 	/* Get full path to this working directory */
 	if (getcwd (cwd, PATH_MAX) == NULL) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to determine current working directory.\n");
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to determine current working directory - exiting.\n");
 		movie_close_files (Ctrl);
 		Return (GMT_RUNTIME_ERROR);
 	}


### PR DESCRIPTION
Now the code follows docs, and docs mention the use of **-Z** to avoid this "inconvenience".  Fixes a few unrelated typos as well.  Closes #4564.
