### PR TITLE
Check that inset begin is given -D

### DIFF
--- a/src/inset.c
+++ b/src/inset.c
@@ -181,8 +181,9 @@ static int parse (struct GMT_CTRL *GMT, struct INSET_CTRL *Ctrl, struct GMT_OPTI
 
 	if (Ctrl->In.mode == INSET_BEGIN) {
 		/* Was -R -J given */
+		n_errors += gmt_M_check_condition (GMT, !Ctrl->D.active, "Option -D is required for gmt inset begin\n");
 		n_errors += gmt_M_check_condition (GMT, GMT->common.J.active && !GMT->common.R.active[RSET], "Option -J: Requires -R as well!\n");
-		if (GMT->common.J.active) {	/* Compute map height */
+		if (!n_errors && GMT->common.J.active) {	/* Compute map height */
 			if (gmt_map_setup (GMT, GMT->common.R.wesn)) n_errors++;
 		}
 	}


### PR DESCRIPTION
The **-D** option is required when setting up an inset, but the code did not check.  Now it does.  Closes #4713.