### PR TITLE
Let legend handle both hidden and given information

### DIFF
--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -18,6 +18,7 @@ Synopsis
 [ |-C|\ *dx*/*dy* ]
 [ |-F|\ *box* ]
 [ |-J|\ *parameters* ]
+[ |-M| ]
 [ |SYN_OPT-R| ]
 [ |-S|\ *scale* ]
 [ |-T|\ *file* ]

--- a/doc/rst/source/legend_common.rst_
+++ b/doc/rst/source/legend_common.rst_
@@ -70,6 +70,14 @@ Optional Arguments
 .. |Add_-J| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-J.rst_
 
+.. _-M:
+
+**-M**
+    Modern mode only: Read both (1) the hidden auto-generated legend information file created by
+    plotting-modules' **-l** option and (2) additional information from input file(s) given on the
+    command line (or via *stdin*) [hidden file only].  For classic mode an input file must be
+    given or else we will read from *stdin*.
+
 .. _-R:
 
 .. |Add_-R| unicode:: 0x20 .. just an invisible code

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -51,6 +51,9 @@ struct PSLEGEND_CTRL {
 		bool debug;			/* If true we draw guide lines */
 		struct GMT_MAP_PANEL *panel;
 	} F;
+	struct PSLEGEND_M {	/* -M */
+		bool active;
+	} M;
 	struct PSLEGEND_S {	/* -S<scale> */
 		bool active;
 		double scale;
@@ -100,7 +103,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<specfile>] -D%s[+w<width>[/<height>]][+l<spacing>]%s [%s]\n", name, GMT_XYANCHOR, GMT_OFFSET, GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-C<dx>[/<dy>]] [-F%s]\n", GMT_PANEL);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] %s%s%s[%s] [-S<scale>]\n", GMT_J_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeo_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-M] %s%s%s[%s] [-S<scale>]\n", GMT_J_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeo_OPT);
 	if (API->GMT->current.setting.run_mode == GMT_MODERN)
 		GMT_Message (API, GMT_TIME_NONE, "\t[-T<file>] [%s] [%s] [%s]\n\t[%s]%s[%s]\n\t[%s] [%s] [%s]\n\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_t_OPT, GMT_PAR_OPT);
 	else
@@ -123,6 +126,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Set the clearance between legend frame and internal items [%gp].\n", GMT_FRAME_CLEARANCE);
 	gmt_mappanel_syntax (API->GMT, 'F', "Specify a rectangular panel behind the legend", 2);
 	GMT_Option (API, "J-,K");
+	GMT_Message (API, GMT_TIME_NONE, "\t-M Merge hidden and explicit legend information files (modern mode only).\n");
 	GMT_Option (API, "O,P,R");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S Scale all symbol sizes by <scale> [1].\n");
 	if (API->GMT->current.setting.run_mode == GMT_MODERN)
@@ -269,7 +273,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSLEGEND_CTRL *Ctrl, struct GMT_O
 				Ctrl->D.spacing = atof (opt->arg);
 				break;
 
+			case 'M':	/* Merge both hidden and explicit legend info */
+				Ctrl->M.active = true;
+				break;
+
 			case 'S':	/* Sets common symbol scale factor [1] */
+				Ctrl->S.active = true;
 				Ctrl->S.scale = atof (opt->arg);
 				break;
 
@@ -300,6 +309,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSLEGEND_CTRL *Ctrl, struct GMT_O
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.off[GMT_X] < 0.0 || Ctrl->C.off[GMT_Y] < 0.0, "Option -C: clearances cannot be negative!\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->D.active, "The -D option is required!\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.scale <= 0.0, "The -S option cannot set a zero scale!\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->M.active && GMT->current.setting.run_mode == GMT_CLASSIC, "The -M option is only available in modern mode\n");
 
 	if (!Ctrl->D.refpoint) return (GMT_PARSE_ERROR);	/* Need to exit because next ones to not apply */
 
@@ -426,15 +436,17 @@ GMT_LOCAL bool pslegend_new_fontsyntax (struct GMT_CTRL *GMT, char *word1, char 
 #define PAR	4
 #define N_DAT	5
 
+#define INFO_HIDDEN	0
+#define INFO_GIVEN	1
 #define PSLEGEND_MAX_COLS	100
 
 EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 	/* High-level function that implements the pslegend task */
-	unsigned int tbl, pos, first = 0, ID, n_item = 0;
+	unsigned int set, tbl, pos, first = 0, ID, n_item = 0;
 	int i, justify = 0, n = 0, n_columns = 1, n_col, col, error = 0, column_number = 0, id, n_scan, status = 0, max_cols = 0;
-	bool flush_paragraph = false, v_line_draw_now = false, gave_label, gave_mapscale_options, did_old = false;
+	bool flush_paragraph = false, v_line_draw_now = false, gave_label, gave_mapscale_options, did_old = false, use[2] = {false, false};
 	bool drawn = false, b_cpt = false, C_is_active = false, do_width = false, in_PS_ok = true, got_line = false;
-	uint64_t seg, row, n_fronts = 0, n_quoted_lines = 0, n_symbols = 0, n_par_lines = 0, n_par_total = 0, krow[N_DAT];
+	uint64_t seg, row, n_fronts = 0, n_quoted_lines = 0, n_symbols = 0, n_par_lines = 0, n_par_total = 0, krow[N_DAT], n_records = 0;
 	int64_t n_para = -1;
 	size_t n_char = 0;
 	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, txt_d[GMT_LEN256] = {""};
@@ -465,7 +477,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 	struct GMT_FONT ifont;
 	struct GMT_PEN current_pen;
 	struct PSLEGEND_TXT *legend_item = NULL;
-	struct GMT_DATASET *In = NULL;
+	struct GMT_DATASET *In = NULL, *INFO[2] = {NULL, NULL};
 	struct GMT_DATASET *D[N_DAT];
 	struct GMT_DATASEGMENT *S[N_DAT];
 	struct GMT_DATASEGMENT_HIDDEN *SH = NULL;
@@ -503,28 +515,39 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 		GMT->current.setting.io_seg_marker[GMT_IN] = '#';
 	}
 
-	if (gmt_legend_file (API, legend_file) == 1) {	/* Running modern mode and we have a hidden legend file to read */
-		GMT_Report (API, GMT_MSG_INFORMATION, "Processing hidden legend specification file %s\n", legend_file);
-		if ((In = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, GMT_READ_NORMAL, NULL, legend_file, NULL)) == NULL) {
-			Return (API->error);
-		}
-		if (Ctrl->T.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, GMT_WRITE_NORMAL, NULL, Ctrl->T.file, In) != GMT_NOERROR) {
-			Return (API->error);
-		}
+	if (GMT->current.setting.run_mode == GMT_MODERN) {
+		if (Ctrl->M.active)	/* use both hidden info and explicit info files */
+			use[INFO_HIDDEN] = use[INFO_GIVEN] = true;
+		else	/* Only read hidden file */
+			use[INFO_HIDDEN] = true;
 	}
-	else {	/* Possibly register stdin and/or read specified input file(s) */
+	else
+			use[INFO_GIVEN] = use[1] = true;
+
+	if (use[INFO_HIDDEN] && gmt_legend_file (API, legend_file) == 1) {	/* Running modern mode and we have a hidden legend file to read */
+		GMT_Report (API, GMT_MSG_INFORMATION, "Processing hidden legend specification file %s\n", legend_file);
+		if ((INFO[INFO_HIDDEN] = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, GMT_READ_NORMAL, NULL, legend_file, NULL)) == NULL) {
+			Return (API->error);
+		}
+		if (Ctrl->T.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, GMT_WRITE_NORMAL, NULL, Ctrl->T.file, INFO[INFO_HIDDEN]) != GMT_NOERROR) {
+			Return (API->error);
+		}
+		n_records += INFO[INFO_HIDDEN]->n_records;
+	}
+	if (use[INFO_GIVEN]) {	/* Possibly register stdin and/or read specified input file(s) */
 		if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {	/* Register data input */
 			Return (API->error);
 		}
-		if ((In = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, 0, GMT_READ_NORMAL, NULL, NULL, NULL)) == NULL) {
+		if ((INFO[INFO_GIVEN] = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, 0, GMT_READ_NORMAL, NULL, NULL, NULL)) == NULL) {
 			Return (API->error);
 		}
+		n_records += INFO[INFO_GIVEN]->n_records;
 	}
 
 	ID = GMT->current.setting.run_mode;	/* Use as index to arrays with correct module names for classic [0] or modern [1] */
 
 	if (Ctrl->D.dim[GMT_X] == 0.0) {	/* Compute legend width */
-		legend_item = gmt_M_memory (GMT, NULL, In->n_records, struct PSLEGEND_TXT);	/* Array to hold all labels */
+		legend_item = gmt_M_memory (GMT, NULL, n_records, struct PSLEGEND_TXT);	/* Array to hold all labels */
 		do_width = true;
 	}
 
@@ -535,226 +558,230 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 	quarter_line_spacing = 0.25 * one_line_spacing;
 
 	height = 2.0 * Ctrl->C.off[GMT_Y];
