### PR TITLE
Let grdcontour -A+T give compativility warning and not an error

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9899,6 +9899,13 @@ int gmt_contlabel_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_CONTOUR *G)
 					bad++;
 				break;
 
+			case 'T':	/* Deprecated, just give a warning that it is the same as +t and deliberately fall through to case 't' */
+				if (gmt_M_compat_check (GMT, 6))
+					GMT_Report (GMT->parent, GMT_MSG_COMPAT, "+T in contour label spec is deprecated, use +t instead\n");
+				else {
+					bad++;
+					break;
+				}
 			case 't':	/* Save contour label locations to given file [x y angle label] */
 				G->save_labels = 1;
 				if (p[1]) strncpy (G->label_file, &p[1], PATH_MAX-1);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -9901,7 +9901,7 @@ int gmt_contlabel_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_CONTOUR *G)
 
 			case 'T':	/* Deprecated, just give a warning that it is the same as +t and deliberately fall through to case 't' */
 				if (gmt_M_compat_check (GMT, 6))
-					GMT_Report (GMT->parent, GMT_MSG_COMPAT, "+T in contour label spec is deprecated, use +t instead\n");
+					GMT_Report (GMT->parent, GMT_MSG_COMPAT, "+T in contour label spec is deprecated; only +t is supported\n");
 				else {
 					bad++;
 					break;


### PR DESCRIPTION
See [forum post](https://forum.generic-mapping-tools.org/t/psxy-plot-sq-option-t-t-modifiers/1228) for background.  In GMT 6 we eliminated the **-A +T** modifier and only use **+t** since it seemed pointless to have both as users can just use the columns they need.  However, it was a mistake to let **+T** trigger an error since it used to be a valid modifier.  This PR allows **+T** under compatibility with version 6 and results in the same output as **+t**.

