### PR TITLE
Let meca take -I for intensity-based color changes

### DIFF
--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -23,6 +23,7 @@ Synopsis
 [ |-E|\ *fill*]
 [ |-F|\ *mode*\ [*args*] ]
 [ |-G|\ *fill*]
+[ |-I|\ [*intens*] ]
 [ |-L|\ [*pen*] ]
 [ |-M| ]
 [ |-N| ]

--- a/doc/rst/source/supplements/seis/meca_common.rst_
+++ b/doc/rst/source/supplements/seis/meca_common.rst_
@@ -96,6 +96,14 @@ Optional Arguments
     compressional quadrants of the focal mechanism beach balls are
     shaded. [Default is black].
 
+.. _-I:
+
+**-I**\ *intens*
+    Use the supplied *intens* value (nominally in the -1 to +1 range) to
+    modulate the compressional fill color by simulating illumination [none].
+    If no intensity is provided we will instead read *intens* from an extra
+    data column after the required input columns determined by **-S**.
+
 .. _-L:
 
 **-L**\ [*pen*]
@@ -146,7 +154,7 @@ Optional Arguments
 **-W**\ *pen*
     Set pen attributes for all lines and the outline of symbols
     [Defaults: default,black,solid]. This
-    setting applies to **-C**, **-L**, **-T**, **-Fp**, **-Ft**, and
+    setting applies to **-A**, **-L**, **-T**, **-Fp**, **-Ft**, and
     **-Fz**, unless overruled by options to those arguments.
 
 .. _-X:

--- a/doc/rst/source/supplements/seis/psmeca.rst
+++ b/doc/rst/source/supplements/seis/psmeca.rst
@@ -23,6 +23,7 @@ Synopsis
 [ |-E|\ *fill*]
 [ |-F|\ *mode*\ [*args*] ]
 [ |-G|\ *fill*]
+[ |-I|\ [*intens*] ]
 [ |-K| ]
 [ |-L|\ [*pen*] ]
 [ |-M| ]

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -231,7 +231,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   z Overlay zero trace moment tensor using default pen (see -W) or append outline pen.\n");
 	gmt_fill_syntax (API->GMT, 'G', NULL, "Set filling of compressive quadrants [Default is black].");
 	GMT_Message (API, GMT_TIME_NONE, "\t-I Use the intensity to modulate the compressive fill color (requires -C or -G).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   If no intensity is given we expect it to follow symbol size in the data record.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If no intensity is given we expect it to follow the required columns in the data record.\n");
 	GMT_Option (API, "K");
 	GMT_Message (API, GMT_TIME_NONE, "\t-L Sets pen attribute for outline other than the default set by -W.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-M Same size for any magnitude. Size is given with -S.\n");


### PR DESCRIPTION
For **meca** to be used in the context of animations via events, it will need the **-I** option used to intensify the current color.  This PR implements this along the lines of **plot**.  Some simple examples. First the case of a beachball with color from a CPT but no intensity variations:

```
gmt makecpt -Cturbo -T0/8 > t.cpt
echo 0 0 6.0 10 35 129 5 0 0 Mixed | gmt meca -Sa10c -Ct.cpt -R-1/1/-1/1 -JM14c -B -L1p -png a
```

![a](https://user-images.githubusercontent.com/26473567/109448845-0ef2ca00-79eb-11eb-8d41-43b7bb3901cf.png)

Now let apply a constant intensity of 0.5:

`echo 0 0 6.0 10 35 129 5 0 0 Mixed | gmt meca -Sa10c -Ct.cpt -R-1/1/-1/1 -JM14c -B -L1p -I0.5 -png b`

![b](https://user-images.githubusercontent.com/26473567/109448899-39448780-79eb-11eb-8379-1b4756844149.png)

Finally, we will read the intensity from the data record following the required columns:

`echo 0 0 6.0 10 35 129 5 -0.5 0 0 Mixed | gmt meca -Sa10c -Ct.cpt -R-1/1/-1/1 -JM14c -B -L1p -I -png c`

![c](https://user-images.githubusercontent.com/26473567/109449029-7f015000-79eb-11eb-86bb-764ccb2ef67e.png)

The only thing I don't really like is the fact that the alternative lon lat is in the file and becomes part of the trailing text but the code checks for this hence the correct label is extracted.  However, it means the intensity must come before those two coordinates, if present.
