### PR TITLE
Improve project -Z option

### DIFF
--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -248,6 +248,8 @@ Optional Arguments
 
 .. include:: explain_colon.rst_
 
+.. include:: explain_distunits.rst_
+
 .. include:: explain_help.rst_
 
 .. include:: explain_precision.rst_

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |-T|\ *px*/*py* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *w\_min*/*w\_max* ]
-[ |-Z|\ *major*/*minor*/*azimuth*\ [**+e**] ]
+[ |-Z|\ *major*/*minor*/*azimuth*\ [**+e**\|\ **n**] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -203,15 +203,18 @@ Optional Arguments
     Width controls. Project only those points whose *q* coordinate is
     within *w\_min* < *q* < *w\_max*.
 
-**-Z**\ *major*/*minor*/*azimuth*\ [**+e**]
+**-Z**\ *major*/*minor*/*azimuth*\ [**+e**\|\ **n**]
     Used in conjunction with **-C** (sets its center) and **-G** (sets the
     distance increment) to create the coordinates of an ellipse
     with *major* and *minor* axes given in km (unless **-N** is given for a
     Cartesian ellipse) and the *azimuth* of the major axis in degrees.
     Append **+e** to adjust the increment set via **-G** so that the the ellipse
     has equal distance increments [Default uses the given increment and closes
-    the ellipse].  For degenerate ellipses you can just supply a single *diameter*
-    instead.  **Note**: For the Cartesian ellipse (which requires **-N**), we
+    the ellipse].  Instead, append **+n** to set a specific number of unique equidistant
+    points via **-G**. For degenerate ellipses you can just supply a single *diameter*
+    instead.  A geographic diameter may be specified in any desired unit other than km [Default]
+    by appending the unit (e.g., 3d for degrees); if so we assume the increment is also given in
+    the same unit (see `Units`_).  **Note**: For the Cartesian ellipse (which requires **-N**), we
     expect *direction* counter-clockwise from the horizontal instead of an *azimuth*.
 
 .. |Add_-bi| replace:: [Default is 2 input columns].

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9887,7 +9887,10 @@ struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, 
 
 	/* Explicitly close the polygon */
 	px[N] = px[0], py[N] = py[0];
-	snprintf (header, GMT_LEN256, "Ellipse around %g/%g with major/minor axes %g/%g km and major axis azimuth %g approximated by %" PRIu64 " points", lon, lat, major_km, minor_km, azimuth, N);
+	if (doubleAlmostEqual (major_km, minor_km))
+		snprintf (header, GMT_LEN256, "Circle around %g/%g with diameter %g km approximated by %" PRIu64 " points", lon, lat, major_km, N);
+	else
+		snprintf (header, GMT_LEN256, "Ellipse around %g/%g with major/minor axes %g/%g km and major axis azimuth %g approximated by %" PRIu64 " points", lon, lat, major_km, minor_km, azimuth, N);
 	S->header = strdup (header);
 	return (S);
 }


### PR DESCRIPTION
**Description of proposed changes**

There are two updates to **-Z** in this PR:

1. Allow **+n** to indicate that the increment in **-G** is actually the number of unique points desired along the perimeter
2. For degenerate geographic ellipses (circles), allow the diameter to take the usual optional distance units (e|k|M|n etc) so that it is easier to specify a circle of 10 degree radius, for instance (10d).

Here are 5 equidistant points along a circle of diameter 100 km and 100 nautical miles as example (output is lon, lat, dist[km]):

```
echo 0 0 | gmt project -Z100k+n -G5
2.7503536839e-17	0.44915764206	0
-0.427175137922	0.138796058687	125.663706144
-0.264011777678	-0.363374879697	251.327412287
0.264011777678	-0.363374879697	376.991118431
0.427175137922	0.138796058687	502.654824574
echo 0 0 | gmt project -Z100n+n -G5
5.09390858687e-17	0.831839953095	0
-0.791132115659	0.257044514079	232.729183778
-0.488965742294	-0.672964490193	465.458367556
0.488965742294	-0.672964490193	698.187551334
0.791132115659	0.257044514079	930.916735112
```
