### PR TITLE
Fix GMT_Set_Default() "API_GRID_LAYOUT" case

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13069,12 +13069,12 @@ int GMT_Set_Default (void *V_API, const char *keyword, const char *txt_val) {
 	}
 #endif
 	else if (!strncmp (keyword, "API_GRID_LAYOUT", 15U)) {	/* Change grid layout */
-		if (!strncmp (keyword, "columns", 7U))
+			if (!strncmp (value, "columns", 7U) || (strlen(value) >= 2 && value[1] == 'C'))		/* Accept also TC, though ignore 1st and 3-end chars. Accept this to be consistent with the "API_IMAGE_LAYOUT" case */
 			API->shape = GMT_IS_COL_FORMAT;	/* Switch to column-major format */
-		else if (!strncmp (keyword, "rows", 4U))
+		else if (!strncmp (value, "rows", 4U) || (strlen(value) >= 2 && value[1] == 'R'))
 			API->shape = GMT_IS_ROW_FORMAT;	/* Switch to row-major format */
 		else
-			GMT_Report (API, GMT_MSG_ERROR, "API_GRID_LAYOUT must be either \"columns\" or \"rows\"",  value);
+			GMT_Report (API, GMT_MSG_ERROR, "API_GRID_LAYOUT must be either \"columns\" (or TC) or \"rows\" (TR)",  value);
 		error = 1;
 	}
 	else	/* Must process as a GMT setting */


### PR DESCRIPTION
Besides the fix, accept also "?R" and "?C" as synonyms of "columns" & "rows" to be consistent with the "API_IMAGE_LAYOUT" use case. 