### PR TITLE
Let a missing size from -S trigger reading from file instead

### DIFF
--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt coupe** [ *table* ] |-J|\ *parameters*
 |SYN_OPT-R| |-A|\ *parameters*
-|-S|\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+|-S|\ *format*\ [*scale*]\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-E|\ *fill* ]

--- a/doc/rst/source/supplements/seis/explain_meca_-S.rst_
+++ b/doc/rst/source/supplements/seis/explain_meca_-S.rst_
@@ -1,4 +1,4 @@
-**-S**\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+**-S**\ *format*\ [*scale*]\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
     Selects the meaning of the columns in the data file.
     *scale* adjusts the scaling of the radius of the "beach ball", which will be proportional to
     the magnitude. *scale* is the size for magnitude = 5 (i.e. scalar seismic moment M0 = 4.0E23 dynes-cm).
@@ -9,13 +9,15 @@
     Append **+a**\ *angle* to change the angle of the text string;
     append **+f**\ *font* to change its font (size,fontname,color); append **+j**\ *justify* to change
     the text location relative to the beachball (default is above the beachball);
-    append **+o** to offset the text string by *dx/dy*.
+    append **+o** to offset the text string by *dx/dy*.  **Note**: If *scale* is missing then
+    we expect to read this value from the data record via the first column after the
+    required columns for the symbol type.
 
     In order to use the same file to plot cross-sections, depth is in third column.
     Nevertheless, it is possible to use "old style" **psvelomeca** input
     files without depth in third column using the **-Fo** option.
 
-**-Sa**\ *scale*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+**-Sa**\ [*scale*]\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
     Focal mechanisms in Aki and Richards convention.
     Parameters are expected to be in the following columns:
 
@@ -40,7 +42,7 @@
     **10**:
     Text string to appear near the beach ball (optional).
 
-**-Sc**\ *scale*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+**-Sc**\ [*scale*]\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
     Focal mechanisms in Global CMT convention.
     Parameters are expected to be in the following columns:
 
@@ -68,7 +70,7 @@
     **14**:
     Text string to appear near the beach ball (optional).
 
-**-Sm\|d\|z**\ *scale*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+**-Sm\|d\|z**\ [*scale*]\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
     Seismic moment tensor.
     **-Sm** plots the full seismic moment tensor.
     **-Sz** plots the deviatoric part of the moment tensor (zero trace).
@@ -98,7 +100,7 @@
     **13**:
     Text string to appear near the beach ball (optional).
 
-**-Sp**\ *scale*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+**-Sp**\ [*scale*]\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
     Focal mechanisms given with partial data on both planes.
     Parameters are expected to be in the following columns:
 
@@ -129,7 +131,7 @@
     **11**:
     Text string to appear near the beach ball (optional).
 
-**-Sx\|y\|t**\ *scale*\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+**-Sx\|y\|t**\ [*scale*]\ [**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
     Principal axis.
     Use **-Sx** to plot full seismic moment tensor.
     Use **-Sy** to plot the closest double couple defined from the moment tensor (zero trace and zero determinant).

--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt meca** [ *table* ]
 |-J|\ *parameters*
 |SYN_OPT-R|
-|-S|\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+|-S|\ *format*\ [*scale*]\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |-A|\ [**+p**\ *pen*][**+s**\ *size*] ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt*]

--- a/doc/rst/source/supplements/seis/pscoupe.rst
+++ b/doc/rst/source/supplements/seis/pscoupe.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt pscoupe** [ *table* ] |-J|\ *parameters*
 |SYN_OPT-R| |-A|\ *parameters*
-|-S|\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+|-S|\ *format*\ [*scale*]\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-E|\ *fill* ]

--- a/doc/rst/source/supplements/seis/psmeca.rst
+++ b/doc/rst/source/supplements/seis/psmeca.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt psmeca** [ *table* ]
 |-J|\ *parameters*
 |SYN_OPT-R|
