### PR TITLE
Replace MAP_FRAME_TYPE fancy+ by fancy-rounded

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -653,7 +653,7 @@ MAP Parameters
 
     **MAP_FRAME_TYPE**
         Choose between **inside**, **plain** and **fancy** (thick boundary,
-        alternating black/white frame; append **+** for rounded corners)
+        alternating black/white frame; append **-rounded** for rounded corners)
         [fancy]. For some map projections (e.g., Oblique Mercator), plain is
         the only option even if fancy is set as default. In general, fancy
         only applies to situations where the projected x and y directions

--- a/doc/scripts/GMT_-B_geo_2.sh
+++ b/doc/scripts/GMT_-B_geo_2.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_-B_geo_2
 	gmt set FORMAT_GEO_MAP ddd:mm:ssF FONT_ANNOT_PRIMARY +9p
-	gmt basemap -R-2/1/0/0.35 -JM4i -Bpa15mf5mg5m -BwSe -Bs1f30mg15m --MAP_FRAME_TYPE=fancy+ \
+	gmt basemap -R-2/1/0/0.35 -JM4i -Bpa15mf5mg5m -BwSe -Bs1f30mg15m --MAP_FRAME_TYPE=fancy-rounded \
 		--MAP_GRID_PEN_PRIMARY=thinnest,black,. --MAP_GRID_CROSS_SIZE_SECONDARY=0.1i \
 		--MAP_FRAME_WIDTH=0.075i --MAP_TICK_LENGTH_PRIMARY=0.1i
 	gmt plot -Sv0.03i+b+e+jc -W0.5p -Gblack -Y-0.5i -N << EOF

--- a/doc/scripts/GMT_general_cyl.sh
+++ b/doc/scripts/GMT_general_cyl.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -R-145/215/-90/90 -JY35/30/12c -B45g45 -Dc -A10000 -Sdodgerblue -Wthinnest --MAP_FRAME_TYPE=fancy+ -ps GMT_general_cyl
+gmt coast -R-145/215/-90/90 -JY35/30/12c -B45g45 -Dc -A10000 -Sdodgerblue -Wthinnest --MAP_FRAME_TYPE=fancy-rounded -ps GMT_general_cyl

--- a/doc/scripts/GMT_mercator.sh
+++ b/doc/scripts/GMT_mercator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 gmt begin GMT_mercator
-	gmt set MAP_FRAME_TYPE fancy+
+	gmt set MAP_FRAME_TYPE fancy-rounded
 	gmt coast -R0/360/-70/70 -Jm0.03c -Bxa60f15 -Bya30f15 -Dc -A5000 -Gred
 gmt end show

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10003,7 +10003,9 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			}
 			else if (!strcmp (lower_value, "fancy"))
 				GMT->current.setting.map_frame_type = GMT_IS_FANCY;
-			else if (!strcmp (lower_value, "fancy+"))
+			else if (!strcmp (lower_value, "fancy-rounded"))
+				GMT->current.setting.map_frame_type = GMT_IS_ROUNDED;
+			else if (!strcmp (lower_value, "fancy+"))	/* Deprecated */
 				GMT->current.setting.map_frame_type = GMT_IS_ROUNDED;
 			else if (!strcmp (lower_value, "inside"))
 				GMT->current.setting.map_frame_type = GMT_IS_INSIDE;
@@ -11524,7 +11526,7 @@ char *gmtlib_putparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			else if (GMT->current.setting.map_frame_type == GMT_IS_FANCY)
 				strcpy (value, "fancy");
 			else if (GMT->current.setting.map_frame_type == GMT_IS_ROUNDED)
-				strcpy (value, "fancy+");
+				strcpy (value, "fancy-rounded");
 			else if (GMT->current.setting.map_frame_type == GMT_IS_INSIDE)
 				strcpy (value, "inside");
 			else


### PR DESCRIPTION
A trailing + is not great when modifier syntax (and eventual conversion to long-format options) is concerned.  I have replaced it with **fancy-rounded** but supporting **fancy+** for backwards compatibility.  This also opens the door for other **fancy**-* variants down the road.
PS. I also fixed the discussion for **MAP_FRAME_AXES** with talked about adding **+** instead of **+b** for 2-D cube but did so directly to master.