### PR TITLE
docs: Copy two C source code to doc/source directory so that literalinclude works

### DIFF
--- a/doc/rst/CMakeLists.txt
+++ b/doc/rst/CMakeLists.txt
@@ -41,6 +41,14 @@ if (SPHINX_FOUND)
 		${CMAKE_CURRENT_BINARY_DIR}/source/_images
 		DEPENDS _docs_copy_rst_tree_source)
 
+	add_custom_target (_docs_rst_src
+		COMMAND ${CMAKE_COMMAND} -E copy
+			${CMAKE_SOURCE_DIR}/src/gmt_common_longoptions.h
+			${CMAKE_SOURCE_DIR}/src/blockmean.c
+			${CMAKE_CURRENT_BINARY_DIR}/source/
+			DEPENDS _docs_copy_rst_tree_source)
+	add_depend_to_target (docs_depends _docs_rst_src)
+
 	# clean target
 	add_custom_target (_rst_clean
 		# cmake<3.15 can't remove multiple directories using cmake -E remove_directory

--- a/doc/rst/CMakeLists.txt
+++ b/doc/rst/CMakeLists.txt
@@ -41,6 +41,7 @@ if (SPHINX_FOUND)
 		${CMAKE_CURRENT_BINARY_DIR}/source/_images
 		DEPENDS _docs_copy_rst_tree_source)
 
+	# Copy two C codes into the build tree, so that they can be included in the documentation
 	add_custom_target (_docs_rst_src
 		COMMAND ${CMAKE_COMMAND} -E copy
 			${CMAKE_SOURCE_DIR}/src/gmt_common_longoptions.h

--- a/doc/rst/source/devdocs/long_options.rst
+++ b/doc/rst/source/devdocs/long_options.rst
@@ -29,7 +29,7 @@ which is pretty self-explanatory.  In the case of GMT, similar long-options alte
 implemented.  For instance, the above :doc:`/blockmean` command can also be written
 
 ::
-    
+
     gmt blockmean --region=0/5/0/6 --increment=1 my_table.txt > new_table.txt
 
 which now becomes much easier to parse (for humans). Unfortunately, GMT syntax is a bit
@@ -106,7 +106,7 @@ when building GMT.
 The translations for the GMT common options are encapsulated in a single include file
 (gmt_common_longoptions.h) that populates a *gmt_common_kw* structure and looks like this:
 
-.. literalinclude:: ../../../../../src/gmt_common_longoptions.h
+.. literalinclude:: ../gmt_common_longoptions.h
     :language: C
     :lines: 10-39
 
@@ -121,7 +121,7 @@ include files as was done for the common options above.  Instead, the translatio
 can be stored directly in the module C file.  For instance, the local *module_kw* structure
 embedded in the blockmean.c module C code looks like this:
 
-.. literalinclude:: ../../../../../src/blockmean.c
+.. literalinclude:: ../blockmean.c
     :language: C
     :lines: 44-52
 


### PR DESCRIPTION
**Description of proposed changes**

Fixes #4740.

Now `src/gmt_common_longoptions.h` and `src/blockmean.c` are copied to
the `BUILDDIR/doc/rst/source/` directory, so we can include the two codes,
no matter what **BUILDDIR** is.


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
