### PR TITLE
Use PSL_FONTNAME_LEN in both gmt and PSL

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6339,11 +6339,11 @@ GMT_LOCAL int gmtinit_init_fonts (struct GMT_CTRL *GMT) {
 				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Trouble decoding custom font info [%s].  Skipping this font.\n", buf);
 				continue;
 			}
-			if (strlen (fullname) >= GMT_LEN64) {
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Font %s exceeds %d characters and will be truncated\n", fullname, GMT_LEN64);
-				fullname[GMT_LEN64-1] = '\0';
+			if (strlen (fullname) >= PSL_FONTNAME_LEN) {
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Font %s exceeds %d characters and will be truncated\n", fullname, PSL_FONTNAME_LEN);
+				fullname[PSL_FONTNAME_LEN-1] = '\0';
 			}
-			strncpy (GMT->session.font[i].name, fullname, GMT_LEN64);
+			strncpy (GMT->session.font[i].name, fullname, PSL_FONTNAME_LEN);
 			i++;
 		}
 		fclose (in);

--- a/src/gmt_texture.h
+++ b/src/gmt_texture.h
@@ -87,7 +87,7 @@ struct GMT_FONT {
 
 /*! Holds information for each predefined font [Matches PSL_FONT structure] */
 struct GMT_FONTSPEC {
-	char name[GMT_LEN64];	/* Name of the font */
+	char name[PSL_FONTNAME_LEN];	/* Name of the font */
 	double height;		/* Height of letter "A" for unit fontsize */
 	int encode;
 	int encode_orig;

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -3268,11 +3268,11 @@ static int psl_init_fonts (struct PSL_CTRL *PSL) {
 				PSL_message (PSL, PSL_MSG_ERROR, "Warning: Trouble decoding custom font info [%s].  Skipping this font\n", buf);
 				continue;
 			}
-			if (strlen (fullname) >= PSL_NAME_LEN) {
-				PSL_message (PSL, PSL_MSG_ERROR, "Warning: Font name %s exceeds %d characters and will be truncated\n", fullname, PSL_NAME_LEN);
-				fullname[PSL_NAME_LEN-1] = '\0';
+			if (strlen (fullname) >= PSL_FONTNAME_LEN) {
+				PSL_message (PSL, PSL_MSG_ERROR, "Warning: Font name %s exceeds %d characters and will be truncated\n", fullname, PSL_FONTNAME_LEN);
+				fullname[PSL_FONTNAME_LEN-1] = '\0';
 			}
-			strncpy (PSL->internal.font[i].name, fullname, PSL_NAME_LEN);
+			strncpy (PSL->internal.font[i].name, fullname, PSL_FONTNAME_LEN);
 			i++;
 			if (i == n_alloc) {
 				n_alloc <<= 1;

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -154,7 +154,7 @@ enum PSL_enum_const {PSL_CM	= 0,
 	PSL_MAX_EPS_FONTS	= 6,
 	PSL_MAX_DIMS		= 13,		/* Max number of dim arguments to PSL_plot_symbol */
 	PSL_N_PATTERNS		= 91,		/* Current number of predefined patterns + 1, # 91 is user-supplied */
-	PSL_NAME_LEN		= 64,		/* Max length of font names */
+	PSL_FONTNAME_LEN	= 64,		/* Max length of font names */
 	PSL_BUFSIZ		= 4096U};
 
 /* PSL codes for pen movements (used by PSL_plotpoint, PSL_plotline, PSL_plotarc) */
@@ -264,7 +264,7 @@ enum PSL_enum_err {PSL_BAD_VALUE = -99,	/* Bad value */
  *--------------------------------------------------------------------*/
 
 struct PSL_FONT {	/* Definition */
-	char name[PSL_NAME_LEN];/* Name of this font */
+	char name[PSL_FONTNAME_LEN];/* Name of this font */
 	double height;		/* Height of A for unit fontsize */
 	int encoded;		/* true if we never should re-encode this font (e.g. symbols) */
 				/* This is also changed to true after we do re-encode a font */


### PR DESCRIPTION
Having separate constants for the max length of font names shared between GMT and PSL is silly and prone to a but down the line.  Now we use **PSL_FONTNAME_LEN** only [64].  This PR is a follow-up to #4608.
