### PR TITLE
Explore separate MAP_ANNOT_OBLIQUE settings for oblique and other projections

### DIFF
--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -154,6 +154,7 @@ struct GMT_DEFAULTS {
 	unsigned int map_logo_justify;		/* Justification of the GMT timestamp box [1 (BL)] */
 	unsigned int map_frame_type;		/* Fancy (0), plain (1), or graph (2) [0] */
 	unsigned int map_graph_extension_unit;	/* If mapframetype is graph, the unit is GMT_CM, GMT_INCH, GMT_PT [%] */
+	bool map_annot_oblique_set;		/* true if user changed map_annot_oblique via a gmt.conf or --par=val */
 	bool map_logo;			/* Plot time and map projection on map [false] */
 	struct GMT_PEN map_default_pen;		/* Default pen for most pens [0.25p] */
 	struct GMT_PEN map_frame_pen;		/* Pen attributes for map boundary [1.25p] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10388,7 +10388,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			ival = gmtinit_parse_map_annot_oblique (GMT, value);
 			if (ival >= GMT_OBL_ANNOT_LON_X_LAT_Y && ival < GMT_OBL_ANNOT_FLAG_LIMIT)  {
 				GMT->current.setting.map_annot_oblique = ival;
-				GMT->current.setting.map_annot_oblique_set = 1;
+				GMT->current.setting.map_annot_oblique_set = true;
 			}
 			else
 				error = true;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6552,6 +6552,7 @@ void gmt_conf_SI (struct GMT_CTRL *GMT) {
 		gmtinit_conf_modern (GMT);
 	else
 		gmtinit_conf_classic (GMT);
+	//GMT->current.setting.map_annot_oblique_set = false;
 }
 
 /*! . */
@@ -18734,7 +18735,7 @@ int gmt_manage_workflow (struct GMTAPI_CTRL *API, unsigned int mode, char *text)
 			if (error) return (error);		/* Bail at this point */
 			gmt_reset_history (API->GMT);	/* No old classic history shall affect a new modern mode session */
 
-			gmt_conf_SI (API->GMT);				/* Get the original system defaults */
+			gmt_conf_SI (API->GMT);			/* Get the original system defaults */
 			if (!clean_start) {
 				/*  Overload any user-supplied defaults via a gmt.conf file but reset PS_MEDIA to the original system default */
 				if (gmt_getdefaults (API->GMT, NULL) == GMT_NOERROR)	/* Ingested a gmt.conf file */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6099,7 +6099,8 @@ GMT_LOCAL void gmtinit_conf_classic (struct GMT_CTRL *GMT) {
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_OFFSET_PRIMARY] = 'p';
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_OFFSET_SECONDARY] = 'p';
 	/* MAP_ANNOT_OBLIQUE */
-	GMT->current.setting.map_annot_oblique = GMT_OBL_ANNOT_ANYWHERE;
+	//GMT->current.setting.map_annot_oblique = GMT_OBL_ANNOT_ANYWHERE;
+	GMT->current.setting.map_annot_oblique = GMT_OBL_ANNOT_LON_HORIZONTAL | GMT_OBL_ANNOT_LAT_HORIZONTAL | GMT_OBL_ANNOT_EXTEND_TICKS;
 	/* MAP_ANNOT_MIN_ANGLE */
 	GMT->current.setting.map_annot_min_angle = 20;
 	/* MAP_ANNOT_MIN_SPACING */
@@ -6474,7 +6475,7 @@ GMT_LOCAL void gmtinit_conf_modern_override (struct GMT_CTRL *GMT) {
 	/* MAP group */
 
 	/* MAP_ANNOT_MIN_SPACING */
-	GMT->current.setting.map_annot_min_spacing = GMT->session.d_NaN; /* 12p */
+	GMT->current.setting.map_annot_min_spacing = GMT->session.d_NaN; /* 28p */
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_MIN_SPACING] = 'p';
 	/* MAP_ANNOT_OFFSET_PRIMARY, MAP_ANNOT_OFFSET_SECONDARY */
 	GMT->current.setting.map_annot_offset[GMT_PRIMARY] = GMT->current.setting.map_annot_offset[GMT_SECONDARY] = GMT->session.d_NaN; /* 3p */
@@ -9970,7 +9971,7 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_HEADING_OFFSET] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_annot_min_spacing)) {
-		GMT->current.setting.map_annot_min_spacing = 12 * pt * scale; /* 12p */
+		GMT->current.setting.map_annot_min_spacing = 28 * pt * scale; /* 28p */
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_ANNOT_MIN_SPACING] = true;
 	}
 
