### PR TITLE
Let pscoupe/coupe use -Ccpt not -Zcpt for depth-coloring

### DIFF
--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -16,6 +16,7 @@ Synopsis
 |SYN_OPT-R| |-A|\ *parameters*
 |-S|\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |SYN_OPT-B| ]
+[ |-C|\ *cpt* ]
 [ |-E|\ *fill* ]
 [ |-F|\ *mode*\ [*args*] ]
 [ |-G|\ *fill* ]
@@ -28,7 +29,6 @@ Synopsis
 [ |-W|\ *pen* ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *cpt* ]
 [ |SYN_OPT-di| ]
 [ |SYN_OPT-e| ]
 [ |SYN_OPT-h| ]

--- a/doc/rst/source/supplements/seis/coupe_common.rst_
+++ b/doc/rst/source/supplements/seis/coupe_common.rst_
@@ -73,6 +73,12 @@ Optional Arguments
 
 .. include:: ../../explain_-B.rst_
 
+.. _-C:
+
+**-C**\ *cpt*
+    Give a CPT and let compressive part color be
+    determined by the z-value in the third column.
+
 .. _-E:
 
 **-E**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
@@ -190,12 +196,6 @@ Optional Arguments
 .. _-X:
 
 .. include:: ../../explain_-XY.rst_
-
-.. _-Z:
-
-**-Z**\ *cpt*
-    Give a CPT and let compressive part color be
-    determined by the z-value in the third column.
 
 .. |Add_-di| unicode:: 0x20 .. just an invisible code
 .. include:: ../../explain_-di.rst_

--- a/doc/rst/source/supplements/seis/pscoupe.rst
+++ b/doc/rst/source/supplements/seis/pscoupe.rst
@@ -16,6 +16,7 @@ Synopsis
 |SYN_OPT-R| |-A|\ *parameters*
 |-S|\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |SYN_OPT-B| ]
+[ |-C|\ *cpt* ]
 [ |-E|\ *fill* ]
 [ |-F|\ *mode*\ [*args*] ]
 [ |-G|\ *fill* ]
@@ -30,7 +31,6 @@ Synopsis
 [ |-W|\ *pen* ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *cpt* ]
 [ |SYN_OPT-di| ]
 [ |SYN_OPT-e| ]
 [ |SYN_OPT-h| ]

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -162,7 +162,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 static void Free_Ctrl (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
-	gmt_M_str_free (C->Z.file);
+	gmt_M_str_free (C->C.file);
 	gmt_M_free (GMT, C);
 }
 
@@ -565,7 +565,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 
 			case 'Z':	/* Backwards compatibility */
 				if (gmt_M_compat_check (GMT, 6))
-					GMT_Report (API, GMT_MSG_COMPAT, "-Z<cpt> is deprecated; use -C<cpt> instead.\n");
+					GMT_Report (GMT->parent, GMT_MSG_COMPAT, "-Z<cpt> is deprecated; use -C<cpt> instead.\n");
 				else {	/* Hard error */
 					n_errors += gmt_default_error (GMT, opt->option);
 					continue;


### PR DESCRIPTION
**Description of proposed changes**

For whatever reason, the cpt-option in **coupe** was selected to be **-Z**_cpt_ and not **-C**_cpt_ as it is in virtually all other GMT modules with similar capability.  I have changed this to **-C** now, but allow for backwards compatibility through GMT 6.
