### PR TITLE
Allow GMT_Put_Vector to convert other text items than datetime

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1369,8 +1369,8 @@ or ISO datetime strings and we do the conversion to internal numerical values an
 allocate a vector to hold the result in the given ``col``.  By default that vector
 will be assigned to type **GMT_DOUBLE** but you can add another primary data type
 for the conversion if you prefer (e.g., **GMT_TEXT**\|\ **GMT_LONG** to get final 
-internal absolute time in integer seconds). For these four special data types GMT
-allocates internal memory to hold the concerted data and ``vector`` is not used
+internal absolute time in integer seconds). For the special data type **GMT_TEXT** GMT
+allocates internal memory to hold the converted data and ``vector`` is not used
 any further.
 
 To extract a custom vector from an output :ref:`GMT_VECTOR <struct-vector>` you can use

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1371,7 +1371,7 @@ a vector to hold the result in the given ``col``.  By default that vector will b
 assigned to type **GMT_DOUBLE** but you can add another primary data type for the
 conversion if you prefer (e.g., **GMT_LONG**\|\ **GMT_DATETIME** to get final 
 internal absolute time in integer seconds). For these four special data types GMT
-allocates internal memory to hold the concerted data and ``vector'' is not used
+allocates internal memory to hold the concerted data and ``vector`` is not used
 any further.
 
 To extract a custom vector from an output :ref:`GMT_VECTOR <struct-vector>` you can use

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1363,9 +1363,11 @@ For vectors the same principles apply:
 where ``V`` is the :ref:`GMT_VECTOR <struct-vector>` created by GMT_Create_Data_, ``col`` is the vector
 column in question, ``type`` is one of the
 recognized data :ref:`types <tbl-types>` used for this vector, and ``vector`` is
-a pointer to this custom vector.  In addition, ``type`` may be also **GMT_DATETIME**, in which case
-we expect an array of strings with ISO datetime strings and we do the conversion to internal
-GMT time and allocate a vector to hold the result in the given ``col``.
+a pointer to this custom vector.  In addition, ``type`` may be also **GMT_TEXTLON**, **GMT_TEXTLAT**,
+or **GMT_DATETIME**, in which case
+we expect an array of strings with longitues, latitudes, or ISO datetime strings and we do the conversion to internal
+numerical values and allocate a vector to hold the result in the given ``col``.  By deault tht vector will be
+**GMT_DOUBLE** but you can add in another data type for the conversion if you prefer (e.g., **GMT_LONG**\|\ **GMT_DATETIME**)
 To extract a custom vector from an output :ref:`GMT_VECTOR <struct-vector>` you can use
 
 .. _GMT_Get_Vector:

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1360,14 +1360,20 @@ For vectors the same principles apply:
     int GMT_Put_Vector (void *API, struct GMT_VECTOR *V, unsigned int col,
 	unsigned int type, void *vector);
 
-where ``V`` is the :ref:`GMT_VECTOR <struct-vector>` created by GMT_Create_Data_, ``col`` is the vector
-column in question, ``type`` is one of the
+where ``V`` is the :ref:`GMT_VECTOR <struct-vector>` created by GMT_Create_Data_,
+``col`` is the vector column in question, ``type`` is one of the
 recognized data :ref:`types <tbl-types>` used for this vector, and ``vector`` is
