### PR TITLE
Let movie and batch use input script mode to decide the OS

### DIFF
--- a/src/batch.c
+++ b/src/batch.c
@@ -598,6 +598,7 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
 				fclose (Ctrl->In.fp);
 				Return (GMT_RUNTIME_ERROR);
+			}
 		}
 		/* Run the pre-flight now which may or may not create a <timefile> needed later via -T, as well as needed data files */
 		if (Ctrl->In.mode == GMT_DOS_MODE)	/* Needs to be "cmd /C" and not "start /B" to let it have time to finish */

--- a/src/batch.c
+++ b/src/batch.c
@@ -593,14 +593,12 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		}
 		fclose (Ctrl->S[BATCH_PREFLIGHT].fp);	/* Done reading the preflight script */
 		fclose (fp);	/* Done writing the temporary preflight script */
-#ifndef WIN32
-		/* Set executable bit if not on Windows */
-		if (chmod (pre_file, S_IRWXU)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
-			fclose (Ctrl->In.fp);
-			Return (GMT_RUNTIME_ERROR);
+		if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows */
+			if (chmod (pre_file, S_IRWXU)) {
+				GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
+				fclose (Ctrl->In.fp);
+				Return (GMT_RUNTIME_ERROR);
 		}
-#endif
 		/* Run the pre-flight now which may or may not create a <timefile> needed later via -T, as well as needed data files */
 		if (Ctrl->In.mode == GMT_DOS_MODE)	/* Needs to be "cmd /C" and not "start /B" to let it have time to finish */
 			sprintf (cmd, "cmd /C %s", pre_file);
@@ -729,14 +727,13 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		fprintf (fp, "cd %s\n", tmpwpath);		/* cd back to the working directory */
 		fclose (Ctrl->S[BATCH_POSTFLIGHT].fp);	/* Done reading the postflight script */
 		fclose (fp);	/* Done writing the postflight script */
-#ifndef WIN32
-		/* Set executable bit if not Windows */
-		if (chmod (post_file, S_IRWXU)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to make postflight script %s executable - exiting\n", post_file);
-			fclose (Ctrl->In.fp);
-			Return (GMT_RUNTIME_ERROR);
+		if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows */
+			if (chmod (post_file, S_IRWXU)) {
+				GMT_Report (API, GMT_MSG_ERROR, "Unable to make postflight script %s executable - exiting\n", post_file);
+				fclose (Ctrl->In.fp);
+				Return (GMT_RUNTIME_ERROR);
+			}
 		}
-#endif
 	}
 
 	/* Create parameter include files, one for each job */

--- a/src/batch.c
+++ b/src/batch.c
@@ -593,13 +593,13 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		}
 		fclose (Ctrl->S[BATCH_PREFLIGHT].fp);	/* Done reading the preflight script */
 		fclose (fp);	/* Done writing the temporary preflight script */
-		if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows */
-			if (chmod (pre_file, S_IRWXU)) {
-				GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
-				fclose (Ctrl->In.fp);
-				Return (GMT_RUNTIME_ERROR);
-			}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+		if (chmod (pre_file, S_IRWXU)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
+			fclose (Ctrl->In.fp);
+			Return (GMT_RUNTIME_ERROR);
 		}
+#endif
 		/* Run the pre-flight now which may or may not create a <timefile> needed later via -T, as well as needed data files */
 		if (Ctrl->In.mode == GMT_DOS_MODE)	/* Needs to be "cmd /C" and not "start /B" to let it have time to finish */
 			sprintf (cmd, "cmd /C %s", pre_file);
@@ -728,13 +728,13 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		fprintf (fp, "cd %s\n", tmpwpath);		/* cd back to the working directory */
 		fclose (Ctrl->S[BATCH_POSTFLIGHT].fp);	/* Done reading the postflight script */
 		fclose (fp);	/* Done writing the postflight script */
