### PR TITLE
Improve ci/build-gmt.sh to allow use ninja

### DIFF
--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -63,7 +63,11 @@ EOF
 # 5. Build and install GMT
 mkdir build
 cd build
-cmake ..
+if command -v ninja >/dev/null 2>&1 ; then
+	cmake .. -G Ninja
+else
+	cmake ..
+fi
 cmake --build .
 cmake --build . --target install
 


### PR DESCRIPTION
**Description of proposed changes**

The `ci/build-gmt.sh` script is used by external projects like PyGMT.

Use ninja if it's available to speed up the building.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
