### PR TITLE
If API_IMAGE_LAYOUT is requested without GDAL lib, give error

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13034,10 +13034,14 @@ int GMT_Get_Default (void *V_API, const char *keyword, char *value) {
 		sprintf (value, "%s", API->GMT->init.runtime_library);
 	else if (!strncmp (keyword, "API_CORES", 9U))	/* Report number of cores */
 		sprintf (value, "%d", API->n_cores);
+	else if (!strncmp (keyword, "API_IMAGE_LAYOUT", 16U)) {	/* Report image/band layout */
 #ifdef HAVE_GDAL
-	else if (!strncmp (keyword, "API_IMAGE_LAYOUT", 16U))	/* Report image/band layout */
 		gmt_M_memcpy (value, API->GMT->current.gdal_read_in.O.mem_layout, 4, char);
+#else
+		GMT_Report (API, GMT_MSG_ERROR, "API_IMAGE_LAYOUT only available when GMT is linked with GDAL; request ignored");
+		error = GMT_NOT_A_VALID_ARG;
 #endif
+	}
 	else if (!strncmp (keyword, "API_GRID_LAYOUT", 15U)) {	/* Report grid layout */
 		if (API->shape == GMT_IS_COL_FORMAT)
 			strcpy (value, "columns");

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13039,6 +13039,7 @@ int GMT_Get_Default (void *V_API, const char *keyword, char *value) {
 		gmt_M_memcpy (value, API->GMT->current.gdal_read_in.O.mem_layout, 4, char);
 #else
 		GMT_Report (API, GMT_MSG_ERROR, "API_IMAGE_LAYOUT only available when GMT is linked with GDAL; request ignored");
+		value[0] = '\0';
 		error = GMT_NOT_A_VALID_ARG;
 #endif
 	}


### PR DESCRIPTION
If a developers builds GMT without GDAL support and then tries to use GMT_Get_Default on **API_IMAGE_LAYOUT** there will now be an error message issued since it is an invalid entry.  Complements #4892.