### PR TITLE
Allow parsing of -Jz1:zzzzzz for vertical scale

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4875,6 +4875,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 			break;
 
 		case GMT_ZAXIS:	/* 3D plot */
+
 			GMT->current.proj.compute_scale[GMT_Z] = width_given;
 			error += (n_slashes > 0) ? 1 : 0;
 			gmt_set_column_type (GMT, GMT_IN, GMT_Z, GMT_IS_UNKNOWN);
@@ -4904,7 +4905,8 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				args_cp[i] = 0;
 			else if (t_pos[GMT_Z] > 0)
 				args_cp[t_pos[GMT_Z]] = 0;
-			GMT->current.proj.z_pars[0] = gmt_M_to_inch (GMT, args_cp);	/* z-scale */
+			//GMT->current.proj.z_pars[0] = gmt_M_to_inch (GMT, args_cp);	/* z-scale */
+			error += gmtinit_scale_or_width (GMT, args_cp, &GMT->current.proj.z_pars[0]);
 
 			GMT->current.proj.xyz_projection[GMT_Z] = GMT_LINEAR;
 			if (l_pos[GMT_Z] > 0)

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4621,7 +4621,7 @@ GMT_LOCAL int gmtinit_project_type (char *args, int *pos, bool *width_given) {
 }
 
 /*! . */
-GMT_LOCAL int gmtinit_scale_or_width (struct GMT_CTRL *GMT, char *scale_or_width, double *value) {
+GMT_LOCAL int gmtinit_scale_or_width (struct GMT_CTRL *GMT, char *scale_or_width, double *value, bool xy_plane) {
 	/* Scans character that may contain a scale (1:xxxx or units per degree) or a width.
 	   Return 1 upon error. Here we want to make an exception for users giving a scale
 	   of 1 in grdproject and mapproject as it is most likely meant to be 1:1. */
@@ -4634,7 +4634,7 @@ GMT_LOCAL int gmtinit_scale_or_width (struct GMT_CTRL *GMT, char *scale_or_width
 		if (k == 1 && scale_or_width[0] == '1' && gmt_M_is_grdmapproject (GMT)) {	/* OK, pretend we got 1:1 */
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Your scale of 1 in -J was interpreted to mean 1:1 since no plotting is involved.\n");
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "If a scale of 1 was intended, please append a unit from %s.\n", GMT_DIM_UNITS_DISPLAY);
-			gmtinit_scale_or_width (GMT, strcat(scale_or_width,":1"), value);
+			gmtinit_scale_or_width (GMT, strcat(scale_or_width,":1"), value, xy_plane);
 			return (GMT_NOERROR);
 		}
 
@@ -4653,7 +4653,7 @@ GMT_LOCAL int gmtinit_scale_or_width (struct GMT_CTRL *GMT, char *scale_or_width
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your scale or width (%s) resulted in a zero value.\n", scale_or_width);
 		return (1);
 	}
-	else if (gmt_M_is_geographic (GMT, GMT_IN) && (*value) < 0.0) {
+	else if (xy_plane && gmt_M_is_geographic (GMT, GMT_IN) && (*value) < 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Geographic scale (%s) cannot be negative.\n", scale_or_width);
 		return (1);
 	}
@@ -4905,8 +4905,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				args_cp[i] = 0;
 			else if (t_pos[GMT_Z] > 0)
 				args_cp[t_pos[GMT_Z]] = 0;
-			//GMT->current.proj.z_pars[0] = gmt_M_to_inch (GMT, args_cp);	/* z-scale */
-			error += gmtinit_scale_or_width (GMT, args_cp, &GMT->current.proj.z_pars[0]);
+			error += gmtinit_scale_or_width (GMT, args_cp, &GMT->current.proj.z_pars[0], false);	/* z-scale */
 
 			GMT->current.proj.xyz_projection[GMT_Z] = GMT_LINEAR;
 			if (l_pos[GMT_Z] > 0)
@@ -5037,7 +5036,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				error += gmt_verify_expectations (GMT, GMT_IS_LON, gmt_scanf (GMT, txt_a, GMT_IS_LON, &GMT->current.proj.pars[0]), txt_a);
 				GMT->current.proj.lon0 = GMT->current.proj.pars[0];	GMT->current.proj.lat0 = 0.0;
 			}
-			error += gmtinit_scale_or_width (GMT, txt_b, &GMT->current.proj.pars[1]);
+			error += gmtinit_scale_or_width (GMT, txt_b, &GMT->current.proj.pars[1], true);
 			error += !(n == n_slashes + 1);
 			break;
 
@@ -5065,7 +5064,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_b, GMT_IS_LAT, &GMT->current.proj.pars[1]), txt_b);
 				GMT->current.proj.lat0 = GMT->current.proj.pars[1];
 			}
-			error += gmtinit_scale_or_width (GMT, txt_c, &GMT->current.proj.pars[2]);
+			error += gmtinit_scale_or_width (GMT, txt_c, &GMT->current.proj.pars[2], true);
 			error += ((project == GMT_CYL_EQ || project == GMT_MERCATOR || project == GMT_POLYCONIC)
 				&& fabs (GMT->current.proj.pars[1]) >= 90.0);
 			error += !(n == n_slashes + 1);
