### PR TITLE
Cannot call gmt_copy_gridheader (GMT, Grid_orig->header, header_G); with externals

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1930,7 +1930,8 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 
 	if (got_z_grid) {	/* If memory grid was passed in we must restore the header */
 		if (mem_G && Grid_orig && header_G) {
-			gmt_copy_gridheader (GMT, Grid_orig->header, header_G);
+			if (GMT->parent->object[0]->alloc_mode != GMT_ALLOC_EXTERNALLY)	/* Because it would call gmt_M_str_free(to->ProjRefWKT) */
+				gmt_copy_gridheader (GMT, Grid_orig->header, header_G);
 			gmt_free_header (API->GMT, &header_G);
 		}
 	}


### PR DESCRIPTION
Because gmt_copy_gridheader will free the ProjRefPROJ4 etc and these makes it crash because it's not GMT owned memory

This bug is harmless when grids have no referencing info but it's fatal when they do. 
This affects equally Julia, Matlab or PyGMT.

EDIT: not so sure if it affects PyGMT as well. It will if projection info is transmitted in the grid and lands in the grid header.