### PR TITLE
Free whichBands when only metadata is required

### DIFF
--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -890,6 +890,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 			Ctrl->hdr[0] += Ctrl->hdr[7] / 2;	Ctrl->hdr[1] -= Ctrl->hdr[7] / 2;
 			Ctrl->hdr[2] += Ctrl->hdr[8] / 2;	Ctrl->hdr[3] -= Ctrl->hdr[8] / 2;
 		}
+		gmt_M_free (GMT, whichBands);
 		return (GMT_NOERROR);
 	}
 


### PR DESCRIPTION
Minor memory leak issue: We returned from _gmt_gdalread_ without freeing this variable when only the header info was required.
