### PR TITLE
Let developers save the antialias counter when projecting grids/images

### DIFF
--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -211,9 +211,10 @@ struct GMT_COMMON {
 		bool active;
 		struct GMT_LEGEND_ITEM item;
 	} l;
-	struct n {	/* -n[b|c|l|n][+a][+b<BC>][+c][+t<threshold>] */
+	struct n {	/* -n[b|c|l|n][+a][+b<BC>][+c][+t<threshold>] (and +A for debugging) */
 		bool active;
 		bool antialias;		/* Defaults to true, if supported */
+		bool save_debug;	/* Write antialias counters to tmp grid */
 		bool truncate;		/* Defaults to false */
 		unsigned int interpolant;	/* Defaults to BCR_BICUBIC */
 		bool bc_set;		/* true if +b was parsed */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2230,6 +2230,11 @@ int gmtinit_parse_n_option (struct GMT_CTRL *GMT, char *item) {
 
 	while ((gmt_strtok (&item[k], "+", &pos, p))) {
 		switch (p[0]) {
+#ifdef DEBUG
+			case 'A':	/* Debug antialias will save the counter to a grid */
+				GMT->common.n.save_debug = true;
+				break;
+#endif
 			case 'a':	/* Turn off antialias */
 				GMT->common.n.antialias = false;
 				break;
@@ -7232,6 +7237,9 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 			gmt_message (GMT, "\t-n[b|c|l|n][+a][+b<BC>][+c][+t<threshold>] Specify the grid interpolation mode.\n");
 			gmt_message (GMT, "\t   (b = B-spline, c = bicubic, l = bilinear, n = nearest-neighbor) [Default is bicubic].\n");
+#ifdef DEBUG
+			gmt_message (GMT, "\t   Append +A to save the antialiasing counter to a grid for debugging.\n");
+#endif
 			gmt_message (GMT, "\t   Append +a to switch off antialiasing (except for l) [Default: on].\n");
 			gmt_message (GMT, "\t   Append +b<BC> to change boundary conditions.  <BC> can be either:\n");
 			gmt_message (GMT, "\t     g for geographic, p for periodic, and n for natural boundary conditions.\n");

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -8107,10 +8107,10 @@ int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *
 			GMT_Report (GMT->parent, GMT_MSG_NOTICE, "gmt_grd_project: Antialias counter nz written to grid file nz_grd_counter.grd\n");
 			GMT_Destroy_Data (GMT->parent, &G);
 		}
-	}
-
-bail_grd_dbg:
+		bail_grd_dbg:
+		ij_out = 0;
 #endif
+	}
 
 /* PART 2: Create weighted average of interpolated and observed points */
 
@@ -8336,11 +8336,10 @@ int gmt_img_project (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, struct GMT_IMAGE
 			GMT_Report (GMT->parent, GMT_MSG_NOTICE, "gmt_grd_project: Antialias counter nz written to grid file nz_img_counter.grd\n");
 			GMT_Destroy_Data (GMT->parent, &G);
 		}
-	}
-
-bail_img_dbg:
+		bail_img_dbg:
+		ij_out = 0;
 #endif
-
+	}
 /* PART 2: Create weighted average of interpolated and observed points */
 
 //#ifdef _OPENMP

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -8096,9 +8096,23 @@ int gmt_grd_project (struct GMT_CTRL *GMT, struct GMT_GRID *I, struct GMT_GRID *
 
 			}
 		}
+#ifdef DEBUG
+		if (GMT->common.n.save_debug) {	/* Write nz as a debug grid to file */
+			uint64_t k;
+			struct GMT_GRID *G = NULL;
+			if ((G = GMT_Create_Data (GMT->parent, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, O->header->wesn, O->header->inc, \
+				O->header->registration, GMT_PAD_DEFAULT, NULL)) == NULL) goto bail_grd_dbg;
+			for (k = 0; k < G->header->size; k++) G->data[k] = (float)nz[k];
+			(void) GMT_Write_Data (GMT->parent, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, "nz_grd_counter.grd", G);
+			GMT_Report (GMT->parent, GMT_MSG_NOTICE, "gmt_grd_project: Antialias counter nz written to grid file nz_grd_counter.grd\n");
+			GMT_Destroy_Data (GMT->parent, &G);
+		}
 	}
 
-	/* PART 2: Create weighted average of interpolated and observed points */
+bail_grd_dbg:
+#endif
+
+/* PART 2: Create weighted average of interpolated and observed points */
 
 /* Open MP does not work yet */
 
@@ -8311,9 +8325,23 @@ int gmt_img_project (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, struct GMT_IMAGE
 				}
 			}
 		}
+#ifdef DEBUG
+		if (GMT->common.n.save_debug) {	/* Write nz as a debug grid to file */
+			uint64_t k;
+			struct GMT_GRID *G = NULL;
+			if ((G = GMT_Create_Data (GMT->parent, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, O->header->wesn, O->header->inc, \
+				O->header->registration, GMT_PAD_DEFAULT, NULL)) == NULL) goto bail_img_dbg;
+			for (k = 0; k < G->header->size; k++) G->data[k] = (float)nz[k];
+			(void) GMT_Write_Data (GMT->parent, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, "nz_img_counter.grd", G);
+			GMT_Report (GMT->parent, GMT_MSG_NOTICE, "gmt_grd_project: Antialias counter nz written to grid file nz_img_counter.grd\n");
+			GMT_Destroy_Data (GMT->parent, &G);
+		}
 	}
 
-	/* PART 2: Create weighted average of interpolated and observed points */
+bail_img_dbg:
+#endif
+
+/* PART 2: Create weighted average of interpolated and observed points */
 
 //#ifdef _OPENMP
 //#pragma omp parallel for private(row_out,y_proj,col_out,ij_out,x_proj,z_int,inv_nz,b) shared(O,GMT,y_out_proj,x_out_proj,inverse,x_out,y_out,I,nz,z_int_bg,nb)


### PR DESCRIPTION
For non-rectangular projections we must do an anti-alias step to ensure we avoid aliasing.  Anti-aliasing can be turned off via **-n+a**.  However, for exploring the function of anti-aliasing, developers can now add **-n+A** to save the averaging counter to a grid for examination.  The modifier is only accessible for developers building with **-DDEBUG** so cannot accidentally be used by users.  Because the anti-alias operation takes time it is good to be able to study this in more detail.

Below is the grid of counters for the sub_low_byte.tif we have examined due to the transparency pixel stuff.  The image shows that close to the pole there are many tiny places where up to ~10 input pixels are averaged for every output pixels, while at the south end it is typically just 1 or sometimes 2.

![t](https://user-images.githubusercontent.com/26473567/104829910-ce653580-581c-11eb-8a15-70911bfc4bcf.png)