-a pointer to this custom vector.  In addition, ``type`` may be also **GMT_TEXTLON**, **GMT_TEXTLAT**,
-or **GMT_DATETIME**, in which case
-we expect an array of strings with longitues, latitudes, or ISO datetime strings and we do the conversion to internal
-numerical values and allocate a vector to hold the result in the given ``col``.  By deault tht vector will be
-**GMT_DOUBLE** but you can add in another data type for the conversion if you prefer (e.g., **GMT_LONG**\|\ **GMT_DATETIME**)
+a pointer to this read-only custom vector.  In addition, ``type`` may be also **GMT_TEXT**,
+**GMT_TEXTLON**, **GMT_TEXTLAT**, or **GMT_DATETIME**, in which case we expect an
+array of strings with numbers, longitudes, latitudes, or ISO datetime strings,\
+respectively, and we do the conversion to internal numerical values and allocate
+a vector to hold the result in the given ``col``.  By default that vector will be
+assigned to type **GMT_DOUBLE** but you can add another primary data type for the
+conversion if you prefer (e.g., **GMT_LONG**\|\ **GMT_DATETIME** to get final 
+internal absolute time in integer seconds). For these four special data types GMT
+allocates internal memory to hold the concerted data and ``vector'' is not used
+any further.
+
 To extract a custom vector from an output :ref:`GMT_VECTOR <struct-vector>` you can use
 
 .. _GMT_Get_Vector:

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1363,13 +1363,12 @@ For vectors the same principles apply:
 where ``V`` is the :ref:`GMT_VECTOR <struct-vector>` created by GMT_Create_Data_,
 ``col`` is the vector column in question, ``type`` is one of the recognized data
 :ref:`types <tbl-types>` used for this vector, and ``vector`` is a pointer to the
-user's read-only custom vector.  In addition, ``type`` may also be one of **GMT_TEXT**,
-**GMT_TEXTLON**, **GMT_TEXTLAT**, or **GMT_DATETIME**, in which case we expect an
-array of strings with numbers, longitudes, latitudes, or ISO datetime strings,
-respectively, and we do the conversion to internal numerical values and allocate
-a vector to hold the result in the given ``col``.  By default that vector will be
-assigned to type **GMT_DOUBLE** but you can add another primary data type for the
-conversion if you prefer (e.g., **GMT_LONG**\|\ **GMT_DATETIME** to get final 
+user's read-only custom vector.  In addition, ``type`` may also be  **GMT_TEXT**,
+in which case we expect an array of strings with numbers, longitudes, latitudes,
+or ISO datetime strings and we do the conversion to internal numerical values and
+allocate a vector to hold the result in the given ``col``.  By default that vector
+will be assigned to type **GMT_DOUBLE** but you can add another primary data type
+for the conversion if you prefer (e.g., **GMT_TEXT**\|\ **GMT_LONG** to get final 
 internal absolute time in integer seconds). For these four special data types GMT
 allocates internal memory to hold the concerted data and ``vector`` is not used
 any further.

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1361,11 +1361,11 @@ For vectors the same principles apply:
 	unsigned int type, void *vector);
 
 where ``V`` is the :ref:`GMT_VECTOR <struct-vector>` created by GMT_Create_Data_,
-``col`` is the vector column in question, ``type`` is one of the
-recognized data :ref:`types <tbl-types>` used for this vector, and ``vector`` is
-a pointer to this read-only custom vector.  In addition, ``type`` may be also **GMT_TEXT**,
+``col`` is the vector column in question, ``type`` is one of the recognized data
+:ref:`types <tbl-types>` used for this vector, and ``vector`` is a pointer to the
+user's read-only custom vector.  In addition, ``type`` may also be one of **GMT_TEXT**,
 **GMT_TEXTLON**, **GMT_TEXTLAT**, or **GMT_DATETIME**, in which case we expect an
-array of strings with numbers, longitudes, latitudes, or ISO datetime strings,\
+array of strings with numbers, longitudes, latitudes, or ISO datetime strings,
 respectively, and we do the conversion to internal numerical values and allocate
 a vector to hold the result in the given ``col``.  By default that vector will be
 assigned to type **GMT_DOUBLE** but you can add another primary data type for the

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -14585,6 +14585,7 @@ int GMT_Put_Vector (void *V_API, struct GMT_VECTOR *V, unsigned int col, unsigne
 			api_put_val (&(V->data[col]), row, value);	/* Place value in vector of selected type */
 		}
 		V->type[col] = type;	/* Flag as the new type after conversion */
