### PR TITLE
Update units documentation

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -78,7 +78,9 @@ two ways to ensure that GMT understands which unit you intend to use:
 
 #. Set the parameter :term:`PROJ_LENGTH_UNIT` to the desired unit. Then,
    all dimensions without explicit units will be interpreted accordingly.
-   By default, GMT always initializes :term:`PROJ_LENGTH_UNIT` to cm.
+   By default, GMT always initializes :term:`PROJ_LENGTH_UNIT` to cm and
+   interprets unitless dimensional values as cm, except for fonts and pen
+   thicknesses which are by default interpreted as points.
 
 The latter method is less robust as other users may have a different
 default unit set and then your script may not work as intended. For portability,
@@ -107,10 +109,10 @@ For Cartesian data the data units do not normally matter
 Geographic data are different, as distances can be specified in a variety
 of ways. GMT programs that accept actual Earth length scales like
 search radii or distances can therefore handle a variety of units. These
-choices are listed in Table :ref:`distunits <tbl-distunits>`; simply append the desired
-unit to the distance value you supply. A value without a unit suffix
-will be consider to be in meters. For example, a distance of 30 nautical
-miles should be given as 30\ **n**.
+choices are listed in the Table :ref:`Distance Units <tbl-distunits>`;
+simply append the desired unit to the distance value you supply. A value
+without a unit suffix will be consider to be in meters. For example, a distance
+of 30 nautical miles should be given as 30\ **n**.
 
 Distance calculations
 ~~~~~~~~~~~~~~~~~~~~~
@@ -162,8 +164,7 @@ for an ellipsoid is required (typically for a limited surface area). For
 instance, a search radius of 5000 feet using this mode of computation
 would be specified as **-S**\ 5000\ **f**.
 
-**Note**: There are two additional
-GMT defaults that control how
+**Note**: There are two additional GMT defaults that control how
 great circle (and Flat Earth) distances are computed. One concerns the
 selection of the "mean radius". This is selected by
 :term:`PROJ_MEAN_RADIUS`, which selects one of several possible

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -12,17 +12,19 @@ Description
 The following is a list of the parameters that are user-definable in
 GMT. The parameter names are always given in **UPPER CASE**. The
 parameter values are case-insensitive unless otherwise noted. The system
-defaults are given in brackets [ for SI (or US) ].
-Note that default distances and lengths below are
-given in both cm or inch; the chosen default depends on your choice of
-default unit (see :term:`PROJ_LENGTH_UNIT`). You can explicitly specify
-the unit used for distances and lengths by appending **c** (cm), **i**
-(inch), or **p** (points). When no unit is indicated the value will be
-assumed to be in the unit set by :term:`PROJ_LENGTH_UNIT`. Several
-parameters take only **true** or **false**. Finally, most of these
-parameters can be changed on-the-fly via the **--PARAMETER**\ =\ *VALUE*
-option to any GMT program. However, a few are static and are only
-read via the **gmt.conf** file; these are labeled (static).
+defaults are given in brackets [ ], with units specified for dimensional
+quantities. Most parameters can be changed by using :doc:`gmtset`, editing a
+**gmt.conf** file that can be aqcuired using :doc:`gmtdefaults`, or setting
+parameters on-the-fly via the **--PARAMETER**\ =\ *VALUE* option to any GMT
+program. However, a few are static and are only read via the **gmt.conf** file;
+these are labeled (static). Several parameters take only **true** or **false**.
+It is recommended that users specify the units for distances and lengths by
+appending **c** (cm), **i** (inch), or **p** (points) when changing parameters
+using any of these methods. By default, when no unit is specified the value will
+be assumed to be cm for parameters not related to fonts or pen thicknesses and
+will be assumed to be points for parameters related to fonts or pen thicknesses.
+The interpretation of unitless dimensional quantities can be changed using the
+parameter :term:`PROJ_LENGTH_UNIT` or specifying US units when building GMT.
 
 Common Specifications
 ---------------------


### PR DESCRIPTION
**Description of proposed changes**

Addresses this issue with the GMT documentation for gmt.conf and the units section of the cookbook:

>     "cm is the default unit for all dimensions except fonts and pen thickness where points are the default unit."
> 
> I'm afraid we never mention that the default units of fonts and pen thickness are points

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes # 4738


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
