### PR TITLE
Reset record status when reading plain text record

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3470,6 +3470,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 	 * check for repeated input column usage.
 	 */
 
+	GMT->current.io.status = 0;	/* Reset status before reading next record */
 	while (!done) {	/* Done becomes true when we successfully have read a data record */
 
 		/* First read until we get a non-blank, non-comment record, or reach EOF */


### PR DESCRIPTION
See #4792. When a data file has header records (starting with #) and then plain text records (i.e., no numerical columns) then we bypassed the part where the record status is reset.  This lead to the very first non-header record being mistaken as another header.