### PR TITLE
Copy gmt.conf if movie or batch detects one in current directory

### DIFF
--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -177,6 +177,14 @@ as well as any new files produced by *mainscript* or the optional scripts set vi
 No path specification is needed to access these files.  Other files may
 require full paths unless their directories were already included in the :term:`DIR_DATA` setting.
 
+Custom gmt.conf files
+---------------------
+
+If you have a gmt.conf file in the top directory with your main script prior to running **batch** then it will be
+used and shared across all the scripts created and executed. The preferred ways of changing GMT defaults is via
+:doc:`gmtset` calls in your input scripts.  **Note**: Each script is run in isolation (modern) mode so trying to
+create a gmt.conf file via the *preflight* script to be used by other scripts is futile.
+
 Constructing the Main Script
 ----------------------------
 

--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -181,9 +181,10 @@ Custom gmt.conf files
 ---------------------
 
 If you have a gmt.conf file in the top directory with your main script prior to running **batch** then it will be
-used and shared across all the scripts created and executed. The preferred ways of changing GMT defaults is via
-:doc:`gmtset` calls in your input scripts.  **Note**: Each script is run in isolation (modern) mode so trying to
-create a gmt.conf file via the *preflight* script to be used by other scripts is futile.
+used and shared across all the scripts created and executed *unless* your scripts use **-C** when starting a new
+modern mode session. The preferred ways of changing GMT defaults is via :doc:`gmtset` calls in your input scripts.
+**Note**: Each script is run in isolation (modern) mode so trying to create a gmt.conf file via the *preflight*
+script to be used by other scripts is futile.
 
 Constructing the Main Script
 ----------------------------

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -330,9 +330,10 @@ Custom gmt.conf files
 ---------------------
 
 If you have a gmt.conf file in the top directory with your main script prior to running **movie** then it will be
-used and shared across all the scripts created and executed. The preferred ways of changing GMT defaults is via
-:doc:`gmtset` calls in your input scripts.  **Note**: Each script is run in isolation (modern) mode so trying to
-create a gmt.conf file via the *preflight* script to be used by other scripts is futile.
+used and shared across all the scripts created and executed *unless* your scripts use **-C** when starting a new
+modern mode session. The preferred ways of changing GMT defaults is via :doc:`gmtset` calls in your input scripts.
+**Note**: Each script is run in isolation (modern) mode so trying to create a gmt.conf file via the *preflight*
+script to be used by other scripts is futile.
 
 Plotting Temporal Changes
 -------------------------

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -326,6 +326,14 @@ as well as any new files produced by *mainscript* or the optional scripts set vi
 No path specification is needed to access these files.  Other files may
 require full paths unless their directories were already included in the :term:`DIR_DATA` setting.
 
+Custom gmt.conf files
+---------------------
+
+If you have a gmt.conf file in the top directory with your main script prior to running **movie** then it will be
+used and shared across all the scripts created and executed. The preferred ways of changing GMT defaults is via
+:doc:`gmtset` calls in your input scripts.  **Note**: Each script is run in isolation (modern) mode so trying to
+create a gmt.conf file via the *preflight* script to be used by other scripts is futile.
+
 Plotting Temporal Changes
 -------------------------
 

