### PR TITLE
Update gmtdefaults documentation

### DIFF
--- a/doc/rst/source/gmtdefaults.rst
+++ b/doc/rst/source/gmtdefaults.rst
@@ -19,19 +19,22 @@ Synopsis
 Description
 -----------
 
-**defaults** lists all the GMT parameter defaults if the option
-**-D** is used. There are three ways to change some of the settings: (1)
-Use the command :doc:`gmtset`, (2) in classic mode you may use any text editor to edit the file
-:doc:`gmt.conf` in your home, ~/.gmt or current directory (if you do not
-have this file, run :doc:`gmtdefaults` **-D** > gmt.conf to get one with the 
-system default settings), or (3) override any parameter by specifying one
-or more **-**\ **-PARAMETER**\ =\ *VALUE* statements on the command line of any
-GMT command (**PARAMETER** and *VALUE* are any combination listed
-below). In classic mode, the first two options are permanent changes until 
-explicitly changed back, while the last option is ephemeral and only applies to 
-the single GMT command that received the override. In modern mode, changes made using
-:doc:`gmtset` stay in effect for the duration of the current session. GMT can provide
-default values in US or SI units. This choice is determined at compile time.
+**defaults** lists all the GMT parameter defaults if the option **-D** is used.
+There are three ways to change some of the settings: (1) use the command
+:doc:`gmtset`, (2) use any text editor to edit the file :doc:`gmt.conf` in your
+home, ~/.gmt or current directory (if you do not have this file, run
+:doc:`gmtdefaults` **-D** > gmt.conf to get one with the system default
+settings), or (3) override any parameter by specifying one or more
+**-**\ **-PARAMETER**\ =\ *VALUE* statements on the command line of any GMT
+command (**PARAMETER** and *VALUE* are any combination in :doc:`gmt.conf`). In
+modern mode, settings can be reset to GMT defaults using :doc:`clear`. Changes
+made using :doc:`gmtset` are permanent until explicitly changed back in classic
+mode and are in effect for the duration of the current session in modern mode.
+Manual changes to the :doc:`gmt.conf` file (option 2) are in effect until
+explicitly changed back, or can be ignored for a modern mode session using the
+**-C** argument of the :doc:`begin` module. Option 3 is ephemeral and only
+applies to the single GMT command that received the override. GMT can provide
+default values in US or SI units based on the choice determined at compile time.
 
 Required Arguments
 ------------------


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes some small inconsistencies in the gmtdefaults documentation, specifically about gmt.conf not impacting modern mode sessions and the location of the parameter-value pairs in the documentation.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
