### PR TITLE
Extract the common keyword/value long-option settings in separate file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -383,7 +383,7 @@ set (GMT_LIB_SRCS block_subs.h gmt_common_byteswap.h gmt_common_math.h
 	gmt_common_runpath.h gmt_common_sighandler.c gmt_common_string.h clear.c begin.c
 	gmt_color_rgb.h gmt_colornames.h gmt_media_size.h gmt_mgg_header2.h
 	gmt_modern.c end.c declspec.h gmt_hidden.h gmt_remote.h gmt_remote.c
-	figure.c gmt_dev.h gmt_common.h gmt_constants.h compat/qsort.h
+	figure.c gmt_dev.h gmt_common.h gmt_common_longoptions.h gmt_constants.h compat/qsort.h
 	gmt_contour.h gmt_customio.h gmt_datums.h gmt_dcw.h gmt_decorate.h gmt_defaults.h
 	gmt_ellipsoids.h gmt_error.h gmt_gdalread.h gmt_glib.h gmt_grd.h gmt_grdio.h gmt_hash.h
 	gmt_internals.h gmt_io.h gmt_macros.h gmt_media_name.h gmt_modern.h

--- a/src/gmt_common_longoptions.h
+++ b/src/gmt_common_longoptions.h
@@ -1,11 +1,13 @@
 	/* GMT Common option long-option to short-option translation table
 	 *
 	 * General short-option syntax:
-	 *		-<sort-option>[<short-directives>][+<short-modifier>[<argument>]]
+	 *		-<short_option>[<short_directives>][+<short_modifiers>[<argument>]]
 	 * General long-option syntax:
-	 * 		--<long-option>[=<long-directive][+<long-modifier>[=<argument>]]
+	 * 		--<long_option>[=<long_directives][+<long_modifiers>[=<argument>]]
 	 *
-	 *  separator, short-option, long-option, short-directives, long-directives, short-modifiers, long-modifiers
+	 * The items below correspond to the named parameters in the GMT_KEYWORD_DICTIONARY structure:
+	 *
+	 *  separator, short_option, long_option, short_directives, long_directives, short_modifiers, long_modifiers
 	 */
 	{   0, 'B', "frame",         "",        "",                                         "b,g,n,o,t,s",				"box,fill,noframe,oblique-pole,title,subtitle" },
 	{   0, 'B', "axis",          "x,y,z",   "x,y,z",                                    "a,f,l,L,p,s,S,u",			"angle,fancy,label,Label,prefix,second-label,Second-label,unit" },

--- a/src/gmt_common_longoptions.h
+++ b/src/gmt_common_longoptions.h
@@ -1,0 +1,38 @@
+	/* GMT Common option long-option to short-option translation table
+	 *
+	 * General short-option syntax:
+	 *		-<sort-option>[<short-directives>][+<short-modifier>[<argument>]]
+	 * General long-option syntax:
+	 * 		--<long-option>[=<long-directive][+<long-modifier>[=<argument>]]
+	 *
+	 *  separator, short-option, long-option, short-directives, long-directives, short-modifiers, long-modifiers
+	 */
+	{   0, 'B', "frame",         "",        "",                                         "b,g,n,o,t,s",				"box,fill,noframe,oblique-pole,title,subtitle" },
+	{   0, 'B', "axis",          "x,y,z",   "x,y,z",                                    "a,f,l,L,p,s,S,u",			"angle,fancy,label,Label,prefix,second-label,Second-label,unit" },
+	{   0, 'J', "projection",    "",        "",                                         "",         				""},
+	{   0, 'R', "region",        "",        "",                                         "r,u",        				"rectangular,unit"},
+	{   0, 'U', "timestamp",     "",        "",                                         "c,j,o",    				"command,justify,offset"},
+	{   0, 'V', "verbosity",     "",        "",                                         "",         				""},
+	{   0, 'X', "xshift",        "a,c,f,r", "absolute,center,fixed,relative",           "",         				""},
+	{   0, 'Y', "yshift",        "a,c,f,r", "absolute,center,fixed,relative",           "",         				""},
+	{   0, 'a', "aspatial",      "",        "",                                         "",         				""},
+	{   0, 'b', "binary",        "",        "",                                         "b,l",      				"big-endian,little-endian"},
+	{   0, 'c', "panel",         "",        "",                                         "",      				    ""},
+	{   0, 'd', "nodata",        "i,o",     "in,out",                                   "",         				""},
+	{   0, 'e', "find",          "",        "",                                         "f",        				"file"},
+	{ ',', 'f', "coltypes",      "i,o",     "in,out",                                   "",        					""},
+	{   0, 'g', "gap",           "",        "",                                         "n,p",        				"negative,positive"},
+	{   0, 'h', "header",        "i,o",     "in,out",                                   "c,d,r,t", 					"columns,delete,remark,title"},
+	{ ',', 'i', "read-columns",  "",        "",                                         "l,o,s",   					"log10,offset,scale"},
+	{   0, 'j', "spherical",     "e,f,g",   "ellipsoidal,flat-earth,great-circle",      "",   			    		""},
+	{   0, 'l', "legend",        "",        "",                                         "D,G,H,L,N,S,V,f,g,j,o,p,s,w",   	"drawline,gap,header,linetext,ncols,size,vertline,font,fill,justify,offset,pen,scale,width"},
+	{   0, 'n', "interpolation", "b,c,l,n", "b-spline,bicubic,linear,nearest-neighbor", "a,b,c,t",     				"antialias,bc,clip,threshold"},
+	{ ',', 'o', "write-columns", "",        "",                                         "",        					""},
+	{   0, 'p', "perspective",   "x,y,z",   "x,y,z",                                    "v,w",     					"view,world"},
+	{ ',', 'q', "read-rows",     "~",       "invert",                                   "a,c,f,s",   				"per-set,column,per-file,per-segment"},
+	{ ',', 'q', "write-rows",    "~",       "invert",                                   "a,c,f,s",   				"per-set,column,per-file,per-segment"},
+	{   0, 'r', "registration",  "g,p",     "gridline,pixel",                           "",        					""},
+	{   0, 's', "skip-rows",     "",       "",                                         "a,r",     					"any,reverse"},
+	{   0, 't', "transparency",  "",        "",                                         "",        					""},
+	{   0, 'x', "cores",         "",        "",                                         "",        					""},
+	{   0, '\0', "",             "",        "",                                         "",        					""}	/* End of list is marked with empty short-option code and strings */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -390,36 +390,7 @@ static char *map_annot_oblique_item[N_MAP_ANNOT_OBLIQUE_ITEMS] = {
  */
 
 static struct GMT_KEYWORD_DICTIONARY gmt_common_kw[] = {
-	/* separator, short-option, long-option, short-directives, long-directives, short-modifiers, long-modifiers */
-	{   0, 'B', "frame",         "",        "",                                         "b,g,n,o,t,s",				"box,fill,noframe,oblique-pole,title,subtitle" },
-	{   0, 'B', "axis",          "x,y,z",   "x,y,z",                                    "a,f,l,L,p,s,S,u",			"angle,fancy,label,Label,prefix,second-label,Second-label,unit" },
-	{   0, 'J', "projection",    "",        "",                                         "",         				""},
-	{   0, 'R', "region",        "",        "",                                         "r,u",        				"rectangular,unit"},
-	{   0, 'U', "timestamp",     "",        "",                                         "c,j,o",    				"command,justify,offset"},
-	{   0, 'V', "verbosity",     "",        "",                                         "",         				""},
-	{   0, 'X', "xshift",        "a,c,f,r", "absolute,center,fixed,relative",           "",         				""},
-	{   0, 'Y', "yshift",        "a,c,f,r", "absolute,center,fixed,relative",           "",         				""},
-	{   0, 'a', "aspatial",      "",        "",                                         "",         				""},
-	{   0, 'b', "binary",        "",        "",                                         "b,l",      				"big-endian,little-endian"},
-	{   0, 'c', "panel",         "",        "",                                         "",      				    ""},
-	{   0, 'd', "nodata",        "i,o",     "in,out",                                   "",         				""},
-	{   0, 'e', "find",          "",        "",                                         "f",        				"file"},
-	{ ',', 'f', "coltypes",      "i,o",     "in,out",                                   "",        					""},
-	{   0, 'g', "gap",           "",        "",                                         "n,p",        				"negative,positive"},
-	{   0, 'h', "header",        "i,o",     "in,out",                                   "c,d,r,t", 					"columns,delete,remark,title"},
-	{ ',', 'i', "read-columns",  "",        "",                                         "l,o,s",   					"log10,offset,scale"},
-	{   0, 'j', "spherical",     "e,f,g",   "ellipsoidal,flat-earth,great-circle",      "",   			    		""},
-	{   0, 'l', "legend",        "",        "",                                         "D,G,H,L,N,S,V,f,g,j,o,p,s,w",   	"drawline,gap,header,linetext,ncols,size,vertline,font,fill,justify,offset,pen,scale,width"},
-	{   0, 'n', "interpolation", "b,c,l,n", "b-spline,bicubic,linear,nearest-neighbor", "a,b,c,t",     				"antialias,bc,clip,threshold"},
-	{ ',', 'o', "write-columns", "",        "",                                         "",        					""},
-	{   0, 'p', "perspective",   "x,y,z",   "x,y,z",                                    "v,w",     					"view,world"},
-	{ ',', 'q', "read-rows",     "~",       "invert",                                   "a,c,f,s",   				"per-set,column,per-file,per-segment"},
-	{ ',', 'q', "write-rows",    "~",       "invert",                                   "a,c,f,s",   				"per-set,column,per-file,per-segment"},
-	{   0, 'r', "registration",  "g,p",     "gridline,pixel",                           "",        					""},
-	{   0, 's', "skip-rows",     "",       "",                                         "a,r",     					"any,reverse"},
-	{   0, 't', "transparency",  "",        "",                                         "",        					""},
-	{   0, 'x', "cores",         "",        "",                                         "",        					""},
-	{   0, '\0', "",             "",        "",                                         "",        					""}	/* End of list marked with empty code and strings */
+#include "gmt_common_longoptions.h"
 };
 #endif
 

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -66,11 +66,11 @@ struct GMT_MATH_MACRO {
 struct GMT_KEYWORD_DICTIONARY {	/* Used for keyword-value lookup */
 	char separator;			/* Single character separating 2 or more identical specifications [0 for no repeat] */
 	char short_option;		/* Single character GMT option code */
-	char long_option[31];		/* Name of corresponding long option */
-	char short_directives[32];	/* Single character directives, comma-separated */
-	char long_directives[256];	/* Long name directives, comma-separated */
-	char short_modifiers[32];	/* Single character modifiers, comma-separated */
-	char long_modifiers[256];	/* Long name modifiers, comma-separated */
+	char long_option[GMT_LEN32-1];		/* Name of corresponding long option */
+	char short_directives[GMT_LEN32];	/* Single character directives, comma-separated */
+	char long_directives[GMT_LEN256];	/* Long name directives, comma-separated */
+	char short_modifiers[GMT_LEN32];	/* Single character modifiers, comma-separated */
+	char long_modifiers[GMT_LEN256];	/* Long name modifiers, comma-separated */
 };
 
 /*! Definition of structure use for finding optimal n_columns/n_rows for surface */


### PR DESCRIPTION
Reorganization only.  This adds file _gmt_common_longoptions.h_ that is then included by _gmt_init.c_ to populate the _gmt_common_kw_ **GMT_KEYWORD_DICTIONARY** structure.  I also added a bit more comments in that file and will later work on the guru doc RST tree.