-	for (tbl = 0; tbl < In->n_tables; tbl++) {	/* We only expect one table but who knows what the user does */
-		for (seg = 0; seg < In->table[tbl]->n_segments; seg++) {	/* We only expect one segment in each table but again... */
-			for (row = 0; row < In->table[tbl]->segment[seg]->n_rows; row++) {	/* Finally processing the rows */
-				line = In->table[tbl]->segment[seg]->text[row];
-				if (gmt_is_a_blank_line (line) || strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Skip all headers or blank lines  */
+	for (set = INFO_HIDDEN; set <= INFO_GIVEN; set++) {
+		if (!use[set]) continue;
+		In = INFO[set];	/* Short-hand */
+		for (tbl = 0; tbl < In->n_tables; tbl++) {	/* We only expect one table but who knows what the user does */
+			for (seg = 0; seg < In->table[tbl]->n_segments; seg++) {	/* We only expect one segment in each table but again... */
+				for (row = 0; row < In->table[tbl]->segment[seg]->n_rows; row++) {	/* Finally processing the rows */
+					line = In->table[tbl]->segment[seg]->text[row];
+					if (gmt_is_a_blank_line (line) || strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Skip all headers or blank lines  */
 
-				/* Data record to process */
+					/* Data record to process */
 
-				if (line[0] != 'T' && flush_paragraph) {	/* Flush contents of pending paragraph [Call GMT_text] */
-					flush_paragraph = false;
-					column_number = 0;
-				}
-
-				switch (line[0]) {
-					case 'B':	/* Color scale Bar [Use GMT_psscale] */
-						/* B cptname offset height[+modifiers] [ Optional psscale args -B -I -L -M -N -S -Z -p ] */
-						sscanf (&line[2], "%*s %*s %s", bar_height);
-						if ((c = strchr (bar_height, '+')) != NULL) c[0] = 0;	/* Chop off any modifiers so we can compute the height */
-						height += gmt_M_to_inch (GMT, bar_height) + GMT->current.setting.map_tick_length[0] + GMT->current.setting.map_annot_offset[0] + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;
+					if (line[0] != 'T' && flush_paragraph) {	/* Flush contents of pending paragraph [Call GMT_text] */
+						flush_paragraph = false;
 						column_number = 0;
-						if (strstr (&line[2], "-B")) b_cpt = true;	/* Passed -B options with the bar presecription */
-						in_PS_ok = false;
-						break;
+					}
 
-					case 'A':	/* Color change, no height implication */
-					case 'C':
-					case 'F':
-						break;
+					switch (line[0]) {
+						case 'B':	/* Color scale Bar [Use GMT_psscale] */
+							/* B cptname offset height[+modifiers] [ Optional psscale args -B -I -L -M -N -S -Z -p ] */
+							sscanf (&line[2], "%*s %*s %s", bar_height);
+							if ((c = strchr (bar_height, '+')) != NULL) c[0] = 0;	/* Chop off any modifiers so we can compute the height */
+							height += gmt_M_to_inch (GMT, bar_height) + GMT->current.setting.map_tick_length[0] + GMT->current.setting.map_annot_offset[0] + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;
+							column_number = 0;
+							if (strstr (&line[2], "-B")) b_cpt = true;	/* Passed -B options with the bar presecription */
+							in_PS_ok = false;
+							break;
 
-					case 'D':	/* Delimiter record: D offset pen [-|=|+] */
-						txt_c[0] = '\0';
-						sscanf (&line[2], "%s %s %s", txt_a, txt_b, txt_c);
-						if (!(txt_c[0] == '-' || txt_c[0] == '=')) height += quarter_line_spacing;
-						if (!(txt_c[0] == '+' || txt_c[0] == '=')) height += quarter_line_spacing;
-						column_number = 0;
-						break;
+						case 'A':	/* Color change, no height implication */
+						case 'C':
+						case 'F':
+							break;
 
-					case 'G':	/* Gap record */
-						sscanf (&line[2], "%s", txt_a);
-						height += (txt_a[strlen(txt_a)-1] == 'l') ? atoi (txt_a) * one_line_spacing : gmt_M_to_inch (GMT, txt_a);
-						column_number = 0;
-						break;
+						case 'D':	/* Delimiter record: D offset pen [-|=|+] */
+							txt_c[0] = '\0';
+							sscanf (&line[2], "%s %s %s", txt_a, txt_b, txt_c);
+							if (!(txt_c[0] == '-' || txt_c[0] == '=')) height += quarter_line_spacing;
+							if (!(txt_c[0] == '+' || txt_c[0] == '=')) height += quarter_line_spacing;
+							column_number = 0;
+							break;
 
-					case 'H':	/* Header record */
-						sscanf (&line[2], "%s %s %[^\n]", size, font, text);
-						if (pslegend_new_fontsyntax (GMT, size, font)) {	/* GMT5 font specification */
-							sscanf (&line[2], "%s %[^\n]", font, text);
-							if (font[0] == '-')
-								sprintf (tmp, "%s", gmt_putfont (GMT, &GMT->current.setting.font_title));
-							else
-								strcpy (tmp, font);	/* Gave a font specification */
-						}
-						else {	/* Old GMT4 syntax for fontsize and font */
-							if (size[0] == '-') size[0] = 0;
-							if (font[0] == '-') font[0] = 0;
-							sprintf (tmp, "%s,%s", size, font);	/* Put size, font together for parsing by gmt_getfont */
-						}
-						ifont = GMT->current.setting.font_title;	/* Set default font */
-						gmt_getfont (GMT, tmp, &ifont);
-						height += Ctrl->D.spacing * ifont.size / PSL_POINTS_PER_INCH;
-						column_number = 0;
-						if (do_width) {
-							gmt_M_memcpy (&legend_item[n_item].font, &ifont, 1, struct GMT_FONT);
-							legend_item[n_item].string = true;
-							legend_item[n_item++].text = strdup (text);
-						}
-						break;
+						case 'G':	/* Gap record */
+							sscanf (&line[2], "%s", txt_a);
+							height += (txt_a[strlen(txt_a)-1] == 'l') ? atoi (txt_a) * one_line_spacing : gmt_M_to_inch (GMT, txt_a);
+							column_number = 0;
+							break;
 
-					case 'I':	/* Image record [use GMT_psimage] */
-						sscanf (&line[2], "%s %s %s", image, size, key);
-						first = gmt_download_file_if_not_found (GMT, image, GMT_CACHE_DIR);
-						if (gmt_getdatapath (GMT, &image[first], path, R_OK) == NULL) {
-							GMT_Report (API, GMT_MSG_ERROR, "Cannot find/open file %s.\n", &image[first]);
-							continue;
-						}
-						if ((aspect = pslegend_get_image_aspect (API, path)) < 0.0) {
-							GMT_Report (API, GMT_MSG_ERROR, "Trouble reading %s! - Skipping.\n", &image[first]);
-							continue;
-						}
-						height += gmt_M_to_inch (GMT, size) * aspect;
-						column_number = 0;
-						in_PS_ok = false;
-						break;
-
-					case 'L':	/* Label record */
-						sscanf (&line[2], "%s %s %s %[^\n]", size, font, key, text);
-						if (pslegend_new_fontsyntax (GMT, size, font)) {	/* GMT5 font specification */
-							sscanf (&line[2], "%s %s %[^\n]", font, key, text);
-							if (font[0] == '-')	/* Want default font */
-								sprintf (tmp, "%s", gmt_putfont (GMT, &GMT->current.setting.font_label));
-							else
-								strcpy (tmp, font);	/* Gave a font specification */
-						}
-						else {	/* Old GMT4 syntax for fontsize and font */
-							if (size[0] == '-') size[0] = 0;
-							if (font[0] == '-') font[0] = 0;
-							sprintf (tmp, "%s,%s", size, font);	/* Put size, font together for parsing by gmt_getfont */
-						}
-						ifont = GMT->current.setting.font_label;	/* Set default font */
-						gmt_getfont (GMT, tmp, &ifont);
-						if (column_number%n_columns == 0) {
+						case 'H':	/* Header record */
+							sscanf (&line[2], "%s %s %[^\n]", size, font, text);
+							if (pslegend_new_fontsyntax (GMT, size, font)) {	/* GMT5 font specification */
+								sscanf (&line[2], "%s %[^\n]", font, text);
+								if (font[0] == '-')
+									sprintf (tmp, "%s", gmt_putfont (GMT, &GMT->current.setting.font_title));
+								else
+									strcpy (tmp, font);	/* Gave a font specification */
+							}
+							else {	/* Old GMT4 syntax for fontsize and font */
+								if (size[0] == '-') size[0] = 0;
+								if (font[0] == '-') font[0] = 0;
+								sprintf (tmp, "%s,%s", size, font);	/* Put size, font together for parsing by gmt_getfont */
+							}
+							ifont = GMT->current.setting.font_title;	/* Set default font */
+							gmt_getfont (GMT, tmp, &ifont);
 							height += Ctrl->D.spacing * ifont.size / PSL_POINTS_PER_INCH;
 							column_number = 0;
-						}
-						column_number++;
-						if (do_width) {
-							gmt_M_memcpy (&legend_item[n_item].font, &ifont, 1, struct GMT_FONT);
-							legend_item[n_item].string = true;
-							legend_item[n_item++].text = strdup (text);
-						}
-						break;
-
-					case 'M':	/* Map scale record M lon0|- lat0 length[n|m|k][+opts] f|p  [-R -J] */
-						sscanf (&line[2], "%s %s %s %s %s %s", txt_a, txt_b, txt_c, txt_d, txt_e, txt_f);
-						for (i = 0, gave_mapscale_options = false; txt_c[i] && !gave_mapscale_options; i++) if (txt_c[i] == '+') gave_mapscale_options = true;
-						/* Default assumes label is added on top */
-						just = 't';
-						gave_label = true;
-						d_off = FONT_HEIGHT_LABEL * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH + fabs(GMT->current.setting.map_label_offset);
-						if ((txt_d[0] == 'f' || txt_d[0] == 'p') && gmt_get_modifier (txt_c, 'j', string))	/* Specified alternate justification old-style */
-							just = string[0];
-						else if (gmt_get_modifier (txt_c, 'a', string))	/* Specified alternate alignment */
-							just = string[0];
-						if (gmt_get_modifier (txt_c, 'u', string))	/* Specified alternate alignment */
-							gave_label = false;	/* Not sure why I do this, will find out */
-						if (gave_label && (just == 't' || just == 'b')) height += d_off;
-						height += GMT->current.setting.map_scale_height + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH + GMT->current.setting.map_annot_offset[0];
-						column_number = 0;
-						in_PS_ok = false;
-						break;
-
-					case 'N':	/* n_columns or column width record */
-						pos = n_columns = 0;
-						while ((gmt_strtok (&line[2], " \t", &pos, p))) {
-							n_columns++;
-							if (n_columns == PSLEGEND_MAX_COLS) {
-								GMT_Report (API, GMT_MSG_ERROR, "Exceeding maximum columns (%d) in N operator\n", PSLEGEND_MAX_COLS);
-								Return (GMT_RUNTIME_ERROR);
+							if (do_width) {
+								gmt_M_memcpy (&legend_item[n_item].font, &ifont, 1, struct GMT_FONT);
+								legend_item[n_item].string = true;
+								legend_item[n_item++].text = strdup (text);
 							}
-						}
-						if (n_columns == 0) n_columns = 1;	/* Default to 1 if nothing is given */
-						/* Check if user gave just the number of columns */
-						if (n_columns == 1 && (pos = atoi (&line[2])) > 1) n_columns = pos;
-						if (n_columns > max_cols) max_cols = n_columns;
-						column_number = 0;
-						break;
-
-					case '>':	/* Paragraph text header */
-						if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through on purpose */
-							GMT_Report (API, GMT_MSG_COMPAT, "Paragraph text header flag > is deprecated; use P instead\n");
-						else {
-							GMT_Report (API, GMT_MSG_ERROR, "Unrecognized record (%s)\n", line);
-							Return (GMT_RUNTIME_ERROR);
 							break;
-						}
-						/* Intentionally fall through */
-					case 'P':	/* Paragraph text header */
-						flush_paragraph = true;
-						column_number = 0;
-						n_par_total++;
-						in_PS_ok = false;
-						break;
 
-					case 'S':	/* Symbol record: S [dx1 symbol size fill pen [ dx2 text ]] */
-						if (column_number%n_columns == 0) {
-							height += one_line_spacing;
+						case 'I':	/* Image record [use GMT_psimage] */
+							sscanf (&line[2], "%s %s %s", image, size, key);
+							first = gmt_download_file_if_not_found (GMT, image, GMT_CACHE_DIR);
+							if (gmt_getdatapath (GMT, &image[first], path, R_OK) == NULL) {
+								GMT_Report (API, GMT_MSG_ERROR, "Cannot find/open file %s.\n", &image[first]);
+								continue;
+							}
+							if ((aspect = pslegend_get_image_aspect (API, path)) < 0.0) {
+								GMT_Report (API, GMT_MSG_ERROR, "Trouble reading %s! - Skipping.\n", &image[first]);
+								continue;
+							}
+							height += gmt_M_to_inch (GMT, size) * aspect;
 							column_number = 0;
-						}
-						column_number++;
-						text[0] = '\0';
-						n_scan = sscanf (line, "%*s %*s %s %s %*s %*s %s %[^\n]", symbol, size, txt_b, text);
-						/* Find the largest symbol size specified */
-						if ((c = strrchr (size, '/')))	/* Front, use the last arg as size since closest to height */
-							x = gmt_M_to_inch (GMT, &c[1]);
-						else {
-							if (strcmp (size, "-")) {
-								char *c = NULL;
-								if ((c = strchr (size, ','))) {	/* Probably got width,height for rectangle */
-									c[0] = '\0';
-									x = gmt_M_to_inch (GMT, size);
-									c[0] = ',';
+							in_PS_ok = false;
+							break;
+
+						case 'L':	/* Label record */
+							sscanf (&line[2], "%s %s %s %[^\n]", size, font, key, text);
+							if (pslegend_new_fontsyntax (GMT, size, font)) {	/* GMT5 font specification */
+								sscanf (&line[2], "%s %s %[^\n]", font, key, text);
+								if (font[0] == '-')	/* Want default font */
+									sprintf (tmp, "%s", gmt_putfont (GMT, &GMT->current.setting.font_label));
+								else
+									strcpy (tmp, font);	/* Gave a font specification */
+							}
+							else {	/* Old GMT4 syntax for fontsize and font */
+								if (size[0] == '-') size[0] = 0;
+								if (font[0] == '-') font[0] = 0;
+								sprintf (tmp, "%s,%s", size, font);	/* Put size, font together for parsing by gmt_getfont */
+							}
+							ifont = GMT->current.setting.font_label;	/* Set default font */
+							gmt_getfont (GMT, tmp, &ifont);
+							if (column_number%n_columns == 0) {
+								height += Ctrl->D.spacing * ifont.size / PSL_POINTS_PER_INCH;
+								column_number = 0;
+							}
+							column_number++;
+							if (do_width) {
+								gmt_M_memcpy (&legend_item[n_item].font, &ifont, 1, struct GMT_FONT);
+								legend_item[n_item].string = true;
+								legend_item[n_item++].text = strdup (text);
+							}
+							break;
+
+						case 'M':	/* Map scale record M lon0|- lat0 length[n|m|k][+opts] f|p  [-R -J] */
+							sscanf (&line[2], "%s %s %s %s %s %s", txt_a, txt_b, txt_c, txt_d, txt_e, txt_f);
+							for (i = 0, gave_mapscale_options = false; txt_c[i] && !gave_mapscale_options; i++) if (txt_c[i] == '+') gave_mapscale_options = true;
+							/* Default assumes label is added on top */
+							just = 't';
+							gave_label = true;
+							d_off = FONT_HEIGHT_LABEL * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH + fabs(GMT->current.setting.map_label_offset);
+							if ((txt_d[0] == 'f' || txt_d[0] == 'p') && gmt_get_modifier (txt_c, 'j', string))	/* Specified alternate justification old-style */
+								just = string[0];
+							else if (gmt_get_modifier (txt_c, 'a', string))	/* Specified alternate alignment */
+								just = string[0];
+							if (gmt_get_modifier (txt_c, 'u', string))	/* Specified alternate alignment */
+								gave_label = false;	/* Not sure why I do this, will find out */
+							if (gave_label && (just == 't' || just == 'b')) height += d_off;
+							height += GMT->current.setting.map_scale_height + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH + GMT->current.setting.map_annot_offset[0];
+							column_number = 0;
+							in_PS_ok = false;
+							break;
+
+						case 'N':	/* n_columns or column width record */
+							pos = n_columns = 0;
+							while ((gmt_strtok (&line[2], " \t", &pos, p))) {
+								n_columns++;
+								if (n_columns == PSLEGEND_MAX_COLS) {
+									GMT_Report (API, GMT_MSG_ERROR, "Exceeding maximum columns (%d) in N operator\n", PSLEGEND_MAX_COLS);
+									Return (GMT_RUNTIME_ERROR);
+								}
+							}
+							if (n_columns == 0) n_columns = 1;	/* Default to 1 if nothing is given */
+							/* Check if user gave just the number of columns */
+							if (n_columns == 1 && (pos = atoi (&line[2])) > 1) n_columns = pos;
+							if (n_columns > max_cols) max_cols = n_columns;
+							column_number = 0;
+							break;
+
+						case '>':	/* Paragraph text header */
+							if (gmt_M_compat_check (GMT, 4)) /* Warn and fall through on purpose */
+								GMT_Report (API, GMT_MSG_COMPAT, "Paragraph text header flag > is deprecated; use P instead\n");
+							else {
+								GMT_Report (API, GMT_MSG_ERROR, "Unrecognized record (%s)\n", line);
+								Return (GMT_RUNTIME_ERROR);
+								break;
+							}
+							/* Intentionally fall through */
+						case 'P':	/* Paragraph text header */
+							flush_paragraph = true;
+							column_number = 0;
+							n_par_total++;
+							in_PS_ok = false;
+							break;
+
+						case 'S':	/* Symbol record: S [dx1 symbol size fill pen [ dx2 text ]] */
+							if (column_number%n_columns == 0) {
+								height += one_line_spacing;
+								column_number = 0;
+							}
+							column_number++;
+							text[0] = '\0';
+							n_scan = sscanf (line, "%*s %*s %s %s %*s %*s %s %[^\n]", symbol, size, txt_b, text);
+							/* Find the largest symbol size specified */
+							if ((c = strrchr (size, '/')))	/* Front, use the last arg as size since closest to height */
+								x = gmt_M_to_inch (GMT, &c[1]);
+							else {
+								if (strcmp (size, "-")) {
+									char *c = NULL;
+									if ((c = strchr (size, ','))) {	/* Probably got width,height for rectangle */
+										c[0] = '\0';
+										x = gmt_M_to_inch (GMT, size);
+										c[0] = ',';
+									}
+									else
+										x = gmt_M_to_inch (GMT, size);
 								}
 								else
-									x = gmt_M_to_inch (GMT, size);
+									x = 0.0;
 							}
-							else
-								x = 0.0;
-						}
-						if (symbol[0] == '-') {	/* Line symbol */
-							got_line = true;
-							if (x > 0.0) line_size = x;
-						}
-						if (x > def_size) def_size = x;
-						if (n_scan > 1 && strcmp (txt_b, "-")) {
-							x = gmt_M_to_inch (GMT, txt_b);
-							if (x > def_dx2) def_dx2 = x;
-						}
-						if (do_width && n_scan == 4 && strlen (text)) {
-							gmt_M_memcpy (&legend_item[n_item].font, &(GMT->current.setting.font_annot[GMT_PRIMARY]), 1, struct GMT_FONT);
-							legend_item[n_item++].text = strdup (text);
-						}
-						break;
+							if (symbol[0] == '-') {	/* Line symbol */
+								got_line = true;
+								if (x > 0.0) line_size = x;
+							}
+							if (x > def_size) def_size = x;
+							if (n_scan > 1 && strcmp (txt_b, "-")) {
+								x = gmt_M_to_inch (GMT, txt_b);
+								if (x > def_dx2) def_dx2 = x;
+							}
+							if (do_width && n_scan == 4 && strlen (text)) {
+								gmt_M_memcpy (&legend_item[n_item].font, &(GMT->current.setting.font_annot[GMT_PRIMARY]), 1, struct GMT_FONT);
+								legend_item[n_item++].text = strdup (text);
+							}
+							break;
 
-					case 'T':	/* paragraph text record */
-						n_char += strlen (line) - 2;
-						if (!flush_paragraph) n_par_total++;	/* paragraph text without leading header provided */
-						flush_paragraph = true;
-						column_number = 0;
-						n_par_lines++;
-						in_PS_ok = false;
-						break;
+						case 'T':	/* paragraph text record */
+							n_char += strlen (line) - 2;
+							if (!flush_paragraph) n_par_total++;	/* paragraph text without leading header provided */
+							flush_paragraph = true;
+							column_number = 0;
+							n_par_lines++;
+							in_PS_ok = false;
+							break;
 
-					case 'V':	/* Vertical line from here to next V */
-						column_number = 0;
-						break;
+						case 'V':	/* Vertical line from here to next V */
+							column_number = 0;
+							break;
 
-					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Unrecognized record (%s)\n", line);
-						Return (GMT_RUNTIME_ERROR);
-					break;
+						default:
+							GMT_Report (API, GMT_MSG_ERROR, "Unrecognized record (%s)\n", line);
+							Return (GMT_RUNTIME_ERROR);
+						break;
+					}
 				}
 			}
 		}
@@ -936,805 +963,812 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 	/* Tech, note: Using GMT->current.setting.io_seg_marker[GMT_IN] instead of GMT_OUT when writing data records as segment records
 	 * since these will become input to plot, and plot will use the GMT_IN marker to identify these as header records. */
 
-	for (tbl = 0; tbl < In->n_tables; tbl++) {	/* We only expect one table but who knows what the user does */
-		for (seg = 0; seg < In->table[tbl]->n_segments; seg++) {	/* We only expect one segment in each table but again... */
-			for (row = 0; row < In->table[tbl]->segment[seg]->n_rows; row++) {	/* Finally processing the rows */
-				line = In->table[tbl]->segment[seg]->text[row];
-				if (gmt_is_a_blank_line (line) || strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Skip all headers or blank lines  */
+	for (set = INFO_HIDDEN; set <= INFO_GIVEN; set++) {
+		if (!use[set]) continue;
+		In = INFO[set];	/* Short-hand */
+		for (tbl = 0; tbl < In->n_tables; tbl++) {	/* We only expect one table but who knows what the user does */
+			for (seg = 0; seg < In->table[tbl]->n_segments; seg++) {	/* We only expect one segment in each table but again... */
+				for (row = 0; row < In->table[tbl]->segment[seg]->n_rows; row++) {	/* Finally processing the rows */
+					line = In->table[tbl]->segment[seg]->text[row];
+					if (gmt_is_a_blank_line (line) || strchr (GMT->current.setting.io_head_marker_in, line[0])) continue;	/* Skip all headers or blank lines  */
 
-				/* Data record to process */
+					/* Data record to process */
 
-				if (line[0] != 'T' && flush_paragraph) {	/* Flush contents of pending paragraph [Call GMT_text] */
-					flush_paragraph = false;
-					column_number = 0;
-				}
-
-				switch (line[0]) {
-					case 'A':	/* Z lookup color table change: A CPT */
-						if (P && GMT_Destroy_Data (API, &P) != GMT_NOERROR)	/* Remove the previous CPT from registration */
-							Return (API->error);
-						for (col = 1; line[col] == ' '; col++);	/* Wind past spaces */
-						if ((P = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, &line[col], NULL)) == NULL)
-							Return (API->error);
-						GMT->current.setting.color_model = GMT_RGB;	/* Since we will be interpreting r/g/b triplets via z=<value> */
-						break;
-
-					case 'B':	/* B cptname offset height[+modifiers] [ Optional psscale args -B -I -L -M -N -S -Z -p ] */
-						/* Color scale Bar [via GMT_psscale] */
-						module_options[0] = '\0';
-						sscanf (&line[2], "%s %s %s %[^\n]", bar_cpt, bar_gap, bar_height, module_options);
-						strcpy (bar_modifiers, bar_height);	/* Save the entire modifier string */
-						if ((c = strchr (bar_height, '+')) != NULL) c[0] = 0;	/* Chop off any modifiers so we can compute the height */
-						row_height = gmt_M_to_inch (GMT, bar_height) + GMT->current.setting.map_tick_length[0] + GMT->current.setting.map_annot_offset[0] + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;
-						pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, 1, fill);
-						x_off = gmt_M_to_inch (GMT, bar_gap);
-						sprintf (buffer, "-C%s -O -K -Dx%gi/%gi+w%gi/%s+h+jTC %s --GMT_HISTORY=readonly", bar_cpt, Ctrl->D.refpoint->x + 0.5 * Ctrl->D.dim[GMT_X], row_base_y, Ctrl->D.dim[GMT_X] - 2 * x_off, bar_modifiers, module_options);
-						GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: gmt psscale %s\n", buffer);
-						status = GMT_Call_Module (API, "psscale", GMT_MODULE_CMD, buffer);	/* Plot the colorbar */
-						if (status) {
-							GMT_Report (API, GMT_MSG_ERROR, "GMT_psscale returned error %d.\n", status);
-							Return (GMT_RUNTIME_ERROR);
-						}
-						row_base_y -= row_height;
+					if (line[0] != 'T' && flush_paragraph) {	/* Flush contents of pending paragraph [Call GMT_text] */
+						flush_paragraph = false;
 						column_number = 0;
-						API->io_enabled[GMT_IN] = true;	/* UNDOING SETTING BY psscale */
-						drawn = true;
-						break;
+					}
 
-					case 'C':	/* Font color change: C textcolor */
-						C_is_active = true;
-						sscanf (&line[2], "%[^\n]", txtcolor);
-						if (!strcmp (txtcolor, "-"))	/* Reset to default color */
-							strcpy (txtcolor, def_txtcolor);
-						else if ((API->error = gmt_get_rgbtxt_from_z (GMT, P, txtcolor)) != 0)
-							Return (GMT_RUNTIME_ERROR);	/* If given z=value then we look up colors */
-						if (gmt_getrgb (GMT, txtcolor, C_rgb)) {
-							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Text color %s not recognized!\n", txtcolor);
-							Return (GMT_RUNTIME_ERROR);
-						}
-						break;
+					switch (line[0]) {
+						case 'A':	/* Z lookup color table change: A CPT */
+							if (P && GMT_Destroy_Data (API, &P) != GMT_NOERROR)	/* Remove the previous CPT from registration */
+								Return (API->error);
+							for (col = 1; line[col] == ' '; col++);	/* Wind past spaces */
+							if ((P = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, &line[col], NULL)) == NULL)
+								Return (API->error);
+							GMT->current.setting.color_model = GMT_RGB;	/* Since we will be interpreting r/g/b triplets via z=<value> */
+							break;
 
-					case 'D':	/* Delimiter record: D [offset] <pen>|- [-|=|+] */
-						n_scan = sscanf (&line[2], "%s %s %s", txt_a, txt_b, txt_c);
-						if (n_scan < 1) {	/* Clearly a bad record */
-							GMT_Report (API, GMT_MSG_ERROR, "Not enough arguments given to D operator\n");
-							Return (GMT_RUNTIME_ERROR);
-						}
-						if (n_scan == 2) {	/* Either got D <offset> <pen OR D <pen> <flag> */
-							if (strchr ("-=+", txt_b[0])) {	/* Offset was skipped and we got D pen flag */
-								GMT_Report (API, GMT_MSG_DEBUG, "Got D pen flag --> D 0 pen flag\n");
-								strcpy (txt_c, txt_b);
+						case 'B':	/* B cptname offset height[+modifiers] [ Optional psscale args -B -I -L -M -N -S -Z -p ] */
+							/* Color scale Bar [via GMT_psscale] */
+							module_options[0] = '\0';
+							sscanf (&line[2], "%s %s %s %[^\n]", bar_cpt, bar_gap, bar_height, module_options);
+							strcpy (bar_modifiers, bar_height);	/* Save the entire modifier string */
+							if ((c = strchr (bar_height, '+')) != NULL) c[0] = 0;	/* Chop off any modifiers so we can compute the height */
+							row_height = gmt_M_to_inch (GMT, bar_height) + GMT->current.setting.map_tick_length[0] + GMT->current.setting.map_annot_offset[0] + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;
+							pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, 1, fill);
+							x_off = gmt_M_to_inch (GMT, bar_gap);
+							sprintf (buffer, "-C%s -O -K -Dx%gi/%gi+w%gi/%s+h+jTC %s --GMT_HISTORY=readonly", bar_cpt, Ctrl->D.refpoint->x + 0.5 * Ctrl->D.dim[GMT_X], row_base_y, Ctrl->D.dim[GMT_X] - 2 * x_off, bar_modifiers, module_options);
+							GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: gmt psscale %s\n", buffer);
+							status = GMT_Call_Module (API, "psscale", GMT_MODULE_CMD, buffer);	/* Plot the colorbar */
+							if (status) {
+								GMT_Report (API, GMT_MSG_ERROR, "GMT_psscale returned error %d.\n", status);
+								Return (GMT_RUNTIME_ERROR);
+							}
+							row_base_y -= row_height;
+							column_number = 0;
+							API->io_enabled[GMT_IN] = true;	/* UNDOING SETTING BY psscale */
+							drawn = true;
+							break;
+
+						case 'C':	/* Font color change: C textcolor */
+							C_is_active = true;
+							sscanf (&line[2], "%[^\n]", txtcolor);
+							if (!strcmp (txtcolor, "-"))	/* Reset to default color */
+								strcpy (txtcolor, def_txtcolor);
+							else if ((API->error = gmt_get_rgbtxt_from_z (GMT, P, txtcolor)) != 0)
+								Return (GMT_RUNTIME_ERROR);	/* If given z=value then we look up colors */
+							if (gmt_getrgb (GMT, txtcolor, C_rgb)) {
+								GMT_Report (GMT->parent, GMT_MSG_ERROR, "Text color %s not recognized!\n", txtcolor);
+								Return (GMT_RUNTIME_ERROR);
+							}
+							break;
+
+						case 'D':	/* Delimiter record: D [offset] <pen>|- [-|=|+] */
+							n_scan = sscanf (&line[2], "%s %s %s", txt_a, txt_b, txt_c);
+							if (n_scan < 1) {	/* Clearly a bad record */
+								GMT_Report (API, GMT_MSG_ERROR, "Not enough arguments given to D operator\n");
+								Return (GMT_RUNTIME_ERROR);
+							}
+							if (n_scan == 2) {	/* Either got D <offset> <pen OR D <pen> <flag> */
+								if (strchr ("-=+", txt_b[0])) {	/* Offset was skipped and we got D pen flag */
+									GMT_Report (API, GMT_MSG_DEBUG, "Got D pen flag --> D 0 pen flag\n");
+									strcpy (txt_c, txt_b);
+									strcpy (txt_b, txt_a);
+									strcpy (txt_a, "0");
+								}
+								else	/* Just wipe text_c */
+									txt_c[0] = '\0';
+							}
+							else if (n_scan == 1) {	/* Offset was skipped and we got D pen */
+								GMT_Report (API, GMT_MSG_DEBUG, "Got D pen --> D 0 pen\n");
+								txt_c[0] = '\0';
 								strcpy (txt_b, txt_a);
 								strcpy (txt_a, "0");
 							}
-							else	/* Just wipe text_c */
-								txt_c[0] = '\0';
-						}
-						else if (n_scan == 1) {	/* Offset was skipped and we got D pen */
-							GMT_Report (API, GMT_MSG_DEBUG, "Got D pen --> D 0 pen\n");
-							txt_c[0] = '\0';
-							strcpy (txt_b, txt_a);
-							strcpy (txt_a, "0");
-						}
-						d_line_hor_offset = gmt_M_to_inch (GMT, txt_a);
-						if (txt_b[0] == '-')	/* Gave - as pen, meaning just note at what y-value we are but draw no line */
-							d_line_half_width = 0.0;
-						else {	/* Process the pen specification */
-							if (txt_b[0] && gmt_getpen (GMT, txt_b, &current_pen)) gmt_pen_syntax (GMT, 'W', NULL, " ", 0);
-							gmt_setpen (GMT, &current_pen);
-							d_line_half_width = 0.5 * current_pen.width / PSL_POINTS_PER_INCH;	/* Half the pen width */
-						}
-						if (!(txt_c[0] == '-' || txt_c[0] == '=')) {	/* Fill the gap before the line, if fill is active */
-							pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-quarter_line_spacing+d_line_half_width, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
-							row_base_y -= quarter_line_spacing;
-						}
-						d_line_last_y0 = row_base_y;	/* Remember the y-value were we potentially draw the horizontal line */
-						if (d_line_half_width > 0.0) {
-							if (do_width) {
-								PSL_defunits (PSL, "PSL_legend_hor_off", 2.0 * d_line_hor_offset);
-								PSL_setcurrentpoint (PSL, Ctrl->D.refpoint->x + d_line_hor_offset, row_base_y);
-								PSL_command (PSL, "PSL_legend_box_width PSL_legend_hor_off sub 0 D S\n");
+							d_line_hor_offset = gmt_M_to_inch (GMT, txt_a);
+							if (txt_b[0] == '-')	/* Gave - as pen, meaning just note at what y-value we are but draw no line */
+								d_line_half_width = 0.0;
+							else {	/* Process the pen specification */
+								if (txt_b[0] && gmt_getpen (GMT, txt_b, &current_pen)) gmt_pen_syntax (GMT, 'W', NULL, " ", 0);
+								gmt_setpen (GMT, &current_pen);
+								d_line_half_width = 0.5 * current_pen.width / PSL_POINTS_PER_INCH;	/* Half the pen width */
 							}
-						else
-							PSL_plotsegment (PSL, Ctrl->D.refpoint->x + d_line_hor_offset, row_base_y, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X] - d_line_hor_offset, row_base_y);
-						}
-						d_line_after_gap = (txt_c[0] == '+' || txt_c[0] == '=') ? 0.0 : quarter_line_spacing;
-						row_base_y -= d_line_after_gap;
-						d_line_after_gap -= d_line_half_width;	/* Shrink the gap fill-height after a D line by half the line width so we don't overwrite the line */
-						column_number = 0;	/* Reset to new row */
-						if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
-						drawn = true;
-						break;
-
-					case 'F':	/* Cell color: F fill1[,fill2,...,filln]  */
-						/* First free all previous entries in fill array */
-						for (col = 0; col < PSLEGEND_MAX_COLS; col++) gmt_M_str_free (fill[col]);
-						pos = n_col = 0;
-						while ((gmt_strtok (&line[2], " \t", &pos, p))) {
-							if ((API->error = gmt_get_rgbtxt_from_z (GMT, P, p)) != 0) Return (GMT_RUNTIME_ERROR);	/* If given z=value then we look up colors */
-							if (strcmp (p, "-")) fill[n_col++] = strdup (p);
-							if (n_col > n_columns) {
-								GMT_Report (API, GMT_MSG_ERROR, "Exceeding specified N columns (%d) in F operator (%d)\n", n_columns, n_col);
-								Return (GMT_RUNTIME_ERROR);
+							if (!(txt_c[0] == '-' || txt_c[0] == '=')) {	/* Fill the gap before the line, if fill is active */
+								pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-quarter_line_spacing+d_line_half_width, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
+								row_base_y -= quarter_line_spacing;
 							}
-						}
-						if (n_col == 1 && n_columns > 1) {	/* Only gave a constant color or - for the entire row, duplicate per column */
-							for (col = 1; col < n_columns; col++) if (fill[0]) fill[col] = strdup (fill[0]);
-						}
-						break;
-
-					case 'G':	/* Gap record: G gap (will be filled with current fill[0] setting if active) */
-						sscanf (&line[2], "%s", txt_a);
-						row_height = (txt_a[strlen(txt_a)-1] == 'l') ? atoi (txt_a) * one_line_spacing : gmt_M_to_inch (GMT, txt_a);
-						pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
-						row_base_y -= row_height;
-						column_number = 0;
-						if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
-						drawn = true;
-						break;
-
-					case 'H':	/* Header record: H fontsize|- font|- header */
-						sscanf (&line[2], "%s %s %[^\n]", size, font, text);
-						if (pslegend_new_fontsyntax (GMT, size, font)) {	/* GMT5 font specification */
-							sscanf (&line[2], "%s %[^\n]", font, text);
-							if (size[0] == '-')	/* Want the default title font */
-								sprintf (tmp, "%s", gmt_putfont (GMT, &GMT->current.setting.font_title));
+							d_line_last_y0 = row_base_y;	/* Remember the y-value were we potentially draw the horizontal line */
+							if (d_line_half_width > 0.0) {
+								if (do_width) {
+									PSL_defunits (PSL, "PSL_legend_hor_off", 2.0 * d_line_hor_offset);
+									PSL_setcurrentpoint (PSL, Ctrl->D.refpoint->x + d_line_hor_offset, row_base_y);
+									PSL_command (PSL, "PSL_legend_box_width PSL_legend_hor_off sub 0 D S\n");
+								}
 							else
-								strcpy (tmp, font);	/* Gave a font specification */
-						}
-						else {	/* Old GMT4 syntax for fontsize and font and must manually add color (e.g., via -C) */
-							if (size[0] == '-') size[0] = 0;
-							if (font[0] == '-') font[0] = 0;
-							sprintf (tmp, "%s,%s,%s", size, font, txtcolor);		/* Put size, font and color together for parsing by gmt_getfont */
-						}
-						ifont = GMT->current.setting.font_title;	/* Set default font */
-						gmt_getfont (GMT, tmp, &ifont);
-						if (C_is_active) gmt_M_rgb_copy (ifont.fill.rgb, C_rgb);	/* Must update text color */
-						d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT (ifont.id)) * ifont.size / PSL_POINTS_PER_INCH;	/* To center the text */
-						row_height = Ctrl->D.spacing * ifont.size / PSL_POINTS_PER_INCH;
-						if (do_width) {
-							row_base_y -= row_height;
-							PSL_setcurrentpoint (PSL, Ctrl->D.refpoint->x, row_base_y + d_off);
-							PSL_setfont (PSL, ifont.id);
-							PSL_command (PSL, "PSL_legend_box_width 2 div 0 G\n");
-							PSL_plottext (PSL, 0.0, 0.0, -ifont.size, text, 0.0, PSL_BC, 0);
-						}
-						else {
-							sprintf (buffer, "%s BC %s", gmt_putfont (GMT, &ifont), text);
-							pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
-							row_base_y -= row_height;
-							/* Build output segment */
-							if ((D[TXT] = pslegend_get_dataset_pointer (API, D[TXT], GMT_IS_NONE, 1U, 64U, 2U, true)) == NULL) return (API->error);
-							S[TXT] = pslegend_get_segment (D, TXT, 0);	/* Since there will only be one table with one segment for each set, except for fronts */
-							S[TXT]->data[GMT_X][krow[TXT]] = Ctrl->D.refpoint->x + 0.5 * Ctrl->D.dim[GMT_X];
-							S[TXT]->data[GMT_Y][krow[TXT]] = row_base_y + d_off;
-							S[TXT]->text[krow[TXT]++] = strdup (buffer);
-							S[TXT]->n_rows++;
-							D[TXT]->n_records++;
-							GMT_Report (API, GMT_MSG_DEBUG, "TXT: %s\n", buffer);
-							pslegend_maybe_realloc_segment (GMT, S[TXT]);
-						}
-						column_number = 0;
-						if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
-						drawn = true;
-						break;
+								PSL_plotsegment (PSL, Ctrl->D.refpoint->x + d_line_hor_offset, row_base_y, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X] - d_line_hor_offset, row_base_y);
+							}
+							d_line_after_gap = (txt_c[0] == '+' || txt_c[0] == '=') ? 0.0 : quarter_line_spacing;
+							row_base_y -= d_line_after_gap;
+							d_line_after_gap -= d_line_half_width;	/* Shrink the gap fill-height after a D line by half the line width so we don't overwrite the line */
+							column_number = 0;	/* Reset to new row */
+							if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
+							drawn = true;
+							break;
 
-					case 'I':	/* Image record [use GMT_psimage]: I imagefile width justification */
-						sscanf (&line[2], "%s %s %s", image, size, key);
-						first = gmt_download_file_if_not_found (GMT, image, GMT_CACHE_DIR);
-						if (gmt_getdatapath (GMT, &image[first], path, R_OK) == NULL) {
-							GMT_Report (API, GMT_MSG_ERROR, "Cannot find/open file %s.\n", &image[first]);
-							Return (GMT_FILE_NOT_FOUND);
-						}
-						if ((aspect = pslegend_get_image_aspect (API, path)) < 0.0) {
-							GMT_Report (API, GMT_MSG_ERROR, "Trouble reading %s! - Skipping.\n", &image[first]);
-							continue;
-						}
-						justify = gmt_just_decode (GMT, key, PSL_NO_DEF);
-						row_height = gmt_M_to_inch (GMT, size) * aspect;
-						pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
-						x_off = Ctrl->D.refpoint->x;
-						x_off += (justify%4 == 1) ? Ctrl->C.off[GMT_X] : ((justify%4 == 3) ? Ctrl->D.dim[GMT_X] - Ctrl->C.off[GMT_X] : 0.5 * Ctrl->D.dim[GMT_X]);
-						sprintf (buffer, "-O -K %s -Dx%gi/%gi+j%s+w%s --GMT_HISTORY=readonly", &image[first], x_off, row_base_y, key, size);
-						GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: gmt psimage %s\n", buffer);
-						status = GMT_Call_Module (API, "psimage", GMT_MODULE_CMD, buffer);	/* Plot the image */
-						if (status) {
-							GMT_Report (API, GMT_MSG_ERROR, "GMT_psimage returned error %d.\n", status);
-							Return (GMT_RUNTIME_ERROR);
-						}
-						row_base_y -= row_height;
-						column_number = 0;
-						drawn = true;
-						break;
+						case 'F':	/* Cell color: F fill1[,fill2,...,filln]  */
+							/* First free all previous entries in fill array */
+							for (col = 0; col < PSLEGEND_MAX_COLS; col++) gmt_M_str_free (fill[col]);
+							pos = n_col = 0;
+							while ((gmt_strtok (&line[2], " \t", &pos, p))) {
+								if ((API->error = gmt_get_rgbtxt_from_z (GMT, P, p)) != 0) Return (GMT_RUNTIME_ERROR);	/* If given z=value then we look up colors */
+								if (strcmp (p, "-")) fill[n_col++] = strdup (p);
+								if (n_col > n_columns) {
+									GMT_Report (API, GMT_MSG_ERROR, "Exceeding specified N columns (%d) in F operator (%d)\n", n_columns, n_col);
+									Return (GMT_RUNTIME_ERROR);
+								}
+							}
+							if (n_col == 1 && n_columns > 1) {	/* Only gave a constant color or - for the entire row, duplicate per column */
+								for (col = 1; col < n_columns; col++) if (fill[0]) fill[col] = strdup (fill[0]);
+							}
+							break;
 
-					case 'L':	/* Label record: L font|- justification label */
-						text[0] = '\0';
-						sscanf (&line[2], "%s %s %s %[^\n]", size, font, key, text);
-						if (pslegend_new_fontsyntax (GMT, size, font)) {	/* GMT5 font specification */
-							sscanf (&line[2], "%s %s %[^\n]", font, key, text);
-							if (font[0] == '-')	/* Want the default label font */
-								sprintf (tmp, "%s", gmt_putfont (GMT, &GMT->current.setting.font_label));
-							else
-								strcpy (tmp, font);	/* Gave a font specification */
-						}
-						else {	/* Old GMT4 syntax for fontsize and font and must manually add color (e.g., via -C) */
-							if (size[0] == '-') size[0] = 0;
-							if (font[0] == '-') font[0] = 0;
-							sprintf (tmp, "%s,%s,%s", size, font, txtcolor);	/* Put size, font and color together for parsing by gmt_getfont */
-						}
-						ifont = GMT->current.setting.font_label;	/* Set default font */
-						gmt_getfont (GMT, tmp, &ifont);
-						if (C_is_active) gmt_M_rgb_copy (ifont.fill.rgb, C_rgb);	/* Must update text color */
-						d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT (ifont.id)) * ifont.size / PSL_POINTS_PER_INCH;	/* To center the text */
-						if (column_number%n_columns == 0) {	/* Label in first column, also fill row if requested */
-							row_height = Ctrl->D.spacing * ifont.size / PSL_POINTS_PER_INCH;
+						case 'G':	/* Gap record: G gap (will be filled with current fill[0] setting if active) */
+							sscanf (&line[2], "%s", txt_a);
+							row_height = (txt_a[strlen(txt_a)-1] == 'l') ? atoi (txt_a) * one_line_spacing : gmt_M_to_inch (GMT, txt_a);
 							pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
 							row_base_y -= row_height;
 							column_number = 0;
 							if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
-						}
-						if (text[0] == '\0') {	/* Nothing to do, just skip to next */
-							column_number++;
-							GMT_Report (API, GMT_MSG_DEBUG, "The L record gave no info so skip to next cell\n");
 							drawn = true;
 							break;
-						}
-						justify = gmt_just_decode (GMT, key, 0);
-						if (do_width) {
-							PSL_setcurrentpoint (PSL, Ctrl->D.refpoint->x + Ctrl->C.off[GMT_X], row_base_y + d_off);
-							PSL_setfont (PSL, ifont.id);
-							if (justify == PSL_BR)
-								PSL_command (PSL, "PSL_legend_box_width PSL_legend_clear_x sub 0 G\n");
-							else if (justify == PSL_BC)
-								PSL_command (PSL, "PSL_legend_box_width PSL_legend_clear_x sub 2 div 0 G\n");
-							PSL_plottext (PSL, 0.0, 0.0, -ifont.size, text, 0.0, justify, 0);
-						}
-						else {
-							x_off = Ctrl->D.refpoint->x + x_off_col[column_number];
-							x_off += (justify%4 == 1) ? Ctrl->C.off[GMT_X] : ((justify%4 == 3) ? (x_off_col[column_number+1]-x_off_col[column_number]) - Ctrl->C.off[GMT_X] : 0.5 * (x_off_col[column_number+1]-x_off_col[column_number]));
-							sprintf (buffer, "%s B%s %s", gmt_putfont (GMT, &ifont), key, text);
-							if ((D[TXT] = pslegend_get_dataset_pointer (API, D[TXT], GMT_IS_NONE, 1U, 64U, 2U, true)) == NULL) return (API->error);
-							S[TXT] = pslegend_get_segment (D, TXT, 0);	/* Since there will only be one table with one segment for each set, except for fronts */
-							S[TXT]->data[GMT_X][krow[TXT]] = x_off;
-							S[TXT]->data[GMT_Y][krow[TXT]] = row_base_y + d_off;
-							S[TXT]->text[krow[TXT]++] = strdup (buffer);
-							S[TXT]->n_rows++;
-							GMT_Report (API, GMT_MSG_DEBUG, "TXT: %s\n", buffer);
-							pslegend_maybe_realloc_segment (GMT, S[TXT]);
-						}
-						column_number++;
-						drawn = true;
-						break;
 
-					case 'M':	/* Map scale record M lon0|- lat0 length[n|m|k][+mods] [-F] [-R -J] */
-						/* Was: Map scale record M lon0|- lat0 length[n|m|k][+opts] f|p  [-R -J] */
-						n_scan = sscanf (&line[2], "%s %s %s %s %s %s", txt_a, txt_b, txt_c, txt_d, txt_e, txt_f);
-						r_options[0] = module_options[0] = '\0';
-						if (txt_d[0] == 'f' || txt_d[0] == 'p') {	/* Old-style args */
-							if (n_scan == 6)	/* Gave -R -J */
-								sprintf (r_options, "%s %s", txt_e, txt_f);
-							if (txt_d[0] == 'f') strcat (txt_c, "+f");	/* Wanted fancy scale so append +f to length */
-						}
-						else {	/* New syntax */
-							if (n_scan == 4)	/* Gave just -F */
-								strcpy (module_options, txt_d);
-							else if (n_scan == 5)	/* Gave -R -J */
-								sprintf (r_options, "%s %s", txt_d, txt_e);
-							else if (n_scan == 6) {	/* Gave -F -R -J which may be in any order */
-								if (txt_d[1] == 'F') {	/* Got -F -R -J */
-									sprintf (module_options, " %s", txt_d);
-									sprintf (r_options, "%s %s", txt_e, txt_f);
-								}
-								else if (txt_f[1] == 'F') {	/* Got -R -J -F */
-									sprintf (r_options, "%s %s", txt_d, txt_e);
-									sprintf (module_options, " %s", txt_f);
-								}
-								else {	/* Got -R -F -J or -J -F -R */
-									sprintf (r_options, "%s %s", txt_d, txt_f);
-									sprintf (module_options, " %s", txt_e);
-								}
+						case 'H':	/* Header record: H fontsize|- font|- header */
+							sscanf (&line[2], "%s %s %[^\n]", size, font, text);
+							if (pslegend_new_fontsyntax (GMT, size, font)) {	/* GMT5 font specification */
+								sscanf (&line[2], "%s %[^\n]", font, text);
+								if (size[0] == '-')	/* Want the default title font */
+									sprintf (tmp, "%s", gmt_putfont (GMT, &GMT->current.setting.font_title));
+								else
+									strcpy (tmp, font);	/* Gave a font specification */
 							}
-						}
-						for (i = 0, gave_mapscale_options = false; txt_c[i] && !gave_mapscale_options; i++) if (txt_c[i] == '+') gave_mapscale_options = true;
-						/* Default assumes label is added on top */
-						just = 't';
-						gave_label = true;
-						row_height = GMT->current.setting.map_scale_height + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH + GMT->current.setting.map_annot_offset[0];
-						d_off = FONT_HEIGHT_LABEL * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH + fabs(GMT->current.setting.map_label_offset);
-						if ((txt_d[0] == 'f' || txt_d[0] == 'p') && gmt_get_modifier (txt_c, 'j', string))	/* Specified alternate justification old-style */
-							just = string[0];
-						else if (gmt_get_modifier (txt_c, 'a', string))	/* Specified alternate alignment */
-							just = string[0];
-						if (gmt_get_modifier (txt_c, 'u', string))	/* Specified alternate alignment */
-							gave_label = false;	/* Not sure why I do this, will find out */
-						h = row_height;
-						if (gave_label && (just == 't' || just == 'b')) h += d_off;
-						pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-h, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
-						if (gave_label && just == 't') row_base_y -= d_off;
-						if (!strcmp (txt_a, "-"))	/* No longitude needed */
-							sprintf (mapscale, "x%gi/%gi+c%s+jTC+w%s", Ctrl->D.refpoint->x + 0.5 * Ctrl->D.dim[GMT_X], row_base_y, txt_b, txt_c);
-						else				/* Gave both lon and lat for scale */
-							sprintf (mapscale, "x%gi/%gi+c%s/%s+jTC+w%s", Ctrl->D.refpoint->x + 0.5 * Ctrl->D.dim[GMT_X], row_base_y, txt_a, txt_b, txt_c);
-						if (r_options[0])	/* Gave specific -R -J on M line */
-							sprintf (buffer, "%s -O -K -L%s", r_options, mapscale);
-						else {	/* Must use -R -J as supplied to pslegend */
-							gmt_set_missing_options (GMT, "RJ");	/* If mode is modern, -R -J exist in the history, and if an overlay we may add these from history automatically */
-							if (!GMT->common.R.active[RSET] || !GMT->common.J.active) {
-								GMT_Report (API, GMT_MSG_ERROR, "The M record must have map -R -J if -Dx and no -R -J is used\n");
-								Return (GMT_RUNTIME_ERROR);
+							else {	/* Old GMT4 syntax for fontsize and font and must manually add color (e.g., via -C) */
+								if (size[0] == '-') size[0] = 0;
+								if (font[0] == '-') font[0] = 0;
+								sprintf (tmp, "%s,%s,%s", size, font, txtcolor);		/* Put size, font and color together for parsing by gmt_getfont */
 							}
-							sprintf (buffer, "-R%s -J%s -O -K -L%s", GMT->common.R.string, GMT->common.J.string, mapscale);
-						}
-						if (module_options[0]) strcat (buffer, module_options);
-						strcat (buffer, " --GMT_HISTORY=readonly");
-						GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: gmt psbasemap %s\n", buffer);
-						status = GMT_Call_Module (API, "psbasemap", GMT_MODULE_CMD, buffer);	/* Plot the scale */
-						if (status) {
-							GMT_Report (API, GMT_MSG_ERROR, "GMT_psbasemap returned error %d.\n", status);
-							Return (GMT_RUNTIME_ERROR);
-						}
-						if (gave_label && just == 'b') row_base_y -= d_off;
-						row_base_y -= row_height;
-						column_number = 0;
-						if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
-						drawn = true;
-						break;
-
-					case 'N':	/* n_columns record: N ncolumns OR rw1 rw2 ... rwn (for relative widths) */
-						n_col = n_columns;	/* Previous setting */
-						pos = n_columns = 0;
-						while ((gmt_strtok (&line[2], " \t", &pos, p))) {
-							col_width[n_columns++] = atof (p);
-							if (n_columns == PSLEGEND_MAX_COLS) {
-								GMT_Report (API, GMT_MSG_ERROR, "Exceeding maximum columns (%d) in N operator\n", PSLEGEND_MAX_COLS);
-								Return (GMT_RUNTIME_ERROR);
-							}
-						}
-						if (n_columns == 0) n_columns = 1;	/* Default to 1 if nothing is given */
-						/* Check if user gave just the number of columns and not relative widths */
-						if (n_columns == 1 && (pos = atoi (&line[2])) > 1) {	/* Set number of columns and indicate equal widths */
-							n_columns = pos;
-							for (column_number = 0; column_number < n_columns; column_number++) col_width[column_number] = 1.0;
-						}
-						for (column_number = 0, sum_width = 0.0; column_number < n_columns; column_number++) sum_width += col_width[column_number];
-						for (column_number = 1, x_off_col[0] = 0.0; column_number < n_columns; column_number++) x_off_col[column_number] = x_off_col[column_number-1] + (Ctrl->D.dim[GMT_X] * col_width[column_number-1] / sum_width);
-						x_off_col[column_number] = Ctrl->D.dim[GMT_X];	/* Holds width of row */
-						if (n_columns > n_col) for (col = 1; col < n_columns; col++) if (fill[0]) fill[col] = strdup (fill[0]);	/* Extend the fill array to match the new column numbers, if fill is active */
-						column_number = 0;
-						if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG)) {
-							double s = gmt_convert_units (GMT, "1", GMT_INCH, GMT->current.setting.proj_length_unit);
-							GMT_Report (API, GMT_MSG_DEBUG, "Selected %d columns.  Column widths are:\n", n_columns);
-							for (col = 1; col <= n_columns; col++)
-								GMT_Report (API, GMT_MSG_DEBUG, "Column %d: %g %s\n", col, s*(x_off_col[col]-x_off_col[col-1]), GMT->session.unit_name[GMT->current.setting.proj_length_unit]);
-						}
-						break;
-
-					case '>':	/* Paragraph text header */
-						if (gmt_M_compat_check (GMT, 4)) {	/* Warn and fall through on purpose */
-							GMT_Report (API, GMT_MSG_COMPAT, "Paragraph text header flag > is deprecated; use P instead\n");
-							n = sscanf (&line[1], "%s %s %s %s %s %s %s %s %s", xx, yy, size, angle, font, key, lspace, tw, jj);
-							if (n < 0) n = 0;	/* Since -1 is returned if no arguments */
-							if (!(n == 0 || n == 9)) {
-								GMT_Report (API, GMT_MSG_ERROR, "The > record must have 0 or 9 arguments (only %d found)\n", n);
-								Return (GMT_RUNTIME_ERROR);
-							}
-							if (n == 0 || size[0] == '-') sprintf (size, "%g", GMT->current.setting.font_annot[GMT_PRIMARY].size);
-							if (n == 0 || font[0] == '-') sprintf (font, "%d", GMT->current.setting.font_annot[GMT_PRIMARY].id);
-							sprintf (tmp, "%s,%s,", size, font);
-							did_old = true;
-						}
-						else {
-							GMT_Report (API, GMT_MSG_ERROR, "Unrecognized record (%s)\n", line);
-							Return (GMT_RUNTIME_ERROR);
-							break;
-						}
-						/* Intentionally fall through */
-					case 'P':	/* Paragraph text header: P paragraph-mode-header-for-text */
-						if (!did_old) {
-							n = sscanf (&line[1], "%s %s %s %s %s %s %s %s", xx, yy, tmp, angle, key, lspace, tw, jj);
-							if (n < 0) n = 0;	/* Since -1 is returned if no arguments */
-							if (!(n == 0 || n == 8)) {
-								GMT_Report (API, GMT_MSG_ERROR, "The P record must have 0 or 8 arguments (only %d found)\n", n);
-								Return (GMT_RUNTIME_ERROR);
-							}
-						}
-						did_old = false;
-						if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
-						if (n == 0 || xx[0] == '-') sprintf (xx, "%g", col_left_x);
-						if (n == 0 || yy[0] == '-') sprintf (yy, "%g", row_base_y);
-						if (n == 0 || tmp[0] == '-') sprintf (tmp, "%gp,%d,%s", GMT->current.setting.font_annot[GMT_PRIMARY].size, GMT->current.setting.font_annot[GMT_PRIMARY].id, txtcolor);
-						if (n == 0 || angle[0] == '-') sprintf (angle, "0");
-						if (n == 0 || key[0] == '-') sprintf (key, "TL");
-						if (n == 0 || lspace[0] == '-') sprintf (lspace, "%gi", one_line_spacing);
-						if (n == 0 || tw[0] == '-') sprintf (tw, "%gi", Ctrl->D.dim[GMT_X] - 2.0 * Ctrl->C.off[GMT_X]);
-						if (n == 0 || jj[0] == '-') sprintf (jj, "j");
-						if (n_para >= 0) {	/* End of previous paragraph for sure */
-							S[PAR]->n_rows = krow[PAR];
-							S[PAR] = D[PAR]->table[0]->segment[n_para] = GMT_Alloc_Segment (GMT->parent, GMT_WITH_STRINGS, krow[PAR], 0U, NULL, S[PAR]);
-						}
-						if ((D[PAR] = pslegend_get_dataset_pointer (API, D[PAR], GMT_IS_TEXT, 1U, n_par_total, 0U, true)) == NULL) return (API->error);
-						sprintf (buffer, "%s %s %s %s %s %s %s %s", xx, yy, angle, tmp, key, lspace, tw, jj);
-						S[PAR] = pslegend_get_segment (D, PAR, ++n_para);	/* We store the header as one of the text records for simplicity */
-						GMT_Report (API, GMT_MSG_DEBUG, "PAR: %s\n", buffer);
-						S[PAR]->header = strdup (buffer);
-						pslegend_maybe_realloc_segment (GMT, S[PAR]);
-						flush_paragraph = true;
-						column_number = 0;
-						drawn = true;
-						krow[PAR] = 0;	/* Start fresh with new segment */
-						break;
-
-					case 'S':	/* Symbol record: S [dx1 symbol size fill pen [ dx2 text ]] */
-						if (strlen (line) > 2)
-							n_scan = sscanf (&line[2], "%s %s %s %s %s %s %[^\n]", txt_a, symbol, size, txt_c, txt_d, txt_b, text);
-						else	/* No args given means skip to next cell */
-							n_scan = 0;
-						if (column_number%n_columns == 0) {	/* Symbol in first column, also fill row if requested */
-							pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-one_line_spacing, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
-							row_base_y -= one_line_spacing;
-							column_number = 0;
-						}
-						if (n_scan <= 0) {	/* No symbol, just skip to next cell */
-							column_number++;
-							GMT_Report (API, GMT_MSG_DEBUG, "The S record give no info so skip to next cell\n");
-							drawn = true;
-							break;
-						}
-						if ((API->error = gmt_get_rgbtxt_from_z (GMT, P, txt_c)) != 0) Return (GMT_RUNTIME_ERROR);	/* If given z=value then we look up colors */
-						if (strchr ("LCR", txt_a[0])) {	/* Gave L, C, or R justification relative to current cell */
-							justify = gmt_just_decode (GMT, txt_a, 0);
-							off_ss = (justify%4 == 1) ? Ctrl->C.off[GMT_X] : ((justify%4 == 3) ? (x_off_col[column_number+1]-x_off_col[column_number]) - Ctrl->C.off[GMT_X] : 0.5 * (x_off_col[column_number+1]-x_off_col[column_number]));
-							x_off = Ctrl->D.refpoint->x + x_off_col[column_number];
-						}
-						else if (!strcmp (txt_a, "-")) {	/* Automatic margin offset */
-							off_ss = GMT_LEGEND_DX1_MUL * Ctrl->S.scale * def_size;
-							x_off = col_left_x + x_off_col[column_number];
-						}
-						else {	/* Gave a specific offset */
-							off_ss = gmt_M_to_inch (GMT, txt_a);
-							x_off = col_left_x + x_off_col[column_number];
-						}
-						if (!strcmp (txt_b, "-"))	/* Automatic label offset */
-							off_tt = GMT_LEGEND_DX2_MUL * Ctrl->S.scale * def_size;
-						else	/* Gave a specific offset */
-							off_tt = gmt_M_to_inch (GMT, txt_b);
-						d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT_PRIMARY) * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;	/* To center the text */
-						row_base_y += half_line_spacing;	/* Move to center of box */
-						if (symbol[0] == '-' && !strcmp (size, "-")) sprintf (size, "%gi", def_size);	/* If no size given then we must pick what we learned above */
-						if (symbol[0] == 'f') {	/* Front is different, must plot as a line segment */
-							double length, tlen, gap;
-							int n = sscanf (size, "%[^/]/%[^/]/%s", A, B, C);
-
-							if (n == 3) {	/* Got line length, tickgap, and ticklength */
-								length = Ctrl->S.scale * gmt_M_to_inch (GMT, A);	/* The length of the line */
-								tlen = Ctrl->S.scale * gmt_M_to_inch (GMT, C);	/* The length of the tick */
-							}
-							else if (n == 2 && B[0] != '-') {	/* Got line length and tickgap only */
-								length = Ctrl->S.scale * gmt_M_to_inch (GMT, A);	/* The length of the line */
-								gap = Ctrl->S.scale * gmt_M_to_inch (GMT, B);	/* The tick gap */
-								tlen = 0.3 * gap;		/* The default length of the tick is 30% of gap */
-							}
-							else {	/* Got line length, select defaults for other things */
-								length = Ctrl->S.scale * gmt_M_to_inch (GMT, A);	/* The length of the line */
-								strcpy (B, "-1");		/* One centered tick */
-								tlen = 0.3 * length;		/* The default length of the tick is 30% of length */
-							}
-							if ((c = strchr (symbol, '+')) != NULL)	/* Pass along all the given modifiers */
-								strcpy (sub, c);
-							else	/* The necessary arguments not supplied, provide reasonable defaults */
-								sprintf (sub, "+l+b");	/* Box to the left of the line is our default front symbol */
-							x = 0.5 * length;
-							/* Place pen and fill colors in segment header */
-							sprintf (buffer, "-Sf%s/%gi%s", B, tlen, sub);
-							if (txt_c[0] != '-') {strcat (buffer, " -G"); strcat (buffer, txt_c);}
-							if (txt_d[0] != '-') {strcat (buffer, " -W"); strcat (buffer, txt_d);}
-							/* Prepare next output segment */
-							if ((D[FRONT] = pslegend_get_dataset_pointer (API, D[FRONT], GMT_IS_LINE, 64U, 2U, 2U, false)) == NULL) return (API->error);
-							S[FRONT] = pslegend_get_segment (D, FRONT, n_fronts);	/* Next front segment */
-							S[FRONT]->header = strdup (buffer);
-							GMT_Report (API, GMT_MSG_DEBUG, "FRONT: %s\n", buffer);
-							/* Set begin and end coordinates of the line segment */
-							S[FRONT]->data[GMT_X][0] = x_off + off_ss-x;	S[FRONT]->data[GMT_Y][0] = row_base_y;
-							S[FRONT]->data[GMT_X][1] = x_off + off_ss+x;	S[FRONT]->data[GMT_Y][1] = row_base_y;
-							S[FRONT]->n_rows = 2;
-							D[FRONT]->n_records += 2;
-							n_fronts++;
-							if (n_fronts == GMT_SMALL_CHUNK) {
-								GMT_Report (API, GMT_MSG_ERROR, "Can handle max %d front lines.  Let us know if this is a problem.\n", GMT_SMALL_CHUNK);
-								return (API->error);
-							}
-						}
-						else if (symbol[0] == 'q' || symbol[0] == '~') {	/* Quoted and decorated line is different, must plot as a line segment */
-							double length = Ctrl->S.scale * gmt_M_to_inch (GMT, size);	/* The length of the line */;
-
-							if ((D[QLINE] = pslegend_get_dataset_pointer (API, D[QLINE], GMT_IS_LINE, 64U, 2U, 2U, false)) == NULL) return (API->error);
-							x = 0.5 * length;
-							/* Place pen and fill colors in segment header */
-							sprintf (buffer, "-S%s", symbol);
-							if (txt_d[0] != '-') {strcat (buffer, " -W"); strcat (buffer, txt_d);}
-							S[QLINE] = pslegend_get_segment (D, QLINE, n_quoted_lines);	/* Next quoted line segment */
-							S[QLINE]->header = strdup (buffer);
-							GMT_Report (API, GMT_MSG_DEBUG, "QLINE: %s\n", buffer);
-							/* Set begin and end coordinates of the line segment */
-							S[QLINE]->data[GMT_X][0] = x_off + off_ss-x;	S[QLINE]->data[GMT_Y][0] = row_base_y;
-							S[QLINE]->data[GMT_X][1] = x_off + off_ss+x;	S[QLINE]->data[GMT_Y][1] = row_base_y;
-							S[QLINE]->n_rows = 2;
-							D[QLINE]->n_records += 2;
-							n_quoted_lines++;
-							if (n_quoted_lines == GMT_SMALL_CHUNK) {
-								GMT_Report (API, GMT_MSG_ERROR, "Can handle max %d quoted/decorated lines.  Let us know if this is a problem.\n", GMT_SMALL_CHUNK);
-								return (API->error);
-							}
-						}
-						else {	/* Regular symbols */
-							if ((D[SYM] = pslegend_get_dataset_pointer (API, D[SYM], GMT_IS_POINT, 64U, 1U, 6U, true)) == NULL) return (API->error);
-							S[SYM] = pslegend_get_segment (D, SYM, n_symbols);	/* Since there will only be one table with one segment for each single row */
-							S[SYM]->data[GMT_X][0] = x_off + off_ss;
-							S[SYM]->data[GMT_Y][0] = row_base_y;
-							S[SYM]->n_rows = 1;
-							if (symbol[0] == 'k' || symbol[0] == 'K')	/* Custom symbols need the full name after k */
-								sprintf (sub, "%s", symbol);
-							else	/* Just the symbol code is needed */
-								sprintf (sub, "%c", symbol[0]);
-							if (symbol[0] == 'E' || symbol[0] == 'e') {	/* Ellipse */
-								if (strchr (size, ',')) {	/* We got dir,major,minor instead of just size; parse and use */
-									sscanf (size, "%[^,],%[^,],%s", A, B, C);
-									az1 = atof (A);
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
-									y = Ctrl->S.scale * gmt_M_to_inch (GMT, C);
-								}
-								else {	/* Ellipse needs more arguments; we use minor = 0.65*major, az = 0 */
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
-									az1 = 0.0;
-									y = 0.65 * x;
-								}
-								S[SYM]->data[2][0] = az1;
-								S[SYM]->data[3][0] = x;
-								S[SYM]->data[4][0] = y;
-							}
-							else if (symbol[0] == 'J' || symbol[0] == 'j') {	/* rotated rectangle */
-								if (strchr (size, ',')) {	/* We got dir,w,h instead of just size; parse and use */
-									sscanf (size, "%[^,],%[^,],%s", A, B, C);
-									az1 = atof (A);
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
-									y = Ctrl->S.scale * gmt_M_to_inch (GMT, C);
-								}
-								else {	/* Rotated rectangle needs more arguments; we use height = 0.65*width, az = 30 */
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
-									y = 0.65 * x;
-									az1 = 30.0;
-								}
-								S[SYM]->data[2][0] = az1;
-								S[SYM]->data[3][0] = x;
-								S[SYM]->data[4][0] = y;
-							}
-							else if (symbol[0] == 'V' || symbol[0] == 'v') {	/* Vector */
-								/* Because we support both GMT4 and GMT5 vector notations this section is a bit messy */
-								if (strchr (size, ',')) {	/* We got dir,length combined as one argument */
-									sscanf (size, "%[^,],%s", A, B);
-									az1 = atof (A);
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
-								}
-								else {	/* No dir given, default to horizontal */
-									az1 = 0.0;
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-								}
-								if (strchr (size, '/') && gmt_M_compat_check (GMT, 4))  {	/* The necessary arguments was supplied via GMT4 size arguments */
-									i = 0;
-									while (size[i] != '/' && size[i]) i++;
-									size[i++] = '\0';	/* So gmt_M_to_inch won't complain */
-									sprintf (sub, "%s%s+jc+e", symbol, &size[i]);
-								}
-								else if ((c = strchr (symbol, '+')) != NULL) {	/* GMT5 syntax: Pass along all the given modifiers */
-									strcpy (sub, symbol);
-									if ((c = strstr (sub, "+j")) != NULL && c[2] != 'c') {	/* Got justification, check if it is +jc */
-										GMT_Report (API, GMT_MSG_ERROR, "Vector justification changed from +j%c to +jc\n", c[2]);
-										c[2] = 'c';	/* Replace with centered justification */
-									}
-									else	/* Add +jc */
-										strcat (sub, "+jc");
-								}
-								else	/* The necessary arguments not supplied, so we make a reasonable default */
-									sprintf (sub, "v%gi+jc+e", 0.3*x);	/* Head size is 30% of length */
-								if (txt_c[0] == '-') strcat (sub, "+g-");
-								else { strcat (sub, "+g"); strcat (sub, txt_c);}
-								if (txt_d[0] == '-') strcat (sub, "+p-");
-								else {
-									struct GMT_PEN pen;
-									gmt_M_memset (&pen, 1, struct GMT_PEN);	/* Wipe the pen */
-									gmt_getpen (GMT, txt_d, &pen);
-									pen.width *= 0.5;
-									strcat (sub, "+p"); strcat (sub, gmt_putpen (API->GMT, &pen));
-								}
-								S[SYM]->data[2][0] = az1;
-								S[SYM]->data[3][0] = x;
-							}
-							else if (symbol[0] == 'r') {	/* Rectangle  */
-								if (strchr (size, ',')) {	/* We got w,h */
-									sscanf (size, "%[^,],%s", A, B);
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, A);
-									y = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
-								}
-								else {	/* Rectangle also need more args, we use h = 0.65*w */
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
-									y = 0.65 * x;
-								}
-								S[SYM]->data[2][0] = x;
-								S[SYM]->data[3][0] = y;
-							}
-							else if (symbol[0] == 'R') {	/* Rounded rectangle  */
-								if (strchr (size, ',')) {	/* We got w,h,r */
-									sscanf (size, "%[^,],%[^,],%s", A, B, C);
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, A);
-									y = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
-									r = Ctrl->S.scale * gmt_M_to_inch (GMT, C);
-								}
-								else {	/* Rounded rectangle also need more args, we use h = 0.65*w and r = 0.1*w */
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
-									y = 0.65 * x;
-									r = 0.1 * x;
-								}
-								S[SYM]->data[2][0] = x;
-								S[SYM]->data[3][0] = y;
-								S[SYM]->data[4][0] = r;
-							}
-							else if (symbol[0] == 'm') {	/* Math angle  */
-								if (strchr (size, ',')) {	/* We got r,az1,az2 */
-									sscanf (size, "%[^,],%[^,],%s", A, B, C);
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, A);
-									az1 = atof (B);
-									az2 = atof (C);
-								}
-								else {	/* Math angle need more args, we set fixed az1,az22 as 10 45 */
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
-									az1 = 10;	az2 = 45;
-								}
-								/* We want to center the arc around its mid-point */
-								m_az = 0.5 * (az1 + az2);
-								dx = 0.25 * x * cosd (m_az);
-								if (!strchr (symbol, '+'))  {	/* The necessary arguments not supplied! */
-									sprintf (sub, "m%gi+b+e", 0.3*x);	/* Double heads, head size 30% of diameter */
-								}
-								if (txt_c[0] == '-') strcat (sub, "+g-");
-								else { strcat (sub, "+g"); strcat (sub, txt_c);}
-								if (txt_d[0] == '-') strcat (sub, "+p-");
-								else { strcat (sub, "+p"); strcat (sub, txt_d);}
-								S[SYM]->data[GMT_X][0] -= dx;
-								S[SYM]->data[2][0] = x;
-								S[SYM]->data[3][0] = az1;
-								S[SYM]->data[4][0] = az2;
-							}
-							else if (symbol[0] == 'w') {	/* Wedge also need more args; we set fixed az1,az2 as -30 30 */
-								if (strchr (size, ',')) {	/* We got az1,az2,d */
-									sscanf (size, "%[^,],%[^,],%s", A, B, C);
-									az1 = atof (A);
-									az2 = atof (B);
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, C);
-								}
-								else {
-									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
-									az1 = -30;	az2 = 30;
-								}
-								/* We want to center the wedge around its mid-point */
-								m_az = 0.5 * (az1 + az2);
-								dx = 0.25 * x * cosd (m_az);
-								S[SYM]->data[GMT_X][0] -= dx;
-								S[SYM]->data[2][0] = x_off + off_ss - dx;
-								S[SYM]->data[3][0] = az1;
-								S[SYM]->data[4][0] = az2;
+							ifont = GMT->current.setting.font_title;	/* Set default font */
+							gmt_getfont (GMT, tmp, &ifont);
+							if (C_is_active) gmt_M_rgb_copy (ifont.fill.rgb, C_rgb);	/* Must update text color */
+							d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT (ifont.id)) * ifont.size / PSL_POINTS_PER_INCH;	/* To center the text */
+							row_height = Ctrl->D.spacing * ifont.size / PSL_POINTS_PER_INCH;
+							if (do_width) {
+								row_base_y -= row_height;
+								PSL_setcurrentpoint (PSL, Ctrl->D.refpoint->x, row_base_y + d_off);
+								PSL_setfont (PSL, ifont.id);
+								PSL_command (PSL, "PSL_legend_box_width 2 div 0 G\n");
+								PSL_plottext (PSL, 0.0, 0.0, -ifont.size, text, 0.0, PSL_BC, 0);
 							}
 							else {
-								x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
-								if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
-								S[SYM]->data[2][0] = x;
+								sprintf (buffer, "%s BC %s", gmt_putfont (GMT, &ifont), text);
+								pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
+								row_base_y -= row_height;
+								/* Build output segment */
+								if ((D[TXT] = pslegend_get_dataset_pointer (API, D[TXT], GMT_IS_NONE, 1U, 64U, 2U, true)) == NULL) return (API->error);
+								S[TXT] = pslegend_get_segment (D, TXT, 0);	/* Since there will only be one table with one segment for each set, except for fronts */
+								S[TXT]->data[GMT_X][krow[TXT]] = Ctrl->D.refpoint->x + 0.5 * Ctrl->D.dim[GMT_X];
+								S[TXT]->data[GMT_Y][krow[TXT]] = row_base_y + d_off;
+								S[TXT]->text[krow[TXT]++] = strdup (buffer);
+								S[TXT]->n_rows++;
+								D[TXT]->n_records++;
+								GMT_Report (API, GMT_MSG_DEBUG, "TXT: %s\n", buffer);
+								pslegend_maybe_realloc_segment (GMT, S[TXT]);
 							}
-							/* Place pen and fill colors in segment header */
-							sprintf (buffer, "-G"); strcat (buffer, txt_c);
-							strcat (buffer, " -W"); strcat (buffer, txt_d);
-							S[SYM]->header = strdup (buffer);
-							GMT_Report (API, GMT_MSG_DEBUG, "SYM: %s\n", buffer);
-							GMT_Report (API, GMT_MSG_DEBUG, "SYM: %s\n", sub);
-							S[SYM]->text[0] = strdup (sub);
-							SH = gmt_get_DS_hidden (S[SYM]);
-							if (S[SYM]->n_rows == SH->n_alloc) S[SYM]->data = gmt_M_memory (GMT, S[SYM]->data, SH->n_alloc += GMT_SMALL_CHUNK, char *);
-							n_symbols++;
-						}
-						/* Finally, print text; skip when empty */
-						row_base_y -= half_line_spacing;	/* Go back to bottom of box */
-						if (n_scan == 7) {	/* Place symbol text */
-							if ((D[TXT] = pslegend_get_dataset_pointer (API, D[TXT], GMT_IS_NONE, 1U, 64U, 2U, true)) == NULL) return (API->error);
-							S[TXT] = pslegend_get_segment (D, TXT, 0);	/* Since there will only be one table with one segment for each set, except for fronts */
-							sprintf (buffer, "%gp,%d,%s BL %s", GMT->current.setting.font_annot[GMT_PRIMARY].size, GMT->current.setting.font_annot[GMT_PRIMARY].id, txtcolor, text);
-							S[TXT]->data[GMT_X][krow[TXT]] = x_off + off_tt;
-							S[TXT]->data[GMT_Y][krow[TXT]] = row_base_y + d_off;
-							S[TXT]->text[krow[TXT]++] = strdup (buffer);
-							S[TXT]->n_rows++;
-							pslegend_maybe_realloc_segment (GMT, S[TXT]);
-							GMT_Report (API, GMT_MSG_DEBUG, "TXT: %s\n", buffer);
-						}
-						column_number++;
-						if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
-						drawn = true;
-						break;
+							column_number = 0;
+							if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
+							drawn = true;
+							break;
 
-					case 'T':	/* paragraph text record: T paragraph-text */
-						if ((D[PAR] = pslegend_get_dataset_pointer (API, D[PAR], GMT_IS_TEXT, n_par_total, n_par_lines, 0U, true)) == NULL) return (API->error);
-						/* If no previous > record, then use defaults */
-						if (!flush_paragraph) {	/* No header record, but a new paragraph. */
+						case 'I':	/* Image record [use GMT_psimage]: I imagefile width justification */
+							sscanf (&line[2], "%s %s %s", image, size, key);
+							first = gmt_download_file_if_not_found (GMT, image, GMT_CACHE_DIR);
+							if (gmt_getdatapath (GMT, &image[first], path, R_OK) == NULL) {
+								GMT_Report (API, GMT_MSG_ERROR, "Cannot find/open file %s.\n", &image[first]);
+								Return (GMT_FILE_NOT_FOUND);
+							}
+							if ((aspect = pslegend_get_image_aspect (API, path)) < 0.0) {
+								GMT_Report (API, GMT_MSG_ERROR, "Trouble reading %s! - Skipping.\n", &image[first]);
+								continue;
+							}
+							justify = gmt_just_decode (GMT, key, PSL_NO_DEF);
+							row_height = gmt_M_to_inch (GMT, size) * aspect;
+							pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
+							x_off = Ctrl->D.refpoint->x;
+							x_off += (justify%4 == 1) ? Ctrl->C.off[GMT_X] : ((justify%4 == 3) ? Ctrl->D.dim[GMT_X] - Ctrl->C.off[GMT_X] : 0.5 * Ctrl->D.dim[GMT_X]);
+							sprintf (buffer, "-O -K %s -Dx%gi/%gi+j%s+w%s --GMT_HISTORY=readonly", &image[first], x_off, row_base_y, key, size);
+							GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: gmt psimage %s\n", buffer);
+							status = GMT_Call_Module (API, "psimage", GMT_MODULE_CMD, buffer);	/* Plot the image */
+							if (status) {
+								GMT_Report (API, GMT_MSG_ERROR, "GMT_psimage returned error %d.\n", status);
+								Return (GMT_RUNTIME_ERROR);
+							}
+							row_base_y -= row_height;
+							column_number = 0;
+							drawn = true;
+							break;
+
+						case 'L':	/* Label record: L font|- justification label */
+							text[0] = '\0';
+							sscanf (&line[2], "%s %s %s %[^\n]", size, font, key, text);
+							if (pslegend_new_fontsyntax (GMT, size, font)) {	/* GMT5 font specification */
+								sscanf (&line[2], "%s %s %[^\n]", font, key, text);
+								if (font[0] == '-')	/* Want the default label font */
+									sprintf (tmp, "%s", gmt_putfont (GMT, &GMT->current.setting.font_label));
+								else
+									strcpy (tmp, font);	/* Gave a font specification */
+							}
+							else {	/* Old GMT4 syntax for fontsize and font and must manually add color (e.g., via -C) */
+								if (size[0] == '-') size[0] = 0;
+								if (font[0] == '-') font[0] = 0;
+								sprintf (tmp, "%s,%s,%s", size, font, txtcolor);	/* Put size, font and color together for parsing by gmt_getfont */
+							}
+							ifont = GMT->current.setting.font_label;	/* Set default font */
+							gmt_getfont (GMT, tmp, &ifont);
+							if (C_is_active) gmt_M_rgb_copy (ifont.fill.rgb, C_rgb);	/* Must update text color */
+							d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT (ifont.id)) * ifont.size / PSL_POINTS_PER_INCH;	/* To center the text */
+							if (column_number%n_columns == 0) {	/* Label in first column, also fill row if requested */
+								row_height = Ctrl->D.spacing * ifont.size / PSL_POINTS_PER_INCH;
+								pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-row_height, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
+								row_base_y -= row_height;
+								column_number = 0;
+								if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
+							}
+							if (text[0] == '\0') {	/* Nothing to do, just skip to next */
+								column_number++;
+								GMT_Report (API, GMT_MSG_DEBUG, "The L record gave no info so skip to next cell\n");
+								drawn = true;
+								break;
+							}
+							justify = gmt_just_decode (GMT, key, 0);
+							if (do_width) {
+								PSL_setcurrentpoint (PSL, Ctrl->D.refpoint->x + Ctrl->C.off[GMT_X], row_base_y + d_off);
+								PSL_setfont (PSL, ifont.id);
+								if (justify == PSL_BR)
+									PSL_command (PSL, "PSL_legend_box_width PSL_legend_clear_x sub 0 G\n");
+								else if (justify == PSL_BC)
+									PSL_command (PSL, "PSL_legend_box_width PSL_legend_clear_x sub 2 div 0 G\n");
+								PSL_plottext (PSL, 0.0, 0.0, -ifont.size, text, 0.0, justify, 0);
+							}
+							else {
+								x_off = Ctrl->D.refpoint->x + x_off_col[column_number];
+								x_off += (justify%4 == 1) ? Ctrl->C.off[GMT_X] : ((justify%4 == 3) ? (x_off_col[column_number+1]-x_off_col[column_number]) - Ctrl->C.off[GMT_X] : 0.5 * (x_off_col[column_number+1]-x_off_col[column_number]));
+								sprintf (buffer, "%s B%s %s", gmt_putfont (GMT, &ifont), key, text);
+								if ((D[TXT] = pslegend_get_dataset_pointer (API, D[TXT], GMT_IS_NONE, 1U, 64U, 2U, true)) == NULL) return (API->error);
+								S[TXT] = pslegend_get_segment (D, TXT, 0);	/* Since there will only be one table with one segment for each set, except for fronts */
+								S[TXT]->data[GMT_X][krow[TXT]] = x_off;
+								S[TXT]->data[GMT_Y][krow[TXT]] = row_base_y + d_off;
+								S[TXT]->text[krow[TXT]++] = strdup (buffer);
+								S[TXT]->n_rows++;
+								GMT_Report (API, GMT_MSG_DEBUG, "TXT: %s\n", buffer);
+								pslegend_maybe_realloc_segment (GMT, S[TXT]);
+							}
+							column_number++;
+							drawn = true;
+							break;
+
+						case 'M':	/* Map scale record M lon0|- lat0 length[n|m|k][+mods] [-F] [-R -J] */
+							/* Was: Map scale record M lon0|- lat0 length[n|m|k][+opts] f|p  [-R -J] */
+							n_scan = sscanf (&line[2], "%s %s %s %s %s %s", txt_a, txt_b, txt_c, txt_d, txt_e, txt_f);
+							r_options[0] = module_options[0] = '\0';
+							if (txt_d[0] == 'f' || txt_d[0] == 'p') {	/* Old-style args */
+								if (n_scan == 6)	/* Gave -R -J */
+									sprintf (r_options, "%s %s", txt_e, txt_f);
+								if (txt_d[0] == 'f') strcat (txt_c, "+f");	/* Wanted fancy scale so append +f to length */
+							}
+							else {	/* New syntax */
+								if (n_scan == 4)	/* Gave just -F */
+									strcpy (module_options, txt_d);
+								else if (n_scan == 5)	/* Gave -R -J */
+									sprintf (r_options, "%s %s", txt_d, txt_e);
+								else if (n_scan == 6) {	/* Gave -F -R -J which may be in any order */
+									if (txt_d[1] == 'F') {	/* Got -F -R -J */
+										sprintf (module_options, " %s", txt_d);
+										sprintf (r_options, "%s %s", txt_e, txt_f);
+									}
+									else if (txt_f[1] == 'F') {	/* Got -R -J -F */
+										sprintf (r_options, "%s %s", txt_d, txt_e);
+										sprintf (module_options, " %s", txt_f);
+									}
+									else {	/* Got -R -F -J or -J -F -R */
+										sprintf (r_options, "%s %s", txt_d, txt_f);
+										sprintf (module_options, " %s", txt_e);
+									}
+								}
+							}
+							for (i = 0, gave_mapscale_options = false; txt_c[i] && !gave_mapscale_options; i++) if (txt_c[i] == '+') gave_mapscale_options = true;
+							/* Default assumes label is added on top */
+							just = 't';
+							gave_label = true;
+							row_height = GMT->current.setting.map_scale_height + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH + GMT->current.setting.map_annot_offset[0];
+							d_off = FONT_HEIGHT_LABEL * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH + fabs(GMT->current.setting.map_label_offset);
+							if ((txt_d[0] == 'f' || txt_d[0] == 'p') && gmt_get_modifier (txt_c, 'j', string))	/* Specified alternate justification old-style */
+								just = string[0];
+							else if (gmt_get_modifier (txt_c, 'a', string))	/* Specified alternate alignment */
+								just = string[0];
+							if (gmt_get_modifier (txt_c, 'u', string))	/* Specified alternate alignment */
+								gave_label = false;	/* Not sure why I do this, will find out */
+							h = row_height;
+							if (gave_label && (just == 't' || just == 'b')) h += d_off;
+							pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-h, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
+							if (gave_label && just == 't') row_base_y -= d_off;
+							if (!strcmp (txt_a, "-"))	/* No longitude needed */
+								sprintf (mapscale, "x%gi/%gi+c%s+jTC+w%s", Ctrl->D.refpoint->x + 0.5 * Ctrl->D.dim[GMT_X], row_base_y, txt_b, txt_c);
+							else				/* Gave both lon and lat for scale */
+								sprintf (mapscale, "x%gi/%gi+c%s/%s+jTC+w%s", Ctrl->D.refpoint->x + 0.5 * Ctrl->D.dim[GMT_X], row_base_y, txt_a, txt_b, txt_c);
+							if (r_options[0])	/* Gave specific -R -J on M line */
+								sprintf (buffer, "%s -O -K -L%s", r_options, mapscale);
+							else {	/* Must use -R -J as supplied to pslegend */
+								gmt_set_missing_options (GMT, "RJ");	/* If mode is modern, -R -J exist in the history, and if an overlay we may add these from history automatically */
+								if (!GMT->common.R.active[RSET] || !GMT->common.J.active) {
+									GMT_Report (API, GMT_MSG_ERROR, "The M record must have map -R -J if -Dx and no -R -J is used\n");
+									Return (GMT_RUNTIME_ERROR);
+								}
+								sprintf (buffer, "-R%s -J%s -O -K -L%s", GMT->common.R.string, GMT->common.J.string, mapscale);
+							}
+							if (module_options[0]) strcat (buffer, module_options);
+							strcat (buffer, " --GMT_HISTORY=readonly");
+							GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: gmt psbasemap %s\n", buffer);
+							status = GMT_Call_Module (API, "psbasemap", GMT_MODULE_CMD, buffer);	/* Plot the scale */
+							if (status) {
+								GMT_Report (API, GMT_MSG_ERROR, "GMT_psbasemap returned error %d.\n", status);
+								Return (GMT_RUNTIME_ERROR);
+							}
+							if (gave_label && just == 'b') row_base_y -= d_off;
+							row_base_y -= row_height;
+							column_number = 0;
+							if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
+							drawn = true;
+							break;
+
+						case 'N':	/* n_columns record: N ncolumns OR rw1 rw2 ... rwn (for relative widths) */
+							n_col = n_columns;	/* Previous setting */
+							pos = n_columns = 0;
+							while ((gmt_strtok (&line[2], " \t", &pos, p))) {
+								col_width[n_columns++] = atof (p);
+								if (n_columns == PSLEGEND_MAX_COLS) {
+									GMT_Report (API, GMT_MSG_ERROR, "Exceeding maximum columns (%d) in N operator\n", PSLEGEND_MAX_COLS);
+									Return (GMT_RUNTIME_ERROR);
+								}
+							}
+							if (n_columns == 0) n_columns = 1;	/* Default to 1 if nothing is given */
+							/* Check if user gave just the number of columns and not relative widths */
+							if (n_columns == 1 && (pos = atoi (&line[2])) > 1) {	/* Set number of columns and indicate equal widths */
+								n_columns = pos;
+								for (column_number = 0; column_number < n_columns; column_number++) col_width[column_number] = 1.0;
+							}
+							for (column_number = 0, sum_width = 0.0; column_number < n_columns; column_number++) sum_width += col_width[column_number];
+							for (column_number = 1, x_off_col[0] = 0.0; column_number < n_columns; column_number++) x_off_col[column_number] = x_off_col[column_number-1] + (Ctrl->D.dim[GMT_X] * col_width[column_number-1] / sum_width);
+							x_off_col[column_number] = Ctrl->D.dim[GMT_X];	/* Holds width of row */
+							if (n_columns > n_col) for (col = 1; col < n_columns; col++) if (fill[0]) fill[col] = strdup (fill[0]);	/* Extend the fill array to match the new column numbers, if fill is active */
+							column_number = 0;
+							if (gmt_M_is_verbose (GMT, GMT_MSG_DEBUG)) {
+								double s = gmt_convert_units (GMT, "1", GMT_INCH, GMT->current.setting.proj_length_unit);
+								GMT_Report (API, GMT_MSG_DEBUG, "Selected %d columns.  Column widths are:\n", n_columns);
+								for (col = 1; col <= n_columns; col++)
+									GMT_Report (API, GMT_MSG_DEBUG, "Column %d: %g %s\n", col, s*(x_off_col[col]-x_off_col[col-1]), GMT->session.unit_name[GMT->current.setting.proj_length_unit]);
+							}
+							break;
+
+						case '>':	/* Paragraph text header */
+							if (gmt_M_compat_check (GMT, 4)) {	/* Warn and fall through on purpose */
+								GMT_Report (API, GMT_MSG_COMPAT, "Paragraph text header flag > is deprecated; use P instead\n");
+								n = sscanf (&line[1], "%s %s %s %s %s %s %s %s %s", xx, yy, size, angle, font, key, lspace, tw, jj);
+								if (n < 0) n = 0;	/* Since -1 is returned if no arguments */
+								if (!(n == 0 || n == 9)) {
+									GMT_Report (API, GMT_MSG_ERROR, "The > record must have 0 or 9 arguments (only %d found)\n", n);
+									Return (GMT_RUNTIME_ERROR);
+								}
+								if (n == 0 || size[0] == '-') sprintf (size, "%g", GMT->current.setting.font_annot[GMT_PRIMARY].size);
+								if (n == 0 || font[0] == '-') sprintf (font, "%d", GMT->current.setting.font_annot[GMT_PRIMARY].id);
+								sprintf (tmp, "%s,%s,", size, font);
+								did_old = true;
+							}
+							else {
+								GMT_Report (API, GMT_MSG_ERROR, "Unrecognized record (%s)\n", line);
+								Return (GMT_RUNTIME_ERROR);
+								break;
+							}
+							/* Intentionally fall through */
+						case 'P':	/* Paragraph text header: P paragraph-mode-header-for-text */
+							if (!did_old) {
+								n = sscanf (&line[1], "%s %s %s %s %s %s %s %s", xx, yy, tmp, angle, key, lspace, tw, jj);
+								if (n < 0) n = 0;	/* Since -1 is returned if no arguments */
+								if (!(n == 0 || n == 8)) {
+									GMT_Report (API, GMT_MSG_ERROR, "The P record must have 0 or 8 arguments (only %d found)\n", n);
+									Return (GMT_RUNTIME_ERROR);
+								}
+							}
+							did_old = false;
+							if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
+							if (n == 0 || xx[0] == '-') sprintf (xx, "%g", col_left_x);
+							if (n == 0 || yy[0] == '-') sprintf (yy, "%g", row_base_y);
+							if (n == 0 || tmp[0] == '-') sprintf (tmp, "%gp,%d,%s", GMT->current.setting.font_annot[GMT_PRIMARY].size, GMT->current.setting.font_annot[GMT_PRIMARY].id, txtcolor);
+							if (n == 0 || angle[0] == '-') sprintf (angle, "0");
+							if (n == 0 || key[0] == '-') sprintf (key, "TL");
+							if (n == 0 || lspace[0] == '-') sprintf (lspace, "%gi", one_line_spacing);
+							if (n == 0 || tw[0] == '-') sprintf (tw, "%gi", Ctrl->D.dim[GMT_X] - 2.0 * Ctrl->C.off[GMT_X]);
+							if (n == 0 || jj[0] == '-') sprintf (jj, "j");
 							if (n_para >= 0) {	/* End of previous paragraph for sure */
 								S[PAR]->n_rows = krow[PAR];
 								S[PAR] = D[PAR]->table[0]->segment[n_para] = GMT_Alloc_Segment (GMT->parent, GMT_WITH_STRINGS, krow[PAR], 0U, NULL, S[PAR]);
 							}
-							n_para++;
-							krow[PAR] = 0;	/* Start fresh with new segment */
-						}
-						if ((S[PAR] = pslegend_get_segment (D, PAR, n_para)) == NULL)	/* Get/Allocate this paragraph segment */
-							S[PAR] = D[PAR]->table[0]->segment[n_para] = GMT_Alloc_Segment (GMT->parent, GMT_WITH_STRINGS, n_par_lines, 0U, NULL, NULL);
-						if (!flush_paragraph) {	/* No header record, create one and add as segment header */
-							d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT_PRIMARY) * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;
-							sprintf (buffer, "%g %g 0 %gp,%d,%s TL %gi %gi j", col_left_x, row_base_y - d_off, GMT->current.setting.font_annot[GMT_PRIMARY].size, GMT->current.setting.font_annot[GMT_PRIMARY].id, txtcolor, one_line_spacing, Ctrl->D.dim[GMT_X] - 2.0 * Ctrl->C.off[GMT_X]);
-							S[PAR]->header = strdup (buffer);
+							if ((D[PAR] = pslegend_get_dataset_pointer (API, D[PAR], GMT_IS_TEXT, 1U, n_par_total, 0U, true)) == NULL) return (API->error);
+							sprintf (buffer, "%s %s %s %s %s %s %s %s", xx, yy, angle, tmp, key, lspace, tw, jj);
+							S[PAR] = pslegend_get_segment (D, PAR, ++n_para);	/* We store the header as one of the text records for simplicity */
 							GMT_Report (API, GMT_MSG_DEBUG, "PAR: %s\n", buffer);
-						}
-						/* Now processes paragraph text */
-						sscanf (&line[2], "%[^\n]", text);
-						S[PAR]->text[krow[PAR]++] = strdup (text);
-						S[PAR]->n_rows++;
-						pslegend_maybe_realloc_segment (GMT, S[PAR]);
-						GMT_Report (API, GMT_MSG_DEBUG, "PAR: %s\n", text);
-						flush_paragraph = true;
-						column_number = 0;
-						drawn = true;
-						break;
+							S[PAR]->header = strdup (buffer);
+							pslegend_maybe_realloc_segment (GMT, S[PAR]);
+							flush_paragraph = true;
+							column_number = 0;
+							drawn = true;
+							krow[PAR] = 0;	/* Start fresh with new segment */
+							break;
 
-					case 'V':	/* Vertical line from here to next V: V offset pen */
-						n_scan = sscanf (&line[2], "%s %s", txt_a, txt_b);
-						if (n_scan == 1) {	/* Assume user forgot to give offset as he/she wants 0 */
-							strcpy (txt_b, txt_a);
-							strcpy (txt_a, "0");
-						}
-						if (v_line_draw_now) {	/* Second time, now draw line */
-							double v_line_y_stop = d_line_last_y0;
-							v_line_ver_offset = gmt_M_to_inch (GMT, txt_a);
-							if (txt_b[0] && gmt_getpen (GMT, txt_b, &current_pen)) {
-								gmt_pen_syntax (GMT, 'V', NULL, " ", 0);
-								Return (GMT_RUNTIME_ERROR);
+						case 'S':	/* Symbol record: S [dx1 symbol size fill pen [ dx2 text ]] */
+							if (strlen (line) > 2)
+								n_scan = sscanf (&line[2], "%s %s %s %s %s %s %[^\n]", txt_a, symbol, size, txt_c, txt_d, txt_b, text);
+							else	/* No args given means skip to next cell */
+								n_scan = 0;
+							if (column_number%n_columns == 0) {	/* Symbol in first column, also fill row if requested */
+								pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-one_line_spacing, row_base_y+gap, x_off_col, &d_line_after_gap, n_columns, fill);
+								row_base_y -= one_line_spacing;
+								column_number = 0;
 							}
-							gmt_setpen (GMT, &current_pen);
-							for (i = 1; i < n_columns; i++) {
-								x_off = Ctrl->D.refpoint->x + x_off_col[i];
-								PSL_plotsegment (PSL, x_off, v_line_y_start-v_line_ver_offset, x_off, v_line_y_stop+v_line_ver_offset);
+							if (n_scan <= 0) {	/* No symbol, just skip to next cell */
+								column_number++;
+								GMT_Report (API, GMT_MSG_DEBUG, "The S record give no info so skip to next cell\n");
+								drawn = true;
+								break;
 							}
-							v_line_draw_now = false;
-						}
-						else {	/* First time, mark from where we draw vertical line */
-							v_line_draw_now = true;
-							v_line_y_start = d_line_last_y0;
-						}
-						column_number = 0;
-						if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
-						break;
+							if ((API->error = gmt_get_rgbtxt_from_z (GMT, P, txt_c)) != 0) Return (GMT_RUNTIME_ERROR);	/* If given z=value then we look up colors */
+							if (strchr ("LCR", txt_a[0])) {	/* Gave L, C, or R justification relative to current cell */
+								justify = gmt_just_decode (GMT, txt_a, 0);
+								off_ss = (justify%4 == 1) ? Ctrl->C.off[GMT_X] : ((justify%4 == 3) ? (x_off_col[column_number+1]-x_off_col[column_number]) - Ctrl->C.off[GMT_X] : 0.5 * (x_off_col[column_number+1]-x_off_col[column_number]));
+								x_off = Ctrl->D.refpoint->x + x_off_col[column_number];
+							}
+							else if (!strcmp (txt_a, "-")) {	/* Automatic margin offset */
+								off_ss = GMT_LEGEND_DX1_MUL * Ctrl->S.scale * def_size;
+								x_off = col_left_x + x_off_col[column_number];
+							}
+							else {	/* Gave a specific offset */
+								off_ss = gmt_M_to_inch (GMT, txt_a);
+								x_off = col_left_x + x_off_col[column_number];
+							}
+							if (!strcmp (txt_b, "-"))	/* Automatic label offset */
+								off_tt = GMT_LEGEND_DX2_MUL * Ctrl->S.scale * def_size;
+							else	/* Gave a specific offset */
+								off_tt = gmt_M_to_inch (GMT, txt_b);
+							d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT_PRIMARY) * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;	/* To center the text */
+							row_base_y += half_line_spacing;	/* Move to center of box */
+							if (symbol[0] == '-' && !strcmp (size, "-")) sprintf (size, "%gi", def_size);	/* If no size given then we must pick what we learned above */
+							if (symbol[0] == 'f') {	/* Front is different, must plot as a line segment */
+								double length, tlen, gap;
+								int n = sscanf (size, "%[^/]/%[^/]/%s", A, B, C);
 
-					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Unrecognized record (%s)\n", line);
-						Return (GMT_RUNTIME_ERROR);
-					break;
+								if (n == 3) {	/* Got line length, tickgap, and ticklength */
+									length = Ctrl->S.scale * gmt_M_to_inch (GMT, A);	/* The length of the line */
+									tlen = Ctrl->S.scale * gmt_M_to_inch (GMT, C);	/* The length of the tick */
+								}
+								else if (n == 2 && B[0] != '-') {	/* Got line length and tickgap only */
+									length = Ctrl->S.scale * gmt_M_to_inch (GMT, A);	/* The length of the line */
+									gap = Ctrl->S.scale * gmt_M_to_inch (GMT, B);	/* The tick gap */
+									tlen = 0.3 * gap;		/* The default length of the tick is 30% of gap */
+								}
+								else {	/* Got line length, select defaults for other things */
+									length = Ctrl->S.scale * gmt_M_to_inch (GMT, A);	/* The length of the line */
+									strcpy (B, "-1");		/* One centered tick */
+									tlen = 0.3 * length;		/* The default length of the tick is 30% of length */
+								}
+								if ((c = strchr (symbol, '+')) != NULL)	/* Pass along all the given modifiers */
+									strcpy (sub, c);
+								else	/* The necessary arguments not supplied, provide reasonable defaults */
+									sprintf (sub, "+l+b");	/* Box to the left of the line is our default front symbol */
+								x = 0.5 * length;
+								/* Place pen and fill colors in segment header */
+								sprintf (buffer, "-Sf%s/%gi%s", B, tlen, sub);
+								if (txt_c[0] != '-') {strcat (buffer, " -G"); strcat (buffer, txt_c);}
+								if (txt_d[0] != '-') {strcat (buffer, " -W"); strcat (buffer, txt_d);}
+								/* Prepare next output segment */
+								if ((D[FRONT] = pslegend_get_dataset_pointer (API, D[FRONT], GMT_IS_LINE, 64U, 2U, 2U, false)) == NULL) return (API->error);
+								S[FRONT] = pslegend_get_segment (D, FRONT, n_fronts);	/* Next front segment */
+								S[FRONT]->header = strdup (buffer);
+								GMT_Report (API, GMT_MSG_DEBUG, "FRONT: %s\n", buffer);
+								/* Set begin and end coordinates of the line segment */
+								S[FRONT]->data[GMT_X][0] = x_off + off_ss-x;	S[FRONT]->data[GMT_Y][0] = row_base_y;
+								S[FRONT]->data[GMT_X][1] = x_off + off_ss+x;	S[FRONT]->data[GMT_Y][1] = row_base_y;
+								S[FRONT]->n_rows = 2;
+								D[FRONT]->n_records += 2;
+								n_fronts++;
+								if (n_fronts == GMT_SMALL_CHUNK) {
+									GMT_Report (API, GMT_MSG_ERROR, "Can handle max %d front lines.  Let us know if this is a problem.\n", GMT_SMALL_CHUNK);
+									return (API->error);
+								}
+							}
+							else if (symbol[0] == 'q' || symbol[0] == '~') {	/* Quoted and decorated line is different, must plot as a line segment */
+								double length = Ctrl->S.scale * gmt_M_to_inch (GMT, size);	/* The length of the line */;
+
+								if ((D[QLINE] = pslegend_get_dataset_pointer (API, D[QLINE], GMT_IS_LINE, 64U, 2U, 2U, false)) == NULL) return (API->error);
+								x = 0.5 * length;
+								/* Place pen and fill colors in segment header */
+								sprintf (buffer, "-S%s", symbol);
+								if (txt_d[0] != '-') {strcat (buffer, " -W"); strcat (buffer, txt_d);}
+								S[QLINE] = pslegend_get_segment (D, QLINE, n_quoted_lines);	/* Next quoted line segment */
+								S[QLINE]->header = strdup (buffer);
+								GMT_Report (API, GMT_MSG_DEBUG, "QLINE: %s\n", buffer);
+								/* Set begin and end coordinates of the line segment */
+								S[QLINE]->data[GMT_X][0] = x_off + off_ss-x;	S[QLINE]->data[GMT_Y][0] = row_base_y;
+								S[QLINE]->data[GMT_X][1] = x_off + off_ss+x;	S[QLINE]->data[GMT_Y][1] = row_base_y;
+								S[QLINE]->n_rows = 2;
+								D[QLINE]->n_records += 2;
+								n_quoted_lines++;
+								if (n_quoted_lines == GMT_SMALL_CHUNK) {
+									GMT_Report (API, GMT_MSG_ERROR, "Can handle max %d quoted/decorated lines.  Let us know if this is a problem.\n", GMT_SMALL_CHUNK);
+									return (API->error);
+								}
+							}
+							else {	/* Regular symbols */
+								if ((D[SYM] = pslegend_get_dataset_pointer (API, D[SYM], GMT_IS_POINT, 64U, 1U, 6U, true)) == NULL) return (API->error);
+								S[SYM] = pslegend_get_segment (D, SYM, n_symbols);	/* Since there will only be one table with one segment for each single row */
+								S[SYM]->data[GMT_X][0] = x_off + off_ss;
+								S[SYM]->data[GMT_Y][0] = row_base_y;
+								S[SYM]->n_rows = 1;
+								if (symbol[0] == 'k' || symbol[0] == 'K')	/* Custom symbols need the full name after k */
+									sprintf (sub, "%s", symbol);
+								else	/* Just the symbol code is needed */
+									sprintf (sub, "%c", symbol[0]);
+								if (symbol[0] == 'E' || symbol[0] == 'e') {	/* Ellipse */
+									if (strchr (size, ',')) {	/* We got dir,major,minor instead of just size; parse and use */
+										sscanf (size, "%[^,],%[^,],%s", A, B, C);
+										az1 = atof (A);
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
+										y = Ctrl->S.scale * gmt_M_to_inch (GMT, C);
+									}
+									else {	/* Ellipse needs more arguments; we use minor = 0.65*major, az = 0 */
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+										if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
+										az1 = 0.0;
+										y = 0.65 * x;
+									}
+									S[SYM]->data[2][0] = az1;
+									S[SYM]->data[3][0] = x;
+									S[SYM]->data[4][0] = y;
+								}
+								else if (symbol[0] == 'J' || symbol[0] == 'j') {	/* rotated rectangle */
+									if (strchr (size, ',')) {	/* We got dir,w,h instead of just size; parse and use */
+										sscanf (size, "%[^,],%[^,],%s", A, B, C);
+										az1 = atof (A);
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
+										y = Ctrl->S.scale * gmt_M_to_inch (GMT, C);
+									}
+									else {	/* Rotated rectangle needs more arguments; we use height = 0.65*width, az = 30 */
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+										if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
+										y = 0.65 * x;
+										az1 = 30.0;
+									}
+									S[SYM]->data[2][0] = az1;
+									S[SYM]->data[3][0] = x;
+									S[SYM]->data[4][0] = y;
+								}
+								else if (symbol[0] == 'V' || symbol[0] == 'v') {	/* Vector */
+									/* Because we support both GMT4 and GMT5 vector notations this section is a bit messy */
+									if (strchr (size, ',')) {	/* We got dir,length combined as one argument */
+										sscanf (size, "%[^,],%s", A, B);
+										az1 = atof (A);
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
+									}
+									else {	/* No dir given, default to horizontal */
+										az1 = 0.0;
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+									}
+									if (strchr (size, '/') && gmt_M_compat_check (GMT, 4))  {	/* The necessary arguments was supplied via GMT4 size arguments */
+										i = 0;
+										while (size[i] != '/' && size[i]) i++;
+										size[i++] = '\0';	/* So gmt_M_to_inch won't complain */
+										sprintf (sub, "%s%s+jc+e", symbol, &size[i]);
+									}
+									else if ((c = strchr (symbol, '+')) != NULL) {	/* GMT5 syntax: Pass along all the given modifiers */
+										strcpy (sub, symbol);
+										if ((c = strstr (sub, "+j")) != NULL && c[2] != 'c') {	/* Got justification, check if it is +jc */
+											GMT_Report (API, GMT_MSG_ERROR, "Vector justification changed from +j%c to +jc\n", c[2]);
+											c[2] = 'c';	/* Replace with centered justification */
+										}
+										else	/* Add +jc */
+											strcat (sub, "+jc");
+									}
+									else	/* The necessary arguments not supplied, so we make a reasonable default */
+										sprintf (sub, "v%gi+jc+e", 0.3*x);	/* Head size is 30% of length */
+									if (txt_c[0] == '-') strcat (sub, "+g-");
+									else { strcat (sub, "+g"); strcat (sub, txt_c);}
+									if (txt_d[0] == '-') strcat (sub, "+p-");
+									else {
+										struct GMT_PEN pen;
+										gmt_M_memset (&pen, 1, struct GMT_PEN);	/* Wipe the pen */
+										gmt_getpen (GMT, txt_d, &pen);
+										pen.width *= 0.5;
+										strcat (sub, "+p"); strcat (sub, gmt_putpen (API->GMT, &pen));
+									}
+									S[SYM]->data[2][0] = az1;
+									S[SYM]->data[3][0] = x;
+								}
+								else if (symbol[0] == 'r') {	/* Rectangle  */
+									if (strchr (size, ',')) {	/* We got w,h */
+										sscanf (size, "%[^,],%s", A, B);
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, A);
+										y = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
+									}
+									else {	/* Rectangle also need more args, we use h = 0.65*w */
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+										if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
+										y = 0.65 * x;
+									}
+									S[SYM]->data[2][0] = x;
+									S[SYM]->data[3][0] = y;
+								}
+								else if (symbol[0] == 'R') {	/* Rounded rectangle  */
+									if (strchr (size, ',')) {	/* We got w,h,r */
+										sscanf (size, "%[^,],%[^,],%s", A, B, C);
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, A);
+										y = Ctrl->S.scale * gmt_M_to_inch (GMT, B);
+										r = Ctrl->S.scale * gmt_M_to_inch (GMT, C);
+									}
+									else {	/* Rounded rectangle also need more args, we use h = 0.65*w and r = 0.1*w */
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+										if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
+										y = 0.65 * x;
+										r = 0.1 * x;
+									}
+									S[SYM]->data[2][0] = x;
+									S[SYM]->data[3][0] = y;
+									S[SYM]->data[4][0] = r;
+								}
+								else if (symbol[0] == 'm') {	/* Math angle  */
+									if (strchr (size, ',')) {	/* We got r,az1,az2 */
+										sscanf (size, "%[^,],%[^,],%s", A, B, C);
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, A);
+										az1 = atof (B);
+										az2 = atof (C);
+									}
+									else {	/* Math angle need more args, we set fixed az1,az22 as 10 45 */
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+										if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
+										az1 = 10;	az2 = 45;
+									}
+									/* We want to center the arc around its mid-point */
+									m_az = 0.5 * (az1 + az2);
+									dx = 0.25 * x * cosd (m_az);
+									if (!strchr (symbol, '+'))  {	/* The necessary arguments not supplied! */
+										sprintf (sub, "m%gi+b+e", 0.3*x);	/* Double heads, head size 30% of diameter */
+									}
+									if (txt_c[0] == '-') strcat (sub, "+g-");
+									else { strcat (sub, "+g"); strcat (sub, txt_c);}
+									if (txt_d[0] == '-') strcat (sub, "+p-");
+									else { strcat (sub, "+p"); strcat (sub, txt_d);}
+									S[SYM]->data[GMT_X][0] -= dx;
+									S[SYM]->data[2][0] = x;
+									S[SYM]->data[3][0] = az1;
+									S[SYM]->data[4][0] = az2;
+								}
+								else if (symbol[0] == 'w') {	/* Wedge also need more args; we set fixed az1,az2 as -30 30 */
+									if (strchr (size, ',')) {	/* We got az1,az2,d */
+										sscanf (size, "%[^,],%[^,],%s", A, B, C);
+										az1 = atof (A);
+										az2 = atof (B);
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, C);
+									}
+									else {
+										x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+										if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
+										az1 = -30;	az2 = 30;
+									}
+									/* We want to center the wedge around its mid-point */
+									m_az = 0.5 * (az1 + az2);
+									dx = 0.25 * x * cosd (m_az);
+									S[SYM]->data[GMT_X][0] -= dx;
+									S[SYM]->data[2][0] = x_off + off_ss - dx;
+									S[SYM]->data[3][0] = az1;
+									S[SYM]->data[4][0] = az2;
+								}
+								else {
+									x = Ctrl->S.scale * gmt_M_to_inch (GMT, size);
+									if (gmt_M_is_zero (x)) x = Ctrl->S.scale * def_size;	/* Safety valve */
+									S[SYM]->data[2][0] = x;
+								}
+								/* Place pen and fill colors in segment header */
+								sprintf (buffer, "-G"); strcat (buffer, txt_c);
+								strcat (buffer, " -W"); strcat (buffer, txt_d);
+								S[SYM]->header = strdup (buffer);
+								GMT_Report (API, GMT_MSG_DEBUG, "SYM: %s\n", buffer);
+								GMT_Report (API, GMT_MSG_DEBUG, "SYM: %s\n", sub);
+								S[SYM]->text[0] = strdup (sub);
+								SH = gmt_get_DS_hidden (S[SYM]);
+								if (S[SYM]->n_rows == SH->n_alloc) S[SYM]->data = gmt_M_memory (GMT, S[SYM]->data, SH->n_alloc += GMT_SMALL_CHUNK, char *);
+								n_symbols++;
+							}
+							/* Finally, print text; skip when empty */
+							row_base_y -= half_line_spacing;	/* Go back to bottom of box */
+							if (n_scan == 7) {	/* Place symbol text */
+								if ((D[TXT] = pslegend_get_dataset_pointer (API, D[TXT], GMT_IS_NONE, 1U, 64U, 2U, true)) == NULL) return (API->error);
+								S[TXT] = pslegend_get_segment (D, TXT, 0);	/* Since there will only be one table with one segment for each set, except for fronts */
+								sprintf (buffer, "%gp,%d,%s BL %s", GMT->current.setting.font_annot[GMT_PRIMARY].size, GMT->current.setting.font_annot[GMT_PRIMARY].id, txtcolor, text);
+								S[TXT]->data[GMT_X][krow[TXT]] = x_off + off_tt;
+								S[TXT]->data[GMT_Y][krow[TXT]] = row_base_y + d_off;
+								S[TXT]->text[krow[TXT]++] = strdup (buffer);
+								S[TXT]->n_rows++;
+								pslegend_maybe_realloc_segment (GMT, S[TXT]);
+								GMT_Report (API, GMT_MSG_DEBUG, "TXT: %s\n", buffer);
+							}
+							column_number++;
+							if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
+							drawn = true;
+							break;
+
+						case 'T':	/* paragraph text record: T paragraph-text */
+							if ((D[PAR] = pslegend_get_dataset_pointer (API, D[PAR], GMT_IS_TEXT, n_par_total, n_par_lines, 0U, true)) == NULL) return (API->error);
+							/* If no previous > record, then use defaults */
+							if (!flush_paragraph) {	/* No header record, but a new paragraph. */
+								if (n_para >= 0) {	/* End of previous paragraph for sure */
+									S[PAR]->n_rows = krow[PAR];
+									S[PAR] = D[PAR]->table[0]->segment[n_para] = GMT_Alloc_Segment (GMT->parent, GMT_WITH_STRINGS, krow[PAR], 0U, NULL, S[PAR]);
+								}
+								n_para++;
+								krow[PAR] = 0;	/* Start fresh with new segment */
+							}
+							if ((S[PAR] = pslegend_get_segment (D, PAR, n_para)) == NULL)	/* Get/Allocate this paragraph segment */
+								S[PAR] = D[PAR]->table[0]->segment[n_para] = GMT_Alloc_Segment (GMT->parent, GMT_WITH_STRINGS, n_par_lines, 0U, NULL, NULL);
+							if (!flush_paragraph) {	/* No header record, create one and add as segment header */
+								d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT_PRIMARY) * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;
+								sprintf (buffer, "%g %g 0 %gp,%d,%s TL %gi %gi j", col_left_x, row_base_y - d_off, GMT->current.setting.font_annot[GMT_PRIMARY].size, GMT->current.setting.font_annot[GMT_PRIMARY].id, txtcolor, one_line_spacing, Ctrl->D.dim[GMT_X] - 2.0 * Ctrl->C.off[GMT_X]);
+								S[PAR]->header = strdup (buffer);
+								GMT_Report (API, GMT_MSG_DEBUG, "PAR: %s\n", buffer);
+							}
+							/* Now processes paragraph text */
+							sscanf (&line[2], "%[^\n]", text);
+							S[PAR]->text[krow[PAR]++] = strdup (text);
+							S[PAR]->n_rows++;
+							pslegend_maybe_realloc_segment (GMT, S[PAR]);
+							GMT_Report (API, GMT_MSG_DEBUG, "PAR: %s\n", text);
+							flush_paragraph = true;
+							column_number = 0;
+							drawn = true;
+							break;
+
+						case 'V':	/* Vertical line from here to next V: V offset pen */
+							n_scan = sscanf (&line[2], "%s %s", txt_a, txt_b);
+							if (n_scan == 1) {	/* Assume user forgot to give offset as he/she wants 0 */
+								strcpy (txt_b, txt_a);
+								strcpy (txt_a, "0");
+							}
+							if (v_line_draw_now) {	/* Second time, now draw line */
+								double v_line_y_stop = d_line_last_y0;
+								v_line_ver_offset = gmt_M_to_inch (GMT, txt_a);
+								if (txt_b[0] && gmt_getpen (GMT, txt_b, &current_pen)) {
+									gmt_pen_syntax (GMT, 'V', NULL, " ", 0);
+									Return (GMT_RUNTIME_ERROR);
+								}
+								gmt_setpen (GMT, &current_pen);
+								for (i = 1; i < n_columns; i++) {
+									x_off = Ctrl->D.refpoint->x + x_off_col[i];
+									PSL_plotsegment (PSL, x_off, v_line_y_start-v_line_ver_offset, x_off, v_line_y_stop+v_line_ver_offset);
+								}
+								v_line_draw_now = false;
+							}
+							else {	/* First time, mark from where we draw vertical line */
+								v_line_draw_now = true;
+								v_line_y_start = d_line_last_y0;
+							}
+							column_number = 0;
+							if (Ctrl->F.debug) pslegend_drawbase (GMT, PSL, Ctrl->D.refpoint->x, Ctrl->D.refpoint->x + Ctrl->D.dim[GMT_X], row_base_y);
+							break;
+
+						default:
+							GMT_Report (API, GMT_MSG_ERROR, "Unrecognized record (%s)\n", line);
+							Return (GMT_RUNTIME_ERROR);
+						break;
+					}
+					if (drawn) gap = 0.0;	/* No longer first record that draws on page */
 				}
-				if (drawn) gap = 0.0;	/* No longer first record that draws on page */
 			}
 		}
 	}