@@ -5079,7 +5078,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 			error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_b, GMT_IS_LAT, &GMT->current.proj.pars[1]), txt_b);
 			error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_c, GMT_IS_LAT, &GMT->current.proj.pars[2]), txt_c);
 			error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_d, GMT_IS_LAT, &GMT->current.proj.pars[3]), txt_d);
-			error += gmtinit_scale_or_width (GMT, txt_e, &GMT->current.proj.pars[4]);
+			error += gmtinit_scale_or_width (GMT, txt_e, &GMT->current.proj.pars[4], true);
 			error += !(n_slashes == 4 && n == 5);
 			GMT->current.proj.lon0 = GMT->current.proj.pars[0];	GMT->current.proj.lat0 = GMT->current.proj.pars[1];
 			break;
@@ -5353,7 +5352,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				error += gmt_verify_expectations (GMT, GMT_IS_LON, gmt_scanf (GMT, txt_c, GMT_IS_LON, &GMT->current.proj.pars[2]), txt_c);
 				error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_d, GMT_IS_LAT, &GMT->current.proj.pars[3]), txt_d);
 			}
-			error += gmtinit_scale_or_width (GMT, txt_e, &GMT->current.proj.pars[4]);
+			error += gmtinit_scale_or_width (GMT, txt_e, &GMT->current.proj.pars[4], true);
 			GMT->current.proj.pars[6] = 0.0;
 			error += !(n == n_slashes + 1);
 			GMT->current.proj.lon0 = GMT->current.proj.pars[0];	GMT->current.proj.lat0 = GMT->current.proj.pars[1];
@@ -5373,7 +5372,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 				GMT->current.proj.pars[2] += 180.0;
 				if (GMT->current.proj.pars[2] >= 360.0) GMT->current.proj.pars[2] -= 360.0;
 			}
-			error += gmtinit_scale_or_width (GMT, txt_e, &GMT->current.proj.pars[4]);
+			error += gmtinit_scale_or_width (GMT, txt_e, &GMT->current.proj.pars[4], true);
 			GMT->current.proj.pars[6] = 1.0;
 			error += !(n_slashes == 4 && n == 5);
 			project = GMT_OBLIQUE_MERC;
@@ -5383,7 +5382,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 		case GMT_UTM:	/* Universal Transverse Mercator */
 			if (!strchr (args, '/')) {	/* No UTM zone given, must obtain from -R */
 				GMT->current.proj.pars[0] = -1.0;	/* Flag we need zone to be set later */
-				error += gmtinit_scale_or_width (GMT, args, &GMT->current.proj.pars[1]);
+				error += gmtinit_scale_or_width (GMT, args, &GMT->current.proj.pars[1], true);
 			}
 			else {
 				n = sscanf (args, "%[^/]/%s", txt_a, txt_b);
@@ -5414,7 +5413,7 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 
 				error += (k < 1 || k > 60);	/* Zones must be 1-60 */
 				GMT->current.proj.utm_zonex = k;
-				error += gmtinit_scale_or_width (GMT, txt_b, &GMT->current.proj.pars[1]);
+				error += gmtinit_scale_or_width (GMT, txt_b, &GMT->current.proj.pars[1], true);
 				error += !(n_slashes == 1 && n == 2);
 			}
 			break;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4648,10 +4648,6 @@ GMT_LOCAL int gmtinit_scale_or_width (struct GMT_CTRL *GMT, char *scale_or_width
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot specify map width with 1:xxxx format in -J option\n");
 			return (1);
 		}
-		if (!xy_plane) {	/* z-units are not necessarily meter so here we want 1:1 to mean 1 zunit = 1 plot unit [cm] */
-			*value /= 100;	/* Undo the cm/meter ration */
-			*value /= GMT->session.u2u[GMT_CM][GMT->current.setting.proj_length_unit];	/* Use selected distance unit */
-		}
 	}
 	if (gmt_M_is_zero (*value)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your scale or width (%s) resulted in a zero value.\n", scale_or_width);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4648,6 +4648,10 @@ GMT_LOCAL int gmtinit_scale_or_width (struct GMT_CTRL *GMT, char *scale_or_width
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot specify map width with 1:xxxx format in -J option\n");
 			return (1);
 		}
