### PR TITLE
Correct Cartesian ellipse output in project and allow degenerate case

### DIFF
--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -206,11 +206,13 @@ Optional Arguments
 **-Z**\ *major*/*minor*/*azimuth*\ [**+e**]
     Used in conjunction with **-C** (sets its center) and **-G** (sets the
     distance increment) to create the coordinates of an ellipse
-    with *major* and *minor* axes given in km (unless **-N** is given) and the *azimuth* of the
-    major axis in degrees.  Append **+e** to adjust the increment set via
-    **-G** so that the the ellipse has equal distance increments [Default
-    uses the given increment and closes the ellipse].  For degenerate ellipses
-    you can just supply a single *diameter* instead.
+    with *major* and *minor* axes given in km (unless **-N** is given for a
+    Cartesian ellipse) and the *azimuth* of the major axis in degrees.
+    Append **+e** to adjust the increment set via **-G** so that the the ellipse
+    has equal distance increments [Default uses the given increment and closes
+    the ellipse].  For degenerate ellipses you can just supply a single *diameter*
+    instead.  **Note**: For the Cartesian ellipse (which requires **-N**), we
+    expect *direction* counter-clockwise from the horizontal instead of an *azimuth*.
 
 .. |Add_-bi| replace:: [Default is 2 input columns].
 .. include:: explain_-bi.rst_
@@ -287,7 +289,7 @@ defined by the great circle from the pole to a point 15E,15N, try
 
     gmt project -C15/15 -T40/85 -G1/80 -L-45/45 > some_circle.xyp
 
-To generate points approximately every 10km along an ellipse centered on (30W,70N) with
+To generate points approximately every 10 km along an ellipse centered on (30W,70N) with
 major axis of 1500 km with azimuth of 30 degree and a minor axis of 600 km, try
 
    ::

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -209,8 +209,8 @@ Optional Arguments
     with *major* and *minor* axes given in km (unless **-N** is given) and the *azimuth* of the
     major axis in degrees.  Append **+e** to adjust the increment set via
     **-G** so that the the ellipse has equal distance increments [Default
-    uses the given increment and closes the ellipse].
-
+    uses the given increment and closes the ellipse].  For degenerate ellipses
+    you can just supply a single *diameter* instead.
 
 .. |Add_-bi| replace:: [Default is 2 input columns].
 .. include:: explain_-bi.rst_

