### PR TITLE
Add the sphinx-togglebutton extension and a figure for MAP_FRAME_TYPES

### DIFF
--- a/doc/rst/_extensions/sphinx_togglebutton/LICENSE
+++ b/doc/rst/_extensions/sphinx_togglebutton/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Chris Holdgraf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/doc/rst/_extensions/sphinx_togglebutton/README.md
+++ b/doc/rst/_extensions/sphinx_togglebutton/README.md
@@ -1,0 +1,4 @@
+This is the source code of sphinx-togglebutton v0.2.3
+Only the `sphinx-togglebutton` directory and the license file is include in the repository.
+
+Homepage: https://github.com/executablebooks/sphinx-togglebutton

--- a/doc/rst/_extensions/sphinx_togglebutton/__init__.py
+++ b/doc/rst/_extensions/sphinx_togglebutton/__init__.py
@@ -1,0 +1,69 @@
+"""A small sphinx extension to add "toggle" buttons to items."""
+import os
+from docutils.parsers.rst import Directive, directives
+from docutils import nodes
+
+__version__ = "0.2.3"
+
+
+def st_static_path(app):
+    static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "_static"))
+    app.config.html_static_path.append(static_path)
+
+
+def add_to_context(app, config):
+    # Update the global context
+    config.html_context.update({"togglebutton_hint": config.togglebutton_hint})
+
+
+# This function reads in a variable and inserts it into JavaScript
+def insert_custom_selection_config(app):
+    # This is a configuration that you've specified for users in `conf.py`
+    selector = app.config["togglebutton_selector"]
+    js_text = "var togglebuttonSelector = '%s';" % selector
+    app.add_js_file(None, body=js_text)
+
+
+class Toggle(Directive):
+    """Hide a block of markup text by wrapping it in a container."""
+
+    optional_arguments = 1
+    final_argument_whitespace = True
+    has_content = True
+
+    option_spec = {"id": directives.unchanged, "show": directives.flag}
+
+    def run(self):
+        self.assert_has_content()
+        classes = ["toggle"]
+        if "show" in self.options:
+            classes.append("toggle-shown")
+
+        parent = nodes.container(classes=classes)
+        self.state.nested_parse(self.content, self.content_offset, parent)
+        return [parent]
+
+
+# We connect this function to the step after the builder is initialized
+def setup(app):
+    # Add our static path
+    app.connect("builder-inited", st_static_path)
+
+    # Add relevant code to headers
+    app.add_css_file("togglebutton.css")
+
+    # Add the string we'll use to select items in the JS
+    # Tell Sphinx about this configuration variable
+    app.add_config_value("togglebutton_selector", ".toggle, .admonition.dropdown", "html")
+    app.add_config_value("togglebutton_hint", "Click to show", "html")
+    app.add_js_file("togglebutton.js")
+
+    # Run the function after the builder is initialized
+    app.connect("builder-inited", insert_custom_selection_config)
+    app.connect("config-inited", add_to_context)
+    app.add_directive("toggle", Toggle)
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/rst/_extensions/sphinx_togglebutton/_static/togglebutton.css_t
+++ b/doc/rst/_extensions/sphinx_togglebutton/_static/togglebutton.css_t
@@ -1,0 +1,90 @@
+/* Visibility of the target */
+.toggle, div.admonition.toggle .admonition-title ~ * {
+    transition: opacity .5s, height .5s;
+}
+
+.toggle-hidden:not(.admonition) {
+    visibility: hidden;
+    opacity: 0;
+    height: 1.5em;
+    margin: 0px;
+    padding: 0px;
+}
+
+/* Overrides for admonition toggles */
+
+/* Titles should cut off earlier to avoid overlapping w/ button */
+div.admonition.toggle p.admonition-title {
+    padding-right: 25%;
+}
+
+/* hides all the content of a page until de-toggled */
+div.admonition.toggle-hidden .admonition-title ~ * {
+    height: 0;
+    margin: 0;
+    float: left; /* so they overlap when hidden */
+    opacity: 0;
+    visibility: hidden;
+}
+
+/* Toggle buttons inside admonitions so we see the title */
+.toggle.admonition {
+    position: relative;
+}
+
+.toggle.admonition.admonition-title:after {
+    content: "" !important;
+}
+
+/* Note, we'll over-ride this in sphinx-book-theme */
+.toggle.admonition button.toggle-button {
+    margin-right: 0.5em;
+    right: 0em;
+    position: absolute;
+    top: .2em;
+}
+
+/* General button style */
+button.toggle-button {
+    background: #999;
+    border: none;
+    z-index: 100;
+    right: -2.5em;
+    margin-left: -2.5em; /* A hack to keep code blocks from being pushed left */
+    position: relative;
+    float: right;
+    border-radius: 100%;
+    width: 1.5em;
+    height: 1.5em;
+    padding: 0px;
+}
+
+@media (min-width: 768px) {
+    button.toggle-button.toggle-button-hidden:before {
+        content: "{{ togglebutton_hint }}";
+        position: absolute;
+        font-size: .8em;
+        left: -6.5em;
+        bottom: .4em;
+    }
+}
+
+
+/* Plus / minus toggles */
+.toggle-button .bar {
+    background-color: white;
+    position: absolute;
+    left: 15%;
+    top: 43%;
+    width: 16px;
+    height: 3px;
+}
+
+.toggle-button .vertical {
+    transition: all 0.25s ease-in-out;
+    transform-origin: center;
+}
+
+.toggle-button-hidden .vertical {
+    transform: rotate(-90deg);
+}

