### PR TITLE
Custom annotation text never checked for color switch

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14703,7 +14703,10 @@ unsigned int gmtlib_load_custom_annot (struct GMT_CTRL *GMT, struct GMT_PLOT_AXI
 		if (strchr (type, 'i')) n_int++;
 		if (strchr (type, 'a')) n_annot++;
 		x[k] = S->data[GMT_X][row];
-		if (text && nc == 2) L[k] = strdup (txt);
+		if (text && nc == 2) {
+			gmtlib_enforce_rgb_triplets (GMT, txt, GMT_BUFSIZ);	/* If @; is used, make sure the color information passed on to ps_text is in r/b/g format */
+			L[k] = strdup (txt);
+		}
 		k++;
 	}
 


### PR DESCRIPTION
The switch text color escape sequence `@;color;` requires any named color to be replaced by r/g/b statements internally via _gmtlib_enforce_rgb_triplets_ before being sent to PSL.  This happens everywhere in GMT **except** when custom labels were read in _gmtlib_load_custom_annot_.  This PR fixes the problem and closes #4668.  Thanks for the example, @uleysky.
