### PR TITLE
Allow up to 64-character font-names in postscriptlight.c

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6335,11 +6335,11 @@ GMT_LOCAL int gmtinit_init_fonts (struct GMT_CTRL *GMT) {
 				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Trouble decoding custom font info [%s].  Skipping this font.\n", buf);
 				continue;
 			}
-			if (strlen (fullname) >= GMT_LEN32) {
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Font %s exceeds %d characters and will be truncated\n", fullname, GMT_LEN32);
-				fullname[GMT_LEN32-1] = '\0';
+			if (strlen (fullname) >= GMT_LEN64) {
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Font %s exceeds %d characters and will be truncated\n", fullname, GMT_LEN64);
+				fullname[GMT_LEN64-1] = '\0';
 			}
-			strncpy (GMT->session.font[i].name, fullname, GMT_LEN32-1);
+			strncpy (GMT->session.font[i].name, fullname, GMT_LEN64);
 			i++;
 		}
 		fclose (in);

--- a/src/gmt_texture.h
+++ b/src/gmt_texture.h
@@ -87,7 +87,7 @@ struct GMT_FONT {
 
 /*! Holds information for each predefined font [Matches PSL_FONT structure] */
 struct GMT_FONTSPEC {
-	char name[GMT_LEN32];	/* Name of the font */
+	char name[GMT_LEN64];	/* Name of the font */
 	double height;		/* Height of letter "A" for unit fontsize */
 	int encode;
 	int encode_orig;

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -3264,11 +3264,11 @@ static int psl_init_fonts (struct PSL_CTRL *PSL) {
 				PSL_message (PSL, PSL_MSG_ERROR, "Warning: Trouble decoding custom font info [%s].  Skipping this font\n", buf);
 				continue;
 			}
-			if (strlen (fullname) >= (PSL_NAME_LEN-1)) {
+			if (strlen (fullname) >= PSL_NAME_LEN) {
 				PSL_message (PSL, PSL_MSG_ERROR, "Warning: Font name %s exceeds %d characters and will be truncated\n", fullname, PSL_NAME_LEN);
 				fullname[PSL_NAME_LEN-1] = '\0';
 			}
-			strncpy (PSL->internal.font[i].name, fullname, PSL_NAME_LEN-1);
+			strncpy (PSL->internal.font[i].name, fullname, PSL_NAME_LEN);
 			i++;
 			if (i == n_alloc) {
 				n_alloc <<= 1;

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -3264,7 +3264,7 @@ static int psl_init_fonts (struct PSL_CTRL *PSL) {
 				PSL_message (PSL, PSL_MSG_ERROR, "Warning: Trouble decoding custom font info [%s].  Skipping this font\n", buf);
 				continue;
 			}
-			if (strlen (fullname) >= PSL_NAME_LEN) {
+			if (strlen (fullname) >= (PSL_NAME_LEN-1)) {
 				PSL_message (PSL, PSL_MSG_ERROR, "Warning: Font name %s exceeds %d characters and will be truncated\n", fullname, PSL_NAME_LEN);
 				fullname[PSL_NAME_LEN-1] = '\0';
 			}

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -154,7 +154,7 @@ enum PSL_enum_const {PSL_CM	= 0,
 	PSL_MAX_EPS_FONTS	= 6,
 	PSL_MAX_DIMS		= 13,		/* Max number of dim arguments to PSL_plot_symbol */
 	PSL_N_PATTERNS		= 91,		/* Current number of predefined patterns + 1, # 91 is user-supplied */
-	PSL_NAME_LEN		= 32,		/* Max length of font names */
+	PSL_NAME_LEN		= 64,		/* Max length of font names */
 	PSL_BUFSIZ		= 4096U};
 
 /* PSL codes for pen movements (used by PSL_plotpoint, PSL_plotline, PSL_plotarc) */


### PR DESCRIPTION
Closes #4605.
