### PR TITLE
Give -i a complimentary +ddivide modifier to simplify scaling with inverse values

### DIFF
--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -1092,10 +1092,10 @@ on columns from the physical record. For instance, to use the 4th,
 **-i**\ 3,6,2 (since 0 is the first column). The chosen data columns
 will be used as given. Optionally, you can specify that input columns
 should be transformed according to a linear or logarithmic conversion.
-Do so by appending [**+l**][**+s**\ *scale*][**+o**\ *offset*] to
+Do so by appending [**+l**][**+d**\ *factor*][**+s**\ *factor*][**+o**\ *offset*] to
 each column (or range of columns). All items are optional: The **+l**
 implies we should first take :math:`\log_{10}` of the data [leave as
-is]. Next, we may scale the result by the given *scale* [1]. Finally, we
+is]. Next, we may multiply or divide the result by the given *factor* [1]. Finally, we
 add in the specified *offset* [0].  If you want the trailing text to remain
 part of your subset logical record then you must also select the special column
 by requesting column **t**, otherwise we ignore trailing text.  If you only

--- a/doc/rst/source/explain_-icols.rst_
+++ b/doc/rst/source/explain_-icols.rst_
@@ -1,2 +1,2 @@
-**-i**\ *cols*\ [**+l**][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]] :ref:`(more ...) <-icols_full>`
+**-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]] :ref:`(more ...) <-icols_full>`
     Select input columns and transformations (0 is first column, **t** is trailing text, append *word* to read one word only).

--- a/doc/rst/source/explain_-icols_full.rst_
+++ b/doc/rst/source/explain_-icols_full.rst_
@@ -1,14 +1,15 @@
 .. _-icols_full:
 
