### PR TITLE
When polar -G is given it sets -C true

### DIFF
--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -309,7 +309,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSPOLAR_CTRL *Ctrl, struct GMT_OP
 				}
 				break;
 			case 'G':	/* Set color for station in compressive part */
-				Ctrl->C.active = true;
+				Ctrl->G.active = true;
 				if (gmt_getfill (GMT, opt->arg, &Ctrl->G.fill)) {
 					gmt_fill_syntax (GMT, 'G', NULL, " ");
 					n_errors++;


### PR DESCRIPTION
Copy/paste error probably, and I think polar is a very under-used module so not noticed.
