### PR TITLE
Fix a couple typos in docs

### DIFF
--- a/doc/rst/source/cookbook/one-liner.rst
+++ b/doc/rst/source/cookbook/one-liner.rst
@@ -5,7 +5,7 @@ Background
 ----------
 
 Modern mode simplifies GMT by placing all commands between gmt :doc:`/begin` and gmt :doc:`/end`.
-However, for very simply plots, such as a simple coastline map that only requires a call to
+However, for very simple plots, such as a simple coastline map that only requires a call to
 a single module, having to place that command between **begin** and **end** makes the documentation
 longer and more tedious to maintain.  Because of this, we have implemented a special and quick way
 to begin and end GMT modern mode within a single call to a plotting module. When the plot finishes

--- a/doc/rst/source/tutorial/session-1.rst
+++ b/doc/rst/source/tutorial/session-1.rst
@@ -61,7 +61,7 @@ you need to be aware of at run-time.
    :width: 600 px
    :align: center
 
-   The GMT run-time environment.  The will initiate with a set of system defaults that
+   The GMT run-time environment.  The session will initiate with a set of system defaults that
    you can override with having your own gmt.conf file in the current directory, specifying
    GMT parameters via the *--PAR=value* technique, and supply module options.  Some GMT modules
    will read hidden data (like coastlines) but most will explicitly need to be given user data.


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes typos in session 1 of the tutorial and the one liner documentation.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

