### PR TITLE
WIP Refactor test for grdsample

### DIFF
--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -202,7 +202,7 @@ EXTERN_MSC int gmtlib_grd_sample (void *V_API, struct GMT_GRID *Gin, double *wes
 	if (V_API == NULL) return (GMT_NOT_A_SESSION);
 	if (Gin == NULL) return (GMT_PTR_IS_NULL);
 	if (G == NULL) return (GMT_PTR_IS_NULL);
-	if ((registration == GMT_GRID_NODE_REG || registration == GMT_GRID_PIXEL_REG)) return (GMT_VALUE_NOT_SET);
+	if (!(registration == GMT_GRID_NODE_REG || registration == GMT_GRID_PIXEL_REG)) return (GMT_VALUE_NOT_SET);
 	API = gmt_get_api_ptr (V_API);
 	GMT = API->GMT;
 


### PR DESCRIPTION
**Description of proposed changes**

This PR breaks up grdsample.c's _GMT_grdsample_ into a new function _gmtlib_grd_sample_ that does the work, while _GMT_grdsample_ deals with the i/o, arguments, options and then calls _gmtlib_grd_sample_. All tests still pass so done OK I think. The prototype looks like this:

 i`nt gmtlib_grd_sample (void *API, struct GMT_GRID *Gin, double *wesn, double *incs, int registration, int mode, struct GMT_GRID **G);`

Yet there are questions:

- We pass API as first argument, like for all API functions. Alternative is a laundry-list of settings and option arguments.
- We pass in a GMT_GRID structure and receives a new one back.  If externals have not wrapped such structures but use matrices, xarrays, etc, then what should the interface be? The current one is the closest to the GMT API without doing any i/o. Do we add additional C wrappers called _gmtlib_matrix_sample_ that now need to pass many more arguments (basically the info in the grid headers, in and out, plus a 2-D array?  Does that simplify anything? Seems it gets more complicated if each wrapper has to use a container specific to its language.
- We still have the pad issue. Resampling requires the 2 boundary pads which all GMT internal grids have.  But externals will pass in grids without pads and then we have to duplicate memory to add pads.