-|-S|\ *<format><scale>*\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+|-S|\ *format*\ [*scale*]\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
 [ |-A|\ [**+p**\ *pen*][**+s**\ *size*] ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt*]

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -92,10 +92,11 @@ struct PSCOUPE_CTRL {
 	struct PSCOUPE_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct PSCOUPE_S {	/* -S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] and -Fs */
+	struct PSCOUPE_S {	/* -S<format>[<scale>][+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] and -Fs */
 		bool active;
 		bool zerotrace;
 		bool no_label;
+		bool read;	/* True if no scale given; must be first column after the required ones */
 		unsigned int readmode;
 		unsigned int plotmode;
 		unsigned int n_cols;
@@ -433,7 +434,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -A<params> %s %s -S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]]\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -A<params> %s %s -S<format>[<scale>][+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]]\n", name, GMT_J_OPT, GMT_Rgeo_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-C<cpt>] [-E<fill>] [-Fa[<size>][/<Psymbol>[<Tsymbol>]] [-Fe<fill>] [-Fg<fill>] [-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]]\n", GMT_B_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Fs<symbol><size>+f<font>+o<dx>/<dy>+j<justify>] [-G<fill>] [-I[<intens>]] %s[-L<pen>] [-M] [-N] %s%s\n", API->K_OPT, API->O_OPT, API->P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-Q] [-T<nplane>[/<pen>]] [%s] [%s] [-W<pen>] \n", GMT_U_OPT, GMT_V_OPT);
@@ -471,6 +472,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth T_value T_azim T_plunge N_value N_azim N_plunge P_value P_azim P_plunge exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   z  Deviatoric part of the moment tensor (zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [newX newY] [event_title]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If <scale> is not given then it is read from the first column after the required columns.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add +a<angle>+f<font>+j<justify>+o<dx>[/<dy>] to change the label angle, font (size,fontname,color), justification and offset.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   fontsize < 0 : no label written; offset is from the limit of the beach ball.\n");
 	GMT_Option (API, "J-,R");
@@ -643,7 +645,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 						Ctrl->S.active = true;
 						Ctrl->S.symbol = opt->arg[1];
 						if ((strstr (opt->arg, "+f")) || strstr (opt->arg, "+o") || strstr (opt->arg, "+j")) {
-							/* New syntax: -Fs<symbol><size>+f<font>+o<dx>/<dy>+j<justify> */
+							/* New syntax: -Fs<symbol>[<size>]+f<font>+o<dx>/<dy>+j<justify> */
 							char word[GMT_LEN256] = {""}, *c = NULL;
 
 							/* parse beachball size */
@@ -682,10 +684,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 							if (Ctrl->S.font.size < 0.0) Ctrl->S.no_label = true;
 							if (p) p[0] = '+';	/* Restore modifier */
 						}
-						if (gmt_M_is_zero (Ctrl->S.scale))
-							Ctrl->S.n_cols = 4;
-						else
-							Ctrl->S.n_cols = 3;
+						if (gmt_M_is_zero (Ctrl->S.scale)) Ctrl->S.read = true;	/* Must get size from input file */
 						break;
 					case 't':	/* Draw outline of T axis symbol [set outline attributes] */
 						Ctrl->T2.active = true;
@@ -816,6 +815,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 					if (Ctrl->S.font.size < 0.0) Ctrl->S.no_label = true;
 					if (p) p[0] = '+';	/* Restore modifier */
 				}
+				if (gmt_M_is_zero (Ctrl->S.scale)) Ctrl->S.read = true;	/* Must get size from input file */
 				break;
 
 			case 'T':
@@ -872,11 +872,11 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 	int n_rec = 0, n_plane_old = 0, form = 0, error;
 	int i, transparence_old = 0, not_defined = 0;
 	int n_scanned = 0;
-	unsigned int icol;
+	unsigned int scol = 0, icol;
 	FILE *pnew = NULL, *pext = NULL;
 
 	double size, xy[2], xynew[2] = {0.0}, plot_x, plot_y, n_dep, distance, fault, depth;
-	double P_x, P_y, T_x, T_y, *in = NULL;
+	double scale, P_x, P_y, T_x, T_y, *in = NULL;
 
 	char event_title[GMT_BUFSIZ] = {""}, Xstring[GMT_BUFSIZ] = {""}, Ystring[GMT_BUFSIZ] = {""};
 
@@ -943,6 +943,14 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 	gmt_setpen (GMT, &Ctrl->W.pen);
 	if (!Ctrl->N.active) gmt_map_clip_on (GMT, GMT->session.no_rgb, 3);
 
+	if (Ctrl->S.read) {	/* Read symbol size from file */
+		Ctrl->S.n_cols++;
+		scol = Ctrl->S.n_cols - 1;
+		gmt_set_column_type (GMT, GMT_IN, icol, GMT_IS_DIMENSION);
+	}
+	else	/* Fixed scale */
+		scale = Ctrl->S.scale;
+
 	if (Ctrl->I.mode) {	/* Read intensity from data file */
 		Ctrl->S.n_cols++;
 		icol = Ctrl->S.n_cols - 1;
@@ -985,7 +993,8 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 
 		in = In->data;
 		n_rec++;
-		size = Ctrl->S.scale;
+		if (Ctrl->S.read) scale = in[scol];
+		size = scale;
 
 		/* Must examine the trailing text for optional columns: newX, newY and title */
 		/* newX and newY are not used in pscoupe, but we promised psmeca and pscoupe can use the same input file */
@@ -1165,7 +1174,7 @@ Definition of scalar moment.
 				moment.exponent = 23;
 			}
 
