### PR TITLE
Ensure output format for time is changed if worked on

### DIFF
--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -705,7 +705,7 @@ contains absolute time, then the default output format for any *other* columns c
 absolute time will be reset to relative time.  Likewise, in scalar mode (**-Q**) the
 time column will be operated on and hence it also will be formatted as relative
 time.  Finally, if **-C** is used to include "time" in the columns operated on then
-we likewise will reset that column's formatting. The user can override this behavior with a
+we likewise will reset that column's format to relative time. The user can override this behavior with a
 suitable **-f** or **-fo** setting.  **Note**: We cannot guess what your operations on the
 time column will do, hence this default behavior.  As examples, if you are computing time differences
 then clearly relative time formatting is required, while if you are computing new absolute times

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -701,7 +701,7 @@ Absolute Time Column(s)
 -----------------------
 
 If input data have more than one column and the "time" column (id set via **-N** [0])
-in contains absolute time, then the default output format for any *other* columns containing
+contains absolute time, then the default output format for any *other* columns containing
 absolute time will be reset to relative time.  Likewise, in scalar mode (**-Q**) the
 time column will be operated on and hence it also will be formatted as relative
 time.  Finally, if **-C** is used to include "time" in the columns operated on then

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -706,7 +706,11 @@ absolute time will be reset to relative time.  Likewise, in scalar mode (**-Q**)
 time column will be operated on and hence it also will be formatted as relative
 time.  Finally, if **-C** is used to include "time" in the columns operated on then
 we likewise will reset that column's formatting. The user can override this behavior with a
-suitable **-f** or **-fo** setting.
+suitable **-f** or **-fo** setting.  **Note**: We cannot guess what your operations on the
+time column will do, hence this default behavior.  As examples, if you are computing time differences
+then clearly relative time formatting is required, while if you are computing new absolute times
+by, say, adding an interval to absolute times then you will need to use **-fo** to set
+the output format for such columns to absolute time.
 
 Examples
 --------

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -697,6 +697,17 @@ in the data then only those columns will be updated, hence the unspecified colum
 On the other hand, if you load the file first and then issue **-C**\ *cols* then the unspecified
 columns will have been loaded but are then ignored until you undo the effect of **-C**.
 
+Absolute Time Column(s)
+-----------------------
+
+If input data have more than one column and the "time" column (id set via **-N** [0])
+in contains absolute time, then the default output format for any *other* columns containing
+absolute time will be reset to relative time.  Likewise, in scalar mode (**-Q**) the
+time column will be operated on and hence it also will be formatted as relative
+time.  Finally, if **-C** is used to include "time" in the columns operated on then
+we likewise will reset that column's formatting. The user can override this behavior with a
+suitable **-f** or **-fo** setting.
+
 Examples
 --------
 


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/deviating-time-unit-default-in-gmt-math-q-mode-just-a-note/1315/2) for background.  This PR implements consistency in how columns with input absolute time is treated on output:

1. If more than one column is involved  and **-C** is _not_ set to include the time column then output will be absolute time
2. If **-Q** is used then the time column is modified by calculations and we set output to relative time.
3. If **-C** involves the time column then format is changed to relative time.

Note of these changes take place if the user has used **-f** or **-fo** to set specific format.