--- a/doc/rst/_extensions/sphinx_togglebutton/_static/togglebutton.js
+++ b/doc/rst/_extensions/sphinx_togglebutton/_static/togglebutton.js
@@ -1,0 +1,76 @@
+var initToggleItems = () => {
+  var itemsToToggle = document.querySelectorAll(togglebuttonSelector);
+  console.log(itemsToToggle, togglebuttonSelector)
+  // Add the button to each admonition and hook up a callback to toggle visibility
+  itemsToToggle.forEach((item, index) => {
+    var toggleID = `toggle-${index}`;
+    var buttonID = `button-${toggleID}`;
+    var collapseButton = `
+      <button id="${buttonID}" class="toggle-button" data-target="${toggleID}" data-button="${buttonID}">
+          <div class="bar horizontal" data-button="${buttonID}"></div>
+          <div class="bar vertical" data-button="${buttonID}"></div>
+      </button>`;
+
+    item.setAttribute('id', toggleID);
+
+    if (!item.classList.contains("toggle")){
+      item.classList.add("toggle");
+    }
+
+    // If it's an admonition block, then we'll add the button inside
+    if (item.classList.contains("admonition")) {
+      item.insertAdjacentHTML("afterbegin", collapseButton);
+    } else {
+      item.insertAdjacentHTML('beforebegin', collapseButton);
+    }
+
+    thisButton = $(`#${buttonID}`);
+    thisButton.on('click', toggleClickHandler);
+    if (!item.classList.contains("toggle-shown")) {
+      toggleHidden(thisButton[0]);
+    }
+  })
+};
+
+// This should simply add / remove the collapsed class and change the button text
+var toggleHidden = (button) => {
+  target = button.dataset['target']
+  var itemToToggle = document.getElementById(target);
+  if (itemToToggle.classList.contains("toggle-hidden")) {
+    itemToToggle.classList.remove("toggle-hidden");
+    button.classList.remove("toggle-button-hidden");
+  } else {
+    itemToToggle.classList.add("toggle-hidden");
+    button.classList.add("toggle-button-hidden");
+  }
+}
+
+var toggleClickHandler = (click) => {
+  button = document.getElementById(click.target.dataset['button']);
+  toggleHidden(button);
+}
+
+// If we want to blanket-add toggle classes to certain cells
+var addToggleToSelector = () => {
+  const selector = "";
+  if (selector.length > 0) {
+    document.querySelectorAll(selector).forEach((item) => {
+      item.classList.add("toggle");
+    })
+  }
+}
+
+// Helper function to run when the DOM is finished
+const sphinxToggleRunWhenDOMLoaded = cb => {
+  if (document.readyState != 'loading') {
+    cb()
+  } else if (document.addEventListener) {
+    document.addEventListener('DOMContentLoaded', cb)
+  } else {
+    document.attachEvent('onreadystatechange', function() {
+      if (document.readyState == 'complete') cb()
+    })
+  }
+}
+sphinxToggleRunWhenDOMLoaded(addToggleToSelector)
+sphinxToggleRunWhenDOMLoaded(initToggleItems)

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -9,7 +9,7 @@ sys.path.append(os.path.abspath('_extensions'))
 
 # -- General configuration -----------------------------------------------------
 needs_sphinx = '1.8'
-extensions = ['sphinx.ext.mathjax', 'jinja', 'youtube', 'sphinx_panels']
+extensions = ['sphinx.ext.mathjax', 'jinja', 'youtube', 'sphinx_panels', 'sphinx_togglebutton']
 source_encoding = 'utf-8-sig'
 source_suffix = '.rst'
 master_doc = 'index'

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -679,7 +679,7 @@ MAP Parameters
 
         .. toggle::
 
