### PR TITLE
Fix movie shift when back/foreground is used and -Xc -Yc is set

### DIFF
--- a/doc/examples/anim05/anim05.sh
+++ b/doc/examples/anim05/anim05.sh
@@ -22,7 +22,7 @@ cat << EOF > main.sh
 gmt begin
 	let k=\${MOVIE_FRAME}+1
 	gmt greenspline @Table_5_11.txt -R0/6.5/0/6.5 -I0.05 -Sc -Gt.nc -Z1 -Cn\${k} -Emisfit.txt
-	gmt grdcontour t.nc -C25 -A50 -Baf -BWsNE -JX4i -Gl3.6/6.5/4.05/0.75 -X0.25i -Y0.4i
+	gmt grdcontour t.nc -C25 -A50 -Baf -BWsNE -JX4i -Gl3.6/6.5/4.05/0.75 -Xc -Y0.4i
 	gmt plot misfit.txt -Ct.cpt -Sc0.15c -Wfaint -i0,1,4
 	printf "%2.2d" \$k | gmt text -F+cTR+jTR+f18p -Dj0.1i -Gwhite -W0.25p
 	gmt colorbar -Ct.cpt -DJBC+e -Bxaf -By+l"misfit"

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -9919,6 +9919,8 @@ int gmt_ps_append (struct GMT_CTRL *GMT, char *source, unsigned int mode, FILE *
 	FILE *fp = NULL;
 	char buffer[GMT_BUFSIZ] = {""};
 	bool go = true;
+	if (mode == 0 || mode == 2)
+		fprintf (dest, "/PSL_xorig 0 def /PSL_yorig 0 def\n");	/* Reset these since we did not use -K in making these pieces */
 
 	if ((fp = fopen (source, "r")) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not open PostScript file %s\n", source);


### PR DESCRIPTION
See #4733 for background.  The issue was that while GMT normally adds layers upon layers to build a final PS file, in the special case of **movie** and **-S** we are in fact building complete plots (the background and foreground plots are complete PostScript files that can be viewed, say, during debug).  However, because of this they have headers which must be skipped when **psconvert** assembles the final _sandwich_ (**-M**) plot. Furthermore (and this part was missing) the memory of what the margin location is (_PSL_xorig, PSL_yorig_) needs to be reset to zero.  With that fix we are in business.  Closes #4733.