+
 	/* If there is clearance and fill is active we must paint the clearance row */
 	if (Ctrl->C.off[GMT_Y] > 0.0) pslegend_fillcell (GMT, Ctrl->D.refpoint->x, row_base_y-Ctrl->C.off[GMT_Y], row_base_y, x_off_col, &d_line_after_gap, n_columns, fill);
 
-	if (GMT_Destroy_Data (API, &In) != GMT_NOERROR) {	/* Remove the main input file from registration */
-		Return (API->error);
+	for (set = INFO_HIDDEN; set <= INFO_GIVEN; set++) {
+		if (use[set] && GMT_Destroy_Data (API, &INFO[set]) != GMT_NOERROR) {	/* Remove the main input file from registration */
+			Return (API->error);
+		}
 	}
 	if (P && GMT_Destroy_Data (API, &P) != GMT_NOERROR)	/* Remove the last CPT from registration */
 		Return (API->error);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -440,7 +440,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 	/* High-level function that implements the pslegend task */
 	unsigned int set, tbl, pos, first = 0, ID, n_item = 0;
 	int i, justify = 0, n = 0, n_columns = 1, n_col, col, error = 0, column_number = 0, id, n_scan, status = 0, max_cols = 0;
-	bool flush_paragraph = false, v_line_draw_now = false, gave_label, gave_mapscale_options, did_old = false, use[2] = {false, false};
+	bool flush_paragraph = false, v_line_draw_now = false, gave_label, gave_mapscale_options, did_old = false, use[2] = {false, true};
 	bool drawn = false, b_cpt = false, C_is_active = false, do_width = false, in_PS_ok = true, got_line = false;
 	uint64_t seg, row, n_fronts = 0, n_quoted_lines = 0, n_symbols = 0, n_par_lines = 0, n_par_total = 0, krow[N_DAT], n_records = 0;
 	int64_t n_para = -1;
@@ -511,14 +511,8 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 		GMT->current.setting.io_seg_marker[GMT_IN] = '#';
 	}
 