-**-i**\ *cols*\ [**+l**][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
+**-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
     Select specific data columns for primary input, in arbitrary order. Columns
     not listed will be skipped. Give individual columns (or column ranges
     in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if
     not specified) separated by commas [Default reads all columns in order,
     starting with the first column (0)]. Columns may be repeated.  To each
     column, optionally add any of  the following: **+l** takes **log10** of
-    the input values first; **+s**\ *scale*, subsequently multiplies by a
-    given  scale factor [1]; **+o**\ *offset*, finally adds a given offset [0].
+    the input values first; **+d**\ *divide*, subsequently divides by a
+    given factor [1]; alternatively, **+s**\ *scale* instead multiplies by the
+    given factor [1]; **+o**\ *offset*, finally adds a given offset [0].
     To read from a given column until the end of the record, leave off *stop*.
     Normally, any trailing text is read but when **-i** is used you must explicitly add
     the column **t** to retain the text. To only ingest a single word from the

--- a/doc/rst/source/std-opts-classic.rst
+++ b/doc/rst/source/std-opts-classic.rst
@@ -44,7 +44,7 @@ Common Options (Classic Mode)
      - Segment data by detecting gaps :ref:`(...) <-g_full>`
    * - **-h**\ [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\ *remark*][**+t**\ *title*]
      - ASCII [*I*\|\ *O*] tables have header record[s] :ref:`(...) <-h_full>`
-   * - **-i**\ *cols*\ [**+l**][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
+   * - **-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
      - Selection of input columns :ref:`(...) <-icols_full>`
    * - **-je**\|\ **f**\|\ **g**
      - Mode of spherical distance calculation :ref:`(...) <-distcalc_full>`

--- a/doc/rst/source/std-opts.rst
+++ b/doc/rst/source/std-opts.rst
@@ -40,7 +40,7 @@ Common Options
      - Segment data by detecting gaps :ref:`(...) <-g_full>`
    * - **-h**\ [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\ *remark*][**+t**\ *title*]
      - ASCII [*I*\|\ *O*] tables have header record[s] :ref:`(...) <-h_full>`
-   * - **-i**\ *cols*\ [**+l**][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
+   * - **-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
      - Selection of input columns :ref:`(...) <-icols_full>`
    * - **-je**\|\ **f**\|\ **g**
      - Mode of spherical distance calculation :ref:`(...) <-distcalc_full>`

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8713,7 +8713,7 @@ GMT_LOCAL unsigned int gmtinit_parse_e_option (struct GMT_CTRL *GMT, char *arg) 
 	return (GMT_NOERROR);
 }
 
-/*! Routine will decode the -i<col>|<colrange>|t[+l][+s<scale>][+o<offset>],... arguments or just -in */
+/*! Routine will decode the -i<col>|<colrange>|t[+l][+d<divisor>][+s<scale>][+o<offset>],... arguments or just -in */
 int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 
 	char copy[GMT_BUFSIZ] = {""}, p[GMT_BUFSIZ] = {""}, word[GMT_LEN256] = {""}, *c = NULL;
@@ -8746,14 +8746,15 @@ int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 
 	while ((gmt_strtok (copy, ",", &pos, p))) {	/* While it is not empty, process the comma-separated sections */
 		convert = 0, scale = 1.0, offset = 0.0;	/* Reset for next column selection */
-		if (new_style) {	/* New format as of 5.4: -i<col>|<colrange>[+l][+s<scale>][+o<offset>],... */
-			if ((c = gmt_first_modifier (GMT, p, "los"))) {	/* Process modifiers */
+		if (new_style) {	/* New format as of 5.4: -i<col>|<colrange>[+l][+d<divide>][+s<scale>][+o<offset>],... */
+			if ((c = gmt_first_modifier (GMT, p, "dlos"))) {	/* Process modifiers */
 				pos_p = 0;	/* Reset to start of new word */
-				while (gmt_getmodopt (GMT, 'i', c, "los", &pos_p, word, &uerr) && uerr == 0) {
+				while (gmt_getmodopt (GMT, 'i', c, "dlos", &pos_p, word, &uerr) && uerr == 0) {
 					switch (word[0]) {
 						case 'l': convert |= 2; break;
 						case 'o': convert |= 1; offset = atof (&word[1]); break;
 						case 's': convert |= 1; scale  = atof (&word[1]); break;
+						case 'd': convert |= 1; scale  = 1.0 / atof (&word[1]); break;
 						default: break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
 					}
 				}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8739,7 +8739,7 @@ int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 		return GMT_NOERROR;
 	}
 
-	new_style = (strstr (arg, "+s") || strstr (arg, "+o") || strstr (arg, "+l"));
+	new_style = (strstr (arg, "+d") || strstr (arg, "+s") || strstr (arg, "+o") || strstr (arg, "+l"));
 
 	strncpy (GMT->common.i.string, arg, GMT_LEN64-1);	/* Verbatim copy */
 	for (i = 0; i < GMT_MAX_COLUMNS; i++) GMT->current.io.col_skip[i] = true;	/* Initially, no input column is requested */

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -114,7 +114,7 @@
 #define GMT_f_OPT	"-f[i|o]<info>"
 #define GMT_g_OPT	"-g[a]x|y|d|X|Y|D|[<col>]z<gap>[+n|p]"
 #define GMT_h_OPT	"-h[i|o][<nrecs>][+c][+d][+m<segheader>][+r<remark>][+t<title>]"
-#define GMT_i_OPT	"-i<cols>[+l][+s<scale>][+o<offset>][,...][,t[<word>]]"
+#define GMT_i_OPT	"-i<cols>[+l][+d<divide>][+s<scale>][+o<offset>][,...][,t[<word>]]"
 #define GMT_j_OPT	"-je|f|g"
 #define GMT_l_OPT	"-l<label>[<mods>]"
 #define GMT_n_OPT	"-n[b|c|l|n][+a][+b<BC>][+c][+t<threshold>]"


### PR DESCRIPTION
It is just **way** easier to divide by 60 using **+d**60 than to scale by 0.01666666 via **+s**0.0166666666, especially when you also may have to compute what the inverse of the factor is in the script, such as 7 or 52, or 3300.
