### PR TITLE
Fix typo in first example (add xt in extension)

### DIFF
--- a/doc/rst/source/histogram.rst
+++ b/doc/rst/source/histogram.rst
@@ -55,7 +55,7 @@ Examples
 
 .. include:: oneliner_info.rst_
 
-To draw a histogram of the remote data v3206_06.t containing seafloor depths,
+To draw a histogram of the remote data v3206_06.txt containing seafloor depths,
 using a 250 meter bin width, center bars, and draw bar outline, use:
 
    ::


### PR DESCRIPTION
BTW, I think that the following example could be add. 

If you instead just want to save the data in a file, use:  

  

    gmt pshistogram  @v3206_06.txt -T250 -Io > data.txt 


If you agree, I will add it. However, I can't managed to do it with GMT Modern Mode One-line Commands. It should be possible to be done in modern mode?