### PR TITLE
Install TeXLive on Linux for testing

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -65,7 +65,7 @@ jobs:
 
           - name: Linux - Tests
             os: ubuntu-latest
-            run_in_pr : true
+            run_in_pr : false
             BUILD_DOCS  : false
             DEPLOY_DOCS : false
             PACKAGE     : false

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -65,7 +65,7 @@ jobs:
 
           - name: Linux - Tests
             os: ubuntu-latest
-            run_in_pr : false
+            run_in_pr : true
             BUILD_DOCS  : false
             DEPLOY_DOCS : false
             PACKAGE     : false

--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -32,6 +32,7 @@ fi
 # packages for running GMT tests
 if [ "$RUN_TESTS" = "true" ]; then
     packages+=" graphicsmagick gdal-bin"
+    packages+=" texlive-latex-base texlive-binaries texlive-fonts-recommended"
 fi
 
 # Install packages


### PR DESCRIPTION
**Description of proposed changes**

To test the LaTeX integration in #4566, we need to have latex, dvips and required fonts installed.

Installing LaTeX on macOS and Windows are difficult, but much easier on Linux.

This PR installs the required LaTeX packages on Ubuntu, so that we can at least run the tests on Linux.


Note: Ubuntu users only need to install these three packages `texlive-latex-base texlive-binaries texlive-fonts-recommended`.
