### PR TITLE
Fix horizontal line-angle in contouring

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1818,7 +1818,7 @@ GMT_LOCAL void gmtsupport_line_angle_ave (struct GMT_CTRL *GMT, double x[], doub
 	else if (sum_x2 < GMT_CONV8_LIMIT)	/* Line is vertical */
 		L->line_angle = (directed && sum_y < 0.0) ? -90.0 : 90.0;
 	else {	/* Least-squares fit of slope */
-		L->line_angle = (gmt_M_is_zero (sum_xy)) ? 90.0 : d_atan2d (sum_xy, sum_x2);
+		L->line_angle = d_atan2d (sum_xy, sum_x2);
 		if (directed && !(gmt_M_is_zero (sum_x) && gmt_M_is_zero (sum_y))) {
 			/* If the line_angle points more or less in the opposite direction as indicated by
 			 * sum_x and sum_y we add 180 to it */

--- a/test/greenspline/gspline_3.ps
+++ b/test/greenspline/gspline_3.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_adda460_2020.08.17 [64-bit] Document from grdview
+%%Title: GMT v6.2.0_9273814-dirty_2021.02.09 [64-bit] Document from grdview
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Aug 17 18:35:29 2020
+%%CreationDate: Tue Feb  9 17:13:06 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -112,9 +112,11 @@
   PSL_eps_state restore
 }!
 /PSL_transp {
-  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
-  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
-  {pop pop} ifelse} ifelse
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
 }!
 /Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
@@ -253,9 +255,16 @@ PSL_pathtextdict begin
     V cpx cpy itransform T
       dy dx atan R
       0 justy M
-      char show
-      0 justy neg G
-      currentpoint transform
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
       /cpy exch def /cpx exch def
     U /setdist setdist charwidth add def
   } def
@@ -279,6 +288,9 @@ end
   /PSL_strokeline false def
   /PSL_fillbox psl_bits 128 and 128 eq def
   /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
   /PSL_n_paths1 PSL_n_paths 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
   PSL_clippath {clipsave N clippath} if
@@ -326,8 +338,10 @@ end
     node_type 1 eq
     {n 0 eq
       {PSL_CT_drawline}
-      {	PSL_CT_reversepath
-	PSL_CT_textline} ifelse
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
       /j 0 def
       PSL_xp j PSL_xx i get put
       PSL_yp j PSL_yy i get put
@@ -554,6 +568,9 @@ end
   /PSL_rounded psl_bits 32 and 32 eq def
   /PSL_fillbox psl_bits 128 and 128 eq def
   /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
   /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
   0 1 PSL_n_labels_minus_1
@@ -568,7 +585,15 @@ end
       PSL_drawbox {V PSL_setboxpen S U} if
       N
     } if
-    PSL_placetext {PSL_ST_place_label} if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
   } for
 } def
 /PSL_straight_path_clip
@@ -638,6 +663,20 @@ end
     psl_label dup sd neg 0 exch G show
     U
 } def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
 /PSL_nclip 0 def
 /PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
@@ -678,6 +717,7 @@ O0
 3.32550952342 setmiterlimit
 /PSL_GPP matrix currentmatrix def [0.906307787037 -0.21130913087 0.422618261741 0.453153893518 -0 1267.85478522] concat
 25 W
+0.000 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 3000 M 0 -3000 D S
@@ -808,8 +848,8 @@ S
 4 W
 -109 169 50 199 109 -170 3 2769 3493 SP
 17 W
-2820 3691 M
--1 0 D
+2819 3691 M
+0 0 D
 S
 4 W
 -109 170 51 198 108 -169 3 2878 3323 SP
@@ -852,14 +892,14 @@ S
 -108 170 50 198 109 -169 3 3639 2137 SP
 -109 169 51 73 108 -44 3 3748 1968 SP
 17 W
-3749 1968 M
-158 28 D
+3748 1968 M
+159 29 D
 S
 4 W
 -109 43 51 55 109 -25 3 3856 1924 SP
 17 W
-3907 1996 M
-1 1 D
+3907 1997 M
+0 0 D
 S
 4 W
 -109 26 51 54 109 -25 3 3965 1899 SP