-            Here is an example showing the apperance of different **MAP_FRAME_TYPE** settings.
+            Here is an example showing the appearance of different **MAP_FRAME_TYPE** settings.
 
             .. literalinclude:: /_verbatim/GMT_map_frame_type.txt
 
@@ -687,7 +687,7 @@ MAP Parameters
                :width: 100%
                :align: center
 
-               Apperance of different **MAP_FRAME_TYPE** settings
+               Appearance of different **MAP_FRAME_TYPE** settings
 
     **MAP_FRAME_WIDTH**
         Width (> 0) of map borders for fancy map frame [default is **5p**]. **Note**: For fancy

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -247,7 +247,7 @@ FORMAT Parameters
         coordinate is to be plotted. This template is then used to guide the
         plotting of geographical coordinates in data fields. See
         :term:`FORMAT_GEO_OUT` for details. In addition, you can append **A**
-        which plots the absolute value of the coordinate [default is **ddd:mm:ss**]. 
+        which plots the absolute value of the coordinate [default is **ddd:mm:ss**].
         Not all items may be plotted as this depends on the annotation interval.
 
     **FORMAT_GEO_OUT**
@@ -668,7 +668,7 @@ MAP Parameters
         geotiffs), chose **inside**.  Finally, for Cartesian plots you can
         also choose **graph**\ , which adds a vector to the end of each axis.
         This works best when you reduce the number of axes plotted to one
-        per dimension. By default, the vector tip extends the length of each axis by 7.5%. 
+        per dimension. By default, the vector tip extends the length of each axis by 7.5%.
         Alternatively, append ,\ *length*, where the optional *unit*
         may be **%** (then *length* is the alternate extension in percent) or one
         of **c**, **i**, or **p** (then *length* is the absolute extension
@@ -676,6 +676,18 @@ MAP Parameters
         is set to match :term:`MAP_FRAME_WIDTH`, while the vector
         head length and width are 10 and 5 times this width, respectively.  You
         may control its shape via :term:`MAP_VECTOR_SHAPE`.
+
+        .. toggle::
+
+            Here is an example showing the apperance of different **MAP_FRAME_TYPE** settings.
+
+            .. literalinclude:: /_verbatim/GMT_map_frame_type.txt
+
+            .. figure:: /_images/GMT_map_frame_type.*
+               :width: 100%
+               :align: center
+
+               Apperance of different **MAP_FRAME_TYPE** settings
 
     **MAP_FRAME_WIDTH**
         Width (> 0) of map borders for fancy map frame [default is **5p**]. **Note**: For fancy
@@ -921,8 +933,8 @@ Projection Parameters
     **PROJ_LENGTH_UNIT**
         Sets the default unit length. Choose between **c**\ m, **i**\ nch, or
         **p**\ oint [default is **c** *(or i)*].
-        **Note**: In GMT, one point is defined as 1/72 inch (the PostScript definition), 
-        while it is often defined as 1/72.27 inch in the typesetting industry. 
+        **Note**: In GMT, one point is defined as 1/72 inch (the PostScript definition),
+        while it is often defined as 1/72.27 inch in the typesetting industry.
         There is no universal definition.)
 
     **PROJ_MEAN_RADIUS**
@@ -933,7 +945,7 @@ Projection Parameters
 
     **PROJ_SCALE_FACTOR**
         Changes the default map scale factor used for the Polar
-        Stereographic [default is **0.9996**], UTM [default is **0.9996**], 
+        Stereographic [default is **0.9996**], UTM [default is **0.9996**],
         and Transverse Mercator [default is **1**]
         projections in order to minimize areal distortion. Provide a new
         scale-factor or leave as default.
@@ -951,8 +963,8 @@ PostScript Parameters
         that the PostScript output generates the correct characters on the
         plot. Choose from **Standard**, **Standard+**, **ISOLatin1**, **ISOLatin1+**, and
         **ISO-8859-x** (where *x* is in the ranges 1-11 or 13-16). See
-        Appendix F for details [default is **ISOLatin1+** *(or Standard+)*].  
-        **Note**: Normally the character set is written as part of the PostScript header.  
+        Appendix F for details [default is **ISOLatin1+** *(or Standard+)*].
+        **Note**: Normally the character set is written as part of the PostScript header.
         If you need to switch to another character set for a later overlay then
         you must use **--PS_CHAR_ENCODING**\ =\ *encoding* on the command line and
         not via gmt :doc:`/gmtset`.  Finally, note 6, 8, and 11 do not work with standard fonts.
