### PR TITLE
Make sure we free GMT items before memtrack_report is called

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12826,12 +12826,13 @@ void gmt_end (struct GMT_CTRL *GMT) {
 	PSL_endsession (GMT->PSL);
 	/* Free remote file information structure */
 	gmt_M_free (GMT, GMT->parent->remote_info);
+	/* Free snapshot of GMT common option structure */
+	gmt_M_free (GMT, GMT->parent->common_snapshot);	/* Free snapshot */
+
 #ifdef MEMDEBUG
 	gmt_memtrack_report (GMT);
 	gmt_M_str_free (GMT->hidden.mem_keeper);
 #endif
-
-	gmt_M_free (GMT, GMT->parent->common_snapshot);	/* Free snapshot */
 
 	gmtinit_free_GMT_ctrl (GMT);	/* Deallocate control structure */
 }


### PR DESCRIPTION
For developers only:  I freed the snap_shot structure after I reported on what memory had not been freed, so it always reported I had not freed this memory.  Now in the correct place.
