### PR TITLE
Improve the GMT landing page using sphinx-panels

### DIFF
--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y --no-install-recommends --no-install-suggests $packages
 # Install more packages for building documentation
 if [ "$BUILD_DOCS" = "true" ]; then
     sudo snap install pngquant
-    pip3 install --user sphinx
+    pip3 install --user sphinx sphinx-panels
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -38,7 +38,7 @@ fi
 brew install ${packages}
 
 if [ "$BUILD_DOCS" = "true" ]; then
-	pip3 install --user sphinx
+	pip3 install --user sphinx sphinx-panels
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -33,7 +33,7 @@ choco install ninja
 choco install ghostscript --version 9.50
 
 if [ "$BUILD_DOCS" = "true" ]; then
-    pip install --user sphinx
+    pip install --user sphinx sphinx-panels
     # Add sphinx to PATH
     echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
 

--- a/ci/vercel-docs.sh
+++ b/ci/vercel-docs.sh
@@ -32,7 +32,7 @@ EOF
 mkdir build
 cd build
 cmake3 .. -G Ninja
-cmake3 --build . &> /dev/null
+cmake3 --build .
 cmake3 --build . --target docs_depends
 #cmake3 --build . --target optimize_images
 cmake3 --build . --target docs_html

--- a/ci/vercel-docs.sh
+++ b/ci/vercel-docs.sh
@@ -9,7 +9,8 @@ set -x -e
 # Vercel uses Amazon Linux 2
 yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install cmake3 ninja-build libcurl-devel netcdf-devel
-pip install sphinx
+# Install Python packages
+pip install -r doc/rst/requirements.txt
 
 # Install latest gs
 curl -SLO https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9533/ghostscript-9.53.3-linux-x86_64.tgz

--- a/ci/vercel-docs.sh
+++ b/ci/vercel-docs.sh
@@ -32,7 +32,7 @@ EOF
 mkdir build
 cd build
 cmake3 .. -G Ninja
-cmake3 --build .
+cmake3 --build . &> /dev/null
 cmake3 --build . --target docs_depends
 #cmake3 --build . --target optimize_images
 cmake3 --build . --target docs_html

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -9,7 +9,7 @@ sys.path.append(os.path.abspath('_extensions'))
 
 # -- General configuration -----------------------------------------------------
 needs_sphinx = '1.8'
-extensions = ['sphinx.ext.mathjax', 'jinja', 'youtube']
+extensions = ['sphinx.ext.mathjax', 'jinja', 'youtube', 'sphinx_panels']
 source_encoding = 'utf-8-sig'
 source_suffix = '.rst'
 master_doc = 'index'

--- a/doc/rst/requirements.txt
+++ b/doc/rst/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-panels

--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -6,6 +6,25 @@ The Generic Mapping Tools Documentation
 Welcome to the GMT Docs! Here you'll find resources for using GMT and examples of what
 it can do.
 
+Quick links
+-----------
+
+.. hlist::
+   :columns: 3
+
+   - :doc:`std-opts`
+   - :doc:`proj-codes`
+   - :doc:`Default Settings (gmt.conf) <gmt.conf>`
+   - :doc:`Colors <gmtcolors>`
+   - :doc:`35 Postscript Fonts </cookbook/postscript-fonts>`
+   - :doc:`Using LaTeX in text </cookbook/gmt-latex>`
+   - :doc:`Built-in CPTs </cookbook/cpts>`
+   - :doc:`Built-in patterns </cookbook/predefined-patterns>`
+   - :doc:`Octal Codes of Characters </cookbook/octal-codes>`
+   - :ref:`Character Escape Sequences <Char-esc-seq>`
+   - :ref:`Pen Syntax <-Wpen_attrib>`
+   - :ref:`Fill Syntax <-Gfill_attrib>`
+   - :ref:`Grid Format Specifications <tbl-grdformats>`
 
 .. Add a hidden toctree to suppress "document isn't included in any toctree" warnings
 .. toctree::
@@ -17,30 +36,6 @@ it can do.
    gmtcolors
 
 .. panels::
-
-    :column: col-lg-12 p-2
-
-    **Quick Links**
-    ^^^^^^^^^^^^^^^
-
-    .. hlist::
-        :columns: 3
-
-        - :doc:`std-opts`
-        - :doc:`proj-codes`
-        - :doc:`Default Settings (gmt.conf) <gmt.conf>`
-        - :doc:`Colors <gmtcolors>`
-        - :doc:`35 Postscript Fonts </cookbook/postscript-fonts>`
-        - :doc:`Using LaTeX in text </cookbook/gmt-latex>`
-        - :doc:`Built-in CPTs </cookbook/cpts>`
-        - :doc:`Built-in patterns </cookbook/predefined-patterns>`
-        - :doc:`Octal Codes of Characters </cookbook/octal-codes>`
-        - :ref:`Character Escape Sequences <Char-esc-seq>`
-        - :ref:`Pen Syntax <-Wpen_attrib>`
-        - :ref:`Fill Syntax <-Gfill_attrib>`
-        - :ref:`Grid Format Specifications <tbl-grdformats>`
-
-    ---
 
     .. toctree::
         :maxdepth: 1

--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -6,25 +6,6 @@ The Generic Mapping Tools Documentation
 Welcome to the GMT Docs! Here you'll find resources for using GMT and examples of what
 it can do.
 
