### PR TITLE
Add vercel.json to silent Vercel comments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "github": {
+    "silent": true
+  },
+  "public": true
+}


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in https://github.com/GenericMappingTools/gmt/issues/4848#issuecomment-785391790, I will try to set up Vercel for Continuous Documentation in GMT (working in #4872).

Before I start, I have to enable Vercel in the GMT repository, and Vercel will create comments for every PRs and every commit into the master branch. So it's quite annoying.

This file is added to the GMT repository to silent the comments.