### PR TITLE
Psrose and default size when not in a subplot or inset

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14100,7 +14100,13 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 				}
 			}
 			else {	/* No old-style -S option given either, so user expects default diameter via -J and no normalization */
-				if ((opt = GMT_Make_Option (API, 'J', "X15c")) == NULL) return NULL;	/* Failure to make -J option */
+				if (GMT->current.setting.run_mode == GMT_MODERN) {
+					if ((opt = GMT_Make_Option (API, 'J', "X?")) == NULL) return NULL;	/* Failure to make -J option */
+					is_psrose = true;
+				}
+				else {
+					if ((opt = GMT_Make_Option (API, 'J', "X15c")) == NULL) return NULL;	/* Failure to make -J option */
+				}
 				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append -J option */
 			}
 		}
@@ -14371,6 +14377,9 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			}
 		}
 
+		if (is_psrose && P == NULL && !GMT->current.plot.inset.active && strchr (opt_J->arg, '?')) {	/* If we still have -JX? and not inset or panel, replace by default */
+			if (GMT_Update_Option (API, opt_J, "X15c")) return NULL;		/* Failed to update -J */
+		}
 		if (is_D_module && !got_R && !got_J && P)	/* Module call with -Dx in a subplot, turn on JR since we know both must exist */
 			required = "JR";
 		if (got_R == false && (strchr (required, 'R') || strchr (required, 'g') || strchr (required, 'd'))) {	/* Need a region but no -R was set */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14075,38 +14075,37 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			GMT_Report (API, GMT_MSG_DEBUG, "Given -E, add equivalent -R%s for pscoast.\n", opt->arg);
 		}
 	}
-	else if (options && gmt_M_compat_check (GMT, 6) && !strncmp (mod_name, "psrose", 6U) && (opt = GMT_Find_Option (API, 'J', *options)) == NULL) {
-		/* Running psrose with old -S[n]<radius syntax.  Need to replace with new -J [-S] syntax */
-		struct GMT_OPTION *S = GMT_Find_Option (API, 'S', *options);
-		if (S && S->arg[0]) {	/* Gave -S option with some arguments */
-			char j_code[GMT_LEN256] = {""};
-			unsigned int k, norm = (S->arg[0] == 'n') ? 1 : 0;
-			double radius;
-			k = norm;
-			if (norm == 0 && S->arg[strlen(S->arg)-1] == 'n') {	/* Old-style -S<radius>n syntax */
-				norm = 2;
-				S->arg[strlen(S->arg)-1] = '\0';
+	else if (options && gmt_M_compat_check (GMT, 6) && !strncmp (mod_name, "psrose", 6U)) {
+		if ((opt = GMT_Find_Option (API, 'J', *options)) == NULL) {
+			/* Running psrose with old -S[n]<radius syntax and no -J.  Need to replace with new -J [-S] syntax */
+			struct GMT_OPTION *S = GMT_Find_Option (API, 'S', *options);
+			if (S && S->arg[0]) {	/* Gave -S option with some arguments */
+				char j_code[GMT_LEN256] = {""};
+				unsigned int k, norm = (S->arg[0] == 'n') ? 1 : 0;
+				double radius;
+				k = norm;
+				if (norm == 0 && S->arg[strlen(S->arg)-1] == 'n') {	/* Old-style -S<radius>n syntax */
+					norm = 2;
+					S->arg[strlen(S->arg)-1] = '\0';
+				}
+				radius = (S->arg[k]) ? gmt_M_to_inch (GMT, &S->arg[k]) : 0.5 * 15 / 2.54;	/* Get the radius or default to (7.5 = 15/2 cm), now in inches */
+				snprintf (j_code, GMT_LEN256, "X%gi", 2 * radius);
+				if ((opt = GMT_Make_Option (API, 'J', j_code)) == NULL) return NULL;		/* Failed to make -J option */
+				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failed to append -J option */
+				if (norm) {	/* Need a plain -S for normalization */
+					if (GMT_Update_Option (API, S, "")) return NULL;		/* Failed to update -S */
+				}
+				else {	/* Remove the S option */
+					if (GMT_Delete_Option (API, S, options)) return NULL;		/* Failed to remove -S */
+				}
 			}
-			radius = (S->arg[k]) ? gmt_M_to_inch (GMT, &S->arg[k]) : 0.5 * 7.5 / 2.54;	/* Get the radius or default to (7.5/2 cm), now in inches */
-			snprintf (j_code, GMT_LEN256, "X%gi", 2 * radius);
-			if ((opt = GMT_Make_Option (API, 'J', j_code)) == NULL) return NULL;		/* Failed to make -J option */
-			if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failed to append -J option */
-			if (norm) {	/* Need a plain -S for normalization */
-				if (GMT_Update_Option (API, S, "")) return NULL;		/* Failed to update -S */
-			}
-			else {	/* Remove the S option */
-				if (GMT_Delete_Option (API, S, options)) return NULL;		/* Failed to remove -S */
+			else {	/* No old-style -S option given either, so user expects default diameter via -J and no normalization */
+				if ((opt = GMT_Make_Option (API, 'J', "X15c")) == NULL) return NULL;	/* Failure to make -J option */
+				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append -J option */
 			}
 		}
-		else {	/* No old-style -S option given either, so user expects default radius and no normalization */
-			if (GMT->current.setting.run_mode == GMT_MODERN) {
-				is_psrose = true;	/* Since psrose does not really parse -J properly we need to flag this */
-				if ((opt = GMT_Make_Option (API, 'J', "X?")) == NULL) return NULL;	/* Failure to make -J option */
-			}
-			else {
-				if ((opt = GMT_Make_Option (API, 'J', "X6i")) == NULL) return NULL;	/* Failure to make -J option */
-			}
-			if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append -J option */
+		else {	/* Gave -J, flag if with ? for subplots or insets */
+			is_psrose = (strchr (opt->arg, '?') && GMT->current.setting.run_mode == GMT_MODERN);
 		}
 	}
 


### PR DESCRIPTION
Because of the ancient history of **psrose**, it had no **-J** option for the first 20 years, with dimensions being set via **-S**_scale_.  We then added **-J** but still honors the old **-S** for backwards compatibility.  Things got a bit dicy when we had to consider rose calls in subplots (e.g., ex 06) and insets.  However, the coding assumed that when no **-J** and old-style **-S**_scale_ it is somehow in a subplot and we then added **-JX?**, but there is no reason to assume that.  The case in #4722 shows the folly of that assumption.
This PR does a more careful job for this outlier:

1. We still add **-JX?** in the case, as before
2. However, after the inset and subplot sections are checked, if psrose **-J** still has ? then we reset to the default **-JX**15c

The OP example plus all tests still pass.  Closes #4722.