### PR TITLE
Enable GMT_Put_Strings to also apply to Palettes

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -840,7 +840,7 @@ The C/C++ API is deliberately kept small to make it easy to use.
     +--------------------------+-------------------------------------------------------+
     | GMT_Put_Row_             | Export a grid row                                     |
     +--------------------------+-------------------------------------------------------+
-    | GMT_Put_Strings_         | Put user strings into vector or matrix container      |
+    | GMT_Put_Strings_         | Put user strings into various containers              |
     +--------------------------+-------------------------------------------------------+
     | GMT_Put_Vector_          | Put user vector into container                        |
     +--------------------------+-------------------------------------------------------+
@@ -1398,8 +1398,8 @@ of in *\ *major*, *\ *minor*, *\ *patch* args can be NULL. If they are not, one 
 version component. The *API* pointer is actually not used in this function, so passing NULL is the best
 option.
 
-Finally, for either vectors or matrices you may optionally add a pointer to an
-array of text strings, one per row.  This is done via
+Finally, for either vectors, matrices or palettes you may optionally add a pointer to an
+array of text strings, one per row (or CPT slice).  This is done via
 
 .. _GMT_Put_Strings:
 
@@ -1407,11 +1407,12 @@ array of text strings, one per row.  This is done via
 
     int GMT_Put_Strings (void *API, unsigned int family, void *X, char **array);
 
-where ``family`` is either GMT_IS_VECTOR or GMT_IS_MATRIX, ``X`` is either a
-:ref:`GMT_VECTOR <struct-vector>` or :ref:`GMT_MATRIX <struct-matrix>`, and
+where ``family`` is either GMT_IS_VECTOR, GMT_IS_MATRIX, or GMT_IS_PALETTE, ``X`` is either a
+:ref:`GMT_VECTOR <struct-vector>`, :ref:`GMT_MATRIX <struct-matrix>` or :ref:`GMT_MATRIX <struct-palette>`, and
 ``array`` is the a pointer to your string array.  You may add ``GMT_IS_DUPLICATE`` to
 ``family`` to indicate you want the array of strings to be duplicated; the default
-is to just set a pointer to ``array``.
+is to just set a pointer to ``array``.  For GMT_IS_PALETTE you must also add
+GMT_IS_PALETTE_LABEL or GMT_IS_PALETTE_KEY to indicate which strings are being set.
 
 To access the string array from an output vector or matrix container you will use
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -14630,16 +14630,20 @@ int GMT_Put_Strings (void *V_API, unsigned int family, void *object, char **arra
 	}
 	else if (family & GMT_IS_REFERENCE)	/* This is the default action, just remove the mode */
 		family -= GMT_IS_REFERENCE;