@@ -898,7 +938,7 @@ S
 -109 26 51 126 109 -97 3 2174 4069 SP
 17 W
 2334 4098 M
--159 -29 D
+-160 -29 D
 S
 4 W
 -108 97 50 199 109 -170 3 2283 3972 SP
@@ -960,14 +1000,14 @@ S
 -109 170 51 198 109 -169 3 3479 2108 SP
 -109 169 51 73 109 -44 3 3588 1939 SP
 17 W
-3589 1939 M
-158 28 D
+3588 1939 M
+160 29 D
 S
 4 W
 -108 44 50 54 109 -25 3 3697 1895 SP
 17 W
-3747 1967 M
-2 1 D
+3748 1968 M
+0 0 D
 S
 4 W
 -109 25 51 54 108 -25 3 3806 1870 SP
@@ -1011,21 +1051,21 @@ S
 4 W
 -109 97 51 199 108 -170 3 2124 3943 SP
 17 W
-2175 4069 M
--1 0 D
+2174 4069 M
+0 0 D
 S
 4 W
 -109 170 51 198 109 -169 3 2232 3773 SP
 -109 169 51 198 109 -169 3 2341 3604 SP
 17 W
-2500 3633 M
--159 -29 D
+2501 3633 M
+-160 -29 D
 S
 4 W
 -108 169 50 199 109 -170 3 2450 3435 SP
 17 W
 2501 3633 M
--1 0 D
+0 0 D
 S
 4 W
 -109 170 51 198 108 -169 3 2559 3265 SP
@@ -1068,14 +1108,14 @@ S
 -108 170 50 198 109 -169 3 3320 2079 SP
 -109 169 51 73 108 -44 3 3429 1910 SP
 17 W
-3430 1910 M
-158 28 D
+3429 1910 M
+159 29 D
 S
 4 W
 -109 44 51 54 109 -25 3 3537 1866 SP
 17 W
-3588 1938 M
-1 1 D
+3588 1939 M
+0 0 D
 S
 4 W
 -109 25 51 54 109 -25 3 3646 1841 SP
@@ -1114,7 +1154,7 @@ S
 -109 25 51 126 109 -97 3 1855 4011 SP
 17 W
 2015 4040 M
--159 -29 D
+-160 -29 D
 S
 4 W
 -109 97 51 199 109 -170 3 1964 3914 SP
@@ -1152,7 +1192,7 @@ S
 -109 169 51 199 109 -170 3 2725 2728 SP
 17 W
 2885 2757 M
--159 -29 D
+-160 -29 D
 S
 4 W
 -109 170 51 198 109 -169 3 2834 2558 SP
@@ -1176,14 +1216,14 @@ S
 -109 170 51 198 109 -169 3 3160 2050 SP
 -109 169 51 73 109 -44 3 3269 1881 SP
 17 W
-3270 1881 M
-158 28 D
+3269 1881 M
+160 29 D
 S
 4 W
 -108 44 50 54 109 -25 3 3378 1837 SP
 17 W
-3428 1909 M
-2 1 D
+3429 1910 M
+0 0 D
 S
 4 W
 -109 25 51 54 108 -25 3 3487 1812 SP
@@ -1227,8 +1267,8 @@ S
 4 W
 -109 97 51 199 108 -170 3 1805 3885 SP
 17 W
-1856 4011 M
--1 0 D
+1855 4011 M
+0 0 D
 S
 4 W
 -109 170 51 198 109 -169 3 1913 3715 SP
@@ -1265,8 +1305,8 @@ S
 4 W
 -109 170 51 198 108 -169 3 2675 2529 SP
 17 W
-2726 2728 M
--1 0 D
+2725 2728 M
+0 0 D
 S
 4 W
 -109 169 51 198 109 -169 3 2783 2360 SP
@@ -1284,14 +1324,14 @@ S
 -108 170 50 198 109 -169 3 3001 2021 SP
 -109 169 51 73 108 -44 3 3110 1852 SP
 17 W
