### PR TITLE
Document the data column order when options are used in seis modules

### DIFF
--- a/doc/rst/source/supplements/seis/coupe_common.rst_
+++ b/doc/rst/source/supplements/seis/coupe_common.rst_
@@ -226,3 +226,5 @@ Optional Arguments
 .. include:: ../../explain_colon.rst_
 
 .. include:: ../../explain_help.rst_
+
+.. include:: seis_extra_cols.rst_

--- a/doc/rst/source/supplements/seis/meca_common.rst_
+++ b/doc/rst/source/supplements/seis/meca_common.rst_
@@ -179,3 +179,5 @@ Optional Arguments
 .. include:: ../../explain_colon.rst_
 
 .. include:: ../../explain_help.rst_
+
+.. include:: seis_extra_cols.rst_

--- a/doc/rst/source/supplements/seis/seis_extra_cols.rst_
+++ b/doc/rst/source/supplements/seis/seis_extra_cols.rst_
@@ -7,10 +7,10 @@ require extra columns, as will a **-S** option without the *scale*.  The
 order of the data record is fixed, even if not all items may be activated.
 We expect data columns to come in the following order::
 
-    lon lat symbol-columns [scale] [intens] [transp [transp2]] [trailing-text]
+    lon lat [depth] symbol-columns [scale] [intens] [transp [transp2]] [trailing-text]
 
 where *symbol-columns* represent the normally required data columns, and items
 given in brackets are optional and under the control of the stated options
-(the trailing text is always optional).
-**Note**: You can use **-i** to rearrange your data record to match the expected
-format.
+(the trailing text is always optional).  **Notes**: (1) *depth* is normally required
+but is not expected if **-Fo** is selected.  (2) You can use **-i** to rearrange your
+data record to match the expected format.

--- a/doc/rst/source/supplements/seis/seis_extra_cols.rst_
+++ b/doc/rst/source/supplements/seis/seis_extra_cols.rst_
@@ -1,0 +1,13 @@
+Data Column Order
+-----------------
+
+The **-S** option determines how many data columns are required to generate
+the selected symbol.  In addition, your use of options **-I** and **-t** will
+require extra columns, as will a **-S** option without the *scale*.  The
+order of the data record is fixed, even if not all items may be activated.
+We expect data columns to come in the following order::
+
+    lon lat [symbol-columns] [scale] [intens] [trans_f [transp_l]] [trailing-text]
+
+**Note**: You can use **i** to rearrange your data record to match the expected
+format.

--- a/doc/rst/source/supplements/seis/seis_extra_cols.rst_
+++ b/doc/rst/source/supplements/seis/seis_extra_cols.rst_
@@ -7,7 +7,10 @@ require extra columns, as will a **-S** option without the *scale*.  The
 order of the data record is fixed, even if not all items may be activated.
 We expect data columns to come in the following order::
 
-    lon lat [symbol-columns] [scale] [intens] [trans_f [transp_l]] [trailing-text]
+    lon lat symbol-columns [scale] [intens] [transp [transp2]] [trailing-text]
 
-**Note**: You can use **i** to rearrange your data record to match the expected
+where *symbol-columns* is likely several data columns, and items given in
+brackets are optional and under the control of the stated options
+(the trailing text is always optional).
+**Note**: You can use **-i** to rearrange your data record to match the expected
 format.

--- a/doc/rst/source/supplements/seis/seis_extra_cols.rst_
+++ b/doc/rst/source/supplements/seis/seis_extra_cols.rst_
@@ -7,10 +7,10 @@ require extra columns, as will a **-S** option without the *scale*.  The
 order of the data record is fixed, even if not all items may be activated.
 We expect data columns to come in the following order::
 
-    lon lat [depth] symbol-columns [scale] [intens] [transp [transp2]] [trailing-text]
+    lon lat depth symbol-columns [scale] [intens] [transp [transp2]] [trailing-text]
 
 where *symbol-columns* represent the normally required data columns, and items
 given in brackets are optional and under the control of the stated options
 (the trailing text is always optional).  **Notes**: (1) *depth* is normally required
-but is not expected if **-Fo** is selected.  (2) You can use **-i** to rearrange your
-data record to match the expected format.
+but will not be expected if **-Fo** is given to **meca**.  (2) You can use **-i** to
+rearrange your data record to match the expected format.

--- a/doc/rst/source/supplements/seis/seis_extra_cols.rst_
+++ b/doc/rst/source/supplements/seis/seis_extra_cols.rst_
@@ -9,8 +9,8 @@ We expect data columns to come in the following order::
 
     lon lat symbol-columns [scale] [intens] [transp [transp2]] [trailing-text]
 
-where *symbol-columns* is likely several data columns, and items given in
-brackets are optional and under the control of the stated options
+where *symbol-columns* represent the normally required data columns, and items
+given in brackets are optional and under the control of the stated options
 (the trailing text is always optional).
 **Note**: You can use **-i** to rearrange your data record to match the expected
 format.


### PR DESCRIPTION
**Description of proposed changes**

This include snippet of RST explains the expected order of data columns and how optional choices like **-I,** **-t** and reading symbol scales from file affects the data format for **meca** and **coupe**.  I will do a similar one for **velo** once my PRs are merged.
