### PR TITLE
Subplot axes

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3977,7 +3977,7 @@ void gmt_handle5_plussign (struct GMT_CTRL *GMT, char *in, char *mods, unsigned 
 }
 
 GMT_LOCAL void gmtinit_sides2axes (struct GMT_CTRL *GMT) {
-	/* Convert GMT->current.map.frame.side to string */
+	/* Convert GMT->current.map.frame.side to corresponding MAP_FRAME_AXES string */
 	unsigned int k, i = 0;
 	char *all = {"WESNZ"}, *tick = {"wesnz"}, *draw = {"lrbtu"};
 	for (k = 0; k <= Z_SIDE; k++) {
@@ -4008,7 +4008,7 @@ GMT_LOCAL int gmtinit_decode5_wesnz (struct GMT_CTRL *GMT, const char *in, bool 
 	}
 	else {
 		GMT->current.map.frame.draw_box = GMT_3D_NONE;
-		if (!strcmp (GMT->current.setting.map_frame_axes, "auto")) return GMT_NOERROR;	/* Not ready yet */
+		if (!strcmp (GMT->current.setting.map_frame_axes, "auto")) return GMT_NOERROR;	/* Not ready to parse yet */
 	}
 	for (k = 0; in[k]; k++) {
 		switch (in[k]) {

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9517,7 +9517,7 @@ int gmt_map_setup (struct GMT_CTRL *GMT, double wesn[]) {
 
 	if ((error = gmt_proj_setup (GMT, wesn)) != GMT_NOERROR) goto gmt_map_setup_end;
 
-	gmt_set_undefined_defaults (GMT, MAX (GMT->current.map.width, GMT->current.map.height));	/* We must change any undefined defaults given max plot dimension */
+	gmt_set_undefined_defaults (GMT, MAX (GMT->current.map.width, GMT->current.map.height), false);	/* We must change any undefined defaults given max plot dimension */
 
 	search = GMT->current.proj.search;
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8374,7 +8374,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 
 	PSL = GMT->PSL;	/* Shorthand */
 
-	gmt_set_undefined_defaults (GMT, MAX (GMT->current.map.width, GMT->current.map.height));	/* We must change any undefined defaults given max plot dimension */
+	gmt_set_undefined_defaults (GMT, MAX (GMT->current.map.width, GMT->current.map.height), false);	/* We must change any undefined defaults given max plot dimension */
 
 	if (GMT->current.map.frame.paint[GMT_Z]) {	/* Must squirrel this away for now since we may call psbasemap during the movie-indicators below */
 		do_paint = true;

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -46,7 +46,7 @@ EXTERN_MSC int gmt_nc_read_cube_info (struct GMT_CTRL *GMT, char *file, double *
 
 /* gmt_init.c: */
 
-EXTERN_MSC void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim);
+EXTERN_MSC void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool conf_update);
 EXTERN_MSC bool gmt_parse_s_option (struct GMT_CTRL *GMT, char *item);
 EXTERN_MSC unsigned int gmt_parse_d_option (struct GMT_CTRL *GMT, char *arg);
 EXTERN_MSC int gmt_parse_g_option (struct GMT_CTRL *GMT, char *txt);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -46,6 +46,7 @@ EXTERN_MSC int gmt_nc_read_cube_info (struct GMT_CTRL *GMT, char *file, double *
 
 /* gmt_init.c: */
 
+EXTERN_MSC void gmt_set_undefined_axes (struct GMT_CTRL *GMT, bool conf_update);
 EXTERN_MSC void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool conf_update);
 EXTERN_MSC bool gmt_parse_s_option (struct GMT_CTRL *GMT, char *item);
 EXTERN_MSC unsigned int gmt_parse_d_option (struct GMT_CTRL *GMT, char *arg);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -529,7 +529,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 	}
 
 	if (!(GMT->common.R.active[RSET] && GMT->common.J.active))	/* When no projection specified (i.e, -Dx is used), we cannot autoscale so set to nominal sizes */
-		gmt_set_undefined_defaults (GMT, 0.0);	/* Must set undefined to their reference values */
+		gmt_set_undefined_defaults (GMT, 0.0, false);	/* Must set undefined to their reference values */
 	else {
 		if (gmt_M_err_pass (GMT, gmt_map_setup (GMT, GMT->common.R.wesn), ""))
 			Return (GMT_PROJECTION_ERROR);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1677,7 +1677,7 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 
 	gmt_M_memset (wesn, 4, double);
 	if (!(GMT->common.R.active[RSET] && GMT->common.J.active)) {	/* When no projection specified, use fake linear projection */
-		gmt_set_undefined_defaults (GMT, 0.0);	/* Must set undefined to their reference values */
+		gmt_set_undefined_defaults (GMT, 0.0, false);	/* Must set undefined to their reference values */
 		GMT->common.R.active[RSET] = true;
 		GMT->common.J.active = false;
 		gmt_parse_common_options (GMT, "J", 'J', text);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1603,6 +1603,7 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 
 	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, NULL, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
 	/* Overrule GMT settings of MAP_FRAME_AXES. Use WESN */
+	strcpy (GMT->current.setting.map_frame_axes, "WESN");
 	GMT->current.map.frame.side[S_SIDE] = GMT->current.map.frame.side[E_SIDE] = GMT->current.map.frame.side[N_SIDE] = GMT->current.map.frame.side[W_SIDE] = GMT_AXIS_ALL;
 	GMT->current.map.frame.draw = false;	/* No -B parsed explicitly yet */
 	if (GMT_Parse_Common (API, THIS_MODULE_OPTIONS, options)) Return (API->error);

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -656,6 +656,7 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 			}
 		}
 		if (!Bframe) {	/* No override, examine the default frame setting instead */
+			gmt_set_undefined_axes (GMT, true);
 			if (Ctrl->S[GMT_X].active)	/* Automatic selection of row sides, so set to WE */
 				strcpy (Ctrl->S[GMT_X].axes, "WE");
 			else {	/* Extract what the MAP_FRAME_AXES has in store instead*/

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -654,18 +654,26 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 			}
 		}
 		if (!Bframe) {	/* No override, examine the default frame setting instead */
-			if (strchr (GMT->current.setting.map_frame_axes, 'S')) Ctrl->S[GMT_X].axes[px++] = 'S';
-			else if (strchr (GMT->current.setting.map_frame_axes, 's')) Ctrl->S[GMT_X].axes[px++] = 's';
-			else if (strchr (GMT->current.setting.map_frame_axes, 'b')) Ctrl->S[GMT_X].axes[px++] = 'b';
-			if (strchr (GMT->current.setting.map_frame_axes, 'N')) Ctrl->S[GMT_X].axes[px++] = 'N';
-			else if (strchr (GMT->current.setting.map_frame_axes, 'n')) Ctrl->S[GMT_X].axes[px++] = 'n';
-			else if (strchr (GMT->current.setting.map_frame_axes, 't')) Ctrl->S[GMT_X].axes[px++] = 't';
-			if (strchr (GMT->current.setting.map_frame_axes, 'W')) Ctrl->S[GMT_Y].axes[py++] = 'W';
-			else if (strchr (GMT->current.setting.map_frame_axes, 'w')) Ctrl->S[GMT_Y].axes[py++] = 'w';
-			else if (strchr (GMT->current.setting.map_frame_axes, 'l')) Ctrl->S[GMT_Y].axes[py++] = 'l';
-			if (strchr (GMT->current.setting.map_frame_axes, 'E')) Ctrl->S[GMT_Y].axes[py++] = 'E';
-			else if (strchr (GMT->current.setting.map_frame_axes, 'e')) Ctrl->S[GMT_Y].axes[py++] = 'e';
-			else if (strchr (GMT->current.setting.map_frame_axes, 'r')) Ctrl->S[GMT_Y].axes[py++] = 'r';
+			if (Ctrl->S[GMT_X].active)	/* Automatic selection of row sides, so set to WE */
+				strcpy (Ctrl->S[GMT_X].axes, "WE");
+			else {	/* Extract what the MAP_FRAME_AXES has in store instead*/
+				if (strchr (GMT->current.setting.map_frame_axes, 'S')) Ctrl->S[GMT_X].axes[px++] = 'S';
+				else if (strchr (GMT->current.setting.map_frame_axes, 's')) Ctrl->S[GMT_X].axes[px++] = 's';
+				else if (strchr (GMT->current.setting.map_frame_axes, 'b')) Ctrl->S[GMT_X].axes[px++] = 'b';
+				if (strchr (GMT->current.setting.map_frame_axes, 'N')) Ctrl->S[GMT_X].axes[px++] = 'N';
+				else if (strchr (GMT->current.setting.map_frame_axes, 'n')) Ctrl->S[GMT_X].axes[px++] = 'n';
+				else if (strchr (GMT->current.setting.map_frame_axes, 't')) Ctrl->S[GMT_X].axes[px++] = 't';
+			}
+			if (Ctrl->S[GMT_Y].active)	/* Automatic selection of column sides, so set to SN */
+				strcpy (Ctrl->S[GMT_Y].axes, "SN");
+			else {	/* Extract what the MAP_FRAME_AXES has in store instead */
+				if (strchr (GMT->current.setting.map_frame_axes, 'W')) Ctrl->S[GMT_Y].axes[py++] = 'W';
+				else if (strchr (GMT->current.setting.map_frame_axes, 'w')) Ctrl->S[GMT_Y].axes[py++] = 'w';
+				else if (strchr (GMT->current.setting.map_frame_axes, 'l')) Ctrl->S[GMT_Y].axes[py++] = 'l';
+				if (strchr (GMT->current.setting.map_frame_axes, 'E')) Ctrl->S[GMT_Y].axes[py++] = 'E';
+				else if (strchr (GMT->current.setting.map_frame_axes, 'e')) Ctrl->S[GMT_Y].axes[py++] = 'e';
+				else if (strchr (GMT->current.setting.map_frame_axes, 'r')) Ctrl->S[GMT_Y].axes[py++] = 'r';
+			}
 		}
 		if (Ctrl->S[GMT_X].b == NULL) Ctrl->S[GMT_X].b = strdup ("af");	/* Default is -Baf if not set */
 		if (Ctrl->S[GMT_Y].b == NULL) Ctrl->S[GMT_Y].b = strdup ("af");

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -389,7 +389,7 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 				}
 				break;
 
-			case 'B':	/* Get a handle on -B args if any */
+			case 'B':	/* Get a handle on -B args, if any */
 				B_args = true;
 				if (strstr (opt->arg, "+n")) noB = true;	/* Turn off all annotations */
 				if (opt->arg[0] == 'x') Bx = opt;		/* Got options for x-axis only */
@@ -656,10 +656,10 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 			}
 		}
 		if (!Bframe) {	/* No override, examine the default frame setting instead */
-			gmt_set_undefined_axes (GMT, true);
-			if (Ctrl->S[GMT_X].active)	/* Automatic selection of row sides, so set to WE */
-				strcpy (Ctrl->S[GMT_X].axes, "WE");
-			else {	/* Extract what the MAP_FRAME_AXES has in store instead*/
+			gmt_set_undefined_axes (GMT, true);	/* We cannot have MAP_FRAME_AXES=auto in subplot during -B parsing, so do the update now */
+			if (Ctrl->S[GMT_X].active)	/* Automatic selection of row sides via -SR, so set to SN */
+				strcpy (Ctrl->S[GMT_X].axes, "SN");
+			else {	/* Extract what the MAP_FRAME_AXES has for this axis instead */
 				if (strchr (GMT->current.setting.map_frame_axes, 'S')) Ctrl->S[GMT_X].axes[px++] = 'S';
 				else if (strchr (GMT->current.setting.map_frame_axes, 's')) Ctrl->S[GMT_X].axes[px++] = 's';
 				else if (strchr (GMT->current.setting.map_frame_axes, 'b')) Ctrl->S[GMT_X].axes[px++] = 'b';
@@ -667,9 +667,9 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 				else if (strchr (GMT->current.setting.map_frame_axes, 'n')) Ctrl->S[GMT_X].axes[px++] = 'n';
 				else if (strchr (GMT->current.setting.map_frame_axes, 't')) Ctrl->S[GMT_X].axes[px++] = 't';
 			}
-			if (Ctrl->S[GMT_Y].active)	/* Automatic selection of column sides, so set to SN */
-				strcpy (Ctrl->S[GMT_Y].axes, "SN");
-			else {	/* Extract what the MAP_FRAME_AXES has in store instead */
+			if (Ctrl->S[GMT_Y].active)	/* Automatic selection of column sides via -SC, so set to WE */
+				strcpy (Ctrl->S[GMT_Y].axes, "WE");
+			else {	/* Extract what the MAP_FRAME_AXES has for this axis instead */
 				if (strchr (GMT->current.setting.map_frame_axes, 'W')) Ctrl->S[GMT_Y].axes[py++] = 'W';
 				else if (strchr (GMT->current.setting.map_frame_axes, 'w')) Ctrl->S[GMT_Y].axes[py++] = 'w';
 				else if (strchr (GMT->current.setting.map_frame_axes, 'l')) Ctrl->S[GMT_Y].axes[py++] = 'l';
@@ -802,7 +802,9 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		}
 		GMT_Report (API, GMT_MSG_NOTICE, "Subplot max panel dimension estimated: %g inch\n", PD);
 
-		gmt_set_undefined_defaults (GMT, PD, true);	/* We must change any undefined defaults given max panel dimension */
+		/* We must change any undefined defaults given max panel dimension now so that font sizes and dimensions
+		 * can be written to this subplot's gmt.conf file and thus give the same settings for all panels. */
+		gmt_set_undefined_defaults (GMT, PD, true);
 
 		/* Update defaults settings that depend on fonts etc */
 		if (gmt_M_is_dnan (Ctrl->A.off[GMT_X]))
@@ -1327,7 +1329,7 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		else if (GMT->init.history[RG_id] && !GMT->init.history[RP_id])	/* History for -RP but not -RG, duplicate*/
 			GMT->init.history[RP_id] = strdup (GMT->init.history[RG_id]);
 
-		gmt_putdefaults (GMT, NULL);	/* Finalize the gmt.conf file with specific settings for the entire subplot */
+		gmt_putdefaults (GMT, NULL);	/* Finalize the gmt.conf file with settings that will apply to all panels in the subplot */
 	}
 	else if (Ctrl->In.mode == SUBPLOT_SET) {	/* SUBPLOT_SET */
 		char legend_justification[4] = {""}, pen[GMT_LEN32] = {""}, fill[GMT_LEN32] = {""}, off[GMT_LEN32] = {""};


### PR DESCRIPTION
**Description of proposed changes**

Dealing with

- Creating a subplot gmt.conf with fixed dimensions when themes have auto-settings so taht all panels share the same dimensions and font sizes
- Handle MAP_FRAME_AXES = auto in various situations, such as special treatment in subplot
- Better handling of -B and MAP_FRAME_AXES in subplot with our without -SR|C.
- Handle the guessing of axes when auto and we have perspective views or polar projections
