### PR TITLE
Ensure we close the opened netCDF file in gmt_nc_is_cube

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2299,13 +2299,13 @@ GMT_LOCAL int gmtapi_open_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID
 	if (R->open) return (GMT_NOERROR);	/* Already set the first time */
 	fmt = GMT->session.grdformat[G->header->type];
 	if (fmt[0] == 'c') {		/* Open netCDF file, old format */
-		gmt_M_err_trap (nc_open (HH->name, cdf_mode[r_w], &R->fid));
+		gmt_M_err_trap (gmt_nc_open (GMT, HH->name, cdf_mode[r_w], &R->fid));
 		R->edge[0] = G->header->n_columns;
 		R->start[0] = 0;
 		R->start[1] = 0;
 	}
 	else if (fmt[0] == 'n') {	/* Open netCDF file, COARDS-compliant format */
-		gmt_M_err_trap (nc_open (HH->name, cdf_mode[r_w], &R->fid));
+		gmt_M_err_trap (gmt_nc_open (GMT, HH->name, cdf_mode[r_w], &R->fid));
 		R->edge[0] = 1;
 		R->edge[1] = G->header->n_columns;
 		R->start[0] = HH->row_order == k_nc_start_north ? 0 : G->header->n_rows-1;
@@ -7727,7 +7727,7 @@ void gmtlib_close_grd (struct GMT_CTRL *GMT, struct GMT_GRID *G) {
 	struct GMT_GRID_ROWBYROW *R = gmtapi_get_rbr_ptr (GH->extra);	/* Shorthand to row-by-row book-keeping structure */
 	gmt_M_free (GMT, R->v_row);
 	if (GMT->session.grdformat[G->header->type][0] == 'c' || GMT->session.grdformat[G->header->type][0] == 'n')
-		nc_close (R->fid);
+		gmt_nc_close (GMT, R->fid);
 	else
 		gmt_fclose (GMT, R->fp);
 	gmt_M_free (GMT, GH->extra);

--- a/src/gmt_cdf.c
+++ b/src/gmt_cdf.c
@@ -190,9 +190,9 @@ int gmt_cdf_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header)
 	int ncid, err;
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 	if (!strcmp (HH->name,"=")) return (GMT_GRDIO_NC_NO_PIPE);
-	gmt_M_err_trap (nc_open (HH->name, NC_NOWRITE, &ncid));
+	gmt_M_err_trap (gmt_nc_open (GMT, HH->name, NC_NOWRITE, &ncid));
 	gmt_M_err_trap (gmt_cdf_grd_info (GMT, ncid, header, 'r'));
-	gmt_M_err_trap (nc_close (ncid));
+	gmt_M_err_trap (gmt_nc_close (GMT, ncid));
 	return (GMT_NOERROR);
 }
 
@@ -200,10 +200,10 @@ int gmt_cdf_update_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *heade
 	int ncid, old_fill_mode, err;
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 	if (!strcmp (HH->name,"=")) return (GMT_GRDIO_NC_NO_PIPE);
-	gmt_M_err_trap (nc_open (HH->name, NC_WRITE, &ncid));
+	gmt_M_err_trap (gmt_nc_open (GMT, HH->name, NC_WRITE, &ncid));
 	gmt_M_err_trap (nc_set_fill (ncid, NC_NOFILL, &old_fill_mode));
 	gmt_M_err_trap (gmt_cdf_grd_info (GMT, ncid, header, 'u'));
-	gmt_M_err_trap (nc_close (ncid));
+	gmt_M_err_trap (gmt_nc_close (GMT, ncid));
 	return (GMT_NOERROR);
 }
 
