### PR TITLE
Add new pstext option to cast a shade beneath a text box

### DIFF
--- a/doc/rst/source/pstext.rst
+++ b/doc/rst/source/pstext.rst
@@ -24,6 +24,7 @@ Synopsis
 [ |-L| ] [ |-M| ] [ |-N| ]
 [ |-O| ] [ |-P| ]
 [ |-Q|\ **l**\|\ **u** ]
+[ |-S|\ [*dx*/*dy*/][*shade*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -81,6 +82,10 @@ To add a text without using input data but only the fixed text option::
 To place a line containing a Latex equation, try::
 
     echo 3 3 'Use @[\Delta g = 2\pi\rho Gh@[' | gmt pstext -R0/6/0/6 -JX15c -Baf -F+f32p+a30 -P > map.ps
+
+To place text with a surrounding box and an underlying, shifted shade, both using a rounded rectangle, try::
+
+    gmt pstext -R0/10/0/5 -Jx1c -F+f32p+cCM+tWELCOME -Baf -Gyellow -Wfaint -S -C+tO -P > map.ps
 
 .. include:: text_notes.rst_
 

--- a/doc/rst/source/text.rst
+++ b/doc/rst/source/text.rst
@@ -22,6 +22,7 @@ Synopsis
 [ |-G|\ [*fill*][**+n**] ]
 [ |-L| ] [ |-M| ] [ |-N| ]
 [ |-Q|\ **l**\|\ **u** ]
+[ |-S|\ [*dx*/*dy*/][*shade*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -72,6 +73,10 @@ To add a typeset figure caption for a 3-inch wide illustration, use
 To place a line containing a Latex equation, try::
 
     echo 3 3 'Use @[\Delta g = 2\pi\rho Gh@[' | gmt text -R0/6/0/6 -JX15c -B -F+f32p+a30 -pdf map
+
+To place text with a surrounding box and an underlying, shifted shade, both using a rounded rectangle, try::
+
+    gmt text -R0/10/0/5 -Jx1c -F+f32p+cCM+tWELCOME -B -Gyellow -Wfaint -S -C+tO -pdf map
 
 .. include:: text_notes.rst_
 

--- a/doc/rst/source/text_common.rst_
+++ b/doc/rst/source/text_common.rst_
@@ -179,6 +179,13 @@ Optional Arguments
     Change all text to either **l**\ ower or **u**\ pper case [Default
     leaves all text as is].
 
+.. _-S:
+
+**-S**\ [*dx*/*dy*/][*shade*]
+    Plot an offset background shaded region beneath the text box. Here, *dx*/*dy*
+    indicates the shift relative to the text box [4\ **p**/-4\ **p**] and *shade*
+    sets the fill color to use for shading [gray50].
+
 .. _-U:
 
 .. include:: explain_-U.rst_

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -382,6 +382,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC bool gmt_is_fill (struct GMT_CTRL *GMT, char *word);
 EXTERN_MSC void gmt_init_next_color (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_set_next_color (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, unsigned int type, double rgb[]);
 EXTERN_MSC uint64_t gmt_make_equidistant_array (struct GMT_CTRL *GMT, double min, double max, double inc, double **array);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6103,7 +6103,15 @@ int gmtlib_detrend (struct GMT_CTRL *GMT, double *x, double *y, uint64_t n, doub
 }
 
 /*! . */
-#define gmt_is_fill(GMT,word) (!strcmp(word,"-") || gmtsupport_is_pattern (GMT,word) || gmtlib_is_color (GMT, word))
+bool gmt_is_fill (struct GMT_CTRL *GMT, char *word) {
+	/* Return true if argument is an image fill or color or no fill (-) */
+	if (!strcmp (word,"-")) return true;	/* Or skip */
+	if (gmtsupport_is_pattern (GMT, word)) return true;
+	if (gmtlib_is_color (GMT, word)) return true;
+	return false;
+}
+
+//#define gmt_is_fill(GMT,word) (!strcmp(word,"-") || gmtsupport_is_pattern (GMT,word) || gmtlib_is_color (GMT, word))
 
 /* The two flip_angle functions are needed when vectors given by angle/length is to be plotted
  * using Cartesian projections in which the direction of positive x and/or y-axis might have

--- a/test/pstext/shade_text.ps
+++ b/test/pstext/shade_text.ps
@@ -1,0 +1,1315 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_b7eaa8f-dirty_2021.01.29 [64-bit] Document from pstext
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sat Jan 30 15:03:48 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-3600 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R0/6/0/9 -Jx1i -P -B0 -F+f+jCM -K -Glightgreen -S -Xc
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 9.00000000 0.000 6.000 0.000 9.000 +xy
+%GMTBoundingBox: -216 72 432 648
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+clipsave
+0 0 M
+7200 0 D
+0 10800 D
+-7200 0 D
+P
+PSL_clip N
+{0.498 A} FS
+O0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+767 F0
+V
+(A TALE OF) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 115 def
+/PSL_dy 115 def
+3667 9533 T PSL_dim_w -2 div PSL_dim_h -2 div T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+4 W
+{0.565 0.933 0.565 C} FS
+V
+(A TALE OF) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 115 def
+/PSL_dy 115 def
+3600 9600 T PSL_dim_w -2 div PSL_dim_h -2 div T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+3600 9600 M (A TALE OF) mc Z
+PSL_cliprestore
+25 W
+0 A
+/PSL_slant_y 0 def
+2 setlinecap
+N 0 10800 M 0 -10800 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7200 0 T
+N 0 10800 M 0 -10800 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7200 0 T
+N 0 0 M 7200 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 10800 T
+N 0 0 M 7200 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -10800 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R0/6/0/9 -Jx1i -F+f+jCM -O -K -Gwhite -W0.5p -S -C+tO
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 9.00000000 0.000 6.000 0.000 9.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 10800 D
+-7200 0 D
+P
+PSL_clip N
+{0.498 A} FS
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+767 F0
+V
+(TWO CITIES!) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 115 def
+/PSL_dy 115 def
+3667 8333 T PSL_dim_w -2 div PSL_dim_h -2 div T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add 115 PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub SB
+U
+8 W
+{1 A} FS
+O1
+V
+(TWO CITIES!) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 115 def
+/PSL_dy 115 def
+3600 8400 T PSL_dim_w -2 div PSL_dim_h -2 div T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add 115 PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub SB
+U
+3600 8400 M (TWO CITIES!) mc Z
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R0/6/0/9 -Jx1i -F+f16p,Times-Roman,red+jTC -O -M -Glightblue -W2p -S8p/-8p/darkblue -C8p+tc
+%@PROJ: xy 0.00000000 6.00000000 0.00000000 9.00000000 0.000 6.000 0.000 9.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7200 0 D
+0 10800 D
+-7200 0 D
+P
+PSL_clip N
+/PSL_linespace 300 def
+/PSL_parwidth 6000 def
+/PSL_parjust 4 def
+PSL_font_encode 4 get 0 eq {ISOLatin1+_Encoding /Times-Roman /Times-Roman PSL_reencode PSL_font_encode 4 1 put} if
+{0 0 0.545 C} FS
+/PSL_setfont {
+  /f exch def
+  /k1 exch def
+  /fz PSL_size k1 get def
+  /fn PSL_fnt k1 get def
+  fn PSL_lastfn eq fz PSL_lastfz eq and not {
+    fz PSL_fontname fn get Y
+    /PSL_lastfn fn def
+    /PSL_lastfz fz def
+  } if
+  /fc PSL_color k1 get def
+  fc PSL_lastfc ne {
+    /PSL_c fc 3 mul def
+    0 1 2 {PSL_c add PSL_rgb exch get} for C
+    /PSL_lastfc fc def
+  } if
+  f 32 and 32 eq {
+    /PSL_UL fz 0.075 mul def
+    fz 0.025 mul W
+    /PSL_show {PSL_ushow} def
+  }
+  {
+    /PSL_show {ashow} def
+  } ifelse
+}!
+/PSL_setfont2 {
+  /f exch def
+  /k1 exch def
+  /fz PSL_size k1 get def
+  /fn PSL_fnt k1 get def
+  fn PSL_lastfn eq fz PSL_lastfz eq and not {
+    fz PSL_fontname fn get Y
+    /PSL_lastfn fn def
+    /PSL_lastfz fz def
+  } if
+}!
+/PSL_wordheight {
+  0 0 M false charpath flattenpath pathbbox /up exch def pop /down exch def pop newpath
+  down PSL_ymin lt {/PSL_ymin down def} if
+  up PSL_ymax gt {/PSL_ymax up def} if
+}!
+/PSL_ushow {
+  currentpoint /y0 exch def /x0 exch def
+  ashow
+  currentpoint pop /x1 exch def
+  x0 y0 PSL_UL sub M x1 y0 PSL_UL sub L S
+  x1 y0 M
+}!
+/PSL_placeword {
+  /k exch def
+  /flag PSL_flag k get def
+  k flag PSL_setfont
+  /sshow {ashow} def
+  PSL_col 0 eq {
+    /PSL_t 0 def
+    flag 4 and 4 eq {
+      pr_char 0 (    ) ashow
+    } if
+  }
+  {
+    /f PSL_flag k 1 sub get def
+    /PSL_t f 3 and def
+    f 32 and 32 eq flag 32 and 32 eq and {/sshow {PSL_ushow} def} if
+  } ifelse
+  /thisword_bshift PSL_bshift k get def
+  thisword_bshift 0.0 ne {0 thisword_bshift G} if
+  flag 8 and 8 eq {
+    pr_char 0 PSL_spaces PSL_t get sshow
+    k PSL_composite
+  } if
+  flag 24 and 0 eq {
+    pr_char 0 PSL_spaces PSL_t get sshow pr_char 0 PSL_word k get PSL_show
+    PSL_width k get 0 gt {/PSL_col PSL_col 1 add def} if
+  } if
+  thisword_bshift 0.0 ne {0 thisword_bshift neg G} if
+}!
+/PSL_composite {
+  /k1 exch def
+  /k2 k1 1 add def
+  /char1 PSL_word k1 get def
+  /char2 PSL_word k2 get def
+  /flag2 PSL_flag k2 get def
+  /w1 char1 stringwidth pop def
+  flag2 64 and 64 eq {
+    /fn2 PSL_fnt k2 get def
+    fz PSL_fontname fn2 get Y
+  } if
+  /w2 char2 stringwidth pop def
+  /delta w1 w2 sub 2 div PSL_scale mul def
+  delta 0.0 gt {
+    /dx1 0 def
+    /dx2 delta def
+  }
+  {
+    /dx1 delta neg def
+    /dx2 0 def
+  } ifelse
+  dx1 0 G currentpoint
+  flag2 64 and 64 eq {
+   /fn1 PSL_fnt k1 get def
+    fz PSL_fontname fn1 get Y
+  } if
+  pr_char 0 char1 PSL_show M
+  delta 0 G
+  flag2 64 and 64 eq {
+    fz PSL_fontname fn2 get Y
+  } if
+  pr_char 0 char2 ashow
+  dx2 0 G
+}!
+/PSL_expand {
+  /k1 exch def
+  /extra PSL_parwidth previous_linewidth sub comp_width add def
+  PSL_CRLF k1 PSL_n1 eq or {/spread 0 def} {/spread extra def} ifelse
+  /PSL_scale previous_linewidth 0.0 gt {PSL_parwidth previous_linewidth div} {1.0} ifelse def
+  /ndiv lsum ncomp sub def
+  ndiv 0 eq {/ndiv 1 def} if
+  PSL_parjust 4 eq {/pr_char spread ndiv div def} {/pr_char 0 def} ifelse
+  PSL_parjust 2 eq {extra 2 div 0 G} if
+  PSL_parjust 3 eq {extra 0 G} if
+  /PSL_col 0 def
+}!
+/PSL_textjustifier {
+  /PSL_mode exch def
+  /PSL_col 0 def
+  /PSL_ybase 0 def
+  /PSL_parheight 0 def
+  /PSL_ymin 0 def
+  /PSL_ymax 0 def
+  /PSL_top 0 def
+  /PSL_bottom 0 def
+  /last_font PSL_fnt 0 get def
+  /last_size PSL_size 0 get def
+  /last_color PSL_color 0 get def
+  /previous_linewidth 0 def
+  /stop 0 def
+  /start 0 def
+  /lsum 0 def
+  /line 0 def
+  /ncomp 0 def
+  /comp_width 0 def
+  0 1 PSL_n1 {
+    /i exch def
+    /thisflag PSL_flag i get def
+    i 0 eq {
+      /PSL_t 0 def
+      /lastflag 0 def
+    }
+    { /lastflag PSL_flag i 1 sub get def
+      /PSL_t lastflag 3 and def
+    } ifelse
+    i thisflag PSL_setfont2
+    /thisword_width PSL_width i get def
+    /comp_add 0 def
+    /compw_add 0 def
+    /PSL_tabwidth (    ) stringwidth pop def
+    /PSL_spacewidths PSL_spaces {stringwidth pop} forall 3 array astore def
+    /ccount PSL_count i get def
+    thisflag 4 and 4 eq {
+      /thisword_width thisword_width PSL_tabwidth add def
+      /ccount ccount 4 add def
+    } if
+    lastflag 8 and 8 eq {/PSL_t 0 def /comp_add 1 def /compw_add thisword_width def} if
+    /new_linewidth previous_linewidth thisword_width add PSL_spacewidths PSL_t get add def
+    /PSL_CRLF thisword_width 0.0 eq thisflag 16 and 0 eq and def
+    /special thisflag 16 and 16 eq {true} {thisword_width 0.0 gt} ifelse def
+    new_linewidth PSL_parwidth le special and
+    {
+      PSL_col 0 eq {
+        /PSL_ymin 0 def
+        /PSL_ymax 0 def
+      } if
+      /stop stop 1 add def
+      /PSL_col PSL_col 1 add def
+      /previous_linewidth new_linewidth def
+      /lsum lsum ccount add PSL_t add def
+      /ncomp ncomp comp_add add def
+      /comp_width comp_width compw_add add def
+    }
+    {
+      1 PSL_mode eq {
+        start PSL_expand
+        start PSL_placeword
+      }
+      {PSL_word start get PSL_wordheight
+      } ifelse
+      /last stop 1 sub def
+      /start start 1 add def
+      1 PSL_mode eq {
+        start 1 last {PSL_placeword} for
+      }
+      {start 1 last {PSL_word exch get PSL_wordheight} for
+        line 0 eq { /PSL_top PSL_ymax def} if
+      } ifelse
+      /start stop def
+      /PSL_ybase PSL_ybase PSL_linespace sub def
+      1 PSL_mode eq {0 PSL_ybase M} if
+      /stop stop 1 add def
+      /previous_linewidth thisword_width def
+      /lsum ccount def
+      /ncomp comp_add def
+      /comp_width compw_add def
+      /PSL_col 0 def
+      /line line 1 add def
+    } ifelse
+  } for
+  /last stop 1 sub def
+  last PSL_n lt {
+    /PSL_CRLF true def
+    1 PSL_mode eq {
+      start PSL_expand
+      start PSL_placeword
+      /start start 1 add def
+      start 1 last {PSL_placeword} for
+    }
+    { /PSL_ymin 0 def
+      PSL_word start get PSL_wordheight
+      /start start 1 add def
+      start 1 last {PSL_word exch get PSL_wordheight} for
+      line 0 eq {
+        /PSL_top PSL_ymax def
+      } if
+    } ifelse
+  } if
+  /PSL_bottom PSL_ymin def
+  /PSL_parheight PSL_ybase neg PSL_top add PSL_bottom sub def
+} def
+/PSL_fontname
+/Times-Roman
+1 array astore def
+/PSL_n 120 def
+/PSL_n1 119 def
+/PSL_y0 5867 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+() (It) (was) (the) (best) (of) (times,) (it) (was) (the) (worst) (of) (times) (,) (it) (was)
+(the) (age) (of) (wisdom,) (it) (was) (the) (age) (of) (foolishness,) (it) (was) (the)
+(epoch) (of) (belief,) (it) (was) (the) (epoch) (of) (incredulity,) (it) (was) (the)
+(season) (of) (Light,) (it) (was) (the) (season) (of) (Darkness,) (it) (was) (the) (spring)
+(of) (hope,) (it) (was) (the) (winter) (of) (despair,) (we) (had) (everything) (before)
+(us,) (we) (had) (nothing) (before) (us,) (we) (were) (all) (going) (direct) (to) (Heaven,)
+(we) (were) (all) (going) (direct) (the) (other) (way­­in) (short,) (the) (period)
+(was) (so) (far) (like) (the) (present) (period,) (that) (some) (of) (its) (noisiest)
+(authorities) (insisted) (on) (its) (being) (received,) (for) (good) (or) (for)
+(evil,) (in) (the) (superlative) (degree) (of) (comparison) (only.)
+120 array astore def
+/PSL_fnt
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+120 array astore def
+/PSL_size
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+120 array astore def
+/PSL_flag
+4 33 33 33 33 33 33 33 33 33 33 33 32 1 1 1 1 1 1 1 1 1 1 1 1
+1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0
+120 array astore def
+/PSL_bshift
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+120 array astore def
+/PSL_color
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+120 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 120 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 120 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 3733 5867 T
+/PSL_xgap 133 def
+/PSL_ygap 133 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 10 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/PSL_h PSL_parheight 2 div PSL_ygap 2 mul add def
+/PSL_w PSL_parwidth 2 div PSL_xgap 2 mul add def
+/PSL_rx PSL_w PSL_w mul PSL_xgap PSL_xgap mul add 2 PSL_xgap mul div def
+/PSL_ry PSL_h PSL_h mul PSL_ygap PSL_ygap mul add 2 PSL_ygap mul div def
+/PSL_ax PSL_w PSL_rx PSL_xgap sub atan def
+/PSL_ay PSL_h PSL_ry PSL_ygap sub atan def
+PSL_xgap 2 mul neg PSL_ygap 2 mul M
+PSL_xgap PSL_ry add neg PSL_parheight 2 div neg PSL_ry PSL_ay dup neg arcn
+PSL_parwidth 2 div PSL_parheight PSL_ygap add PSL_rx add neg PSL_rx 90 PSL_ax add 90 PSL_ax sub arcn
+PSL_parwidth PSL_xgap add PSL_ry add PSL_parheight 2 div neg PSL_ry 180 PSL_ay add 180 PSL_ay sub arcn
+PSL_parwidth 2 div PSL_ygap PSL_rx add PSL_rx 270 PSL_ax add 270 PSL_ax sub arcn
+FO U
+33 W
+0 A
+{0.678 0.847 0.902 C} FS
+O1
+/PSL_fontname
+/Times-Roman
+1 array astore def
+/PSL_n 120 def
+/PSL_n1 119 def
+/PSL_y0 6000 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+() (It) (was) (the) (best) (of) (times,) (it) (was) (the) (worst) (of) (times) (,) (it) (was)
+(the) (age) (of) (wisdom,) (it) (was) (the) (age) (of) (foolishness,) (it) (was) (the)
+(epoch) (of) (belief,) (it) (was) (the) (epoch) (of) (incredulity,) (it) (was) (the)
+(season) (of) (Light,) (it) (was) (the) (season) (of) (Darkness,) (it) (was) (the) (spring)
+(of) (hope,) (it) (was) (the) (winter) (of) (despair,) (we) (had) (everything) (before)
+(us,) (we) (had) (nothing) (before) (us,) (we) (were) (all) (going) (direct) (to) (Heaven,)
+(we) (were) (all) (going) (direct) (the) (other) (way­­in) (short,) (the) (period)
+(was) (so) (far) (like) (the) (present) (period,) (that) (some) (of) (its) (noisiest)
+(authorities) (insisted) (on) (its) (being) (received,) (for) (good) (or) (for)
+(evil,) (in) (the) (superlative) (degree) (of) (comparison) (only.)
+120 array astore def
+/PSL_fnt
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+120 array astore def
+/PSL_size
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+267 267 267 267 267 267 267 267 267 267 267 267 267 267 267
+120 array astore def
+/PSL_flag
+4 33 33 33 33 33 33 33 33 33 33 33 32 1 1 1 1 1 1 1 1 1 1 1 1
+1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0
+120 array astore def
+/PSL_bshift
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+120 array astore def
+/PSL_color
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+120 array astore def
+/PSL_rgb
+0 0 0
+3 array astore def
+/PSL_width 120 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 120 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 3600 6000 T
+/PSL_xgap 133 def
+/PSL_ygap 133 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 10 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/PSL_h PSL_parheight 2 div PSL_ygap 2 mul add def
+/PSL_w PSL_parwidth 2 div PSL_xgap 2 mul add def
+/PSL_rx PSL_w PSL_w mul PSL_xgap PSL_xgap mul add 2 PSL_xgap mul div def
+/PSL_ry PSL_h PSL_h mul PSL_ygap PSL_ygap mul add 2 PSL_ygap mul div def
+/PSL_ax PSL_w PSL_rx PSL_xgap sub atan def
+/PSL_ay PSL_h PSL_ry PSL_ygap sub atan def
+PSL_xgap 2 mul neg PSL_ygap 2 mul M
+PSL_xgap PSL_ry add neg PSL_parheight 2 div neg PSL_ry PSL_ay dup neg arcn
+PSL_parwidth 2 div PSL_parheight PSL_ygap add PSL_rx add neg PSL_rx 90 PSL_ax add 90 PSL_ax sub arcn
+PSL_parwidth PSL_xgap add PSL_ry add PSL_parheight 2 div neg PSL_ry 180 PSL_ay add 180 PSL_ay sub arcn
+PSL_parwidth 2 div PSL_ygap PSL_rx add PSL_rx 270 PSL_ax add 270 PSL_ax sub arcn
+FO U
+1 0 0 C
+V 3600 6000 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 10 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+PSL_cliprestore
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/pstext/shade_text.sh
+++ b/test/pstext/shade_text.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # Test pstext paragraph mode
-ps=book.ps
-gmt pstext -R0/6/0/9 -Jx1i -P -B0 -F+f+jCM -K << EOF > $ps
-3	8	46p	A Tale of Two Cities
-3	7	32p	Dickens, Charles
-3	6.4	24p	1812-1973
+ps=shade_text.ps
+gmt pstext -R0/6/0/9 -Jx1i -P -B0 -F+f+jCM -K -Glightgreen -S -Xc << EOF > $ps
+3	8	46p	A TALE OF
+EOF
+gmt pstext -R -J -F+f+jCM -O -K -Gwhite -W0.5p -S -C+tO << EOF >> $ps
+3	7	46p	TWO CITIES!
 EOF
 # First Paragraph
-gmt pstext -R -J -F+f16p,Times-Roman,red+jTC -O -M << EOF >> $ps
+gmt pstext -R -J -F+f16p,Times-Roman,red+jTC -O -M -Glightblue -W2p -S8p/-8p/darkblue -C8p+tc << EOF >> $ps
 > 3 5 18p 5i j
 	@_It was the best of times, it was the worst of times@_,
 it was the age of wisdom, it was the age of foolishness,
@@ -20,11 +21,4 @@ the other way--in short, the period was so far like the present
 period, that some of its noisiest authorities insisted on its
 being received, for good or for evil, in the superlative degree
 of comparison only.
-
-	There were a king with a large jaw and a queen with a plain face,
-on the throne of England; there were a king with a large jaw and
-a queen with a fair face, on the throne of France.  In both
-countries it was clearer than crystal to the lords of the State
-preserves of loaves and fishes, that things in general were
-settled for ever.
 EOF


### PR DESCRIPTION
**Description of proposed changes**

This PR is made in support of #4703 by adding new option **-S**[_dx_/_dy_/][_shade_] to **pstext** so that either single or paragraph text may enjoy the optional shade-effect.  In the process, I did

1. Report an error if **-C+tc**|**C** is used with regular (i.e., not **-M**) text
2. Add a test to demonstrate that the option works for both types of text
3. Fix a minor issue in another test (book.sh)
4. Implement **-S** so that the backwards compatibility for GMT4 **-S**_pen_ still is honored.

As an example, this suggestion is now listed in the documentation:

`gmt text -R0/10/0/5 -Jx1c -F+f32p+cCM+tWELCOME -B -Gyellow -Wfaint -S -C+tO -pdf map`

with this result:

![map](https://user-images.githubusercontent.com/26473567/106371815-0b492600-630d-11eb-9556-0bb9c73aa684.png)
