### PR TITLE
Implement -I for coupe following how it was done in meca

### DIFF
--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -20,6 +20,7 @@ Synopsis
 [ |-E|\ *fill* ]
 [ |-F|\ *mode*\ [*args*] ]
 [ |-G|\ *fill* ]
+[ |-I|\ [*intens*] ]
 [ |-L|\ [*pen*] ]
 [ |-M| ] [ |-N| ]
 [ |-Q| ]

--- a/doc/rst/source/supplements/seis/coupe_common.rst_
+++ b/doc/rst/source/supplements/seis/coupe_common.rst_
@@ -138,6 +138,14 @@ Optional Arguments
 **-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
     Sets color or fill pattern for compressional quadrants [Default is black].
 
+.. _-I:
+
+**-I**\ *intens*
+    Use the supplied *intens* value (nominally in the -1 to +1 range) to
+    modulate the compressional fill color by simulating illumination [none].
+    If no intensity is provided we will instead read *intens* from an extra
+    data column after the required input columns determined by **-S**.
+
 .. _-L:
 
 **-L**\ [*pen*]

--- a/doc/rst/source/supplements/seis/pscoupe.rst
+++ b/doc/rst/source/supplements/seis/pscoupe.rst
@@ -21,6 +21,7 @@ Synopsis
 [ |-F|\ *mode*\ [*args*] ]
 [ |-G|\ *fill* ]
 [ |-K| ]
+[ |-I|\ [*intens*] ]
 [ |-L|\ *[pen]* ]
 [ |-M| ] [ |-N| ]
 [ |-O| ]


### PR DESCRIPTION
Useful to modulate fill color via intensities, and required if we wish to do animations via events.
Again as a test: This plot uses no **-I**:

![a](https://user-images.githubusercontent.com/26473567/109570996-0eac0a80-7a8f-11eb-9b1d-7f769653280a.png)

Here we pass **-I**-0.5 on the command line to darken the colors:

![b](https://user-images.githubusercontent.com/26473567/109571020-17044580-7a8f-11eb-95b5-9a6462f81a48.png)

Finally, we pass extra columns (-0.65 for left symbol, +0.5 for right) and give a blank **-I** on the command line:

![c](https://user-images.githubusercontent.com/26473567/109571092-37340480-7a8f-11eb-88cd-f38be02be386.png)