+		if (L_type == GMT_IS_UNKNOWN) L_type = GMT_IS_FLOAT;	/* We held out this long but now must default to it */
 		gmt_set_column_type (API->GMT, GMT_IO, col, L_type);
 		if (n_bad) {	/* Report on values that could not be converted */
 			if (L_type == GMT_IS_LON)

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -14515,7 +14515,7 @@ int GMT_Put_Vector (void *V_API, struct GMT_VECTOR *V, unsigned int col, unsigne
 	 * It is the user's responsibility to pass correct type for the given vector.
 	 * We also check that the number of rows have been set earlier.
 	 * We also allow special text-based arrays for longitude, latitude, datetime or Cartesian data to be passed
-	 * which may be logically OR'ed with desired array type (e.g., GMT_LONG|GMT_TEXT.
+	 * which may be logically OR'ed with desired array type (e.g., GMT_LONG|GMT_TEXT).
 	 * Note: We do not check for data loss in the conversion (e..g, GMT_UCHAR|GMT_TEXT) */
 	unsigned int special_type;
 	enum GMT_enum_alloc alloc_mode = GMT_ALLOC_EXTERNALLY;	/* Default is to pass vectors in read-only */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -14512,7 +14512,7 @@ int GMT_Put_Vector (void *V_API, struct GMT_VECTOR *V, unsigned int col, unsigne
 	/* Hooks a users custom vector onto V's column array and sets the type.
 	 * It is the user's responsibility to pass correct type for the given vector.
 	 * We also check that the number of rows have been set earlier.
-	 * We also allow special text-based arrays for longitude, latitdue, and datetime to be passed
+	 * We also allow special text-based arrays for longitude, latitude, datetime or Cartesian data to be passed
 	 * which may be logically OR'ed with desired array type (e.g., GMT_LONG|GMT_DATETIME.
 	 * Note: We do not check for data loss in the conversion (e..g, GMT_UCHAR|GMT_TEXTLON) */
 	unsigned int special_type;

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -14516,7 +14516,7 @@ int GMT_Put_Vector (void *V_API, struct GMT_VECTOR *V, unsigned int col, unsigne
 	 * We also check that the number of rows have been set earlier.
 	 * We also allow special text-based arrays for longitude, latitude, datetime or Cartesian data to be passed
 	 * which may be logically OR'ed with desired array type (e.g., GMT_LONG|GMT_TEXT).
-	 * Note: We do not check for data loss in the conversion (e..g, GMT_UCHAR|GMT_TEXT) */
+	 * Note: We do not check for data loss in the conversion (e.g., GMT_UCHAR|GMT_TEXT) */
 	unsigned int special_type;
 	enum GMT_enum_alloc alloc_mode = GMT_ALLOC_EXTERNALLY;	/* Default is to pass vectors in read-only */
 	struct GMTAPI_CTRL *API = NULL;

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 255
+#define GMT_N_API_ENUMS 253
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -235,8 +235,6 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_SYNOPSIS", 1},
 	{"GMT_TBL", 0},
 	{"GMT_TEXT", 16},
-	{"GMT_TEXTLAT", 64},
-	{"GMT_TEXTLON", 128},
 	{"GMT_TIME_CLOCK", 1},
 	{"GMT_TIME_ELAPSED", 2},
 	{"GMT_TIME_NONE", 0},

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 253
+#define GMT_N_API_ENUMS 255
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -76,7 +76,7 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_CPT_TIME", 16},
 	{"GMT_CUBE_IS_STACK", 64},
 	{"GMT_DATA_ONLY", 2},
-	{"GMT_DATETIME", 11},
+	{"GMT_DATETIME", 32},
 	{"GMT_DOUBLE", 9},
 	{"GMT_DUPLICATE_ALLOC", 1},
 	{"GMT_DUPLICATE_DATA", 2},
@@ -234,7 +234,9 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_STRICT_CONVERSION", 1024},
 	{"GMT_SYNOPSIS", 1},
 	{"GMT_TBL", 0},
-	{"GMT_TEXT", 10},
+	{"GMT_TEXT", 16},
+	{"GMT_TEXTLAT", 64},
+	{"GMT_TEXTLON", 128},
 	{"GMT_TIME_CLOCK", 1},
 	{"GMT_TIME_ELAPSED", 2},
 	{"GMT_TIME_NONE", 0},

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -925,12 +925,20 @@ GMT_LOCAL unsigned int gmtio_assign_aspatial_cols (struct GMT_CTRL *GMT) {
 	return (n);	/* Only numerical columns add to the count */
 }
 
+GMT_LOCAL unsigned int gmtio_type_index (unsigned int type) {
+	if (type == GMT_TEXT) return GMT_N_TYPES-2;
+	if (type == GMT_DATETIME) return GMT_N_TYPES-1;
+	return type;
+}
+
 /*! Fill a string with the aspatial columns */
 void gmt_list_aspatials (struct GMT_CTRL *GMT, char buffer[]) {
 	char item[GMT_LEN64] = {""};
+	unsigned int type;
 	sprintf (buffer, "Aspatial columns:");
 	for (unsigned int k = 0; k < GMT->common.a.n_aspatial; k++) {
-		sprintf (item, " %s[%s]", GMT->common.a.name[k], GMT_type[GMT->common.a.type[k]]);
+		type = gmtio_type_index (GMT->common.a.type[k]);
+		sprintf (item, " %s[%s]", GMT->common.a.name[k], GMT_type[type]);
 		strcat (buffer, item);
 	}
 }
@@ -4320,7 +4328,7 @@ int gmtlib_append_ogr_item (struct GMT_CTRL *GMT, char *name, enum GMT_enum_type
 //*! . */
 void gmtlib_write_ogr_header (FILE *fp, struct GMT_OGR *G) {
 	/* Write out table-level OGR/GMT header metadata */
-	unsigned int k, col;
+	unsigned int k, col, type;
 	char *flavor = "egpw";
 
 	fprintf (fp, "# @VGMT1.0 @G");
@@ -4335,8 +4343,12 @@ void gmtlib_write_ogr_header (FILE *fp, struct GMT_OGR *G) {
 	if (G->n_aspatial) {
 		fprintf (fp, "# @N%s", G->name[0]);
 		for (col = 1; col < G->n_aspatial; col++) fprintf (fp, "|%s", G->name[col]);
-		fprintf (fp, "\n# @T%s", GMT_type[G->type[0]]);
-		for (col = 1; col < G->n_aspatial; col++) fprintf (fp, "|%s", GMT_type[G->type[col]]);
+		type = gmtio_type_index (G->type[0]);
+		fprintf (fp, "\n# @T%s", GMT_type[type]);
+		for (col = 1; col < G->n_aspatial; col++) {
+			type = gmtio_type_index (G->type[col]);
+			fprintf (fp, "|%s", GMT_type[type]);
+		}
 		fprintf (fp, "\n");
 	}
 	fprintf (fp, "# FEATURE_DATA\n");

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -90,9 +90,11 @@ enum GMT_enum_type {
 	GMT_ULONG	=    7,  /* uint64_t, 8-byte unsigned integer type */
 	GMT_FLOAT	=    8,  /* 4-byte data float type */
 	GMT_DOUBLE	=    9,  /* 8-byte data float type */
-	GMT_TEXT	=   10,  /* Arbitrarily long text string [OGR/GMT use only] */
-	GMT_DATETIME	=   11,  /* string with date/time info [OGR/GMT use only] */
+	GMT_TEXT	=   16,  /* Arbitrarily long text string [OGR/GMT use only and GMT_Put_Vector only] */
+	GMT_DATETIME	=   32,  /* string with date/time info [OGR/GMT use and GMT_Put_Vector only] */
 	GMT_N_TYPES	=   12,  /* The number of supported data types above */
+	GMT_TEXTLAT	=   64,  /* string with latitude info [GMT_Put_Vector use only] */
+	GMT_TEXTLON	=   128,  /* string with longitude info [GMT_Put_VectorT use only] */
 	GMT_VIA_CHAR	=  100,  /* int8_t, 1-byte signed integer type */
 	GMT_VIA_UCHAR	=  200,  /* uint8_t, 1-byte unsigned integer type */
 	GMT_VIA_SHORT	=  300,  /* int16_t, 2-byte signed integer type */

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -93,8 +93,6 @@ enum GMT_enum_type {
 	GMT_TEXT	=   16,  /* Arbitrarily long text string [OGR/GMT use only and GMT_Put_Vector only] */
 	GMT_DATETIME	=   32,  /* string with date/time info [OGR/GMT use and GMT_Put_Vector only] */
 	GMT_N_TYPES	=   12,  /* The number of supported data types above */
-	GMT_TEXTLAT	=   64,  /* string with latitude info [GMT_Put_Vector use only] */
-	GMT_TEXTLON	=   128,  /* string with longitude info [GMT_Put_VectorT use only] */
 	GMT_VIA_CHAR	=  100,  /* int8_t, 1-byte signed integer type */
 	GMT_VIA_UCHAR	=  200,  /* uint8_t, 1-byte unsigned integer type */
 	GMT_VIA_SHORT	=  300,  /* int16_t, 2-byte signed integer type */

--- a/src/testapi_putvector.c
+++ b/src/testapi_putvector.c
@@ -1,0 +1,34 @@
+#include "gmt.h"
+/*
+ * Testing the use GMT_Put_Vector and its ability to convert ascii stuff.
+ */
+
+/* Dimensions of the test dataset */
+#define NCOLS 4
+#define NROWS 2
+
+int main () {
+	void *API = NULL;							/* The API control structure */
+	struct GMT_VECTOR *V = NULL;				/* Structure to hold input dataset as vectors */
+
+	uint64_t dim[4] = {NCOLS, NROWS, 1, 0};		/* ncols, nrows, nlayers, type */
+	/* two records with cartesian, time, lon, lat data */
+	char *S0[NROWS] = {"134.9", "202"};
+	char *S1[NROWS] = {"2020-06-01T14:55:33", "2020-06005T16:00:50.75"};
+	char *S2[NROWS] = {"12:45:36W", "19:48E"};
+	char *S3[NROWS] = {"16:15:00S", "29:30N"};
+
+	/* Initialize the GMT session */
+	API = GMT_Create_Session ("testapi_putvector", 2U, GMT_SESSION_EXTERNAL, NULL);
+	/* Create a dataset */
+	V = GMT_Create_Data (API, GMT_IS_VECTOR, GMT_IS_POINT, GMT_CONTAINER_ONLY, dim, NULL, NULL, 0, 0, NULL);
+	/* Hook the five converted text vectors up to this container */
+	GMT_Put_Vector(API, V, 0, GMT_TEXT|GMT_DOUBLE, S0);
+	GMT_Put_Vector(API, V, 1, GMT_TEXT|GMT_LONG, S1);
+	GMT_Put_Vector(API, V, 2, GMT_TEXT|GMT_DOUBLE, S2);
+	GMT_Put_Vector(API, V, 3, GMT_TEXT|GMT_DOUBLE, S3);
+	/* Write table to stdout */
+	GMT_Write_Data (API, GMT_IS_VECTOR, GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_SET, NULL, NULL, V);
+	/* Destroy the GMT session */
+	GMT_Destroy_Session (API);
+};

--- a/test/api/apiputvector.sh
+++ b/test/api/apiputvector.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test the GMT_Put_Vector function for mixed textcolumns of
+# Cartesian values, datetime, longitude, and latitude strings
+
+# This file holds what is expected to be produced on output
+cat << EOF > answer.txt
+134.9	2020-06-01T14:55:33	-12.76	-16.25
+-158	2020-06-01T16:00:51	19.8	29.5
+EOF
+testapi_putvector > results.txt
+diff -q --strip-trailing-cr results.txt answer.txt > fail


### PR DESCRIPTION
See [this post](https://github.com/GenericMappingTools/pygmt/issues/647) for background.  While we added support for **GMT_DATETIME** last year, this PR generalizes the conversion from text to numbers via the type **GMT_TEXT**.  The strings may be either Cartesian numbers, datetime, longitude, or latitude, and we also allow these to be converted to other internal representations than **GMT_DOUBLE** (e.g., **GMT_FLOAT**, **GMT_LONG**, etc.) via logical addition (e.g., pass type as  **GMT_TEXT**|**GMT_FLOAT**).

I have left the prior scheme of **GMT_DATETIME** for datetime so we are backwards compatible, but one now only needs to select **GMT_TEXT** and GMT figures out what you passed, hopefully.  We assume each column has the same type and there is no error checking if you pass both time and longitude as part of a single column.  I added _testapi_putvector.c_ and calling script _apiputvector.sh_ which demonstrates that it works.

I think a quick test and this can be approved and merged.
