### PR TITLE
Save the GMT->common.R structure in a new GMT->hidden.common_R so that it can be accessed by externals

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -15101,6 +15101,18 @@ EXTERN_MSC void * gmtlib_get_ctrl (void *V_API) {
 	return API->GMT;	/* Pass back the GMT ctrl pointer as void pointer */
 }
 
+EXTERN_MSC void *gmtlib_get_common_R (void *V_API) {
+	/* For external environments that need to access GMT->common.R */
+	struct GMTAPI_CTRL *API = NULL;
+	struct COMMON_R R;
+
+	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
+	API = gmtapi_get_api_ptr (V_API);
+	gmt_M_memcpy (&R, &API->GMT->hidden.common_R, 1, struct COMMON_R);
+
+	return &R;	/* Pass back the GMT ctrl pointer as void pointer */
+}
+
 int64_t gmt_eliminate_duplicates (struct GMTAPI_CTRL *API, struct GMT_DATASET *D, uint64_t cols[], uint64_t ncols, bool text) {
 	/* Scan dataset per segment and eliminate any duplicate records as identified by having no change in all the specified cols.
 	 * If no change then we skip the duplicate records.  No segment will be eliminated since first record always survives.

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -15101,16 +15101,15 @@ EXTERN_MSC void * gmtlib_get_ctrl (void *V_API) {
 	return API->GMT;	/* Pass back the GMT ctrl pointer as void pointer */
 }
 
-EXTERN_MSC void *gmtlib_get_common_R (void *V_API) {
+EXTERN_MSC int gmtlib_get_common_R (void *V_API, struct COMMON_R *R) {
 	/* For external environments that need to access GMT->common.R */
 	struct GMTAPI_CTRL *API = NULL;
-	struct COMMON_R R;
 
-	if (V_API == NULL) return_null (V_API, GMT_NOT_A_SESSION);
+	if (V_API == NULL) { gmtlib_report_error(API,GMT_NOT_A_SESSION); return -1;}
 	API = gmtapi_get_api_ptr (V_API);
-	gmt_M_memcpy (&R, &API->GMT->hidden.common_R, 1, struct COMMON_R);
+	gmt_M_memcpy (R, &API->GMT->hidden.common_R, 1, struct COMMON_R);
 
-	return &R;	/* Pass back the GMT ctrl pointer as void pointer */
+	return 0;
 }
 
 int64_t gmt_eliminate_duplicates (struct GMTAPI_CTRL *API, struct GMT_DATASET *D, uint64_t cols[], uint64_t ncols, bool text) {

--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -75,6 +75,19 @@ struct GMT_LEGEND_ITEM {	/* Information about one item in a legend */
 	unsigned int ID;		/* ID to use if label contains C-format for integer */
 };
 
+/* If this struct is ever changed, Julia must know about it */
+struct COMMON_R {          /* -Rw/e/s/n[/z_min/z_max][r] or -Rgridfile */
+	bool active[4];		   /* RSET = 0: -R, ISET = 1: inc, GSET = 2: -r, FSET = 3: read grid */
+	bool oblique;		   /* true when -R...r was given (oblique map, probably), else false (map borders are meridians/parallels) */
+	uint32_t registration; /* Registration mode of a grid given via -r or -Rgrid */
+	int row_order;		   /* Order of rows in NetCDF output: 0 (not set) or k_nc_start_north or k_nc_start_south */
+	unsigned int mode;	   /* For modern mode only: 0 = get exact region from data, 1 = rounded region from data */
+	double wesn[6];		   /* Boundaries of west, east, south, north, low-z and hi-z */
+	double wesn_orig[4];   /* Original Boundaries of west, east, south, north (oblique projection may reset wesn above) */
+	double inc[2];		   /* For grid increments set via -Idx/dy or implicitly via -Ggrid */
+	char string[GMT_LEN256];
+};
+
 /*! Structure with all information given via the common GMT command-line options -R -J .. */
 struct GMT_COMMON {
 	struct synopsis {	/* \0 (zero) or ^ */
@@ -104,17 +117,7 @@ struct GMT_COMMON {
 	struct P {	/* -P */
 		bool active;
 	} P;
-	struct R {	/* -Rw/e/s/n[/z_min/z_max][r] or -Rgridfile */
-		bool active[4];	/* RSET = 0: -R, ISET = 1: inc, GSET = 2: -r, FSET = 3: read grid */
-		bool oblique;	/* true when -R...r was given (oblique map, probably), else false (map borders are meridians/parallels) */
-		uint32_t registration;	/* Registration mode of a grid given via -r or -Rgrid */
-		int row_order;	/* Order of rows in NetCDF output: 0 (not set) or k_nc_start_north or k_nc_start_south */
-		unsigned int mode;	/* For modern mode only: 0 = get exact region from data, 1 = rounded region from data */
-		double wesn[6];		/* Boundaries of west, east, south, north, low-z and hi-z */
-		double wesn_orig[4];	/* Original Boundaries of west, east, south, north (oblique projection may reset wesn above) */
-		double inc[2];	/* For grid increments set via -Idx/dy or implicitly via -Ggrid */
-		char string[GMT_LEN256];
-	} R;
+	struct COMMON_R R;
 	struct U {	/* -U */
 		bool active;
 		unsigned int just;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14675,6 +14675,9 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 
 	gmtlib_fft_cleanup (GMT); /* Clean FFT resources */
 
+	/* Before resetting GMT, copy common_R into GMT->hiden.common_R, but we have to do it indirectly */
+	gmt_M_memcpy (&Ccopy->hidden.common_R, &GMT->common.R, 1, struct COMMON_R);
+
 	/* Overwrite GMT with what we saved in gmt_init_module */
 	gmt_M_memcpy (GMT, Ccopy, 1, struct GMT_CTRL);	/* Overwrite struct with things from Ccopy */
 	/* ALL POINTERS IN GMT ARE NOW JUNK AGAIN */

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -391,6 +391,7 @@ struct GMT_INTERNAL {
 	double **mem_coord;		/* Columns of temp memory */
 	char **mem_txt;			/* For temp text */
 	struct MEMORY_TRACKER *mem_keeper;	/* Only filled when #ifdef MEMDEBUG  */
+	struct COMMON_R common_R;	/* gmt_end_module saves API->GMT->common.R here so we can access it from externals */
 #ifdef DEBUG
 	bool gridline_debug;
 	char gridline_kind;


### PR DESCRIPTION
In order to be able to guess a reasonable projection from the map limits it is necessary to know, for example, what **-RDE** has turned to in terms of lon/lat. Currently I use the trick of asking ``gmt2kml`` the boundingbox only and then parse the output kml. But this is cumbersome and slow.

This PR adds a new struct, ``GMT->common.R`` to ``GMT->hidden`` and a new function ``void *gmtlib_get_common_R (void *V_API)`` that allows easy access to the **R** settings from Julia. Possibly a similar solution for ``common.J`` would be interesting too but I have not yet add a need for it. 