### PR TITLE
Escape spaces in option substitutions

### DIFF
--- a/doc/rst/source/common_SYN_OPTs.rst_
+++ b/doc/rst/source/common_SYN_OPTs.rst_
@@ -86,157 +86,157 @@
 
    </span></a></strong>
 
-.. |-A| replace:: |h-A| **-A**\ |h-x|
+.. |-A| replace:: |h-A|\ **-A**\ |h-x|
 
 .. |h-A| raw:: html
 
    <a class="reference internal" href="#a"><span>
 
-.. |-B| replace:: |h-B| **-B**\ |h-x|
+.. |-B| replace:: |h-B|\ **-B**\ |h-x|
 
 .. |h-B| raw:: html
 
    <a class="reference internal" href="#b"><span>
 
-.. |-C| replace:: |h-C| **-C**\ |h-x|
+.. |-C| replace:: |h-C|\ **-C**\ |h-x|
 
 .. |h-C| raw:: html
 
    <a class="reference internal" href="#c"><span>
 
-.. |-D| replace:: |h-D| **-D**\ |h-x|
+.. |-D| replace:: |h-D|\ **-D**\ |h-x|
 
 .. |h-D| raw:: html
 
    <a class="reference internal" href="#d"><span>
 
-.. |-E| replace:: |h-E| **-E**\ |h-x|
+.. |-E| replace:: |h-E|\ **-E**\ |h-x|
 
 .. |h-E| raw:: html
 
    <a class="reference internal" href="#e"><span>
 
-.. |-F| replace:: |h-F| **-F**\ |h-x|
+.. |-F| replace:: |h-F|\ **-F**\ |h-x|
 
 .. |h-F| raw:: html
 
    <a class="reference internal" href="#f"><span>
 
-.. |-G| replace:: |h-G| **-G**\ |h-x|
+.. |-G| replace:: |h-G|\ **-G**\ |h-x|
 
 .. |h-G| raw:: html
 
    <a class="reference internal" href="#g"><span>
 
-.. |-H| replace:: |h-H| **-H**\ |h-x|
+.. |-H| replace:: |h-H|\ **-H**\ |h-x|
 
 .. |h-H| raw:: html
 
    <a class="reference internal" href="#h"><span>
 
-.. |-I| replace:: |h-I| **-I**\ |h-x|
+.. |-I| replace:: |h-I|\ **-I**\ |h-x|
 
 .. |h-I| raw:: html
 
    <a class="reference internal" href="#i"><span>
 
-.. |-J| replace:: |h-J| **-J**\ |h-x|
+.. |-J| replace:: |h-J|\ **-J**\ |h-x|
 
 .. |h-J| raw:: html
 
    <a class="reference internal" href="#j"><span>
 
-.. |-K| replace:: |h-K| **-K**\ |h-x|
+.. |-K| replace:: |h-K|\ **-K**\ |h-x|
 
 .. |h-K| raw:: html
 
    <a class="reference internal" href="#k"><span>
 
-.. |-L| replace:: |h-L| **-L**\ |h-x|
+.. |-L| replace:: |h-L|\ **-L**\ |h-x|
 
 .. |h-L| raw:: html
 
    <a class="reference internal" href="#l"><span>
 
-.. |-M| replace:: |h-M| **-M**\ |h-x|
+.. |-M| replace:: |h-M|\ **-M**\ |h-x|
 
 .. |h-M| raw:: html
 
    <a class="reference internal" href="#m"><span>
 
-.. |-N| replace:: |h-N| **-N**\ |h-x|
+.. |-N| replace:: |h-N|\ **-N**\ |h-x|
 
 .. |h-N| raw:: html
 
    <a class="reference internal" href="#n"><span>
 
-.. |-O| replace:: |h-O| **-O**\ |h-x|
+.. |-O| replace:: |h-O|\ **-O**\ |h-x|
 
 .. |h-O| raw:: html
 
    <a class="reference internal" href="#o"><span>
 
-.. |-P| replace:: |h-P| **-P**\ |h-x|
+.. |-P| replace:: |h-P|\ **-P**\ |h-x|
 
 .. |h-P| raw:: html
 
    <a class="reference internal" href="#p"><span>
 
-.. |-Q| replace:: |h-Q| **-Q**\ |h-x|
+.. |-Q| replace:: |h-Q|\ **-Q**\ |h-x|
 
 .. |h-Q| raw:: html
 
    <a class="reference internal" href="#q"><span>
 
-.. |-R| replace:: |h-R| **-R**\ |h-x|
+.. |-R| replace:: |h-R|\ **-R**\ |h-x|
 
 .. |h-R| raw:: html
 
    <a class="reference internal" href="#r"><span>
 
-.. |-S| replace:: |h-S| **-S**\ |h-x|
+.. |-S| replace:: |h-S|\ **-S**\ |h-x|
 
 .. |h-S| raw:: html
 
    <a class="reference internal" href="#s"><span>
 
-.. |-T| replace:: |h-T| **-T**\ |h-x|
+.. |-T| replace:: |h-T|\ **-T**\ |h-x|
 
 .. |h-T| raw:: html
 
    <a class="reference internal" href="#t"><span>
 
-.. |-U| replace:: |h-U| **-U**\ |h-x|
+.. |-U| replace:: |h-U|\ **-U**\ |h-x|
 
 .. |h-U| raw:: html
 
    <a class="reference internal" href="#u"><span>
 
-.. |-V| replace:: |h-V| **-V**\ |h-x|
+.. |-V| replace:: |h-V|\ **-V**\ |h-x|
 
 .. |h-V| raw:: html
 
    <a class="reference internal" href="#v"><span>
 
-.. |-W| replace:: |h-W| **-W**\ |h-x|
+.. |-W| replace:: |h-W|\ **-W**\ |h-x|
 
 .. |h-W| raw:: html
 
    <a class="reference internal" href="#w"><span>
 
-.. |-X| replace:: |h-X| **-X**\ |h-x|
+.. |-X| replace:: |h-X|\ **-X**\ |h-x|
 
 .. |h-X| raw:: html
 
    <a class="reference internal" href="#x"><span>
 
-.. |-Y| replace:: |h-Y| **-Y**\ |h-x|
+.. |-Y| replace:: |h-Y|\ **-Y**\ |h-x|
 
 .. |h-Y| raw:: html
 
    <a class="reference internal" href="#y"><span>
 
-.. |-Z| replace:: |h-Z| **-Z**\ |h-x|
+.. |-Z| replace:: |h-Z|\ **-Z**\ |h-x|
 
 .. |h-Z| raw:: html
 


### PR DESCRIPTION
**Description of proposed changes**

This PR escapes the spaces in the substitutions for options. I have checked that the links in the synopses still work properly.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
