### PR TITLE
Fix typo for reverse doc string

### DIFF
--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -156,7 +156,7 @@ Optional Arguments
     :term:`COLOR_FOREGROUND`.
     Append **z** to reverse the sign of z-values in the color table.  Note that
     this change of *z*-direction happens before **-G** and **-S** values are used
-    so the latter much be compatible with the changed *z*-range. See also :ref:`manipulating_CPTs`
+    so the latter must be compatible with the changed *z*-range. See also :ref:`manipulating_CPTs`
 
 .. _-L:
 


### PR DESCRIPTION
The doc string for `-I` previous said "so the latter much be compatible with the changed". I'm assuming that "much" should be "must" so I submitted this PR.