@@ -1080,7 +1092,7 @@ Calendar/Time Parameters
         Specifies the value of the calendar and clock at the origin (zero
         point) of relative time units (see :term:`TIME_UNIT`). It is a string
         of the form **yyyy-mm-ddT[hh:mm:ss]** (Gregorian) or
-        **yyyy-Www-ddT[hh:mm:ss]** (ISO) [default is **1970-01-01T00:00:00** 
+        **yyyy-Www-ddT[hh:mm:ss]** (ISO) [default is **1970-01-01T00:00:00**
         *(the origin of the UNIX time epoch*)].
 
     **TIME_INTERVAL_FRACTION**
@@ -1100,8 +1112,8 @@ Calendar/Time Parameters
         truncate to previous whole number of *n* units and then center time
         on the following interval. (3) **-n**\ *unit*. Same, but center time on
         the previous interval [default is **off**].
-        For example, with **TIME_IS_INTERVAL** =+1o, an input data string 
-        like 1999-12 will be interpreted to mean 1999-12-15T12:00:00.0 (exactly middle of December), 
+        For example, with **TIME_IS_INTERVAL** =+1o, an input data string
+        like 1999-12 will be interpreted to mean 1999-12-15T12:00:00.0 (exactly middle of December),
         while if **TIME_IS_INTERVAL** = **off** then that date is interpreted to mean
         1999-12-01T00:00:00.0 (start of December).
 

--- a/doc/scripts/GMT_map_frame_type.ps
+++ b/doc/scripts/GMT_map_frame_type.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_02fd79e-dirty_2021.03.06 [64-bit] Document from plot
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_6426c3a_2021.03.07 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Mar  7 15:33:24 2021
+%%CreationDate: Sun Mar  7 16:18:44 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -686,10 +686,10 @@ end
 %%EndSetup
 %%Page: 1 1
 %%BeginPageSetup
-V 595 0 T 90 R 0.06 0.06 scale
+V 612 0 T 90 R 0.06 0.06 scale
 %%EndPageSetup
-/PSL_page_xsize 14033 def
-/PSL_page_ysize 9917 def
+/PSL_page_xsize 13200 def
+/PSL_page_ysize 10200 def
 /PSL_plot_completion {} def
 /PSL_movie_label_completion {} def
 /PSL_movie_prog_indicator_completion {} def

--- a/doc/scripts/GMT_map_frame_type.ps
+++ b/doc/scripts/GMT_map_frame_type.ps
@@ -1,0 +1,1348 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 595 842
+%%HiResBoundingBox: 0 0 595.0000 842.0000
+%%Title: GMT v6.2.0_02fd79e-dirty_2021.03.06 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Mar  7 15:33:24 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Landscape
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 595 0 T 90 R 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 14033 def
+/PSL_page_ysize 9917 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/9.61213/0/1.37795 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 9.61213000 0.00000000 1.37795000 0.000 9.612 0.000 1.378 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 1 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JM1.378i -Baf -BWSen+tfancy --MAP_FRAME_TYPE=fancy -Xa0i -Ya0i -R0/10/0/10
+%@PROJ: merc 0.00000000 10.00000000 0.00000000 10.00000000 -556597.454 556597.454 -0.000 1111475.103 +proj=merc +lon_0=5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 0 0 M 0 -83 D S
+N 0 1651 M 0 83 D S
+N 331 0 M 0 -83 D S
+N 331 1651 M 0 83 D S
+N 661 0 M 0 -83 D S
+N 661 1651 M 0 83 D S
+N 992 0 M 0 -83 D S
+N 992 1651 M 0 83 D S
+N 1323 0 M 0 -83 D S
+N 1323 1651 M 0 83 D S
+N 1654 0 M 0 -83 D S
+N 1654 1651 M 0 83 D S
+N 0 0 M -83 0 D S
+N 1654 0 M 83 0 D S
+N 0 329 M -83 0 D S
+N 1654 329 M 83 0 D S
+N 0 658 M -83 0 D S
+N 1654 658 M 83 0 D S
+N 0 987 M -83 0 D S
+N 1654 987 M 83 0 D S
+N 0 1318 M -83 0 D S
+N 1654 1318 M 83 0 D S
+N 0 1651 M -83 0 D S
+N 1654 1651 M 83 0 D S
+25 W
+83 W
+N -42 0 M 0 164 D S
+N 1695 0 M 0 164 D S
+1 A
+N -42 164 M 0 165 D S
+N 1695 164 M 0 165 D S
+0 A
+N -42 329 M 0 164 D S
+N 1695 329 M 0 164 D S
+1 A
+N -42 493 M 0 165 D S
+N 1695 493 M 0 165 D S
+0 A
+N -42 658 M 0 164 D S
+N 1695 658 M 0 164 D S
+1 A
+N -42 822 M 0 165 D S
+N 1695 822 M 0 165 D S
+0 A
+N -42 987 M 0 166 D S
+N 1695 987 M 0 166 D S
+1 A
+N -42 1153 M 0 165 D S
+N 1695 1153 M 0 165 D S
+0 A
+N -42 1318 M 0 166 D S
+N 1695 1318 M 0 166 D S
+1 A
+N -42 1484 M 0 167 D S
+N 1695 1484 M 0 167 D S
+0 A
+N 0 -42 M 165 0 D S
+N 0 1693 M 165 0 D S
+1 A
+N 165 -42 M 166 0 D S
+N 165 1693 M 166 0 D S
+0 A
+N 331 -42 M 165 0 D S
+N 331 1693 M 165 0 D S
+1 A
+N 496 -42 M 165 0 D S
+N 496 1693 M 165 0 D S
+0 A
+N 661 -42 M 166 0 D S
+N 661 1693 M 166 0 D S
+1 A
+N 827 -42 M 165 0 D S
+N 827 1693 M 165 0 D S
+0 A
+N 992 -42 M 166 0 D S
+N 992 1693 M 166 0 D S
+1 A
+N 1158 -42 M 165 0 D S
+N 1158 1693 M 165 0 D S
+0 A
+N 1323 -42 M 165 0 D S
+N 1323 1693 M 165 0 D S
+1 A
+N 1488 -42 M 166 0 D S
+N 1488 1693 M 166 0 D S
+0 A
+8 W
+N -83 0 M 1820 0 D S
+N -83 -83 M 1820 0 D S
+N 1654 -83 M 0 1817 D S
+N 1737 -83 M 0 1817 D S
+N 1737 1651 M -1820 0 D S
+N 1737 1734 M -1820 0 D S
+N 0 1734 M 0 -1817 D S
+N -83 1734 M 0 -1817 D S
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(100°) sh add def
+827 1651 PSL_H_y add M
+300 F0
+(fancy) bc Z
+0 -167 M 200 F0
+(0°) tc Z
+331 -167 M (2°) tc Z
+661 -167 M (4°) tc Z
+992 -167 M (6°) tc Z
+1323 -167 M (8°) tc Z
+1654 -167 M (10°) tc Z
+-167 0 M (0°) mr Z
+-167 329 M (2°) mr Z
+-167 658 M (4°) mr Z
+-167 987 M (6°) mr Z
+-167 1318 M (8°) mr Z
+-167 1651 M (10°) mr Z
+0 A
+%%EndObject
+0 -1 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+2470 1 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JM1.378i -Baf -BWSen+tfancy+ --MAP_FRAME_TYPE=fancy+ -Xa2.0585i -Ya0i -R0/10/0/10
+%@PROJ: merc 0.00000000 10.00000000 0.00000000 10.00000000 -556597.454 556597.454 -0.000 1111475.103 +proj=merc +lon_0=5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 0 0 M 0 -83 D S
+N 0 1651 M 0 83 D S
+N 331 0 M 0 -83 D S
+N 331 1651 M 0 83 D S
+N 661 0 M 0 -83 D S
+N 661 1651 M 0 83 D S
+N 992 0 M 0 -83 D S
+N 992 1651 M 0 83 D S
+N 1323 0 M 0 -83 D S
+N 1323 1651 M 0 83 D S
+N 1654 0 M 0 -83 D S
+N 1654 1651 M 0 83 D S
+N 0 0 M -83 0 D S
+N 1654 0 M 83 0 D S
+N 0 329 M -83 0 D S
+N 1654 329 M 83 0 D S
+N 0 658 M -83 0 D S
+N 1654 658 M 83 0 D S
+N 0 987 M -83 0 D S
+N 1654 987 M 83 0 D S
+N 0 1318 M -83 0 D S
+N 1654 1318 M 83 0 D S
+N 0 1651 M -83 0 D S
+N 1654 1651 M 83 0 D S
+25 W
+83 W
+N -42 0 M 0 164 D S
+N 1695 0 M 0 164 D S
+1 A
+N -42 164 M 0 165 D S
+N 1695 164 M 0 165 D S
+0 A
+N -42 329 M 0 164 D S
+N 1695 329 M 0 164 D S
+1 A
+N -42 493 M 0 165 D S
+N 1695 493 M 0 165 D S
+0 A
+N -42 658 M 0 164 D S
+N 1695 658 M 0 164 D S
+1 A
+N -42 822 M 0 165 D S
+N 1695 822 M 0 165 D S
+0 A
+N -42 987 M 0 166 D S
+N 1695 987 M 0 166 D S
+1 A
+N -42 1153 M 0 165 D S
+N 1695 1153 M 0 165 D S
+0 A
+N -42 1318 M 0 166 D S
+N 1695 1318 M 0 166 D S
+1 A
+N -42 1484 M 0 167 D S
+N 1695 1484 M 0 167 D S
+0 A
+N 0 -42 M 165 0 D S
+N 0 1693 M 165 0 D S
+1 A
+N 165 -42 M 166 0 D S
+N 165 1693 M 166 0 D S
+0 A
+N 331 -42 M 165 0 D S
+N 331 1693 M 165 0 D S
+1 A
+N 496 -42 M 165 0 D S
+N 496 1693 M 165 0 D S
+0 A
+N 661 -42 M 166 0 D S
+N 661 1693 M 166 0 D S
+1 A
+N 827 -42 M 165 0 D S
+N 827 1693 M 165 0 D S
+0 A
+N 992 -42 M 166 0 D S
+N 992 1693 M 166 0 D S
+1 A
+N 1158 -42 M 165 0 D S
+N 1158 1693 M 165 0 D S
+0 A
+N 1323 -42 M 165 0 D S
+N 1323 1693 M 165 0 D S
+1 A
+N 1488 -42 M 166 0 D S
+N 1488 1693 M 166 0 D S
+0 A
+8 W
+N 0 0 M 1654 0 D S
+N 0 -83 M 1654 0 D S
+N 1654 0 M 0 1651 D S
+N 1737 0 M 0 1651 D S
+N 1654 1651 M -1654 0 D S
+N 1654 1734 M -1654 0 D S
+N 0 1651 M 0 -1651 D S
+N -83 1651 M 0 -1651 D S
+N 1654 0 83 270 360 arc S
+N 1654 1651 83 360 450 arc S
+N 0 1651 83 90 180 arc S
+N 0 0 83 180 270 arc S
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(100°) sh add def
+827 1651 PSL_H_y add M
+300 F0
+(fancy+) bc Z
+0 -167 M 200 F0
+(0°) tc Z
+331 -167 M (2°) tc Z
+661 -167 M (4°) tc Z
+992 -167 M (6°) tc Z
+1323 -167 M (8°) tc Z
+1654 -167 M (10°) tc Z
+-167 0 M (0°) mr Z
+-167 329 M (2°) mr Z
+-167 658 M (4°) mr Z
+-167 987 M (6°) mr Z
+-167 1318 M (8°) mr Z
+-167 1651 M (10°) mr Z
+0 A
+%%EndObject
+-2470 -1 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4941 1 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JM1.378i -Baf -BWSen+tplain --MAP_FRAME_TYPE=plain -Xa4.1171i -Ya0i -R0/10/0/10
+%@PROJ: merc 0.00000000 10.00000000 0.00000000 10.00000000 -556597.454 556597.454 -0.000 1111475.103 +proj=merc +lon_0=5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 0 0 M 0 -83 D S
+N 0 1651 M 0 83 D S
+N 331 0 M 0 -83 D S
+N 331 1651 M 0 83 D S
+N 661 0 M 0 -83 D S
+N 661 1651 M 0 83 D S
+N 992 0 M 0 -83 D S
+N 992 1651 M 0 83 D S
+N 1323 0 M 0 -83 D S
+N 1323 1651 M 0 83 D S
+N 1654 0 M 0 -83 D S
+N 1654 1651 M 0 83 D S
+N 0 0 M -83 0 D S
+N 1654 0 M 83 0 D S
+N 0 329 M -83 0 D S
+N 1654 329 M 83 0 D S
+N 0 658 M -83 0 D S
+N 1654 658 M 83 0 D S
+N 0 987 M -83 0 D S
+N 1654 987 M 83 0 D S
+N 0 1318 M -83 0 D S
+N 1654 1318 M 83 0 D S
+N 0 1651 M -83 0 D S
+N 1654 1651 M 83 0 D S
+N 0 0 M 0 -42 D S
+N 0 1651 M 0 42 D S
+N 165 0 M 0 -42 D S
+N 165 1651 M 0 42 D S
+N 331 0 M 0 -42 D S
+N 331 1651 M 0 42 D S
+N 496 0 M 0 -42 D S
+N 496 1651 M 0 42 D S
+N 661 0 M 0 -42 D S
+N 661 1651 M 0 42 D S
+N 827 0 M 0 -42 D S
+N 827 1651 M 0 42 D S
+N 992 0 M 0 -42 D S
+N 992 1651 M 0 42 D S
+N 1158 0 M 0 -42 D S
+N 1158 1651 M 0 42 D S
+N 1323 0 M 0 -42 D S
+N 1323 1651 M 0 42 D S
+N 1488 0 M 0 -42 D S
+N 1488 1651 M 0 42 D S
+N 1654 0 M 0 -42 D S
+N 1654 1651 M 0 42 D S
+N 0 0 M -42 0 D S
+N 1654 0 M 41 0 D S
+N 0 164 M -42 0 D S
+N 1654 164 M 41 0 D S
+N 0 329 M -42 0 D S
+N 1654 329 M 41 0 D S
+N 0 493 M -42 0 D S
+N 1654 493 M 41 0 D S
+N 0 658 M -42 0 D S
+N 1654 658 M 41 0 D S
+N 0 822 M -42 0 D S
+N 1654 822 M 41 0 D S
+N 0 987 M -42 0 D S
+N 1654 987 M 41 0 D S
+N 0 1153 M -42 0 D S
+N 1654 1153 M 41 0 D S
+N 0 1318 M -42 0 D S
+N 1654 1318 M 41 0 D S
+N 0 1484 M -42 0 D S
+N 1654 1484 M 41 0 D S
+N 0 1651 M -42 0 D S
+N 1654 1651 M 41 0 D S
+25 W
+0 0 M
+1654 0 D
+0 1651 D
+-414 0 D
+-413 0 D
+-414 0 D
+-413 0 D
+0 -1651 D
+P S
+/PSL_H_y 400 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(100°) sh add def
+827 1651 PSL_H_y add M
+300 F0
+(plain) bc Z
+0 -167 M 200 F0
+(0°) tc Z
+331 -167 M (2°) tc Z
+661 -167 M (4°) tc Z
+992 -167 M (6°) tc Z
+1323 -167 M (8°) tc Z
+1654 -167 M (10°) tc Z
+-167 0 M (0°) mr Z
+-167 329 M (2°) mr Z
+-167 658 M (4°) mr Z
+-167 987 M (6°) mr Z
+-167 1318 M (8°) mr Z
+-167 1651 M (10°) mr Z
+0 A
+%%EndObject
+-4941 -1 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+7411 0 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JX1.378i -Baf -BWSen+tinside --MAP_FRAME_TYPE=inside -Xa6.1756i -Ya0i -R0/10/0/10
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1654 M 0 -1654 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 331 M 83 0 D S
+N 0 661 M 83 0 D S
+N 0 992 M 83 0 D S
+N 0 1323 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+331 PSL_A0_y MM
+(2) mr Z
+661 PSL_A0_y MM
+(4) mr Z
+992 PSL_A0_y MM
+(6) mr Z
+1323 PSL_A0_y MM
+(8) mr Z
+N 0 165 M 42 0 D S
+N 0 496 M 42 0 D S
+N 0 827 M 42 0 D S
+N 0 1158 M 42 0 D S
+N 0 1488 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+1654 0 T
+25 W
+N 0 1654 M 0 -1654 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 331 M -83 0 D S
+N 0 661 M -83 0 D S
+N 0 992 M -83 0 D S
+N 0 1323 M -83 0 D S
+N 0 165 M -42 0 D S
+N 0 496 M -42 0 D S
+N 0 827 M -42 0 D S
+N 0 1158 M -42 0 D S
+N 0 1488 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-1654 0 T
+25 W
+N 0 0 M 1654 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 331 0 M 0 83 D S
+N 661 0 M 0 83 D S
+N 992 0 M 0 83 D S
+N 1323 0 M 0 83 D S
+/MM {M} def
+/PSL_AH0 0
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+331 PSL_A0_y MM
+(2) bc Z
+661 PSL_A0_y MM
+(4) bc Z
+992 PSL_A0_y MM
+(6) bc Z
+1323 PSL_A0_y MM
+(8) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 165 0 M 0 42 D S
+N 496 0 M 0 42 D S
+N 827 0 M 0 42 D S
+N 1158 0 M 0 42 D S
+N 1488 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1654 T
+25 W
+N 0 0 M 1654 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 331 0 M 0 -83 D S
+N 661 0 M 0 -83 D S
+N 992 0 M 0 -83 D S
+N 1323 0 M 0 -83 D S
+N 165 0 M 0 -42 D S
+N 496 0 M 0 -42 D S
+N 827 0 M 0 -42 D S
+N 1158 0 M 0 -42 D S
+N 1488 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1654 T
+0 setlinecap
+/PSL_H_y 233 def
+827 1654 PSL_H_y add PSL_slant_y add M
+300 F0
+(inside) bc Z
+0 A
+%%EndObject
+-7411 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+9881 0 TM
+% PostScript produced by:
+%@GMT: gmt basemap -JX1.378i -Baf -BWS+tgraph --MAP_FRAME_TYPE=graph -Xa8.2342i -Ya0i -R0/10/0/10
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1654 M 0 -1654 D S
+{0 A} FS
+O0
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+V 0 1654 T 90 R
+U
+V 0 1778 T 90 R
+PSL_vecheadpen
+25 W
+0 0 M
+-250 62 D
+0 -124 D
+P clip fs N 
+U
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 331 M -83 0 D S
+N 0 661 M -83 0 D S
+N 0 992 M -83 0 D S
+N 0 1323 M -83 0 D S
+N 0 1654 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+(10) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+331 PSL_A0_y MM
+(2) mr Z
+661 PSL_A0_y MM
+(4) mr Z
+992 PSL_A0_y MM
+(6) mr Z
+1323 PSL_A0_y MM
+(8) mr Z
+1654 PSL_A0_y MM
+(10) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 165 M -42 0 D S
+N 0 496 M -42 0 D S
+N 0 827 M -42 0 D S
+N 0 1158 M -42 0 D S
+N 0 1488 M -42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+25 W
+N 0 0 M 1654 0 D S
+/PSL_vecheadpen {25 W 0 A [] 0 B} def
+V 1654 0 T U
+V 1778 0 T PSL_vecheadpen
+25 W
+0 0 M
+-250 62 D
+0 -124 D
+P clip fs N 
+U
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 331 0 M 0 -83 D S
+N 661 0 M 0 -83 D S
+N 992 0 M 0 -83 D S
+N 1323 0 M 0 -83 D S
+N 1654 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+331 PSL_A0_y MM
+(2) bc Z
+661 PSL_A0_y MM
+(4) bc Z
+992 PSL_A0_y MM
+(6) bc Z
+1323 PSL_A0_y MM
+(8) bc Z
+1654 PSL_A0_y MM
+(10) bc Z
+N 165 0 M 0 -42 D S
+N 496 0 M 0 -42 D S
+N 827 0 M 0 -42 D S
+N 1158 0 M 0 -42 D S
+N 1488 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+/PSL_H_y 233 def
+827 1654 PSL_H_y add PSL_slant_y add M
+300 F0
+(graph) bc Z
+0 A
+%%EndObject
+-9881 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/doc/scripts/GMT_map_frame_type.sh
+++ b/doc/scripts/GMT_map_frame_type.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-gmt begin GMT_map_frame_type ps
+gmt begin GMT_map_frame_type
   gmt set FONT_TITLE 18p
   gmt subplot begin 1x5 -Fs3.5c/3.5c -M0.2c -R0/10/0/10
     gmt basemap -JM? -Baf -BWSen+t"fancy" -c --MAP_FRAME_TYPE=fancy

--- a/doc/scripts/GMT_map_frame_type.sh
+++ b/doc/scripts/GMT_map_frame_type.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+gmt begin GMT_map_frame_type ps
+  gmt set FONT_TITLE 18p
+  gmt subplot begin 1x5 -Fs3.5c/3.5c -M0.2c -R0/10/0/10
+    gmt basemap -JM? -Baf -BWSen+t"fancy" -c --MAP_FRAME_TYPE=fancy
+    gmt basemap -JM? -Baf -BWSen+t"fancy+" -c --MAP_FRAME_TYPE=fancy+
+    gmt basemap -JM? -Baf -BWSen+t"plain" -c --MAP_FRAME_TYPE=plain
+    gmt basemap -JX? -Baf -BWSen+t"inside" -c --MAP_FRAME_TYPE=inside
+    gmt basemap -JX? -Baf -BWS+t"graph" -c --MAP_FRAME_TYPE=graph
+  gmt subplot end
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the [`sphinx-togglebutton`](https://sphinx-togglebutton.readthedocs.io/en/latest/) extension (~20 KB) to the repository, and also an example figure for MAP_FRAME_TYPE showing how the togglebutton works.

**Preview link:** https://gmt-p0akp8sm5-gmt.vercel.app/gmt.conf.html#term-MAP_FRAME_TYPE

It shows a toggle button on the right:

![image](https://user-images.githubusercontent.com/3974108/110254726-51be2000-7f5e-11eb-8c26-429969dc93ad.png)

Click the button, and you will see:

![image](https://user-images.githubusercontent.com/3974108/110254747-68fd0d80-7f5e-11eb-9e55-391c3999707c.png)


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
