### PR TITLE
Only access the cube-scanning in grdimage if a z-grid.

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1633,7 +1633,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 	Conf->nm        = header_work->nm;
 
 	NaN_rgb = (P) ? P->bfn[GMT_NAN].rgb : GMT->current.setting.color_patch[GMT_NAN];	/* Determine which color represents a NaN grid node */
-	if (Ctrl->Q.active) {	/* Want colormasking via the grid's NaN entries */
+	if (got_z_grid && Ctrl->Q.active) {	/* Want colormasking via the grid's NaN entries */
 		if (gray_only) {
 			GMT_Report (API, GMT_MSG_INFORMATION, "Your image is gray scale only but -Q requires building a 24-bit image; your image will be expanded to 24-bit.\n");
 			gray_only = false;	/* Since we cannot do 8-bit and colormasking */
@@ -1775,7 +1775,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 					grdimage_img_color_no_intensity (GMT, Ctrl, Conf, bitimage_24);
 			}
 		}
-		if (Ctrl->Q.active) {	/* Fill in the RGB cube use */
+		if (rgb_cube_scan) {	/* Fill in the RGB cube use */
 			int index = 0, ks;
 			/* Check that we found an unused r/g/b value so that colormasking will work as advertised */
 			index = (gmt_M_u255(P->bfn[GMT_NAN].rgb[0])*256 + gmt_M_u255(P->bfn[GMT_NAN].rgb[1]))*256 + gmt_M_u255(P->bfn[GMT_NAN].rgb[2]);	/* The index into the cube for the selected NaN color */
@@ -1802,7 +1802,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			done = true;	/* Only doing the loop once here since no -Q */
 	}
 
-	if (Ctrl->Q.active) gmt_M_free (GMT, rgb_used);	/* Done using the r/g/b cube */
+	if (rgb_cube_scan) gmt_M_free (GMT, rgb_used);	/* Done using the r/g/b cube */
 	gmt_M_free (GMT, Conf->actual_row);
 	gmt_M_free (GMT, Conf->actual_col);
 


### PR DESCRIPTION
We unfortunately tried to pick a NaN color when we had an input image and no CPT, hitting a NULL pointer.  This is part of the problem (the crash) discussed on the [forum](https://forum.generic-mapping-tools.org/t/nan-color-by-grdimage-with-arctic-polar-pojection/1183/3).