--- a/test/project/ellipses.ps
+++ b/test/project/ellipses.ps
@@ -1,0 +1,1308 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 595 842
+%%HiResBoundingBox: 0 0 595.0000 842.0000
+%%Title: GMT v6.2.0_ed99d93_2021.01.23 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sat Jan 23 11:53:43 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 9917 def
+/PSL_page_ysize 14033 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R-2/5/-2/5 -Jx1.5c -Bafg1 -W1p -Glightgray
+%@PROJ: xy -2.00000000 5.00000000 -2.00000000 5.00000000 -2.000 5.000 -2.000 5.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+V
+17 W
+clipsave
+0 0 M
+4961 0 D
+0 4961 D
+-4961 0 D
+P
+PSL_clip N
+{0.827 A} FS
+O1
+/FO {P}!
+4252 2126 M
+-4 80 D
+-12 79 D
+-20 78 D
+-27 75 D
+-33 72 D
+-39 69 D
+-45 65 D
+-48 61 D
+-53 56 D
+-55 52 D
+-58 48 D
+-59 44 D
+-60 40 D
+-62 36 D
+-62 32 D
+-62 29 D
+-62 26 D
+-62 23 D
+-62 20 D
+-62 18 D
+-61 15 D
+-123 23 D
+-121 15 D
+-60 4 D
+-120 3 D
+-61 -2 D
+-60 -3 D
+-60 -5 D
+-61 -8 D
+-61 -9 D
+-61 -12 D
+-61 -13 D
+-62 -17 D
+-62 -19 D
+-62 -21 D
+-62 -24 D
+-62 -28 D
+-62 -31 D
+-62 -34 D
+-61 -38 D
+-60 -42 D
+-58 -45 D
+-57 -50 D
+-54 -55 D
+-50 -58 D
+-47 -63 D
+-42 -67 D
+-36 -70 D
+-30 -74 D
+-24 -77 D
+-16 -78 D
+-8 -80 D
+0 -80 D
+8 -80 D
+16 -78 D
+24 -77 D
+30 -74 D
+36 -70 D
+42 -67 D
+47 -63 D
+50 -58 D
+54 -55 D
+57 -50 D
+58 -45 D
+60 -42 D
+61 -38 D
+62 -34 D
+62 -31 D
+62 -28 D
+62 -24 D
+62 -21 D
+62 -19 D
+62 -17 D
+122 -25 D
+122 -17 D
+120 -9 D
+61 -1 D
+120 3 D
+60 4 D
+121 15 D
+61 10 D
+62 13 D
+61 15 D
+62 18 D
+62 20 D
+62 23 D
+62 26 D
+62 29 D
+62 32 D
+62 36 D
+60 40 D
+59 44 D
+58 48 D
+55 52 D
+53 56 D
+48 61 D
+45 65 D
+39 69 D
+33 72 D
+27 75 D
+20 78 D
+12 79 D
+P
+FO
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+4 W
+0 A
+0 0 M
+0 4961 D
+S
+709 0 M
+0 4961 D
+S
+1417 0 M
+0 4961 D
+S
+2126 0 M
+0 4961 D
+S
+2835 0 M
+0 4961 D
+S
+3543 0 M
+0 4961 D
+S
+4252 0 M
+0 4961 D
+S
+4961 0 M
+0 4961 D
+S
+0 0 M
+4961 0 D
+S
+0 709 M
+4961 0 D
+S
+0 1417 M
+4961 0 D
+S
+0 2126 M
+4961 0 D
+S
+0 2835 M
+4961 0 D
+S
+0 3543 M
+4961 0 D
+S
+0 4252 M
+4961 0 D
+S
+0 4961 M
+4961 0 D
+S
+25 W
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 4961 M 0 -4961 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 1417 M -83 0 D S
+N 0 2835 M -83 0 D S
+N 0 4252 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-2) sw mx
+(0) sw mx
+(2) sw mx
+(4) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(-2) mr Z
+1417 PSL_A0_y MM
+(0) mr Z
+2835 PSL_A0_y MM
+(2) mr Z
+4252 PSL_A0_y MM
+(4) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 709 M -42 0 D S
+N 0 2126 M -42 0 D S
+N 0 3543 M -42 0 D S
+N 0 4961 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4961 0 T
+25 W
+N 0 4961 M 0 -4961 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 1417 M 83 0 D S
+N 0 2835 M 83 0 D S
+N 0 4252 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+(-2) sw mx
+(0) sw mx
+(2) sw mx
+(4) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-2) mr Z
+1417 PSL_A0_y MM
+(0) mr Z
+2835 PSL_A0_y MM
+(2) mr Z
+4252 PSL_A0_y MM
+(4) mr Z
+N 0 709 M 42 0 D S
+N 0 2126 M 42 0 D S
+N 0 3543 M 42 0 D S
+N 0 4961 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-4961 0 T
+25 W
+N 0 0 M 4961 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 2835 0 M 0 -83 D S
+N 4252 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(-2) sh mx
+(0) sh mx
+(2) sh mx
+(4) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-2) bc Z
+1417 PSL_A0_y MM
+(0) bc Z
+2835 PSL_A0_y MM
+(2) bc Z
+4252 PSL_A0_y MM
+(4) bc Z
+N 709 0 M 0 -42 D S
+N 2126 0 M 0 -42 D S
+N 3543 0 M 0 -42 D S
+N 4961 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4961 T
+25 W
+N 0 0 M 4961 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 2835 0 M 0 83 D S
+N 4252 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(-2) sh mx
+(0) sh mx
+(2) sh mx
+(4) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(-2) bc Z
+1417 PSL_A0_y MM
+(0) bc Z
+2835 PSL_A0_y MM
+(2) bc Z
+4252 PSL_A0_y MM
+(4) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 709 0 M 0 42 D S
+N 2126 0 M 0 42 D S
+N 3543 0 M 0 42 D S
+N 4961 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4961 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 5669 TM
+% PostScript produced by:
+%@GMT: gmt plot -Jm1.5c -Bafg1 -W1p -Glightgray -Y12c -R-2/5/-2/5
+%@PROJ: merc -2.00000000 5.00000000 -2.00000000 5.00000000 -389618.218 389618.218 -221194.077 553583.847 +proj=merc +lon_0=1.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 0 0 M 0 -83 D S
+N 0 4932 M 0 84 D S
+N 1417 0 M 0 -83 D S
+N 1417 4932 M 0 84 D S
+N 2835 0 M 0 -83 D S
+N 2835 4932 M 0 84 D S
+N 4252 0 M 0 -83 D S
+N 4252 4932 M 0 84 D S
+N 0 0 M -83 0 D S
+N 4961 0 M 83 0 D S
+N 0 1408 M -83 0 D S
+N 4961 1408 M 83 0 D S
+N 0 2816 M -83 0 D S
+N 4961 2816 M 83 0 D S
+N 0 4226 M -83 0 D S
+N 4961 4226 M 83 0 D S
+0 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-2°) tc Z
+0 5099 M (-2°) bc Z
+1417 -167 M (0°) tc Z
+1417 5099 M (0°) bc Z
+2835 -167 M (2°) tc Z
+2835 5099 M (2°) bc Z
+4252 -167 M (4°) tc Z
+4252 5099 M (4°) bc Z
+-167 0 M (-2°) mr Z
+5127 0 M (-2°) ml Z
+-167 1408 M (0°) mr Z
+5127 1408 M (0°) ml Z
+-167 2816 M (2°) mr Z
+5127 2816 M (2°) ml Z
+-167 4226 M (4°) mr Z
+5127 4226 M (4°) ml Z
+V
+17 W
+clipsave
+0 0 M
+4961 0 D
+0 4932 D
+-4961 0 D
+P
+PSL_clip N
+{0.827 A} FS
+O1
+/FO {P}!
+2835 3378 M
+-14 -1 D
+-14 0 D
+-13 -1 D
+-14 -1 D
+-13 -1 D
+-14 -1 D
+-13 -2 D
+-14 -2 D
+-13 -2 D
+-14 -2 D
+-13 -3 D
+-14 -3 D
+-13 -3 D
+-13 -3 D
+-14 -4 D
+-13 -4 D
+-13 -4 D
+-13 -5 D
+-13 -5 D
+-13 -4 D
+-13 -6 D
+-13 -5 D
+-13 -6 D
+-13 -5 D
+-26 -13 D
+-25 -14 D
+-25 -14 D
+-24 -15 D
+-36 -25 D
+-47 -36 D
+-57 -50 D
+-43 -44 D
+-48 -55 D
+-51 -68 D
+-36 -54 D
+-11 -19 D
+-11 -19 D
+-37 -68 D
+-42 -93 D
+-17 -42 D
+-33 -99 D
+-24 -90 D
+-16 -81 D
+-13 -82 D
+-7 -60 D
+-6 -107 D
+1 -120 D
+7 -95 D
+13 -95 D
+15 -81 D
+32 -125 D
+26 -77 D
+29 -74 D
+38 -82 D
+26 -49 D
+28 -47 D
+29 -45 D
+44 -61 D
+33 -41 D
+53 -57 D
+55 -52 D
+58 -47 D
+60 -41 D
+50 -29 D
+51 -25 D
+52 -21 D
+66 -21 D
+67 -14 D
+54 -7 D
+27 -3 D
+54 -1 D
+41 3 D
+41 4 D
+53 9 D
+54 13 D
+65 22 D
+65 28 D
+50 27 D
+61 39 D
+36 26 D
+46 38 D
+45 41 D
+70 76 D
+19 25 D
+39 51 D
+53 82 D
+42 77 D
+34 72 D
+37 95 D
+22 66 D
+19 68 D
+13 57 D
+14 69 D
+14 107 D
+7 95 D
+2 84 D
+-3 84 D
+-5 71 D
+-14 106 D
+-18 93 D
+-17 69 D
+-24 77 D
+-27 76 D
+-36 83 D
+-30 60 D
+-38 67 D
+-54 81 D
+-39 51 D
+-48 55 D
+-43 44 D
+-56 50 D
+-71 53 D
+-62 37 D
+-51 27 D
+-51 22 D
+-79 26 D
+-67 14 D
+-54 7 D
+P
+FO
+/FO {fs os}!
+FO
+PSL_cliprestore
+U
+4 W
+0 A
+0 0 M
+0 4932 D
+S
+709 0 M
+0 4932 D
+S
+1417 0 M
+0 4932 D
+S
+2126 0 M
+0 4932 D
+S
+2835 0 M
+0 4932 D
+S
+3543 0 M
+0 4932 D
+S
+4252 0 M
+0 4932 D
+S
+4961 0 M
+0 4932 D
+S
+0 0 M
+4961 0 D
+S
+0 704 M
+4961 0 D
+S
+0 1408 M
+4961 0 D
+S
+0 2112 M
+4961 0 D
+S
+0 2816 M
+4961 0 D
+S
+0 3521 M
+4961 0 D
+S
+0 4226 M
+4961 0 D
+S
+0 4932 M
+4961 0 D
+S
+25 W
+83 W
+N -42 0 M 0 704 D S
+N 5002 0 M 0 704 D S
+1 A
+N -42 704 M 0 704 D S
+N 5002 704 M 0 704 D S
+0 A
+N -42 1408 M 0 704 D S
+N 5002 1408 M 0 704 D S
+1 A
+N -42 2112 M 0 704 D S
+N 5002 2112 M 0 704 D S
+0 A
+N -42 2816 M 0 705 D S
+N 5002 2816 M 0 705 D S
+1 A
+N -42 3521 M 0 705 D S
+N 5002 3521 M 0 705 D S
+0 A
+N -42 4226 M 0 706 D S
+N 5002 4226 M 0 706 D S
+N 0 -42 M 709 0 D S
+N 0 4974 M 709 0 D S
+1 A
+N 709 -42 M 708 0 D S
+N 709 4974 M 708 0 D S
+0 A
+N 1417 -42 M 709 0 D S
+N 1417 4974 M 709 0 D S
+1 A
+N 2126 -42 M 709 0 D S
+N 2126 4974 M 709 0 D S
+0 A
+N 2835 -42 M 708 0 D S
+N 2835 4974 M 708 0 D S
+1 A
+N 3543 -42 M 709 0 D S
+N 3543 4974 M 709 0 D S
+0 A
+N 4252 -42 M 709 0 D S
+N 4252 4974 M 709 0 D S
+8 W
+N -83 0 M 5127 0 D S
+N -83 -83 M 5127 0 D S
+N 4961 -83 M 0 5099 D S
+N 5044 -83 M 0 5099 D S
+N 5044 4932 M -5127 0 D S
+N 5044 5016 M -5127 0 D S
+N 0 5016 M 0 -5099 D S
+N -83 5016 M 0 -5099 D S
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/project/ellipses.ps
+++ b/test/project/ellipses.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
 %%Title: GMT v6.2.0_ed99d93_2021.01.23 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Jan 23 11:53:43 2021
