### PR TITLE
Let meca use -C for cpt like the rest of GMT

### DIFF
--- a/doc/rst/source/supplements/seis/explain_meca_-S.rst_
+++ b/doc/rst/source/supplements/seis/explain_meca_-S.rst_
@@ -32,7 +32,7 @@
     magnitude
 
     **8**,\ **9**:
-    longitude, latitude at which to place beachball if **-C** is used (optional).
+    longitude, latitude at which to place beachball if **-A** is used (optional).
     Using 0,0 in columns 8 and 9 will plot the beach ball at the longitude,
     latitude given in columns 1 and 2. The **-:** option will interchange the order of
     columns (1,2) and (8,9).
@@ -60,7 +60,7 @@
     mantissa and exponent of moment in dyne-cm
 
     **12**,\ **13**:
-    longitude, latitude at which to place beachball if **-C** is used (optional).
+    longitude, latitude at which to place beachball if **-A** is used (optional).
     Using 0,0 in columns 12 and 13 will plot the beach ball at the longitude,
     latitude given in columns 1 and 2. The **-:** option will interchange the order of
     columns (1,2) and (12,13).
@@ -90,7 +90,7 @@
     exponent
 
     **11**,\ **12**:
-    longitude, latitude at which to place beachball if **-C** is used (optional).
+    longitude, latitude at which to place beachball if **-A** is used (optional).
     Using 0,0 in columns 11 and 12 will plot the beach ball at the longitude,
     latitude given in columns 1 and 2. The **-:** option will interchange the order of
     columns (1,2) and (11,12).
@@ -121,7 +121,7 @@
     magnitude
 
     **9**,\ **10**:
-    longitude, latitude at which to place beachball if **-C** is used (optional).
+    longitude, latitude at which to place beachball if **-A** is used (optional).
     Using 0,0 in columns 9 and 10 will plot the beach ball at the longitude,
     latitude given in columns 1 and 2. The **-:** option will interchange the order of
     columns (1,2) and (9,10).
@@ -149,7 +149,7 @@
     exponent
 
     **14**,\ **15**:
-    longitude, latitude at which to place beachball if **-C** is used (optional).
+    longitude, latitude at which to place beachball if **-A** is used (optional).
     Using 0,0 in columns 14 and 15 will plot the beach ball at the longitude,
     latitude given in columns 1 and 2. The **-:** option will interchange the order of
     columns (1,2) and (14,15).

--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -12,12 +12,18 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt meca** [ *table* ] |-J|\ *parameters* |SYN_OPT-R|
+**gmt meca** [ *table* ]
+|-J|\ *parameters*
+|SYN_OPT-R|
 |-S|\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+[ |-A|\ [**+p**\ *pen*][**+s**\ *size*] ]
 [ |SYN_OPT-B| ]
-[ |-C|\ [*pen*][**+s**\ *size*] ] [ |-D|\ *depmin*/*depmax* ]
+[ |-C|\ *cpt*]
+[ |-D|\ *depmin*/*depmax* ]
 [ |-E|\ *fill*]
