### PR TITLE
Update link to custom supplements repository

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -702,7 +702,7 @@ code, available from the repository gmt-custom, obtainable via
 
 .. code-block:: bash
 
-   git clone https://github.com/GenericMappingTools/gmt-custom.git
+   git clone https://github.com/GenericMappingTools/custom-supplements.git
 
 
 List of API functions


### PR DESCRIPTION
**Description of proposed changes**

In the GMT C API documentation, the [plugins section](https://docs.generic-mapping-tools.org/dev/api.html#plugins) lists this command for getting fully functioning examples of more involved code:

```git clone https://github.com/GenericMappingTools/gmt-custom.git```

The closest repository address to this in the GMT GitHub organization is [custom-supplements](https://github.com/GenericMappingTools/custom-supplements). This PR updates this line to:

```git clone https://github.com/GenericMappingTools/custom-supplements.git```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