-3111 1852 M
-158 28 D
+3110 1852 M
+159 29 D
 S
 4 W
 -109 44 51 54 109 -25 3 3218 1808 SP
 17 W
-3269 1880 M
-1 1 D
+3269 1881 M
+0 0 D
 S
 4 W
 -109 25 51 54 109 -25 3 3327 1783 SP
@@ -1330,7 +1370,7 @@ S
 -109 25 51 126 109 -97 3 1536 3953 SP
 17 W
 1696 3982 M
--159 -29 D
+-160 -29 D
 S
 4 W
 -109 97 51 199 109 -170 3 1645 3856 SP
@@ -1368,7 +1408,7 @@ S
 -109 169 51 199 109 -170 3 2406 2670 SP
 17 W
 2566 2699 M
--159 -29 D
+-160 -29 D
 S
 4 W
 -109 170 51 198 109 -169 3 2515 2500 SP
@@ -1392,14 +1432,14 @@ S
 -109 170 51 198 109 -169 3 2841 1992 SP
 -109 169 51 73 109 -44 3 2950 1823 SP
 17 W
-2951 1823 M
-158 28 D
+2950 1823 M
+160 29 D
 S
 4 W
 -108 44 50 54 109 -25 3 3059 1779 SP
 17 W
-3109 1851 M
-2 1 D
+3110 1852 M
+0 0 D
 S
 4 W
 -109 25 51 54 108 -25 3 3168 1754 SP
@@ -1463,8 +1503,8 @@ S
 4 W
 -109 97 51 199 108 -170 3 1486 3827 SP
 17 W
-1537 3953 M
--1 0 D
+1536 3953 M
+0 0 D
 S
 4 W
 -109 170 51 198 109 -169 3 1594 3657 SP
@@ -1501,8 +1541,8 @@ S
 4 W
 -109 170 51 198 108 -169 3 2356 2471 SP
 17 W
-2407 2670 M
--1 0 D
+2406 2670 M
+0 0 D
 S
 4 W
 -109 169 51 198 109 -169 3 2464 2302 SP
@@ -1520,14 +1560,14 @@ S
 -108 170 50 198 109 -169 3 2682 1963 SP
 -109 169 50 73 109 -44 3 2791 1794 SP
 17 W
-2792 1793 M
-158 29 D
+2791 1794 M
+159 29 D
 S
 4 W
 -109 44 51 54 108 -25 3 2900 1750 SP
 17 W
-2950 1822 M
-1 1 D
+2950 1823 M
+0 0 D
 S
 4 W
 -109 25 51 54 109 -25 3 3008 1725 SP
@@ -1596,7 +1636,7 @@ S
 -109 25 51 126 109 -97 3 1217 3895 SP
 17 W
 1377 3924 M
--159 -29 D
+-160 -29 D
 S
 4 W
 -109 97 51 199 109 -170 3 1326 3798 SP
@@ -1634,7 +1674,7 @@ S
 -109 169 51 199 109 -170 3 2087 2612 SP
 17 W
 2247 2641 M
--159 -29 D
+-160 -29 D
 S
 4 W
 -109 170 51 198 109 -169 3 2196 2442 SP
@@ -1658,14 +1698,14 @@ S
 -109 170 51 198 108 -169 3 2523 1934 SP
 -109 169 51 73 109 -44 3 2631 1765 SP
 17 W
-2632 1764 M
-158 29 D
+2631 1765 M
+160 29 D
 S
 4 W
 -109 44 51 54 109 -25 3 2740 1721 SP
 17 W
-2790 1793 M
-2 0 D
+2791 1794 M
+0 0 D
 S
 4 W
 -108 25 50 54 109 -25 3 2849 1696 SP
@@ -1749,8 +1789,8 @@ S
 4 W
 -109 97 51 199 108 -170 3 1167 3769 SP
 17 W
-1218 3895 M
--1 0 D
+1217 3895 M
+0 0 D
 S
 4 W
 -109 170 51 198 109 -169 3 1275 3599 SP
@@ -1787,8 +1827,8 @@ S
 4 W
 -109 170 50 198 109 -169 3 2037 2413 SP
 17 W
