### PR TITLE
Allow +a<angle> for y-axis as well as x-axis

### DIFF
--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -359,13 +359,12 @@ but you may also split this into two separate invocations for clarity, i.e.,
     default setting :term:`FORMAT_GEO_MAP`). However, for other plots you can add
     specific units by adding **+u**\ *unit*.  If any of these text strings contain
     spaces or special characters you will need to enclose them in quotes.
-    Cartesian x-axes also allow for the optional **+a**\ *angle*, which
+    Cartesian axes also allow for the optional **+a**\ *angle*, which
     will plot slanted annotations; *angle* is measured with respect to the horizontal
     and must be in the -90 <= *angle* <= 90 range only.  Also, **+an** is a shorthand
-    for normal (i.e., **+a**\ 90) and **+ap** for parallel (i.e., **+a**\ 0) annotations
-    [Default].  For the y-axis, arbitrary angles are not allowed but **+an** and **+ap**
-    specify annotations normal [Default] and parallel to the axis, respectively.  Note that
-    these defaults can be changed via :term:`MAP_ANNOT_ORTHO`.
+    for normal (i.e., **+a**\ 90) [Default for y-axis] and **+ap** for parallel (i.e.,
+    **+a**\ 0) annotations [Default for x-axis]. Note that these defaults can be changed
+    via :term:`MAP_ANNOT_ORTHO`.
 
 The *intervals* specification is a concatenated string made up of substrings of the form
 

--- a/doc/rst/source/explain_-B_full.rst_
+++ b/doc/rst/source/explain_-B_full.rst_
@@ -64,12 +64,11 @@
     default setting :term:`FORMAT_GEO_MAP`). However, for other plots you can add
     specific units by adding **+u**\ *unit*.  If any of these text strings contain
     spaces or special characters you will need to enclose them in quotes.
-    Cartesian x-axes also allow for the optional **+a**\ *angle*, which
+    Cartesian axes also allow for the optional **+a**\ *angle*, which
     will plot slanted annotations; *angle* is measured with respect to the horizontal
     and must be in the -90 <= *angle* <= 90 range only.  Also, **+an** is a shorthand