-	else if (family & GMT_IS_KEY) {	/* This is specific to CPTs */
-		family -= GMT_IS_KEY;
-		code = GMT_IS_KEY;
+	if (family & GMT_IS_PALETTE) {	/* This is specific to CPTs */
+		if (family & GMT_IS_PALETTE_KEY) {
+			family -= GMT_IS_PALETTE_KEY;
+			code = GMT_IS_PALETTE_KEY;
+		}
+		else if (family & GMT_IS_PALETTE_LABEL) {
+			family -= GMT_IS_PALETTE_LABEL;
+			code = GMT_IS_PALETTE_LABEL;
+		}
+		else
+			return_error (V_API, GMT_VALUE_NOT_SET);
 	}
-	else if (family & GMT_IS_LABEL) {	/* This is specific to CPTs */
-		family -= GMT_IS_LABEL;
-		code = GMT_IS_LABEL;
-	}
-
 	if (!(family == GMT_IS_VECTOR || family == GMT_IS_MATRIX || family == GMT_IS_PALETTE)) return_error (V_API, GMT_NOT_A_VALID_FAMILY);
+
 	if (family == GMT_IS_VECTOR) {
 		struct GMT_VECTOR *V = gmtapi_get_vector_data (object);
 		struct GMT_VECTOR_HIDDEN *VH = gmt_get_V_hidden (V);
@@ -14679,16 +14683,16 @@ int GMT_Put_Strings (void *V_API, unsigned int family, void *object, char **arra
 		}
 	}
 	else if (family == GMT_IS_PALETTE) {
-		unsigned int k, item = (code == GMT_IS_LABEL) ? GMT_CPT_INDEX_LBL : GMT_CPT_INDEX_KEY;
+		unsigned int k, item = (code == GMT_IS_PALETTE_LABEL) ? GMT_CPT_INDEX_LBL : GMT_CPT_INDEX_KEY;
 		struct GMT_PALETTE *P = gmtapi_get_palette_data (object);
 		struct GMT_PALETTE_HIDDEN *CH = gmt_get_C_hidden (P);
 		for (k = 0; k < P->n_colors; k++) {
 			if (array[k] == NULL) continue;	/* No string given for this entry */
-			if (code == GMT_IS_LABEL) {
+			if (code == GMT_IS_PALETTE_LABEL) {
 				if (dup && P->data[k].label) gmt_M_str_free (P->data[k].label);	/* Free any old entry */
 				P->data[k].label = (dup) ? strdup (array[k]) : array[k];
 			}
-			else if (code == GMT_IS_KEY) {
+			else if (code == GMT_IS_PALETTE_KEY) {
 				if (dup && P->data[k].key) gmt_M_str_free (P->data[k].key);	/* Free any old entry */
 				P->data[k].key = (dup) ? strdup (array[k]) : array[k];
 			}

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -258,6 +258,8 @@ enum GMT_time_period {
 #define GMT_CPT_CATEGORICAL_KEY		2	/* Categorical CPT with text key */
 #define GMT_COLOR_AUTO_TABLE		1	/* Flag in rgb for auto-color changing per table */
 #define GMT_COLOR_AUTO_SEGMENT		2	/* Flag in rgb for auto-color changing per segment */
+#define GMT_CPT_INDEX_LBL		0	/* Index into hidden alloc_mode_text[] for labels */
+#define GMT_CPT_INDEX_KEY		1	/* Index into hidden alloc_mode_text[] for keys */
 
 /* Default CPT if nothing specified or overruled by remote dataset preferences */
 #define GMT_DEFAULT_CPT_NAME	"turbo"

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 251
+#define GMT_N_API_ENUMS 253
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -152,6 +152,8 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_IS_NONE", 16},
 	{"GMT_IS_OUTPUT", 1024},
 	{"GMT_IS_PALETTE", 3},
+	{"GMT_IS_PALETTE_KEY", 1024},
+	{"GMT_IS_PALETTE_LABEL", 2048},
 	{"GMT_IS_PERIMETER", 0},
 	{"GMT_IS_PLP", 7},
 	{"GMT_IS_POINT", 1},

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -110,7 +110,7 @@ struct GMT_PALETTE_HIDDEN {	/* Supporting information hidden from the API */
 	uint64_t id;			/* The internal number of the data set */
 	size_t n_alloc;            	/* Memory allocated so far */
 	enum GMT_enum_alloc alloc_mode;	/* Allocation mode [GMT_ALLOC_INTERNALLY] */
-	enum GMT_enum_alloc alloc_mode_text[2];	/* Allocation mode per ley|labels [GMT_ALLOC_INTERNALLY] */
+	enum GMT_enum_alloc alloc_mode_text[2];	/* Allocation mode per label|key [GMT_ALLOC_INTERNALLY] */
 	unsigned int alloc_level;	/* The level it was allocated at */
 	unsigned int auto_scale;	/* If 1 then we must resample to fit actual data range */
 	unsigned int skip;		/* true if current z-slice is to be skipped */

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -110,6 +110,7 @@ struct GMT_PALETTE_HIDDEN {	/* Supporting information hidden from the API */
 	uint64_t id;			/* The internal number of the data set */
 	size_t n_alloc;            	/* Memory allocated so far */
 	enum GMT_enum_alloc alloc_mode;	/* Allocation mode [GMT_ALLOC_INTERNALLY] */
+	enum GMT_enum_alloc alloc_mode_text[2];	/* Allocation mode per ley|labels [GMT_ALLOC_INTERNALLY] */
 	unsigned int alloc_level;	/* The level it was allocated at */
 	unsigned int auto_scale;	/* If 1 then we must resample to fit actual data range */
 	unsigned int skip;		/* true if current z-slice is to be skipped */

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -155,6 +155,11 @@ enum GMT_enum_family {
 	GMT_N_FAMILIES	  = 9	/* Total number of families [API Developers only]  */
 };
 
+enum GMT_enum_CPT {
+	GMT_IS_KEY    = 1024,	/* Strings to GMT_Put_Strings are keys */
+	GMT_IS_LABEL  = 2048	/* Strings to GMT_Put_Strings are labels */
+};
+
 #define GMT_IS_CPT	GMT_IS_PALETTE		/* Backwards compatibility for < 5.3.3; */
 
 /*! These are modes for handling comments */

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -156,8 +156,8 @@ enum GMT_enum_family {
 };
 
 enum GMT_enum_CPT {
-	GMT_IS_KEY    = 1024,	/* Strings to GMT_Put_Strings are keys */
-	GMT_IS_LABEL  = 2048	/* Strings to GMT_Put_Strings are labels */
+	GMT_IS_PALETTE_KEY    = 1024,	/* Strings to GMT_Put_Strings are keys */
+	GMT_IS_PALETTE_LABEL  = 2048	/* Strings to GMT_Put_Strings are labels */
 };
 
 #define GMT_IS_CPT	GMT_IS_PALETTE		/* Backwards compatibility for < 5.3.3; */


### PR DESCRIPTION
See #4799 for background.  There are two types of strings in palettes: Labels and categorical keys.  They are typically read in from a CPT file and allocated in GMT.  However, externals have no good way to set these in memory.  This PR addresses this by

1. Adding new variables to the hidden palette structure: 	`enum GMT_enum_alloc alloc_mode_text[2];	/* Allocation mode per key|labels [GMT_ALLOC_INTERNALLY] */`
2. Setting these to GMT_IS **GMT_ALLOC_INTERNALLY** when GMT reads in from CPT and allocates space for any of them.
3. Consult these settings when freeing or not freeing the memory.

_GMT_Put_Strings_ now recognize the family **GMT_IS_PALETTE**, which must have **GMT_IS_PALETTE_LABEL** or **GMT_IS_PALETTE_KEY** added to it.  The **GMT_IS_DUPLICATE**|**REFERENCE** may also be added and controls allocation versus pointer assignments.

Note: GMT_Get_Strings does not yet accept **GMT_IS_PALETTE** since it is not clear if it is needed and unlike **GMT_IS_MATRIX** an **GMT_IS_VECTOR** there is no single array, just strings spread across **GMT_LUT** structures.
