### PR TITLE
docs: Disable the sphinx_panels extension for manpage build

### DIFF
--- a/doc/rst/CMakeLists.txt
+++ b/doc/rst/CMakeLists.txt
@@ -83,6 +83,7 @@ if (SPHINX_FOUND)
 			-c "${CMAKE_CURRENT_BINARY_DIR}"
 			-d "${SPHINX_CACHE_DIR}"
 			-w "${CMAKE_CURRENT_BINARY_DIR}/man.log"
+			-t nosphinxpanels
 			${CMAKE_CURRENT_BINARY_DIR}/source
 			${CMAKE_CURRENT_BINARY_DIR}/man
 			COMMAND ${GZIP} -9 -n -f ${CMAKE_CURRENT_BINARY_DIR}/man/*.?

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -21,6 +21,10 @@ smartquotes_action = 'qe'
 highlight_language = 'bash'
 pygments_style = 'sphinx'
 
+# Disable sphinx_panels extension for manpage build
+if tags.has("nosphinxpanels"):
+    extensions.remove("sphinx_panels")
+
 # -- Project configuration ------------------------------------------------
 project = 'GMT'
 copyright = "@GMT_VERSION_YEAR@, The GMT Team."


### PR DESCRIPTION
**Description of proposed changes**

In #4916, we added the `sphinx-panels` extension to redesign the landing page.

However, the extension is not compatible with "manpage" builds, and building manpages gives errors.

This PR fixes the issue by disable the `sphinx-panels` extension for manpage builds. However, as we use `.. panels` directives in the landing pages, building manpage still reports some warnings. 


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