-    for normal (i.e., **+a**\ 90) and **+ap** for parallel (i.e., **+a**\ 0) annotations
-    [Default].  For the y- and z-axes, arbitrary angles are not allowed but **+an** and **+ap**
-    specify annotations normal [Default] and parallel to the axis, respectively. Note that
+    for normal (i.e., **+a**\ 90) [Default for y-axis] and **+ap** for parallel  (i.e.,
+    **+a**\ 0) annotations [Default for x-axis].  Note that
     these defaults can be changed via :term:`MAP_ANNOT_ORTHO`. Geographic axes can
     take **+f** which will give fancy annotations with W|E|S|N suffices encoding the sign.
     **Note**: Text items such as *title*, *subtitle*, *label* and *seclabel* are seen by GMT as part of

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4462,12 +4462,14 @@ GMT_LOCAL int gmtinit_parse5_B_option (struct GMT_CTRL *GMT, char *in) {
 								GMT->current.map.frame.axis[no].angle = 0.0;
 							else if (p[1] == 'p')	/* +ap is code for normal to y/z-axis; this triggers ortho=false later */
 								GMT->current.map.frame.axis[no].angle = 90.0;
-							else if (!implicit) {	/* Means user gave -By...+a<angle> which is no good */
-								GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: Only modifiers +an|p is allowed for the %c-axis\n", the_axes[no]);
+							else	/* Assume a variable angle */
+								GMT->current.map.frame.axis[no].angle = atof (&p[1]);
+							if (GMT->current.map.frame.axis[no].angle < -90.0 || GMT->current.map.frame.axis[no].angle > 90.0) {
+								GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: +a<angle> must be in the -90 to +90 range\n");
 								error++;
 							}
 							else	/* Probably did -Baf+a30 and only meant that to apply to the x-axis */
-								GMT->current.map.frame.axis[no].use_angle = false;
+								GMT->current.map.frame.axis[no].use_angle = true;
 						}
 						break;
 					case 'f':	/* Select fancy annotations with trailing W|E|S|N */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4441,22 +4441,17 @@ GMT_LOCAL int gmtinit_parse5_B_option (struct GMT_CTRL *GMT, char *in) {
 						if (gmt_M_is_geographic (GMT, GMT_IN)) {
 							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: Cannot use +a for geographic basemaps\n");
 							error++;
+							continue;
 						}
-						else if (no == GMT_X) {	/* Variable angles are only allowed for the x-axis */
+						if (no == GMT_X) {	/* Variable angles for the x-axis */
 							if (p[1] == 'n')	/* +an is short for +a90 or normal to x-axis */
 								GMT->current.map.frame.axis[no].angle = 90.0;
 							else if (p[1] == 'p')	/* +ap is short for +a0 or parallel to x-axis */
 								GMT->current.map.frame.axis[no].angle = 0.0;
 							else	/* Assume a variable angle */
 								GMT->current.map.frame.axis[no].angle = atof (&p[1]);
-							if (GMT->current.map.frame.axis[no].angle < -90.0 || GMT->current.map.frame.axis[no].angle > 90.0) {
-								GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: +a<angle> must be in the -90 to +90 range\n");
-								error++;
-							}
-							else
-								GMT->current.map.frame.axis[no].use_angle = true;
 						}
-						else {	/* Only +an|p is allowed for y/z-axis */
+						else {	/* Variable angles for the y/z-axis */
 							GMT->current.map.frame.axis[no].use_angle = true;
 							if (p[1] == 'n')	/* +an is code for normal to y/z-axis;*/
 								GMT->current.map.frame.axis[no].angle = 0.0;
@@ -4464,13 +4459,13 @@ GMT_LOCAL int gmtinit_parse5_B_option (struct GMT_CTRL *GMT, char *in) {
 								GMT->current.map.frame.axis[no].angle = 90.0;
 							else	/* Assume a variable angle */
 								GMT->current.map.frame.axis[no].angle = atof (&p[1]);
-							if (GMT->current.map.frame.axis[no].angle < -90.0 || GMT->current.map.frame.axis[no].angle > 90.0) {
-								GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: +a<angle> must be in the -90 to +90 range\n");
-								error++;
-							}
-							else	/* Probably did -Baf+a30 and only meant that to apply to the x-axis */
-								GMT->current.map.frame.axis[no].use_angle = true;
 						}
+						if (GMT->current.map.frame.axis[no].angle < -90.0 || GMT->current.map.frame.axis[no].angle > 90.0) {
+							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: +a<angle> must be in the -90 to +90 range\n");
+							error++;
+						}
+						else
+							GMT->current.map.frame.axis[no].use_angle = true;
 						break;
 					case 'f':	/* Select fancy annotations with trailing W|E|S|N */
 						if (gmt_M_x_is_lon(GMT,GMT_IN) || gmt_M_y_is_lat(GMT,GMT_IN))
@@ -6799,7 +6794,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 			gmt_message (GMT, "\t     To prepend a prefix to each annotation (e.g., $ 10, $ 20 ...), add +p<prefix>.\n");
 			gmt_message (GMT, "\t     To append a unit to each annotation (e.g., 5 km, 10 km ...), add +u<unit>.\n");
 			gmt_message (GMT, "\t     Cartesian x-axis takes optional +a<angle> for slanted or +an for orthogonal annotations [+ap].\n");
-			gmt_message (GMT, "\t     Cartesian y- and z-axes take optional +ap for parallel annotations [+an].\n");
+			gmt_message (GMT, "\t     Cartesian y- and z-axes take optional +a<angle> for slanted or +ap for parallel annotations [+an].\n");
 			gmt_message (GMT, "\t     Geographic axes take optional +f for \"fancy\" annotations with W|E|S|N suffices.\n");
 			gmt_message (GMT, "\t     To label an axis, add +l<label>.  Use +L to enforce horizontal labels for y-axes.\n");
 			gmt_message (GMT, "\t     For another axis label on the opposite axis, use +s|S as well.\n");

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5319,7 +5319,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 	if (A->type != GMT_TIME)						/* Set the annotation format template */
 		gmt_get_format (GMT, gmtlib_get_map_interval (GMT, A->type, &A->item[GMT_ANNOT_UPPER]), A->unit, A->prefix, format);
 	text_angle = (ortho == horizontal) ? 90.0 : 0.0;
-	justify = (ortho) ? PSL_MR : PSL_BC;
+	justify = (ortho && axis == GMT_X) ? PSL_MR : PSL_BC;
 	if (A->use_angle && !skip) {	/* User override annotation angle */
 		text_angle = A->angle;
 		angled = true;
@@ -5330,7 +5330,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		if (axis == GMT_Y) ortho = true;
 		if (axis == GMT_X) {
 			cos_a = 0.5 * cosd (text_angle);	/* Half-height of text at an angle */
-			sin_a = 0.5 * fabs (sind (text_angle));	/* Fraction of y offset due to slanted annotation */
+			sin_a = fabs (sind (text_angle));	/* Fraction of y offset due to slanted annotation */
 		}
 		else {
 			cos_a = cosd (text_angle);	/* Full-height of text at an angle */
@@ -5485,9 +5485,11 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 					gmtlib_get_coordinate_label (GMT, string, &GMT->current.plot.calclock, format, T, knots[nx1-1]);	/* Get annotation string */
 				PSL_deftextdim (PSL, "-w", font.size, string);	/* Compute the width */
 				PSL_command (PSL, " %.12g mul def\n", sin_a);	/* Multiply this width by sine of the angle to get the y-component */
+				//PSL_command (PSL, " %.12g mul %g add def\n", sin_a, PSL_IZ (PSL, 72.0 * GMT->current.setting.font_annot[GMT_PRIMARY].size));	/* Multiply this width by sine of the angle to get the y-component */
 			}
 			else if (angled && axis == GMT_Y) {	/* Need a slant in x and reset PSL_AH? to 0 */
-				PSL_command (PSL, "/PSL_slant_x PSL_AH%d %.12g mul def\n", annot_pos, cos_a);	/* Largest annotation width (or height) so far */
+				//PSL_command (PSL, "/PSL_slant_x PSL_AH%d %.12g mul %g add def\n", annot_pos, cos_a, PSL_IZ (PSL, 72.0 * GMT->current.setting.font_annot[GMT_PRIMARY].size));	/* Largest annotation width (or height) so far */
+				PSL_command (PSL, "/PSL_slant_x PSL_AH%d %.12g mul  def\n", annot_pos, cos_a);	/* Largest annotation width (or height) so far */
 				PSL_command (PSL, "/PSL_AH%d 0 def\n", annot_pos);	/* Largest annotation width (or height) so far */
 			}
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -456,7 +456,7 @@ GMT_LOCAL void gmtplot_linear_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTR
 	x_length = GMT->current.proj.rect[XHI] - GMT->current.proj.rect[XLO];
 	y_length = GMT->current.proj.rect[YHI] - GMT->current.proj.rect[YLO];
 
-	PSL_command (PSL, "/PSL_slant_y 0 def\n");	/* Unless x-annotations are slanted there is no adjustment. PSL_slant_y may be revised in gmt_xy_axis */
+	PSL_command (PSL, "/PSL_slant_y 0 def /PSL_slant_x 0 def\n");	/* Unless x-annotations are slanted there is no adjustment. PSL_slant_y may be revised in gmt_xy_axis */
 
 	if (GMT->current.map.frame.draw) {
 		/* Temporarily change to square cap so rectangular frames have neat corners */
@@ -5310,7 +5310,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 	if (A->use_angle) {	/* Must honor the +a modifier */
 		if (axis != GMT_X && doubleAlmostEqualZero (A->angle, 90.0)) ortho = false;	/* Y/Z-Annotations are parallel */
 		else if (axis != GMT_X && doubleAlmostEqualZero (A->angle, 0.0)) ortho = true;	/* Y/Z-Annotations are normal */
-		if (axis == GMT_X && doubleAlmostEqualZero (A->angle, 0.0)) skip = true;	/* X-Annotations are parallel so do nothing */
+		if (doubleAlmostEqualZero (A->angle, 0.0)) skip = true;	/* Annotations are parallel so do nothing */
 	}
 	else if (strchr (GMT->current.setting.map_annot_ortho, axis_chr[axis][below]))
 		ortho = true;	/* Annotations are orthogonal for this axis */
@@ -5320,15 +5320,22 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		gmt_get_format (GMT, gmtlib_get_map_interval (GMT, A->type, &A->item[GMT_ANNOT_UPPER]), A->unit, A->prefix, format);
 	text_angle = (ortho == horizontal) ? 90.0 : 0.0;
 	justify = (ortho) ? PSL_MR : PSL_BC;
-	if (axis == GMT_X && A->use_angle && !skip) {	/* User override annotation angle */
+	if (A->use_angle && !skip) {	/* User override annotation angle */
 		text_angle = A->angle;
 		angled = true;
 		if (text_angle > 0.0)
 			justify = (below) ? PSL_MR : PSL_ML;
 		else
 			justify = (below) ? PSL_ML : PSL_MR;
-		cos_a = 0.5 * cosd (text_angle);	/* Half-height of text at an angle */
-		sin_a = fabs (sind (text_angle));	/* Fraction of y offset due to slanted annotation */
+		if (axis == GMT_Y) ortho = true;
+		if (axis == GMT_X) {
+			cos_a = 0.5 * cosd (text_angle);	/* Half-height of text at an angle */
+			sin_a = 0.5 * fabs (sind (text_angle));	/* Fraction of y offset due to slanted annotation */
+		}
+		else {
+			cos_a = cosd (text_angle);	/* Full-height of text at an angle */
+			sin_a = fabs (sind (text_angle));	/* The y offset due to slanted annotation */
+		}
 	}
 	flip = (GMT->current.setting.map_frame_type & GMT_IS_INSIDE);	/* Inside annotation */
 	if (axis != GMT_Z && GMT->current.proj.three_D && GMT->current.proj.z_project.cos_az > 0) {	/* Rotate x/y-annotations when seen "from North" */
@@ -5469,7 +5476,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 				PSL_command (PSL, "mx\n");		/* Update the longest annotation stored in PSL_AH? */
 			}
 			PSL_command (PSL, "def\n");	/* Finalize the definition of longest (y-axis) or tallest (x-annotation) found */
-			if (angled) {	/* Also need annotation width since a component of length is projected in the y-direction so label and title must be displaced by this amount */
+			if (angled && axis == GMT_X) {	/* Also need annotation width since a component of length is projected in the y-direction so label and title must be displaced by this amount */
 				/* Note: PSL_slant_y will also be used when placing a Cartesian frame title */
 				PSL_command (PSL, "/PSL_slant_y ");
 				if (label_c && label_c[nx1-1] && label_c[nx1-1][0])	/* We only use the string for the max annotation value at index nx1-1 */
@@ -5479,6 +5486,11 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 				PSL_deftextdim (PSL, "-w", font.size, string);	/* Compute the width */
 				PSL_command (PSL, " %.12g mul def\n", sin_a);	/* Multiply this width by sine of the angle to get the y-component */
 			}
+			else if (angled && axis == GMT_Y) {	/* Need a slant in x and reset PSL_AH? to 0 */
+				PSL_command (PSL, "/PSL_slant_x PSL_AH%d %.12g mul def\n", annot_pos, cos_a);	/* Largest annotation width (or height) so far */
+				PSL_command (PSL, "/PSL_AH%d 0 def\n", annot_pos);	/* Largest annotation width (or height) so far */
+			}
+
 			if (annot_pos == 0)
 				PSL_command (PSL, "/PSL_A0_y PSL_A0_y %d add ", PSL_IZ (PSL, GMT->current.setting.map_annot_offset[annot_pos]));
 			else
@@ -5531,8 +5543,10 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		PSL_command (PSL, "def\n");
 		PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset), (neg == horizontal) ? "PSL_LH add " : "");
 		/* Move to new anchor point for label */
-		if (angled)	/* Add offset due to angled x-annotations */
+		if (angled && axis == GMT_X)	/* Add offset due to angled x-annotations */
 			PSL_command (PSL, "%d PSL_L_y PSL_slant_y add MM\n", PSL_IZ (PSL, 0.5 * length));
+		else if (angled && axis == GMT_Y)
+			PSL_command (PSL, "%d PSL_L_y PSL_slant_x add MM\n", PSL_IZ (PSL, 0.5 * length));
 		else
 			PSL_command (PSL, "%d PSL_L_y MM\n", PSL_IZ (PSL, 0.5 * length));
 		if (axis == GMT_Y && A->label_mode) {

--- a/test/psbasemap/slanted.sh
+++ b/test/psbasemap/slanted.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test slanted Cartesian x-axis annotations
 ps=slanted.ps
-gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Ba1f+a90 -P -K -Xc -Y3c > $ps
+gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Bxa1f+a90 -Bya1f -P -K -Xc -Y3c > $ps
 gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Bxa1f+a-60 -Bya1f -O -K -Y6.5c >> $ps
 gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Bxa1f+a45 -Bya1f -O -K -Y6.5c >> $ps
 gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Bxa1f+a30 -Bya1f+ap -O -Y6.5c >> $ps

--- a/test/psbasemap/slanted.sh
+++ b/test/psbasemap/slanted.sh
@@ -2,6 +2,6 @@
 # Test slanted Cartesian x-axis annotations
 ps=slanted.ps
 gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Ba1f+a90 -P -K -Xc -Y3c > $ps
-gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Ba1f+a-60 -O -K -Y6.5c >> $ps
-gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Ba1f+a45 -O -K -Y6.5c >> $ps
+gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Bxa1f+a-60 -Bya1f -O -K -Y6.5c >> $ps
+gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Bxa1f+a45 -Bya1f -O -K -Y6.5c >> $ps
 gmt psbasemap  -R2000/2020/35/40 -JX15c/3c -Bxa1f+a30 -Bya1f+ap -O -Y6.5c >> $ps

--- a/test/psbasemap/xyslant.ps
+++ b/test/psbasemap/xyslant.ps
@@ -1,0 +1,1207 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_2fd582a-dirty_2021.03.05 [64-bit] Document from basemap
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Mar  5 20:42:50 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt basemap -R0/1000/10000/20000 -JX15c/9c '-Bx100+lMY X-LABEL+a30' '-Byaf+lMY Y-LABEL'
+%@PROJ: xy 0.00000000 1000.00000000 10000.00000000 20000.00000000 0.000 1000.000 10000.000 20000.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 4252 M 0 -4252 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 850 M -83 0 D S
+N 0 1701 M -83 0 D S
+N 0 2551 M -83 0 D S
+N 0 3402 M -83 0 D S
+N 0 4252 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(10000) sw mx
+(12000) sw mx
+(14000) sw mx
+(16000) sw mx
+(18000) sw mx
+(20000) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(10000) mr Z
+850 PSL_A0_y MM
+(12000) mr Z
+1701 PSL_A0_y MM
+(14000) mr Z
+2551 PSL_A0_y MM
+(16000) mr Z
+3402 PSL_A0_y MM
+(18000) mr Z
+4252 PSL_A0_y MM
+(20000) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 425 M -42 0 D S
+N 0 1276 M -42 0 D S
+N 0 2126 M -42 0 D S
+N 0 2976 M -42 0 D S
+N 0 3827 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+2126 PSL_L_y MM
+V 90 R (MY Y-LABEL) bc Z U
+7087 0 T
+25 W
+N 0 4252 M 0 -4252 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 850 M 83 0 D S
+N 0 1701 M 83 0 D S
+N 0 2551 M 83 0 D S
+N 0 3402 M 83 0 D S
+N 0 4252 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+200 F0
+(10000) sw mx
+(12000) sw mx
+(14000) sw mx
+(16000) sw mx
+(18000) sw mx
+(20000) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(10000) mr Z
+850 PSL_A0_y MM
+(12000) mr Z
+1701 PSL_A0_y MM
+(14000) mr Z
+2551 PSL_A0_y MM
+(16000) mr Z
+3402 PSL_A0_y MM
+(18000) mr Z
+4252 PSL_A0_y MM
+(20000) mr Z
+N 0 425 M 42 0 D S
+N 0 1276 M 42 0 D S
+N 0 2126 M 42 0 D S
+N 0 2976 M 42 0 D S
+N 0 3827 M 42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+2126 PSL_L_y MM
+V 90 R (MY Y-LABEL) bc Z U
+-7087 0 T
+25 W
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 709 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 2126 0 M 0 -83 D S
+N 2835 0 M 0 -83 D S
+N 3543 0 M 0 -83 D S
+N 4252 0 M 0 -83 D S
+N 4961 0 M 0 -83 D S
+N 5669 0 M 0 -83 D S
+N 6378 0 M 0 -83 D S
+N 7087 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+200 F0
+(0) sh mx
+(100) sh mx
+(200) sh mx
+(300) sh mx
+(400) sh mx
+(500) sh mx
+(600) sh mx
+(700) sh mx
+(800) sh mx
+(900) sh mx
+(1000) sh mx
+def
+/PSL_slant_y (1000) sw  0.5 mul def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (0) mr Z U
+709 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (100) mr Z U
+1417 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (200) mr Z U
+2126 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (300) mr Z U
+2835 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (400) mr Z U
+3543 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (500) mr Z U
+4252 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (600) mr Z U
+4961 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (700) mr Z U
+5669 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (800) mr Z U
+6378 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (900) mr Z U
+7087 PSL_A0_y MM
+0 PSL_AH0 1 0.433012701892 sub mul G
+V 30 R (1000) mr Z U
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+3543 PSL_L_y PSL_slant_y add MM
+(MY X-LABEL) bc Z
+0 4252 T
+25 W
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 709 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 2126 0 M 0 83 D S
+N 2835 0 M 0 83 D S
+N 3543 0 M 0 83 D S
+N 4252 0 M 0 83 D S
+N 4961 0 M 0 83 D S
+N 5669 0 M 0 83 D S
+N 6378 0 M 0 83 D S
+N 7087 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+200 F0
+(0) sh mx
+(100) sh mx
+(200) sh mx
+(300) sh mx
+(400) sh mx
+(500) sh mx
+(600) sh mx
+(700) sh mx
+(800) sh mx
+(900) sh mx
+(1000) sh mx
+def
+/PSL_slant_y (1000) sw  0.5 mul def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (0) ml Z U
+709 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (100) ml Z U
+1417 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (200) ml Z U
+2126 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (300) ml Z U
+2835 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (400) ml Z U
+3543 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (500) ml Z U
+4252 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (600) ml Z U
+4961 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (700) ml Z U
+5669 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (800) ml Z U
+6378 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (900) ml Z U
+7087 PSL_A0_y MM
+0 PSL_AH0 0.433012701892 mul G
+V 30 R (1000) ml Z U
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+3543 PSL_L_y PSL_slant_y add MM
+(MY X-LABEL) bc Z
+0 -4252 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 6142 TM
+% PostScript produced by:
+%@GMT: gmt basemap '-Bx100+lMY X-LABEL' '-Byaf+lMY Y-LABEL+a30' -Y13c -R0/1000/10000/20000 -JX15c/9c
+%@PROJ: xy 0.00000000 1000.00000000 10000.00000000 20000.00000000 0.000 1000.000 10000.000 20000.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 4252 M 0 -4252 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 850 M -83 0 D S
+N 0 1701 M -83 0 D S
+N 0 2551 M -83 0 D S
+N 0 3402 M -83 0 D S
+N 0 4252 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(10000) sw mx
+(12000) sw mx
+(14000) sw mx
+(16000) sw mx
+(18000) sw mx
+(20000) sw mx
+def
+/PSL_slant_x PSL_AH0 0.866025403784 mul  def
+/PSL_AH0 0 def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+0 PSL_AH0 1 0.866025403784 sub mul G
+V 30 R (10000) mr Z U
+850 PSL_A0_y MM
+0 PSL_AH0 1 0.866025403784 sub mul G
+V 30 R (12000) mr Z U
+1701 PSL_A0_y MM
+0 PSL_AH0 1 0.866025403784 sub mul G
+V 30 R (14000) mr Z U
+2551 PSL_A0_y MM
+0 PSL_AH0 1 0.866025403784 sub mul G
+V 30 R (16000) mr Z U
+3402 PSL_A0_y MM
+0 PSL_AH0 1 0.866025403784 sub mul G
+V 30 R (18000) mr Z U
+4252 PSL_A0_y MM
+0 PSL_AH0 1 0.866025403784 sub mul G
+V 30 R (20000) mr Z U
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 425 M -42 0 D S
+N 0 1276 M -42 0 D S
+N 0 2126 M -42 0 D S
+N 0 2976 M -42 0 D S
+N 0 3827 M -42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+2126 PSL_L_y PSL_slant_x add MM
+V 90 R (MY Y-LABEL) bc Z U
+7087 0 T
+25 W
+N 0 4252 M 0 -4252 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 850 M 83 0 D S
+N 0 1701 M 83 0 D S
+N 0 2551 M 83 0 D S
+N 0 3402 M 83 0 D S
+N 0 4252 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+200 F0
+(10000) sw mx
+(12000) sw mx
+(14000) sw mx
+(16000) sw mx
+(18000) sw mx
+(20000) sw mx
+def
+/PSL_slant_x PSL_AH0 0.866025403784 mul  def
+/PSL_AH0 0 def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+0 PSL_AH0 0.866025403784 mul G
+V 30 R (10000) ml Z U
+850 PSL_A0_y MM
+0 PSL_AH0 0.866025403784 mul G
+V 30 R (12000) ml Z U
+1701 PSL_A0_y MM
+0 PSL_AH0 0.866025403784 mul G
+V 30 R (14000) ml Z U
+2551 PSL_A0_y MM
+0 PSL_AH0 0.866025403784 mul G
+V 30 R (16000) ml Z U
+3402 PSL_A0_y MM
+0 PSL_AH0 0.866025403784 mul G
+V 30 R (18000) ml Z U
+4252 PSL_A0_y MM
+0 PSL_AH0 0.866025403784 mul G
+V 30 R (20000) ml Z U
+N 0 425 M 42 0 D S
+N 0 1276 M 42 0 D S
+N 0 2126 M 42 0 D S
+N 0 2976 M 42 0 D S
+N 0 3827 M 42 0 D S
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+2126 PSL_L_y PSL_slant_x add MM
+V 90 R (MY Y-LABEL) bc Z U
+-7087 0 T
+25 W
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 709 0 M 0 -83 D S
+N 1417 0 M 0 -83 D S
+N 2126 0 M 0 -83 D S
+N 2835 0 M 0 -83 D S
+N 3543 0 M 0 -83 D S
+N 4252 0 M 0 -83 D S
+N 4961 0 M 0 -83 D S
+N 5669 0 M 0 -83 D S
+N 6378 0 M 0 -83 D S
+N 7087 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+200 F0
+(0) sh mx
+(100) sh mx
+(200) sh mx
+(300) sh mx
+(400) sh mx
+(500) sh mx
+(600) sh mx
+(700) sh mx
+(800) sh mx
+(900) sh mx
+(1000) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+709 PSL_A0_y MM
+(100) bc Z
+1417 PSL_A0_y MM
+(200) bc Z
+2126 PSL_A0_y MM
+(300) bc Z
+2835 PSL_A0_y MM
+(400) bc Z
+3543 PSL_A0_y MM
+(500) bc Z
+4252 PSL_A0_y MM
+(600) bc Z
+4961 PSL_A0_y MM
+(700) bc Z
+5669 PSL_A0_y MM
+(800) bc Z
+6378 PSL_A0_y MM
+(900) bc Z
+7087 PSL_A0_y MM
+(1000) bc Z
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
+3543 PSL_L_y MM
+(MY X-LABEL) bc Z
+0 4252 T
+25 W
+N 0 0 M 7087 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 709 0 M 0 83 D S
+N 1417 0 M 0 83 D S
+N 2126 0 M 0 83 D S
+N 2835 0 M 0 83 D S
+N 3543 0 M 0 83 D S
+N 4252 0 M 0 83 D S
+N 4961 0 M 0 83 D S
+N 5669 0 M 0 83 D S
+N 6378 0 M 0 83 D S
+N 7087 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+200 F0
+(0) sh mx
+(100) sh mx
+(200) sh mx
+(300) sh mx
+(400) sh mx
+(500) sh mx
+(600) sh mx
+(700) sh mx
+(800) sh mx
+(900) sh mx
+(1000) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) bc Z
+709 PSL_A0_y MM
+(100) bc Z
+1417 PSL_A0_y MM
+(200) bc Z
+2126 PSL_A0_y MM
+(300) bc Z
+2835 PSL_A0_y MM
+(400) bc Z
+3543 PSL_A0_y MM
+(500) bc Z
+4252 PSL_A0_y MM
+(600) bc Z
+4961 PSL_A0_y MM
+(700) bc Z
+5669 PSL_A0_y MM
+(800) bc Z
+6378 PSL_A0_y MM
+(900) bc Z
+7087 PSL_A0_y MM
+(1000) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+/PSL_LH 267 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add def
+3543 PSL_L_y MM
+(MY X-LABEL) bc Z
+0 -4252 T
+0 setlinecap
+0 A
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psbasemap/xyslant.sh
+++ b/test/psbasemap/xyslant.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Test the angled annotation for x and y Cartesian axes
+gmt begin xyslant ps
+	gmt basemap -R0/1000/10000/20000 -JX15c/9c -Bx100+l"MY X-LABEL"+a30 -Byaf+l"MY Y-LABEL"
+	gmt basemap -Bx100+l"MY X-LABEL" -Byaf+l"MY Y-LABEL"+a30 -Y13c
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

Until now, setting annotations at arbitrary angles via **-B**...**+a**_angle_ has been a feature restricted to the x-axis.  This PR opens that up to the y-axis (and by extension - but not tested - the z-axis].  All tests still pass and a new test using the arbitrary angle on the y-axis looks fine:

![xyslant](https://user-images.githubusercontent.com/26473567/110221197-e6e1eb80-7e6e-11eb-918b-c2b881268bc1.png)

Closes #4575.