### PR TITLE
Control media cropping via PS_CONVERT settings

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -88,7 +88,8 @@
 #define GMT_TOP_MODULE	1	/* func_level of top-level module being called */
 
 #define GMT_PAPER_DIM		32767	/* Upper limit on PostScript paper size under modern mode, in points (~11.6 meters) */
-#define GMT_PAPER_MARGIN	5	/* Default paper margin under modern mode, in inches (12.7 centimeter) */
+#define GMT_PAPER_MARGIN_AUTO	5	/* Default paper margin under modern mode, in inches (12.7 centimeter) for auto-size mode */
+#define GMT_PAPER_MARGIN_FIXED	1	/* Default paper margin under modern mode, in inches (12.7 centimeter) for fixed-size mode */
 
 /*! whether to ignore/read/write history file gmt.history */
 enum GMT_enum_history {

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -171,6 +171,7 @@ struct GMT_DEFAULTS {
 	struct ELLIPSOID ref_ellipsoid[GMT_N_ELLIPSOIDS];	/* Ellipsoid parameters */
 	/* PS group [These are arguments to pass to PSL_beginsession and PSL_setdefaults] */
 	/* [All other internal PSL settings are set directly when parsing PSL settings ] */
+	double ps_def_page_size[2];			/* Default Width and height of paper to plot on in points [Letter or A4] */
 	double ps_page_size[2];			/* Width and height of paper to plot on in points [Letter or A4] */
 	double ps_page_rgb[4];			/* Default paper color [white] */
 	double ps_magnify[2];			/* Width and height of paper to plot on in points [Letter or A4] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18106,8 +18106,14 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			if (error) return (error);		/* Bail at this point */
 			gmt_reset_history (API->GMT);	/* No old classic history shall affect a new modern mode session */
 
-			gmt_conf (API->GMT);				/* Get the original system defaults */
-			if (!clean_start) gmt_getdefaults (API->GMT, NULL);		/* Overload user defaults */
+			gmt_conf (API->GMT);				/* Get the GMT system defaults */
+			if (!clean_start) {
+				int default_media = API->GMT->current.setting.ps_media;
+				gmt_getdefaults (API->GMT, NULL);		/* Overload any user-supplied defaults via a gmt.conf file */
+				gmtinit_setautopagesize (API->GMT);
+				/* But reset PS_MEDIA to the original system default */
+				//API->GMT->current.setting.ps_media = default_media;
+			}
 			snprintf (dir, PATH_MAX, "%s/%s", API->gwf_dir, GMT_SETTINGS_FILE);	/* Reuse dir string for saving gmt.conf to this dir */
 			API->GMT->current.setting.run_mode = GMT_MODERN;	/* Enable modern mode here so putdefaults can skip writing PS_MEDIA if not PostScript output */
 			error = gmtinit_put_session_name (API, text);		/* Store session name, possibly setting psconvert options */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -12467,7 +12467,7 @@ void gmt_putdefaults (struct GMT_CTRL *GMT, char *this_file) {
 /*! Read user's gmt.conf file and initialize parameters */
 int gmt_getdefaults (struct GMT_CTRL *GMT, char *this_file) {
 	char file[PATH_MAX];
-	int err = GMT_NOTSET;
+	int err = GMT_NOTSET;	/* Returned if this_file == NULL, classic mode, and no gmt.conf found */
 
 	if (this_file)	/* Defaults file is specified */
 		err = gmtinit_loaddefaults (GMT, this_file);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18111,7 +18111,6 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			gmt_conf (API->GMT);				/* Get the GMT system defaults */
 			if (!clean_start) {
 				/*  Overload any user-supplied defaults via a gmt.conf file but reset PS_MEDIA to the original system default */
-				int default_media = API->GMT->current.setting.ps_media;
 				if (gmt_getdefaults (API->GMT, NULL) == GMT_NOERROR)	/* Ingested a gmt.conf file */
 					gmtinit_setautopagesize (API->GMT);	/* Reset to auto */
 			}

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -52,6 +52,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC bool gmtlib_fixed_paper_size (struct GMTAPI_CTRL *API);
 EXTERN_MSC struct GMT_CUBE *gmtlib_create_cube (struct GMT_CTRL *GMT);
 EXTERN_MSC struct GMT_CUBE *gmtlib_duplicate_cube (struct GMT_CTRL *GMT, struct GMT_CUBE *U, unsigned int mode);
 EXTERN_MSC void gmt_free_cube (struct GMT_CTRL *GMT, struct GMT_CUBE **U, bool free_cube);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8392,6 +8392,12 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Write PS to hidden gmt_#.ps- file.  No -O -K allowed */
 		char *verb[2] = {"Create", "Append to"};
 		bool wants_PS;
+		double paper_margin = GMT_PAPER_MARGIN;
+		if (gmtlib_fixed_paper_size (GMT->parent)) {	/* Must honor paper sized and regular margin */
+			double paper_margin = 1.0;
+			gmt_M_memcpy (media_size, GMT->current.setting.ps_def_page_size, 2, double);
+		}
+
 		if ((k = gmt_set_psfilename (GMT)) == GMT_NOTSET) {	/* Get hidden file name for PS */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "No workflow directory\n");
 			GMT->parent->error = GMT_ERROR_ON_FOPEN;
@@ -8424,9 +8430,9 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Use PS_MEDIA and/or PS_PAGE_ORIENTATION to specify correct paper dimensions and/or orientation if our guesses are inadequate.\n");
 			}
 		}
-		else if (!O_active) {	/* Not desiring PS output so we can add safety margin of GMT_PAPER_MARGIN inches for initial layer unless PS_MEDIA was set */
+		else if (!O_active) {	/* Not desiring PS output so we can add safety margin of paper_margin inches for initial layer unless PS_MEDIA was set */
 			if (!(GMT->common.X.active || GMT->common.Y.active) && auto_media)
-				GMT->current.setting.map_origin[GMT_X] = GMT->current.setting.map_origin[GMT_Y] = GMT_PAPER_MARGIN;
+				GMT->current.setting.map_origin[GMT_X] = GMT->current.setting.map_origin[GMT_Y] = paper_margin;
 		}
 		if (!O_active) {	/* See if special movie labeling file exists under modern mode */
 			char file[PATH_MAX] = {""}, record[GMT_LEN256] = {""};

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8393,8 +8393,9 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 		char *verb[2] = {"Create", "Append to"};
 		bool wants_PS;
 		double paper_margin = GMT_PAPER_MARGIN_AUTO;
-		if (gmtlib_fixed_paper_size (GMT->parent)) {	/* Must honor paper sized and regular margin */
-			double paper_margin = GMT_PAPER_MARGIN_FIXED;
+
+		if (gmtlib_fixed_paper_size (GMT->parent)) {	/* Must honor paper size and regular margin */
+			paper_margin = GMT_PAPER_MARGIN_FIXED;
 			gmt_M_memcpy (media_size, GMT->current.setting.ps_def_page_size, 2, double);
 		}
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8392,9 +8392,9 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Write PS to hidden gmt_#.ps- file.  No -O -K allowed */
 		char *verb[2] = {"Create", "Append to"};
 		bool wants_PS;
-		double paper_margin = GMT_PAPER_MARGIN;
+		double paper_margin = GMT_PAPER_MARGIN_AUTO;
 		if (gmtlib_fixed_paper_size (GMT->parent)) {	/* Must honor paper sized and regular margin */
-			double paper_margin = 1.0;
+			double paper_margin = GMT_PAPER_MARGIN_FIXED;
 			gmt_M_memcpy (media_size, GMT->current.setting.ps_def_page_size, 2, double);
 		}
 

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -117,7 +117,7 @@ EXTERN_MSC void gmt_vector_syntax (struct GMT_CTRL *GMT, unsigned int mode);
 EXTERN_MSC void gmt_segmentize_syntax (struct GMT_CTRL *GMT, char option, unsigned int mode);
 EXTERN_MSC void gmt_img_syntax (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_GSHHG_syntax (struct GMT_CTRL *GMT, char option);
-EXTERN_MSC void gmt_getdefaults (struct GMT_CTRL *GMT, char *this_file);
+EXTERN_MSC int gmt_getdefaults (struct GMT_CTRL *GMT, char *this_file);
 EXTERN_MSC void gmt_putdefaults (struct GMT_CTRL *GMT, char *this_file);
 EXTERN_MSC int gmt_hash_init (struct GMT_CTRL *GMT, struct GMT_HASH *hashnode , char **keys, unsigned int n_hash, unsigned int n_keys);
 EXTERN_MSC void gmt_extract_label (struct GMT_CTRL *GMT, char *line, char *label, struct GMT_OGR_SEG *G);

--- a/src/gmtdefaults.c
+++ b/src/gmtdefaults.c
@@ -149,7 +149,7 @@ EXTERN_MSC int GMT_gmtdefaults (void *V_API, int mode, void *args) {
 			gmt_conf_US (GMT);	/* Change a few to US defaults */
 	}
 	else
-		gmt_getdefaults (GMT, NULL);	/* Get local GMT default settings (if any) [and PSL if selected] */
+		(void)gmt_getdefaults (GMT, NULL);	/* Get local GMT default settings (if any) [and PSL if selected] */
 
 	/* To ensure that all is written to stdout we must set updated to true */
 

--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -317,7 +317,12 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 
 	/* Read the supplied default file or the users defaults to override system settings */
 
-	if (Ctrl->G.active || API->external) gmt_getdefaults (GMT, Ctrl->G.file);	/* Update defaults if using external API */
+	if (Ctrl->G.active || API->external) {
+		if (gmt_getdefaults (GMT, Ctrl->G.file) && Ctrl->G.file) {	/* Update defaults if using external API */
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to access or read %s\n", Ctrl->G.file);
+			Return (GMT_RUNTIME_ERROR);
+		}
+	}
 
 	error = gmt_pickdefaults (GMT, Ctrl->L.active, options);		/* Process command line arguments */
 

--- a/src/gmtset.c
+++ b/src/gmtset.c
@@ -166,10 +166,16 @@ EXTERN_MSC int GMT_gmtset (void *V_API, int mode, void *args) {
 		if (Ctrl->D.mode == 'u')
 			gmt_conf_US (GMT);	/* Change a few to US defaults */
 	}
-	else if (Ctrl->C.active)
-		gmt_getdefaults (GMT, ".gmtdefaults4");
-	else if (Ctrl->G.active)
-		gmt_getdefaults (GMT, Ctrl->G.file);
+	else if (Ctrl->C.active) {	/* Convert deprecated .gmtdefaults4 files */
+		if (gmt_getdefaults (GMT, ".gmtdefaults4")) {
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to find or read .gmtdefaults4 settings file\n");
+			Return (GMT_RUNTIME_ERROR);
+		}
+	}
+	else if (Ctrl->G.active && gmt_getdefaults (GMT, Ctrl->G.file)) {
+		GMT_Report (API, GMT_MSG_ERROR, "Unable to access or read %s\n", Ctrl->G.file);
+		Return (GMT_RUNTIME_ERROR);
+	}
 
 	if (gmt_setdefaults (GMT, options)) Return (GMT_PARSE_ERROR);		/* Process command line arguments, return error if failures */
 

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -113,7 +113,8 @@ struct PSCONVERT_CTRL {
 		bool outline;      /* Draw frame around plot with selected pen (+p) [0.25p] */
 		bool paint;        /* Paint box behind plot with selected fill (+g) */
 		bool crop;         /* If true we must find the BB; turn off via -A+n */
-		bool fade;         /* If true we must fade out the plot to black*/
+		bool fade;         /* If true we must fade out the plot to black */
+		bool media;        /* If true we must crop to current media size in PS_MEDIA. Only issued indirectly by gmt end */
 		double scale;      /* Scale factor to go along with the 'rescale' option */
 		double fade_level;      /* Fade to black at this level of transparency */
 		double new_size[2];
@@ -344,6 +345,9 @@ GMT_LOCAL int psconvert_parse_A_settings (struct GMT_CTRL *GMT, char *arg, struc
 				break;
 			case 'n':	/* No crop */
 				Ctrl->A.crop = false;
+				break;
+			case 'M':	/* Crop to media */
+				Ctrl->A.media = true;
 				break;
 			case 'p':	/* Draw outline */
 				Ctrl->A.outline = true;
@@ -1814,7 +1818,13 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 
 		/* Adjust to a tight BoundingBox if user requested so */
 
-		if (Ctrl->A.crop) {
+		if (Ctrl->A.media) {	/* Crop to set PS_MEDIA size */
+			x1 = GMT->current.setting.ps_def_page_size[0];
+			y1 = GMT->current.setting.ps_def_page_size[1];
+			got_BB = got_HRBB = got_end = true;
+			GMT_Report (API, GMT_MSG_INFORMATION, "Crop to media BoundingBox [%g %g %g %g].\n", x0, y0, x1, y1);
+		}
+		else if (Ctrl->A.crop) {
 			char *psfile_to_use = NULL;
 			GMT_Report (API, GMT_MSG_INFORMATION, "Find HiResBoundingBox ...\n");
 			if (GMT->current.setting.run_mode == GMT_MODERN)	/* Place BB file in session dir */


### PR DESCRIPTION
See #4734 for context.  This PR consider the session and figure settings for the **PS_CONVERT** options and if containing **A+n** (no cropping) we replace that under the hood with **A+M** before passing options to **psconvert**.  This undocumented option leads to cropping to the current default media size (set by **PS_MEDIA** [a4]).  Furthermore, any **PS_MEDIA** settings given during the session will be honored as well.  All tests still pass. Now, these cases all work as I expect:

```
rm -f gmt.conf
gmt begin map png A+n
  gmt coast -Rg -JH180/15c -Gpink -B -Xc -Yc
gmt end show
```

which now yields a page-size PNG.  Take out that **A+n**:

```
rm -f gmt.conf
gmt begin map png
  gmt coast -Rg -JH180/15c -Gpink -B -Xc -Yc
gmt end show
```

and we are back to exact cropping.  Furthermore, Having a prior gmt.conf before session also gives a tight crop:

```
gmt set PS_MEDIA a8
gmt begin map png
  gmt coast -Rg -JH180/15c -Gpink -B -Xc -Yc
gmt end show
```

even though the session inherits that existing gmt.conf as I now override the **PS_MEDIA** settings.  Finally,

```
rm -f gmt.conf
gmt begin map png
  gmt set PS_MEDIA a8
  gmt coast -Rg -JH180/15c -Gpink -B -Xc -Yc
gmt end show
```

honors the selected A8 media for all output formats since the setting was selected during the session.

