### PR TITLE
CI: Run cppcheck on macOS

### DIFF
--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -2,7 +2,7 @@
 
 on:
   # enable pull request for debugging
-  pull_request:
+  # pull_request:
   # Schedule runs daily
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -12,7 +12,7 @@ name: Lint Checker
 jobs:
   lint-checker:
     name: Lint Checker
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - name: Check out repository
@@ -21,9 +21,7 @@ jobs:
     - name: Install cppcheck
       run: |
         set -x -e
-        #sudo snap install cppcheck
-        # Install the dev version due to a packaging issue of cppcheck 2.3
-        sudo snap install cppcheck --edge
+        brew install cppcheck
         cppcheck --version
 
     - name: Run cppcheck

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -2,7 +2,7 @@
 
 on:
   # enable pull request for debugging
-  #pull_request:
+  pull_request:
   # Schedule runs daily
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
**Description of proposed changes**

For unknown reasons, cppcheck is no longer available from the snap store.

To install the latest cppcheck, the easiest way is to run the CI on macOS,
and install cppcheck via homebrew.

This PR switch the cppcheck from Linux to macOS.

