### PR TITLE
Add Vincenty direct problem solution to gmt vector -Tt

### DIFF
--- a/doc/rst/source/gmtvector.rst
+++ b/doc/rst/source/gmtvector.rst
@@ -121,7 +121,8 @@ Optional Arguments
     from the third and fourth data column in the file, and **x** for cross-product.
     If **-T** is not given then no transformation takes place; the
     output is determined by other options such as **-A**, **-C**,
-    **-E**, and **-N**.
+    **-E**, and **-N**. **Note**: For **-Tt** and geographic coordinates we will
+    perform a great circle calculation unless **-je** is selected.
 
 .. _-V:
 
@@ -210,10 +211,15 @@ the point -30/60 at an azimuth of 105 degrees, use::
     gmt vector -A-30/60 -Tp105 -fg > pole.txt
 
 To translate all locations in the geographic file points.txt
-by 65 km to the NE, try::
+by 65 km to the NE on a spherical Earth, try::
 
     gmt vector points -Tt45/65k -fg > shifted.txt
 
+
+To determine the point that is 23 nautical miles along a geodesic
+with a bearing of 310 degrees from the origin at (8E, 50N), try::
+
+    echo 8 50 | gmt vector -Tt310/23n -je
 
 Rotations
 ---------

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5319,7 +5319,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				error += gmt_verify_expectations (GMT, GMT_IS_LON, gmt_scanf (GMT, txt_a, GMT_IS_LON, &GMT->current.proj.pars[0]), txt_a);
 				error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_b, GMT_IS_LAT, &GMT->current.proj.pars[1]), txt_b);
 				/* compute point 10 degrees from origin along azimuth */
