### PR TITLE
Testing a GMT_THEME off solution

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9640,6 +9640,7 @@ GMT_LOCAL int gmtinit_update_theme (struct GMT_CTRL *GMT) {
 	char theme_file[PATH_MAX] = {""};
 
 	if (!GMT->current.setting.update_theme) return GMT_NOERROR;	/* Nothing to do */
+	if (!strcmp (GMT->current.setting.theme, "off")) return GMT_NOERROR;	/* Nothing to do */
 
 	/* Got a GMT_THEME setting, take delayed action now */
 	GMT->current.setting.update_theme = false;
@@ -11294,7 +11295,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		case GMTCASE_GMT_THEME:
 			if (strlen (value) < GMT_LEN64) {
 				strncpy (GMT->current.setting.theme, value, GMT_LEN64-1);
-				GMT->current.setting.update_theme = true;
+				GMT->current.setting.update_theme = (strcmp (GMT->current.setting.theme, "off") != 0);
 				if (core == false)	/* Must deal with this right away */
 					error = gmtinit_update_theme (GMT);
 			}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11296,7 +11296,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			if (strlen (value) < GMT_LEN64) {
 				strncpy (GMT->current.setting.theme, value, GMT_LEN64-1);
 				GMT->current.setting.update_theme = (strcmp (GMT->current.setting.theme, "off") != 0);
-				if (core == false)	/* Must deal with this right away */
+				//if (core == false)	/* Must deal with this right away */
 					error = gmtinit_update_theme (GMT);
 			}
 			else {

--- a/src/gmtset.c
+++ b/src/gmtset.c
@@ -173,6 +173,8 @@ EXTERN_MSC int GMT_gmtset (void *V_API, int mode, void *args) {
 
 	if (gmt_setdefaults (GMT, options)) Return (GMT_PARSE_ERROR);		/* Process command line arguments, return error if failures */
 
+	strcpy (GMT->current.setting.theme, "off");	/* To preserve changes the user may have set */
+
 	gmt_putdefaults (GMT, Ctrl->G.file);	/* Write out the revised settings */
 
 	Return (GMT_NOERROR);


### PR DESCRIPTION
Goal is to allow classic mode users to override specifics in a modern-mode theme settings without having the **GMT_THEME** be parsed again at the end and thus overwrite the changes.

@meghanrjones, see if this sub-branch off gmt-themes works as you expect.  It does allow a classic user to say

```
gmt defaults -D > gmt.conf
gmt set GMT_THEME modern FONT_ANNOT_PRIMARY auto,Times-Roman,black
gmt psbasemap -RDE+R10m -Bpa30m -Bsa1d -JL10.5/51/49/53/17c > test.ps
```

and get autoscaling with selected annotation font.  In order to allow that 2nd command to work I now update all settings immediately if **GMT_THEME** is encountered - before we waiting until all other settings had been parsed before we overrode everything.  I think it makes more sense that later options to gmt set overrides whatever the earlier ones set.
