### PR TITLE
pspolar: Merge -C with -D and improve parsing

### DIFF
--- a/doc/rst/source/supplements/seis/polar.rst
+++ b/doc/rst/source/supplements/seis/polar.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt polar**
 [ *table* ]
-|-D|\ *lon/lat*\ [**+z**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *size*]]
+|-D|\ *lon/lat*
 |-J|\ *parameters*
 |SYN_OPT-R|
 |-M|\ *size*\ [**+m**\ *mag*]

--- a/doc/rst/source/supplements/seis/polar.rst
+++ b/doc/rst/source/supplements/seis/polar.rst
@@ -12,12 +12,14 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt polar** [ *table* ] |-D|\ *lon/lat* |-J|\ *parameters*
+**gmt polar**
+[ *table* ]
+|-D|\ *lon/lat*\ [**+z**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *size*]]
+|-J|\ *parameters*
 |SYN_OPT-R|
 |-M|\ *size*\ [**+m**\ *mag*]
 |-S|\ *<symbol><size>*
 [ |SYN_OPT-B| ]
-[ |-C|\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *pointsize*] ]
 [ |-E|\ *fill* ]
 [ |-F|\ *fill* ]
 [ |-G|\ *fill* ]
@@ -58,7 +60,7 @@ Examples
 
 Use special format derived from HYPO71 output::
 
-    gmt polar -R239/240/34/35.2 -JM8c -N -Sc0.4 -D239.5/34.5 -M5 -Qh -pdf test <<END
+    gmt polar -R239/240/34/35.2 -JM8c -N -Sc0.4 -D239:30E/34:30N -M5 -Qh -pdf test <<END
     #Date Or. time stat azim ih
     910223 1 22 0481 11 147 ipu0
     910223 1 22 6185 247 120 ipd0

--- a/doc/rst/source/supplements/seis/polar_common.rst_
+++ b/doc/rst/source/supplements/seis/polar_common.rst_
@@ -9,7 +9,8 @@ will plot stations on focal mechanisms on a map.
 Parameters are expected to be in the following columns:
 
     **1**,\ **2**,\ **3**:
-        station\_code, azimuth, take-off angle
+        *station-code azimuth take-off-angle*
+        (must all be numerical values)
     **4**:
         polarity:
 
@@ -25,23 +26,18 @@ Required Arguments
 .. |Add_intables| unicode:: 0x20 .. just an invisible code
 .. include:: ../../explain_intables.rst_
 
+.. _-D:
+
+**-D**\ *lon/lat*\ [**+z**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *size*]]
+    Places the focal sphere at given longitude and latitude point on the map.  Alternatively,
+    offset the hemisphere plot to the location specified via **+z**, place a
+    small circle at the original point, and connect the two points via a line.
+    Optionally, change the pen via **+p** [0.25p] and the circle diameter via **+s** [0.5p]
+
 .. _-J:
 
 .. |Add_-J| unicode:: 0x20 .. just an invisible code
 .. include:: ../../explain_-J.rst_
-
-.. _-R:
-
-.. |Add_-Rgeo| unicode:: 0x20 .. just an invisible code
-.. include:: ../../explain_-Rgeo.rst_
-
-.. _-D:
-
-**-D**\ *lon/lat*\ [**+z**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *size*]]
-    Places the focal sphere at given longitude and latitude point.  Alternatively,
-    offset the hemisphere plot to the location specified via **+z**, place a
-    small circle at the original point, and connect the two points via a line.
-    Optionally, change the pen via **+p** [0.25p] and the circle diameter via **+s**..
 
 .. _-M:
 
@@ -50,6 +46,11 @@ Required Arguments
     default units (unless **c**, **i**, or **p** is appended).
     Optionally append **+m**\ *mag* to specify its magnitude,
     then beachball size is *mag* / 5.0 * *size*.
+
+.. _-R:
+
+.. |Add_-Rgeo| unicode:: 0x20 .. just an invisible code
+.. include:: ../../explain_-Rgeo.rst_
 
 .. _-S:
 

--- a/doc/rst/source/supplements/seis/polar_common.rst_
+++ b/doc/rst/source/supplements/seis/polar_common.rst_
@@ -4,8 +4,7 @@ Description
 -----------
 
 Reads data values from *files* [or standard input] and
