### PR TITLE
Add gmt in the command of Mollweide example

### DIFF
--- a/doc/rst/source/basemap.rst
+++ b/doc/rst/source/basemap.rst
@@ -388,7 +388,7 @@ the Dateline:
 
    ::
 
-    basemap -Rg -JW180/25c -Bafg -B+tMollweide -pdf mollweide
+    gmt basemap -Rg -JW180/25c -Bafg -B+tMollweide -pdf mollweide
 
 Van der Grinten
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
All others examples have 'gmt' at the beginning.