-		if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows */
-			if (chmod (post_file, S_IRWXU)) {
-				GMT_Report (API, GMT_MSG_ERROR, "Unable to make postflight script %s executable - exiting\n", post_file);
-				fclose (Ctrl->In.fp);
-				Return (GMT_RUNTIME_ERROR);
-			}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+		if (chmod (post_file, S_IRWXU)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to make postflight script %s executable - exiting\n", post_file);
+			fclose (Ctrl->In.fp);
+			Return (GMT_RUNTIME_ERROR);
 		}
+#endif
 	}
 
 	/* Create parameter include files, one for each job */
@@ -828,12 +828,12 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 	if (Ctrl->In.mode == GMT_DOS_MODE)
 		gmt_strrepc (topdir, '\\', '/');	/* Revert */
 
-	if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows */
-		if (chmod (main_file, S_IRWXU)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", main_file);
-			Return (GMT_RUNTIME_ERROR);
-		}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+	if (chmod (main_file, S_IRWXU)) {
+		GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", main_file);
+		Return (GMT_RUNTIME_ERROR);
 	}
+#endif
 
 	/* Prepare the cleanup script */
 	sprintf (cleanup_file, "batch_cleanup.%s", extension[Ctrl->In.mode]);
@@ -860,12 +860,12 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 		fprintf (fp, "%s %s%c%s\n", rmfile[Ctrl->In.mode], tmpwpath, dir_sep_, main_file);	/* Delete the main script */
 	}
 	fclose (fp);
-	if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows */
-		if (chmod (cleanup_file, S_IRWXU)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to make cleanup script %s executable - exiting\n", cleanup_file);
-			Return (GMT_RUNTIME_ERROR);
-		}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+	if (chmod (cleanup_file, S_IRWXU)) {
+		GMT_Report (API, GMT_MSG_ERROR, "Unable to make cleanup script %s executable - exiting\n", cleanup_file);
+		Return (GMT_RUNTIME_ERROR);
 	}
+#endif
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Total jobs to process: %u\n", n_to_run);
 

--- a/src/movie.c
+++ b/src/movie.c
@@ -1543,13 +1543,13 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			}
 			fclose (Ctrl->S[MOVIE_PREFLIGHT].fp);	/* Done reading the foreground script */
 			fclose (fp);	/* Done writing the preflight script */
-			if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
-				if (chmod (pre_file, S_IRWXU)) {
-					GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
-					fclose (Ctrl->In.fp);
-					Return (GMT_RUNTIME_ERROR);
-				}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+			if (chmod (pre_file, S_IRWXU)) {
+				GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
+				fclose (Ctrl->In.fp);
+				Return (GMT_RUNTIME_ERROR);
 			}
+#endif
 			/* Run the pre-flight now which may or may not create a <timefile> needed later via -T, as well as a background plot */
 			if (Ctrl->In.mode == GMT_DOS_MODE)	/* Needs to be "cmd /C" and not "start /B" to let it have time to finish */
 				sprintf (cmd, "cmd /C %s", pre_file);
@@ -1697,13 +1697,13 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			}
 			fclose (Ctrl->S[MOVIE_POSTFLIGHT].fp);	/* Done reading the foreground script */
 			fclose (fp);	/* Done writing the postflight script */
-			if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
 				if (chmod (post_file, S_IRWXU)) {
 					GMT_Report (API, GMT_MSG_ERROR, "Unable to make postflight script %s executable - exiting\n", post_file);
 					fclose (Ctrl->In.fp);
 					Return (GMT_RUNTIME_ERROR);
 				}
-			}
+#endif
 			/* Run post-flight now before dealing with the loop so the overlay exists */
 			if (Ctrl->In.mode == GMT_DOS_MODE)	/* Needs to be "cmd /C" and not "start /B" to let it have time to finish */
 				sprintf (cmd, "cmd /C %s", post_file);
@@ -1867,12 +1867,12 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fprintf (fp, "exit\n");
 		fclose (fp);	/* Done writing loop script */
 
