### PR TITLE
add OpenBSD and improve documentation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,7 @@
 # Building GMT
 
 This document describes how to build GMT from source codes
-(stable release or development version) on Linux, FreeBSD, macOS and Windows.
+(stable release or development version) on Linux, FreeBSD, OpenBSD, macOS and Windows.
 
 ## Contents
 
@@ -141,7 +141,7 @@ with a focus on speed.
 In the build directory, type
 
 ```
-# Linux/macOS/FreeBSD
+# Linux/macOS/FreeBSD/OpenBSD
 cmake --build .
 
 # Windows
@@ -156,7 +156,7 @@ default number is used.
 ## Installing
 
 ```
-# Linux/macOS/FreeBSD
+# Linux/macOS/FreeBSD/OpenBSD
 cmake --build . --target install
 
 # Windows

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 [![GitHub release](https://img.shields.io/github/release/GenericMappingTools/gmt)](https://github.com/GenericMappingTools/gmt/releases)
 
-GMT is available on Windows, macOS, Linux and FreeBSD.
+GMT is available on Windows, macOS, Linux, FreeBSD and OpenBSD.
 Source and binary packages are provided for the latest release,
 and can be downloaded from the [GMT main site](https://www.generic-mapping-tools.org)
 and [the GitHub repository](https://github.com/GenericMappingTools/gmt/releases).
@@ -26,7 +26,9 @@ for compiling GMT source package (either stable release or development version).
 - [Cross Platform Install Instructions](#cross-platform-install-instructions)
   * [Install via conda](#install-via-conda)
 - [FreeBSD](#freebsd)
-  * [Install via Ports](#install-via-ports)
+  * [Install via Ports](#install-via-freebsd-ports)
+- [OpenBSD](#openbsd)
+  * [Install via Ports](#install-via-openbsd-ports)
 
 ## Windows
 
@@ -227,6 +229,16 @@ latest release from source](BUILDING.md).
 
 The FreeBSD Ports Collection is a diverse collection of utility and application software that has been ported to FreeBSD.
 
+**Precompiled**
+
+Install precompiled gmt binaries with
+
+```
+$ pkg install gmt
+```
+
+**Compile from Ports**
+
 If not done already, set up the **Ports Collection** (see
 https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/ports-using.html):
 
@@ -245,4 +257,22 @@ Then change into directory `/usr/ports/graphics/gmt` and build:
 
 ```
 make install clean
+```
+
+## OpenBSD
+
+GMT may be installed on OpenBSD using Ports or from source.
+
+**NOTE:** The Ports Collection may provide old GMT versions. If you want the latest GMT release, consider [building the
+latest release from source](BUILDING.md).
+
+### Install via Ports
+For more information, please refer to relevant documentation from the OpenBSD project.
+
+**Precompiled**
+
+Install precompiled gmt binaries with
+
+```
+$ pkg_add gmt
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ hobbyists.
 
 ## Installation
 
-GMT has been installed successfully under UNIX/Linux/macOS/FreeBSD on workstations. It
+GMT has been installed successfully under UNIX/Linux/macOS/FreeBSD/OpenBSD on workstations. It
 also installs under Windows and in UNIX emulators such as Cygwin or on virtual
 machines.  We anticipate few problems if you are installing the package on
 other platforms.


### PR DESCRIPTION
Bleeding edge GMT tested on OpenBSD with success;

```
$ uname -a
OpenBSD openbsd.home 6.8 GENERIC.MP#98 amd64
```

OpenBSD does not suffer from the problem that FreeBSD did (described in #4396 and fixed in #4405).

I'll expand on OpenBSD dependencies and improve description of gmt installation on FreeBSD/OpenBSD when I have the time.

OpenBSD has a severely outdated GMT in it's port collection (https://openports.se/graphics/gmt, GMT4.1.3). This might be worth taking a look at in time.