### PR TITLE
Fix GMT_Get_Common so it works outside a module

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12920,55 +12920,55 @@ int GMT_Get_Common (void *V_API, unsigned int option, double par[]) {
 	GMT = API->GMT;
 
 	switch (option) {
-		case 'B':	if (GMT->common.B.active[0] || GMT->common.B.active[1]) ret = 0; break;
+		case 'B':	if (API->common_snapshot->B.active[0] || API->common_snapshot->B.active[1]) ret = 0; break;
 		case 'I':
-			if (GMT->common.R.active[ISET]) {
+			if (API->common_snapshot->R.active[ISET]) {
 				ret = 2;
-				if (par) gmt_M_memcpy (par, GMT->common.R.inc, 2, double);
+				if (par) gmt_M_memcpy (par, API->common_snapshot->R.inc, 2, double);
 			}
 			break;
-		case 'J':	if (GMT->common.J.active) ret = 0; break;
-		case 'K':	if (GMT->common.K.active) ret = 0; break;
-		case 'O':	if (GMT->common.O.active) ret = 0; break;
-		case 'P':	if (GMT->common.P.active) ret = 0; break;
+		case 'J':	if (API->common_snapshot->J.active) ret = 0; break;
+		case 'K':	if (API->common_snapshot->K.active) ret = 0; break;
+		case 'O':	if (API->common_snapshot->O.active) ret = 0; break;
+		case 'P':	if (API->common_snapshot->P.active) ret = 0; break;
 		case 'R':
-			if (GMT->common.R.active[RSET]) {
+			if (API->common_snapshot->R.active[RSET]) {
 				ret = 4;
-				if (par) gmt_M_memcpy (par, GMT->common.R.wesn, 4, double);
+				if (par) gmt_M_memcpy (par, API->common_snapshot->R.wesn, 4, double);
 			}
 			break;
-		case 'U':	if (GMT->common.U.active) ret = 0; break;
-		case 'V':	if (GMT->common.V.active) ret = GMT->current.setting.verbose; break;
+		case 'U':	if (API->common_snapshot->U.active) ret = 0; break;
+		case 'V':	if (API->common_snapshot->V.active) ret = GMT->current.setting.verbose; break;
 		case 'X':
-			if (GMT->common.X.active) {
+			if (API->common_snapshot->X.active) {
 				ret = 1;
-				if (par) par[0] = GMT->common.X.off;
+				if (par) par[0] = API->common_snapshot->X.off;
 			}
 			break;
 		case 'Y':
-			if (GMT->common.Y.active) {
+			if (API->common_snapshot->Y.active) {
 				ret = 1;
-				if (par) par[0] = GMT->common.Y.off;
+				if (par) par[0] = API->common_snapshot->Y.off;
 			}
 			break;
-		case 'a':	if (GMT->common.a.active) ret = GMT->common.a.geometry; break;
-		case 'b':	if (GMT->common.b.active[GMT_IN]) ret = GMT_IN; else if (GMT->common.b.active[GMT_OUT]) ret = GMT_OUT; break;
-		case 'f':	if (GMT->common.f.active[GMT_IN]) ret = GMT_IN; else if (GMT->common.f.active[GMT_OUT]) ret = GMT_OUT; break;
-		case 'g':	if (GMT->common.g.active) ret = 0; break;
-		case 'h':	if (GMT->common.h.active) ret = GMT->common.h.mode; break;
-		case 'i':	if (GMT->common.i.select) ret = (int)GMT->common.i.n_cols; break;
-		case 'n':	if (GMT->common.n.active) ret = 0; break;
-		case 'o':	if (GMT->common.o.select) ret = (int)GMT->common.o.n_cols; break;
-		case 'p':	if (GMT->common.p.active) ret = 0; break;
-		case 'r':	if (GMT->common.R.active[GSET]) ret = GMT->common.R.registration; break;
-		case 's':	if (GMT->common.s.active) ret = 0; break;
+		case 'a':	if (API->common_snapshot->a.active) ret = API->common_snapshot->a.geometry; break;
+		case 'b':	if (API->common_snapshot->b.active[GMT_IN]) ret = GMT_IN; else if (API->common_snapshot->b.active[GMT_OUT]) ret = GMT_OUT; break;
+		case 'f':	if (API->common_snapshot->f.active[GMT_IN]) ret = GMT_IN; else if (API->common_snapshot->f.active[GMT_OUT]) ret = GMT_OUT; break;
+		case 'g':	if (API->common_snapshot->g.active) ret = 0; break;
+		case 'h':	if (API->common_snapshot->h.active) ret = API->common_snapshot->h.mode; break;
+		case 'i':	if (API->common_snapshot->i.select) ret = (int)API->common_snapshot->i.n_cols; break;
+		case 'n':	if (API->common_snapshot->n.active) ret = 0; break;
+		case 'o':	if (API->common_snapshot->o.select) ret = (int)API->common_snapshot->o.n_cols; break;
+		case 'p':	if (API->common_snapshot->p.active) ret = 0; break;
+		case 'r':	if (API->common_snapshot->R.active[GSET]) ret = API->common_snapshot->R.registration; break;
+		case 's':	if (API->common_snapshot->s.active) ret = 0; break;
 		case 't':
-			if (GMT->common.t.active) {
+			if (API->common_snapshot->t.active) {
 				ret = 2;
-				if (par) gmt_M_memcpy (par, GMT->common.t.value, 2, double);
+				if (par) gmt_M_memcpy (par, API->common_snapshot->t.value, 2, double);
 			}
 			break;
-		case ':':	if (GMT->common.colon.toggle[GMT_IN]) ret = GMT_IN; else if (GMT->common.colon.toggle[GMT_OUT]) ret = GMT_OUT; break;
+		case ':':	if (API->common_snapshot->colon.toggle[GMT_IN]) ret = GMT_IN; else if (API->common_snapshot->colon.toggle[GMT_OUT]) ret = GMT_OUT; break;
 		default:
 			gmtlib_report_error (API, GMT_OPTION_NOT_FOUND);
 			break;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12831,6 +12831,8 @@ void gmt_end (struct GMT_CTRL *GMT) {
 	gmt_M_str_free (GMT->hidden.mem_keeper);
 #endif
 
+	gmt_M_free (GMT, GMT->parent->common_snapshot);	/* Free snapshot */
+
 	gmtinit_free_GMT_ctrl (GMT);	/* Deallocate control structure */
 }
 
@@ -14674,6 +14676,8 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 	gmtinit_free_dirnames (GMT);		/* Wipe previous dir names */
 
 	gmtlib_fft_cleanup (GMT); /* Clean FFT resources */
+
+	gmt_M_memcpy (GMT->parent->common_snapshot, &GMT->common, 1, struct GMT_COMMON);	/* Get a common option snapshot */
 
 	/* Overwrite GMT with what we saved in gmt_init_module */
 	gmt_M_memcpy (GMT, Ccopy, 1, struct GMT_CTRL);	/* Overwrite struct with things from Ccopy */
@@ -17043,6 +17047,8 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 	gmtlib_fft_initialization (GMT);	/* Determine which FFT algos are available and set pointers */
 
 	gmtinit_set_today (GMT);	/* Determine today's rata die value */
+
+	API->common_snapshot = gmt_M_memory (GMT, NULL, 1U, struct GMT_COMMON);	/* For holding snapshots of common options */
 
 	return (GMT);
 }

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -69,6 +69,7 @@ enum GMT_enum_pars {GMTAPI_TYPE = 0,	/* ipar[0] = data type (GMTAPI_{BYTE|SHORT|
  *===================================================================================*/
 
 struct GMT_CTRL; /* forward declaration of GMT_CTRL */
+struct GMT_COMMON; /* forward declaration of GMT_COMMON */
 
 struct GMTAPI_DATA_OBJECT {
 	/* Information for each input or output data entity, including information
@@ -206,6 +207,7 @@ struct GMTAPI_CTRL {
 	int n_remote_info;	/* How many remote server files we know of */
 	struct GMT_DATA_INFO *remote_info;
 	bool server_announced;	/* Set to true after we have announced which GMT data server we are using */
+	struct GMT_COMMON *common_snapshot;	/* Holds the latest GMT common option settings after a module completes. */
 };
 
 /* Macro to test if filename is a special name indicating memory location */


### PR DESCRIPTION
_GMT_Get_Common_ can report back the current settings of GMT common options like **-R -I**.  However, because modules destroy the GMT struct copy we instead make a snapshot at the end of a module of the full GMT common structure and let _GMT_Get_Common_ report values from it instead.