-	if (GMT->current.setting.run_mode == GMT_MODERN) {
-		if (Ctrl->M.active)	/* use both hidden info and explicit info files */
-			use[INFO_HIDDEN] = use[INFO_GIVEN] = true;
-		else	/* Only read hidden file */
-			use[INFO_HIDDEN] = true;
-	}
-	else
-			use[INFO_GIVEN] = use[1] = true;
+	if (GMT->current.setting.run_mode == GMT_MODERN)	/* Possibly use both hidden info and explicit info files */
+		use[INFO_HIDDEN] =  true;
 
 	if (use[INFO_HIDDEN] && gmt_legend_file (API, legend_file) == 1) {	/* Running modern mode and we have a hidden legend file to read */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Processing hidden legend specification file %s\n", legend_file);
@@ -528,8 +522,12 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 		if (Ctrl->T.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_TEXT, GMT_WRITE_NORMAL, NULL, Ctrl->T.file, INFO[INFO_HIDDEN]) != GMT_NOERROR) {
 			Return (API->error);
 		}
+		if (!Ctrl->M.active) use[INFO_GIVEN] = false;	/* Without -M we only read one source */
 		n_records += INFO[INFO_HIDDEN]->n_records;
 	}
+	else
+		use[INFO_HIDDEN] =  false;
+
 	if (use[INFO_GIVEN]) {	/* Possibly register stdin and/or read specified input file(s) */
 		if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {	/* Register data input */
 			Return (API->error);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -104,10 +104,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<specfile>] -D%s[+w<width>[/<height>]][+l<spacing>]%s [%s]\n", name, GMT_XYANCHOR, GMT_OFFSET, GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-C<dx>[/<dy>]] [-F%s]\n", GMT_PANEL);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-M] %s%s%s[%s] [-S<scale>]\n", GMT_J_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeo_OPT);
