### PR TITLE
Take more care to recognize blank lines

### DIFF
--- a/doc/rst/source/cookbook/file-formats.rst
+++ b/doc/rst/source/cookbook/file-formats.rst
@@ -18,7 +18,7 @@ Optional file header records
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The first data record may be preceded by one or more header records. Any
-records that begins with '#' is considered a header or comment line and
+records that has '#' as the *first* character is considered a header or comment line and
 are always processed correctly. If your data file has leading header
 records that do *not* start with '#' then you must make sure to use the
 **-h** option and set the parameter :term:`IO_N_HEADER_RECS` in the :doc:`/gmt.conf` file

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4855,9 +4855,9 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 			strcat (head->PS_macro, buffer);
 			continue;
 		}
+		if (buffer[0] == '#') continue;	/* Skip comments */
 		gmt_chop (buffer);	/* Get rid of \n \r */
 		if (gmt_is_a_blank_line (buffer)) continue;	/* Skip blank lines */
-		if (buffer[0] == '#' || buffer[0] == '\0') continue;	/* Skip comments or blank lines */
 		if (buffer[0] == 'N' && buffer[1] == ':') {	/* Got extra parameter specs. This is # of data columns expected beyond the x,y[,z] stuff */
 			char flags[GMT_LEN64] = {""};
 			nc = sscanf (&buffer[2], "%d %s", &head->n_required, flags);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4846,7 +4846,7 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 					head->PS_BB[0] = atof (c1);	head->PS_BB[2] = atof (c2);
 					head->PS_BB[1] = atof (c3);	head->PS_BB[3] = atof (c4);
 					got_BB[bb] = true;
-					if (bb == 0) got_BB[1] = true;	/* If we find Highres BB then we don't need to look for lowres BB */
+					if (bb == 0) got_BB[1] = true;	/* If we find HighRes BB then we don't need to look for LowRes BB */
 					GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Custom EPS symbol %s has width %g and height %g inches [%s]\n",
 						&name[pos], (head->PS_BB[1] - head->PS_BB[0]) / 72, (head->PS_BB[3] - head->PS_BB[2]) / 72, &BB_string[bb][2]);
 				}
@@ -4856,6 +4856,7 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 			continue;
 		}
 		gmt_chop (buffer);	/* Get rid of \n \r */
+		if (gmt_is_a_blank_line (buffer)) continue;	/* Skip blank lines */
 		if (buffer[0] == '#' || buffer[0] == '\0') continue;	/* Skip comments or blank lines */
 		if (buffer[0] == 'N' && buffer[1] == ':') {	/* Got extra parameter specs. This is # of data columns expected beyond the x,y[,z] stuff */
 			char flags[GMT_LEN64] = {""};
@@ -15121,6 +15122,7 @@ int gmt_load_macros (struct GMT_CTRL *GMT, char *mtype, struct GMT_MATH_MACRO **
 	while (fgets (line, GMT_BUFSIZ, fp)) {
 		if (line[0] == '#') continue;
 		gmt_chop (line);
+		if (gmt_is_a_blank_line (line)) continue;
 		if ((c = strstr (line, ": ")))	/* This macro has comments */
 			c[0] = '\0';		/* Chop off the comments */
 		gmt_strstrip (line, true);	/* Remove leading and trailing whitespace */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -361,7 +361,7 @@ GMT_LOCAL int psxy_plot_decorations (struct GMT_CTRL *GMT, struct GMT_DATASET *D
 				fprintf (fp, "# Rotated custom symbol, read size and rotation from data file\nN: 1 o\n$1 R\n");
 				first = false;
 			}
-			fprintf (fp, "%s", buffer);
+			fprintf (fp, "%s", buffer);	/* Pass remaining lines unchanged */
 		}
 		fclose (fpc);
 	}

--- a/src/spotter/grdspotter.c
+++ b/src/spotter/grdspotter.c
@@ -670,7 +670,9 @@ EXTERN_MSC int GMT_grdspotter (void *V_API, int mode, void *args) {
 				Return (GMT_ERROR_ON_FOPEN);
 			}
 			while (fgets (line, GMT_BUFSIZ, fp)) {
-				if (line[0] == '#' || line[0] == '\n') continue;
+				if (line[0] == '#') continue;
+				gmt_chop (line);
+				if (gmt_is_a_blank_line (line)) continue;
 				k = sscanf (line, "%*s %d %lf %lf %lf %lf", &Qid, &wq, &eq, &sq, &nq);
 				ID_info[Ctrl->Q.id].ok = true;
 				if (k == 5) {	/* Got restricted wesn also */

--- a/src/spotter/spotter.c
+++ b/src/spotter/spotter.c
@@ -488,7 +488,9 @@ int spotter_init (struct GMT_CTRL *GMT, char *file, struct EULER **p, unsigned i
 	if (flowline) total_out = true;	/* Override so we get finite poles for conversion to forward stage poles at the end */
 
 	while (gmt_fgets (GMT, buffer, GMT_BUFSIZ, fp) != NULL) { /* Expects lon lat t0 t1 ccw-angle */
-		if (buffer[0] == '#' || buffer[0] == '\n') continue;
+		if (buffer[0] == '#') continue;
+		gmt_chop (buffer);
+		if (gmt_is_a_blank_line (buffer)) continue;
 
 		if (GPlates) {
 			if ((nf = sscanf (buffer, "%d %lf %lf %lf %lf %d %[^\n]", &p1, &t, &lat, &lon, &rot, &p2, comment)) != 7) continue;
@@ -631,7 +633,9 @@ int spotter_hotspot_init (struct GMT_CTRL *GMT, char *file, bool geocentric, str
 	e = gmt_M_memory (GMT, NULL, n_alloc, struct HOTSPOT);
 
 	while (gmt_fgets (GMT, buffer, GMT_BUFSIZ, fp) != NULL) {
-		if (buffer[0] == '#' || buffer[0] == '\n') continue;
+		if (buffer[0] == '#') continue;
+		gmt_chop (buffer);
+		if (gmt_is_a_blank_line (buffer)) continue;
 		n = sscanf (buffer, "%lf %lf %s %d %lf %lf %lf %c %c %c %s",
 		            &e[i].lon, &e[i].lat, e[i].abbrev, &ival, &e[i].radius, &e[i].t_off, &e[i].t_on, &create, &fit, &plot, e[i].name);
 		if (n == 3) ival = i + 1;	/* Minimal lon, lat, abbrev */


### PR DESCRIPTION
We have a _gmt_is_a_blank_line_ function but it was not used when processing symbol macro files (and in a few supplements).  Closes #4638.
