### PR TITLE
Let -G+z automatically set -L

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -914,6 +914,10 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 		}
 	}
 
+	if (Ctrl->G.set_color && !Ctrl->L.polygon) {	/* Otherwise -G+z -Z and open polylines would color only the outline */
+		Ctrl->L.active = Ctrl->L.polygon = true;
+	}
+
 	gmt_consider_current_cpt (API, &Ctrl->C.active, &(Ctrl->C.file));
 
 	/* Check that the options selected are mutually consistent */


### PR DESCRIPTION
I had to debug to find out that without **-L** bellow the plot would only color the countries outline instead of painting them. But this is tricky and if a user selects **-G+z** a filled plot is expected. This PR sets **-L** if one was not set already when **-G+z** is active 
```
gmt pscoast -M -EPT,ES,FR+z > lixo.dat
gmt makecpt -TPT,ES,FR > lixo.cpt
gmt psxy lixo.dat -R-10/9.7/35.6/51.1 -Clixo.cpt -Ba -JM12 -G+z -L -png lixo
```
![lixo](https://user-images.githubusercontent.com/537321/107858976-b5a56b00-6e2e-11eb-8f17-efe0a2c12dcb.png)