+		if (!xy_plane) {	/* z-units are not necessarily meter so here we want 1:1 to mean 1 zunit = 1 plot unit [cm] */
+			*value /= 100;	/* Undo the cm/meter ration */
+			*value /= GMT->session.u2u[GMT_CM][GMT->current.setting.proj_length_unit];	/* Use selected distance unit */
+		}
 	}
 	if (gmt_M_is_zero (*value)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your scale or width (%s) resulted in a zero value.\n", scale_or_width);

--- a/test/psbasemap/zcaling.sh
+++ b/test/psbasemap/zcaling.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-#
-# Test that -Jz1:zzzz means 1 plot unit (cm, inch) == zzzz z-units (mGal, degree T, meter)
-
-ps=zscaling.ps
-
-gmt psbasemap -R0/5/0/5/0/8 -Jx1:100 -Jz1:1 -BWSneZ -Baf -Bzaf+l"1 inch == 1 z unit" -p135/5 --PROJ_LENGTH_UNIT=inch -P -K > $ps
-gmt psbasemap -R -J -Jz -BWSneZ -Baf -Bzaf+l"1 cm == 1 z unit" -p135/5 -O -X10c --PROJ_LENGTH_UNIT=cm >> $ps

--- a/test/psbasemap/zcaling.sh
+++ b/test/psbasemap/zcaling.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Test that -Jz1:zzzz means 1 plot unit (cm, inch) == zzzz z-units (mGal, degree T, meter)
+
+ps=zscaling.ps
+
+gmt psbasemap -R0/5/0/5/0/8 -Jx1:100 -Jz1:1 -BWSneZ -Baf -Bzaf+l"1 inch == 1 z unit" -p135/5 --PROJ_LENGTH_UNIT=inch -P -K > $ps
+gmt psbasemap -R -J -Jz -BWSneZ -Baf -Bzaf+l"1 cm == 1 z unit" -p135/5 -O -X10c --PROJ_LENGTH_UNIT=cm >> $ps

--- a/test/psbasemap/zscaling.ps
+++ b/test/psbasemap/zscaling.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_6904cf1_2021.01.24 [64-bit] Document from psbasemap
+%%Title: GMT v6.2.0_b8536c6_2021.01.24 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Jan 24 13:01:50 2021
+%%CreationDate: Sun Jan 24 13:43:38 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -708,25 +708,26 @@ O0
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -R0/5/0/5/0/8 -Jx1:100 -Jz1:1 -BWSneZ -Baf '-Bzaf+l1 inch == 1 z unit' -p135/5 --PROJ_LENGTH_UNIT=inch -P -K
-%@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
-%GMTBoundingBox: 72 72 141.732283465 141.732283465
+%@GMT: gmt psbasemap -R0/7/0/7/0/10 -Jx1:100 -Jz1:50 -BWSneZ -Baf '-Bzaf+l1 meter == 50 z unit, H -> 7.87 inch [PROJ_LENGTH_UNIT=inch]' -p175/5 --PROJ_LENGTH_UNIT=inch -P -K
+%@PROJ: xy 0.00000000 7.00000000 0.00000000 7.00000000 0.000 7.000 0.000 7.000 +xy
+%GMTBoundingBox: 72 72 198.42519685 198.42519685
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0.0871557427477 0.0868240888335 -0 25.1210383263] concat
 25 W
 0 A
 /PSL_slant_y 0 def
 2 setlinecap
-N 0 2362 M 0 -2362 D S
+N 0 3307 M 0 -3307 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
 N 0 945 M -83 0 D S
 N 0 1890 M -83 0 D S
+N 0 2835 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
@@ -734,6 +735,7 @@ PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reenco
 (0) sw mx
 (2) sw mx
 (4) sw mx
+(6) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
@@ -742,38 +744,45 @@ def
 (2) mr Z
 1890 PSL_A0_y MM
 (4) mr Z
+2835 PSL_A0_y MM
+(6) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
 N 0 472 M -42 0 D S
 N 0 1417 M -42 0 D S
 N 0 2362 M -42 0 D S
+N 0 3307 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2362 0 T
+3307 0 T
 25 W
-N 0 2362 M 0 -2362 D S
+N 0 3307 M 0 -3307 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 83 0 D S
 N 0 945 M 83 0 D S
 N 0 1890 M 83 0 D S
+N 0 2835 M 83 0 D S
 N 0 472 M 42 0 D S
 N 0 1417 M 42 0 D S
 N 0 2362 M 42 0 D S
+N 0 3307 M 42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--2362 0 T
+-3307 0 T
 25 W
-N 0 0 M 2362 0 D S
+N 0 0 M 3307 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
 N 945 0 M 0 -83 D S
 N 1890 0 M 0 -83 D S
+N 2835 0 M 0 -83 D S
 /MM {neg M} def
 /PSL_AH0 0
 (0) sh mx
 (2) sh mx
 (4) sh mx
+(6) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
@@ -782,195 +791,122 @@ def
 (2) bc Z
 1890 PSL_A0_y MM
 (4) bc Z
+2835 PSL_A0_y MM
+(6) bc Z
 N 472 0 M 0 -42 D S
 N 1417 0 M 0 -42 D S
 N 2362 0 M 0 -42 D S
+N 3307 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 2362 T
+0 3307 T
 25 W
-N 0 0 M 2362 0 D S
+N 0 0 M 3307 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 83 D S
 N 945 0 M 0 83 D S
 N 1890 0 M 0 83 D S
+N 2835 0 M 0 83 D S
 N 472 0 M 0 42 D S
 N 1417 0 M 0 42 D S
 N 2362 0 M 0 42 D S
+N 3307 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -2362 T
+0 -3307 T
 0 setlinecap
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0 0.996194698092 0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0 0.996194698092 0 25.1210383263] concat
 25 W
-N 0 9600 M 0 -9600 D S
+N 0 9449 M 0 -9449 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 1200 M -83 0 D S
-N 0 2400 M -83 0 D S
-N 0 3600 M -83 0 D S
-N 0 4800 M -83 0 D S
-N 0 6000 M -83 0 D S
-N 0 7200 M -83 0 D S
-N 0 8400 M -83 0 D S
-N 0 9600 M -83 0 D S
+N 0 1890 M -83 0 D S
+N 0 3780 M -83 0 D S
+N 0 5669 M -83 0 D S
+N 0 7559 M -83 0 D S
+N 0 9449 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-(1) sw mx
 (2) sw mx
