### PR TITLE
Add MAP_FRAME_PERCENT to control fancy frame fat pen width

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -651,6 +651,10 @@ MAP Parameters
     **MAP_FRAME_PEN**
         Pen attributes used to draw plain map frame [thicker,black].
 
+    **MAP_FRAME_PERCENT**
+        Percentage of the fancy frame width to use for the internal checkerboard
+        frame lines [100].
+
     **MAP_FRAME_TYPE**
         Choose between **inside**, **plain** and **fancy** (thick boundary,
         alternating black/white frame; append **-rounded** for rounded corners)

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -133,6 +133,7 @@ struct GMT_DEFAULTS {
 	double map_annot_offset[2];		/* Distance between primary or secondary annotation and tickmarks [5p/5p] */
 	double map_annot_min_angle;		/* If angle between map boundary and annotation is less, no annotation is drawn [20] */
 	double map_annot_min_spacing;	/* If an annotation is closer that this to an older annotation, the annotation is skipped [0.0] */
+	double map_frame_percent;		/* Percentage of fancy map frame width to actually draw [100] */
 	double map_frame_width;			/* Thickness of fancy map frame [5p] */
 	double map_grid_cross_size[2];	/* Size of primary & secondary gridcrosses.  0 means draw continuous gridlines */
 	double map_heading_offset;		/* Distance between top of panel title and base of subplot heading [18p] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -215,6 +215,7 @@ static struct GMT_parameter GMT_keyword_active[]= {
 	{ 0, "MAP_DEGREE_SYMBOL"},
 	{ 0, "MAP_FRAME_AXES"},
 	{ 0, "MAP_FRAME_PEN"},
+	{ 0, "MAP_FRAME_PERCENT"},
 	{ 0, "MAP_FRAME_TYPE"},
 	{ 0, "MAP_FRAME_WIDTH"},
 	{ 0, "MAP_GRID_CROSS_SIZE_PRIMARY"},
@@ -5988,8 +5989,8 @@ void gmt_conf (struct GMT_CTRL *GMT) {
 	error += gmtinit_decode5_wesnz (GMT, "WESNZ", false);
 	/* MAP_DEFAULT_PEN */
 	error += gmt_getpen (GMT, "default,black", &GMT->current.setting.map_default_pen);
-	/* MAP_FRAME_PEN */
-	error += gmt_getpen (GMT, "thicker,black", &GMT->current.setting.map_frame_pen);
+	/* MAP_FRAME_PERCENT */
+	GMT->current.setting.map_frame_percent = 100.0;
 	/* MAP_FRAME_TYPE (fancy) */
 	GMT->current.setting.map_frame_type = GMT_IS_FANCY;
 	GMT->current.setting.map_graph_extension_unit = GMT_GRAPH_EXTENSION_UNIT;	/* Defaults for graph */
@@ -9975,6 +9976,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		case GMTCASE_MAP_FRAME_PEN:
 			error = gmt_getpen (GMT, value, &GMT->current.setting.map_frame_pen);
 			break;
+		case GMTCASE_MAP_FRAME_PERCENT:
+			dval = atof (value);
+			if (dval <= 0.0 || dval > 100.0)
+				error = true;
+			else
+				GMT->current.setting.map_frame_percent = dval;
+			break;
 		case GMTCASE_BASEMAP_TYPE:
 			GMT_COMPAT_TRANSLATE ("MAP_FRAME_TYPE");
 			break;
@@ -11500,6 +11508,9 @@ char *gmtlib_putparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			/* Intentionally fall through */
 		case GMTCASE_MAP_FRAME_PEN:
 			snprintf (value, GMT_LEN256, "%s", gmt_putpen (GMT, &GMT->current.setting.map_frame_pen));
+			break;
+		case GMTCASE_MAP_FRAME_PERCENT:
+			snprintf (value, GMT_LEN256, "%g", GMT->current.setting.map_frame_percent);
 			break;
 		case GMTCASE_BASEMAP_TYPE:
 			if (gmt_M_compat_check (GMT, 4))	/* GMT4: */

--- a/src/gmt_keywords.txt
+++ b/src/gmt_keywords.txt
@@ -107,6 +107,7 @@ MAP_FRAME_AXES			# Which axes should be plotted [WESNZ]
 MAP_FRAME_PEN			# Pen used to draw plain map frame
 MAP_FRAME_TYPE			# Type of map frame (plain or fancy)
 MAP_FRAME_WIDTH			# Width of the fancy map frame
+MAP_FRAME_PERCENT		# Percentage of fat pen to use for fancy frames [100]
 MAP_GRID_CROSS_SIZE		# Size of any grid crosses (0 for gridlines) [does not go in gmt.conf]
 MAP_GRID_CROSS_SIZE_PRIMARY	# Size of primary grid crosses (0 for gridlines)
 MAP_GRID_CROSS_SIZE_SECONDARY	# Size of secondary grid crosses (0 for gridlines)

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1310,9 +1310,14 @@ GMT_LOCAL void gmtplot_wesn_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL 
 	}
 }
 