-2088 2612 M
--1 0 D
+2087 2612 M
+0 0 D
 S
 4 W
 -109 169 51 198 108 -169 3 2146 2244 SP
@@ -1806,14 +1846,14 @@ S
 -109 170 51 198 109 -169 3 2363 1905 SP
 -108 169 50 73 109 -44 3 2472 1736 SP
 17 W
-2473 1735 M
-158 29 D
+2472 1736 M
+159 29 D
 S
 4 W
 -109 44 51 54 108 -25 3 2581 1692 SP
 17 W
-2631 1764 M
-1 0 D
+2631 1765 M
+0 0 D
 S
 4 W
 -109 25 51 54 109 -25 3 2689 1667 SP
@@ -1918,7 +1958,7 @@ S
 -109 25 51 126 109 -97 3 898 3837 SP
 17 W
 1058 3866 M
--159 -29 D
+-160 -29 D
 S
 4 W
 -109 97 51 199 109 -170 3 1007 3740 SP
@@ -1980,14 +2020,14 @@ S
 -109 170 51 198 108 -169 3 2204 1876 SP
 -109 169 51 73 109 -44 3 2312 1707 SP
 17 W
-2313 1706 M
-158 29 D
+2312 1707 M
+160 29 D
 S
 4 W
 -109 44 51 54 109 -25 3 2421 1663 SP
 17 W
-2471 1735 M
-2 0 D
+2472 1736 M
+0 0 D
 S
 4 W
 -108 25 50 54 109 -25 3 2530 1638 SP
@@ -2087,8 +2127,8 @@ S
 4 W
 -109 97 50 199 109 -170 3 848 3711 SP
 17 W
-899 3837 M
--1 0 D
+898 3837 M
+0 0 D
 S
 4 W
 -109 170 51 198 108 -169 3 957 3541 SP
@@ -2119,14 +2159,14 @@ S
 -109 170 51 198 109 -169 3 1500 2694 SP
 -109 169 51 199 109 -170 3 1609 2525 SP
 17 W
-1768 2554 M
--159 -29 D
+1769 2554 M
+-160 -29 D
 S
 4 W
 -108 170 50 198 109 -169 3 1718 2355 SP
 17 W
 1769 2554 M
--1 0 D
+0 0 D
 S
 4 W
 -109 169 51 199 108 -170 3 1827 2186 SP
@@ -2144,14 +2184,14 @@ S
 -109 169 51 198 109 -169 3 2044 1847 SP
 -108 169 50 73 109 -44 3 2153 1678 SP
 17 W
-2154 1677 M
-158 29 D
+2153 1678 M
+159 29 D
 S
 4 W
 -109 44 51 54 108 -25 3 2262 1634 SP
 17 W
-2312 1706 M
-1 0 D
+2312 1707 M
+0 0 D
 S
 4 W
 -109 25 51 54 109 -25 3 2370 1609 SP
@@ -2335,14 +2375,14 @@ S
 -109 169 51 198 108 -169 3 1885 1818 SP
 -109 169 51 73 109 -44 3 1993 1649 SP
 17 W
-1994 1648 M
-158 29 D
+1993 1649 M
+160 29 D
 S
 4 W
 -109 44 51 54 109 -25 3 2102 1605 SP
 17 W
-2152 1677 M
-2 0 D
+2153 1678 M
+0 0 D
 S
 4 W
 -108 25 50 54 109 -25 3 2211 1580 SP
@@ -2493,14 +2533,14 @@ S
 -109 169 51 198 109 -169 3 1725 1789 SP
 -108 169 50 73 109 -44 3 1834 1620 SP
 17 W
-1835 1619 M
-158 29 D
+1834 1620 M
+159 29 D
 S
 4 W
 -109 44 51 54 108 -25 3 1943 1576 SP
 17 W
-1993 1648 M
-1 0 D
+1993 1649 M
+0 0 D
 S
 4 W
 -109 25 51 54 109 -25 3 2051 1551 SP
@@ -2651,14 +2691,14 @@ S
 -109 169 51 198 108 -169 3 1566 1760 SP
 -109 169 51 73 109 -44 3 1674 1591 SP
 17 W