-(3) sw mx
 (4) sw mx
-(5) sw mx
 (6) sw mx
-(7) sw mx
 (8) sw mx
+(10) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
-1200 PSL_A0_y MM
-(1) mr Z
-2400 PSL_A0_y MM
+1890 PSL_A0_y MM
 (2) mr Z
-3600 PSL_A0_y MM
-(3) mr Z
-4800 PSL_A0_y MM
+3780 PSL_A0_y MM
 (4) mr Z
-6000 PSL_A0_y MM
-(5) mr Z
-7200 PSL_A0_y MM
+5669 PSL_A0_y MM
 (6) mr Z
-8400 PSL_A0_y MM
-(7) mr Z
-9600 PSL_A0_y MM
+7559 PSL_A0_y MM
 (8) mr Z
+9449 PSL_A0_y MM
+(10) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 240 M -42 0 D S
-N 0 480 M -42 0 D S
-N 0 720 M -42 0 D S
-N 0 960 M -42 0 D S
-N 0 1440 M -42 0 D S
-N 0 1680 M -42 0 D S
-N 0 1920 M -42 0 D S
-N 0 2160 M -42 0 D S
-N 0 2640 M -42 0 D S
-N 0 2880 M -42 0 D S
-N 0 3120 M -42 0 D S
-N 0 3360 M -42 0 D S
-N 0 3840 M -42 0 D S
-N 0 4080 M -42 0 D S
-N 0 4320 M -42 0 D S
-N 0 4560 M -42 0 D S
-N 0 5040 M -42 0 D S
-N 0 5280 M -42 0 D S
-N 0 5520 M -42 0 D S
-N 0 5760 M -42 0 D S
-N 0 6240 M -42 0 D S
-N 0 6480 M -42 0 D S
-N 0 6720 M -42 0 D S
-N 0 6960 M -42 0 D S
-N 0 7440 M -42 0 D S
-N 0 7680 M -42 0 D S
-N 0 7920 M -42 0 D S
-N 0 8160 M -42 0 D S
-N 0 8640 M -42 0 D S
-N 0 8880 M -42 0 D S
-N 0 9120 M -42 0 D S
-N 0 9360 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 2835 M -42 0 D S
+N 0 4724 M -42 0 D S
+N 0 6614 M -42 0 D S
+N 0 8504 M -42 0 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
-4800 PSL_L_y MM
-V 90 R (1 inch == 1 z unit) bc Z U
+4724 PSL_L_y MM
+V 90 R (1 meter == 50 z unit, H ­\> 7.87 inch \[PROJ_LENGTH_UNIT=inch\]) bc Z U
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0.0871557427477 0.0868240888335 -0 25.1210383263] concat
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0 0.996194698092 0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0 0.996194698092 0 25.1210383263] concat
 25 W
 0 A
-N 0 9600 M 0 -9600 D S
+N 0 9449 M 0 -9449 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 1200 M -83 0 D S
-N 0 2400 M -83 0 D S
-N 0 3600 M -83 0 D S
-N 0 4800 M -83 0 D S
-N 0 6000 M -83 0 D S
-N 0 7200 M -83 0 D S
-N 0 8400 M -83 0 D S
-N 0 9600 M -83 0 D S
+N 0 1890 M -83 0 D S
+N 0 3780 M -83 0 D S
+N 0 5669 M -83 0 D S
+N 0 7559 M -83 0 D S
+N 0 9449 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
 200 F0
-(1) sw mx
 (2) sw mx
-(3) sw mx
 (4) sw mx
-(5) sw mx
 (6) sw mx
-(7) sw mx
 (8) sw mx
+(10) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
-1200 PSL_A0_y MM
-(1) mr Z
-2400 PSL_A0_y MM
+1890 PSL_A0_y MM
 (2) mr Z
-3600 PSL_A0_y MM
-(3) mr Z
-4800 PSL_A0_y MM
+3780 PSL_A0_y MM
 (4) mr Z
-6000 PSL_A0_y MM
-(5) mr Z
-7200 PSL_A0_y MM
+5669 PSL_A0_y MM
 (6) mr Z
-8400 PSL_A0_y MM
-(7) mr Z
-9600 PSL_A0_y MM
+7559 PSL_A0_y MM
 (8) mr Z