-GMT_LOCAL double gmtplot_fancy_pen_width (struct GMT_CTRL *GMT) {
+GMT_LOCAL double gmtplot_fancy_fat_pen_width (struct GMT_CTRL *GMT) {
 	/* Return the pen width of the black/white checker fancy frame in points */
 	return (fabs (0.01 * GMT->current.setting.map_frame_percent * GMT->current.setting.map_frame_width) * GMT->session.u2u[GMT_INCH][GMT_PT]);
+}
+
+GMT_LOCAL double gmtplot_fancy_thin_pen_width (struct GMT_CTRL *GMT, double width) {
+	/* Return the pen width of the enclosing checker fancy frame in points as 10% of fat pen width */
+	return (0.1 * width / ( GMT->current.setting.map_frame_percent * 0.01 ));
 }
 
 GMT_LOCAL void gmtplot_fancy_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n) {
@@ -1327,12 +1332,12 @@ GMT_LOCAL void gmtplot_fancy_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 
 	PSL_setcolor (PSL, GMT->current.setting.map_frame_pen.rgb, PSL_IS_STROKE);
 
-	fat_pen = gmtplot_fancy_pen_width (GMT);
+	fat_pen = gmtplot_fancy_fat_pen_width (GMT);
 	if (GMT->current.map.frame.axis[GMT_Y].item[GMT_TICK_LOWER].active) {	/* Need two-layer frame */
 		fat_pen *= 0.5;
 		dual = true;
 	}
-	thin_pen = 0.1 * fat_pen;
+	thin_pen = gmtplot_fancy_thin_pen_width (GMT, fat_pen);
 
 	/* Draw frame checkers */
 	/* This needs to be done with BUTT cap since checker segments are drawn as heavy lines */
@@ -1398,12 +1403,12 @@ GMT_LOCAL void gmtplot_polar_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 
 	/* Here draw fancy map boundary */
 
-	fat_pen = gmtplot_fancy_pen_width (GMT);
+	fat_pen = gmtplot_fancy_fat_pen_width (GMT);
 	if (GMT->current.map.frame.axis[GMT_Y].item[GMT_TICK_LOWER].active) {	/* Need two-layer frame */
 		fat_pen *= 0.5;
 		dual = true;
 	}
-	thin_pen = 0.1 * fat_pen;
+	thin_pen = gmtplot_fancy_thin_pen_width (GMT, fat_pen);
 
 	/* Draw frame checkers */
 	/* This needs to be done with BUTT cap since checker segments are drawn as heavy lines */
@@ -1453,12 +1458,12 @@ GMT_LOCAL void gmtplot_conic_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 	if (GMT->current.proj.north_pole && gmt_M_is_Npole (n)) /* Cannot have northern boundary */
 		GMT->current.map.frame.side[N_SIDE] = GMT_AXIS_NONE;
 
-	fat_pen = gmtplot_fancy_pen_width (GMT);
+	fat_pen = gmtplot_fancy_fat_pen_width (GMT);
 	if (GMT->current.map.frame.axis[GMT_Y].item[GMT_TICK_LOWER].active) {	/* Need two-layer frame */
 		fat_pen *= 0.5;
 		dual = true;
 	}
-	thin_pen = 0.1 * fat_pen;
+	thin_pen = gmtplot_fancy_thin_pen_width (GMT, fat_pen);
 
 	/* Draw frame checkers */
 	/* This needs to be done with BUTT cap since checker segments are drawn as heavy lines */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -1310,6 +1310,11 @@ GMT_LOCAL void gmtplot_wesn_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL 
 	}
 }
 
