### PR TITLE
Fix bug in PSL library related to writing HSV colors

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -1063,6 +1063,7 @@ static void psl_rgb_to_hsv (double rgb[], double hsv[]) {
 	hsv[0] = 120.0 * imax + 60.0 * (rgb[(imax + 1) % 3] - rgb[(imax + 2) % 3]) / diff;
 	if (hsv[0] < 0.0) hsv[0] += 360.0;
 	if (hsv[0] > 360.0) hsv[0] -= 360.0;
+	hsv[0] /= 360.0;	/* All h,s,v values in PostScript are 0-1 range */
 }
 
 #if 0 /* Not used */


### PR DESCRIPTION
The **PS_COLOR_MODEL** settings [_rgb_] can be set to _hsv_ and then color specifications written in the _PostScript_ uses the _sethsbcolor_ operator instead of _setrgbcolor_.  Both requres triplets in 0-1 range but for hsv we kept hue in angle 0-360, resulting in the wrong color.  This PR fixes this issue but the discussion will continue (#4753).