-Quick links
------------
-
-.. hlist::
-   :columns: 3
-
-   - :doc:`std-opts`
-   - :doc:`proj-codes`
-   - :doc:`Default Settings (gmt.conf) <gmt.conf>`
-   - :doc:`Colors <gmtcolors>`
-   - :doc:`35 Postscript Fonts </cookbook/postscript-fonts>`
-   - :doc:`Using LaTeX in text </cookbook/gmt-latex>`
-   - :doc:`Built-in CPTs </cookbook/cpts>`
-   - :doc:`Built-in patterns </cookbook/predefined-patterns>`
-   - :doc:`Octal Codes of Characters </cookbook/octal-codes>`
-   - :ref:`Character Escape Sequences <Char-esc-seq>`
-   - :ref:`Pen Syntax <-Wpen_attrib>`
-   - :ref:`Fill Syntax <-Gfill_attrib>`
-   - :ref:`Grid Format Specifications <tbl-grdformats>`
 
 .. Add a hidden toctree to suppress "document isn't included in any toctree" warnings
 .. toctree::
@@ -36,6 +17,30 @@ Quick links
    gmtcolors
 
 .. panels::
+
+    :column: col-lg-12 p-2
+
+    **Quick Links**
+    ^^^^^^^^^^^^^^^
+
+    .. hlist::
+        :columns: 3
+
+        - :doc:`std-opts`
+        - :doc:`proj-codes`
+        - :doc:`Default Settings (gmt.conf) <gmt.conf>`
+        - :doc:`Colors <gmtcolors>`
+        - :doc:`35 Postscript Fonts </cookbook/postscript-fonts>`
+        - :doc:`Using LaTeX in text </cookbook/gmt-latex>`
+        - :doc:`Built-in CPTs </cookbook/cpts>`
+        - :doc:`Built-in patterns </cookbook/predefined-patterns>`
+        - :doc:`Octal Codes of Characters </cookbook/octal-codes>`
+        - :ref:`Character Escape Sequences <Char-esc-seq>`
+        - :ref:`Pen Syntax <-Wpen_attrib>`
+        - :ref:`Fill Syntax <-Gfill_attrib>`
+        - :ref:`Grid Format Specifications <tbl-grdformats>`
+
+    ---
 
     .. toctree::
         :maxdepth: 1

--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -35,48 +35,58 @@ Quick links
    gmt.conf
    gmtcolors
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Getting started
+.. panels::
 
-   gallery
-   animations
-   tutorial
+    .. toctree::
+        :maxdepth: 1
+        :caption: Getting started
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Reference documentation
+        gallery
+        animations
+        tutorial
 
-   modules
-   cookbook
-   datasets
+    ---
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Resources
+    .. toctree::
+        :maxdepth: 1
+        :caption: Reference documentation
 
-   users-contrib-scripts
-   users-contrib-symbols
-   changes
-   deprecated-defaults
-   switching
-   migrating
+        modules
+        cookbook
+        datasets
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Classic Mode
+    ---
 
-   std-opts-classic
-   modules-classic
+    .. toctree::
+        :maxdepth: 1
+        :caption: Resources
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Developer Resources
+        users-contrib-scripts
+        users-contrib-symbols
+        changes
+        deprecated-defaults
+        switching
+        migrating
 
-   Contributing Guide <https://github.com/GenericMappingTools/gmt/blob/master/CONTRIBUTING.md>
-   Code of Conduct <https://github.com/GenericMappingTools/gmt/blob/master/CODE_OF_CONDUCT.md>
-   reStructuredText Cheatsheet <rst-cheatsheet>
-   Debugging GMT <debug>
-   GMT C API <api>
-   PostScriptLight C API <postscriptlight>
-   devdocs
+    ---
+
+    .. toctree::
+        :maxdepth: 1
+        :caption: Classic Mode
+
+        std-opts-classic
+        modules-classic
+
+    ---
+
+    .. toctree::
+        :maxdepth: 1
+        :caption: Developer Resources
+
+        Contributing Guide <https://github.com/GenericMappingTools/gmt/blob/master/CONTRIBUTING.md>
+        Code of Conduct <https://github.com/GenericMappingTools/gmt/blob/master/CODE_OF_CONDUCT.md>
+        reStructuredText Cheatsheet <rst-cheatsheet>
+        Debugging GMT <debug>
+        GMT C API <api>
+        PostScriptLight C API <postscriptlight>
+        devdocs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build:docs": "curl https://raw.githubusercontent.com/GenericMappingTools/gmt/master/ci/vercel-docs.sh | bash",
+    "build:docs": "curl https://raw.githubusercontent.com/GenericMappingTools/gmt/landing-page/ci/vercel-docs.sh | bash",
     "build": "npm run build:docs"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build:docs": "curl https://raw.githubusercontent.com/GenericMappingTools/gmt/landing-page/ci/vercel-docs.sh | bash",
+    "build:docs": "bash ci/vercel-docs.sh",
     "build": "npm run build:docs"
   }
 }


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in #4743, this PR adds the `sphinx-panels` extension to redesign the GMT documentation landing page.

|  Old | New |
|---|---|
| ![image](https://user-images.githubusercontent.com/3974108/110185090-78098180-7ddf-11eb-8d0e-c206ea71ffe1.png) | ![image](https://user-images.githubusercontent.com/3974108/110190414-3255b480-7df1-11eb-87e0-648cc0b97c57.png) |

- Old landing page: https://docs.generic-mapping-tools.org/6.1/
- Preview the new landing page: https://gmt-35efcu8gq-gmt.vercel.app/

**NOTE:** As mentioned in #4743, the `sphinx-panel` extension is not included in the repository. Anyone who wants to build the documentation locally must install it manually.

The command is:

```
pip install sphinx sphinx-panels
```

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
