### PR TITLE
Fix typo in mgd77sniffer

### DIFF
--- a/doc/rst/source/supplements/mgd77/mgd77sniffer.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77sniffer.rst
@@ -499,7 +499,7 @@ Sandwell/Smith 2 min gravity version 11, try
 
    ::
 
-    mgd77sniffer 08010001 -Gdepth,/data/GRIDS/etopo5_hdr.i2 \
+    gmt mgd77sniffer 08010001 -Gdepth,/data/GRIDS/etopo5_hdr.i2 \
                  -Gfaa,/data/GRIDS/grav.11.2.img,0.1,1
 
 See Also


### PR DESCRIPTION
Add 'gmt' in last example.