### PR TITLE
Improved parsing of grid increments

### DIFF
--- a/doc/rst/source/explain_-I.rst_
+++ b/doc/rst/source/explain_-I.rst_
@@ -1,6 +1,6 @@
 **-I**\ *xinc*\ [**+e**\|\ **n**][/\ *yinc*\ [**+e**\|\ **n**]]
     *x_inc* [and optionally *y_inc*] is the grid spacing. **Geographical
-    (degrees) coordinates**: Optionally, append a increment unit. Chose among
+    (degrees) coordinates**: Optionally, append a increment unit. Choose among
     **m** to indicate arc minutes or **s** to indicate arc seconds. If one
     of the units **e**, **f**, **k**, **M**, **n** or **u** is appended
     instead, the increment is assumed to be given in meter, foot, km, Mile,

--- a/doc/rst/source/explain_-I.rst_
+++ b/doc/rst/source/explain_-I.rst_
@@ -1,6 +1,6 @@
 **-I**\ *xinc*\ [**+e**\|\ **n**][/\ *yinc*\ [**+e**\|\ **n**]]
-    *x_inc* [and optionally *y_inc*] is the grid spacing. Optionally,
-    append a suffix modifier. **Geographical (degrees) coordinates**: Append
+    *x_inc* [and optionally *y_inc*] is the grid spacing. **Geographical
+    (degrees) coordinates**: Optionally, append a increment unit. Chose among
     **m** to indicate arc minutes or **s** to indicate arc seconds. If one
     of the units **e**, **f**, **k**, **M**, **n** or **u** is appended
     instead, the increment is assumed to be given in meter, foot, km, Mile,
@@ -14,8 +14,9 @@
     may be adjusted slightly to fit the given domain]. Finally, instead of
     giving an increment you may specify the *number of nodes* desired by
     appending **+n** to the supplied integer argument; the increment is then
-    recalculated from the number of nodes and the domain. The resulting
-    increment value depends on whether you have selected a
+    recalculated from the number of nodes, the *registration*, and the domain.
+    The resulting increment value depends on whether you have selected a
     gridline-registered or pixel-registered grid; see :ref:`GMT File Formats` for
-    details. **Note**: If **-R**\ *grdfile* is used then the grid spacing (and registration) have
-    already been initialized; use **-I** (and **-r**) to override the values.
+    details. **Note**: If **-R**\ *grdfile* is used then the grid spacing and
+    the registration have already been initialized; use **-I** and **-r**
+    to override these values.

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6919,7 +6919,7 @@ GMT_LOCAL unsigned int gmtsupport_set_geo (struct GMT_CTRL *GMT) {
 	/* Returns 0 for all Cartesian, or sum of GMT_IS_LON if longitudes and GMT_IS_LAT if latitudes */
 	unsigned int x = GMT_IS_LON, y = GMT_IS_LAT;
 	if (!GMT->common.R.active[RSET]) return x + y;	/* Just as before to avoid breaking things */
-	/* Here we have -Rw/e/s/n.  If it clearly is not geographic we return false, else true */
+	/* Here we have -Rw/e/s/n.  If it clearly is not geographic then we return 0, else we return one or the sum of GMT_IS_LON and GMT_IS_LAT */
 	if ((GMT->common.R.wesn[XHI] - GMT->common.R.wesn[XLO]) > 360.0) x = 0;	/* Cannot exceed 360 degrees longitude */
 	if ((GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO]) > 180.0) y = 0;	/* Cannot exceed 180 degrees latitude */
 	if (GMT->common.R.wesn[XLO] < -720.0 || GMT->common.R.wesn[XLO] > 360.0) x = 0;	/* Clearly outside normal longitude range */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6915,10 +6915,24 @@ bool gmt_getinc (struct GMT_CTRL *GMT, char *line, double inc[]) {
 	return (false);
 }
 