-[ |-F|\ *mode*\ [*args*] ] [ |-G|\ *fill*] [ |-L|\ [*pen*] ]
+[ |-F|\ *mode*\ [*args*] ]
+[ |-G|\ *fill*]
+[ |-L|\ [*pen*] ]
 [ |-M| ]
 [ |-N| ]
 [ |-T|\ *nplane*\ [/*pen*] ]
@@ -26,7 +32,6 @@ Synopsis
 [ |-W|\ *pen* ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *cpt*]
 [ |SYN_OPT-di| ]
 [ |SYN_OPT-e| ]
 [ |SYN_OPT-h| ]

--- a/doc/rst/source/supplements/seis/meca_common.rst_
+++ b/doc/rst/source/supplements/seis/meca_common.rst_
@@ -29,19 +29,26 @@ Required Arguments
 Optional Arguments
 ------------------
 
+.. _-A:
+
+**-A**\ [**+p**\ *pen*][**+s**\ *size*]
+    Offsets focal mechanisms to the alternate longitudes, latitudes given
+    in the last two columns of the input file before the (optional) text
+    string. We will draw a line connecting the original and relocated
+    beachball positions and place a small circle at the original location.
+    Use **+s**\ *size* to change the diameter of the circle [0.1c]. The
+    line pen defaults to the pen given via **-W** but can be overridden
+    by using **+p**\ *pen* [0.25p].
+
 .. _-B:
 
 .. include:: ../../explain_-B.rst_
 
 .. _-C:
 
-**-C**\ [*pen*][**+s**\ *size*]
-    Offsets focal mechanisms to the longitude, latitude specified in the
-    last two columns of the input file before the (optional) text
-    string. A small circle is plotted at the initial location and a line
-    connects the beachball to the circle. Specify *pen* and optionally append
-    **+s**\ *size* to change the line style and/or size of the circle.
-    [Defaults: *pen* as given by **-W**; *size* is 0].
+**-C**\ *cpt*
+    Give a CPT and let compressive part color be
+    determined by the z-value in the third column.
 
 .. _-D:
 
@@ -145,12 +152,6 @@ Optional Arguments
 .. _-X:
 
 .. include:: ../../explain_-XY.rst_
-
-.. _-Z:
-
-**-Z**\ *cpt*
-    Give a CPT and let compressive part color be
-    determined by the z-value in the third column.
 
 .. |Add_-di| unicode:: 0x20 .. just an invisible code
 .. include:: ../../explain_-di.rst_

--- a/doc/rst/source/supplements/seis/meca_common.rst_
+++ b/doc/rst/source/supplements/seis/meca_common.rst_
@@ -35,9 +35,9 @@ Optional Arguments
     Offsets focal mechanisms to the alternate longitudes, latitudes given
     in the last two columns of the input file before the (optional) text
     string. We will draw a line connecting the original and relocated
-    beachball positions and place a small circle at the original location.
-    Use **+s**\ *size* to change the diameter of the circle [0.1c]. The
-    line pen defaults to the pen given via **-W** but can be overridden
+    beachball positions and optionally place a small circle at the original
+    location.  Use **+s**\ *size* to set the diameter of the circle [no circle].
+    The line pen defaults to that given via **-W** but can be overridden
     by using **+p**\ *pen* [0.25p].
 
 .. _-B:

--- a/doc/rst/source/supplements/seis/psmeca.rst
+++ b/doc/rst/source/supplements/seis/psmeca.rst
@@ -12,21 +12,29 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt psmeca** [ *table* ] |-J|\ *parameters* |SYN_OPT-R|
+**gmt psmeca** [ *table* ]
+|-J|\ *parameters*
+|SYN_OPT-R|
 |-S|\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+[ |-A|\ [**+p**\ *pen*][**+s**\ *size*] ]
 [ |SYN_OPT-B| ]
-[ |-C|\ [*pen*][**+s**\ *size*] ] [ |-D|\ *depmin*/*depmax* ]
+[ |-C|\ *cpt*]
+[ |-D|\ *depmin*/*depmax* ]
 [ |-E|\ *fill*]
-[ |-F|\ *mode*\ [*args*] ] [ |-G|\ *fill*] [ |-K| ] [ |-L|\ [*pen*] ]
+[ |-F|\ *mode*\ [*args*] ]
+[ |-G|\ *fill*]
+[ |-K| ]
+[ |-L|\ [*pen*] ]
 [ |-M| ]
-[ |-N| ] [ |-O| ] [ |-P| ]
+[ |-N| ]
+[ |-O| ]
+[ |-P| ]
 [ |-T|\ *nplane*\ [*pen*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *cpt*]
 [ |SYN_OPT-di| ]
 [ |SYN_OPT-e| ]
 [ |SYN_OPT-h| ]

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -831,7 +831,7 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 				gmt_setpen (GMT, &Ctrl->A.pen);
 				gmt_geo_to_xy (GMT, xynew[GMT_X], xynew[GMT_Y], &plot_xnew, &plot_ynew);
 				gmt_setfill (GMT, &Ctrl->G.fill, 1);
-				PSL_plotsymbol (PSL, plot_x, plot_y, &Ctrl->A.size, PSL_CIRCLE);
+				if (Ctrl->A.size > 0.0) PSL_plotsymbol (PSL, plot_x, plot_y, &(Ctrl->A.size), PSL_CIRCLE);
 				PSL_plotsegment (PSL, plot_x, plot_y, plot_xnew, plot_ynew);
 				plot_x = plot_xnew;
 				plot_y = plot_ynew;

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -172,8 +172,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t-S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] [%s]\n", GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-A[+p<pen>][+s<size>]] [-C<cpt>] [-D<depmin>/<depmax>] [-E<fill>] [-G<fill>] %s[-L<pen>] [-M]\n", API->K_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t-S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] [-A[+p<pen>][+s<size>]]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-C<cpt>] [-D<depmin>/<depmax>] [-E<fill>] [-G<fill>] %s[-L<pen>] [-M]\n", GMT_B_OPT, API->K_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Fa[<size>[/<Psymbol>[<Tsymbol>]]] [-Fe<fill>] [-Fg<fill>] [-Fo] [-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]] [-Fz[<pen>]]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[-N] %s%s[-T<nplane>[/<pen>]] [%s] [%s] [-W<pen>]\n", API->O_OPT, API->P_OPT, GMT_U_OPT, GMT_V_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s]\n", GMT_X_OPT, GMT_Y_OPT);

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -142,7 +142,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 
-	C->A.size = 0.1 / 2.54;	/* 0.1 cm size */
+	C->A.size = 0.0;	/* No circle will be plotted */
 	C->A.pen = C->L.pen = C->T.pen = C->T2.pen = C->P2.pen = C->Z2.pen = C->W.pen = GMT->current.setting.map_default_pen;
 	/* Set width temporarily to -1. This will indicate later that we need to replace by W.pen */
 	C->A.pen.width = C->L.pen.width = C->T.pen.width = C->T2.pen.width = C->P2.pen.width = C->Z2.pen.width = -1.0;
@@ -210,8 +210,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Option (API, "<,B-");
 	GMT_Message (API, GMT_TIME_NONE, "\t-A Offset focal mechanisms to the alternate positions given in the last two columns of the input file before label.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   A line is plotted between both positions; see -W for pen used or specify via +p [0.25p].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   A small circle is plotted at the original location. Append +s<size> to change its diameter [0.1c].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   A line is drawn between both positions; see -W for pen used or specify it separately via +p [0.25p].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, a small circle is plotted at the original location. Append +s<size> to set its diameter [no circle].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Use CPT to assign colors based on depth-value in 3rd column.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Plot events between <depmin> and <depmax> deep.\n");
 	gmt_fill_syntax (API->GMT, 'E', NULL, "Set filling of extensive quadrants [Default is white].");
@@ -247,6 +247,7 @@ GMT_LOCAL bool psmeca_is_old_C_option (struct GMT_CTRL *GMT, char *arg) {
 	if (strstr (arg, ".cpt")) return false;	/* Clearly a CPT file given */
 	if (strstr (arg, "+s") || strchr (arg, 'P')) return true;	/* Clearly setting the circle diameter in old -C */
 	if (GMT->current.setting.run_mode == GMT_CLASSIC && arg[0] == '\0') return true;	/* A blank -C in classic mode is clearly the old -C with no settings */
+	if (arg[0]) return true;	/* Whatever this is, it is for -A to deal with */
 	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Option -C: Must assume under modern mode that -C here means use current CPT\n");
 	return false;	/* This assumes nobody would use just -C in modern mode but actually mean the old -C */
 }

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -46,10 +46,14 @@ PostScript code is written to stdout.
 
 /* Control structure for psmeca */
 struct PSMECA_CTRL {
-	struct PSMECA_C {	/* -C[<pen>][+s<size>] */
+	struct PSMECA_A {	/* -A[+p<pen>][+s<size>] */
 		bool active;
 		double size;
 		struct GMT_PEN pen;
+	} A;
+	struct PSMECA_C {	/* -C<cpt> */
+		bool active;
+		char *file;
 	} C;
 	struct PSMECA_D {	/* -D<min/max> */
 		bool active;
@@ -97,10 +101,6 @@ struct PSMECA_CTRL {
 		bool active;
 		struct GMT_PEN pen;
 	} W;
-	struct PSMECA_Z {	/* -Z<cpt> */
-		bool active;
-		char *file;
-	} Z;
 	struct PSMECA_A2 {	/* -Fa[size[/Psymbol[Tsymbol]]] */
 		bool active;
 		char P_symbol, T_symbol;
@@ -142,10 +142,10 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 
-	C->C.size = GMT_DOT_SIZE;
-	C->C.pen = C->L.pen = C->T.pen = C->T2.pen = C->P2.pen = C->Z2.pen = C->W.pen = GMT->current.setting.map_default_pen;
+	C->A.size = 0.1 / 2.54;	/* 0.1 cm size */
+	C->A.pen = C->L.pen = C->T.pen = C->T2.pen = C->P2.pen = C->Z2.pen = C->W.pen = GMT->current.setting.map_default_pen;
 	/* Set width temporarily to -1. This will indicate later that we need to replace by W.pen */
-	C->C.pen.width = C->L.pen.width = C->T.pen.width = C->T2.pen.width = C->P2.pen.width = C->Z2.pen.width = -1.0;
+	C->A.pen.width = C->L.pen.width = C->T.pen.width = C->T2.pen.width = C->P2.pen.width = C->Z2.pen.width = -1.0;
 	C->D.depmin = -FLT_MAX;
 	C->D.depmax = FLT_MAX;
 	C->L.active = false;
@@ -162,7 +162,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 static void Free_Ctrl (struct GMT_CTRL *GMT, struct PSMECA_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
-	gmt_M_str_free (C->Z.file);
+	gmt_M_str_free (C->C.file);
 	gmt_M_free (GMT, C);
 }
 
@@ -173,10 +173,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t-S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] [%s]\n", GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-C[<pen>][+s<size>]] [-D<depmin>/<depmax>] [-E<fill>] [-G<fill>] %s[-L<pen>] [-M]\n", API->K_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-A[+p<pen>][+s<size>]] [-C<cpt>] [-D<depmin>/<depmax>] [-E<fill>] [-G<fill>] %s[-L<pen>] [-M]\n", API->K_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Fa[<size>[/<Psymbol>[<Tsymbol>]]] [-Fe<fill>] [-Fg<fill>] [-Fo] [-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]] [-Fz[<pen>]]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t[-N] %s%s[-T<nplane>[/<pen>]] [%s] [%s] [-W<pen>]\n", API->O_OPT, API->P_OPT, GMT_U_OPT, GMT_V_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [-Z<cpt>]\n", GMT_X_OPT, GMT_Y_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s]\n", GMT_X_OPT, GMT_Y_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t%s[%s] [%s] [%s]\n\t[%s]\n\t[%s]\n\t[%s] [%s] [%s] [%s]\n\n", API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_t_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -209,10 +209,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   fontsize < 0 : no label written; offset is from the limit of the beach ball.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
 	GMT_Option (API, "<,B-");
-	GMT_Message (API, GMT_TIME_NONE, "\t-C Offset focal mechanisms to the latitude and longitude specified in the last two columns of the input file before label.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Default pen attributes are set by -W.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   A line is plotted between both positions.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   A small circle is plotted at the initial location. Append +s<size> to change the size of the circle.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-A Offset focal mechanisms to the alternate positions given in the last two columns of the input file before label.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   A line is plotted between both positions; see -W for pen used or specify via +p [0.25p].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   A small circle is plotted at the original location. Append +s<size> to change its diameter [0.1c].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-C Use CPT to assign colors based on depth-value in 3rd column.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Plot events between <depmin> and <depmax> deep.\n");
 	gmt_fill_syntax (API->GMT, 'E', NULL, "Set filling of extensive quadrants [Default is white].");
 	GMT_Message (API, GMT_TIME_NONE, "\t-F Sets various attributes of symbols depending on <mode>:\n");
@@ -238,10 +238,73 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   If moment tensor is required, nodal planes overlay moment tensor.\n");
 	GMT_Option (API, "U,V");
 	GMT_Message (API, GMT_TIME_NONE, "\t-W Set pen attributes [%s].\n", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
-	GMT_Message (API, GMT_TIME_NONE, "\t-Z Use CPT to assign colors based on depth-value in 3rd column.\n");
 	GMT_Option (API, "X,c,di,e,h,i,p,qi,t,:,.");
 
 	return (GMT_MODULE_USAGE);
+}
+
+GMT_LOCAL bool psmeca_is_old_C_option (struct GMT_CTRL *GMT, char *arg) {
+	if (strstr (arg, ".cpt")) return false;	/* Clearly a CPT file given */
+	if (strstr (arg, "+s") || strchr (arg, 'P')) return true;	/* Clearly setting the circle diameter in old -C */
+	if (GMT->current.setting.run_mode == GMT_CLASSIC && arg[0] == '\0') return true;	/* A blank -C in classic mode is clearly the old -C with no settings */
+	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Option -C: Must assume under modern mode that -C here means use current CPT\n");
+	return false;	/* This assumes nobody would use just -C in modern mode but actually mean the old -C */
+}
+
+GMT_LOCAL unsigned int psmeca_A_parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, char *arg) {
+	unsigned int n_errors = 0;
+	char txt[GMT_LEN256] = {""}, *c = NULL, *q = NULL;
+	strncpy (txt, arg, GMT_LEN256-1);
+
+	/* Deal with these possible variations of old -C and new -A options:
+	 * 1. -A[+p<pen>][+s<size>]	which is the current syntax
+	 * 2. -C[<pen>][+s<size>]	which was the GMT5-6.1.1 syntax
+	 * 3. -C[<pen>][P<size>]	which was the GMT4 syntax */
+
+	if ((c = gmt_first_modifier (GMT, txt, "ps"))) {	/* Found at least one valid modifier */
+		unsigned int pos = 0;
+		char p[GMT_LEN256] = {""};
+		while (gmt_getmodopt (GMT, 'A', c, "ps", &pos, p, &n_errors) && n_errors == 0) {
+			switch (p[0]) {
+				case 'p':	/* Line and circle pen */
+					if (p[1] == '\0' || gmt_getpen (GMT, &p[1], &Ctrl->A.pen)) {
+						gmt_pen_syntax (GMT, 'A', NULL, " ", 0);
+						n_errors++;
+					}
+					break;
+				case 's':	/* Circle diameter */
+					if (p[1] == '\0' || (Ctrl->A.size = gmt_M_to_inch (GMT, (p+2))) < 0.0) {
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A: Circle diameter cannot be negative or not given!\n");
+						n_errors++;
+					}
+					break;
+				default: break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
+			}
+		}
+		c[0] = '\0';	/* Chop off the modifiers */
+	}
+	/* If the user used modern modifiers only as case 1 above then we might be done here */
+	if (arg[0] == '\0') return n_errors;
+
+	/* Here we got older syntax: -C<pen>[+s<size>] or -C[<pen>][P<size>] (but the +s<size> would have been stripped off
+	 * so here we must either have -C<pen> or -C[<pen>][P<size>] */
+
+	if ((q = strchr (txt, 'P')) != NULL) {	/* Case 3 way of changing the diameter */
+		if (q[1] == '\0' || (Ctrl->A.size = gmt_M_to_inch (GMT, &q[1])) < 0.0) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A: Circle diameter cannot be negative or not given!\n");
+			n_errors++;
+		}
+		q[0] = '\0';	/* Chop off the Psize setting; if txt is not empty we also have an optional pen */
+		if (arg[0] && gmt_getpen (GMT, txt, &Ctrl->A.pen)) {
+			gmt_pen_syntax (GMT, 'A', NULL, " ", 0);
+			n_errors++;
+		}
+	}
+	else if (gmt_getpen (GMT, txt, &Ctrl->A.pen)) {	/* Here we just have -C<pen> to deal with */
+		gmt_pen_syntax (GMT, 'A', NULL, " ", 0);
+		n_errors++;
+	}
+	return n_errors;
 }
 
 static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPTION *options) {
@@ -266,18 +329,19 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 
 			/* Processes program-specific parameters */
 
-			case 'C':	/* Change position [set line attributes] */
-				Ctrl->C.active = true;
-				if (!opt->arg[0]) break;
-				strncpy (txt, opt->arg, GMT_LEN256-1);
-				if ((p = strstr (txt, "+s")) != NULL) Ctrl->C.size = gmt_M_to_inch (GMT, (p+2));
-				else if ((p = strchr (txt, 'P')) != NULL) Ctrl->C.size = gmt_M_to_inch (GMT, (p+1));
-				if (txt[0] != 'P' && strncmp (txt, "+s", 2U)) {	/* Have a pen up front */
-					if (p) p[0] = '\0';
-					if (gmt_getpen (GMT, txt, &Ctrl->C.pen)) {
-						gmt_pen_syntax (GMT, 'C', NULL, " ", 0);
-						n_errors++;
-					}
+			case 'A':
+				Ctrl->A.active = true;
+				n_errors += psmeca_A_parse (GMT, Ctrl, opt->arg);
+				break;
+			case 'C':	/* Either modern -Ccpt option of a deprecated -C now served by -A */
+				/* Change position [set line attributes] */
+				if (psmeca_is_old_C_option (GMT, opt->arg)) {	/* Need the -A parser for obsolete -C syntax */
+					Ctrl->A.active = true;
+					n_errors += psmeca_A_parse (GMT, Ctrl, opt->arg);
+				}
+				else {	/* Here we have the modern -C<cpt> parsing */
+					Ctrl->C.active = true;
+					if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				}
 				break;
 			case 'D':	/* Plot events between depmin and depmax deep */
@@ -474,27 +538,23 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 					n_errors++;
 				}
 				break;
-			case 'Z':	/* Vary symbol color with z */
-				Ctrl->Z.active = true;
-				if (opt->arg[0]) Ctrl->Z.file = strdup (opt->arg);
-				break;
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);
 				break;
 		}
 	}
 
