### PR TITLE
Let histogram -C apply to either bin center of bin value

### DIFF
--- a/doc/rst/source/histogram.rst
+++ b/doc/rst/source/histogram.rst
@@ -16,7 +16,7 @@ Synopsis
 |-T|\ [*min/max*\ /]\ *inc*\ [**+i**\|\ **n**] \|\ |-T|\ *file*\|\ *list*
 [ |-A| ]
 [ |SYN_OPT-B| ]
-[ |-C|\ *cpt* ]
+[ |-C|\ *cpt*\ [**+b**] ]
 [ |-D|\ [**+b**][**+f**\ *font*][**+o**\ *off*][**+r**] ]
 [ |-E|\ *width*\ [**+o**\ *offset*] ]
 [ |-F| ]

--- a/doc/rst/source/histogram_common.rst_
+++ b/doc/rst/source/histogram_common.rst_
@@ -44,11 +44,11 @@ Optional Arguments
 .. _-C:
 
 **-C**\ *cpt*\ [**+b**]
-    Give a CPT. The mid-bar coordinate for each bar is used to
-    look-up the bar color.  Alternatively, use the *count* in
-    each bin as the look-up value, unless **-Z** involves percentages,
+    Give a CPT. The mid-coordinate for each bar is used to look up
+    the bar color.  Alternatively, append **+b** to use the *bin* value
+    as the look-up value, unless **-Z** involves percentages,
     in which case the look-up value is the *percentage* computed. If
-    we are in modern mode and no argument is given then we select the
+    we are in modern mode and no *cpt* is given then we select the
     current CPT.
 
 .. _-D:

--- a/doc/rst/source/histogram_common.rst_
+++ b/doc/rst/source/histogram_common.rst_
@@ -43,12 +43,13 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ *cpt*
-    Give a CPT. The bar-value for each bar is used to
-    look-up the bar color.  If modern mode and no argument is given
-    then we select the current CPT.  **Note**: We use the *count* in
+**-C**\ *cpt*\ [**+b**]
+    Give a CPT. The mid-bar coordinate for each bar is used to
+    look-up the bar color.  Alternatively, use the *count* in
     each bin as the look-up value, unless **-Z** involves percentages,
-    in which case the look-up value is the *percentage* computed.
+    in which case the look-up value is the *percentage* computed. If
+    we are in modern mode and no argument is given then we select the
+    current CPT.
 
 .. _-D:
 

--- a/doc/rst/source/pshistogram.rst
+++ b/doc/rst/source/pshistogram.rst
@@ -16,7 +16,7 @@ Synopsis
 |-T|\ [*min/max*\ /]\ *inc*\ [**+i**\|\ **n**] \|\ |-T|\ *file*\|\ *list*
 [ |-A| ]
 [ |SYN_OPT-B| ]