+%%CreationDate: Sat Jan 23 12:07:13 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -688,8 +688,8 @@ end
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-/PSL_page_xsize 9917 def
-/PSL_page_ysize 14033 def
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
 /PSL_movie_label_completion {} def
 /PSL_movie_prog_indicator_completion {} def
@@ -1013,9 +1013,9 @@ N 4961 0 M 0 42 D S
 0 A
 FQ
 O0
-0 5669 TM
+0 6142 TM
 % PostScript produced by:
-%@GMT: gmt plot -Jm1.5c -Bafg1 -W1p -Glightgray -Y12c -R-2/5/-2/5
+%@GMT: gmt plot -Jm1.5c -Bafg1 -W1p -Glightgray -Y13c -R-2/5/-2/5
 %@PROJ: merc -2.00000000 5.00000000 -2.00000000 5.00000000 -389618.218 389618.218 -221194.077 553583.847 +proj=merc +lon_0=1.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap

--- a/test/project/ellipses.sh
+++ b/test/project/ellipses.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Tests gmt project to make Cartesian or geographic ellipses.
+# Cartesian case expects direction while geographic expects azimuth
+# This matches the expectations in psxy
+
+gmt begin ellipses ps
+	gmt project -N -Z4/3/0+e -G0.1 -C2/1 | gmt plot -R-2/5/-2/5 -Jx1.5c -Bafg1 -W1p -Glightgray
+	gmt project -Z400/300/0+e -G10 -C2/1 | gmt plot -Jm1.5c -Bafg1 -W1p -Glightgray -Y13c
+gmt end show


### PR DESCRIPTION
The **-Z** option in **project** can be used to create the coordinates of an ellipse in either geographic or Cartesian space. Unfortunately, the Cartesian case had a bug in that it assumed we gave it semi-axes, not full axes like for the geographic case, as well as is the expectations in **psxy**.  This is now fixed.  I also now check that the major axis is not shorter than the minor axis. In addition, I made it simpler to specify circular output (the degenerate ellipse) by just providing the diameter (again, like in **psxy -SE-**).  Finally, I fixed the problem that the Cartesian case used the given angle as an azimuth but as per psxy the angular argument should be the direction CCW from the horizontal.  Given all this, I added a simple test to that plots both a geographic or Cartesian ellipses.