-	if (API->GMT->current.setting.run_mode == GMT_MODERN)
-		GMT_Message (API, GMT_TIME_NONE, "\t[-T<file>] [%s] [%s] [%s]\n\t[%s]%s[%s]\n\t[%s] [%s] [%s]\n\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_t_OPT, GMT_PAR_OPT);
-	else
-		GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s]\n\t[%s]%s[%s]\n\t[%s] [%s] [%s]\n\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_t_OPT, GMT_PAR_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-T<file>] [%s] [%s] [%s]\n\t[%s]%s[%s]\n\t[%s] [%s] [%s]\n\n", GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_t_OPT, GMT_PAR_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\tReads legend layout specification from <specfile> [or stdin].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t(See module documentation for more information and <specfile> format).\n\n");
 
@@ -129,8 +126,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Merge hidden and explicit legend information files (modern mode only).\n");
 	GMT_Option (API, "O,P,R");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S Scale all symbol sizes by <scale> [1].\n");
-	if (API->GMT->current.setting.run_mode == GMT_MODERN)
-		GMT_Message (API, GMT_TIME_NONE, "\t-T Write hidden legend specification file to <file>.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-T Modern mode: Write hidden legend specification file to <file>.\n");
 	GMT_Option (API, "U,V,X,c,p,qi,t,.");
 
 	return (GMT_MODULE_USAGE);

