### PR TITLE
CI: Exclude the link to Google KML icons from Link Checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -26,6 +26,7 @@ jobs:
           --exclude "^ftp://"
           --exclude "^https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$"
           --exclude "^https://download1.rpmfusion.org/free/el/rpmfusion-free-release-$"
+          --exclude "^http://maps.google.com/mapfiles/kml/$"
           --exclude "^-W@weight.png$"
           --verbose
           "**/*.rst"

--- a/doc/rst/source/gmt2kml.rst
+++ b/doc/rst/source/gmt2kml.rst
@@ -148,8 +148,7 @@ Optional Arguments
 **-I**\ *icon*
     Specify the URL to an alternative icon that should be used for the
     symbol [Default is a Google Earth circle]. If the URL starts with +
-    then we will prepend
-    `http://maps.google.com/mapfiles/kml/ <http://maps.google.com/mapfiles/kml/>`_
+    then we will prepend ``http://maps.google.com/mapfiles/kml/``
     to the name. To turn off icons entirely (e.g., when just wanting a
     text label), use **-I**-. [Default is a local icon with no directory path].
 


### PR DESCRIPTION
**Description of proposed changes**

The links to Google KML icons like http://maps.google.com/mapfiles/kml/pal4/icon57.png
is valid, but the link http://maps.google.com/mapfiles/kml is not.

This PR changes the link http://maps.google.com/mapfiles/kml to a code
block, and also exclude the link from weekly link checkers.

Address #4929 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
