### PR TITLE
Fix auto y-range in histogram

### DIFF
--- a/doc/rst/source/histogram.rst
+++ b/doc/rst/source/histogram.rst
@@ -65,12 +65,14 @@ using a 250 meter bin width, center bars, and draw bar outline, use:
 If you know the distribution of your data, you may explicitly specify
 range and scales. E.g., to plot a histogram of the y-values (2nd column)
 in the file errors.xy using a 1 meter bin width, plot from -10 to +10
-meters @ 0.75 cm/m, annotate every 2 m and 100 counts, and use black
-bars, run:
+meters @ 0.75 cm/m and 0.01c/count in y, annotate every 2 m and 100 counts,
+and use black bars, run:
 
    ::
 
-    gmt histogram errors.xy -T1 -R-10/10/0/0 -Jxc/0.01c -Bx2+lError -By100+lCounts -Gblack -i1 -V -pdf plot
+    gmt begin plot
+      gmt histogram errors.xy -T1 -R-10/10/0/0 -Jx0.75c/0.01c -Bx2+lError -By100+lCounts -Gblack -i1
+    gmt end show
 
 Since no y-range was specified, **histogram** will calculate *ymax* in even
 increments of 100.

--- a/doc/rst/source/pshistogram.rst
+++ b/doc/rst/source/pshistogram.rst
@@ -65,12 +65,12 @@ using a 250 meter bin width, center bars, and draw bar outline, use:
 If you know the distribution of your data, you may explicitly specify
 range and scales. E.g., to plot a histogram of the y-values (2nd column)
 in the file errors.xy using a 1 meter bin width, plot from -10 to +10
-meters @ 0.75 cm/m, annotate every 2 m and 100 counts, and use black
-bars, run:
+meters @ 0.75 cm/m and 0.01c/count in y, annotate every 2 m and 100 counts,
+and use black bars, run:
 
    ::
 
-    gmt pshistogram errors.xy -T1 -R-10/10/0/0 -Jxc/0.01c \
+    gmt pshistogram errors.xy -T1 -R-10/10/0/0 -Jx0.75c/0.01c \
                     -Bx2+lError -By100+lCounts -Gblack -i1 -V > plot.ps
 
 Since no y-range was specified, **pshistogram** will calculate *ymax* in even

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -893,7 +893,7 @@ EXTERN_MSC int GMT_pshistogram (void *V_API, int mode, void *args) {
 	F.extremes = Ctrl->L.mode;
 	F.weights = Ctrl->Z.weights;
 	F.T = &(Ctrl->T.T);
-	if (!Ctrl->I.active && !GMT->common.R.active[RSET]) automatic = true;
+	if (!Ctrl->I.active && !GMT->common.R.active[RSET] || GMT->common.R.wesn[YLO] == GMT->common.R.wesn[YHI]) automatic = true;
 	if (GMT->common.R.active[RSET]) {	/* Gave -R which initially defines the bins also */
 		gmt_M_memcpy (F.wesn, GMT->common.R.wesn, 4, double);
 		Ctrl->T.T.min = F.wesn[XLO]; Ctrl->T.T.max = F.wesn[XHI];


### PR DESCRIPTION
See [forum](https://forum.generic-mapping-tools.org/t/histogram-with-y-range-not-specified/1384/2) post.  Needed to specifically check if y-range in **-R** was zero.  Also, cannot run a 1-liner with that sort of **-R** so changed to a regular session.  Finally, the **-J** was missing the x-scaling information.