--- a/test/pslegend/autolegend.ps
+++ b/test/pslegend/autolegend.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.1.0_9e17e0c-dirty_2020.07.02 [64-bit] Document from psxy
+%%Title: GMT v6.2.0_72cbc3f-dirty_2021.02.13 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jul  2 14:58:27 2020
+%%CreationDate: Sun Feb 14 12:56:00 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -111,9 +111,11 @@
   PSL_eps_state restore
 }!
 /PSL_transp {
-  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
-  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
-  {pop pop} ifelse} ifelse
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
 }!
 /Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
@@ -252,9 +254,16 @@ PSL_pathtextdict begin
     V cpx cpy itransform T
       dy dx atan R
       0 justy M
-      char show
-      0 justy neg G
-      currentpoint transform
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
       /cpy exch def /cpx exch def
     U /setdist setdist charwidth add def
   } def
@@ -278,6 +287,9 @@ end
   /PSL_strokeline false def
   /PSL_fillbox psl_bits 128 and 128 eq def
   /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
   /PSL_n_paths1 PSL_n_paths 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
   PSL_clippath {clipsave N clippath} if
@@ -325,8 +337,10 @@ end
     node_type 1 eq
     {n 0 eq
       {PSL_CT_drawline}
-      {	PSL_CT_reversepath
-	PSL_CT_textline} ifelse
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
       /j 0 def
       PSL_xp j PSL_xx i get put
       PSL_yp j PSL_yy i get put
@@ -553,6 +567,9 @@ end
   /PSL_rounded psl_bits 32 and 32 eq def
   /PSL_fillbox psl_bits 128 and 128 eq def
   /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
   /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
   0 1 PSL_n_labels_minus_1
@@ -567,7 +584,15 @@ end
       PSL_drawbox {V PSL_setboxpen S U} if
       N
     } if
