### PR TITLE
Disallow grdimage -I+d if input data is an image

### DIFF
--- a/doc/rst/source/grdimage_common.rst_
+++ b/doc/rst/source/grdimage_common.rst_
@@ -109,7 +109,9 @@ Optional Arguments
     default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
     specific intensity scenario then run :doc:`grdgradient` separately first.
     If we should derive intensities from another file than *grid*, specify the
-    file with suitable modifiers [Default is no illumination].
+    file with suitable modifiers [Default is no illumination].  **Note**: If
+    the input data is an *image* then an *intensfile* or constant *intensity*
+    must be provided.
 
 .. _-M:
 

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1237,7 +1237,10 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 #endif
 
 	if (Ctrl->D.active) {	/* Main input is a single image and not a grid */
-
+		if (Ctrl->I.derive) {	/* Cannot auto-derive intensities from an image */
+			GMT_Report (API, GMT_MSG_INFORMATION, "Cannot derive intensities from input image %s- ignored\n", Ctrl->I.file);
+			Ctrl->I.derive = use_intensity_grid = false;
+		}
 		if (use_intensity_grid && GMT->common.R.active[RSET]) {
 			/* Make sure the region of the intensity grid and -R are in agreement within a noise threshold */
 			double xnoise = Intens_orig->header->inc[GMT_X]*GMT_CONV4_LIMIT, ynoise = Intens_orig->header->inc[GMT_Y]*GMT_CONV4_LIMIT;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1238,7 +1238,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 
 	if (Ctrl->D.active) {	/* Main input is a single image and not a grid */
 		if (Ctrl->I.derive) {	/* Cannot auto-derive intensities from an image */
-			GMT_Report (API, GMT_MSG_INFORMATION, "Cannot derive intensities from input image %s- ignored\n", Ctrl->I.file);
+			GMT_Report (API, GMT_MSG_WARNING, "Cannot derive intensities from an input image file; -I ignored\n");
 			Ctrl->I.derive = use_intensity_grid = false;
 		}
 		if (use_intensity_grid && GMT->common.R.active[RSET]) {


### PR DESCRIPTION
We cannot compute derivatives from images so we turn that feature off if given and give a warning.  Closes #4651.