-		if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
-			if (chmod (intro_file, S_IRWXU)) {
-				GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", intro_file);
-				Return (GMT_RUNTIME_ERROR);
-			}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+		if (chmod (intro_file, S_IRWXU)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", intro_file);
+			Return (GMT_RUNTIME_ERROR);
 		}
+#endif
 	}
 
 	/* Create parameter include files, one for each frame */
@@ -2202,13 +2202,13 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		fclose (fp);	/* Done writing loop script */
 
-		if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
-			if (chmod (master_file, S_IRWXU)) {
-				GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", master_file);
-				fclose (Ctrl->In.fp);
-				Return (GMT_RUNTIME_ERROR);
-			}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+		if (chmod (master_file, S_IRWXU)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", master_file);
+			fclose (Ctrl->In.fp);
+			Return (GMT_RUNTIME_ERROR);
 		}
+#endif
 		sprintf (cmd, "%s %s %*.*d", sc_call[Ctrl->In.mode], master_file, precision, precision, Ctrl->M.frame);
 		if ((error = run_script (cmd))) {
 			GMT_Report (API, GMT_MSG_ERROR, "Running script %s returned error %d - exiting.\n", cmd, error);
@@ -2329,12 +2329,12 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		fprintf (fp, "exit\n");
 	fclose (fp);	/* Done writing loop script */
 
-	if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows */
-		if (chmod (main_file, S_IRWXU)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", main_file);
-			Return (GMT_RUNTIME_ERROR);
-		}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+	if (chmod (main_file, S_IRWXU)) {
+		GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", main_file);
+		Return (GMT_RUNTIME_ERROR);
 	}
+#endif
 
 	n_frames += Ctrl->E.duration;	/* THis is the total set of frames to process */
 	GMT_Report (API, GMT_MSG_INFORMATION, "Total frames to process: %u\n", n_frames);
@@ -2503,12 +2503,12 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fprintf (fp, "%s %s%c*.ps\n", rmfile[Ctrl->In.mode], tmpwpath, dir_sep);	/* Delete any PostScript layers */
 	}
 	fclose (fp);
-	if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
-		if (chmod (cleanup_file, S_IRWXU)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to make cleanup script %s executable - exiting\n", cleanup_file);
-			Return (GMT_RUNTIME_ERROR);
-		}
+#ifndef WIN32	/* Set executable bit if not Windows cmd */
+	if (chmod (cleanup_file, S_IRWXU)) {
+		GMT_Report (API, GMT_MSG_ERROR, "Unable to make cleanup script %s executable - exiting\n", cleanup_file);
+		Return (GMT_RUNTIME_ERROR);
 	}
+#endif
 	if (!Ctrl->Q.active) {
 		/* Run cleanup script at the end */
 		if (Ctrl->In.mode == GMT_DOS_MODE)

--- a/src/movie.c
+++ b/src/movie.c
@@ -1543,14 +1543,13 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			}
 			fclose (Ctrl->S[MOVIE_PREFLIGHT].fp);	/* Done reading the foreground script */
 			fclose (fp);	/* Done writing the preflight script */
-	#ifndef WIN32
-			/* Set executable bit if not on Windows */
-			if (chmod (pre_file, S_IRWXU)) {
-				GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
-				fclose (Ctrl->In.fp);
-				Return (GMT_RUNTIME_ERROR);
+			if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
+				if (chmod (pre_file, S_IRWXU)) {
+					GMT_Report (API, GMT_MSG_ERROR, "Unable to make preflight script %s executable - exiting.\n", pre_file);
+					fclose (Ctrl->In.fp);
+					Return (GMT_RUNTIME_ERROR);
+				}
 			}
-	#endif
 			/* Run the pre-flight now which may or may not create a <timefile> needed later via -T, as well as a background plot */
 			if (Ctrl->In.mode == GMT_DOS_MODE)	/* Needs to be "cmd /C" and not "start /B" to let it have time to finish */
 				sprintf (cmd, "cmd /C %s", pre_file);
