### PR TITLE
Use 128 and not 127.5 as default gray value

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -87,7 +87,7 @@ COLOR Parameters
         in CMYK but interpolates in RGB).
 
     **COLOR_NAN**
-        Color used for the non-defined areas of images (i.e., where z = NaN) [127.5].
+        Color used for the non-defined areas of images (i.e., where z = NaN) [128].
 
     **COLOR_SET**
         Default comma-separated list of colors (or a *categorical* CPT name) for automatic,

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6034,7 +6034,7 @@ void gmt_conf (struct GMT_CTRL *GMT) {
 	/* COLOR_MODEL */
 	GMT->current.setting.color_model = GMT_RGB;
 	/* COLOR_NAN */
-	error += gmt_getrgb (GMT, "127.5", GMT->current.setting.color_patch[GMT_NAN]);
+	error += gmt_getrgb (GMT, "128", GMT->current.setting.color_patch[GMT_NAN]);
 	/* COLOR_HSV_MIN_S */
 	GMT->current.setting.color_hsv_min_s = 1;
 	/* COLOR_HSV_MAX_S */


### PR DESCRIPTION
The 127.5 is rounded to 128 anyway in images so mostly annoying.