-	gmt_consider_current_cpt (GMT->parent, &Ctrl->Z.active, &(Ctrl->Z.file));
+	gmt_consider_current_cpt (GMT->parent, &Ctrl->C.active, &(Ctrl->C.file));
 
 	/* Check that the options selected are mutually consistent */
 	n_errors += gmt_M_check_condition(GMT, !Ctrl->S.active, "Must specify -S option\n");
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.R.active[RSET], "Must specify -R option\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && Ctrl->S.scale <= 0.0, "Option -S: must specify scale\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && Ctrl->O2.active, "Option -Z cannot be combined with -Fo\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->O2.active, "Option -Z cannot be combined with -Fo\n");
 
 	/* Set to default pen where needed */
 
-	if (Ctrl->C.pen.width  < 0.0) Ctrl->C.pen  = Ctrl->W.pen;
+	if (Ctrl->A.pen.width  < 0.0) Ctrl->A.pen  = Ctrl->W.pen;
 	if (Ctrl->L.pen.width  < 0.0) Ctrl->L.pen  = Ctrl->W.pen;
 	if (Ctrl->T.pen.width  < 0.0) Ctrl->T.pen  = Ctrl->W.pen;
 	if (Ctrl->T2.pen.width < 0.0) Ctrl->T2.pen = Ctrl->W.pen;
