### PR TITLE
Add two bash functions for viewing failures

### DIFF
--- a/admin/bashrc_for_gmt
+++ b/admin/bashrc_for_gmt
@@ -125,7 +125,7 @@ function view_png_failures_r {
 	popd
 }
 
-# View all release PNG failures one at the time with given sleep gap [3s]
+# View all release PDF failures one at the time with given sleep gap [3s]
 function view_pdf_failures_r {
 	if [ "X$1" == "X" ]; then
 		w=3

--- a/admin/bashrc_for_gmt
+++ b/admin/bashrc_for_gmt
@@ -133,7 +133,7 @@ function view_pdf_failures_r {
 		w=$1
 	fi
 	pushd .; gtop; cd rbuild;
-	ls */*/*/*.png */*/*/*/*.png > /tmp/vpf
+	ls */*/*/*.pdf */*/*/*/*.pdf > /tmp/vpf
 	while read pdf; do
 		$pdfview $pdf
 		sleep $w

--- a/admin/bashrc_for_gmt
+++ b/admin/bashrc_for_gmt
@@ -105,3 +105,39 @@ alias vgd=vpngdbuild
 alias vpd=vpdfdbuild
 alias vgr=vpngrbuild
 alias vpr=vpdfrbuild
+
+# View large sets of failures one at the time with gap in time between launch:
+
+# View all release PNG failures one at the time with given sleep gap [3s]
+function view_png_failures_r {
+	if [ "X$1" == "X" ]; then
+		w=3
+	else
+		w=$1
+	fi
+	pushd .; gtop; cd rbuild;
+	ls */*/*/*.png */*/*/*/*.png > /tmp/vpf
+	while read png; do
+		$pngview $png
+		sleep $w
+	done < /tmp/vpf
+	rm -f /tmp/vpf
+	popd
+}
+
+# View all release PNG failures one at the time with given sleep gap [3s]
+function view_pdf_failures_r {
+	if [ "X$1" == "X" ]; then
+		w=3
+	else
+		w=$1
+	fi
+	pushd .; gtop; cd rbuild;
+	ls */*/*/*.png */*/*/*/*.png > /tmp/vpf
+	while read pdf; do
+		$pdfview $pdf
+		sleep $w
+	done < /tmp/vpf
+	rm -f /tmp/vpf
+	popd
+}


### PR DESCRIPTION
These are useful when there are lots of failures and you want to launch one plot at the time with a few seconds in between. Set up for release builds only and takes optional argument for wait time [3 seconds].  Example of usage:

1. First run the tests for the release build (ctr)
2. view_png_failures_r 4

for a 4 second wait.  Both _view_png_failures_r_ and _view_pdf_failures_r_ are provided.

