### PR TITLE
Remove MAP_ANNOT_MIN_SPACING auto-scaling

### DIFF
--- a/share/themes/minimal.conf
+++ b/share/themes/minimal.conf
@@ -18,7 +18,6 @@ FORMAT_GEO_MAP                 = ddd:mm:ssF
 # MAP Parameters
 #
 MAP_FRAME_AXES                 = WrStZ
-MAP_ANNOT_MIN_SPACING          = auto
 MAP_ANNOT_OFFSET_PRIMARY       = auto
 MAP_ANNOT_OFFSET_SECONDARY     = auto
 MAP_FRAME_TYPE                 = plain

--- a/share/themes/modern.conf
+++ b/share/themes/modern.conf
@@ -18,7 +18,6 @@ FORMAT_GEO_MAP                 = ddd:mm:ssF
 # MAP Parameters
 #
 MAP_FRAME_AXES                 = WrStZ
-MAP_ANNOT_MIN_SPACING          = auto
 MAP_ANNOT_OFFSET_PRIMARY       = auto
 MAP_ANNOT_OFFSET_SECONDARY     = auto
 MAP_FRAME_TYPE                 = fancy

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6345,9 +6345,6 @@ GMT_LOCAL void gmtinit_conf_modern_override (struct GMT_CTRL *GMT) {
 
 	/* MAP group */
 
-	/* MAP_ANNOT_MIN_SPACING */
-	GMT->current.setting.map_annot_min_spacing = GMT->session.d_NaN; /* 36p */
-	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_MIN_SPACING] = 'p';
 	/* MAP_ANNOT_OFFSET_PRIMARY, MAP_ANNOT_OFFSET_SECONDARY */
 	GMT->current.setting.map_annot_offset[GMT_PRIMARY] = GMT->current.setting.map_annot_offset[GMT_SECONDARY] = GMT->session.d_NaN; /* 3p */
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_OFFSET_PRIMARY] = 'p';
@@ -9761,8 +9758,6 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim) {
 		GMT->current.setting.map_title_offset = 12 * pt * scale;	/* 12p */
 	if (gmt_M_is_dnan (GMT->current.setting.map_heading_offset))
 		GMT->current.setting.map_heading_offset = 16 * pt * scale;	/* 16p */
-	if (gmt_M_is_dnan (GMT->current.setting.map_annot_min_spacing))
-		GMT->current.setting.map_annot_min_spacing = 36 * pt * scale; /* 36p */
 
 	/* Tick lengths */
 


### PR DESCRIPTION
**Description of proposed changes**

Removes auto-scaling option for the parameter MAP_ANNOT_MIN_SPACING