-1676 1590 M
-157 29 D
+1674 1591 M
+160 29 D
 S
 4 W
 -109 44 51 54 109 -25 3 1783 1547 SP
 17 W
-1833 1619 M
-2 0 D
+1834 1620 M
+0 0 D
 S
 4 W
 -108 25 50 54 109 -25 3 1892 1522 SP
@@ -2832,14 +2872,14 @@ S
 -109 169 51 198 109 -169 3 1406 1731 SP
 -108 169 50 73 109 -44 3 1515 1562 SP
 17 W
-1516 1561 M
-158 29 D
+1515 1562 M
+159 29 D
 S
 4 W
 -109 44 51 54 108 -25 3 1624 1518 SP
 17 W
-1674 1590 M
-2 0 D
+1674 1591 M
+0 0 D
 S
 4 W
 -109 25 51 55 109 -26 3 1732 1493 SP
@@ -2976,14 +3016,14 @@ S
 -109 169 50 198 109 -169 3 1247 1702 SP
 -109 169 51 73 108 -44 3 1356 1533 SP
 17 W
-1357 1532 M
-157 29 D
+1356 1533 M
+159 29 D
 S
 4 W
 -109 44 51 54 109 -25 3 1464 1489 SP
 17 W
-1514 1561 M
-2 0 D
+1515 1562 M
+0 0 D
 S
 4 W
 -108 25 50 55 109 -26 3 1573 1464 SP
@@ -3125,14 +3165,14 @@ S
 -109 169 51 198 109 -169 3 1087 1673 SP
 -109 169 51 73 109 -44 3 1196 1504 SP
 17 W
-1197 1503 M
-158 29 D
+1196 1504 M
+160 29 D
 S
 4 W
 -108 44 50 54 109 -25 3 1305 1460 SP
 17 W
-1355 1532 M
-2 0 D
+1356 1533 M
+0 0 D
 S
 4 W
 -109 25 51 55 108 -26 3 1414 1435 SP
@@ -3218,14 +3258,14 @@ S
 -108 169 50 198 109 -169 3 384 2491 SP
 -109 169 50 199 109 -170 3 493 2322 SP
 17 W
-652 2350 M
--159 -28 D
+652 2351 M
+-159 -29 D
 S
 4 W
 -109 170 51 198 108 -169 3 602 2152 SP
 17 W
 652 2351 M
-0 -1 D
+0 0 D
 S
 4 W
 -109 169 51 199 109 -170 3 710 1983 SP
@@ -3243,14 +3283,14 @@ S
 -108 169 50 198 109 -169 3 928 1644 SP
 -109 169 51 73 108 -44 3 1037 1475 SP
 17 W
-1038 1474 M
-158 29 D
+1037 1474 M
+159 30 D
 S
 4 W
 -109 44 51 54 109 -25 3 1145 1431 SP
 17 W
-1196 1503 M
-1 0 D
+1196 1504 M
+0 0 D
 S
 4 W
 -109 25 51 55 109 -26 3 1254 1406 SP
@@ -3326,14 +3366,14 @@ S
 -109 25 51 55 109 -25 3 5604 391 SP
 -109 169 51 199 109 -170 3 333 2293 SP
 17 W
-493 2321 M
+493 2322 M
 -160 -29 D
 S
 4 W
 -109 170 51 198 109 -169 3 442 2123 SP
 17 W
 493 2322 M
-0 -1 D
+0 0 D
 S
 4 W
 -108 169 50 199 109 -170 3 551 1954 SP
@@ -3351,14 +3391,14 @@ S
 -109 169 51 199 109 -170 3 768 1615 SP
 -109 169 51 73 109 -43 3 877 1445 SP
 17 W
-878 1445 M
-158 29 D
+877 1445 M
+160 29 D
 S
 4 W
 -108 44 50 54 109 -25 3 986 1402 SP
 17 W
-1036 1474 M
-2 0 D
+1037 1474 M
+0 0 D
 S
 4 W
 -109 25 51 55 108 -26 3 1095 1377 SP