--- a/src/batch.c
+++ b/src/batch.c
@@ -577,7 +577,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[BATCH_PREFLIGHT].fp)) {	/* Read the preflight script and copy to the temporary preflight script with some exceptions */
 			if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert the DIR_DATA statement */
 				fprintf (fp, "%s", line);
-				if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+				if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 				fprintf (fp, "\tgmt set DIR_DATA \"%s\"\n", datadir);
 			}
 			else if (!strstr (line, "#!/"))	 {	/* Skip any leading shell incantation since already placed by gmt_set_script */
@@ -713,7 +713,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[BATCH_POSTFLIGHT].fp)) {	/* Read the postflight script and copy to the temporary postflight script with some exceptions */
 			if (gmt_is_gmtmodule (line, "begin")) {
 				fprintf (fp, "%s", line);	/* Allow args since the script may make a plot */
-				if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+				if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 				fprintf (fp, "\tgmt set DIR_DATA \"%s\"\n", datadir);
 			}
 			else if (!strstr (line, "#!/"))	{	/* Skip any leading shell incantation since already placed */
@@ -803,7 +803,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 	while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->In.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
 		if (gmt_is_gmtmodule (line, "begin")) {	/* Must insert DIR_DATA setting */
 			fprintf (fp, "%s", line);
-			if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+			if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 			fprintf (fp, "\tgmt set DIR_DATA \"%s\"\n", datadir);
 		}
 		else if (!strstr (line, "#!/")) {		/* Skip any leading shell incantation since already placed */

--- a/src/movie.c
+++ b/src/movie.c
@@ -1517,7 +1517,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_PREFLIGHT].fp)) {	/* Read the background script and copy to preflight script with some exceptions */
 				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert gmt figure after this line (or as first line) in case a background plot will be made */
 					fprintf (fp, "gmt begin\n");	/* To ensure there are no args here since we are using gmt figure instead */
-					if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+					if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 					gmt_set_comment (fp, Ctrl->In.mode, "\tSet fixed background output ps name");
 					fprintf (fp, "\tgmt figure movie_background ps\n");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
@@ -1673,7 +1673,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_POSTFLIGHT].fp)) {	/* Read the foreground script and copy to postflight script with some exceptions */
 				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert gmt figure after this line */
 					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-					if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+					if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 					gmt_set_comment (fp, Ctrl->In.mode, "\tSet fixed foreground output ps name");
 					fprintf (fp, "\tgmt figure movie_foreground ps\n");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
@@ -1823,7 +1823,6 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		if (Ctrl->E.PS) {	/* There is no title script, just a PS, so we make a dummy script that plots nothing */
 			fclose (Ctrl->E.fp);
 			fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-			if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 			gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 			fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c GMT_MAX_CORES 1\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 			fprintf (fp, "\tgmt figure ../%s %s", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
@@ -1835,7 +1834,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->E.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
 				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-					if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+					if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 					gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 					fprintf (fp, "\tgmt figure ../%s %s", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
@@ -2120,7 +2119,6 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		if (is_title) {	/* Process title page script or PS */
 			if (Ctrl->E.PS) {	/* There is no title script, just a PS, so we make a dummy script that plots nothing */
 				fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-				if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 				gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 				fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 				fprintf (fp, "\tgmt figure %s %s", Ctrl->N.prefix, Ctrl->M.format);
@@ -2138,7 +2136,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->E.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
 					if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 						fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-						if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+						if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 						gmt_set_comment (fp, Ctrl->In.mode, "\tSet output name and plot conversion parameters");
 						fprintf (fp, "\tgmt figure %s %s", Ctrl->N.prefix, Ctrl->M.format);
 						fprintf (fp, " %s", extra);
@@ -2161,7 +2159,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->In.fp)) {	/* Read the mainscript and copy to loop script, with some exceptions */
 				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-					if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+					if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 					gmt_set_comment (fp, Ctrl->In.mode, "\tSet output name and plot conversion parameters");
 					fprintf (fp, "\tgmt figure %s %s", Ctrl->N.prefix, Ctrl->M.format);
 					fprintf (fp, " %s", extra);
@@ -2290,7 +2288,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->In.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
 		if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
 			fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
-			if (has_conf) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+			if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
 			gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 			fprintf (fp, "\tgmt figure ../%s %s", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
 			fprintf (fp, " E%s,%s", gmt_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);


### PR DESCRIPTION
**Description of proposed changes**

This PR seeks to let **batch** and **movie** be able to use any gmt.conf files found in the directory when these commands are run.  The reason we need to do something specific is that the GMT commands contained in the scripts are run in different directories than where batch or movie starts.  Thus, we must actually place the gmt.conf file in all the directories where the scripts are run form.  The algorithm implement is this:

1. If gmt.conf is found in the current directory then we keep the full path to this file in a variable
2. As we build the pre/post-flight and parallel scripts from input scripts we check if **gmt begin** is given the **-C** option, and if not then we copy in the gmt.conf it it was found in step 1.

The documentation has been updated and also points out that users cannot use the preflight script to create a gmt.conf since it will be created in a hidden directory that is deleted upon completion.