-    PSL_placetext {PSL_ST_place_label} if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
   } for
 } def
 /PSL_straight_path_clip
@@ -637,6 +662,20 @@ end
     psl_label dup sd neg 0 exch G show
     U
 } def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
 /PSL_nclip 0 def
 /PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
@@ -661,13 +700,58 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7.2/3/7.2 -Jx1i -B /Users/pwessel/.gmt/cache/Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D
+%@GMT: gmt plot -R0/7.2/3/7.2 -Jx1i -B /Users/pwessel/.gmt/cache/Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D
 %@PROJ: xy 0.00000000 7.20000000 3.00000000 7.20000000 0.000 7.200 3.000 7.200 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+0 A
+clipsave
+0 0 M
+8640 0 D
+0 5040 D
+-8640 0 D
+P
+PSL_clip N
+V
+0 W
+{0.565 0.933 0.565 C} FS
+O1
+90 360 3720 Sc
+90 1680 3840 Sc
+90 2880 3720 Sc
+90 4320 3840 Sc
+90 6840 3840 Sc
+90 1920 2640 Sc
+90 3480 2520 Sc
+90 4080 2760 Sc
+90 4080 3240 Sc
+90 5760 3120 Sc
+90 6360 2400 Sc
+90 7440 2640 Sc
+90 240 1560 Sc
+90 1080 1440 Sc
+90 2760 2160 Sc
+90 3000 1800 Sc
+90 3600 1800 Sc
+90 4200 1800 Sc
+90 4920 1920 Sc
+90 5880 1440 Sc
+90 7560 1560 Sc
+90 1080 240 Sc
+90 2040 960 Sc
+90 2880 960 Sc
+90 4440 600 Sc
+90 5400 240 Sc
+90 6240 240 Sc
+90 7560 480 Sc
+90 6840 0 Sc
+90 4320 3600 Sc
+U
+PSL_cliprestore
 25 W