@@ -561,8 +621,8 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 	gmt_M_memset (&N, 1, struct AXIS);
 	gmt_M_memset (&P, 1, struct AXIS);
 
-	if (Ctrl->Z.active) {
-		if ((CPT = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, Ctrl->Z.file, NULL)) == NULL) {
+	if (Ctrl->C.active) {
+		if ((CPT = GMT_Read_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, Ctrl->C.file, NULL)) == NULL) {
 			Return (API->error);
 		}
 	}
@@ -621,7 +681,7 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 		if (new_fmt) {
 			depth = in[GMT_Z];
 			if (depth < Ctrl->D.depmin || depth > Ctrl->D.depmax) continue;
-			if (Ctrl->Z.active) gmt_get_fill_from_z (GMT, CPT, depth, &Ctrl->G.fill);
+			if (Ctrl->C.active) gmt_get_fill_from_z (GMT, CPT, depth, &Ctrl->G.fill);
 		}
 
 		/* Must examine the trailing text for optional columns: newX, newY and title */
@@ -765,12 +825,12 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 
 		/* If option -C is used, read the new position */
 
-		if (Ctrl->C.active) {
+		if (Ctrl->A.active) {
 			if (fabs (xynew[GMT_X]) > EPSIL || fabs (xynew[GMT_Y]) > EPSIL) {
-				gmt_setpen (GMT, &Ctrl->C.pen);
+				gmt_setpen (GMT, &Ctrl->A.pen);
 				gmt_geo_to_xy (GMT, xynew[GMT_X], xynew[GMT_Y], &plot_xnew, &plot_ynew);
 				gmt_setfill (GMT, &Ctrl->G.fill, 1);
-				PSL_plotsymbol (PSL, plot_x, plot_y, &Ctrl->C.size, PSL_CIRCLE);
+				PSL_plotsymbol (PSL, plot_x, plot_y, &Ctrl->A.size, PSL_CIRCLE);
 				PSL_plotsegment (PSL, plot_x, plot_y, plot_xnew, plot_ynew);
 				plot_x = plot_xnew;
 				plot_y = plot_ynew;


### PR DESCRIPTION
See #4869 for context. In the refreshing process for common CPT settings we also needed to move **-C** to **-A**.  This was all done with backwards compatibility in mind.  Existing scripts run as before.  Note: The circle drawn at the original epicenter (-C, now -A) was zero size in GMT 3-4 and became nonzero but not discernible in GMT 5-6.1.1 (size 0.005 inches).  We now simply state the circle is optional and users can set a nonzero diameter if they want it rather than get a speck of dirt on their plot.  This PR completes the prepping discussed in #4869 and complements #4870.