-[ |-C|\ *cpt* ]
+[ |-C|\ *cpt*\ [**+b**] ]
 [ |-D|\ [**+b**][**+f**\ *font*][**+o**\ *off*][**+r**] ]
 [ |-E|\ *width*\ [**+o**\ *offset*] ]
 [ |-F| ]

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -45,8 +45,9 @@ struct PSHISTOGRAM_CTRL {
 	struct PSHISTOGRAM_A {	/* -A */
 		bool active;
 	} A;
-	struct PSHISTOGRAM_C {	/* -C<cpt> */
+	struct PSHISTOGRAM_C {	/* -C<cpt>[+b] */
 		bool active;
+		bool binval;	/* Select CPT based on binned value (i.e., the hist count) and not the mid-point of the bin */
 		char *file;
 	} C;
 	struct PSHISTOGRAM_D {	/* -D[+r][+f<font>][+o<off>][+b] */
@@ -348,7 +349,7 @@ GMT_LOCAL double pshistogram_plot_boxes (struct GMT_CTRL *GMT, struct PSL_CTRL *
 	uint64_t ibox;
 	char label[GMT_LEN64] = {""};
 	bool first = true, stairs = Ctrl->S.active, flip_to_y = Ctrl->A.active, draw_outline = Ctrl->W.active, cpt = Ctrl->C.active;
-	double area = 0.0, rgb[4], x[4], y[4], bin_width, zval, label_angle = 0.0, *px = NULL, *py = NULL;
+	double area = 0.0, rgb[4], x[4], y[4], bin_width, xval, zval, cval, label_angle = 0.0, *px = NULL, *py = NULL;
 	double plot_x = 0.0, plot_y = 0.0, *xpol = NULL, *ypol = NULL;
 	struct GMT_FILL *f = NULL;
 	struct GMT_PEN *pen = &Ctrl->W.pen;
@@ -376,6 +377,7 @@ GMT_LOCAL double pshistogram_plot_boxes (struct GMT_CTRL *GMT, struct PSL_CTRL *
 	for (ibox = 0; ibox < F->n_boxes; ibox++) {
 		if (stairs || F->boxh[ibox]) {
 			bin_width = F->T->array[ibox+1] - F->T->array[ibox];
+			xval = 0.5 * (F->T->array[ibox] + F->T->array[ibox+1]);
 			if (F->cumulative)
 				area = F->boxh[ibox];	/* Just pick up the final bin as it has the entire sum */
 			else	/* Add up as we go along */
@@ -392,7 +394,9 @@ GMT_LOCAL double pshistogram_plot_boxes (struct GMT_CTRL *GMT, struct PSL_CTRL *
 				/* The final polygon will be plotted after the loop */
 			}
 			else if (cpt) {	/* Each bar will have a unique color based on its value */
-				index = gmt_get_rgb_from_z (GMT, P, zval, rgb);
+				cval = (Ctrl->C.binval) ? zval : xval;	/* Used for cpt lookup */
+
+				index = gmt_get_rgb_from_z (GMT, P, cval, rgb);
 				f = gmt_M_get_cptslice_pattern (P,index);
 				if (f)	/* Pattern */
 					gmt_setfill (GMT, f, draw_outline);
@@ -527,7 +531,7 @@ GMT_LOCAL bool pshistogram_new_syntax (struct GMT_CTRL *GMT, char *L, char *T, c
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s -T[<min>/<max>/]<inc>[+i|n] [-A] [%s] [-C<cpt>] [-D[+b][+f<font>][+o<off>][+r]]\n", name, GMT_Jx_OPT, GMT_B_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s -T[<min>/<max>/]<inc>[+i|n] [-A] [%s] [-C<cpt>[+b]] [-D[+b][+f<font>][+o<off>][+r]]\n", name, GMT_Jx_OPT, GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-E<width>[+o<offset>]] [-F] [-G<fill>] [-I[o|O]] %s[-Ll|h|b] [-N[<mode>][+p<pen>]] %s%s[-Q[r]]\n", API->K_OPT, API->O_OPT, API->P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-S] [%s]\n\t[%s] [-W<pen>] [%s] [%s] [-Z[0-5][+w]]\n", GMT_Rx_OPT, GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t%s[%s] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n", API->c_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT,
@@ -545,7 +549,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Option (API, "<,B-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Plot horizontal bars, i.e., flip x and y axis [Default is vertical].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-C Use CPT to assign fill to bars based on the bar-values (count or percent only; see -Z).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-C Use CPT to assign color to bars based on the mid-bar coordinate.  Alternatively, append +b.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   to assign color based on the histogram value instead (count or percent only; see -Z).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Place histogram count labels on top of each bar; optionally append modifiers:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   +b places the labels beneath the bars [above]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   +f<font> sets the label font [FONT_ANNOT_PRIMARY]\n");
@@ -624,8 +629,13 @@ static int parse (struct GMT_CTRL *GMT, struct PSHISTOGRAM_CTRL *Ctrl, struct GM
 				break;
 			case 'C':
 				Ctrl->C.active = true;
+				if (opt->arg[0] && (c = strstr (opt->arg, "+b"))) {
+					Ctrl->C.binval = true;
+					c[0] = '\0';	/* Remove modifier */
+				}
 				gmt_M_str_free (Ctrl->C.file);
 				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
+				if (c) c[0] = '+';	/* Restore modifier */
 				break;
 			case 'D':
 				Ctrl->D.active = true;

--- a/test/pshistogram/flip.ps
+++ b/test/pshistogram/flip.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.2.0_2fdbcb1_2020.10.24 [64-bit] Document from pshistogram
+%%Title: GMT v6.2.0_70b38ae-dirty_2021.02.23 [64-bit] Document from pshistogram
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Oct 24 12:08:56 2020
+%%CreationDate: Wed Feb 24 13:35:15 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -112,9 +112,11 @@
   PSL_eps_state restore
 }!
 /PSL_transp {
-  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
-  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
-  {pop pop} ifelse} ifelse
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
 }!
 /Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
@@ -253,9 +255,16 @@ PSL_pathtextdict begin
     V cpx cpy itransform T
       dy dx atan R
       0 justy M
-      char show
-      0 justy neg G
-      currentpoint transform
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
       /cpy exch def /cpx exch def
     U /setdist setdist charwidth add def
   } def
@@ -279,6 +288,9 @@ end
   /PSL_strokeline false def
   /PSL_fillbox psl_bits 128 and 128 eq def
   /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
   /PSL_n_paths1 PSL_n_paths 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
   PSL_clippath {clipsave N clippath} if
@@ -326,8 +338,10 @@ end
     node_type 1 eq
     {n 0 eq
       {PSL_CT_drawline}
-      {	PSL_CT_reversepath
-	PSL_CT_textline} ifelse
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
       /j 0 def
       PSL_xp j PSL_xx i get put
       PSL_yp j PSL_yy i get put
@@ -554,6 +568,9 @@ end
   /PSL_rounded psl_bits 32 and 32 eq def
   /PSL_fillbox psl_bits 128 and 128 eq def
   /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
   /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
   0 1 PSL_n_labels_minus_1
@@ -568,7 +585,15 @@ end
       PSL_drawbox {V PSL_setboxpen S U} if
       N
     } if
-    PSL_placetext {PSL_ST_place_label} if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
   } for
 } def
 /PSL_straight_path_clip
@@ -638,6 +663,20 @@ end
     psl_label dup sd neg 0 exch G show
     U
 } def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
 /PSL_nclip 0 def
 /PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
 /PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
@@ -677,6 +716,7 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 4 W
+0 A
 0 0 M
 0 4724 D
 S
@@ -707,210 +747,212 @@ clipsave
 P
 PSL_clip N
 0 W
-{0.203 0 0 C} FS
+{0.188 0.0706 0.231 C} FS
 O1
 -38 0 0 3033 38 0 3 0 0 SP
-{1 0.79 0 C} FS
+{0.202 0.101 0.305 C} FS
 -75 0 0 4428 75 0 3 38 0 SP
-{1 A} FS
+{0.212 0.131 0.375 C} FS
 -76 0 0 4698 76 0 3 113 0 SP
-{1 0.714 0 C} FS
+{0.222 0.161 0.443 C} FS
 -76 0 0 4400 76 0 3 189 0 SP
-{1 0.173 0 C} FS
+{0.232 0.187 0.507 C} FS
 -75 0 0 4157 75 0 3 265 0 SP
-{0.977 0 0 C} FS
+{0.242 0.217 0.563 C} FS
 -76 0 0 4040 76 0 3 340 0 SP
-{0.822 0 0 C} FS
+{0.248 0.245 0.619 C} FS
 -75 0 0 3930 75 0 3 416 0 SP
-{0.937 0 0 C} FS
+{0.255 0.273 0.672 C} FS
 -76 0 0 4013 76 0 3 491 0 SP
-{0.885 0 0 C} FS
+{0.26 0.299 0.718 C} FS
 -76 0 0 3977 76 0 3 567 0 SP
-{0.681 0 0 C} FS
+{0.267 0.329 0.764 C} FS
 -75 0 0 3809 75 0 3 643 0 SP
-{0.649 0 0 C} FS
+{0.271 0.355 0.804 C} FS
 -76 0 0 3778 76 0 3 718 0 SP
-{0.583 0 0 C} FS
+{0.275 0.381 0.84 C} FS
 -75 0 0 3710 75 0 3 794 0 SP
-{0.491 0 0 C} FS
+{0.275 0.407 0.874 C} FS
 -76 0 0 3599 76 0 3 869 0 SP
-{0.423 0 0 C} FS
+{0.278 0.433 0.904 C} FS
 -75 0 0 3504 75 0 3 945 0 SP
-{0.367 0 0 C} FS
+{0.278 0.459 0.93 C} FS
 -76 0 0 3414 76 0 3 1020 0 SP
-{0.294 0 0 C} FS
+{0.277 0.484 0.951 C} FS
 -76 0 0 3271 76 0 3 1096 0 SP
-{0.394 0 0 C} FS
+{0.275 0.508 0.971 C} FS
 -75 0 0 3458 75 0 3 1172 0 SP
-{0.374 0 0 C} FS
+{0.273 0.534 0.986 C} FS
 -76 0 0 3425 76 0 3 1247 0 SP
-{0.328 0 0 C} FS
+{0.267 0.56 0.996 C} FS
 -75 0 0 3341 75 0 3 1323 0 SP
-{0.259 0 0 C} FS
+{0.257 0.584 1 C} FS
 -76 0 0 3190 76 0 3 1398 0 SP
-{0.196 0 0 C} FS
+{0.243 0.608 0.996 C} FS
 -76 0 0 3010 76 0 3 1474 0 SP
-{0.135 0 0 C} FS
+{0.229 0.634 0.99 C} FS
 -75 0 0 2771 75 0 3 1550 0 SP
-{0.106 0 0 C} FS
+{0.215 0.66 0.98 C} FS
 -76 0 0 2615 76 0 3 1625 0 SP
-{0.0837 0 0 C} FS
+{0.195 0.684 0.964 C} FS
 -75 0 0 2467 75 0 3 1701 0 SP
-{0.0475 0 0 C} FS
+{0.179 0.708 0.947 C} FS
 -76 0 0 2104 76 0 3 1776 0 SP
-{0.0358 0 0 C} FS
+{0.159 0.734 0.925 C} FS
 -76 0 0 1922 76 0 3 1852 0 SP
-{0.0261 0 0 C} FS
+{0.143 0.756 0.902 C} FS
 -75 0 0 1720 75 0 3 1928 0 SP
-{0.0236 0 0 C} FS
+{0.127 0.779 0.876 C} FS
 -76 0 0 1655 76 0 3 2003 0 SP
-{0.0151 0 0 C} FS
+{0.115 0.799 0.852 C} FS
 -75 0 0 1372 75 0 3 2079 0 SP
-{0.0156 0 0 C} FS
+{0.102 0.823 0.824 C} FS
 -76 0 0 1389 76 0 3 2154 0 SP
+{0.0961 0.839 0.798 C} FS
 -76 0 0 1389 76 0 3 2230 0 SP
-{0.0126 0 0 C} FS
+{0.0941 0.859 0.772 C} FS
 -75 0 0 1255 75 0 3 2306 0 SP
-{0.0109 0 0 C} FS
+{0.0941 0.875 0.746 C} FS
 -76 0 0 1164 76 0 3 2381 0 SP
-{0.0114 0 0 C} FS
+{0.0986 0.891 0.724 C} FS
 -75 0 0 1188 75 0 3 2457 0 SP
-{0.00715 0 0 C} FS
+{0.113 0.905 0.7 C} FS
 -76 0 0 891 76 0 3 2532 0 SP
-{0.0164 0 0 C} FS
+{0.127 0.919 0.673 C} FS
 -75 0 0 1423 75 0 3 2608 0 SP
-{0.00841 0 0 C} FS
+{0.151 0.932 0.645 C} FS
 -76 0 0 995 76 0 3 2683 0 SP
-{0.00757 0 0 C} FS
+{0.177 0.943 0.615 C} FS
 -76 0 0 928 76 0 3 2759 0 SP
-{0.0118 0 0 C} FS
+{0.207 0.953 0.582 C} FS
 -75 0 0 1211 75 0 3 2835 0 SP
-{0.00547 0 0 C} FS
+{0.241 0.963 0.55 C} FS
 -76 0 0 720 76 0 3 2910 0 SP
-{0.00631 0 0 C} FS
+{0.275 0.973 0.518 C} FS
 -75 0 0 811 75 0 3 2986 0 SP
-{0.0114 0 0 C} FS
+{0.315 0.979 0.484 C} FS
 -76 0 0 1188 76 0 3 3061 0 SP
-{0.00715 0 0 C} FS
+{0.351 0.985 0.449 C} FS
 -76 0 0 891 76 0 3 3137 0 SP
-{0.0101 0 0 C} FS
+{0.391 0.991 0.416 C} FS
 -75 0 0 1112 75 0 3 3213 0 SP
-{0.00799 0 0 C} FS
+{0.431 0.996 0.382 C} FS
 -76 0 0 963 76 0 3 3288 0 SP
-{0.0135 0 0 C} FS
+{0.471 0.996 0.352 C} FS
 -75 0 0 1296 75 0 3 3364 0 SP
-{0.00926 0 0 C} FS
+{0.507 1 0.323 C} FS
 -76 0 0 1057 76 0 3 3439 0 SP
-{0.0114 0 0 C} FS
+{0.543 1 0.296 C} FS
 -76 0 0 1188 76 0 3 3515 0 SP
+{0.579 0.998 0.274 C} FS
 -75 0 0 1188 75 0 3 3591 0 SP
-{0.0126 0 0 C} FS
+{0.611 0.996 0.251 C} FS
 -76 0 0 1255 76 0 3 3666 0 SP
-{0.00926 0 0 C} FS
+{0.637 0.99 0.237 C} FS
 -75 0 0 1057 75 0 3 3742 0 SP
-{0.0147 0 0 C} FS
+{0.663 0.984 0.223 C} FS
 -76 0 0 1354 76 0 3 3817 0 SP
-{0.0118 0 0 C} FS
+{0.691 0.978 0.213 C} FS
 -76 0 0 1211 76 0 3 3893 0 SP
-{0.0105 0 0 C} FS
+{0.719 0.968 0.208 C} FS
 -75 0 0 1138 75 0 3 3969 0 SP
-{0.0109 0 0 C} FS
+{0.743 0.958 0.204 C} FS
 -76 0 0 1164 76 0 3 4044 0 SP
-{0.0101 0 0 C} FS
+{0.768 0.944 0.204 C} FS
 -75 0 0 1112 75 0 3 4120 0 SP
-{0.0126 0 0 C} FS
+{0.794 0.931 0.204 C} FS
 -76 0 0 1255 76 0 3 4195 0 SP
-{0.0114 0 0 C} FS
+{0.818 0.916 0.205 C} FS
 -75 0 0 1188 75 0 3 4271 0 SP
-{0.0122 0 0 C} FS
+{0.842 0.899 0.208 C} FS
 -76 0 0 1233 76 0 3 4346 0 SP
-{0.016 0 0 C} FS
+{0.862 0.883 0.214 C} FS
 -76 0 0 1407 76 0 3 4422 0 SP
-{0.0181 0 0 C} FS
+{0.882 0.867 0.216 C} FS
 -75 0 0 1486 75 0 3 4498 0 SP
-{0.0164 0 0 C} FS
+{0.902 0.847 0.222 C} FS
 -76 0 0 1423 76 0 3 4573 0 SP
-{0.0177 0 0 C} FS
+{0.922 0.827 0.224 C} FS
 -75 0 0 1471 75 0 3 4649 0 SP
-{0.0156 0 0 C} FS
+{0.936 0.807 0.227 C} FS
 -76 0 0 1389 76 0 3 4724 0 SP
-{0.0118 0 0 C} FS
+{0.951 0.787 0.227 C} FS
 -76 0 0 1211 76 0 3 4800 0 SP
-{0.0185 0 0 C} FS
+{0.964 0.767 0.227 C} FS
 -75 0 0 1500 75 0 3 4876 0 SP
-{0.0164 0 0 C} FS
+{0.974 0.743 0.224 C} FS
 -76 0 0 1423 76 0 3 4951 0 SP
-{0.0177 0 0 C} FS
+{0.984 0.723 0.22 C} FS
 -75 0 0 1471 75 0 3 5027 0 SP
-{0.0311 0 0 C} FS
+{0.988 0.699 0.212 C} FS
 -76 0 0 1833 76 0 3 5102 0 SP
-{0.0252 0 0 C} FS
+{0.992 0.675 0.204 C} FS
 -76 0 0 1699 76 0 3 5178 0 SP
-{0.0236 0 0 C} FS
+{0.996 0.649 0.194 C} FS
 -75 0 0 1655 75 0 3 5254 0 SP
-{0.0303 0 0 C} FS
+{0.996 0.619 0.184 C} FS
 -76 0 0 1816 76 0 3 5329 0 SP
-{0.0257 0 0 C} FS
+{0.996 0.593 0.17 C} FS
 -75 0 0 1710 75 0 3 5405 0 SP
-{0.0299 0 0 C} FS
+{0.995 0.563 0.16 C} FS
 -76 0 0 1807 76 0 3 5480 0 SP
-{0.0278 0 0 C} FS
+{0.989 0.533 0.146 C} FS
 -75 0 0 1760 75 0 3 5556 0 SP
-{0.0383 0 0 C} FS
+{0.984 0.503 0.132 C} FS
 -76 0 0 1966 76 0 3 5631 0 SP
-{0.0299 0 0 C} FS
+{0.977 0.473 0.118 C} FS
 -76 0 0 1807 76 0 3 5707 0 SP
-{0.0278 0 0 C} FS
+{0.971 0.443 0.107 C} FS
 -75 0 0 1760 75 0 3 5783 0 SP
-{0.0252 0 0 C} FS
+{0.961 0.413 0.0945 C} FS
 -76 0 0 1699 76 0 3 5858 0 SP
-{0.0231 0 0 C} FS
+{0.951 0.383 0.0806 C} FS
 -75 0 0 1643 75 0 3 5934 0 SP
-{0.0248 0 0 C} FS
+{0.941 0.357 0.0706 C} FS
 -76 0 0 1688 76 0 3 6009 0 SP
-{0.0257 0 0 C} FS
+{0.927 0.329 0.0606 C} FS
 -76 0 0 1710 76 0 3 6085 0 SP
-{0.0168 0 0 C} FS
+{0.917 0.305 0.0506 C} FS
 -75 0 0 1439 75 0 3 6161 0 SP
-{0.0185 0 0 C} FS
+{0.901 0.281 0.0445 C} FS
 -76 0 0 1500 76 0 3 6236 0 SP
-{0.0202 0 0 C} FS
+{0.885 0.261 0.0384 C} FS
 -75 0 0 1556 75 0 3 6312 0 SP
-{0.0122 0 0 C} FS
+{0.869 0.241 0.0314 C} FS
 -76 0 0 1233 76 0 3 6387 0 SP
-{0.0172 0 0 C} FS
+{0.853 0.221 0.0263 C} FS
 -76 0 0 1455 76 0 3 6463 0 SP
-{0.0122 0 0 C} FS
+{0.833 0.201 0.0202 C} FS
 -75 0 0 1233 75 0 3 6539 0 SP
-{0.0101 0 0 C} FS
+{0.813 0.181 0.018 C} FS
 -76 0 0 1112 76 0 3 6614 0 SP
-{0.00673 0 0 C} FS
+{0.793 0.165 0.0157 C} FS
 -75 0 0 853 75 0 3 6690 0 SP
-{0.0105 0 0 C} FS
+{0.769 0.147 0.0118 C} FS
 -76 0 0 1138 76 0 3 6765 0 SP
-{0.0122 0 0 C} FS
+{0.745 0.129 0.00784 C} FS
 -76 0 0 1233 76 0 3 6841 0 SP
-{0.00968 0 0 C} FS
+{0.721 0.115 0.00784 C} FS
 -75 0 0 1085 75 0 3 6917 0 SP
-{0.00631 0 0 C} FS
+{0.696 0.101 0.00392 C} FS
 -76 0 0 811 76 0 3 6992 0 SP
-{0.00463 0 0 C} FS
+{0.666 0.0875 0.00392 C} FS
 -75 0 0 613 75 0 3 7068 0 SP
-{0.00252 0 0 C} FS
+{0.64 0.0735 0.00392 C} FS
 -76 0 0 225 76 0 3 7143 0 SP
-{0.00505 0 0 C} FS
+{0.61 0.0596 0.00392 C} FS
 -75 0 0 668 75 0 3 7219 0 SP
-{0.0021 0 0 C} FS
+{0.58 0.0482 0.00392 C} FS
 -76 0 0 108 76 0 3 7294 0 SP
-{0.00337 0 0 C} FS
+{0.546 0.0357 0.00745 C} FS
 -76 0 0 409 76 0 3 7370 0 SP
-{0.000841 0 0 C} FS
+{0.515 0.0257 0.00784 C} FS
 -75 0 0 -479 75 0 3 7446 0 SP
-{0.00168 0 0 C} FS
+{0.478 0.0157 0.0118 C} FS
 -38 0 0 -35 38 0 3 7521 0 SP
 PSL_cliprestore
-0 A [] 0 B
 25 W
+0 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 4724 M 0 -4724 D S
@@ -1054,13 +1096,14 @@ O0
 0 6142 TM
 
 % PostScript produced by:
-%@GMT: gmt pshistogram -R0/5000/0.01/16 -JX16c/10cl -O /Users/pwessel/.gmt/cache/bin_data_hist.b -bi1f -Z1 -Ccolor.cpt -F -T50 -Wfaint '-Bxafg+u m' '-Byafg+lFrequency (\045)' -BWSne -A -Y13c
+%@GMT: gmt pshistogram -R0/5000/0.01/16 -JX16c/10cl -O /Users/pwessel/.gmt/cache/bin_data_hist.b -bi1f -Z1 -Ccolor.cpt+b -F -T50 -Wfaint '-Bxafg+u m' '-Byafg+lFrequency (\045)' -BWSne -A -Y13c
 %@PROJ: xy 0.01000000 16.00000000 0.00000000 5000.00000000 -2.000 1.204 0.000 5000.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
 4 W
+0 A
 N 0 0 M 0 4724 D S
 N 2359 0 M 0 4724 D S
 N 4718 0 M 0 4724 D S
@@ -1082,210 +1125,132 @@ clipsave
 P
 PSL_clip N
 0 W
-{0.203 0 0 C} FS
+{0.103 0 0 C} FS
 O1
 0 -24 4853 0 0 24 3 0 0 SP
-{1 0.79 0 C} FS
-0 -47 7085 0 0 47 3 0 24 SP
 {1 A} FS
+0 -47 7085 0 0 47 3 0 24 SP
 0 -47 7517 0 0 47 3 0 71 SP
-{1 0.714 0 C} FS
+{1 1 0.919 C} FS
 0 -47 7040 0 0 47 3 0 118 SP
-{1 0.173 0 C} FS
+{1 1 0.223 C} FS
 0 -48 6651 0 0 48 3 0 165 SP
-{0.977 0 0 C} FS
+{1 0.96 0 C} FS
 0 -47 6464 0 0 47 3 0 213 SP
-{0.822 0 0 C} FS
+{1 0.693 0 C} FS
 0 -47 6287 0 0 47 3 0 260 SP
-{0.937 0 0 C} FS
+{1 0.891 0 C} FS
 0 -47 6421 0 0 47 3 0 307 SP
-{0.885 0 0 C} FS
+{1 0.801 0 C} FS
 0 -48 6363 0 0 48 3 0 354 SP
-{0.681 0 0 C} FS
+{1 0.448 0 C} FS
 0 -47 6094 0 0 47 3 0 402 SP
-{0.649 0 0 C} FS
+{1 0.394 0 C} FS
 0 -47 6045 0 0 47 3 0 449 SP
-{0.583 0 0 C} FS
+{1 0.279 0 C} FS
 0 -47 5935 0 0 47 3 0 496 SP
-{0.491 0 0 C} FS
+{1 0.119 0 C} FS
 0 -48 5758 0 0 48 3 0 543 SP
-{0.423 0 0 C} FS
+{1 0.00217 0 C} FS
 0 -47 5606 0 0 47 3 0 591 SP
-{0.367 0 0 C} FS
+{0.777 0 0 C} FS
 0 -47 5462 0 0 47 3 0 638 SP
-{0.294 0 0 C} FS
+{0.477 0 0 C} FS
 0 -47 5234 0 0 47 3 0 685 SP
-{0.394 0 0 C} FS
+{0.886 0 0 C} FS
 0 -48 5533 0 0 48 3 0 732 SP
-{0.374 0 0 C} FS
+{0.805 0 0 C} FS
 0 -47 5480 0 0 47 3 0 780 SP
-{0.328 0 0 C} FS
+{0.617 0 0 C} FS
 0 -47 5346 0 0 47 3 0 827 SP
-{0.259 0 0 C} FS
+{0.334 0 0 C} FS
 0 -47 5105 0 0 47 3 0 874 SP
-{0.196 0 0 C} FS
+{0.0733 0 0 C} FS
 0 -48 4816 0 0 48 3 0 921 SP
-{0.135 0 0 C} FS
+{0 A} FS
 0 -47 4434 0 0 47 3 0 969 SP
-{0.106 0 0 C} FS
 0 -47 4185 0 0 47 3 0 1016 SP
-{0.0837 0 0 C} FS
 0 -47 3947 0 0 47 3 0 1063 SP
-{0.0475 0 0 C} FS
 0 -47 3367 0 0 47 3 0 1110 SP
-{0.0358 0 0 C} FS
 0 -48 3075 0 0 48 3 0 1157 SP
-{0.0261 0 0 C} FS
 0 -47 2752 0 0 47 3 0 1205 SP
-{0.0236 0 0 C} FS
 0 -47 2648 0 0 47 3 0 1252 SP
-{0.0151 0 0 C} FS
 0 -47 2195 0 0 47 3 0 1299 SP
-{0.0156 0 0 C} FS
 0 -48 2223 0 0 48 3 0 1346 SP
 0 -47 2223 0 0 47 3 0 1394 SP
-{0.0126 0 0 C} FS
 0 -47 2008 0 0 47 3 0 1441 SP
-{0.0109 0 0 C} FS
 0 -47 1862 0 0 47 3 0 1488 SP
-{0.0114 0 0 C} FS
 0 -48 1900 0 0 48 3 0 1535 SP
-{0.00715 0 0 C} FS
 0 -47 1426 0 0 47 3 0 1583 SP
-{0.0164 0 0 C} FS
 0 -47 2277 0 0 47 3 0 1630 SP
-{0.00841 0 0 C} FS
 0 -47 1593 0 0 47 3 0 1677 SP
-{0.00757 0 0 C} FS
 0 -48 1485 0 0 48 3 0 1724 SP
-{0.0118 0 0 C} FS
 0 -47 1938 0 0 47 3 0 1772 SP
-{0.00547 0 0 C} FS
 0 -47 1151 0 0 47 3 0 1819 SP
-{0.00631 0 0 C} FS
 0 -47 1298 0 0 47 3 0 1866 SP
-{0.0114 0 0 C} FS
 0 -48 1900 0 0 48 3 0 1913 SP
-{0.00715 0 0 C} FS
 0 -47 1426 0 0 47 3 0 1961 SP
-{0.0101 0 0 C} FS
 0 -47 1780 0 0 47 3 0 2008 SP
-{0.00799 0 0 C} FS
 0 -47 1540 0 0 47 3 0 2055 SP
-{0.0135 0 0 C} FS
 0 -48 2074 0 0 48 3 0 2102 SP
-{0.00926 0 0 C} FS
 0 -47 1690 0 0 47 3 0 2150 SP
-{0.0114 0 0 C} FS
 0 -47 1900 0 0 47 3 0 2197 SP
 0 -47 1900 0 0 47 3 0 2244 SP
-{0.0126 0 0 C} FS
 0 -48 2008 0 0 48 3 0 2291 SP
-{0.00926 0 0 C} FS
 0 -47 1690 0 0 47 3 0 2339 SP
-{0.0147 0 0 C} FS
 0 -47 2166 0 0 47 3 0 2386 SP
-{0.0118 0 0 C} FS
 0 -47 1938 0 0 47 3 0 2433 SP
-{0.0105 0 0 C} FS
 0 -48 1821 0 0 48 3 0 2480 SP
-{0.0109 0 0 C} FS
 0 -47 1862 0 0 47 3 0 2528 SP
-{0.0101 0 0 C} FS
 0 -47 1780 0 0 47 3 0 2575 SP
-{0.0126 0 0 C} FS
 0 -47 2008 0 0 47 3 0 2622 SP
-{0.0114 0 0 C} FS
 0 -48 1900 0 0 48 3 0 2669 SP
-{0.0122 0 0 C} FS
 0 -47 1973 0 0 47 3 0 2717 SP
-{0.016 0 0 C} FS
 0 -47 2250 0 0 47 3 0 2764 SP
-{0.0181 0 0 C} FS
 0 -47 2377 0 0 47 3 0 2811 SP
-{0.0164 0 0 C} FS
 0 -48 2277 0 0 48 3 0 2858 SP
-{0.0177 0 0 C} FS
 0 -47 2353 0 0 47 3 0 2906 SP
-{0.0156 0 0 C} FS
 0 -47 2223 0 0 47 3 0 2953 SP
-{0.0118 0 0 C} FS
 0 -47 1938 0 0 47 3 0 3000 SP
-{0.0185 0 0 C} FS
 0 -47 2401 0 0 47 3 0 3047 SP
-{0.0164 0 0 C} FS
 0 -48 2277 0 0 48 3 0 3094 SP
-{0.0177 0 0 C} FS
 0 -47 2353 0 0 47 3 0 3142 SP
-{0.0311 0 0 C} FS
 0 -47 2933 0 0 47 3 0 3189 SP
-{0.0252 0 0 C} FS
 0 -47 2718 0 0 47 3 0 3236 SP
-{0.0236 0 0 C} FS
 0 -48 2648 0 0 48 3 0 3283 SP
-{0.0303 0 0 C} FS
 0 -47 2905 0 0 47 3 0 3331 SP
-{0.0257 0 0 C} FS
 0 -47 2735 0 0 47 3 0 3378 SP
-{0.0299 0 0 C} FS
 0 -47 2891 0 0 47 3 0 3425 SP
-{0.0278 0 0 C} FS
 0 -48 2816 0 0 48 3 0 3472 SP
-{0.0383 0 0 C} FS
 0 -47 3145 0 0 47 3 0 3520 SP
-{0.0299 0 0 C} FS
 0 -47 2891 0 0 47 3 0 3567 SP
-{0.0278 0 0 C} FS
 0 -47 2816 0 0 47 3 0 3614 SP
-{0.0252 0 0 C} FS
 0 -48 2718 0 0 48 3 0 3661 SP
-{0.0231 0 0 C} FS
 0 -47 2629 0 0 47 3 0 3709 SP
-{0.0248 0 0 C} FS
 0 -47 2701 0 0 47 3 0 3756 SP
-{0.0257 0 0 C} FS
 0 -47 2735 0 0 47 3 0 3803 SP
-{0.0168 0 0 C} FS
 0 -48 2303 0 0 48 3 0 3850 SP
-{0.0185 0 0 C} FS
 0 -47 2401 0 0 47 3 0 3898 SP
-{0.0202 0 0 C} FS
 0 -47 2490 0 0 47 3 0 3945 SP
-{0.0122 0 0 C} FS
 0 -47 1973 0 0 47 3 0 3992 SP
-{0.0172 0 0 C} FS
 0 -48 2328 0 0 48 3 0 4039 SP
-{0.0122 0 0 C} FS
 0 -47 1973 0 0 47 3 0 4087 SP
-{0.0101 0 0 C} FS
 0 -47 1780 0 0 47 3 0 4134 SP
-{0.00673 0 0 C} FS
 0 -47 1364 0 0 47 3 0 4181 SP
-{0.0105 0 0 C} FS
 0 -48 1821 0 0 48 3 0 4228 SP
-{0.0122 0 0 C} FS
 0 -47 1973 0 0 47 3 0 4276 SP
-{0.00968 0 0 C} FS
 0 -47 1736 0 0 47 3 0 4323 SP
-{0.00631 0 0 C} FS
 0 -47 1298 0 0 47 3 0 4370 SP
-{0.00463 0 0 C} FS
 0 -48 980 0 0 48 3 0 4417 SP
-{0.00252 0 0 C} FS
 0 -47 359 0 0 47 3 0 4465 SP
-{0.00505 0 0 C} FS
 0 -47 1069 0 0 47 3 0 4512 SP
-{0.0021 0 0 C} FS
 0 -47 172 0 0 47 3 0 4559 SP
-{0.00337 0 0 C} FS
 0 -48 654 0 0 48 3 0 4606 SP
-{0.000841 0 0 C} FS
 0 -47 -766 0 0 47 3 0 4654 SP
-{0.00168 0 0 C} FS
 0 -23 -56 0 0 23 3 0 4701 SP
 PSL_cliprestore
-0 A [] 0 B
 25 W
+0 A
 /PSL_slant_y 0 def
 2 setlinecap
 N 0 4724 M 0 -4724 D S

--- a/test/pshistogram/flip.sh
+++ b/test/pshistogram/flip.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Test -A with log axis
 ps=flip.ps
-gmt makecpt -Chot -T0/15 > color.cpt
+gmt makecpt -Cturbo -T0/5000 > color.cpt
 gmt pshistogram -R0/5000/0.01/16 -JX16c/10cl -P @bin_data_hist.b -bi1f -Z1 -Ccolor.cpt -F -K -T50 -Wfaint -Bxafg+u" m" -Byafg+l"Frequency (\045)" -BWSne -Xc > $ps
-gmt pshistogram -R -J -O @bin_data_hist.b -bi1f -Z1 -Ccolor.cpt -F -T50 -Wfaint -Bxafg+u" m" -Byafg+l"Frequency (\045)" -BWSne -A -Y13c >> $ps
+gmt makecpt -Chot -T0/1 -Q > color.cpt
+gmt pshistogram -R -J -O @bin_data_hist.b -bi1f -Z1 -Ccolor.cpt+b -F -T50 -Wfaint -Bxafg+u" m" -Byafg+l"Frequency (\045)" -BWSne -A -Y13c >> $ps


### PR DESCRIPTION
See forum [post](https://forum.generic-mapping-tools.org/t/create-histogram-with-color-bar-based-on-cpt/1374/9) for background.  Up through 6.1.1 the color lookup was based on mid-point on the bar, but I changed that to the bin value instead (count, percent) in master without providing a path to the original scheme.  This PR restores the original scheme as the default and adds the other scheme via modifier **+b** to **-C**.  I have updated flip.sh test to show both in action and also fix the lack of a logarithmic CPT there.

![flip](https://user-images.githubusercontent.com/26473567/109081563-974d3400-76a6-11eb-9fa0-e519ae067afd.png)