+9449 PSL_A0_y MM
+(10) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 240 M -42 0 D S
-N 0 480 M -42 0 D S
-N 0 720 M -42 0 D S
-N 0 960 M -42 0 D S
-N 0 1440 M -42 0 D S
-N 0 1680 M -42 0 D S
-N 0 1920 M -42 0 D S
-N 0 2160 M -42 0 D S
-N 0 2640 M -42 0 D S
-N 0 2880 M -42 0 D S
-N 0 3120 M -42 0 D S
-N 0 3360 M -42 0 D S
-N 0 3840 M -42 0 D S
-N 0 4080 M -42 0 D S
-N 0 4320 M -42 0 D S
-N 0 4560 M -42 0 D S
-N 0 5040 M -42 0 D S
-N 0 5280 M -42 0 D S
-N 0 5520 M -42 0 D S
-N 0 5760 M -42 0 D S
-N 0 6240 M -42 0 D S
-N 0 6480 M -42 0 D S
-N 0 6720 M -42 0 D S
-N 0 6960 M -42 0 D S
-N 0 7440 M -42 0 D S
-N 0 7680 M -42 0 D S
-N 0 7920 M -42 0 D S
-N 0 8160 M -42 0 D S
-N 0 8640 M -42 0 D S
-N 0 8880 M -42 0 D S
-N 0 9120 M -42 0 D S
-N 0 9360 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 2835 M -42 0 D S
+N 0 4724 M -42 0 D S
+N 0 6614 M -42 0 D S
+N 0 8504 M -42 0 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
-4800 PSL_L_y MM
-V 90 R (1 inch == 1 z unit) bc Z U
+4724 PSL_L_y MM
+V 90 R (1 meter == 50 z unit, H ­\> 7.87 inch \[PROJ_LENGTH_UNIT=inch\]) bc Z U
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0.0871557427477 0.0868240888335 -0 25.1210383263] concat
 PSL_GPP setmatrix
 %%EndObject
 0 A
@@ -979,24 +915,25 @@ O0
 4724 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -R0/5/0/5/0/8 -Jx1:100 -Jz1:1 -BWSneZ -Baf '-Bzaf+l1 cm == 1 z unit' -p135/5 -O -X10c --PROJ_LENGTH_UNIT=cm
-%@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
+%@GMT: gmt psbasemap -R0/7/0/7/0/10 -Jx1:100 -Jz1:50 -BWSneZ -Baf '-Bzaf+l1 meter == 50 z unit, H -> 20 cm [PROJ_LENGTH_UNIT=cm' -p175/5 -O -X10c --PROJ_LENGTH_UNIT=cm
+%@PROJ: xy 0.00000000 7.00000000 0.00000000 7.00000000 0.000 7.000 0.000 7.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0.0871557427477 0.0868240888335 -0 25.1210383263] concat
 25 W
 0 A
 /PSL_slant_y 0 def
 2 setlinecap
-N 0 2362 M 0 -2362 D S
+N 0 3307 M 0 -3307 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
 N 0 945 M -83 0 D S
 N 0 1890 M -83 0 D S
+N 0 2835 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
@@ -1004,6 +941,7 @@ PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reenco
 (0) sw mx
 (2) sw mx
 (4) sw mx
+(6) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
 0 PSL_A0_y MM
@@ -1012,38 +950,45 @@ def
 (2) mr Z
 1890 PSL_A0_y MM
 (4) mr Z
+2835 PSL_A0_y MM
+(6) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
 N 0 472 M -42 0 D S
 N 0 1417 M -42 0 D S
 N 0 2362 M -42 0 D S
+N 0 3307 M -42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-2362 0 T
+3307 0 T
 25 W
-N 0 2362 M 0 -2362 D S
+N 0 3307 M 0 -3307 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 83 0 D S
 N 0 945 M 83 0 D S
 N 0 1890 M 83 0 D S
+N 0 2835 M 83 0 D S
 N 0 472 M 42 0 D S
 N 0 1417 M 42 0 D S
 N 0 2362 M 42 0 D S
+N 0 3307 M 42 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--2362 0 T
+-3307 0 T
 25 W
-N 0 0 M 2362 0 D S
+N 0 0 M 3307 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 -83 D S
 N 945 0 M 0 -83 D S
 N 1890 0 M 0 -83 D S
+N 2835 0 M 0 -83 D S
 /MM {neg M} def
 /PSL_AH0 0
 (0) sh mx
 (2) sh mx
 (4) sh mx
+(6) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
@@ -1052,78 +997,89 @@ def
 (2) bc Z
 1890 PSL_A0_y MM
 (4) bc Z
+2835 PSL_A0_y MM
+(6) bc Z
 N 472 0 M 0 -42 D S
 N 1417 0 M 0 -42 D S
 N 2362 0 M 0 -42 D S
+N 3307 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 2362 T
+0 3307 T
 25 W
-N 0 0 M 2362 0 D S
+N 0 0 M 3307 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M 0 83 D S
 N 945 0 M 0 83 D S
 N 1890 0 M 0 83 D S
+N 2835 0 M 0 83 D S
 N 472 0 M 0 42 D S
 N 1417 0 M 0 42 D S
 N 2362 0 M 0 42 D S
+N 3307 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -2362 T
+0 -3307 T
 0 setlinecap
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0 0.996194698092 0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0 0.996194698092 0 25.1210383263] concat
 25 W
-N 0 3780 M 0 -3780 D S
+N 0 9449 M 0 -9449 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 945 M -83 0 D S
 N 0 1890 M -83 0 D S
-N 0 2835 M -83 0 D S
 N 0 3780 M -83 0 D S
+N 0 5669 M -83 0 D S
+N 0 7559 M -83 0 D S
+N 0 9449 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
 (2) sw mx
 (4) sw mx
 (6) sw mx
 (8) sw mx
+(10) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
-945 PSL_A0_y MM
-(2) mr Z
 1890 PSL_A0_y MM