-				gmt_translate_point (GMT, GMT->current.proj.pars[0], GMT->current.proj.pars[1], az, 10.0, &GMT->current.proj.pars[2], &GMT->current.proj.pars[3]);
+				gmt_translate_point (GMT, GMT->current.proj.pars[0], GMT->current.proj.pars[1], az, 10.0, &GMT->current.proj.pars[2], &GMT->current.proj.pars[3], NULL);
 			}
 			else if (n_slashes == 4) {
 				n = sscanf (args, "%[^/]/%[^/]/%[^/]/%[^/]/%s", txt_a, txt_b, txt_c, txt_d, txt_e);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4275,7 +4275,10 @@ void gmt_set_geographic (struct GMT_CTRL *GMT, unsigned int dir) {
 	/* Eliminate lots of repeated statements to do this: */
 	gmt_set_column_type (GMT, dir, GMT_X, GMT_IS_LON);
 	gmt_set_column_type (GMT, dir, GMT_Y, GMT_IS_LAT);
-	if (dir == GMT_IN) (void) gmt_init_distaz (GMT, GMT_MAP_DIST_UNIT, GMT_GREATCIRCLE, GMT_MAP_DIST);	/* Default spherical distance calculations are in meters (cannot fail) */
+	if (dir == GMT_IN) {	/* Default spherical distance calculations are in meters (cannot fail) */
+		int mode = (GMT->common.j.active) ? GMT->common.j.mode : GMT_GREATCIRCLE;
+		(void) gmt_init_distaz (GMT, GMT_MAP_DIST_UNIT, mode, GMT_MAP_DIST);
+	}
 }
 
 /*! . */

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9570,8 +9570,8 @@ unsigned int gmt_init_distaz (struct GMT_CTRL *GMT, char unit, unsigned int mode
 	if (gmt_M_is_geographic (GMT, GMT_IN) && GMT->common.j.active) {	/* User specified a -j setting */
 		static char *kind[5] = {"Cartesian", "Flat Earth", "Great Circle", "Geodesic", "Loxodrome"};
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Spherical distance calculation mode: %s.\n", kind[GMT->common.j.active]);
-		if (mode != GMT_GREATCIRCLE)	/* We override a selection due to deprecated leading -|+ signs before increment or radius */
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Your distance mode (%s) differs from your -j option (%s) which takes precedence.\n", kind[mode], kind[GMT->common.j.active]);
+		if (mode != GMT->common.j.mode)	/* We override a selection due to deprecated leading -|+ signs before increment or radius */
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Your distance mode (%s) differs from your -j option (%s) which takes precedence.\n", kind[mode], kind[GMT->common.j.mode]);
 		mode = GMT->common.j.mode;	/* Override with what -j said */
 	}
 

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -3209,7 +3209,7 @@ GMT_LOCAL int gmtmap_init_lambert (struct GMT_CTRL *GMT, bool *search) {
  *	TRANSFORMATION ROUTINES FOR THE OBLIQUE MERCATOR PROJECTION (GMT_OBLIQUE_MERC)
  */
 
-void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat) {
+GMT_LOCAL void gmtmap_translate_point_spherical (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat, double *back_azimuth) {
 	/* compute new point dist degrees from input point along azimuth */
 	double sa, ca, sd, cd, sy, cy;
 	gmt_M_unused (GMT);
@@ -3218,6 +3218,47 @@ void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double a
 	sincosd (distance, &sd, &cd);
 	*tlon = lon + atand (sd * sa / (cy * cd - sy * sd * ca));
 	*tlat = d_asind (sy * cd + cy * sd * ca);
+	if (back_azimuth)
+		*back_azimuth = gmtmap_az_backaz_sphere (GMT, lon, lat, *tlon, *tlat, true);
+}
+
+void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat, double *back_azimuth) {
+	/* compute new point dist degrees from input point along azimuth */
+	gmtmap_translate_point_spherical (GMT, lon, lat, azimuth, distance, tlon, tlat, back_azimuth);
+}
+
+GMT_LOCAL void gmtmap_translate_point_geodesic (struct GMT_CTRL *GMT, double lon1, double lat1, double azimuth, double distance_m, double *lon2, double *lat2, double *back_azimuth) {
+	/* Use Vincenty (1975) solution to the direct geodesic problem.  Unstable for near antipodal points */
+	double a = GMT->current.proj.EQ_RAD, f = GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].flattening, f1 = 1.0 - f;
+	double b = a * f1, s = distance_m, alpha1 = azimuth * D2R, s_alpha1, c_alpha1, tan_U1, c_U1, s_U1, sigma1, s_alpha, cosSqAlpha, cos2SigmaM, tmp;
+	double uSq, A, B, sigma, sigmaP, deltaSigma, sinSigma, cosSigma, lambda, C, L;
+
+	sincos (alpha1, &s_alpha1, &c_alpha1);
+	tan_U1 = f1 * tand (lat1);
+	c_U1 = 1.0 / sqrt ((1.0 + tan_U1 * tan_U1));
+	s_U1 = tan_U1 * c_U1,
+	sigma1 = atan2 (tan_U1, c_alpha1);
+	s_alpha = c_U1 * s_alpha1;
+	cosSqAlpha = 1.0 - s_alpha * s_alpha;
+	uSq = cosSqAlpha * (a * a - b * b) / (b * b);
+	A = 1.0 + uSq / 16384.0 * (4096.0 + uSq * (-768.0 + uSq * (320.0 - 175.0 * uSq)));
+	B = uSq / 1024.0 * (256.0 + uSq * (-128.0 + uSq * (74.0 - 47.0 * uSq)));
+	sigma = s / (b * A);
+	sigmaP = 2 * M_PI;
+	while (fabs (sigma - sigmaP) > 1e-12) {
+		cos2SigmaM = cos (2.0 * sigma1 + sigma);
+		sincos (sigma, &sinSigma, &cosSigma);
+		deltaSigma = B * sinSigma * (cos2SigmaM + B / 4.0 * (cosSigma * (-1.0 + 2.0 * cos2SigmaM * cos2SigmaM) - B / 6.0 * cos2SigmaM * (-3.0 + 4.0 * sinSigma * sinSigma) * (-3.0 + 4.0 * cos2SigmaM * cos2SigmaM)));
+		sigmaP = sigma;
+		sigma = s / (b * A) + deltaSigma;
+	}
+	tmp = s_U1 * sinSigma - c_U1 * cosSigma * c_alpha1;
+	*lat2 = R2D * atan2 (s_U1 * cosSigma + c_U1 * sinSigma * c_alpha1, f1 * sqrt (s_alpha * s_alpha + tmp * tmp));
+	lambda = atan2 (sinSigma * s_alpha1, c_U1 * cosSigma - s_U1 * sinSigma * c_alpha1);
+	C = f / 16.0 * cosSqAlpha * (4.0 + f * (4.0 - 3.0 * cosSqAlpha));
+	L = lambda - (1.0 - C) * f * s_alpha * (sigma + C * sinSigma * (cos2SigmaM + C * cosSigma * (-1.0 + 2.0 * cos2SigmaM * cos2SigmaM)));
+	*lon2 = lon1 + L * R2D;
+	if (back_azimuth) *back_azimuth = R2D * atan2 (s_alpha, -tmp); /* final back azimuth */
 }
 
 GMT_LOCAL void gmtmap_pole_rotate_forward (struct GMT_CTRL *GMT, double lon, double lat, double *tlon, double *tlat) {
@@ -3334,7 +3375,7 @@ GMT_LOCAL int gmtmap_init_oblique (struct GMT_CTRL *GMT, bool *search) {
 		gmtmap_get_origin (GMT, o_x, o_y, p_x, p_y, &o_x, &o_y);
 		az = atand (cosd (p_y) * sind (p_x - o_x) / (cosd (o_y) * sind (p_y) - sind (o_y) * cosd (p_y) * cosd (p_x - o_x))) + 90.0;
 		/* compute point 10 degrees from origin along azimuth */
-		gmt_translate_point (GMT, o_x, o_y, az, 10.0, &b_x, &b_y);
+		gmt_translate_point (GMT, o_x, o_y, az, 10.0, &b_x, &b_y, NULL);
 
 		GMT->current.proj.pars[0] = o_x;	GMT->current.proj.pars[1] = o_y;
 		GMT->current.proj.pars[2] = b_x;	GMT->current.proj.pars[3] = b_y;
@@ -6298,12 +6339,14 @@ GMT_LOCAL int gmtmap_set_distaz (struct GMT_CTRL *GMT, unsigned int mode, unsign
 		case GMT_DIST_M+GMT_GREATCIRCLE:	/* 2-D lon, lat data, use spherical distances in meter */
 			GMT->current.map.dist[type].func = &gmt_great_circle_dist_meter;
 			GMT->current.map.azimuth_func = &gmtmap_az_backaz_sphere;
+			GMT->current.map.second_point = &gmtmap_translate_point_spherical;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%s distance calculation will be using great circle approximation with %s auxiliary latitudes and %s radius = %.4f m, in %s.\n",
 				type_name[type], aux[choice], rad[GMT->current.setting.proj_mean_radius], GMT->current.proj.mean_radius, unit_name);
 			break;
 		case GMT_DIST_M+GMT_GEODESIC:	/* 2-D lon, lat data, use geodesic distances in meter */
 			GMT->current.map.dist[type].func = GMT->current.map.geodesic_meter;
 			GMT->current.map.azimuth_func = GMT->current.map.geodesic_az_backaz;
+			GMT->current.map.second_point = &gmtmap_translate_point_geodesic;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%s distance calculation will be using %s geodesics in %s\n", type_name[type], GEOD_TEXT[GMT->current.setting.proj_geodesic], unit_name);
 			break;
 		case GMT_DIST_DEG+GMT_FLATEARTH:	/* 2-D lon, lat data, use Flat Earth distances in degrees */
@@ -6314,23 +6357,27 @@ GMT_LOCAL int gmtmap_set_distaz (struct GMT_CTRL *GMT, unsigned int mode, unsign
 		case GMT_DIST_DEG+GMT_GREATCIRCLE:	/* 2-D lon, lat data, use spherical distances in degrees */
 			GMT->current.map.dist[type].func = &gmtlib_great_circle_dist_degree;
 			GMT->current.map.azimuth_func = &gmtmap_az_backaz_sphere;
+			GMT->current.map.second_point = &gmtmap_translate_point_spherical;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%s distance calculation will be using great circle approximation with %s auxiliary latitudes and return lengths in %s.\n", unit_name,
 				type_name[type], aux[choice]);
 			break;
 		case GMT_DIST_DEG+GMT_GEODESIC:	/* 2-D lon, lat data, use geodesic distances in degrees */
 			GMT->current.map.dist[type].func = &gmtmap_geodesic_dist_degree;
 			GMT->current.map.azimuth_func = GMT->current.map.geodesic_az_backaz;
+			GMT->current.map.second_point = &gmtmap_translate_point_geodesic;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%s distance calculation will be using geodesics in %s\n", type_name[type], unit_name);
 			break;
 		case GMT_DIST_COS+GMT_GREATCIRCLE:	/* 2-D lon, lat data, and Green's function needs cosine of spherical distance */
 			GMT->current.map.dist[type].func = &gmtmap_great_circle_dist_cos;
 			GMT->current.map.azimuth_func = &gmtmap_az_backaz_sphere;
+			GMT->current.map.second_point = &gmtmap_translate_point_spherical;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%s distance calculation will be using great circle approximation with %s auxiliary latitudes and return cosine of spherical angles.\n",
 				type_name[type], aux[choice]);
 			break;
 		case GMT_DIST_COS+GMT_GEODESIC:	/* 2-D lon, lat data, and Green's function needs cosine of geodesic distance */
 			GMT->current.map.dist[type].func = &gmtmap_geodesic_dist_cos;
 			GMT->current.map.azimuth_func = GMT->current.map.geodesic_az_backaz;
+			GMT->current.map.second_point = &gmtmap_translate_point_geodesic;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "%s distance calculation will be using cosine of geodesic angle\n", type_name[type]);
 			break;
 		case GMT_DIST_M+GMT_LOXODROME:	/* 2-D lon, lat data, but measure distance along rhumblines in meter */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -544,7 +544,7 @@ EXTERN_MSC void gmt_gcal_from_dt (struct GMT_CTRL *GMT, double t, struct GMT_GCA
 
 
 EXTERN_MSC int gmt_circle_to_region (struct GMT_CTRL *GMT, double lon, double lat, double radius, double *wesn);
-EXTERN_MSC void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat);
+EXTERN_MSC void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat, double *back_az);
 EXTERN_MSC bool gmt_segment_BB_outside_map_BB (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S);
 EXTERN_MSC struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth, uint64_t m);
 EXTERN_MSC double gmt_half_map_width (struct GMT_CTRL *GMT, double y);

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -277,6 +277,7 @@ struct GMT_MAP {		/* Holds all map-related parameters */
 	void (*get_crossings) (struct GMT_CTRL *, double *, double *, double, double, double, double);	/* Returns map crossings in x or y */
 	double (*geodesic_meter) (struct GMT_CTRL *, double, double, double, double);	/* pointer to geodesic function returning distance between two points points in meter */
 	double (*geodesic_az_backaz) (struct GMT_CTRL *, double, double, double, double, bool);	/* pointer to geodesic function returning azimuth or backazimuth between two points points */
+	void (*second_point) (struct GMT_CTRL *, double, double, double, double, double *, double *, double *);	/* pointer to function returning second point (and bakaz) given first point, az, and dist */
 };
 
 struct GMT_GCAL {	/* (proleptic) Gregorian calendar  */

--- a/src/gmtvector.c
+++ b/src/gmtvector.c
@@ -290,7 +290,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTVECTOR_CTRL *Ctrl, struct GMT_
 	}
 
 	if ((Ctrl->T.mode == DO_ROT3D || Ctrl->T.mode == DO_POLE) && gmt_M_is_cartesian (GMT, GMT_IN)) gmt_parse_common_options (GMT, "f", 'f', "g"); /* Set -fg unless already set for 3-D rots and pole ops */