@@ -10385,8 +10386,10 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_MAP_ANNOT_OBLIQUE:
 			ival = gmtinit_parse_map_annot_oblique (GMT, value);
-			if (ival >= GMT_OBL_ANNOT_LON_X_LAT_Y && ival < GMT_OBL_ANNOT_FLAG_LIMIT)
+			if (ival >= GMT_OBL_ANNOT_LON_X_LAT_Y && ival < GMT_OBL_ANNOT_FLAG_LIMIT)  {
 				GMT->current.setting.map_annot_oblique = ival;
+				GMT->current.setting.map_annot_oblique_set = 1;
+			}
 			else
 				error = true;
 			break;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6099,7 +6099,6 @@ GMT_LOCAL void gmtinit_conf_classic (struct GMT_CTRL *GMT) {
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_OFFSET_PRIMARY] = 'p';
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_OFFSET_SECONDARY] = 'p';
 	/* MAP_ANNOT_OBLIQUE */
-	//GMT->current.setting.map_annot_oblique = GMT_OBL_ANNOT_ANYWHERE;
 	GMT->current.setting.map_annot_oblique = GMT_OBL_ANNOT_LON_HORIZONTAL | GMT_OBL_ANNOT_LAT_HORIZONTAL | GMT_OBL_ANNOT_EXTEND_TICKS;
 	/* MAP_ANNOT_MIN_ANGLE */
 	GMT->current.setting.map_annot_min_angle = 20;
@@ -6552,7 +6551,7 @@ void gmt_conf_SI (struct GMT_CTRL *GMT) {
 		gmtinit_conf_modern (GMT);
 	else
 		gmtinit_conf_classic (GMT);
-	//GMT->current.setting.map_annot_oblique_set = false;
+	GMT->current.setting.map_annot_oblique_set = false;
 }
 
 /*! . */

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9331,8 +9331,8 @@ void gmtmap_reset_oblique_settings (struct GMT_CTRL *GMT) {
 	 * THus, if the current projection is not like that then we reset the default to a more benign default setting.  However, if
 	 * the user has actively changed the MAP_ANNOT_OBLIQUE value then we do nothing. */
 
-	if (GMT->current.setting.map_annot_oblique_set) return;	/* User touched MAP_ANNOT_OBLIQUE so we cannot reset anything */
-	if (GMT->common.R.oblique) return;	/* These are the appropriate defaults */
+	if (GMT->current.setting.map_annot_oblique_set) return;	/* User changed MAP_ANNOT_OBLIQUE so we cannot reset anything */
+	if (GMT->common.R.oblique) return;	/* These are the appropriate defaults for oblique projections with rectangular borders */
 
 	GMT_Report (GMT->parent, GMT_MSG_NOTICE, "Reset MAP_ANNOT_OBLIQUE to anywhere\n");
 


### PR DESCRIPTION
This PR to be merged into gmt-themes sets the new default for **MAP_ANNOT_OBLIQUE** to be **lon_horizontal,lat_horizontal,tick_extend** but we then proceed to reset this to the previous default **anywhere** if the projection/region is not oblique, _unless_ the user manually changed the setting.

With this scheme I get happy results for things like

```
gmt basemap -R-200/200/-200/200+uk -JOa8/88/46/15c -T8/87/3c -Bxa5fg -Bya1fg -BNSWE -png a
gmt basemap -R0/20/0/20 -JM6i -B -png b
gmt basemap -R-180/-20/0/90 -JPoly/10c -Bx30g10 -By10g10 -png c
gmt basemap -Rg -JH0/15c -Ba30fg -BWSNE -png d
```

See what you think, @meghanrjones.  Note I also upped the **ANNOT_MIN_SPACING** default to 28p (~1 cm) since the annotations for plot **a** are horizontal and it needs more space to not overprint widely.  Also note that my caveat about **subplot** seems to have been premature.  To place latitudes for rectilinear projections parallel to the border we require **-SR**...**+p** anyway.  That seems to work still with this PR:

```
gmt begin t pdf
  gmt subplot begin 2x2 -Fs3i -M5p -A -SCb -SRl+p -Bwstr -R-11/11/-11/11 -JM3i
    gmt basemap
    gmt basemap -c
    gmt basemap -c
    gmt basemap -c
  gmt subplot end
gmt end show
```

Apart from setting the new defaults in gmt_init.c, the reset takes place in _gmtmap_reset_oblique_settings_ in gmt_map.c.
