### PR TITLE
Allow the Rounded rect symbol in custom symbol definition files

### DIFF
--- a/doc/rst/source/cookbook/custom-symbols.rst
+++ b/doc/rst/source/cookbook/custom-symbols.rst
@@ -113,7 +113,7 @@ are constants.
 +---------------+------------+----------------------------------------+--------------------------------------------+
 | **Name**      | **Code**   | **Purpose**                            | **Arguments**                              |
 +===============+============+========================================+============================================+
-| rotate        | **R**      | Rotate the coordinate system           | :math:`\alpha`\[**a**]                     |
+| rotate        | **O**      | Rotate the coordinate system           | :math:`\alpha`\[**a**]                     |
 +---------------+------------+----------------------------------------+--------------------------------------------+
 | moveto        | **M**      | Set a new anchor point                 | :math:`x_0, y_0`                           |
 +---------------+------------+----------------------------------------+--------------------------------------------+
@@ -151,6 +151,8 @@ are constants.
 +---------------+------------+----------------------------------------+--------------------------------------------+
 | rect          | **r**      | Plot a rectangle                       | :math:`x, y, width, height`                |
 +---------------+------------+----------------------------------------+--------------------------------------------+
+| roundrect     | **R**      | Plot a rounded rectangle               | :math:`x, y, width, height, radius`        |
++---------------+------------+----------------------------------------+--------------------------------------------+
 | square        | **s**      | Plot a square                          | :math:`x, y, size`                         |
 +---------------+------------+----------------------------------------+--------------------------------------------+
 | triangle      | **t**      | Plot a triangle                        | :math:`x, y, size`                         |
@@ -164,11 +166,11 @@ are constants.
 | y-dash        | **y**      | Plot a y-dash                          | :math:`x, y, size`                         |
 +---------------+------------+----------------------------------------+--------------------------------------------+
 
-Note for **R**\: if an **a** is appended to the angle then :math:`\alpha` is considered
+Note for **O**\: if an **a** is appended to the angle then :math:`\alpha` is considered
 to be a map azimuth; otherwise it is a Cartesian map angle.  The **a** modifier
 does not apply if the angle is given via a variable, in which case the type of angle
-has already been specified via **N:** above and already converged before seen by **R**.
-Finally, the **R** command can also be given the negative of a variable, e.g., -$2 to
+has already been specified via **N:** above and already converged before seen by **O**.
+Finally, the **O** command can also be given the negative of a variable, e.g., -$2 to
 undo a rotation, if necessary.
 
 Symbol fill and outline

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7109,7 +7109,7 @@ int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double s
 			case PSL_PLUS:
 			case PSL_INVTRIANGLE:
 			case PSL_RECT:
-			/* case PSL_RNDRECT: Cannot use as conflicts with GMT_SYMBOL_ROTATE */
+			case PSL_RNDRECT:
 			case PSL_XDASH:
 			case PSL_YDASH:
 				if (flush) gmtplot_flush_symbol_piece (GMT, PSL, xx, yy, &n, &p, &f, this_outline, &flush);

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -47,7 +47,7 @@
 #define GMT_SYMBOL_DRAW		((int)'D')
 #define GMT_SYMBOL_STROKE	((int)'S')
 #define GMT_SYMBOL_ARC		((int)'A')
-#define GMT_SYMBOL_ROTATE	((int)'R')
+#define GMT_SYMBOL_ROTATE	((int)'O')	/* Since R stands for rounded rectangle in plot */
 #define GMT_SYMBOL_VARROTATE	((int)'V')
 #define GMT_SYMBOL_AZIMROTATE	((int)'Z')
 #define GMT_SYMBOL_TEXTURE	((int)'T')

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4988,6 +4988,10 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 			s->x = atof (col[GMT_X]);
 			s->y = atof (col[GMT_Y]);
 		}
+		/* Unfortunately, "R" was used for two things: General rotation and Rounded rectangle symbol.  We now use "O" for rotation
+		 * but for backwards compatibility we must fix any old-style "R" for rotation here by replacing with "O" */
+		if (s->action == 'R' && last == 1)	/* Got the deprecated R for rotate the coordinate system, not R for rounded rectangle */
+			s->action = GMT_SYMBOL_ROTATE;
 
 		switch (s->action) {
 
@@ -5012,7 +5016,7 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 				gmtsupport_decode_arg (col[4], 2, s);	/* angle2 could be a variable or constant degrees */
 				break;
 
-			case 'R':		/* Rotate coordinate system about (0,0) */
+			case GMT_SYMBOL_ROTATE:		/* Rotate coordinate system about (0,0) */
 				if (last != 1) error++;
 				s->action = gmtsupport_decode_arg (col[0], 0, s);	/* angle could be a variable or constant heading or azimuth in degrees */
 				break;
@@ -5068,7 +5072,7 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 				}
 				s->font = GMT->current.setting.font_annot[GMT_PRIMARY];	/* Default font for symbols */
 				s->justify = PSL_MC;				/* Default justification of text */
-				head->text = 1;	/* We will be typsetting text so fonts are required */
+				head->text = 1;	/* We will be typesetting text so fonts are required */
 				if (s->action == GMT_SYMBOL_VARTEXT && c[1] == 't') head->text = 2;	/* Flag that trailing text will be used */
 				k = 1;
 				while (col[last][k] && col[last][k] != '+') k++;
@@ -5103,6 +5107,13 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 				if (last != 4) error++;
 				s->p[0] = atof (col[2]);
 				s->p[1] = atof (col[3]);
+				break;
+
+			case 'R':		/* Draw rounded rect symbol */
+				if (last != 5) error++;
+				s->p[0] = atof (col[2]);
+				s->p[1] = atof (col[3]);
+				s->p[2] = atof (col[4]);
 				break;
 
 			case 'e':		/* Draw ellipse symbol */

--- a/test/modern/longbasemap.sh
+++ b/test/modern/longbasemap.sh
@@ -3,6 +3,6 @@
 gmt begin longbasemap ps
   gmt subplot begin 2x1 -F6i/8.5i -M5p -A1+c+o0.2i
   gmt basemap --region=0/40/0/50 --projection=X? --frame=WSne+fill=lightblue --axis=x:af+unit=k+angle=45 --axis=y:afg+prefix="$" -c1
-  gmt basemap --region=0/70/-20/25 --projection=M? --frame=WSne+fill=lightgreen+oblique-pole=60/20 --axis=x:afg --axis=y:afg -c0
+  gmt basemap --region=0/70/-20/25 --projection=M? --frame=WSne+fill=lightgreen+obliquepole=60/20 --axis=x:afg --axis=y:afg -c0
   gmt subplot end
 gmt end show


### PR DESCRIPTION
**Description of proposed changes**

This problem was detected when fixing #4635 as pointed out by @KristofKoch.  Unfortunately, we have selected **R** to mean "rotate" but **R** was already taken as a symbol code for the Rounded rectangle.  I fixed this by now using **O** for rotate but handling this as a backwards compatibility problem since it is easy to tell these two apart based on the different numbers of arguments.