-
+	if (Ctrl->T.dmode >= GMT_GREATCIRCLE || GMT->common.j.active) gmt_parse_common_options (GMT, "f", 'f', "g"); /* Set -fg implicitly */
 	n_in = (Ctrl->C.active[GMT_IN] && gmt_M_is_geographic (GMT, GMT_IN)) ? 3 : 2;
 	if (Ctrl->T.a_and_d) n_in += 2;	/* Must read azimuth and distance as well */
 	if (GMT->common.b.active[GMT_IN] && GMT->common.b.ncol[GMT_IN] == 0) GMT->common.b.ncol[GMT_IN] = n_in;
@@ -481,6 +481,13 @@ GMT_LOCAL void gmtvector_gmt_make_rot2d_matrix (double angle, double R[3][3]) {
 	R[1][0] = s;	R[1][1] = c;
 }
 
+GMT_LOCAL double gmtvector_dist_to_meter (struct GMT_CTRL *GMT, double d_in) {
+	double d_out = d_in / GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in degrees or meters */
+	if (GMT->current.map.dist[GMT_MAP_DIST].arc)	/* Got arc measure */
+		d_out *= GMT->current.proj.DIST_M_PR_DEG;	/* Now in degrees */
+	return (d_out);
+}
+
 GMT_LOCAL double gmtvector_dist_to_degree (struct GMT_CTRL *GMT, double d_in) {
 	double d_out = d_in / GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in degrees or meters */
 	if (!GMT->current.map.dist[GMT_MAP_DIST].arc)	/* Got unit distance measure */
@@ -545,12 +552,18 @@ EXTERN_MSC int GMT_gmtvector (void *V_API, int mode, void *args) {
 	}
 
 	if (Ctrl->T.mode == DO_TRANSLATE && geo) {	/* Initialize distance machinery */
-		int mode = (GMT->common.j.active) ? GMT->common.j.mode : GMT_GREATCIRCLE;
-		if (Ctrl->T.a_and_d)	/* Read az and dist from file, set units here */
-			error = gmt_init_distaz (GMT, Ctrl->T.unit, mode, GMT_MAP_DIST);
-		else {	/* Got a fixed set, set units here */
+		int def_mode = (GMT->common.j.active) ? GMT->common.j.mode : GMT_GREATCIRCLE;
+		if (Ctrl->T.a_and_d) {	/* Read az and dist from file, set units here */
+			Ctrl->T.dmode = def_mode;	/* Store the setting here */
 			error = gmt_init_distaz (GMT, Ctrl->T.unit, Ctrl->T.dmode, GMT_MAP_DIST);
-			Ctrl->T.par[1] = gmtvector_dist_to_degree (GMT, Ctrl->T.par[1]);	/* Make sure we have degrees from whatever -Tt set */
+		}
+		else {	/* Got a fixed set, set units here */
+			if (GMT->common.j.active) Ctrl->T.dmode = def_mode;	/* Override any setting in -T */
+			error = gmt_init_distaz (GMT, Ctrl->T.unit, Ctrl->T.dmode, GMT_MAP_DIST);
+			if (Ctrl->T.dmode == GMT_GREATCIRCLE)
+				Ctrl->T.par[1] = gmtvector_dist_to_degree (GMT, Ctrl->T.par[1]);	/* Make sure we have degrees from whatever -Tt set */
+			else 	/* Get meters */
+				Ctrl->T.par[1] = gmtvector_dist_to_meter (GMT, Ctrl->T.par[1]);	/* Make sure we have degrees from whatever -Tt set */
 		}
 		if (error == GMT_NOT_A_VALID_TYPE) Return (error);
 	}
@@ -696,7 +709,10 @@ EXTERN_MSC int GMT_gmtvector (void *V_API, int mode, void *args) {
 					case DO_TRANSLATE:	/* Return translated points moved a distance d in the direction of azimuth  */
 						if (Ctrl->T.a_and_d) {	/* Get azimuth and distance from input file */
 							Ctrl->T.par[0] = Sin->data[2][row];
-							Ctrl->T.par[1] = (geo) ? gmtvector_dist_to_degree (GMT, Sin->data[3][row]) : Sin->data[3][row];	/* Make sure we have degrees from meters for get */
+							if (geo)
+								Ctrl->T.par[1] = (Ctrl->T.dmode == GMT_GREATCIRCLE) ? gmtvector_dist_to_degree (GMT, Sin->data[3][row]) : gmtvector_dist_to_meter (GMT, Sin->data[3][row]);	/* Make sure we have degrees or meters for calculations */
+							else
+								Ctrl->T.par[1] = Sin->data[3][row];	/* Pass as is */
 						}
 						gmtvector_translate_point (GMT, vector_1, vector_3, Ctrl->T.par, geo);
 						break;

--- a/src/gmtvector.c
+++ b/src/gmtvector.c
@@ -376,7 +376,8 @@ GMT_LOCAL void gmtvector_get_azpole (struct GMT_CTRL *GMT, double A[3], double P
 GMT_LOCAL void gmtvector_translate_point (struct GMT_CTRL *GMT, double A[3], double B[3], double a_d[], bool geo) {
 	/* Given point in A, azimuth az and distance d, return the point P away from A */
 	if (geo)
-		gmt_translate_point (GMT, A[GMT_X], A[GMT_Y], a_d[0], a_d[1], &B[GMT_X], &B[GMT_Y]);
+		GMT->current.map.second_point (GMT, A[GMT_X], A[GMT_Y], a_d[0], a_d[1], &B[GMT_X], &B[GMT_Y], NULL);
+		// gmt_translate_point (GMT, A[GMT_X], A[GMT_Y], a_d[0], a_d[1], &B[GMT_X], &B[GMT_Y]);
 	else {	/* Cartesian translation */
 		double s, c;
 		sincosd (90.0 - a_d[0], &s, &c);
@@ -544,8 +545,9 @@ EXTERN_MSC int GMT_gmtvector (void *V_API, int mode, void *args) {
 	}
 
 	if (Ctrl->T.mode == DO_TRANSLATE && geo) {	/* Initialize distance machinery */
+		int mode = (GMT->common.j.active) ? GMT->common.j.mode : GMT_GREATCIRCLE;
 		if (Ctrl->T.a_and_d)	/* Read az and dist from file, set units here */
-			error = gmt_init_distaz (GMT, Ctrl->T.unit, GMT_GREATCIRCLE, GMT_MAP_DIST);
+			error = gmt_init_distaz (GMT, Ctrl->T.unit, mode, GMT_MAP_DIST);
 		else {	/* Got a fixed set, set units here */
 			error = gmt_init_distaz (GMT, Ctrl->T.unit, Ctrl->T.dmode, GMT_MAP_DIST);
 			Ctrl->T.par[1] = gmtvector_dist_to_degree (GMT, Ctrl->T.par[1]);	/* Make sure we have degrees from whatever -Tt set */


### PR DESCRIPTION
**Description of proposed changes**

In addition the the spherical solution, this PR adds the ellipsoidal (Vincenty-1975) solution to the direct geodetic problem: Given a point, a bearing, and distance, determine the end point.  The **-j** option is used to control which solution is returned. This relates to this [posting](https://forum.generic-mapping-tools.org/t/how-to-calculate-coordinates-from-bearing-distance/1217/8) on the Forum.  After this PR, the second point that is 23 nautical miles in azimuth 310 from (50N, 8E) is

Spherical [Default or **-j**g]:
```
echo 8 50 | gmt vector -Tt310/23n
7.54112215577	50.24533433

```
Ellipsoidal [**-je**]
```
echo 8 50 | gmt vector -Tt310/23n -je
7.54254355708	50.2452568932

```

As @joa-quim reported, the proj/geod reports

7.542543557083350 50.245256893178066

Same if I mess with **FORMAT_FLOAT_OUT**.