-(4) mr Z
-2835 PSL_A0_y MM
-(6) mr Z
+(2) mr Z
 3780 PSL_A0_y MM
+(4) mr Z
+5669 PSL_A0_y MM
+(6) mr Z
+7559 PSL_A0_y MM
 (8) mr Z
+9449 PSL_A0_y MM
+(10) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 472 M -42 0 D S
-N 0 1417 M -42 0 D S
-N 0 2362 M -42 0 D S
-N 0 3307 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 2835 M -42 0 D S
+N 0 4724 M -42 0 D S
+N 0 6614 M -42 0 D S
+N 0 8504 M -42 0 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
-1890 PSL_L_y MM
-V 90 R (1 cm == 1 z unit) bc Z U
+4724 PSL_L_y MM
+V 90 R (1 meter == 50 z unit, H ­\> 20 cm \[PROJ_LENGTH_UNIT=cm) bc Z U
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0.0871557427477 0.0868240888335 -0 25.1210383263] concat
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0 0.996194698092 0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0 0.996194698092 0 25.1210383263] concat
 25 W
 0 A
-N 0 3780 M 0 -3780 D S
+N 0 9449 M 0 -9449 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 N 0 0 M -83 0 D S
-N 0 945 M -83 0 D S
 N 0 1890 M -83 0 D S
-N 0 2835 M -83 0 D S
 N 0 3780 M -83 0 D S
+N 0 5669 M -83 0 D S
+N 0 7559 M -83 0 D S
+N 0 9449 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
 200 F0
@@ -1131,28 +1087,32 @@ N 0 3780 M -83 0 D S
 (4) sw mx
 (6) sw mx
 (8) sw mx
+(10) sw mx
 def
 /PSL_A0_y PSL_A0_y 83 add def
-945 PSL_A0_y MM
-(2) mr Z
 1890 PSL_A0_y MM
-(4) mr Z
-2835 PSL_A0_y MM
-(6) mr Z
+(2) mr Z
 3780 PSL_A0_y MM
+(4) mr Z
+5669 PSL_A0_y MM
+(6) mr Z
+7559 PSL_A0_y MM
 (8) mr Z
+9449 PSL_A0_y MM
+(10) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 472 M -42 0 D S
-N 0 1417 M -42 0 D S
-N 0 2362 M -42 0 D S
-N 0 3307 M -42 0 D S
+N 0 945 M -42 0 D S
+N 0 2835 M -42 0 D S
+N 0 4724 M -42 0 D S
+N 0 6614 M -42 0 D S
+N 0 8504 M -42 0 D S
 /PSL_LH 267 F0
 (M) sh def
 /PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