-			size = (meca_computed_mw (moment, meca.magms) / 5.0) * Ctrl->S.scale;
+			size = (meca_computed_mw (moment, meca.magms) / 5.0) * scale;
 
 			if (!Ctrl->Q.active) fprintf (pext, "%s\n", In->text);
 			if (Ctrl->S.readmode == READ_AXIS) {

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -85,9 +85,10 @@ struct PSMECA_CTRL {
 	struct PSMECA_N {	/* -N */
 		bool active;
 	} N;
-	struct PSMECA_S {	/* -S<format><scale>[+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] */
+	struct PSMECA_S {	/* -S<format>[<scale>][+a<angle>][+f<font>][+j<justify>][+o<dx>[/<dy>]] */
 		bool active;
 		bool no_label;
+		bool read;	/* True if no scale given; must be first column after the required ones */
 		unsigned int readmode;
 		unsigned int plotmode;
 		unsigned int n_cols;
@@ -210,6 +211,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   z  Deviatoric part of the moment tensor (zero trace):\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        X Y depth mrr mtt mff mrt mrf mtf exp [newX newY] [event_title]\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use -Fo option for old (psvelomeca) format (no depth in third column).\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If <scale> is not given then it is read from the first column after the required columns.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally add +a<angle>+f<font>+j<justify>+o<dx>[/<dy>] to change the label angle, font (size,fontname,color), justification and offset.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   fontsize < 0 : no label written; offset is from the limit of the beach ball.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
@@ -537,6 +539,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 					if (Ctrl->S.font.size < 0.0) Ctrl->S.no_label = true;
 					if (p) p[0] = '+';	/* Restore modifier */
 				}
+				if (gmt_M_is_zero (Ctrl->S.scale)) Ctrl->S.read = true;	/* Must get size from input file */
 				break;
 			case 'T':
 				Ctrl->T.active = true;
@@ -564,7 +567,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 	/* Check that the options selected are mutually consistent */
 	n_errors += gmt_M_check_condition(GMT, !Ctrl->S.active, "Must specify -S option\n");
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.R.active[RSET], "Must specify -R option\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && Ctrl->S.scale <= 0.0, "Option -S: must specify scale\n");
+	//n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && Ctrl->S.scale <= 0.0, "Option -S: must specify scale\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->O2.active, "Option -Z cannot be combined with -Fo\n");
 
 	/* Set to default pen where needed */
@@ -592,12 +595,12 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 	int i, n, form = 0, new_fmt;
 	int n_rec = 0, n_plane_old = 0, error;
 	int n_scanned = 0;
-	unsigned int icol;
+	unsigned int scol = 0, icol;
 	bool transparence_old = false, not_defined = false;
 
 	double plot_x, plot_y, plot_xnew, plot_ynew, delaz, *in = NULL;
 	double t11 = 1.0, t12 = 0.0, t21 = 0.0, t22 = 1.0, xynew[2] = {0.0};
-	double fault, depth, size, P_x, P_y, T_x, T_y;
+	double scale, fault, depth, size, P_x, P_y, T_x, T_y;
 
 	char string[GMT_BUFSIZ] = {""}, Xstring[GMT_BUFSIZ] = {""}, Ystring[GMT_BUFSIZ] = {""}, event_title[GMT_BUFSIZ] = {""};
 
@@ -658,6 +661,13 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 
 	if (Ctrl->O2.active) Ctrl->S.n_cols--;	/* No depth */
 
+	if (Ctrl->S.read) {	/* Read symbol size from file */
+		Ctrl->S.n_cols++;
+		scol = Ctrl->S.n_cols - 1;
+		gmt_set_column_type (GMT, GMT_IN, icol, GMT_IS_DIMENSION);
+	}
+	else	/* Fixed scale */
+		scale = Ctrl->S.scale;
 	if (Ctrl->I.mode) {	/* Read intensity from data file */
 		Ctrl->S.n_cols++;
 		icol = Ctrl->S.n_cols - 1;
@@ -875,9 +885,10 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 			meca.moment.exponent = 23;
 		}
 
+		if (Ctrl->S.read) scale = in[scol];
 		moment.mant = meca.moment.mant;
 		moment.exponent = meca.moment.exponent;
-		size = (meca_computed_mw(moment, meca.magms) / 5.0) * Ctrl->S.scale;
+		size = (meca_computed_mw(moment, meca.magms) / 5.0) * scale;
 
 		if (size < 0.0) {	/* Addressing Bug #1171 */
 			GMT_Report (API, GMT_MSG_WARNING, "Skipping negative symbol size %g for record # %d.\n", size, n_rec);


### PR DESCRIPTION
LIke for **plot -S**, if no _scale_ is provided then we expect it in the data file.  Here, we expect to find it after the required columns (whose number vary with format and symbol).  With this PR and #4881 we should be able to start implementing the use of **meca** and **coupe** from events.
