### PR TITLE
Use gmt_contour_edge_init to hide away confusing edge allocation

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -635,6 +635,7 @@ EXTERN_MSC void gmt_sort_array (struct GMT_CTRL *GMT, void *base, uint64_t n, un
 EXTERN_MSC bool gmt_polygon_is_open (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n);
 EXTERN_MSC int gmt_polygon_centroid (struct GMT_CTRL *GMT, double *x, double *y, uint64_t n, double *Cx, double *Cy);
 EXTERN_MSC int gmt_get_distance (struct GMT_CTRL *GMT, char *line, double *dist, char *unit);
+EXTERN_MSC unsigned int *gmt_contour_edge_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, unsigned int *n_edges);
 EXTERN_MSC int64_t gmt_contours (struct GMT_CTRL *GMT, struct GMT_GRID *Grid, unsigned int smooth_factor, unsigned int int_scheme, int orient, unsigned int *edge, bool *first, double **x, double **y);
 EXTERN_MSC int gmt_get_format (struct GMT_CTRL *GMT, double interval, char *unit, char *prefix, char *format);
 EXTERN_MSC int gmt_get_index (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double value);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -10839,6 +10839,15 @@ void gmt_symbol_free (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S) {
 		gmtsupport_decorate_free (GMT, &(S->D));
 }
 
+unsigned int *gmt_contour_edge_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, unsigned int *n_edges) {
+	/* Create and return the edge bit flag array used to keep track of contours and return now many edges */
+	unsigned int *edge = NULL;
+	*n_edges = header->n_rows * (urint (ceil (header->n_columns / 16.0)));
+	edge = gmt_M_memory (GMT, NULL, *n_edges, unsigned int);
+	if (edge == NULL) *n_edges = 0;	/* Disaster, but at least return consistent values */
+	return (edge);
+}
+
 /*! . */
 int64_t gmt_contours (struct GMT_CTRL *GMT, struct GMT_GRID *G, unsigned int smooth_factor, unsigned int int_scheme, int orient, unsigned int *edge, bool *first, double **x, double **y) {
 	/* The routine finds the zero-contour in the grd dataset.  it assumes that

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -1353,8 +1353,8 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		gmt_M_free (GMT, cont);
 		Return (GMT_RUNTIME_ERROR); /* Original copy of grid used for contouring */
 	}
-	n_edges = G->header->n_rows * (urint (ceil (G->header->n_columns / 16.0)));
-	edge = gmt_M_memory (GMT, NULL, n_edges, unsigned int);	/* Bit flags used to keep track of contours */
+
+	edge = gmt_contour_edge_init (GMT, G->header, &n_edges);
 
 	if (Ctrl->D.active) {
 		uint64_t dim[GMT_DIM_SIZE] = {0, 0, 0, 3};
@@ -1565,6 +1565,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		}
 		if (ns < 0) Return (-ns);
 	}
+	gmt_M_free (GMT, edge);
 
 	if (make_plot && n_cont_attempts == 0) GMT_Report (API, GMT_MSG_INFORMATION, "No contours drawn, check your -A, -C, -L settings?\n");
 
@@ -1630,7 +1631,6 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 
 	if (Ctrl->contour.save_labels) {	/* Close file with the contour label locations (lon, lat, angle, label) */
 		if ((error = gmt_contlabel_save_end (GMT, &Ctrl->contour)) != 0) {
-			gmt_M_free (GMT, edge);
 			gmt_M_free (GMT, cont);
 			Return (error);
 		}
@@ -1643,7 +1643,6 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 	if (GMT_Destroy_Data (GMT->parent, &G_orig) != GMT_NOERROR) {
 		GMT_Report (API, GMT_MSG_ERROR, "Failed to free G_orig\n");
 	}
-	gmt_M_free (GMT, edge);
 	gmt_M_free (GMT, cont);
 
 	Return (GMT_NOERROR);

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -791,8 +791,8 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 	bool get_contours, bad, pen_set, begin, saddle, drape_resample = false;
 	bool nothing_inside = false, use_intensity_grid, do_G_reading = true;
 
-	unsigned int c, nk, n4, row, col, n_edges, d_reg[3], i_reg = 0, id[2], good;
-	unsigned int t_reg, n_out, k, k1, ii, jj, PS_colormask_off = 0, *edge = NULL;
+	unsigned int c, nk, n4, row, col, d_reg[3], i_reg = 0, id[2], good;
+	unsigned int t_reg, n_out, k, k1, ii, jj, PS_colormask_off = 0;
 
 	int i, j, i_bin, j_bin, i_bin_old, j_bin_old, way, bin_inc[4], ij_inc[4], error = 0;
 	int start[2], stop[2], inc[2];
@@ -1063,10 +1063,11 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 	y_inc[0] = y_inc[1] = 0.0;	y_inc[2] = y_inc[3] = Z->header->inc[GMT_Y];
 
 	if (get_contours) {	/* Need to find contours */
+		unsigned int n_edges, *edge = NULL;
 		struct GMT_GRID *Z_orig = NULL;
 		GMT_Report (API, GMT_MSG_INFORMATION, "Find contours\n");
-		n_edges = Z->header->n_rows * (urint (ceil (Z->header->n_columns / 16.0)));
-		edge = gmt_M_memory (GMT, NULL, n_edges, unsigned int);
+
+		edge = gmt_contour_edge_init (GMT, Z->header, &n_edges);
 		binij = gmt_M_memory (GMT, NULL, Topo->header->nm, struct GRDVIEW_BIN);
 		if ((Z_orig = GMT_Duplicate_Data (API, GMT_IS_GRID, GMT_DUPLICATE_DATA, Z)) == NULL) {
 			gmt_M_free (GMT, edge);		gmt_M_free (GMT, binij);

--- a/src/psmask.c
+++ b/src/psmask.c
@@ -873,8 +873,7 @@ EXTERN_MSC int GMT_psmask (void *V_API, int mode, void *args) {
 			x = gmt_M_memory (GMT, NULL, max_alloc_points, double);
 			y = gmt_M_memory (GMT, NULL, max_alloc_points, double);
 
-			n_edges = Grid->header->n_rows * (urint (ceil (Grid->header->n_columns / 16.0)));
-			edge = gmt_M_memory (GMT, NULL, n_edges, unsigned int);
+			edge = gmt_contour_edge_init (GMT, Grid->header, &n_edges);
 
 			GMT_Report (API, GMT_MSG_INFORMATION, "Tracing the clip path\n");
 


### PR DESCRIPTION
All modules needing to call _gmt_contours_ need to set up an edge bit array.  This new function _gmt_contour_edge_init_  is now used across GMT rather than leaving mysterious bit flag allocations.