-1890 PSL_L_y MM
-V 90 R (1 cm == 1 z unit) bc Z U
+4724 PSL_L_y MM
+V 90 R (1 meter == 50 z unit, H ­\> 20 cm \[PROJ_LENGTH_UNIT=cm) bc Z U
 PSL_GPP setmatrix
-/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+/PSL_GPP matrix currentmatrix def [0.996194698092 -0.0075961234939 0.0871557427477 0.0868240888335 -0 25.1210383263] concat
 PSL_GPP setmatrix
 %%EndObject
 

--- a/test/psbasemap/zscaling.ps
+++ b/test/psbasemap/zscaling.ps
@@ -1,0 +1,1170 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_6904cf1_2021.01.24 [64-bit] Document from psbasemap
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Jan 24 13:01:50 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/5/0/5/0/8 -Jx1:100 -Jz1:1 -BWSneZ -Baf '-Bzaf+l1 inch == 1 z unit' -p135/5 --PROJ_LENGTH_UNIT=inch -P -K
+%@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
+%GMTBoundingBox: 72 72 141.732283465 141.732283465
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 2362 M 0 -2362 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 945 M -83 0 D S
+N 0 1890 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+945 PSL_A0_y MM
+(2) mr Z
+1890 PSL_A0_y MM
+(4) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 472 M -42 0 D S
+N 0 1417 M -42 0 D S
+N 0 2362 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 2362 M 0 -2362 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 945 M 83 0 D S
+N 0 1890 M 83 0 D S
+N 0 472 M 42 0 D S
+N 0 1417 M 42 0 D S
+N 0 2362 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+945 PSL_A0_y MM
+(2) bc Z
+1890 PSL_A0_y MM
+(4) bc Z
+N 472 0 M 0 -42 D S
+N 1417 0 M 0 -42 D S
+N 2362 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2362 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 472 0 M 0 42 D S
+N 1417 0 M 0 42 D S
+N 2362 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -2362 T
+0 setlinecap
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0 0.996194698092 0 145.578937125] concat
+25 W
+N 0 9600 M 0 -9600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 1200 M -83 0 D S
+N 0 2400 M -83 0 D S
+N 0 3600 M -83 0 D S
+N 0 4800 M -83 0 D S
+N 0 6000 M -83 0 D S
+N 0 7200 M -83 0 D S
+N 0 8400 M -83 0 D S
+N 0 9600 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+(1) sw mx
+(2) sw mx
+(3) sw mx
+(4) sw mx
+(5) sw mx
+(6) sw mx
+(7) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+1200 PSL_A0_y MM
+(1) mr Z
+2400 PSL_A0_y MM
+(2) mr Z
+3600 PSL_A0_y MM
+(3) mr Z
+4800 PSL_A0_y MM
+(4) mr Z
+6000 PSL_A0_y MM
+(5) mr Z
+7200 PSL_A0_y MM
+(6) mr Z
+8400 PSL_A0_y MM
+(7) mr Z
+9600 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 240 M -42 0 D S
+N 0 480 M -42 0 D S
+N 0 720 M -42 0 D S
+N 0 960 M -42 0 D S
+N 0 1440 M -42 0 D S
+N 0 1680 M -42 0 D S
+N 0 1920 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 2640 M -42 0 D S
+N 0 2880 M -42 0 D S
+N 0 3120 M -42 0 D S
+N 0 3360 M -42 0 D S
+N 0 3840 M -42 0 D S
+N 0 4080 M -42 0 D S
+N 0 4320 M -42 0 D S
+N 0 4560 M -42 0 D S
+N 0 5040 M -42 0 D S
+N 0 5280 M -42 0 D S
+N 0 5520 M -42 0 D S
+N 0 5760 M -42 0 D S
+N 0 6240 M -42 0 D S
+N 0 6480 M -42 0 D S
+N 0 6720 M -42 0 D S
+N 0 6960 M -42 0 D S
+N 0 7440 M -42 0 D S
+N 0 7680 M -42 0 D S
+N 0 7920 M -42 0 D S
+N 0 8160 M -42 0 D S
+N 0 8640 M -42 0 D S
+N 0 8880 M -42 0 D S
+N 0 9120 M -42 0 D S
+N 0 9360 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+4800 PSL_L_y MM
+V 90 R (1 inch == 1 z unit) bc Z U
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0 0.996194698092 0 145.578937125] concat
+25 W
+0 A
+N 0 9600 M 0 -9600 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 1200 M -83 0 D S
+N 0 2400 M -83 0 D S
+N 0 3600 M -83 0 D S
+N 0 4800 M -83 0 D S
+N 0 6000 M -83 0 D S
+N 0 7200 M -83 0 D S
+N 0 8400 M -83 0 D S
+N 0 9600 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(1) sw mx
+(2) sw mx
+(3) sw mx
+(4) sw mx
+(5) sw mx
+(6) sw mx
+(7) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+1200 PSL_A0_y MM
+(1) mr Z
+2400 PSL_A0_y MM
+(2) mr Z
+3600 PSL_A0_y MM
+(3) mr Z
+4800 PSL_A0_y MM
+(4) mr Z
+6000 PSL_A0_y MM
+(5) mr Z
+7200 PSL_A0_y MM
+(6) mr Z
+8400 PSL_A0_y MM
+(7) mr Z
+9600 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 240 M -42 0 D S
+N 0 480 M -42 0 D S
+N 0 720 M -42 0 D S
+N 0 960 M -42 0 D S
+N 0 1440 M -42 0 D S
+N 0 1680 M -42 0 D S
+N 0 1920 M -42 0 D S
+N 0 2160 M -42 0 D S
+N 0 2640 M -42 0 D S
+N 0 2880 M -42 0 D S
+N 0 3120 M -42 0 D S
+N 0 3360 M -42 0 D S
+N 0 3840 M -42 0 D S
+N 0 4080 M -42 0 D S
+N 0 4320 M -42 0 D S
+N 0 4560 M -42 0 D S
+N 0 5040 M -42 0 D S
+N 0 5280 M -42 0 D S
+N 0 5520 M -42 0 D S
+N 0 5760 M -42 0 D S
+N 0 6240 M -42 0 D S
+N 0 6480 M -42 0 D S
+N 0 6720 M -42 0 D S
+N 0 6960 M -42 0 D S
+N 0 7440 M -42 0 D S
+N 0 7680 M -42 0 D S
+N 0 7920 M -42 0 D S
+N 0 8160 M -42 0 D S
+N 0 8640 M -42 0 D S
+N 0 8880 M -42 0 D S
+N 0 9120 M -42 0 D S
+N 0 9360 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+4800 PSL_L_y MM
+V 90 R (1 inch == 1 z unit) bc Z U
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+PSL_GPP setmatrix
+%%EndObject
+0 A
+FQ
+O0
+4724 0 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -R0/5/0/5/0/8 -Jx1:100 -Jz1:1 -BWSneZ -Baf '-Bzaf+l1 cm == 1 z unit' -p135/5 -O -X10c --PROJ_LENGTH_UNIT=cm
+%@PROJ: xy 0.00000000 5.00000000 0.00000000 5.00000000 0.000 5.000 0.000 5.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 2362 M 0 -2362 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 945 M -83 0 D S
+N 0 1890 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+945 PSL_A0_y MM
+(2) mr Z
+1890 PSL_A0_y MM
+(4) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 472 M -42 0 D S
+N 0 1417 M -42 0 D S
+N 0 2362 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2362 0 T
+25 W
+N 0 2362 M 0 -2362 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 945 M 83 0 D S
+N 0 1890 M 83 0 D S
+N 0 472 M 42 0 D S
+N 0 1417 M 42 0 D S
+N 0 2362 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-2362 0 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 945 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+945 PSL_A0_y MM
+(2) bc Z
+1890 PSL_A0_y MM
+(4) bc Z
+N 472 0 M 0 -42 D S
+N 1417 0 M 0 -42 D S
+N 2362 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2362 T
+25 W
+N 0 0 M 2362 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 945 0 M 0 83 D S
+N 1890 0 M 0 83 D S
+N 472 0 M 0 42 D S
+N 1417 0 M 0 42 D S
+N 2362 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -2362 T
+0 setlinecap
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0 0.996194698092 0 145.578937125] concat
+25 W
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 945 M -83 0 D S
+N 0 1890 M -83 0 D S
+N 0 2835 M -83 0 D S
+N 0 3780 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+945 PSL_A0_y MM
+(2) mr Z
+1890 PSL_A0_y MM
+(4) mr Z
+2835 PSL_A0_y MM
+(6) mr Z
+3780 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 472 M -42 0 D S
+N 0 1417 M -42 0 D S
+N 0 2362 M -42 0 D S
+N 0 3307 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+1890 PSL_L_y MM
+V 90 R (1 cm == 1 z unit) bc Z U
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0 0.996194698092 0 145.578937125] concat
+25 W
+0 A
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 945 M -83 0 D S
+N 0 1890 M -83 0 D S
+N 0 2835 M -83 0 D S
+N 0 3780 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+200 F0
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+945 PSL_A0_y MM
+(2) mr Z
+1890 PSL_A0_y MM
+(4) mr Z
+2835 PSL_A0_y MM
+(6) mr Z
+3780 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 472 M -42 0 D S
+N 0 1417 M -42 0 D S
+N 0 2362 M -42 0 D S
+N 0 3307 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+1890 PSL_L_y MM
+V 90 R (1 cm == 1 z unit) bc Z U
+PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.707106781187 -0.0616284167162 0.707106781187 0.0616284167162 -0 145.578937125] concat
+PSL_GPP setmatrix
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psbasemap/zscaling.sh
+++ b/test/psbasemap/zscaling.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Test that -Jz1:zzzz always means 1 m == zzzz z-units (mGal, degree T, meter)
+# regardless of chosen projection distance unit (cm. inch, point)
 
 ps=zscaling.ps
 

