### PR TITLE
Fix grdcut example in remote dataset docs

### DIFF
--- a/doc/rst/source/datasets/remote-data.rst
+++ b/doc/rst/source/datasets/remote-data.rst
@@ -130,7 +130,7 @@ Should you need a single grid from any of our tiled dataset, e.g., to feed into 
 not depend on GMT, you can create that via :doc:`/grdcut`.  For instance, to make a global grid from the
 eight tiles that make up the 2m x 2m gridline-registered data, try::
 
-    gmt grdcut @earth_relief_02m_g -Gearth_at_2m.grd
+    gmt grdcut @earth_relief_02m_g -Gearth_at_2m.grd -Rg
 
 ----
 


### PR DESCRIPTION
**Description of proposed changes**

This updates the ``grdcut`` example command in the remote datasets documentation because ``grdcut`` does not work without either **-R**, **-S**, or **-Z**.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