@@ -211,10 +211,10 @@ int gmt_cdf_write_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 	int ncid, old_fill_mode, err;
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 	if (!strcmp (HH->name,"=")) return (GMT_GRDIO_NC_NO_PIPE);
-	gmt_M_err_trap (nc_create (HH->name, NC_CLOBBER, &ncid));
+	gmt_M_err_trap (gmt_nc_create (GMT, HH->name, NC_CLOBBER, &ncid));
 	gmt_M_err_trap (nc_set_fill (ncid, NC_NOFILL, &old_fill_mode));
 	gmt_M_err_trap (gmt_cdf_grd_info (GMT, ncid, header, 'w'));
-	gmt_M_err_trap (nc_close (ncid));
+	gmt_M_err_trap (gmt_nc_close (GMT, ncid));
 	return (GMT_NOERROR);
 }
 
@@ -254,7 +254,7 @@ int gmt_cdf_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 		gmt_M_free (GMT, actual_col);
 		return (GMT_GRDIO_NC_NO_PIPE);
 	}
-	if ((err = nc_open (HH->name, NC_NOWRITE, &ncid)) != 0) {
+	if ((err = gmt_nc_open (GMT, HH->name, NC_NOWRITE, &ncid)) != 0) {
 		gmt_M_free (GMT, actual_col);
 		return err;
 	}
@@ -276,7 +276,7 @@ int gmt_cdf_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 		if ((err = gmt_nc_get_vara_grdfloat (ncid, HH->z_id, start, edge, tmp))) {	/* Get one row */
 			gmt_M_free (GMT, actual_col);
 			gmt_M_free (GMT, tmp);
-			nc_close (ncid);
+			gmt_nc_close (GMT, ncid);
 			return (err);
 		}
 		for (i = 0; i < width_in; i++) {	/* Check for and handle NaN proxies */
@@ -299,7 +299,7 @@ int gmt_cdf_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_
 
 	gmt_M_free (GMT, actual_col);
 	gmt_M_free (GMT, tmp);
-	gmt_M_err_trap (nc_close (ncid));
+	gmt_M_err_trap (gmt_nc_close (GMT, ncid));
 
 	return (GMT_NOERROR);
 }
@@ -364,7 +364,7 @@ int gmt_cdf_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 
 	/* Write grid header */
 
-	if ((err = nc_create (HH->name, NC_CLOBBER, &ncid))) {
+	if ((err = gmt_nc_create (GMT, HH->name, NC_CLOBBER, &ncid))) {
 		gmt_M_free (GMT, actual_col);
 		return (err);
 	}
@@ -456,7 +456,7 @@ int gmt_cdf_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 
 	/* Close grid */
 
-	gmt_M_err_trap (nc_close (ncid));
+	gmt_M_err_trap (gmt_nc_close (GMT, ncid));
 
 	return (GMT_NOERROR);
 }

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -389,7 +389,7 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 		}
 	}
 
-	if ((retval = nc_open (path, NC_NOWRITE, &ncid))) {
+	if ((retval = gmt_nc_open (GMT, path, NC_NOWRITE, &ncid))) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot open file %s!\n", path);
 		gmt_free_segment (GMT, &P);
 		gmt_M_free (GMT, order);
@@ -626,7 +626,7 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 		tbl++;
 	}
 
-	nc_close (ncid);
+	gmt_nc_close (GMT, ncid);
 	gmt_M_free (GMT, GMT_DCW_country);
 	gmt_M_free (GMT, GMT_DCW_state);
 	gmt_M_free (GMT, Out);