-will plot stations on focal mechanisms
-on a map.
+will plot stations on focal mechanisms on a map.
 
 Parameters are expected to be in the following columns:
 
@@ -38,8 +37,11 @@ Required Arguments
 
 .. _-D:
 
-**-D**\ *longitude/latitude*
-    Maps the bubble at given longitude and latitude point.
+**-D**\ *lon/lat*\ [**+z**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *size*]]
+    Places the focal sphere at given longitude and latitude point.  Alternatively,
+    offset the hemisphere plot to the location specified via **+z**, place a
+    small circle at the original point, and connect the two points via a line.
+    Optionally, change the pen via **+p** [0.25p] and the circle diameter via **+s**..
 
 .. _-M:
 
@@ -63,13 +65,6 @@ Optional Arguments
 .. _-B:
 
 .. include:: ../../explain_-B.rst_
-
-.. _-C:
-
-**-C**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *pointsize*]
-    Offsets focal mechanisms to the latitude and longitude specified in
-    the last two columns of the input file.  Optionally set the pen and
-    symbol point size.
 
 .. _-E:
 

--- a/doc/rst/source/supplements/seis/polar_common.rst_
+++ b/doc/rst/source/supplements/seis/polar_common.rst_
@@ -42,10 +42,10 @@ Required Arguments
 .. _-M:
 
 **-M**\ *size*\ [**+m**\ *mag*]
-    Sets the size of the beach ball to plot polarities in. *size* is in
+    Sets the size of the focal sphere to plot polarities in. *size* is in
     default units (unless **c**, **i**, or **p** is appended).
     Optionally append **+m**\ *mag* to specify its magnitude,
-    then beachball size is *mag* / 5.0 * *size*.
+    then focal sphere size is *mag* / 5.0 * *size*.
 
 .. _-R:
 
@@ -77,7 +77,7 @@ Optional Arguments
 .. _-F:
 
 **-F**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
-    Sets background color of the beach ball. Default is no fill.
+    Sets background color of the focal sphere. Default is no fill.
 
 .. _-G:
 
@@ -99,7 +99,7 @@ Optional Arguments
         Outline symbols in extensive quadrants using *pen* or the default pen (see |-W|).
 
     **-Qf**\ [pen]
-        Outline the beach ball using *pen* or the default pen (see |-W|).
+        Outline the focal sphere using *pen* or the default pen (see |-W|).
 
     **-Qg**\ [pen]
         Outline symbols in compressional quadrants using *pen* or the default pen (see |-W|).

--- a/doc/rst/source/supplements/seis/polar_common.rst_
+++ b/doc/rst/source/supplements/seis/polar_common.rst_
@@ -28,11 +28,8 @@ Required Arguments
 
 .. _-D:
 
-**-D**\ *lon/lat*\ [**+z**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *size*]]
-    Places the focal sphere at given longitude and latitude point on the map.  Alternatively,
-    offset the hemisphere plot to the location specified via **+z**, place a
-    small circle at the original point, and connect the two points via a line.
-    Optionally, change the pen via **+p** [0.25p] and the circle diameter via **+s** [0.5p]
+**-D**\ *lon/lat*
+    Centers the focal sphere at given longitude and latitude point on the map.
 
 .. _-J:
 

--- a/doc/rst/source/supplements/seis/polar_common.rst_
+++ b/doc/rst/source/supplements/seis/polar_common.rst_
@@ -3,14 +3,16 @@
 Description
 -----------
 
-Reads data values from *files* [or standard input] and
-will plot stations on focal mechanisms on a map.
+Plot observations from a single earthquake observed at various stations
+at different azimuths and distances on the lower hemisphere of the focal
+sphere.  The focal sphere is typically plotted at the location of the earthquake,
+specified via **-D**. Reads data values from *files* [or standard input].
 
 Parameters are expected to be in the following columns:
 
     **1**,\ **2**,\ **3**:
         *station-code azimuth take-off-angle*
-        (must all be numerical values)
+        (all three columns must contain numerical values)
     **4**:
         polarity:
 

