### PR TITLE
CI: Add earth_relief_01d_g to CI cache

### DIFF
--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Download remote data
         run: |
           # list of datasets used in tests
-          data="@earth_relief_01d \
+          data="@earth_relief_01d earth_relief_01d_g \
                 @earth_relief_30m \
                 @earth_relief_20m \
                 @earth_relief_15m \


### PR DESCRIPTION
**Description of proposed changes**

`earth_relief_01d_g.grd` is needed in `test/api/apimat2grd.sh`.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