+GMT_LOCAL double gmtplot_fancy_pen_width (struct GMT_CTRL *GMT) {
+	/* Return the pen width of the black/white checker fancy frame in points */
+	return (fabs (0.01 * GMT->current.setting.map_frame_percent * GMT->current.setting.map_frame_width) * GMT->session.u2u[GMT_INCH][GMT_PT]);
+}
+
 GMT_LOCAL void gmtplot_fancy_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n) {
 	double fat_pen, thin_pen;
 	bool dual = false;
@@ -1322,7 +1327,7 @@ GMT_LOCAL void gmtplot_fancy_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 
 	PSL_setcolor (PSL, GMT->current.setting.map_frame_pen.rgb, PSL_IS_STROKE);
 
-	fat_pen = fabs (GMT->current.setting.map_frame_width) * GMT->session.u2u[GMT_INCH][GMT_PT];
+	fat_pen = gmtplot_fancy_pen_width (GMT);
 	if (GMT->current.map.frame.axis[GMT_Y].item[GMT_TICK_LOWER].active) {	/* Need two-layer frame */
 		fat_pen *= 0.5;
 		dual = true;
@@ -1393,7 +1398,7 @@ GMT_LOCAL void gmtplot_polar_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 
 	/* Here draw fancy map boundary */
 
-	fat_pen = fabs (GMT->current.setting.map_frame_width) * GMT->session.u2u[GMT_INCH][GMT_PT];
+	fat_pen = gmtplot_fancy_pen_width (GMT);
 	if (GMT->current.map.frame.axis[GMT_Y].item[GMT_TICK_LOWER].active) {	/* Need two-layer frame */
 		fat_pen *= 0.5;
 		dual = true;
@@ -1448,7 +1453,7 @@ GMT_LOCAL void gmtplot_conic_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTRL
 	if (GMT->current.proj.north_pole && gmt_M_is_Npole (n)) /* Cannot have northern boundary */
 		GMT->current.map.frame.side[N_SIDE] = GMT_AXIS_NONE;
 
-	fat_pen = fabs (GMT->current.setting.map_frame_width) * GMT->session.u2u[GMT_INCH][GMT_PT];
+	fat_pen = gmtplot_fancy_pen_width (GMT);
 	if (GMT->current.map.frame.axis[GMT_Y].item[GMT_TICK_LOWER].active) {	/* Need two-layer frame */
 		fat_pen *= 0.5;
 		dual = true;


### PR DESCRIPTION
See discussion on the [forum](https://forum.generic-mapping-tools.org/t/noaa-nautical-charts-border-style/1156/21).  This PR just allows the fat pen to change via **MAP_FRAME_PERCENT** [100].

`gmt basemap -R0/30/0/30 -JM15c -B -png t --MAP_FRAME_PERCENT=25`

The initial test shows that the cross-frame ticks were not needed when the setting was fixed at 100% but now there seems to be a need for tick lines?  While ticks are drawn for plain frame, no frame ticks are drawn for fancy frames since the ends of the fat lines were good enough.  Accepting comments, @joa-quim and @KristofKoch.

![t](https://user-images.githubusercontent.com/26473567/103497407-83432f80-4de5-11eb-8ae7-e6c90b66d7ab.png)