+GMT_LOCAL unsigned int gmtsupport_set_geo (struct GMT_CTRL *GMT) {
+	/* Returns 0 for all Cartesian, or sum of GMT_IS_LON if longitudes and GMT_IS_LAT if latitudes */
+	unsigned int x = GMT_IS_LON, y = GMT_IS_LAT;
+	if (!GMT->common.R.active[RSET]) return x + y;	/* Just as before to avoid breaking things */
+	/* Here we have -Rw/e/s/n.  If it clearly is not geographic we return false, else true */
+	if ((GMT->common.R.wesn[XHI] - GMT->common.R.wesn[XLO]) > 360.0) x = 0;	/* Cannot exceed 360 degrees longitude */
+	if ((GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO]) > 180.0) y = 0;	/* Cannot exceed 180 degrees latitude */
+	if (GMT->common.R.wesn[XLO] < -720.0 || GMT->common.R.wesn[XLO] > 360.0) x = 0;	/* Clearly outside normal longitude range */
+	if (GMT->common.R.wesn[XHI] < -360.0 || GMT->common.R.wesn[XHI] > 720.0) x = 0;	/* Clearly outside normal longitude range */
+	if (GMT->common.R.wesn[YLO] < -90.0 || GMT->common.R.wesn[YLO] > 90.0) y = 0;	/* Clearly outside normal latitude range */
+	if (GMT->common.R.wesn[YHI] < -90.0 || GMT->common.R.wesn[YHI] > 90.0) y = 0;	/* Clearly outside normal latitude range */
+	return x+y;	/* Might still be geographic for the purpose of parsing -I */
+}
+
 /*! . */
 int gmt_getincn (struct GMT_CTRL *GMT, char *line, double inc[], unsigned int n) {
-	unsigned int last, i, pos;
-	bool geo = true;	/* Until proven wrong in the switch */
+	bool separate;
+	unsigned int last, i, pos, bit = 1, geo = gmtsupport_set_geo (GMT);	/* true unless clearly -R is Cartesian */
 	char p[GMT_BUFSIZ];
 	double scale = 1.0;
 
@@ -6929,7 +6943,7 @@ int gmt_getincn (struct GMT_CTRL *GMT, char *line, double inc[], unsigned int n)
 	gmt_M_memset (inc, n, double);
 
 	i = pos = GMT->current.io.inc_code[GMT_X] = GMT->current.io.inc_code[GMT_Y] = 0;
-
+	separate = (strchr (line, '/') != NULL);
 	while (i < n && (gmt_strtok (line, "/", &pos, p))) {
 		last = (unsigned int)strlen (p) - 1;
 		if (last && p[last] == 'e' && p[last-1] == '+') {	/* +e: Let -I override -R */
@@ -6951,6 +6965,12 @@ int gmt_getincn (struct GMT_CTRL *GMT, char *line, double inc[], unsigned int n)
 			p[last] = 0;
 			if (i < 2) GMT->current.io.inc_code[i] |= GMT_INC_IS_NNODES;
 			if (last) last--;	/* Coverity rightly points out that if last == 0 it would become 4294967295 */
+		}
+		if (geo == 0 || (separate && (geo & bit) == 0) ) {
+			if (p[last] && strchr (GMT_LEN_UNITS "c", p[last])) {
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Unit %c is ignored for Cartesian data\n", p[last]);
+				p[last] = 0;
+			}
 		}
 		switch (p[last]) {
 			case 'd':	/* Gave arc degree */
@@ -7009,8 +7029,16 @@ int gmt_getincn (struct GMT_CTRL *GMT, char *line, double inc[], unsigned int n)
 		}
 		inc[i] *= scale;
 		i++;	/* Goto next increment */
+		bit <<= 1;
 	}
-	if (geo) gmt_set_geographic (GMT, GMT_IN);
+	if (geo) {
+		if (geo == (GMT_IS_LON+GMT_IS_LAT))	/* Regular lon/lat region presumably */
+			gmt_set_geographic (GMT, GMT_IN);
+		else if (geo & GMT_IS_LON)
+			gmt_set_column_type (GMT, GMT_IN, GMT_X, GMT_IS_LON);
+		else if (geo & GMT_IS_LAT)
+			gmt_set_column_type (GMT, GMT_IN, GMT_Y, GMT_IS_LAT);
+	}
 
 	return (i);	/* Returns the number of increments found */
 }

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6966,9 +6966,14 @@ int gmt_getincn (struct GMT_CTRL *GMT, char *line, double inc[], unsigned int n)
 			if (i < 2) GMT->current.io.inc_code[i] |= GMT_INC_IS_NNODES;
 			if (last) last--;	/* Coverity rightly points out that if last == 0 it would become 4294967295 */
 		}
-		if (geo == 0 || (separate && (geo & bit) == 0) ) {
+		if (geo == 0 || (separate && (geo & bit) == 0) ) {	/* Gave a unit to a Cartesian axes that does not take any unit */
 			if (p[last] && strchr (GMT_LEN_UNITS "c", p[last])) {
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Unit %c is ignored for Cartesian data\n", p[last]);
+				if (separate) {	/* Report per axis since separate increments where given */
+					static char *A = "xyzvuw";
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Unit %c is ignored as the %c-axis is not geographic\n", p[last], A[i]);
+				}
+				else	/* Single message since common increment for all axes */
+					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Unit %c is ignored as no axis is geographic\n", p[last]);
 				p[last] = 0;
 			}
 		}

--- a/test/grdimage/hovmuller.sh
+++ b/test/grdimage/hovmuller.sh
@@ -9,5 +9,5 @@ gmt set MAP_ANNOT_ORTHO ""
 
 gmt makecpt -Crainbow -T-1/1/0.05 > tmp.cpt
 # Make a fake longitude/time grid
-gmt grdmath -R-180/180/0/3 -f0x,1t -I10/5m X SIND Y 2 MUL PI MUL SIN MUL = tmp.nc
+gmt grdmath -R-180/180/0/3 -f0x,1t -I10/37+n X SIND Y 2 MUL PI MUL SIN MUL = tmp.nc
 gmt grdimage tmp.nc -Ctmp.cpt -JX15c/22cT -Bx30f10 -By1O -Bsy1Y -E100 -P -Xc > $ps


### PR DESCRIPTION
**Description of proposed changes**

The confusion experienced on the [forum](https://forum.generic-mapping-tools.org/t/xyz2grd-wants-to-produce-massive-file-runs-out-of-memory/1221/4) has happened many times before: People misread (or don't read) and append units to the increment even though their data is Cartesian (e.g., UTM meters). However, we clearly do not what the user's

`-R265060/267360/4154020/4155500 -I50e`

 to result in 50e being interpreted as "convert an increment of 50 meter along Equator to longitude increment" when from **-R** it is clear we are not dealing with longitudes.

This PR is much more careful in making such assumtions.  If the given range of _x_ or _y_ in **-R** clearly cannot be longitude or latitude we use that to ignore any unit in the increment and issue a warning instead.  Testing this I got a failure in hovmuller.sh where the test used `-I10/5m` even though the y-axis was set up to be time in years and the 5m was a sloppy way (because of how GMT worked above) to use an increment of 5/60 years (and not 5 minutes).  Now replaced with `-I10/37+n` and all tests pass.  Also improved the **-I** documentation.
