### PR TITLE
Warn if annotations are skipped due to crowding along axis

### DIFF
--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -95,7 +95,7 @@ struct GMT_DEFAULTS {
 	size_t url_size_limit;
 	unsigned int refresh_time; /* Only refresh server catalog when the local copy is this old in days) */
 	unsigned int compatibility; /* Choose between 4 (GMT4) and up to latest version (5 for now) */
-	unsigned int auto_download;   /* 0 (GMT_NO_DOWNLOAD) or 1 (GMT_YES_DOWNLOAD): For auto-downlaod of known files */
+	unsigned int auto_download;   /* 0 (GMT_NO_DOWNLOAD) or 1 (GMT_YES_DOWNLOAD): For auto-download of known files */
 	unsigned int interpolant; /* Choose between 0 (Linear), 1 (Akima), or 2 (Cubic spline) */
 	unsigned int triangulate; /* 0 for Watson [Default], 1 for Shewchuk (if configured) */
 	unsigned int verbose;     /* Level of verbosity 0-4 [1] */
@@ -130,6 +130,7 @@ struct GMT_DEFAULTS {
 	char io_head_marker_in[GMT_LEN32];  /* Characters used to recognize input header records [#%!;"'] */
 	char io_head_marker_out;            /* Character used to recognize and write header records [#,#] */
 	/* MAP group */
+	char map_annot_min_spacing_txt[GMT_LEN16];	/* Text version of this setting */
 	double map_annot_offset[2];		/* Distance between primary or secondary annotation and tickmarks [5p/5p] */
 	double map_annot_min_angle;		/* If angle between map boundary and annotation is less, no annotation is drawn [20] */
 	double map_annot_min_spacing;	/* If an annotation is closer that this to an older annotation, the annotation is skipped [0.0] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6055,6 +6055,7 @@ void gmt_conf (struct GMT_CTRL *GMT) {
 	/* MAP_ANNOT_MIN_SPACING */
 	GMT->current.setting.map_annot_min_spacing = 0; /* 0p */
 	GMT->current.setting.given_unit[GMTCASE_MAP_ANNOT_MIN_SPACING] = 'p';
+	strncpy (GMT->current.setting.map_annot_min_spacing_txt, "0p", GMT_LEN16);
 	/* MAP_ANNOT_ORTHO */
 	strcpy (GMT->current.setting.map_annot_ortho, "we");
 	/* MAP_DEGREE_SYMBOL (degree) */
@@ -10026,8 +10027,10 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		case GMTCASE_MAP_ANNOT_MIN_SPACING:
 			if (value[0] == '-')	/* Negative */
 				error = true;
-			else
+			else {
 				GMT->current.setting.map_annot_min_spacing = gmt_M_to_inch (GMT, value);
+				strncpy (GMT->current.setting.map_annot_min_spacing_txt, value, GMT_LEN16);
+			}
 			break;
 		case GMTCASE_Y_AXIS_TYPE:
 			if (gmt_M_compat_check (GMT, 4)) {

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6248,7 +6248,7 @@ void gmt_map_basemap (struct GMT_CTRL *GMT) {
 		}
 		if (GMT_n_annotations_skip[side]) {
 			static char *name[4] = {"bottom", "right", "top", "left"};
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "%d annotations along the %s border were skipped due to crowding\n", GMT_n_annotations_skip[side], name[side]);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "%d annotations along the %s border were skipped due to crowding.\n", GMT_n_annotations_skip[side], name[side]);
 			too_crowded = true;
 			GMT_n_annotations_skip[side] = 0;
 		}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -82,8 +82,8 @@
 
 /* Local variables to this file */
 
+static unsigned int GMT_n_annotations_skip[4] = {0, 0, 0, 0};
 static size_t GMT_n_annotations[4] = {0, 0, 0, 0};
-static size_t GMT_n_annotations_skip[4] = {0, 0, 0, 0};
 static size_t GMT_alloc_annotations[4] = {0, 0, 0, 0};
 static double *GMT_x_annotation[4] = {NULL, NULL, NULL, NULL}, *GMT_y_annotation[4] = {NULL, NULL, NULL, NULL};
 
@@ -6248,13 +6248,14 @@ void gmt_map_basemap (struct GMT_CTRL *GMT) {
 		}
 		if (GMT_n_annotations_skip[side]) {
 			static char *name[4] = {"bottom", "right", "top", "left"};
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "%d annotations on the %s border skipped due to crowding\n", GMT_n_annotations_skip[side], name[side]);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "%d annotations along the %s border were skipped due to crowding\n", GMT_n_annotations_skip[side], name[side]);
 			too_crowded = true;
+			GMT_n_annotations_skip[side] = 0;
 		}
 	}
 	if (too_crowded) {
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Crowding decisions depends on the value of MAP_ANNOT_MIN_SPACING, currently set to %g\n", GMT->current.setting.map_annot_min_spacing);
-
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Crowding decisions is controlled by MAP_ANNOT_MIN_SPACING, currently set to %s.\n", GMT->current.setting.map_annot_min_spacing_txt);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Decrease or increase MAP_ANNOT_MIN_SPACING to see more or fewer annotations, with 0 showing all annotations.\n");
 	}
 	PSL_setcolor (PSL, GMT->current.setting.map_default_pen.rgb, PSL_IS_STROKE);
 


### PR DESCRIPTION
**Description of proposed changes**

The minimum spacing between nearby annotations is controlled by **MAP_ANNOT_MIN_SPACING**, whose default has remained at zero since introduction.  Thus, to get any effect the user had to change the value and then be prepared to see annotations being dropped.

In modern mode and themes, we will use a modest, nonzero limitation to prevent the worst of overprinting that can happen with oblique projections close to the poles.  Given that, we need to warn users when crowding decisions eliminate some annotations so they can be aware of this fact and take action if they want to change the outcome.

Being generally useful, this warning is implemented in master.