@@ -3425,7 +3465,7 @@ S
 -109 25 51 54 108 -25 3 5554 337 SP
 -109 170 51 198 108 -169 3 283 2094 SP
 17 W
-333 2292 M
+333 2293 M
 0 0 D
 S
 4 W
@@ -3444,14 +3484,14 @@ S
 -108 169 50 199 109 -170 3 609 1586 SP
 -109 170 51 72 108 -43 3 718 1416 SP
 17 W
-719 1416 M
-158 29 D
+718 1416 M
+159 29 D
 S
 4 W
 -109 43 51 54 109 -25 3 826 1373 SP
 17 W
 877 1445 M
-1 0 D
+0 0 D
 S
 4 W
 -109 25 51 55 109 -26 3 935 1348 SP
@@ -3512,14 +3552,14 @@ S
 -109 169 51 199 109 -170 3 449 1557 SP
 -109 170 51 72 109 -43 3 558 1387 SP
 17 W
-559 1387 M
-158 29 D
+558 1387 M
+160 29 D
 S
 4 W
 -108 43 50 54 109 -25 3 667 1344 SP
 17 W
-717 1416 M
-2 0 D
+718 1416 M
+0 0 D
 S
 4 W
 -109 25 51 55 108 -26 3 776 1319 SP
@@ -3575,14 +3615,14 @@ S
 -108 169 50 199 109 -170 3 290 1528 SP
 -109 170 51 72 108 -43 3 399 1358 SP
 17 W
-400 1358 M
-158 29 D
+399 1358 M
+159 29 D
 S
 4 W
 -109 43 51 54 109 -25 3 507 1315 SP
 17 W
 558 1387 M
-1 0 D
+0 0 D
 S
 4 W
 -109 25 51 55 109 -26 3 616 1290 SP
@@ -3633,14 +3673,14 @@ S
 -109 169 51 199 109 -170 3 130 1499 SP
 -109 170 51 72 109 -43 3 239 1329 SP
 17 W
-240 1329 M
-158 29 D
+239 1329 M
+160 29 D
 S
 4 W
 -108 43 50 54 109 -25 3 348 1286 SP
 17 W
-398 1358 M
-2 0 D
+399 1358 M
+0 0 D
 S
 4 W
 -109 25 51 55 108 -26 3 457 1261 SP
@@ -3691,14 +3731,14 @@ S
 -109 25 50 55 109 -26 3 5351 120 SP
 -109 170 51 72 108 -43 3 80 1300 SP
 17 W
-81 1300 M
-158 29 D
+80 1300 M
+159 29 D
 S
 4 W
 -109 43 51 54 109 -25 3 188 1257 SP
 17 W
 239 1329 M
-1 0 D
+0 0 D
 S
 4 W
 -109 25 51 55 109 -26 3 297 1232 SP
@@ -3748,6 +3788,9 @@ S
 -109 25 51 54 108 -25 3 5083 116 SP
 -109 25 51 55 109 -26 3 5191 91 SP
 -109 26 51 54 109 -25 3 5300 65 SP
+/PSL_GPP matrix currentmatrix def [0.906307787037 -0.21130913087 0.422618261741 0.453153893518 -0 1267.85478522] concat
+0.000 A
+PSL_GPP setmatrix
 /PSL_GPP matrix currentmatrix def [0.906307787037 -0.21130913087 0 0.866025403784 0 1257.46248061] concat
 0 12 T
 25 W
@@ -3787,6 +3830,8 @@ def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -12 T
 PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.906307787037 -0.21130913087 0.422618261741 0.453153893518 -0 1267.85478522] concat
+PSL_GPP setmatrix
 %%EndObject
 0 A
 FQ
@@ -3800,6 +3845,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+0 A
 clipsave
 0 0 M
 6720 0 D
@@ -3841,7 +3887,7 @@ PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencod
 ] def
 /PSL_gap_x 22 def
 /PSL_gap_y 22 def
