### PR TITLE
If -f indicates abstime then dont fuss that -J does not

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3292,9 +3292,9 @@ GMT_LOCAL void gmtio_assign_col_type_if_notset (struct GMT_CTRL *GMT, unsigned i
 		}
 	}
 	else {	/* logical equal physical, so no column shopping */
-		if (!GMT->current.io.col_set[GMT_IN][col])
+		if (GMT->current.io.col_set[GMT_IN][col] == GMT_IS_UNKNOWN)
 			gmt_set_column_type (GMT, GMT_IN, col, type);
-		if (!GMT->current.io.col_set[GMT_OUT][col])
+		if (GMT->current.io.col_set[GMT_OUT][col] == GMT_IS_UNKNOWN)
 			gmt_set_column_type (GMT, GMT_OUT, col, type);
 	}
 }

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3292,9 +3292,9 @@ GMT_LOCAL void gmtio_assign_col_type_if_notset (struct GMT_CTRL *GMT, unsigned i
 		}
 	}
 	else {	/* logical equal physical, so no column shopping */
-		if (GMT->current.io.col_set[GMT_IN][col] == GMT_IS_UNKNOWN)
+		if (!GMT->current.io.col_set[GMT_IN][col])
 			gmt_set_column_type (GMT, GMT_IN, col, type);
-		if (GMT->current.io.col_set[GMT_OUT][col] == GMT_IS_UNKNOWN)
+		if (!GMT->current.io.col_set[GMT_OUT][col])
 			gmt_set_column_type (GMT, GMT_OUT, col, type);
 	}
 }

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2590,8 +2590,10 @@ GMT_LOCAL int gmtmap_init_linear (struct GMT_CTRL *GMT, bool *search) {
 	GMT->current.proj.xyz_pos[GMT_Y] = (GMT->current.proj.scale[GMT_Y] >= 0.0);	/* False if user wants y to increase down */
 	switch ( (GMT->current.proj.xyz_projection[GMT_X]%3)) {	/* Modulo 3 so that GMT_TIME (3) maps to GMT_LINEAR (0) */
 		case GMT_LINEAR:	/* Regular scaling */
-			if (gmt_M_type (GMT, GMT_IN, GMT_X) == GMT_IS_ABSTIME && GMT->current.proj.xyz_projection[GMT_X] != GMT_TIME)
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -JX|x: Your x-column contains absolute time but -JX|x...T was not specified!\n");
+			if (gmt_M_type (GMT, GMT_IN, GMT_X) == GMT_IS_ABSTIME && GMT->current.proj.xyz_projection[GMT_X] != GMT_TIME) {
+				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Option -JX|x: Your x-column contains absolute time but -JX|x...T was not specified!\n");
+				GMT->current.proj.xyz_projection[GMT_X] = GMT_TIME;
+			}
 			GMT->current.proj.fwd_x = ((gmt_M_x_is_lon (GMT, GMT_IN)) ? &gmtproj_translind  : &gmtlib_translin);
 			GMT->current.proj.inv_x = ((gmt_M_x_is_lon (GMT, GMT_IN)) ? &gmtproj_itranslind : &gmtlib_itranslin);
 			if (GMT->current.proj.xyz_pos[GMT_X]) {
@@ -2625,8 +2627,10 @@ GMT_LOCAL int gmtmap_init_linear (struct GMT_CTRL *GMT, bool *search) {
 	}
 	switch (GMT->current.proj.xyz_projection[GMT_Y]%3) {	/* Modulo 3 so that GMT_TIME (3) maps to GMT_LINEAR (0) */
 		case GMT_LINEAR:	/* Regular scaling */
-			if (gmt_M_type (GMT, GMT_IN, GMT_Y) == GMT_IS_ABSTIME && GMT->current.proj.xyz_projection[GMT_Y] != GMT_TIME)
-				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -JX|x:  Your y-column contains absolute time but -JX|x...T was not specified!\n");
+			if (gmt_M_type (GMT, GMT_IN, GMT_Y) == GMT_IS_ABSTIME && GMT->current.proj.xyz_projection[GMT_Y] != GMT_TIME) {
+				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Option -JX|x:  Your y-column contains absolute time but -JX|x...T was not specified!\n");
+				GMT->current.proj.xyz_projection[GMT_Y] = GMT_TIME;
+			}
 			GMT->current.proj.fwd_y = ((gmt_M_y_is_lon (GMT, GMT_IN)) ? &gmtproj_translind  : &gmtlib_translin);
 			GMT->current.proj.inv_y = ((gmt_M_y_is_lon (GMT, GMT_IN)) ? &gmtproj_itranslind : &gmtlib_itranslin);
 			if (GMT->current.proj.xyz_pos[GMT_Y]) {
@@ -6714,6 +6718,7 @@ void gmt_auto_frame_interval (struct GMT_CTRL *GMT, unsigned int axis, unsigned 
 		if (unit == 'O' && d == 12.0) d = 1.0, f /= 12.0, unit = 'Y';
 		if (unit == 'H' && d == 24.0) d = 1.0, f /= 24.0, unit = 'D';
 		sunit[0] = unit;	/* Since we need a string in strcat */
+		A->type = GMT_TIME;
 	}
 
 	/* Set annotation/major tick interval */


### PR DESCRIPTION
We used to get this annoying message from _gmt_map_setup_ if **-f** had indicated absolute time but **-JX** did not have that 'T':

`Option -JX|x: Your x-column contains absolute time but -JX|x...T was not specified!`

It was just a warning, but then it continued, taking no corrective action, and screwing things up.  This PR now does two things:

1. Sets the missing linear projection type to **GMT_TIME** and relegating that message to **GMT_DEBUG**.
2. Fixes a related issue in _gmt_auto_frame_interval_ so that it knows the axis is absolute time so that a 6 month interval is not attempted to be used as 6 seconds and giving 1000000 annotations....