--- a/src/gmt_gdalwrite.c
+++ b/src/gmt_gdalwrite.c
@@ -583,9 +583,9 @@ int gmt_gdalwrite (struct GMT_CTRL *GMT, char *fname, struct GMT_GDALWRITE_CTRL 
 
 	if (!prhs->H.active && gmt_strlcmp(pszFormat,"netCDF")) { /* Change some attributes written by GDAL (not finished) */
 		int ncid;
-		error = nc_open (fname, NC_WRITE, &ncid);
+		error = gmt_nc_open (GMT, fname, NC_WRITE, &ncid);
 		error += nc_put_att_text (ncid, NC_GLOBAL, "history", strlen(prhs->command), prhs->command);
-		error += nc_close (ncid);
+		error += gmt_nc_close (GMT, ncid);
 		if (error) GMT_Report(GMT->parent,GMT_MSG_ERROR,"Error adding history: %d\n", error);
 	}
 

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1132,7 +1132,7 @@ int gmt_grd_get_format (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEADER
 		/* First check if we have a netCDF grid. This MUST be first, because ?var needs to be stripped off. */
 		if ((val = gmtlib_is_nc_grid (GMT, header)) == GMT_NOERROR)
 			return (GMT_NOERROR);
-		/* Continue only when file was not a pipe or when nc_open didn't like the file or when the grid was COARDS-compliant. */
+		/* Continue only when file was not a pipe or when gmt_nc_open didn't like the file or when the grid was COARDS-compliant. */
 		if (val != GMT_GRDIO_NC_NO_PIPE && val != GMT_GRDIO_OPEN_FAILED && val != GMT_GRDIO_NC_NOT_COARDS)
 			return (val);
 		/* Then check for native binary GMT grid */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4014,7 +4014,7 @@ GMT_LOCAL FILE *gmtio_nc_fopen (struct GMT_CTRL *GMT, const char *filename, cons
 		file, varnm[0], varnm[1], varnm[2], varnm[3], varnm[4], varnm[5], varnm[6], varnm[7], varnm[8], varnm[9], varnm[10],
 		varnm[11], varnm[12], varnm[13], varnm[14], varnm[15], varnm[16], varnm[17], varnm[18], varnm[19]) - 1;
 	if (gmt_getdatapath (GMT, file, path, R_OK) == NULL) return (NULL);	/* No such file */
-	if (nc_open (path, NC_NOWRITE, &GMT->current.io.ncid)) return (NULL);
+	if (gmt_nc_open (GMT, path, NC_NOWRITE, &GMT->current.io.ncid)) return (NULL);
 	pstr = strrchr (filename, ',');
 	qstr = strchr (filename, '?');
 
@@ -4409,7 +4409,7 @@ int gmt_fclose (struct GMT_CTRL *GMT, FILE *stream) {
 	if (stream == GMT->session.std[GMT_ERR]) return (0);
 	if ((size_t)stream == (size_t)-GMT->current.io.ncid) {
 		/* Special treatment for netCDF files */
-		nc_close (GMT->current.io.ncid);
+		gmt_nc_close (GMT, GMT->current.io.ncid);
 		gmt_M_free (GMT, GMT->current.io.grpid);
 		gmt_M_free (GMT, GMT->current.io.varid);
 		gmt_M_free (GMT, GMT->current.io.add_offset);

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1472,7 +1472,7 @@ int gmt_nc_create (struct GMT_CTRL *GMT, char *path, int mode, int *id) {
 }
 
 int gmt_nc_open (struct GMT_CTRL *GMT, char *path, int mode, int *id) {
-	int err = nc_open (path, NC_WRITE, id);	/* Open the file, return error code */
+	int err = nc_open (path, mode, id);	/* Open the file, return error code */
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Calling nc_open on %s, ncid = %d, err = %d\n", path, *id, err);
 	return err;	/* Open the file, return error code */
 }

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -43,6 +43,9 @@ EXTERN_MSC char * gmt_strdup (struct GMT_CTRL *GMT, const char *s);
 
 EXTERN_MSC bool gmt_nc_is_cube (struct GMTAPI_CTRL *API, char *file);
 EXTERN_MSC int gmt_nc_read_cube_info (struct GMT_CTRL *GMT, char *file, double *wrange, uint64_t *nz, double **zarray);
+EXTERN_MSC int gmt_nc_open (struct GMT_CTRL *GMT, char *path, int mode, int *id);
+EXTERN_MSC int gmt_nc_close (struct GMT_CTRL *GMT, int id);
+EXTERN_MSC int gmt_nc_create (struct GMT_CTRL *GMT, char *path, int mode, int *id);
 
 /* gmt_init.c: */
 

--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -575,7 +575,7 @@ int gmt_init_shore (struct GMT_CTRL *GMT, char res, struct GMT_SHORE *c, double 
 		gmt_M_memset (c, 1, struct GMT_SHORE);
 
 	/* Open shoreline file */
-	gmt_M_err_trap (nc_open (path, NC_NOWRITE, &c->cdfid));
+	gmt_M_err_trap (gmt_nc_open (GMT, path, NC_NOWRITE, &c->cdfid));
 
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "NetCDF Library Version: %s\n", nc_inq_libvers());
 
@@ -999,7 +999,7 @@ int gmt_init_br (struct GMT_CTRL *GMT, char which, char res, struct GMT_BR *c, d
 	if (!gmtshore_getpathname (GMT, stem, path, true, true))
 		return (GMT_GRDIO_FILE_NOT_FOUND); /* Failed to find file */
 
-	gmt_M_err_trap (nc_open (path, NC_NOWRITE, &c->cdfid));
+	gmt_M_err_trap (gmt_nc_open (GMT, path, NC_NOWRITE, &c->cdfid));
 
 	/* Get all id tags */
 	gmt_M_err_trap (nc_inq_varid (c->cdfid, "Bin_size_in_minutes", &c->bin_size_id));
@@ -1511,14 +1511,14 @@ void gmt_shore_cleanup (struct GMT_CTRL *GMT, struct GMT_SHORE *c) {
 	gmt_M_free (GMT, c->GSHHS_area_fraction);
 	if (c->min_area > 0.0) gmt_M_free (GMT, c->GSHHS_node);
 	gmt_M_free (GMT, c->GSHHS_parent);
-	nc_close (c->cdfid);
+	gmt_nc_close (GMT, c->cdfid);
 }
 
 void gmt_br_cleanup (struct GMT_CTRL *GMT, struct GMT_BR *c) {
 	gmt_M_free (GMT, c->bins);
 	gmt_M_free (GMT, c->bin_nseg);
 	gmt_M_free (GMT, c->bin_firstseg);
-	nc_close (c->cdfid);
+	gmt_nc_close (GMT, c->cdfid);
 }
 
 int gmt_prep_shore_polygons (struct GMT_CTRL *GMT, struct GMT_GSHHS_POL **p_old, unsigned int np, bool sample, double step, int anti_bin) {

--- a/src/mgd77/mgd77.c
+++ b/src/mgd77/mgd77.c
@@ -1742,7 +1742,7 @@ static int mgd77_write_header_record_cdf (struct GMT_CTRL *GMT, char *file, stru
 	 * written as scalars.  The read routine will replicate these to columns.
 	 * This function simply defines the file and header attributes and is called by
 	 * mgd77_write_file_cdf which also writes the data.  Note that no optional factors
-	 * such as 2ndary correction scale and offset are defined since they do not exist
+	 * such as secondary correction scale and offset are defined since they do not exist
 	 * for MGD77 standard files.  Such terms can be added by mgd77manage.
 	 */
 
@@ -1754,7 +1754,7 @@ static int mgd77_write_header_record_cdf (struct GMT_CTRL *GMT, char *file, stru
 
 	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_WRITE_MODE)) return (-1);	/* Basically creates the full path */
 
-	MGD77_nc_status (GMT, nc_create (F->path, NC_NOCLOBBER, &F->nc_id));	/* Create the file */
+	MGD77_nc_status (GMT, gmt_nc_create (GMT, F->path, NC_NOCLOBBER, &F->nc_id));	/* Create the file */
 
 	/* Put attributes header, author, title and history */
 
@@ -1942,7 +1942,7 @@ static int mgd77_write_file_cdf (struct GMT_CTRL *GMT, char *file, struct MGD77_
 	err = mgd77_write_data_cdf (GMT, file, F, S);
 	if (err) return (err);
 
-	MGD77_nc_status (GMT, nc_close (F->nc_id));
+	MGD77_nc_status (GMT, gmt_nc_close (GMT, F->nc_id));
 
 	return (MGD77_NO_ERROR);
 }
@@ -2246,7 +2246,7 @@ static int mgd77_read_file_cdf (struct GMT_CTRL *GMT, char *file, struct MGD77_C
 	err = mgd77_read_data_cdf (GMT, file, F, S);
 	if (err) return (err);
 
-	MGD77_nc_status (GMT, nc_close (F->nc_id));
+	MGD77_nc_status (GMT, gmt_nc_close (GMT, F->nc_id));
 
 	return (MGD77_NO_ERROR);
 }
@@ -2308,7 +2308,7 @@ static int mgd77_read_header_record_cdf (struct GMT_CTRL *GMT, char *file, struc
 
 	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_READ_MODE)) return (-1);			/* Basically sets the path */
 
-	MGD77_nc_status (GMT, nc_open (F->path, NC_NOWRITE, &F->nc_id));	/* Open the file */
+	MGD77_nc_status (GMT, gmt_nc_open (GMT, F->path, NC_NOWRITE, &F->nc_id));	/* Open the file */
 
 	gmt_M_memset (H, 1, struct MGD77_HEADER);	/* Initialize header */
 
@@ -2866,7 +2866,7 @@ int MGD77_Close_File (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F) {
 			error = fclose (F->fp);
 			break;
 		case MGD77_FORMAT_CDF:	/* netCDF file is accessed by ID*/
-			MGD77_nc_status (GMT, nc_close (F->nc_id));
+			MGD77_nc_status (GMT, gmt_nc_close (GMT, F->nc_id));
 			error = 0;
 			break;
 		default:
@@ -3087,7 +3087,7 @@ GMT_LOCAL int mgd77_read_file_cdf_nohdr (struct GMT_CTRL *GMT, char *file, struc
 	err = mgd77_read_data_cdf (GMT, file, F, S);
 	if (err) return (err);
 
-	MGD77_nc_status (GMT, nc_close (F->nc_id));
+	MGD77_nc_status (GMT, gmt_nc_close (GMT, F->nc_id));
 
 	return (MGD77_NO_ERROR);
 }

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -1222,7 +1222,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 			flags = gmt_M_memory (GMT, NULL, D->H.n_records, unsigned int);
 			n_E77_flags = n_E77_headers = n_E77_scales = n_E77_offsets = n_E77_recalcs = 0;
 
-			MGD77_nc_status (GMT, nc_open (In.path, NC_WRITE, &In.nc_id));	/* Open the file */
+			MGD77_nc_status (GMT, gmt_nc_open (GMT, In.path, NC_WRITE, &In.nc_id));	/* Open the file */
 			MGD77_nc_status (GMT, nc_redef (In.nc_id));				/* Enter define mode */
 			(void)MGD77_Remove_E77 (GMT, &In);				/* Remove any previously revised header parameters */
 			while (gmt_fgets (GMT, line, GMT_BUFSIZ, fp_e) && strncmp (line, "# Errata: Data", 14U)) {	/* Read until we get to data record section */
@@ -1544,7 +1544,7 @@ EXTERN_MSC int GMT_mgd77manage (void *V_API, int mode, void *args) {
 
 		if (MGD77_Open_File (GMT, list[argno], &In, MGD77_UPDATE_MODE)) return (-1);	/* Only creates the full path to the new file */
 
-		MGD77_nc_status (GMT, nc_open (In.path, NC_WRITE, &In.nc_id));	/* Open the file */
+		MGD77_nc_status (GMT, gmt_nc_open (GMT, In.path, NC_WRITE, &In.nc_id));	/* Open the file */
 		MGD77_nc_status (GMT, nc_redef (In.nc_id));				/* Enter define mode */
 
 		dims[0] = In.nc_recid;	dims[1] = LEN;


### PR DESCRIPTION
The (new) _gmt_nc_is_cube_ function prematurely returned without closing the door. Closes #4745.
