### PR TITLE
Add test script showing failure of clipping in TM projection

### DIFF
--- a/test/psxy/tissot_TM.sh
+++ b/test/psxy/tissot_TM.sh
@@ -3,4 +3,4 @@
 # Demonstrate failure to clip ellipses against periodic TM boundary in y.
 # See https://forum.generic-mapping-tools.org/t/how-to-avoid-the-funky-look-of-jt-and-se/1224
 ps=tissot_TM.ps
-echo 30 -60 2000k | gmt psxy -R0/360/-80/80 -JT-15/15/16c -Bafg -SE- -Gred@50 -Wred -P > $ps
+echo 30 -60 2000k | gmt psxy -R0/360/-80/80 -JT-15/15/16c -Bafg -SE- -Gred -Wthin -P > $ps

--- a/test/psxy/tissot_TM.sh
+++ b/test/psxy/tissot_TM.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+# Demonstrate failure to clip ellipses against periodic TM boundary in y.
+# See https://forum.generic-mapping-tools.org/t/how-to-avoid-the-funky-look-of-jt-and-se/1224
+ps=tissot_TM.ps
+echo 30 -60 2000k | gmt psxy -R0/360/-80/80 -JT-15/15/16c -Bafg -SE- -Gred@50 -Wred -P > $ps


### PR DESCRIPTION
See [forum](https://forum.generic-mapping-tools.org/t/how-to-avoid-the-funky-look-of-jt-and-se/1224) for background.  This PR just adds a minimal failing script to remind us to address this problem.