--- a/doc/rst/source/supplements/seis/pspolar.rst
+++ b/doc/rst/source/supplements/seis/pspolar.rst
@@ -12,12 +12,14 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt pspolar** [ *table* ] |-D|\ *lon/lat* |-J|\ *parameters*
+**gmt pspolar**
+[ *table* ]
+|-D|\ *lon/lat*\ [**+z**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *size*]]
+|-J|\ *parameters*
 |SYN_OPT-R|
 |-M|\ *size*\ [**+m**\ *mag*]
 |-S|\ *<symbol><size>*
 [ |SYN_OPT-B| ]
-[ |-C|\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *pointsize*] ]
 [ |-E|\ *fill* ]
 [ |-F|\ *fill* ]
 [ |-G|\ *fill* ]

--- a/doc/rst/source/supplements/seis/pspolar.rst
+++ b/doc/rst/source/supplements/seis/pspolar.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt pspolar**
 [ *table* ]
-|-D|\ *lon/lat*\ [**+z**\ *lon*/*lat*\ [**+p**\ *pen*][**+s**\ *size*]]
+|-D|\ *lon/lat*
 |-J|\ *parameters*
 |SYN_OPT-R|
 |-M|\ *size*\ [**+m**\ *mag*]

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -119,7 +119,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	/* Initialize values whose defaults are not 0/false/NULL */
 
 	/* Deprecated -C option */
-	C->OLD_C.size = 0.1 / 2.54;	/* Let -C original point circle be 0.1 cm */
+	C->OLD_C.size = 0.0;	/* Default is to plot no circle */
 	C->OLD_C.pen = GMT->current.setting.map_default_pen;
 
 	C->E.pen = C->F.pen = C->G.pen = GMT->current.setting.map_default_pen;
@@ -543,7 +543,7 @@ EXTERN_MSC int GMT_pspolar (void *V_API, int mode, void *args) {
 	if (Ctrl->OLD_C.active) {	/* This is deprecated but honored in a backwards compatible way */
 		gmt_setpen (GMT, &Ctrl->OLD_C.pen);
 		gmt_geo_to_xy (GMT, Ctrl->OLD_C.lon2, Ctrl->OLD_C.lat2, &new_plot_x0, &new_plot_y0);
-		PSL_plotsymbol (PSL, plot_x0, plot_y0, &(Ctrl->OLD_C.size), PSL_CIRCLE);
+		if (Ctrl->OLD_C.size > 0.0) PSL_plotsymbol (PSL, plot_x0, plot_y0, &(Ctrl->OLD_C.size), PSL_CIRCLE);
 		PSL_plotsegment (PSL, plot_x0, plot_y0, new_plot_x0, new_plot_y0);
 		plot_x0 = new_plot_x0;
 		plot_y0 = new_plot_y0;

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -147,7 +147,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   We then draw a line between the two positions and place a circle at the original point\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append +p<pen> to change pen [%s] and +s<size> to change circle diameter [0.5p].\n", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Option (API, "J-");
-	GMT_Message (API, GMT_TIME_NONE, "\t-M Set size of beachball in %s. Append +m<mag> to specify its magnitude, and beachball size is <mag> / 5.0 * <size>.\n",
+	GMT_Message (API, GMT_TIME_NONE, "\t-M Set size of focal sphere in %s. Append +m<mag> to specify a magnitude, and focal sphere size is <mag> / 5.0 * <size>.\n",
 		API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
 	GMT_Option (API, "R");
 	GMT_Message (API, GMT_TIME_NONE, "\t-S Select symbol type and symbol size (in %s).  Choose between:\n",
@@ -160,7 +160,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Fill can be either <r/g/b> (each 0-255) for color \n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   or <gray> (0-255) for gray-shade [0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Default is light gray.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-F Specify background color of beach ball. It can be\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-F Specify background color of focal sphere. It can be\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <r/g/b> (each 0-255) for color or <gray> (0-255) for gray-shade [0].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   [Default is no fill].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Specify color symbol for station in compressive part.\n");
@@ -172,7 +172,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "O,P");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Sets various attributes of symbols depending on <mode>:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   e Outline of station symbol in extensive part [Default is current pen].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   f Outline beach ball.  Add <pen attributes> [Default is current pen].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   f Outline focal sphere.  Add <pen attributes> [Default is current pen].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   g Outline of station symbol in compressive part.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     Add <pen attributes> if not current pen.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   h Use special format derived from HYPO71 output.\n");
@@ -355,7 +355,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSPOLAR_CTRL *Ctrl, struct GMT_OP
 					n_errors++;
 				}
 				break;
-			case 'F':	/* Set background color of beach ball */
+			case 'F':	/* Set background color of focal sphere */
 				Ctrl->F.active = true;
 				if (gmt_getfill (GMT, opt->arg, &Ctrl->F.fill)) {
 					gmt_fill_syntax (GMT, 'F', NULL, " ");
@@ -379,10 +379,10 @@ static int parse (struct GMT_CTRL *GMT, struct PSPOLAR_CTRL *Ctrl, struct GMT_OP
 							n_errors++;
 						}
 						break;
-					case 'f':	/* Outline beach ball */
+					case 'f':	/* Outline focal sphere */
 						Ctrl->F.active = true;
 						if (strlen (&opt->arg[1]) && gmt_getpen (GMT, &opt->arg[1], &Ctrl->F.pen)) {
-							gmt_pen_syntax (GMT, ' ', "Qf", "Outline beach ball [Default current pen]", 0);
+							gmt_pen_syntax (GMT, ' ', "Qf", "Outline focal sphere [Default current pen]", 0);
 							n_errors++;
 						}
 						break;

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -17,7 +17,11 @@
  * Date:	19-OCT-1995 (psprojstations)
  * Version:	5
  * Roots:	heavily based on psxy.c; ported to GMT5 by P. Wessel
- *
+ * Updated March 1, 2021: No longer support the relocation of the
+ *   focal sphere and the optional line/point plotting since that is
+ *   better handled by meca.  However, it remains backwards supported
+ *   via the old -C option, just no longer documented.  The -D option
+ *   is used to place the focal sphere wherever you want.
  */
 
 #include "gmt_dev.h"
@@ -114,6 +118,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 
+	/* Deprecated -C option */
 	C->OLD_C.size = 0.1 / 2.54;	/* Let -C original point circle be 0.1 cm */
 	C->OLD_C.pen = GMT->current.setting.map_default_pen;
 
@@ -146,7 +151,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Set longitude/latitude of where to place the focal sphere on the map.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-D Set longitude/latitude of where to center the focal sphere on the map.\n");
 	GMT_Option (API, "J-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Set size of focal sphere in %s. Append +m<mag> to specify a magnitude, and focal sphere size is <mag> / 5.0 * <size>.\n",
 		API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);


### PR DESCRIPTION
See #4869 for background.

To make room for a possible **-C**_cpt_ option across many modules, we let the optional alternate point be set via a modifier to **-D** (which sets the primary point) instead. The new parsing allows for long/lat to be given in the usual geographic syntax accepted elsewhere in GMT (i.e., ddd:mm:ssF as well as decimal).

A few concerns remain (apart from the letter used for the modifier in **-D** – currently **+z**):

1. The description of **-M** is strange: "Sets the size of the beach ball to plot polarities in".  We are not plotting beachballs here but the lower half of the focal sphere, no?  Copy/paste issue? I can understand the **+m** modifier to scale size to magnitude for beachballs.  Does this still make sense for a focal sphere and we just update the language?
2. The default size of the small circle at the point set via **-D** when an alternate location is given is listed as 0.015i. But the code is using **GMT_DOT_SIZE** which is actually 0.005i.  So that is a factor of 3 between usage documentation and actual values, and the documentation is quiet about it.  The 0.005i is 0.36 points so I put in 0.5 points so the circle can be seen.  However, I never make these plots so I do not know what is a useful default, but being smalle than the pen thickness of 0.25p cannot be useful. **Note**: This will be the same issue for **meca** (and possibly **coupe** if that capability is added). I also note that **meca** uses the same 0.005i default diameter but says in the documentation it is 0 (presumably means no circle).  So there needs to be a common default and common language used in both usage and docs across these modules.

Hoping @seisman can opine on these issues.
