### PR TITLE
Allow variable transparency option in velo

### DIFF
--- a/doc/rst/source/supplements/geodesy/psvelo.rst
+++ b/doc/rst/source/supplements/geodesy/psvelo.rst
@@ -35,7 +35,7 @@ Synopsis
 [ |SYN_OPT-i| ]
 [ |SYN_OPT-p| ]
 [ |SYN_OPT-qi| ]
-[ |SYN_OPT-t| ]
+[ |SYN_OPT-tv| ]
 [ |SYN_OPT-:| ]
 [ |SYN_OPT--| ]
 

--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -34,7 +34,7 @@ Synopsis
 [ |SYN_OPT-i| ]
 [ |SYN_OPT-p| ]
 [ |SYN_OPT-qi| ]
-[ |SYN_OPT-t| ]
+[ |SYN_OPT-tv| ]
 [ |SYN_OPT-:| ]
 [ |SYN_OPT--| ]
 

--- a/doc/rst/source/supplements/geodesy/velo_common.rst_
+++ b/doc/rst/source/supplements/geodesy/velo_common.rst_
@@ -225,7 +225,7 @@ Optional Arguments
 .. include:: ../../explain_perspective.rst_
 
 .. include:: ../../explain_-qi.rst_
-.. include:: ../../explain_-t.rst_
+.. include:: ../../explain_-tv_full.rst_
 .. include:: ../../explain_colon.rst_
 .. include:: ../../explain_help.rst_
 


### PR DESCRIPTION
Similar to the _seis_ modules and necessary for **events** to call **velo**. Just following the same steps as **meca** and **coupe**.