-/PSL_label_angle [ 45.00 90.00 45.00 356.11 45.00 357.63 45.00 355.37 45.00 351.86 
+/PSL_label_angle [ 45.00 0.00 45.00 356.11 45.00 357.63 45.00 355.37 45.00 351.86 
 	45.00 ] def
 /PSL_label_str [
 	(0)
@@ -4269,6 +4315,7 @@ U
 U
 PSL_cliprestore
 25 W
+0 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 3360 M 0 -3360 D S
@@ -4384,8 +4431,8 @@ clipsave
 -6720 0 D
 P
 PSL_clip N
-4 W
 V
+4 W
 {0 A} FS
 30 142 3300 Sc
 30 2879 3319 Sc
@@ -4556,6 +4603,7 @@ O0
 3.32550952342 setmiterlimit
 /PSL_GPP matrix currentmatrix def [0.906307787037 -0.21130913087 0.422618261741 0.453153893518 -0 1267.85478522] concat
 25 W
+0.000 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 3000 M 0 -3000 D S
@@ -8083,6 +8131,9 @@ S
 -109 23 51 68 108 -24 3 5112 142 SP
 -109 40 51 70 109 -42 3 5220 118 SP
 -109 63 51 74 109 -67 3 5329 76 SP
+/PSL_GPP matrix currentmatrix def [0.906307787037 -0.21130913087 0.422618261741 0.453153893518 -0 1267.85478522] concat
+0.000 A
+PSL_GPP setmatrix
 /PSL_GPP matrix currentmatrix def [0.906307787037 -0.21130913087 0 0.866025403784 0 1208.83557957] concat
 0 68 T
 25 W
@@ -8122,6 +8173,8 @@ def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -68 T
 PSL_GPP setmatrix
+/PSL_GPP matrix currentmatrix def [0.906307787037 -0.21130913087 0.422618261741 0.453153893518 -0 1267.85478522] concat
+PSL_GPP setmatrix
 %%EndObject
 0 A
 FQ
@@ -8135,6 +8188,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+0 A
 clipsave
 0 0 M
 6720 0 D
@@ -8274,6 +8328,7 @@ lu@7l$3_`t+q.46EU'OR.4UHKYU1>ojR"V7[jnFIEGa=/J6S:*fSG5:rpH-R%]8on]Sam>9VaY%`q1"/
 U
 PSL_cliprestore
 25 W
+0 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 3360 M 0 -3360 D S
@@ -8383,6 +8438,7 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+0 A
 clipsave
 0 0 M
 6720 0 D
@@ -8912,6 +8968,7 @@ U
 U
 PSL_cliprestore
 25 W
+0 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 3360 M 0 -3360 D S
@@ -9027,8 +9084,8 @@ clipsave
 -6720 0 D
 P
 PSL_clip N
-4 W
 V
+4 W
 {0 A} FS
 30 142 3300 Sc
 30 2879 3319 Sc
@@ -9175,7 +9232,7 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/2/0/1 -Jx2.8i -O -K -N -F+jBR+f24p -Dj0.1i/0.3i
+%@GMT: gmt pstext -R0/2/0/1 -Jx2.8i -O -N -F+jBR+f24p -Dj0.1i/0.3i
 %@PROJ: xy 0.00000000 2.00000000 0.00000000 1.00000000 0.000 2.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
@@ -9184,19 +9241,6 @@ O0
 -120 3720 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 400 F0
 (b\)) br Z
-%%EndObject
-0 A
-FQ
-O0
-0 0 TM
-
-% PostScript produced by:
-%@GMT: gmt psxy -R0/2/0/1 -Jx2.8i -O -T
-%@PROJ: xy 0.00000000 2.00000000 0.00000000 1.00000000 0.000 2.000 0.000 1.000 +xy
-%%BeginObject PSL_Layer_10
-0 setlinecap
-0 setlinejoin
-3.32550952342 setmiterlimit
 %%EndObject
 
 grestore


### PR DESCRIPTION
The computed line-angle for an exact symmetric case (e.g., center-top of a parabola) where the answer should be horizontal (0 degrees) we had a dumb special check that said 90.  However, _atan2_ is perfectly capable of doing this for us when the y-argument is exactly zero.  This fixes an unnoticed error in _gspline_3.ps_ where one annotation was 90 degree rotated.