@@ -1698,14 +1697,13 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			}
 			fclose (Ctrl->S[MOVIE_POSTFLIGHT].fp);	/* Done reading the foreground script */
 			fclose (fp);	/* Done writing the postflight script */
-	#ifndef WIN32
-			/* Set executable bit if not Windows */
-			if (chmod (post_file, S_IRWXU)) {
-				GMT_Report (API, GMT_MSG_ERROR, "Unable to make postflight script %s executable - exiting\n", post_file);
-				fclose (Ctrl->In.fp);
-				Return (GMT_RUNTIME_ERROR);
+			if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
+				if (chmod (post_file, S_IRWXU)) {
+					GMT_Report (API, GMT_MSG_ERROR, "Unable to make postflight script %s executable - exiting\n", post_file);
+					fclose (Ctrl->In.fp);
+					Return (GMT_RUNTIME_ERROR);
+				}
 			}
-	#endif
 			/* Run post-flight now before dealing with the loop so the overlay exists */
 			if (Ctrl->In.mode == GMT_DOS_MODE)	/* Needs to be "cmd /C" and not "start /B" to let it have time to finish */
 				sprintf (cmd, "cmd /C %s", post_file);
@@ -1869,13 +1867,12 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fprintf (fp, "exit\n");
 		fclose (fp);	/* Done writing loop script */
 
-#ifndef WIN32
-		/* Set executable bit if not Windows */
-		if (chmod (intro_file, S_IRWXU)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", intro_file);
-			Return (GMT_RUNTIME_ERROR);
+		if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
+			if (chmod (intro_file, S_IRWXU)) {
+				GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", intro_file);
+				Return (GMT_RUNTIME_ERROR);
+			}
 		}
-#endif
 	}
 
 	/* Create parameter include files, one for each frame */
@@ -2332,13 +2329,12 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		fprintf (fp, "exit\n");
 	fclose (fp);	/* Done writing loop script */
 
-#ifndef WIN32
-	/* Set executable bit if not Windows */
-	if (chmod (main_file, S_IRWXU)) {
-		GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", main_file);
-		Return (GMT_RUNTIME_ERROR);
+	if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows */
+		if (chmod (main_file, S_IRWXU)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to make script %s executable - exiting\n", main_file);
+			Return (GMT_RUNTIME_ERROR);
+		}
 	}
-#endif
 
 	n_frames += Ctrl->E.duration;	/* THis is the total set of frames to process */
 	GMT_Report (API, GMT_MSG_INFORMATION, "Total frames to process: %u\n", n_frames);
@@ -2507,13 +2503,12 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fprintf (fp, "%s %s%c*.ps\n", rmfile[Ctrl->In.mode], tmpwpath, dir_sep);	/* Delete any PostScript layers */
 	}
 	fclose (fp);
-#ifndef _WIN32
-	/* Set executable bit if not on Windows */
-	if (chmod (cleanup_file, S_IRWXU)) {
-		GMT_Report (API, GMT_MSG_ERROR, "Unable to make cleanup script %s executable - exiting\n", cleanup_file);
-		Return (GMT_RUNTIME_ERROR);
+	if (Ctrl->In.mode != GMT_DOS_MODE) {	/* Set executable bit if not Windows cmd */
+		if (chmod (cleanup_file, S_IRWXU)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to make cleanup script %s executable - exiting\n", cleanup_file);
+			Return (GMT_RUNTIME_ERROR);
+		}
 	}
-#endif
 	if (!Ctrl->Q.active) {
 		/* Run cleanup script at the end */
 		if (Ctrl->In.mode == GMT_DOS_MODE)


### PR DESCRIPTION
When running the windows-installer versions of **movie** or **batch** the user may wish to write scripts in bash or batch.  Thus, commands for moving and copying files as well as directory separators should be determined based on the script type and not just the fact it is a windows binary.  Hopefully this PR will address #4821.

Left in WIP mode for now since we need more cross-platform testing for the Windows executables.