--- a/test/psbasemap/zscaling.sh
+++ b/test/psbasemap/zscaling.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Test that -Jz1:zzzz always means 1 m == zzzz z-units (mGal, degree T, meter)
+
+ps=zscaling.ps
+
+gmt psbasemap -R0/7/0/7/0/10 -Jx1:100 -Jz1:50 -BWSneZ -Baf -Bzaf+l"1 meter == 50 z unit, H -> 7.87 inch [PROJ_LENGTH_UNIT=inch]" -p175/5 --PROJ_LENGTH_UNIT=inch -P -K > $ps
+gmt psbasemap -R -J -Jz -BWSneZ -Baf -Bzaf+l"1 meter == 50 z unit, H -> 20 cm [PROJ_LENGTH_UNIT=cm" -p175/5 -O -X10c --PROJ_LENGTH_UNIT=cm >> $ps


### PR DESCRIPTION
**Description of proposed changes**

For map projections we have allowed scales given as 1:xxxxxx from the beginning.  For these projections, the 1:xxxxx means "xxxxx meters on the Earth will map to 1 meter on your plot".  In these cases, the actual user distances are always meters on the Earth. For instance, this map of a 1 arc minute by 1 arc minute at the Equator should be roughly 1852 meters square, so for this to fit on a piece of paper I would think 1:10000 will work since that would mean 10000 meters = 1 meter plot, so 1852 meters should give 0.1852 meter plot of 18.5 cm:

`gmt basemap -R0/0:01/0/0:01 -Jm1:10000 -B -BWSne -png map1`

and that works as expected:

![map1](https://user-images.githubusercontent.com/26473567/105646963-fcfb9580-5e46-11eb-8c29-92502be55ce3.png)

2. Now, if I happen to have a Cartesian data set in meters already I could use **-Jx**1:10000 as well:

gmt basemap -R0/1852/0/1852 -Jx1:10000 -B -png map2

![map2](https://user-images.githubusercontent.com/26473567/105646992-32a07e80-5e47-11eb-94bc-86b75b0aeb41.png)

However, if my x/y data represent something else, say x and y are weights in kg, then if I wanted to say that 100 kg should equal 1 cm, then I would want **-Jx**1:100, but in fact there is the assumption of meters built in and I still have to use **-Jx**1:10000 to fit on the page.

3. With **-Jz** there is no internal knowledge of what the z-unit is.  We may be plotting a DEM or a gravity field or crustal ages. Hence, for consistency it seems we should parse **-Jz**1:zzzzz the same way as **-Jx1**:xxxxx, meaning we always refer to plot distance in meters.  The implementation in this PR uses that definition, so that a z range or 0/5 with **-Jz**1:100 will yield a 5 cm (or ~2 inch) tall z-axis.  I added a test script (celebration: Our 1000th script!) showing that it does not matter what unit the user prefers (cm or inch): For a z-range of 10 and a scale of 1:50 the plot axis length is 20 cm in both cases (10/50) m.

![zscaling](https://user-images.githubusercontent.com/26473567/105647695-74cbbf00-5e4b-11eb-974f-61e68eda1735.png)