+0 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 5040 M 0 -5040 D S
@@ -914,61 +998,19 @@ N 8640 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -5040 T
 0 setlinecap
-clipsave
-0 0 M
-8640 0 D
-0 5040 D
--8640 0 D
-P
-PSL_clip N
-0 W
-V
-{0.565 0.933 0.565 C} FS
-O1
-90 360 3720 Sc
-90 1680 3840 Sc
-90 2880 3720 Sc
-90 4320 3840 Sc
-90 6840 3840 Sc
-90 1920 2640 Sc
-90 3480 2520 Sc
-90 4080 2760 Sc
-90 4080 3240 Sc
-90 5760 3120 Sc
-90 6360 2400 Sc
-90 7440 2640 Sc
-90 240 1560 Sc
-90 1080 1440 Sc
-90 2760 2160 Sc
-90 3000 1800 Sc
-90 3600 1800 Sc
-90 4200 1800 Sc
-90 4920 1920 Sc
-90 5880 1440 Sc
-90 7560 1560 Sc
-90 1080 240 Sc
-90 2040 960 Sc
-90 2880 960 Sc
-90 4440 600 Sc
-90 5400 240 Sc
-90 6240 240 Sc
-90 7560 480 Sc
-90 6840 0 Sc
-90 4320 3600 Sc
-U
-PSL_cliprestore
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt psxy /Users/pwessel/.gmt/cache/Table_5_11.txt -W1.5p,gray '-lMy Lines' -R0/7.2/3/7.2 -Jx1i
+%@GMT: gmt plot /Users/pwessel/.gmt/cache/Table_5_11.txt -W1.5p,gray '-lMy Lines' -R0/7.2/3/7.2 -Jx1i
 %@PROJ: xy 0.00000000 7.20000000 3.00000000 7.20000000 0.000 7.200 3.000 7.200 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+V
 25 W
 0.745 A
 clipsave
@@ -1012,13 +1054,14 @@ PSL_clip N
 -2520 3600 D
 S
 PSL_cliprestore
+U
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt psxy /Users/pwessel/.gmt/cache/Table_5_11.txt -St0.15i -Gorange -lOranges -R0/7.2/3/7.2 -Jx1i
+%@GMT: gmt plot /Users/pwessel/.gmt/cache/Table_5_11.txt -St0.15i -Gorange -lOranges -R0/7.2/3/7.2 -Jx1i
 %@PROJ: xy 0.00000000 7.20000000 3.00000000 7.20000000 0.000 7.200 3.000 7.200 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -1031,8 +1074,8 @@ clipsave
 -8640 0 D
 P
 PSL_clip N
-4 W
 V
+4 W
 {1 0.647 0 C} FS
 90 360 3720 St
 90 1680 3840 St
@@ -1072,46 +1115,49 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt pslegend -DjTR+w1.15i+o0.1i -F+p1p -R0/7.2/3/7.2 -Jx1i
+%@GMT: gmt legend -DjTR+w1.5i+o0.1i -F+p1p+gwhite -M -R0/7.2/3/7.2 -Jx1i
 %@PROJ: xy 0.00000000 7.20000000 3.00000000 7.20000000 0.000 7.200 3.000 7.200 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-/PSL_legend_box_width 1380 def
-/PSL_legend_box_height 1197 def
-7140 3723 T
+/PSL_legend_box_width 1800 def
+/PSL_legend_box_height 1362 def
+6720 3558 T
+{1 A} FS
+1362 1800 900 681 Sr
 4 W
-N 0 782 M 1380 0 D S
+N 0 947 M 1800 0 D S
 17 W
+FQ
 O1
-1197 1380 690 598 Sr
+1362 1800 900 681 Sr
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt psxy -R0/7.2/0/4.2 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000002 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=false
+%@GMT: gmt plot -R0/7.2/0/4.2 -Jx1i -O -K -N -S @GMTAPI@-S-I-D-D-T-N-000003 --PROJ_LENGTH_UNIT=inch --GMT_HISTORY=readonly
 %@PROJ: xy 0.00000000 7.20000000 0.00000000 4.20000000 0.000 7.200 0.000 4.200 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-4 W
 V
+4 W
 {0.565 0.933 0.565 C} FS
 O1
 0 W
-90 185 617 Sc
+90 185 782 Sc
 FQ
 25 W
 0.745 A
-118 185 397 S-
+118 185 562 S-
 {1 0.647 0 C} FS
 O0
 4 W
 0 A
-90 185 177 St
+90 185 342 St
 U
 %%EndObject
 0 A
@@ -1119,21 +1165,23 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt pstext -R0/7.2/0/4.2 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000001 --GMT_HISTORY=false
+%@GMT: gmt text -R0/7.2/0/4.2 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000002 --GMT_HISTORY=readonly
 %@PROJ: xy 0.00000000 7.20000000 0.00000000 4.20000000 0.000 7.200 0.000 4.200 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-690 890 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+900 1055 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 267 F0
 (LEGEND) bc Z
-421 547 M 200 F0
+421 712 M 200 F0
 (Apples) bl Z
-421 327 M (My Lines) bl Z
-421 107 M (Oranges) bl Z
+421 492 M (My Lines) bl Z
+421 272 M (Oranges) bl Z
+1733 97 M 150 F0
+(2020) br Z
 %%EndObject
--7140 -3723 T
+-6720 -3558 T
 %%EndObject
 grestore
 PSL_movie_label_completion /PSL_movie_label_completion {} def

--- a/test/pslegend/autolegend.sh
+++ b/test/pslegend/autolegend.sh
@@ -3,5 +3,5 @@ gmt begin autolegend ps
   gmt plot -R0/7.2/3/7.2 -Jx1i -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+H"LEGEND"+f16p+D
   gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"
   gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
-  gmt legend -DjTR+w1.15i+o0.1i -F+p1p
+  echo "L 9p R 2020" | gmt legend -DjTR+w1.5i+o0.1i -F+p1p+gwhite -M
 gmt end show


### PR DESCRIPTION
Allow merging of hidden and given legend info.  See #4805 for background.  Also fixes the silly usage message restriction.  Tested by modifying the _autolegend.sh_ script and PS.
