### PR TITLE
Check how close to pole we are with -JOa

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5407,11 +5407,14 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 			}
 			GMT->current.proj.N_hemi = (strchr ("AB", GMT->common.J.string[1]) == NULL) ? true : false;	/* Upper case -JoA, -JoB allows S pole views */
 			if (n_slashes == 3) {
+				double distance = 10.0;	/* Default spherical length for gmt_translate_point */
 				n = sscanf (args, "%[^/]/%[^/]/%lf/%s", txt_a, txt_b, &az, txt_e);
 				error += gmt_verify_expectations (GMT, GMT_IS_LON, gmt_scanf (GMT, txt_a, GMT_IS_LON, &GMT->current.proj.pars[0]), txt_a);
 				error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_b, GMT_IS_LAT, &GMT->current.proj.pars[1]), txt_b);
-				/* compute point 10 degrees from origin along azimuth */
-				gmt_translate_point (GMT, GMT->current.proj.pars[0], GMT->current.proj.pars[1], az, 10.0, &GMT->current.proj.pars[2], &GMT->current.proj.pars[3], NULL);
+				if ((90.0 - fabs (GMT->current.proj.pars[1])) < distance)
+					distance = 90.0 - fabs (GMT->current.proj.pars[1]) - GMT_CONV4_LIMIT;
+				/* compute point <distance> degrees from origin along azimuth */
+				gmt_translate_point (GMT, GMT->current.proj.pars[0], GMT->current.proj.pars[1], az, distance, &GMT->current.proj.pars[2], &GMT->current.proj.pars[3], NULL);
 			}
 			else if (n_slashes == 4) {
 				n = sscanf (args, "%[^/]/%[^/]/%[^/]/%[^/]/%s", txt_a, txt_b, txt_c, txt_d, txt_e);

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -3398,6 +3398,7 @@ GMT_LOCAL int gmtmap_init_oblique (struct GMT_CTRL *GMT, bool *search) {
 	o_x = GMT->current.proj.pars[0];	o_y = GMT->current.proj.pars[1];
 
 	if (lrint (GMT->current.proj.pars[6]) == 1) {	/* Must get correct origin, then get second point */
+		double distance = 10.0;	/* Default spherical length for gmt_translate_point */
 		p_x = GMT->current.proj.pars[2];	p_y = GMT->current.proj.pars[3];
 
 		GMT->current.proj.o_pole_lon = p_x;
@@ -3409,8 +3410,10 @@ GMT_LOCAL int gmtmap_init_oblique (struct GMT_CTRL *GMT, bool *search) {
 
 		gmtmap_get_origin (GMT, o_x, o_y, p_x, p_y, &o_x, &o_y);
 		az = atand (cosd (p_y) * sind (p_x - o_x) / (cosd (o_y) * sind (p_y) - sind (o_y) * cosd (p_y) * cosd (p_x - o_x))) + 90.0;
-		/* compute point 10 degrees from origin along azimuth */
-		gmt_translate_point (GMT, o_x, o_y, az, 10.0, &b_x, &b_y, NULL);
+		if ((90.0 - fabs (o_y)) < distance)
+			distance = 90.0 - fabs (o_y) - GMT_CONV4_LIMIT;
+		/* compute point <distance> degrees from origin along azimuth */
+		gmt_translate_point (GMT, o_x, o_y, az, distance, &b_x, &b_y, NULL);
 
 		GMT->current.proj.pars[0] = o_x;	GMT->current.proj.pars[1] = o_y;
 		GMT->current.proj.pars[2] = b_x;	GMT->current.proj.pars[3] = b_y;

--- a/test/psbasemap/JOb_pole.ps
+++ b/test/psbasemap/JOb_pole.ps
@@ -1,0 +1,5737 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_92a6791-dirty_2021.02.12 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Feb 12 15:25:16 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/6.98899/0/6.98899 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.98899000 0.00000000 6.98899000 0.000 6.989 0.000 6.989 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4607 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JOa8/82/46/3.1496i -T8/82/3c -Ba5fg -BWENS -Xa0i -Ya3.8394i -R-200/200/-200/200+uk
+%@PROJ: omerc -9.89079338 25.70601553 79.35704396 84.64268898 -200000.000 200000.000 -200000.000 200000.000 +unavailable +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+-1 3641 M
+1 0 D
+247 139 D
+4 1 D S
+-1 3463 M
+1 0 D
+78 46 D
+103 60 D
+286 166 D
+77 45 D
+3 1 D S
+-1 3281 M
+1 1 D
+165 100 D
+86 52 D
+86 52 D
+94 57 D
+95 57 D
+117 71 D
+94 57 D
+86 52 D
+3 1 D S
+-1 3096 M
+1 1 D
+44 27 D
+155 98 D
+39 24 D
+155 98 D
+39 24 D
+155 98 D
+39 24 D
+147 93 D
+47 29 D
+147 93 D
+47 29 D
+72 46 D
+3 1 D S
+-1 2906 M
+1 1 D
+274 179 D
+630 411 D
+230 151 D
+202 132 D
+3 1 D S
+-1 2713 M
+1 1 D
+133 89 D
+22 16 D
+31 20 D
+22 16 D
+31 20 D
+22 16 D
+31 20 D
+15 11 D
+152 103 D
+205 138 D
+22 16 D
+31 20 D
+22 16 D
+31 20 D
+15 11 D
+152 103 D
+152 102 D
+22 16 D
+31 20 D
+22 16 D
+31 20 D
+15 11 D
+152 103 D
+152 102 D
+22 16 D
+37 25 D
+2 1 D S
+-1 2515 M
+1 0 D
+141 99 D
+22 16 D
+38 26 D
+37 27 D
+38 26 D
+22 16 D
+38 26 D
+37 27 D
+150 105 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+22 16 D
+113 79 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+30 22 D
+2 1 D S
+-1 2311 M
+1 1 D
+1797 1311 D
+215 157 D
+2 1 D S
+-1 2103 M
+1 1 D
+60 45 D
+29 23 D
+37 27 D
+36 28 D
+30 22 D
+36 28 D
+22 16 D
+95 72 D
+110 83 D
+36 28 D
+37 27 D
+36 28 D
+15 11 D
+80 61 D
+37 27 D
+29 23 D
+37 27 D
+36 28 D
+37 27 D
+58 45 D
+37 27 D
+51 39 D
+146 111 D
+37 27 D
+36 28 D
+37 27 D
+29 23 D
+37 27 D
+36 28 D
+30 22 D
+65 50 D
+37 27 D
+58 45 D
+37 27 D
+66 50 D
+36 28 D
+37 27 D
+66 50 D
+36 28 D
+37 27 D
+102 78 D
+37 27 D
+102 78 D
+37 27 D
+36 28 D
+30 22 D
+28 22 D
+2 1 D S
+-1 1889 M
+1 1 D
+111 88 D
+15 11 D
+50 40 D
+22 16 D
+14 12 D
+15 11 D
+50 40 D
+15 11 D
+50 40 D
+15 11 D
+21 17 D
+15 11 D
+195 153 D
+64 51 D
+15 11 D
+50 40 D
+22 16 D
+14 12 D
+15 11 D
+50 40 D
+15 11 D
+65 51 D
+21 17 D
+15 11 D
+195 153 D
+64 51 D
+15 11 D
+86 68 D
+15 11 D
+50 40 D
+15 11 D
+50 40 D
+22 16 D
+14 12 D
+15 11 D
+50 40 D
+15 11 D
+65 51 D
+21 17 D
+15 11 D
+50 40 D
+15 11 D
+65 51 D
+21 17 D
+15 11 D
+130 102 D
+21 17 D
+15 11 D
+130 102 D
+21 17 D
+15 11 D
+130 102 D
+21 17 D
+15 11 D
+50 40 D
+15 11 D
+41 33 D
+2 1 D S
+-1 1670 M
+1 1 D
+74 60 D
+64 52 D
+583 473 D
+64 52 D
+64 52 D
+64 52 D
+57 47 D
+15 11 D
+49 41 D
+15 11 D
+49 41 D
+15 11 D
+50 41 D
+64 52 D
+64 52 D
+313 254 D
+92 75 D
+64 52 D
+64 52 D
+29 23 D
+42 35 D
+15 11 D
+50 41 D
+64 52 D
+85 69 D
+64 52 D
+64 52 D
+64 52 D
+64 52 D
+29 23 D
+42 34 D
+57 47 D
+15 11 D
+50 41 D
+40 33 D
+2 1 D S
+-1 1444 M
+1 1 D
+408 343 D
+511 430 D
+162 136 D
+358 301 D
+448 377 D
+92 77 D
+322 271 D
+92 77 D
+287 242 D
+15 11 D
+82 70 D
+2 1 D S
+-1 1211 M
+1 1 D
+218 190 D
+215 187 D
+159 138 D
+6 7 D
+367 318 D
+41 37 D
+332 288 D
+69 61 D
+304 264 D
+118 103 D
+255 222 D
+395 344 D
+380 330 D
+69 61 D
+21 18 D
+1 1 D S
+-1 971 M
+1 2 D
+102 91 D
+6 7 D
+69 61 D
+61 55 D
+61 55 D
+41 37 D
+14 12 D
+6 7 D
+41 36 D
+55 50 D
+102 92 D
+41 36 D
+6 7 D
+62 55 D
+34 30 D
+6 7 D
+41 36 D
+62 56 D
+40 36 D
+89 80 D
+7 6 D
+6 7 D
+62 55 D
+41 37 D
+40 36 D
+62 56 D
+40 36 D
+89 80 D
+14 12 D
+6 7 D
+41 36 D
+55 50 D
+136 122 D
+7 6 D
+6 7 D
+41 36 D
+55 49 D
+6 7 D
+41 36 D
+89 80 D
+102 92 D
+7 6 D
+6 7 D
+48 42 D
+55 50 D
+40 36 D
+96 86 D
+7 6 D
+6 7 D
+41 36 D
+55 50 D
+47 42 D
+89 80 D
+7 6 D
+6 7 D
+69 61 D
+61 55 D
+61 55 D
+55 49 D
+6 7 D
+41 36 D
+62 56 D
+40 36 D
+96 86 D
+7 6 D
+6 7 D
+41 36 D
+89 80 D
+85 77 D
+1 1 D S
+-1 724 M
+1 2 D
+75 69 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+14 12 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+21 18 D
+6 7 D
+54 50 D
+47 43 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+67 62 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+14 12 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+40 37 D
+108 100 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+41 37 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+40 37 D
+108 100 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+40 37 D
+1 2 D
+2 1 D S
+-1 469 M
+1 1 D
+2 3 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+106 102 D
+13 12 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+53 50 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+86 82 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+119 114 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+106 101 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+53 51 D
+33 31 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+106 101 D
+6 7 D
+27 25 D
+6 7 D
+106 102 D
+33 31 D
+6 7 D
+27 25 D
+6 7 D
+106 101 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+106 102 D
+13 12 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+106 101 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+106 101 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+106 102 D
+33 31 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+86 82 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+8 9 D
+2 1 D S
+-1 205 M
+1 2 D
+10 9 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+38 39 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+12 13 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+13 12 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+12 13 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+13 12 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+12 13 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+25 26 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+51 52 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+51 52 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+77 78 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+103 104 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+103 104 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+129 130 D
+7 6 D
+6 7 D
+7 6 D
+155 156 D
+7 6 D
+842 843 D
+7 6 D
+6 7 D
+7 6 D
+155 156 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+129 130 D
+7 6 D
+6 7 D
+7 6 D
+5 6 D
+1 1 D S
+63 -1 M
+1 1 D
+100 103 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+114 119 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+114 119 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+101 106 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+114 119 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+114 119 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+50 53 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+82 86 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+51 53 D
+31 33 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+50 53 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+50 53 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+50 53 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+82 86 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+102 106 D
+12 13 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+82 86 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+82 86 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+102 106 D
+12 13 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+102 106 D
+12 13 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+10 12 D
+2 1 D S
+325 -1 M
+1 1 D
+75 80 D
+31 34 D
+7 6 D
+12 14 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+62 67 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+12 14 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+100 108 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+62 67 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+62 67 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+62 67 D
+75 81 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+37 40 D
+15 16 D
+1 1 D S
+579 -1 M
+1 1 D
+39 43 D
+92 102 D
+36 41 D
+7 6 D
+36 41 D
+50 55 D
+42 47 D
+80 89 D
+6 7 D
+7 6 D
+36 41 D
+56 62 D
+36 40 D
+93 103 D
+92 102 D
+42 47 D
+80 89 D
+6 7 D
+7 6 D
+42 48 D
+50 55 D
+36 40 D
+86 96 D
+6 7 D
+7 6 D
+55 62 D
+30 34 D
+7 6 D
+36 41 D
+56 62 D
+36 40 D
+86 96 D
+6 7 D
+7 6 D
+55 62 D
+37 41 D
+36 40 D
+56 62 D
+36 40 D
+86 96 D
+6 7 D
+7 6 D
+61 69 D
+55 61 D
+68 75 D
+42 47 D
+80 89 D
+6 7 D
+7 6 D
+61 69 D
+55 61 D
+98 109 D
+92 102 D
+6 7 D
+7 6 D
+42 48 D
+50 55 D
+122 136 D
+6 7 D
+7 6 D
+55 62 D
+37 41 D
+36 40 D
+56 62 D
+36 40 D
+86 96 D
+6 7 D
+7 6 D
+36 41 D
+80 89 D
+6 7 D
+7 6 D
+55 62 D
+37 41 D
+36 40 D
+51 56 D
+1 2 D S
+825 -1 M
+1 1 D
+184 211 D
+306 352 D
+103 118 D
+240 276 D
+169 194 D
+198 228 D
+61 69 D
+324 373 D
+404 464 D
+354 407 D
+349 401 D
+259 298 D
+3 2 D
+1 2 D S
+1064 -1 M
+1 1 D
+292 347 D
+77 92 D
+301 358 D
+342 407 D
+347 413 D
+154 183 D
+230 274 D
+336 399 D
+11 15 D
+348 413 D
+89 106 D
+188 223 D
+1 2 D S
+1296 -1 M
+1 1 D
+66 81 D
+52 64 D
+23 29 D
+34 42 D
+47 57 D
+11 15 D
+41 49 D
+11 15 D
+41 50 D
+52 64 D
+75 92 D
+52 64 D
+109 135 D
+52 64 D
+47 57 D
+11 15 D
+41 49 D
+11 15 D
+41 50 D
+52 64 D
+69 85 D
+52 64 D
+52 64 D
+161 199 D
+52 64 D
+47 57 D
+11 15 D
+40 49 D
+47 57 D
+11 15 D
+41 49 D
+11 15 D
+41 50 D
+52 64 D
+69 85 D
+52 64 D
+179 221 D
+75 92 D
+109 135 D
+52 64 D
+47 57 D
+11 15 D
+41 49 D
+11 15 D
+41 50 D
+46 56 D
+11 15 D
+41 50 D
+52 64 D
+75 92 D
+15 18 D
+1 2 D S
+1521 -1 M
+1 1 D
+52 65 D
+11 15 D
+113 144 D
+57 72 D
+16 22 D
+63 79 D
+11 15 D
+40 50 D
+16 22 D
+63 79 D
+11 15 D
+113 144 D
+85 108 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+11 15 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+11 15 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+11 15 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+11 15 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+3 3 D
+1 2 D S
+1741 -1 M
+1 1 D
+135 179 D
+61 80 D
+27 37 D
+23 29 D
+27 37 D
+28 36 D
+27 37 D
+23 29 D
+27 37 D
+28 36 D
+27 37 D
+23 29 D
+16 22 D
+111 146 D
+27 37 D
+50 66 D
+28 36 D
+27 37 D
+78 102 D
+27 37 D
+28 36 D
+27 37 D
+23 29 D
+27 37 D
+28 36 D
+27 37 D
+45 58 D
+27 37 D
+61 80 D
+11 15 D
+94 124 D
+22 30 D
+28 36 D
+16 22 D
+83 110 D
+28 36 D
+27 37 D
+72 95 D
+94 124 D
+22 30 D
+28 36 D
+16 22 D
+111 146 D
+27 37 D
+78 102 D
+27 37 D
+28 36 D
+27 37 D
+23 29 D
+27 37 D
+28 36 D
+8 11 D
+1 2 D S
+1955 -1 M
+1 1 D
+321 441 D
+513 704 D
+410 563 D
+464 637 D
+116 159 D
+1 2 D S
+2163 -1 M
+1 1 D
+33 48 D
+27 37 D
+47 68 D
+16 22 D
+26 38 D
+27 37 D
+47 68 D
+16 22 D
+26 38 D
+16 22 D
+79 113 D
+16 22 D
+26 38 D
+16 22 D
+79 113 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+13 17 D
+1 2 D S
+2367 -1 M
+1 1 D
+8 13 D
+103 152 D
+41 61 D
+11 15 D
+25 38 D
+11 15 D
+66 99 D
+11 15 D
+25 38 D
+11 15 D
+67 99 D
+35 53 D
+11 15 D
+67 99 D
+113 167 D
+113 167 D
+113 167 D
+113 167 D
+149 220 D
+113 167 D
+35 53 D
+11 15 D
+66 99 D
+11 15 D
+25 38 D
+11 15 D
+47 69 D
+1 3 D S
+2566 -1 M
+0 1 D
+330 505 D
+880 1351 D
+4 5 D
+1 3 D S
+2760 -1 M
+1 1 D
+60 96 D
+161 256 D
+24 39 D
+88 139 D
+97 156 D
+93 147 D
+34 55 D
+78 124 D
+24 39 D
+93 147 D
+29 47 D
+146 233 D
+92 146 D
+1 3 D S
+2950 -1 M
+1 1 D
+83 137 D
+47 78 D
+90 149 D
+38 63 D
+52 87 D
+57 94 D
+71 117 D
+28 48 D
+81 133 D
+52 86 D
+52 87 D
+57 94 D
+104 172 D
+17 28 D
+1 3 D S
+3137 -1 M
+0 1 D
+125 215 D
+147 254 D
+69 118 D
+138 238 D
+46 80 D
+69 118 D
+46 80 D
+3 4 D
+1 3 D S
+3319 -1 M
+1 1 D
+331 595 D
+125 224 D
+4 6 D
+1 3 D S
+3498 -1 M
+1 1 D
+55 104 D
+22 41 D
+52 97 D
+56 105 D
+39 72 D
+56 106 D
+1 0 D
+1 3 D S
+3674 -1 M
+1 1 D
+104 204 D
+1 1 D
+1 3 D S
+-2 820 M
+2 -2 D
+109 -116 D
+29 -31 D
+8 -7 D
+29 -31 D
+15 -16 D
+8 -7 D
+37 -39 D
+8 -7 D
+37 -39 D
+8 -7 D
+7 -8 D
+31 -30 D
+7 -8 D
+39 -37 D
+7 -8 D
+39 -37 D
+7 -8 D
+16 -14 D
+7 -8 D
+24 -22 D
+7 -8 D
+165 -153 D
+152 -136 D
+46 -41 D
+2 -2 D S
+-2 2488 M
+2 -2 D
+80 -112 D
+127 -170 D
+95 -122 D
+102 -128 D
+25 -29 D
+18 -23 D
+25 -29 D
+37 -45 D
+133 -153 D
+39 -43 D
+25 -29 D
+66 -71 D
+19 -22 D
+133 -140 D
+40 -42 D
+21 -20 D
+33 -35 D
+35 -34 D
+6 -7 D
+42 -40 D
+20 -21 D
+161 -153 D
+50 -46 D
+85 -78 D
+29 -25 D
+65 -58 D
+132 -113 D
+52 -43 D
+52 -43 D
+151 -121 D
+53 -42 D
+39 -29 D
+61 -47 D
+148 -109 D
+126 -89 D
+151 -104 D
+41 -26 D
+68 -45 D
+3 -2 D S
+419 3781 M
+1 -1 D
+30 -53 D
+79 -133 D
+77 -124 D
+74 -116 D
+10 -14 D
+9 -15 D
+43 -64 D
+53 -78 D
+15 -21 D
+9 -15 D
+140 -195 D
+67 -90 D
+11 -13 D
+15 -21 D
+11 -13 D
+63 -82 D
+11 -13 D
+75 -94 D
+28 -33 D
+32 -40 D
+95 -111 D
+51 -58 D
+11 -13 D
+29 -32 D
+11 -13 D
+35 -38 D
+11 -13 D
+41 -44 D
+41 -44 D
+53 -56 D
+126 -129 D
+30 -31 D
+117 -114 D
+13 -11 D
+62 -59 D
+63 -59 D
+20 -17 D
+31 -29 D
+20 -17 D
+25 -23 D
+26 -22 D
+32 -29 D
+46 -39 D
+105 -89 D
+40 -32 D
+26 -22 D
+54 -43 D
+40 -32 D
+48 -37 D
+13 -11 D
+123 -93 D
+160 -117 D
+92 -64 D
+120 -81 D
+116 -76 D
+65 -41 D
+109 -68 D
+185 -109 D
+83 -46 D
+22 -13 D
+23 -12 D
+22 -13 D
+46 -24 D
+22 -13 D
+5 -2 D
+1 0 D S
+1659 3781 M
+1 -1 D
+35 -51 D
+35 -49 D
+26 -37 D
+89 -121 D
+101 -132 D
+24 -29 D
+80 -99 D
+39 -47 D
+73 -86 D
+25 -28 D
+19 -23 D
+65 -73 D
+6 -5 D
+61 -67 D
+30 -33 D
+6 -5 D
+25 -28 D
+11 -10 D
+15 -17 D
+6 -5 D
+20 -22 D
+6 -5 D
+10 -11 D
+6 -5 D
+36 -38 D
+11 -10 D
+5 -6 D
+11 -10 D
+5 -6 D
+11 -10 D
+5 -6 D
+33 -31 D
+10 -11 D
+17 -15 D
+10 -11 D
+44 -41 D
+5 -6 D
+28 -25 D
+5 -6 D
+50 -46 D
+163 -145 D
+23 -19 D
+28 -25 D
+64 -53 D
+99 -81 D
+112 -88 D
+139 -104 D
+60 -44 D
+43 -30 D
+50 -35 D
+155 -105 D
+85 -55 D
+1 0 D S
+2988 3781 M
+1 -1 D
+23 -27 D
+5 -4 D
+21 -25 D
+5 -4 D
+12 -15 D
+5 -4 D
+17 -20 D
+5 -4 D
+26 -29 D
+17 -19 D
+5 -4 D
+26 -29 D
+5 -4 D
+22 -24 D
+5 -4 D
+4 -5 D
+5 -4 D
+22 -24 D
+5 -4 D
+4 -5 D
+5 -4 D
+31 -33 D
+5 -4 D
+4 -5 D
+56 -54 D
+4 -5 D
+5 -4 D
+4 -5 D
+38 -35 D
+4 -5 D
+62 -57 D
+4 -5 D
+10 -8 D
+4 -5 D
+20 -17 D
+4 -5 D
+92 -81 D
+5 -4 D
+4 -5 D
+40 -33 D
+4 -5 D
+65 -54 D
+74 -61 D
+8 -6 D
+1 -1 D S
+8 W
+N 1336 3780 M 70 45 D S
+N 2411 3780 M 66 51 D S
+N 3272 3780 M 61 56 D S
+N 580 0 M -56 -62 D S
+N 1742 0 M -50 -66 D S
+N 2761 0 M -45 -71 D S
+N 3675 0 M -39 -74 D S
+N 0 818 M -57 62 D S
+N 247 3780 M 37 20 D S
+N 544 3780 M 36 20 D S
+N 823 3780 M 35 21 D S
+N 1086 3780 M 36 22 D S
+N 1336 3780 M 35 22 D S
+N 1573 3780 M 34 23 D S
+N 1798 3780 M 34 23 D S
+N 2012 3780 M 34 24 D S
+N 2216 3780 M 33 25 D S
+N 2411 3780 M 33 25 D S
+N 2598 3780 M 32 26 D S
+N 2777 3780 M 32 26 D S
+N 2949 3780 M 31 27 D S
+N 3114 3780 M 30 27 D S
+N 3272 3780 M 31 28 D S
+N 3425 3780 M 30 28 D S
+N 3573 3780 M 29 29 D S
+N 64 0 M -29 -30 D S
+N 3715 3780 M 29 29 D S
+N 326 0 M -28 -30 D S
+N 580 0 M -28 -31 D S
+N 826 0 M -27 -31 D S
+N 1065 0 M -27 -32 D S
+N 1297 0 M -26 -32 D S
+N 1522 0 M -25 -33 D S
+N 1742 0 M -25 -33 D S
+N 1956 0 M -25 -34 D S
+N 2164 0 M -24 -34 D S
+N 2368 0 M -24 -35 D S
+N 2566 0 M -22 -35 D S
+N 2761 0 M -22 -35 D S
+N 2951 0 M -22 -36 D S
+N 3137 0 M -21 -36 D S
+N 3320 0 M -21 -36 D S
+N 3499 0 M -20 -37 D S
+N 3675 0 M -19 -37 D S
+N 0 818 M -28 31 D S
+N 0 2486 M -24 34 D S
+N 3780 514 M 36 -20 D S
+N 3780 1730 M 35 -22 D S
+N 3780 3022 M 32 -26 D S
+25 W
+2 setlinecap
+N 0 0 M 0 3780 D S
+N 3780 0 M 0 3780 D S
+N 0 0 M 3780 0 D S
+N 0 3780 M 3780 0 D S
+0 setlinecap
+1406 3908 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(î5è) bc Z
+2477 3914 M (0è) bc Z
+3333 3920 M (5è) bc Z
+524 -145 M (10è) tc Z
+1692 -150 M (15è) tc Z
+2716 -154 M (20è) tc Z
+3636 -157 M (25è) tc Z
+-140 880 M (80è) mr Z
+10 setmiterlimit
+8 W
+{0 A} FS
+O1
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+14 W
+V 1397 1380 T 46.0014536255 R
+N 0 0 M 1205 0 D S
+U
+V 2382 2400 T 46.0014536255 R
+PSL_vecheadpen
+0 W
+0 0 M
+-213 35 D
+0 -70 D
+P clip fs N 
+U
+FQ
+177 1890 1890 Sc
+N 1635 2136 M 510 -492 D S
+2440 2459 M 400 F0
+V -43.9985463745 R (N) bc Z U
+3.32550952342 setmiterlimit
+0 A
+%%EndObject
+0 -4607 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4607 4607 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JOa8/87/46/3.1496i -T8/87/3c -Ba5fg -BWENS -Xa3.8394i -Ya3.8394i -R-200/200/-200/200+uk
+%@PROJ: omerc -32.84237209 47.99826800 84.35696082 89.64075728 -200000.000 200000.000 -200000.000 200000.000 +unavailable +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+0 734 M
+55 46 D
+S
+0 611 M
+108 94 D
+7 5 D
+S
+0 484 M
+76 69 D
+27 23 D
+72 66 D
+S
+0 353 M
+62 58 D
+104 97 D
+71 66 D
+S
+0 218 M
+32 30 D
+12 13 D
+26 24 D
+6 7 D
+39 37 D
+57 55 D
+7 6 D
+12 13 D
+26 24 D
+6 7 D
+26 24 D
+6 7 D
+39 37 D
+6 6 D
+S
+0 78 M
+18 19 D
+13 12 D
+6 7 D
+38 37 D
+6 7 D
+38 37 D
+6 7 D
+38 37 D
+6 7 D
+38 37 D
+6 7 D
+151 150 D
+S
+64 0 M
+13 14 D
+13 12 D
+18 20 D
+13 12 D
+24 26 D
+7 6 D
+24 26 D
+7 6 D
+37 39 D
+61 64 D
+13 12 D
+18 20 D
+13 12 D
+24 26 D
+7 6 D
+37 39 D
+37 38 D
+S
+202 0 M
+58 62 D
+84 91 D
+7 6 D
+78 85 D
+7 6 D
+60 65 D
+S
+336 0 M
+37 42 D
+84 92 D
+23 27 D
+84 92 D
+S
+465 0 M
+51 58 D
+52 61 D
+53 60 D
+11 13 D
+S
+590 0 M
+55 65 D
+57 68 D
+S
+712 0 M
+61 75 D
+S
+830 0 M
+14 18 D
+S
+-1 968 M
+1 1 D
+69 55 D
+22 16 D
+14 12 D
+15 11 D
+21 17 D
+15 11 D
+137 107 D
+115 90 D
+100 79 D
+22 16 D
+14 12 D
+15 11 D
+64 51 D
+22 16 D
+14 12 D
+22 16 D
+14 12 D
+15 11 D
+21 17 D
+15 11 D
+64 51 D
+15 11 D
+21 17 D
+15 11 D
+101 79 D
+115 90 D
+136 107 D
+22 16 D
+14 12 D
+15 11 D
+64 51 D
+22 16 D
+14 12 D
+15 11 D
+21 17 D
+15 11 D
+101 79 D
+151 118 D
+100 79 D
+22 16 D
+57 45 D
+36 29 D
+22 16 D
+14 12 D
+15 11 D
+21 17 D
+15 11 D
+100 79 D
+15 11 D
+21 17 D
+15 11 D
+101 79 D
+100 79 D
+22 16 D
+57 45 D
+72 57 D
+22 16 D
+14 12 D
+15 11 D
+21 17 D
+15 11 D
+101 79 D
+115 90 D
+136 107 D
+22 16 D
+14 12 D
+15 11 D
+21 17 D
+15 11 D
+101 79 D
+136 107 D
+22 16 D
+14 12 D
+15 11 D
+21 17 D
+15 11 D
+137 107 D
+100 79 D
+22 16 D
+15 13 D
+3 1 D S
+-2 849 M
+2 -2 D
+46 -56 D
+55 -65 D
+122 -137 D
+84 -89 D
+9 -8 D
+86 -87 D
+62 -59 D
+8 -9 D
+108 -99 D
+139 -120 D
+29 -23 D
+37 -31 D
+82 -64 D
+2 -2 D S
+-2 849 M
+2 -2 D
+46 -56 D
+55 -65 D
+122 -137 D
+84 -89 D
+9 -8 D
+86 -87 D
+62 -59 D
+8 -9 D
+108 -99 D
+139 -120 D
+29 -23 D
+37 -31 D
+82 -64 D
+2 -2 D S
+-2 3151 M
+2 -8 D
+28 -106 D
+33 -113 D
+20 -65 D
+48 -138 D
+42 -110 D
+41 -100 D
+51 -116 D
+51 -106 D
+9 -17 D
+54 -104 D
+38 -69 D
+84 -143 D
+68 -107 D
+60 -89 D
+80 -111 D
+102 -132 D
+56 -68 D
+90 -103 D
+80 -86 D
+89 -91 D
+91 -88 D
+15 -13 D
+21 -20 D
+15 -13 D
+36 -33 D
+75 -63 D
+22 -19 D
+107 -86 D
+109 -82 D
+88 -62 D
+25 -16 D
+49 -33 D
+115 -73 D
+101 -60 D
+26 -14 D
+94 -52 D
+131 -66 D
+18 -8 D
+17 -9 D
+125 -57 D
+135 -56 D
+129 -48 D
+157 -53 D
+47 -14 D
+141 -40 D
+133 -32 D
+134 -29 D
+145 -25 D
+33 -5 D
+14 -2 D S
+949 3780 M
+20 -140 D
+23 -123 D
+23 -100 D
+18 -71 D
+43 -148 D
+38 -111 D
+42 -110 D
+46 -108 D
+53 -112 D
+20 -40 D
+45 -84 D
+29 -51 D
+26 -44 D
+27 -44 D
+39 -62 D
+70 -103 D
+61 -82 D
+59 -75 D
+71 -85 D
+15 -16 D
+14 -17 D
+95 -101 D
+31 -32 D
+37 -35 D
+5 -6 D
+65 -60 D
+66 -58 D
+17 -14 D
+68 -56 D
+29 -22 D
+17 -14 D
+18 -13 D
+11 -9 D
+77 -56 D
+116 -78 D
+88 -54 D
+121 -68 D
+72 -37 D
+59 -29 D
+80 -37 D
+81 -35 D
+82 -32 D
+103 -37 D
+98 -31 D
+85 -25 D
+106 -27 D
+108 -23 D
+94 -17 D
+167 -24 D
+53 -5 D
+0 0 D S
+2012 3780 M
+12 -63 D
+28 -114 D
+34 -113 D
+44 -119 D
+47 -108 D
+9 -17 D
+17 -35 D
+37 -70 D
+59 -101 D
+32 -49 D
+74 -104 D
+67 -84 D
+65 -73 D
+40 -43 D
+70 -68 D
+15 -13 D
+36 -33 D
+38 -31 D
+22 -19 D
+86 -66 D
+40 -28 D
+56 -38 D
+109 -66 D
+95 -50 D
+134 -61 D
+100 -38 D
+93 -31 D
+104 -28 D
+76 -18 D
+106 -19 D
+23 -3 D
+0 0 D S
+3099 3780 M
+40 -92 D
+35 -64 D
+37 -58 D
+34 -48 D
+50 -60 D
+41 -43 D
+6 -7 D
+15 -13 D
+3 -4 D
+22 -19 D
+3 -4 D
+15 -12 D
+46 -37 D
+56 -40 D
+41 -26 D
+69 -37 D
+58 -27 D
+23 -9 D
+46 -17 D
+41 -13 D
+0 0 D S
+8 W
+N 1396 3780 M 82 11 D S
+N 2443 3780 M 81 18 D S
+N 2917 3780 M 79 25 D S
+N 3190 3780 M 76 32 D S
+N 3369 3780 M 74 39 D S
+N 3498 3780 M 70 45 D S
+N 3596 3780 M 66 51 D S
+N 3675 3780 M 61 56 D S
+N 336 0 M -56 -62 D S
+N 3740 3780 M 56 61 D S
+N 946 0 M -50 -67 D S
+N 1481 0 M -45 -71 D S
+N 1960 0 M -38 -74 D S
+N 2398 0 M -31 -77 D S
+N 2807 0 M -24 -80 D S
+N 3194 0 M -17 -82 D S
+N 3567 0 M -10 -83 D S
+N 0 847 M -52 65 D S
+N 500 3780 M 42 4 D S
+N 1011 3780 M 41 5 D S
+N 1396 3780 M 41 5 D S
+N 1696 3780 M 42 6 D S
+N 1938 3780 M 41 7 D S
+N 2137 3780 M 40 7 D S
+N 2302 3780 M 41 8 D S
+N 2443 3780 M 41 9 D S
+N 2564 3780 M 41 10 D S
+N 2670 3780 M 40 10 D S
+N 2762 3780 M 40 11 D S
+N 2844 3780 M 40 12 D S
+N 2917 3780 M 39 12 D S
+N 2982 3780 M 40 13 D S
+N 3042 3780 M 39 14 D S
+N 3095 3780 M 39 14 D S
+N 3145 3780 M 38 15 D S
+N 3190 3780 M 38 16 D S
+N 3231 3780 M 38 16 D S
+N 3270 3780 M 37 17 D S
+N 3305 3780 M 38 18 D S
+N 3338 3780 M 37 18 D S
+N 3369 3780 M 37 19 D S
+N 3398 3780 M 37 20 D S
+N 3426 3780 M 36 20 D S
+N 3451 3780 M 36 21 D S
+N 3475 3780 M 36 22 D S
+N 3498 3780 M 35 22 D S
+N 3520 3780 M 34 23 D S
+N 3540 3780 M 35 23 D S
+N 3560 3780 M 34 24 D S
+N 3579 3780 M 33 25 D S
+N 3596 3780 M 33 25 D S
+N 3614 3780 M 32 26 D S
+N 3630 3780 M 32 26 D S
+N 3645 3780 M 32 27 D S
+N 3660 3780 M 31 27 D S
+N 3675 3780 M 30 28 D S
+N 3689 3780 M 30 28 D S
+N 3702 3780 M 30 29 D S
+N 64 0 M -29 -30 D S
+N 3715 3780 M 29 29 D S
+N 202 0 M -28 -30 D S
+N 3728 3780 M 28 30 D S
+N 336 0 M -28 -31 D S
+N 3740 3780 M 28 30 D S
+N 465 0 M -28 -31 D S
+N 3752 3780 M 27 31 D S
+N 590 0 M -27 -32 D S
+N 3763 3780 M 27 31 D S
+N 712 0 M -26 -32 D S
+N 3774 3780 M 26 32 D S
+N 830 0 M -25 -33 D S
+N 946 0 M -25 -33 D S
+N 1058 0 M -25 -34 D S
+N 1167 0 M -23 -34 D S
+N 1274 0 M -23 -35 D S
+N 1379 0 M -23 -35 D S
+N 1481 0 M -23 -35 D S
+N 1580 0 M -21 -36 D S
+N 1678 0 M -21 -36 D S
+N 1774 0 M -20 -36 D S
+N 1868 0 M -20 -37 D S
+N 1960 0 M -19 -37 D S
+N 2051 0 M -19 -37 D S
+N 2140 0 M -18 -38 D S
+N 2227 0 M -17 -38 D S
+N 2313 0 M -16 -38 D S
+N 2398 0 M -15 -39 D S
+N 2482 0 M -15 -39 D S
+N 2565 0 M -14 -39 D S
+N 2647 0 M -14 -39 D S
+N 2727 0 M -13 -40 D S
+N 2807 0 M -12 -40 D S
+N 2886 0 M -12 -40 D S
+N 2964 0 M -11 -40 D S
+N 3041 0 M -10 -40 D S
+N 3118 0 M -9 -41 D S
+N 3194 0 M -8 -41 D S
+N 3270 0 M -8 -41 D S
+N 3345 0 M -7 -41 D S
+N 3419 0 M -6 -41 D S
+N 3493 0 M -5 -41 D S
+N 3567 0 M -5 -41 D S
+N 3641 0 M -5 -41 D S
+N 3714 0 M -4 -42 D S
+N 0 847 M -26 32 D S
+N 0 3143 M -10 40 D S
+N 3780 1019 M 41 -4 D S
+N 3780 2077 M 41 -6 D S
+N 3780 3150 M 39 -12 D S
+25 W
+2 setlinecap
+N 0 0 M 0 3780 D S
+N 3780 0 M 0 3780 D S
+N 0 0 M 3780 0 D S
+N 0 3780 M 3780 0 D S
+0 setlinecap
+1478 3875 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(î30è) bc Z
+2524 3882 M (î25è) bc Z
+3266 3895 M (î15è) bc Z
+280 -145 M (10è) tc Z
+896 -150 M (15è) tc Z
+1436 -154 M (20è) tc Z
+2367 -161 M (30è) tc Z
+3177 -165 M (40è) tc Z
+-136 912 M (85è) mr Z
+10 setmiterlimit
+8 W
+{0 A} FS
+O1
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+14 W
+V 1397 1380 T 46.0014536254 R
+N 0 0 M 1205 0 D S
+U
+V 2382 2400 T 46.0014536254 R
+PSL_vecheadpen
+0 W
+0 0 M
+-213 35 D
+0 -70 D
+P clip fs N 
+U
+FQ
+177 1890 1890 Sc
+N 1635 2136 M 510 -492 D S
+2440 2459 M 400 F0
+V -43.9985463746 R (N) bc Z U
+3.32550952342 setmiterlimit
+0 A
+%%EndObject
+-4607 -4607 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JOa8/-82/46/3.1496i -T8/-82/3c -Ba5fg -BWENS -Xa0i -Ya0i -R-200/200/-200/200+uk
+%@PROJ: omerc -9.70601553 25.89079338 -84.64268898 -79.35704396 -200000.000 200000.000 -200000.000 200000.000 +unavailable +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+-2 3571 M
+2 4 D
+105 205 D
+0 0 D S
+-2 3251 M
+2 3 D
+108 203 D
+22 41 D
+52 97 D
+99 185 D
+0 1 D S
+-2 2951 M
+2 3 D
+410 735 D
+50 91 D
+0 1 D S
+-2 2669 M
+2 3 D
+21 36 D
+138 238 D
+115 199 D
+69 118 D
+138 238 D
+115 199 D
+46 80 D
+1 1 D S
+-2 2404 M
+2 3 D
+88 145 D
+104 173 D
+71 117 D
+52 87 D
+114 188 D
+104 173 D
+71 117 D
+90 149 D
+90 149 D
+38 63 D
+7 12 D
+0 1 D S
+-2 2153 M
+2 3 D
+136 216 D
+24 39 D
+88 139 D
+97 156 D
+88 139 D
+34 55 D
+146 233 D
+88 139 D
+97 156 D
+93 147 D
+34 55 D
+94 150 D
+0 1 D S
+-2 1916 M
+2 2 D
+328 504 D
+321 492 D
+564 866 D
+1 1 D S
+-2 1691 M
+2 2 D
+31 47 D
+16 22 D
+61 92 D
+16 22 D
+20 31 D
+16 22 D
+61 92 D
+16 22 D
+20 31 D
+16 22 D
+61 92 D
+16 22 D
+31 46 D
+113 167 D
+113 167 D
+113 167 D
+113 167 D
+102 152 D
+16 22 D
+31 46 D
+66 99 D
+16 22 D
+20 31 D
+16 22 D
+61 92 D
+16 22 D
+20 31 D
+16 22 D
+20 31 D
+11 15 D
+66 99 D
+16 22 D
+20 31 D
+11 15 D
+55 82 D
+1 1 D S
+-2 1477 M
+2 2 D
+33 48 D
+16 22 D
+26 38 D
+27 37 D
+68 98 D
+16 22 D
+26 38 D
+16 22 D
+121 173 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+27 37 D
+68 98 D
+16 22 D
+26 38 D
+16 22 D
+100 143 D
+16 22 D
+26 38 D
+27 37 D
+68 98 D
+16 22 D
+26 38 D
+27 37 D
+68 98 D
+16 22 D
+26 38 D
+27 37 D
+68 98 D
+16 22 D
+26 38 D
+27 37 D
+17 26 D
+1 1 D S
+-2 1274 M
+2 2 D
+439 603 D
+216 296 D
+410 563 D
+529 726 D
+230 316 D
+1 1 D S
+-2 1080 M
+2 2 D
+74 98 D
+28 36 D
+27 37 D
+78 102 D
+27 37 D
+28 36 D
+27 37 D
+23 29 D
+27 37 D
+28 36 D
+27 37 D
+78 102 D
+27 37 D
+78 102 D
+27 37 D
+28 36 D
+27 37 D
+23 29 D
+27 37 D
+28 36 D
+27 37 D
+45 58 D
+27 37 D
+61 80 D
+11 15 D
+94 124 D
+22 30 D
+28 36 D
+16 22 D
+83 110 D
+28 36 D
+27 37 D
+72 95 D
+111 146 D
+27 37 D
+28 36 D
+27 37 D
+23 29 D
+27 37 D
+28 36 D
+27 37 D
+23 29 D
+16 22 D
+94 125 D
+17 21 D
+27 37 D
+72 95 D
+83 110 D
+28 36 D
+27 37 D
+75 99 D
+1 1 D S
+-2 894 M
+2 3 D
+48 60 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+11 15 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+40 50 D
+11 15 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+16 22 D
+12 14 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+11 15 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+51 65 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+11 15 D
+51 65 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+51 65 D
+17 21 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+40 50 D
+11 15 D
+68 86 D
+11 15 D
+6 8 D
+1 1 D S
+-2 717 M
+2 2 D
+73 90 D
+98 121 D
+75 92 D
+52 64 D
+109 135 D
+52 64 D
+47 57 D
+11 15 D
+41 49 D
+11 15 D
+35 42 D
+11 15 D
+41 49 D
+11 15 D
+41 49 D
+11 15 D
+41 50 D
+52 64 D
+69 85 D
+52 64 D
+179 221 D
+34 42 D
+52 64 D
+46 57 D
+52 64 D
+47 57 D
+11 15 D
+41 49 D
+11 15 D
+41 50 D
+52 64 D
+69 85 D
+52 64 D
+52 64 D
+161 199 D
+52 64 D
+47 57 D
+11 15 D
+41 49 D
+11 15 D
+41 50 D
+52 64 D
+69 85 D
+52 64 D
+52 64 D
+52 64 D
+52 64 D
+52 64 D
+23 29 D
+35 42 D
+8 11 D
+1 1 D S
+-2 547 M
+2 2 D
+94 112 D
+347 413 D
+360 428 D
+77 92 D
+289 344 D
+353 420 D
+260 309 D
+118 141 D
+348 414 D
+348 414 D
+121 144 D
+1 1 D S
+-2 384 M
+2 2 D
+86 100 D
+7 6 D
+324 374 D
+49 55 D
+319 367 D
+378 435 D
+85 97 D
+300 346 D
+7 6 D
+372 429 D
+85 97 D
+270 311 D
+73 83 D
+252 290 D
+187 215 D
+145 166 D
+12 13 D
+2 4 D
+2 1 D S
+-2 228 M
+2 2 D
+69 76 D
+92 102 D
+36 41 D
+7 6 D
+36 41 D
+49 55 D
+7 6 D
+36 41 D
+80 89 D
+6 7 D
+7 6 D
+61 69 D
+55 61 D
+98 109 D
+6 7 D
+7 6 D
+55 62 D
+30 34 D
+7 6 D
+36 41 D
+56 62 D
+36 40 D
+86 96 D
+6 7 D
+7 6 D
+36 41 D
+56 62 D
+36 40 D
+56 62 D
+36 40 D
+86 96 D
+6 7 D
+7 6 D
+61 69 D
+55 61 D
+55 61 D
+37 41 D
+12 14 D
+7 6 D
+55 62 D
+30 34 D
+7 6 D
+61 69 D
+55 61 D
+98 109 D
+6 7 D
+7 6 D
+55 62 D
+30 34 D
+7 6 D
+42 48 D
+50 55 D
+122 136 D
+6 7 D
+7 6 D
+55 62 D
+37 41 D
+92 102 D
+36 40 D
+86 96 D
+6 7 D
+7 6 D
+36 41 D
+56 62 D
+36 40 D
+80 89 D
+12 14 D
+7 6 D
+36 41 D
+50 55 D
+36 41 D
+7 6 D
+55 62 D
+30 34 D
+7 6 D
+36 41 D
+80 89 D
+92 102 D
+37 41 D
+31 34 D
+1 2 D
+2 1 D S
+-2 77 M
+2 2 D
+33 35 D
+31 34 D
+7 6 D
+100 108 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+37 40 D
+100 108 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+18 21 D
+7 6 D
+12 14 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+100 108 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+62 67 D
+75 81 D
+7 6 D
+100 108 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+62 67 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+12 14 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+43 47 D
+7 6 D
+12 14 D
+7 6 D
+18 21 D
+7 6 D
+75 81 D
+18 20 D
+1 1 D S
+63 -1 M
+1 1 D
+17 18 D
+7 6 D
+25 27 D
+7 6 D
+102 106 D
+31 33 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+102 106 D
+12 13 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+102 106 D
+12 13 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+101 106 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+82 86 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+102 106 D
+12 13 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+101 106 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+101 106 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+101 106 D
+7 6 D
+25 27 D
+7 6 D
+101 106 D
+7 6 D
+25 27 D
+7 6 D
+101 106 D
+7 6 D
+25 27 D
+7 6 D
+102 106 D
+31 33 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+101 106 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+114 119 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+50 53 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+50 53 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+25 27 D
+7 6 D
+50 53 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+82 86 D
+7 6 D
+25 27 D
+7 6 D
+12 14 D
+7 6 D
+6 7 D
+7 6 D
+12 14 D
+7 6 D
+80 84 D
+2 1 D S
+205 -1 M
+2 1 D
+11 12 D
+7 6 D
+6 7 D
+130 129 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+156 155 D
+6 7 D
+7 6 D
+6 7 D
+843 842 D
+6 7 D
+156 155 D
+6 7 D
+7 6 D
+6 7 D
+130 129 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+104 103 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+104 103 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+78 77 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+52 51 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+52 51 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+26 25 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+13 12 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+12 13 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+13 12 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+12 13 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+13 12 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+39 38 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+7 6 D
+6 7 D
+4 3 D
+1 1 D S
+353 -1 M
+1 1 D
+29 27 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+106 101 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+53 51 D
+33 31 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+106 101 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+106 102 D
+13 12 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+106 101 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+53 51 D
+33 31 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+53 50 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+86 82 D
+6 7 D
+27 25 D
+6 7 D
+106 102 D
+33 31 D
+6 7 D
+27 25 D
+6 7 D
+106 101 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+53 50 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+53 51 D
+33 31 D
+6 7 D
+27 25 D
+6 7 D
+14 12 D
+6 7 D
+119 114 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+106 101 D
+6 7 D
+27 25 D
+6 7 D
+106 102 D
+33 31 D
+6 7 D
+27 25 D
+6 7 D
+106 101 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+86 82 D
+6 7 D
+14 12 D
+6 7 D
+7 6 D
+6 7 D
+14 12 D
+6 7 D
+106 102 D
+13 12 D
+6 7 D
+14 12 D
+6 7 D
+27 25 D
+6 7 D
+82 78 D
+1 1 D S
+506 -2 M
+1 2 D
+136 126 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+94 87 D
+81 75 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+108 100 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+41 37 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+67 62 D
+81 75 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+67 62 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+41 37 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+20 18 D
+6 7 D
+21 18 D
+6 7 D
+81 75 D
+67 62 D
+6 7 D
+81 75 D
+47 43 D
+6 7 D
+81 75 D
+8 7 D
+1 1 D S
+664 -2 M
+2 2 D
+78 70 D
+14 12 D
+6 7 D
+41 36 D
+89 80 D
+102 92 D
+41 37 D
+109 98 D
+7 6 D
+6 7 D
+62 55 D
+41 37 D
+40 36 D
+62 56 D
+41 36 D
+6 7 D
+41 36 D
+55 49 D
+6 7 D
+41 36 D
+89 80 D
+102 92 D
+41 37 D
+75 68 D
+40 36 D
+96 86 D
+7 6 D
+6 7 D
+41 36 D
+55 50 D
+136 122 D
+7 6 D
+6 7 D
+62 55 D
+34 30 D
+6 7 D
+41 36 D
+62 56 D
+40 36 D
+89 80 D
+14 12 D
+6 7 D
+41 36 D
+55 50 D
+40 36 D
+62 56 D
+41 36 D
+6 7 D
+41 36 D
+55 49 D
+6 7 D
+41 36 D
+55 50 D
+47 42 D
+89 80 D
+7 6 D
+6 7 D
+41 36 D
+62 56 D
+40 36 D
+89 80 D
+102 92 D
+41 37 D
+75 68 D
+40 36 D
+89 80 D
+1 1 D S
+829 -2 M
+2 2 D
+269 234 D
+402 350 D
+366 318 D
+69 61 D
+304 264 D
+118 103 D
+255 222 D
+215 187 D
+159 138 D
+6 7 D
+367 318 D
+41 37 D
+332 288 D
+41 37 D
+5 3 D
+1 1 D S
+1001 -2 M
+2 2 D
+264 223 D
+15 11 D
+400 337 D
+420 353 D
+484 407 D
+541 455 D
+497 418 D
+156 131 D
+1 1 D S
+1180 -2 M
+1 2 D
+98 79 D
+71 58 D
+64 52 D
+64 52 D
+29 23 D
+43 35 D
+64 52 D
+85 69 D
+64 52 D
+64 52 D
+64 52 D
+64 52 D
+64 52 D
+29 23 D
+42 34 D
+64 52 D
+57 47 D
+15 11 D
+49 41 D
+15 11 D
+50 41 D
+64 52 D
+64 52 D
+92 75 D
+391 317 D
+64 52 D
+64 52 D
+64 52 D
+57 47 D
+15 11 D
+49 41 D
+15 11 D
+49 41 D
+15 11 D
+49 41 D
+15 11 D
+50 41 D
+64 52 D
+64 52 D
+64 52 D
+64 52 D
+67 54 D
+1 1 D S
+1366 -2 M
+2 2 D
+63 50 D
+22 16 D
+144 114 D
+22 16 D
+144 114 D
+22 16 D
+144 114 D
+22 16 D
+79 63 D
+15 11 D
+50 40 D
+22 16 D
+79 63 D
+15 11 D
+50 40 D
+22 16 D
+14 12 D
+15 11 D
+50 40 D
+15 11 D
+50 40 D
+15 11 D
+21 17 D
+15 11 D
+50 40 D
+15 11 D
+86 68 D
+15 11 D
+195 153 D
+64 51 D
+15 11 D
+50 40 D
+22 16 D
+14 12 D
+15 11 D
+50 40 D
+15 11 D
+50 40 D
+15 11 D
+21 17 D
+15 11 D
+195 153 D
+64 51 D
+15 11 D
+50 40 D
+22 16 D
+14 12 D
+15 11 D
+50 40 D
+15 11 D
+65 51 D
+21 17 D
+15 11 D
+50 40 D
+4 2 D
+1 1 D S
+1561 -2 M
+2 2 D
+175 132 D
+146 111 D
+37 27 D
+102 78 D
+37 27 D
+36 28 D
+37 27 D
+29 23 D
+37 27 D
+36 28 D
+30 22 D
+36 28 D
+22 16 D
+146 111 D
+37 27 D
+58 45 D
+37 27 D
+102 78 D
+37 27 D
+36 28 D
+30 22 D
+36 28 D
+22 16 D
+66 50 D
+80 61 D
+37 27 D
+58 45 D
+37 27 D
+51 39 D
+146 111 D
+37 27 D
+36 28 D
+37 27 D
+29 23 D
+22 16 D
+95 72 D
+146 111 D
+39 29 D
+1 0 D S
+1765 -2 M
+3 2 D
+481 351 D
+1526 1113 D
+5 3 D
+1 1 D S
+1979 -2 M
+3 2 D
+90 63 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+22 16 D
+113 79 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+45 31 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+68 47 D
+22 16 D
+38 26 D
+37 27 D
+14 9 D
+1 1 D S
+2204 -2 M
+3 2 D
+226 153 D
+61 41 D
+22 16 D
+31 20 D
+15 11 D
+99 66 D
+22 16 D
+31 20 D
+15 11 D
+38 25 D
+15 11 D
+99 67 D
+205 138 D
+22 16 D
+31 20 D
+22 16 D
+31 20 D
+15 11 D
+38 25 D
+15 11 D
+99 67 D
+205 138 D
+22 16 D
+31 20 D
+22 16 D
+31 20 D
+22 16 D
+88 59 D
+1 1 D S
+2441 -2 M
+2 2 D
+717 468 D
+620 404 D
+1 1 D S
+2690 -2 M
+3 2 D
+399 251 D
+39 24 D
+155 98 D
+39 24 D
+155 98 D
+39 24 D
+147 93 D
+47 29 D
+67 42 D
+1 1 D S
+2954 -2 M
+3 2 D
+211 128 D
+86 52 D
+86 52 D
+94 57 D
+95 57 D
+188 114 D
+63 38 D
+1 0 D S
+3233 -2 M
+3 2 D
+196 114 D
+119 69 D
+229 133 D
+1 1 D S
+3529 -2 M
+3 2 D
+245 137 D
+3 1 D
+1 1 D S
+-1 758 M
+1 -1 D
+107 -87 D
+49 -42 D
+49 -43 D
+77 -68 D
+4 -5 D
+39 -34 D
+4 -5 D
+29 -26 D
+4 -5 D
+10 -8 D
+4 -5 D
+38 -35 D
+4 -5 D
+24 -22 D
+4 -5 D
+33 -31 D
+27 -28 D
+5 -4 D
+4 -5 D
+5 -4 D
+31 -33 D
+5 -4 D
+4 -5 D
+5 -4 D
+22 -24 D
+5 -4 D
+22 -24 D
+5 -4 D
+70 -76 D
+5 -4 D
+34 -39 D
+5 -4 D
+43 -49 D
+14 -16 D
+1 -1 D S
+-1 2050 M
+1 -1 D
+84 -54 D
+25 -17 D
+143 -97 D
+49 -35 D
+43 -30 D
+127 -94 D
+132 -101 D
+29 -24 D
+99 -80 D
+87 -73 D
+57 -49 D
+107 -94 D
+5 -6 D
+67 -61 D
+33 -30 D
+5 -6 D
+28 -25 D
+10 -11 D
+17 -15 D
+5 -6 D
+22 -20 D
+5 -6 D
+54 -52 D
+10 -11 D
+6 -5 D
+10 -11 D
+6 -5 D
+10 -11 D
+6 -5 D
+31 -33 D
+11 -10 D
+15 -17 D
+11 -10 D
+67 -71 D
+5 -6 D
+6 -5 D
+46 -50 D
+145 -163 D
+49 -57 D
+48 -58 D
+48 -58 D
+42 -53 D
+19 -23 D
+32 -42 D
+19 -23 D
+104 -138 D
+13 -19 D
+36 -48 D
+17 -25 D
+22 -31 D
+26 -37 D
+26 -38 D
+1 -1 D S
+-1 3266 M
+1 -1 D
+65 -35 D
+90 -49 D
+22 -13 D
+90 -51 D
+162 -97 D
+95 -59 D
+152 -98 D
+35 -24 D
+15 -9 D
+57 -39 D
+133 -93 D
+133 -96 D
+109 -82 D
+28 -21 D
+13 -11 D
+95 -74 D
+13 -11 D
+67 -54 D
+26 -22 D
+47 -38 D
+98 -84 D
+116 -102 D
+139 -128 D
+56 -53 D
+129 -126 D
+37 -36 D
+102 -105 D
+53 -56 D
+23 -25 D
+24 -25 D
+11 -13 D
+70 -76 D
+11 -13 D
+46 -51 D
+28 -33 D
+51 -58 D
+94 -112 D
+32 -40 D
+22 -26 D
+32 -41 D
+11 -13 D
+95 -122 D
+21 -27 D
+87 -117 D
+106 -147 D
+53 -77 D
+49 -72 D
+52 -78 D
+9 -15 D
+56 -86 D
+9 -15 D
+77 -124 D
+79 -133 D
+34 -60 D
+1 0 D
+0 -1 D S
+1192 3781 M
+3 -1 D
+27 -19 D
+41 -26 D
+184 -125 D
+134 -95 D
+147 -109 D
+39 -29 D
+160 -124 D
+38 -30 D
+22 -19 D
+68 -55 D
+37 -30 D
+29 -25 D
+45 -37 D
+153 -133 D
+93 -84 D
+114 -105 D
+105 -100 D
+6 -7 D
+69 -67 D
+35 -34 D
+40 -42 D
+28 -27 D
+53 -55 D
+93 -98 D
+73 -78 D
+19 -22 D
+39 -43 D
+77 -86 D
+132 -154 D
+43 -52 D
+43 -52 D
+18 -23 D
+19 -22 D
+108 -137 D
+53 -68 D
+52 -70 D
+69 -93 D
+45 -63 D
+17 -23 D
+18 -25 D
+1 -3 D S
+2935 3781 M
+2 -1 D
+167 -148 D
+32 -29 D
+7 -8 D
+56 -50 D
+7 -8 D
+40 -36 D
+7 -8 D
+32 -29 D
+7 -8 D
+31 -29 D
+70 -67 D
+7 -8 D
+54 -52 D
+30 -31 D
+8 -7 D
+52 -54 D
+8 -7 D
+37 -39 D
+8 -7 D
+22 -24 D
+8 -7 D
+14 -16 D
+8 -7 D
+29 -32 D
+8 -7 D
+94 -101 D
+1 -1 D S
+8 W
+N 829 3780 M 43 71 D S
+N 1824 3780 M 49 67 D S
+N 2953 3780 M 55 62 D S
+N 354 0 M -60 -58 D S
+N 1181 0 M -64 -52 D S
+N 2207 0 M -69 -47 D S
+N 3532 0 M -73 -41 D S
+N 3780 2961 M 56 -61 D S
+N 105 3780 M 19 37 D S
+N 281 3780 M 19 36 D S
+N 460 3780 M 20 36 D S
+N 642 3780 M 21 36 D S
+N 829 3780 M 21 35 D S
+N 1019 3780 M 22 35 D S
+N 1213 3780 M 23 34 D S
+N 1412 3780 M 23 34 D S
+N 1615 3780 M 24 34 D S
+N 1824 3780 M 24 33 D S
+N 2038 3780 M 25 33 D S
+N 2257 3780 M 26 32 D S
+N 2483 3780 M 26 32 D S
+N 2715 3780 M 26 31 D S
+N 2953 3780 M 28 31 D S
+N 3199 3780 M 28 30 D S
+N 3453 3780 M 29 30 D S
+N 64 0 M -29 -30 D S
+N 3715 3780 M 29 29 D S
+N 207 0 M -30 -29 D S
+N 354 0 M -30 -29 D S
+N 507 0 M -30 -28 D S
+N 666 0 M -31 -28 D S
+N 831 0 M -31 -27 D S
+N 1003 0 M -32 -27 D S
+N 1181 0 M -32 -26 D S
+N 1368 0 M -33 -26 D S
+N 1563 0 M -33 -25 D S
+N 1768 0 M -34 -25 D S
+N 1982 0 M -34 -24 D S
+N 2207 0 M -35 -23 D S
+N 2443 0 M -34 -23 D S
+N 2693 0 M -35 -22 D S
+N 2957 0 M -36 -22 D S
+N 3236 0 M -36 -21 D S
+N 3532 0 M -36 -20 D S
+N 0 757 M -32 27 D S
+N 0 2049 M -35 23 D S
+N 0 3265 M -37 20 D S
+N 3780 1294 M 24 -34 D S
+N 3780 2961 M 28 -30 D S
+25 W
+2 setlinecap
+N 0 0 M 0 3780 D S
+N 3780 0 M 0 3780 D S
+N 0 0 M 3780 0 D S
+N 0 3780 M 3780 0 D S
+0 setlinecap
+872 3934 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(î5è) bc Z
+1873 3930 M (0è) bc Z
+3008 3926 M (5è) bc Z
+294 -141 M (10è) tc Z
+1117 -136 M (15è) tc Z
+2138 -130 M (20è) tc Z
+3459 -124 M (25è) tc Z
+3919 2900 M (î80è) ml Z
+10 setmiterlimit
+8 W
+{0 A} FS
+O1
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+14 W
+V 1397 1380 T 46.0014536255 R
+N 0 0 M 1205 0 D S
+U
+V 2382 2400 T 46.0014536255 R
+PSL_vecheadpen
+0 W
+0 0 M
+-213 35 D
+0 -70 D
+P clip fs N 
+U
+FQ
+177 1890 1890 Sc
+N 1635 2136 M 510 -492 D S
+2440 2459 M 400 F0
+V -43.9985463745 R (N) bc Z U
+3.32550952342 setmiterlimit
+0 A
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4607 0 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JOa8/-87/46/3.1496i -T8/-87/3c -Ba5fg -BWENS -Xa3.8394i -Ya0i -R-200/200/-200/200+uk
+%@PROJ: omerc -31.99826800 48.84237209 -89.64075728 -84.35696082 -200000.000 200000.000 -200000.000 200000.000 +unavailable +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+2935 3762 M
+14 18 D
+1 1 D S
+3007 3705 M
+22 28 D
+23 27 D
+15 20 D
+2 1 D S
+3078 3647 M
+80 95 D
+31 38 D
+1 1 D S
+3147 3587 M
+47 54 D
+47 53 D
+35 41 D
+39 45 D
+1 1 D S
+3216 3526 M
+113 126 D
+54 59 D
+23 27 D
+38 42 D
+1 1 D S
+3283 3464 M
+103 111 D
+7 6 D
+78 85 D
+7 6 D
+91 98 D
+6 6 D
+2 4 D
+2 1 D S
+3350 3401 M
+24 26 D
+7 6 D
+24 26 D
+7 6 D
+74 77 D
+24 26 D
+13 12 D
+18 20 D
+13 12 D
+24 26 D
+7 6 D
+24 26 D
+7 6 D
+67 71 D
+13 12 D
+19 21 D
+2 1 D S
+3415 3337 M
+227 226 D
+37 38 D
+7 6 D
+37 38 D
+7 6 D
+37 38 D
+13 12 D
+1 2 D S
+3479 3272 M
+26 24 D
+6 7 D
+26 24 D
+6 7 D
+71 67 D
+12 13 D
+20 18 D
+12 13 D
+26 24 D
+6 7 D
+39 37 D
+32 30 D
+6 7 D
+13 12 D
+1 1 D S
+3542 3205 M
+124 116 D
+104 97 D
+6 6 D
+4 2 D
+1 2 D S
+3604 3138 M
+33 30 D
+27 23 D
+105 95 D
+11 10 D
+1 1 D S
+3665 3069 M
+67 59 D
+48 41 D
+1 1 D S
+3724 3000 M
+28 22 D
+28 24 D
+1 1 D S
+-2 34 M
+2 2 D
+190 261 D
+333 458 D
+306 421 D
+263 362 D
+306 421 D
+306 421 D
+349 480 D
+290 399 D
+379 521 D
+0 1 D S
+2911 3781 M
+2 -1 D
+110 -88 D
+112 -94 D
+100 -89 D
+99 -92 D
+8 -9 D
+27 -25 D
+8 -9 D
+27 -25 D
+77 -79 D
+8 -9 D
+9 -8 D
+91 -99 D
+89 -100 D
+87 -103 D
+7 -10 D
+8 -8 D
+1 -2 D S
+-1 630 M
+1 0 D
+59 -20 D
+55 -22 D
+58 -27 D
+60 -32 D
+33 -21 D
+29 -19 D
+43 -31 D
+23 -18 D
+27 -22 D
+3 -4 D
+22 -19 D
+29 -27 D
+23 -25 D
+4 -3 D
+6 -8 D
+4 -3 D
+38 -45 D
+36 -46 D
+14 -20 D
+5 -9 D
+21 -32 D
+23 -38 D
+27 -52 D
+29 -63 D
+9 -24 D
+1 -1 D S
+0 1703 M
+109 -19 D
+95 -21 D
+104 -29 D
+93 -30 D
+101 -39 D
+98 -43 D
+87 -44 D
+94 -53 D
+91 -58 D
+87 -62 D
+62 -48 D
+53 -44 D
+36 -33 D
+15 -13 D
+77 -75 D
+41 -42 D
+19 -22 D
+58 -67 D
+49 -61 D
+52 -71 D
+54 -81 D
+46 -76 D
+60 -112 D
+49 -106 D
+23 -55 D
+24 -64 D
+31 -92 D
+27 -95 D
+20 -85 D
+13 -63 D
+0 0 D S
+0 2761 M
+140 -17 D
+109 -17 D
+129 -26 D
+100 -24 D
+127 -35 D
+77 -24 D
+104 -36 D
+110 -43 D
+107 -46 D
+113 -54 D
+13 -7 D
+71 -37 D
+109 -62 D
+81 -50 D
+92 -60 D
+96 -69 D
+69 -53 D
+41 -32 D
+67 -57 D
+17 -14 D
+76 -69 D
+64 -61 D
+26 -25 D
+35 -37 D
+6 -5 D
+94 -103 D
+14 -17 D
+29 -33 D
+69 -86 D
+35 -47 D
+14 -17 D
+80 -114 D
+72 -111 D
+19 -31 D
+7 -13 D
+37 -63 D
+52 -97 D
+49 -99 D
+57 -127 D
+33 -82 D
+40 -110 D
+34 -105 D
+33 -112 D
+7 -29 D
+29 -121 D
+21 -108 D
+15 -94 D
+7 -44 D
+4 -38 D
+0 0 D S
+308 3782 M
+14 -2 D
+168 -29 D
+153 -32 D
+133 -33 D
+122 -35 D
+149 -47 D
+83 -29 D
+128 -49 D
+73 -30 D
+160 -71 D
+88 -43 D
+87 -45 D
+78 -42 D
+76 -44 D
+17 -9 D
+92 -56 D
+82 -53 D
+89 -60 D
+96 -69 D
+101 -77 D
+46 -36 D
+22 -19 D
+38 -31 D
+37 -32 D
+59 -51 D
+58 -53 D
+85 -81 D
+35 -34 D
+68 -70 D
+13 -15 D
+34 -35 D
+19 -22 D
+33 -36 D
+89 -104 D
+86 -107 D
+94 -125 D
+67 -96 D
+16 -25 D
+27 -41 D
+68 -107 D
+50 -84 D
+14 -26 D
+15 -25 D
+78 -147 D
+47 -96 D
+73 -161 D
+48 -118 D
+24 -63 D
+36 -102 D
+28 -83 D
+18 -56 D
+40 -141 D
+18 -68 D
+2 -9 D S
+2911 3781 M
+2 -1 D
+110 -88 D
+112 -94 D
+100 -89 D
+99 -92 D
+8 -9 D
+27 -25 D
+8 -9 D
+27 -25 D
+77 -79 D
+8 -9 D
+9 -8 D
+91 -99 D
+89 -100 D
+87 -103 D
+7 -10 D
+8 -8 D
+1 -2 D S
+8 W
+N 139 3780 M 9 82 D S
+N 510 3780 M 16 81 D S
+N 894 3780 M 23 80 D S
+N 1297 3780 M 30 77 D S
+N 1729 3780 M 37 74 D S
+N 2199 3780 M 43 71 D S
+N 2722 3780 M 49 67 D S
+N 28 0 M -55 -63 D S
+N 3315 3780 M 54 62 D S
+N 91 0 M -60 -58 D S
+N 166 0 M -65 -52 D S
+N 260 0 M -69 -47 D S
+N 381 0 M -73 -40 D S
+N 548 0 M -76 -34 D S
+N 797 0 M -79 -27 D S
+N 1215 0 M -81 -20 D S
+N 2083 0 M -82 -13 D S
+N 3780 2933 M 52 -65 D S
+N 66 3780 M 3 41 D S
+N 139 3780 M 4 41 D S
+N 212 3780 M 5 41 D S
+N 286 3780 M 6 41 D S
+N 360 3780 M 7 41 D S
+N 435 3780 M 7 41 D S
+N 510 3780 M 8 40 D S
+N 585 3780 M 9 40 D S
+N 661 3780 M 10 40 D S
+N 738 3780 M 10 40 D S
+N 816 3780 M 10 40 D S
+N 894 3780 M 11 40 D S
+N 973 3780 M 12 39 D S
+N 1052 3780 M 13 39 D S
+N 1133 3780 M 14 39 D S
+N 1215 3780 M 14 39 D S
+N 1297 3780 M 15 38 D S
+N 1381 3780 M 16 38 D S
+N 1466 3780 M 16 38 D S
+N 1552 3780 M 17 38 D S
+N 1640 3780 M 18 37 D S
+N 1729 3780 M 18 37 D S
+N 1820 3780 M 19 37 D S
+N 1912 3780 M 19 36 D S
+N 2006 3780 M 20 36 D S
+N 2101 3780 M 21 36 D S
+N 2199 3780 M 22 35 D S
+N 2299 3780 M 22 35 D S
+N 2401 3780 M 23 34 D S
+N 2505 3780 M 24 34 D S
+N 2612 3780 M 24 34 D S
+N 2722 3780 M 24 33 D S
+N 2834 3780 M 25 33 D S
+N 2949 3780 M 26 32 D S
+N 5 0 M -26 -32 D S
+N 3067 3780 M 27 32 D S
+N 16 0 M -26 -32 D S
+N 3189 3780 M 27 31 D S
+N 28 0 M -28 -31 D S
+N 3315 3780 M 27 31 D S
+N 40 0 M -28 -31 D S
+N 3444 3780 M 28 30 D S
+N 52 0 M -29 -30 D S
+N 3577 3780 M 29 30 D S
+N 64 0 M -29 -30 D S
+N 3715 3780 M 29 29 D S
+N 77 0 M -29 -29 D S
+N 91 0 M -30 -29 D S
+N 105 0 M -31 -28 D S
+N 119 0 M -31 -28 D S
+N 134 0 M -31 -27 D S
+N 150 0 M -32 -27 D S
+N 166 0 M -32 -26 D S
+N 183 0 M -33 -26 D S
+N 201 0 M -33 -25 D S
+N 220 0 M -34 -24 D S
+N 239 0 M -34 -24 D S
+N 260 0 M -35 -23 D S
+N 281 0 M -35 -23 D S
+N 304 0 M -35 -22 D S
+N 328 0 M -35 -21 D S
+N 354 0 M -36 -21 D S
+N 381 0 M -36 -20 D S
+N 410 0 M -37 -20 D S
+N 441 0 M -37 -19 D S
+N 474 0 M -37 -18 D S
+N 510 0 M -38 -18 D S
+N 548 0 M -38 -17 D S
+N 590 0 M -39 -16 D S
+N 635 0 M -39 -16 D S
+N 684 0 M -39 -15 D S
+N 738 0 M -39 -14 D S
+N 797 0 M -39 -14 D S
+N 863 0 M -40 -13 D S
+N 936 0 M -40 -12 D S
+N 1018 0 M -40 -11 D S
+N 1110 0 M -40 -11 D S
+N 1215 0 M -40 -10 D S
+N 1336 0 M -40 -9 D S
+N 1477 0 M -41 -9 D S
+N 1643 0 M -41 -8 D S
+N 1841 0 M -41 -7 D S
+N 2083 0 M -41 -7 D S
+N 2384 0 M -41 -6 D S
+N 2769 0 M -41 -5 D S
+N 3279 0 M -41 -4 D S
+N 0 630 M -40 12 D S
+N 0 1703 M -41 6 D S
+N 0 2761 M -41 4 D S
+N 3780 636 M 10 -40 D S
+N 3780 2933 M 26 -33 D S
+25 W
+2 setlinecap
+N 0 0 M 0 3780 D S
+N 3780 0 M 0 3780 D S
+N 0 0 M 3780 0 D S
+N 0 3780 M 3780 0 D S
+0 setlinecap
+148 3946 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(î30è) bc Z
+917 3943 M (î20è) bc Z
+1766 3938 M (î10è) bc Z
+2771 3930 M (0è) bc Z
+-27 -146 M (5è) tc Z
+3369 3926 M (5è) bc Z
+718 -110 M (35è) tc Z
+2001 -96 M (45è) tc Z
+3915 2868 M (î85è) ml Z
+10 setmiterlimit
+8 W
+{0 A} FS
+O1
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+14 W
+V 1397 1380 T 46.0014536254 R
+N 0 0 M 1205 0 D S
+U
+V 2382 2400 T 46.0014536254 R
+PSL_vecheadpen
+0 W
+0 0 M
+-213 35 D
+0 -70 D
+P clip fs N 
+U
+FQ
+177 1890 1890 Sc
+N 1635 2136 M 510 -492 D S
+2440 2459 M 400 F0
+V -43.9985463746 R (N) bc Z U
+3.32550952342 setmiterlimit
+0 A
+%%EndObject
+-4607 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psbasemap/JOb_pole.sh
+++ b/test/psbasemap/JOb_pole.sh
@@ -1,0 +1,11 @@
+ #!/usr/bin/env bash
+# Ensure -JOa works close to a pole
+gmt begin JOb_pole
+	gmt set MAP_ANNOT_MIN_SPACING 32p MAP_ANNOT_OBLIQUE separate,lon_horizontal,lat_horizontal
+	gmt subplot begin 2x2 -Fs8c -M6p  -R-200/200/-200/200+uk
+ 		gmt basemap -JOa8/82/46/ -T8/82/3c -Ba5fg -c
+ 		gmt basemap -JOa8/87/46/ -T8/87/3c -Ba5fg -c
+ 		gmt basemap -JOa8/-82/46/ -T8/-82/3c -Ba5fg -c
+ 		gmt basemap -JOa8/-87/46/ -T8/-87/3c -Ba5fg -c
+ 	gmt subplot end
+ gmt end show


### PR DESCRIPTION
This particular formulation of the oblique Mercator takes a point and an azimuth and then computes a second point in that direction that is 10 degrees away from the first.  Well, if the first point is close to a pole then we might end up on the other side of the pole, doing some major longitude shifting.  This is what caused the problem in #4798.

This PR checks the distance to the pole and makes sure we do not use a distance larger than |90-lat|.  I added a new test to make sure this remains functioning.  Closes #4798.