### PR TITLE
Add autosectionlabel sphinx extension and rename duplicate headers

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -9,7 +9,7 @@ sys.path.append(os.path.abspath('_extensions'))
 
 # -- General configuration -----------------------------------------------------
 needs_sphinx = '1.8'
-extensions = ['sphinx.ext.mathjax', 'jinja', 'youtube', 'sphinx_panels', 'sphinx_togglebutton', 'sphinx_copybutton']
+extensions = ['sphinx.ext.mathjax', 'sphinx.ext.autosectionlabel', 'jinja', 'youtube', 'sphinx_panels', 'sphinx_togglebutton', 'sphinx_copybutton']
 source_encoding = 'utf-8-sig'
 source_suffix = '.rst'
 master_doc = 'index'
@@ -20,6 +20,8 @@ smartquotes_action = 'qe'
 # default language to highlight source code
 highlight_language = 'bash'
 pygments_style = 'sphinx'
+autosectionlabel_prefix_document = True
+autosectionlabel_maxdepth = 2
 
 # Disable sphinx_panels extension for manpage build
 if tags.has("nosphinxpanels"):

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -21,7 +21,6 @@ smartquotes_action = 'qe'
 highlight_language = 'bash'
 pygments_style = 'sphinx'
 autosectionlabel_prefix_document = True
-autosectionlabel_maxdepth = 2
 
 # Disable sphinx_panels extension for manpage build
 if tags.has("nosphinxpanels"):

--- a/doc/rst/source/basemap.rst
+++ b/doc/rst/source/basemap.rst
@@ -203,8 +203,8 @@ Another basemap for middle Europe may be created by
 
     gmt basemap -R0/90/25/55 -Jl45/20/32/45/0.1i -Bafg -B+t"Lambert Conformal Conic" -pdf lambertc
 
-Equidistant
-~~~~~~~~~~~
+Conic Equidistant
+~~~~~~~~~~~~~~~~~
 
 Yet another basemap of width 6 inch for middle Europe may be created by
 
@@ -238,8 +238,8 @@ Follow the instructions for stereographic projection if you want to
 impose rectangular boundaries on the azimuthal equal-area map but
 substitute |-J|\ **a** for |-J|\ **s**.
 
-Equidistant
-~~~~~~~~~~~
+Azimuthal Equidistant
+~~~~~~~~~~~~~~~~~~~~~
 
 A 15-cm-wide global map in which distances from the center (here 125/10)
 to any point is true can be obtained by:

--- a/doc/rst/source/basemap_common.rst_
+++ b/doc/rst/source/basemap_common.rst_
@@ -48,8 +48,8 @@ Optional Arguments
     or map rose (|-T|) using :term:`MAP_FRAME_PEN`. Used in combination with |-D|, |-L| or |-T|.  Append **d** for map
     inset, **l** for map scale, or **t** for map rose to specify which plot embellisment the |-F| parameters should be
     applied to [default uses the same panel parameters for all selected map embellishments]. The following modifiers can
-    be appended to |-F|, with additional explanation and examples provided in the :ref:`Background-panel` cookbook
-    section:
+    be appended to |-F|, with additional explanation and examples provided in the
+    :ref:`cookbook/features:The background panel` cookbook section:
 
     .. include:: explain_-F_box.rst_
 

--- a/doc/rst/source/changes.rst
+++ b/doc/rst/source/changes.rst
@@ -38,22 +38,22 @@ changes, we mention
  #. Allow both **-i** and **-o** to specify an open-ended list of columns to end of record.
  #. API improvements to support the GMT/MEX, PyGMT, and GMT.jl environments.
 
-New Common Options:
--------------------
+New Common Options in GMT 6.1:
+------------------------------
  #. **-l**: Add automatic legend entries from the modules :doc:`plot`, :doc:`plot3d`, 
     :doc:`grdcontour` and :doc:`pscontour` in modern mode.
  #. **-q**\[**i**\|\ **o**\ ]: Select specific data rows to complement selection of data columns (via **-i**, **-o**).
 
-New Modules:
-------------
+New Modules in GMT 6.1:
+-----------------------
 
 #. :doc:`batch`: Automate batch job processing by replicating a master script with job-specific parameters.
 #. :doc:`grdmix`: Blending and transforming grids and images, including manipulating transparency.
 #. :doc:`grdinterpolate`: Interpolate new 2-D grids or 1-D data series from a 3-D data cube.
 #. :doc:`grdgdal`: Execute GDAL raster programs (such as info, dem, grid, translate, rasterize or warp), from GMT.
 
-New Core Module Features:
--------------------------
+New Core Module Features in GMT 6.1:
+------------------------------------
 
 #. :doc:`begin`: Ignore the user's *gmt.conf* files normally included by using **-C**.
 #. :doc:`colorbar`: Option **-S** has been enhanced to handle bar appearance when **-B** is not used.
@@ -87,8 +87,8 @@ New Core Module Features:
 #. :doc:`sample1d`: Adds a smoothing cubic spline via **-Fs**\ *p* (for a fit parameter *p*), with optional weights (**-W**).
 #. :doc:`surface`: Let **-D** take a modifier **+z**\ *value* to set a constant breakline level.
 
-Supplement updates:
--------------------
+Supplement updates in GMT 6.1:
+------------------------------
 #. *seis*: Update all module syntax to GMT 6 standards and make their i/o more robust.
 #. *potential*: :doc:`grdflexure </supplements/potential/grdflexure>` adds new transfer functions now documented with equations.
 
@@ -113,8 +113,8 @@ there are numerous changes:
 #. The default mode remains *classic*, the only mode previously available.  All
    existing classic mode GMT 4 and 5 scripts will run as before.
 
-Modern mode modules
--------------------
+Modern mode modules in GMT 6.0
+------------------------------
 
 GMT modern mode is supported by five new commands:
 
@@ -137,16 +137,16 @@ The entire cookbook, tutorial and gallery examples all use modern mode. In moder
 the default graphics format is PDF and scripts can open up the plots in the default
 viewer automatically.
 
-New modules
------------
+New modules in GMT 6.0
+----------------------
 
 Apart from modern mode we have added a few modules that are accessible to all users:
 
 #. :doc:`events` makes a snapshot of all time-dependent events.
 #. :doc:`/supplements/geodesy/earthtide` (supplement) computes the solid Earth tides.
 
-General improvements
---------------------
+General improvements in GMT 6.0
+-------------------------------
 
 While our focus has been almost exclusively on GMT modern mode, there is a
 range of new capabilities have been added to all of GMT; here is a
@@ -211,8 +211,8 @@ summary of these changes:
    options **-Re** and **-Ra** will examine the data files given and determine the exact or approximate region,
    respectively.
 
-Module enhancements
--------------------
+Module enhancements in GMT 6.0
+------------------------------
 
 Several modules have obtained new options to extend their capabilities:
 
@@ -324,8 +324,8 @@ to standardize GMT non-common option usage across the suite.
 Nevertheless, there have been many user-level enhancements as well.
 Here is a summary of these changes in three key areas:
 
-New modules
------------
+New modules in GMT 5.4
+----------------------
 
 We have added a new module to the GMT core called
 :doc:`ternary`.
@@ -335,8 +335,8 @@ The *mgd77* supplement has gained a new tool :doc:`mgd77header <supplements/mgd7
 for creating a valid MGD77-format header from basic metadata and information
 determined from the header-less data file.
 
-General improvements
---------------------
+General improvements in GMT 5.4
+-------------------------------
 
 A range of new capabilities have been added to all of GMT; here is a
 summary of these changes:
@@ -421,8 +421,8 @@ summary of these changes:
    will now get the old-style symbol.  The new and superior vector symbols
    will require the use of the new (and standard) syntax.
 
-Module enhancements
--------------------
+Module enhancements in GMT 5.4
+------------------------------
 
 Several modules have obtained new options to extend their capabilities:
 
@@ -491,8 +491,8 @@ Several modules have obtained new options to extend their capabilities:
    groups of jobs across many cores, packaging KMLs into a single KMZ archive,
    and more.
 
-API changes
------------
+API changes in GMT 5.4
+----------------------
 
 We have introduced one change that breaks backwards compatibility for users of
 the API functions.  We don't do this lightly but given the API is still considered
@@ -566,8 +566,8 @@ we are building toward MATLAB and Python.  Nevertheless, there have
 been many user-level enhancements as well.
 Here is a summary of these changes in three key areas:
 
-New modules
------------
+New modules in GMT 5.3
+----------------------
 
 We have added a new module to the GMT core called
 :doc:`solar`.
@@ -588,8 +588,8 @@ to the *potential* supplement.  This tool is a Green's function gridding module
 that grids vector data assumed to be coupled via an elastic model.  The prime
 usage is for gridding GPS velocity components.
 
-General improvements
---------------------
+General improvements in GMT 5.3
+-------------------------------
 
 There are many changes to GMT, mostly under the hood, but also changes that
 affect users directly.  We have added four new examples and one new animation
@@ -730,8 +730,8 @@ only added to the 5.2-series.  All in all, almost 200 new features (a combinatio
 of new programs, new options, and enhancements) have been implemented.
 Here is a summary of these changes in six key areas:
 
-New modules
------------
+New modules in GMT 5.2
+----------------------
 
 There are two new modules in the core system:
 
@@ -776,8 +776,8 @@ Finally, we have renamed our PostScript Light (PSL) library from psl
 to PostScriptLight to avoid package name conflicts.  This library will eventually
 become decoupled from GMT and end up as a required prerequisite.
 
-New common options
-------------------
+New common options in GMT 5.2
+-----------------------------
 
 We have added two new lower-case GMT common options:
 
@@ -798,8 +798,8 @@ We have added two new lower-case GMT common options:
    supplement's :doc:`x2sys_solve <supplements/x2sys/x2sys_solve>`.
    This list will grow longer with time.
 
-New default parameters
-----------------------
+New default parameters in GMT 5.2
+---------------------------------
 
 There have been a few changes to the GMT Defaults parameters.  All changes
 are backwards compatible:
@@ -825,8 +825,8 @@ are backwards compatible:
 
 *  :term:`TIME_REPORT` now has defaults for absolute or elapsed time stamps.
 
-Updated common options
-----------------------
+Updated common options in GMT 5.2
+---------------------------------
 
 Two of the established GMT common options have seen minor improvements:
 
@@ -841,8 +841,8 @@ Two of the established GMT common options have seen minor improvements:
    dimensions (requires **-I** to use the increments).  The optional justification
    keys specify how the reference point relate to the grid region.
 
-General improvements
---------------------
+General improvements in GMT 5.2
+-------------------------------
 
 Several changes have affects across GMT; these are:
 
@@ -888,8 +888,8 @@ Several changes have affects across GMT; these are:
    means the desired code will be given as last item on each data record.  Such custom
    symbols must be specified with uppercase **-SK**.
 
-Program-specific improvements
------------------------------
+Program-specific improvements in GMT 5.2
+----------------------------------------
 
 Finally, here is a list of enhancements to individual modules.  Any
 changes to existing syntax will be backwards compatible:
@@ -1104,8 +1104,8 @@ switches (you will receive a warning instead).  This is discussed below.
 
 Below are six key areas of improvements in GMT 5.
 
-New programs
-------------
+New programs in GMT 5
+---------------------
 
 First, a few new programs have been added and some have been
 promoted (and possibly renamed) from earlier supplements:
@@ -1200,8 +1200,8 @@ Finally, the spotter supplement has added one new module:
 :doc:`grdpmodeler <supplements/spotter/grdpmodeler>`:
     Evaluate a plate model on a geographic grid.
 
-New common options
-------------------
+New common options in GMT 5
+---------------------------
 
 First we discuss changes that have been
 implemented by a series of new lower-case GMT common options:
@@ -1240,8 +1240,8 @@ implemented by a series of new lower-case GMT common options:
    transparency level for that layer. However, as PostScript has no provision for
    transparency you can only see the effect if you convert it to PDF.
 
-Updated common options
-----------------------
+Updated common options in GMT 5
+-------------------------------
 
 Some of the established GMT common options have seen significant
 improvements; these include:
@@ -1264,8 +1264,8 @@ While just giving - (the hyphen) as argument presents just the synopsis of the c
 line arguments, we now also support giving + which in addition will list
 the explanations for all options that are not among the GMT common set.
 
-New default parameters
-----------------------
+New default parameters in GMT 5
+-------------------------------
 
 Most of the GMT default parameters have changed names in order to
 group parameters into logical groups and to use more consistent naming.
@@ -1322,8 +1322,8 @@ Among these are:
 *  *DIR_TMP*: was supposed to indicate the directory in which to store temporary files. But needs to be known without
    gmt.conf file as well. So the environment variable **$GMT_TMPDIR** is used instead.
 
-General improvements
---------------------
+General improvements in GMT 5
+-----------------------------
 
 Other wide-ranging changes have been implemented in different
 ways, such as
@@ -1373,8 +1373,8 @@ ways, such as
 
 *  GMT now ships with 36 standard color palette tables (CPT), up from 24.
 
-Program-specific improvements
------------------------------
+Program-specific improvements in GMT 5
+--------------------------------------
 
 Finally, here is a list of numerous enhancements to individual programs:
 

--- a/doc/rst/source/cookbook/coordinate-transformations.rst
+++ b/doc/rst/source/cookbook/coordinate-transformations.rst
@@ -6,9 +6,9 @@ on a plot. This is achieved by selecting one of several coordinate
 transformations or projections. We distinguish between three sets of
 such conversions:
 
--  Cartesian coordinate transformations
+-  :ref:`cookbook/coordinate-transformations:Cartesian coordinate transformations`
 
--  Polar coordinate transformations
+-  :ref:`cookbook/coordinate-transformations:Polar coordinate transformations`
 
 -  Map coordinate transformations
 
@@ -24,8 +24,8 @@ Finally, note that while we will specify dimensions in inches (by
 appending **i**), you may want to use cm (**c**), or points (**p**) as
 unit instead (see the :doc:`/gmt.conf` man page).
 
-Cartesian transformations
--------------------------
+Cartesian coordinate transformations
+--------------------------------------------------------------------------------
 
 GMT Cartesian coordinate transformations come in three flavors:
 
@@ -228,7 +228,7 @@ transformation <GMT_pow>`)
 
 .. literalinclude:: /_verbatim/GMT_pow.txt
 
-Linear projection with polar coordinates (**-Jp** **-JP**) :ref:`... <-Jp_full>`
+Polar coordinate transformations
 --------------------------------------------------------------------------------
 
 .. _GMT_polar:

--- a/doc/rst/source/datasets/earth-age.rst_
+++ b/doc/rst/source/datasets/earth-age.rst_
@@ -13,8 +13,8 @@ the seafloor crustal age. `EarthByte <https://www.earthbyte.org/>`_ has pioneere
 the creation of crustal age grids since 1997 and we offer their latest version for
 remote use in GMT.
 
-Usage
-~~~~~
+Usage - Global Earth Seafloor Crustal Age Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You access a global crustal age grid by specifying the special name
 
@@ -45,8 +45,8 @@ All of these data will, when downloaded, be placed in your ~/.gmt/server directo
 the earth_age files being placed in an ``earth/earth_age`` sub-directory. If you do not
 specify a CPT, the default CPT for this data set will be used (*@age_chrons_GTS2012_2020.cpt*)
 
-Technical Information
-~~~~~~~~~~~~~~~~~~~~~
+Technical Information - Global Earth Seafloor Crustal Age Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We scale and reformat the original data to take up very little space so that downloads
 from the servers are as fast as possible.  For the seafloor crustal age grid this means
@@ -55,7 +55,7 @@ model.  Data are scaled and shifted to fit in a short integer grid that is highl
 by netCDF lossless compression and chunking.  The data are reported in Myr relative
 to the 2012 Geological Time Scale.
 
-Data References
-~~~~~~~~~~~~~~~
+Data References - Global Earth Seafloor Crustal Age Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. Seton et al., 2020: http://dx.doi.org/10.1029/2020GC009214].

--- a/doc/rst/source/datasets/earth-daynight.rst_
+++ b/doc/rst/source/datasets/earth-daynight.rst_
@@ -17,8 +17,8 @@ These images may be plotted with :doc:`/grdimage` or :doc:`/grdview` and manipul
 by :doc:`/grdmix`.  The above example mixes both images according to a day-night
 mask and adds illumination from a corresponding Earth DEM.
 
-Usage
-~~~~~
+Usage - Global Earth Day/Night Images
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You access a global daytime image by specifying the special names
 
@@ -53,8 +53,8 @@ Code Dimensions        Size     Description
 All of these images will, when downloaded, be placed in your ~/.gmt/server director under
 the ``earth/earth_day`` and ``earth/earth_night`` sub-directories.
 
-Technical Information
-~~~~~~~~~~~~~~~~~~~~~
+Technical Information - Global Earth Day/Night Images
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The 01m and lower resolution images are derivatives of NASA's Blue and Black marble image mosaics.
 We have downsampled them via Cartesian Gaussian filtering to prevent aliasing while preserving
@@ -65,8 +65,8 @@ to the geotiff files on the remote server. **Note**: This data set is experiment
 format and delivery is likely to change in the future (e.g., via image tiles).  To make the
 files as small as possible we have also downgraded them from 24-bit to 8-bit indexed images.
 
-Data References
-~~~~~~~~~~~~~~~
+Data References - Global Earth Day/Night Images
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. Blue Marble [https://visibleearth.nasa.gov/images/57752/blue-marble-land-surface-shallow-water-and-shaded-topography].
 #. Black Marble: [https://earthobservatory.nasa.gov/features/NightLights/page3.php].

--- a/doc/rst/source/datasets/earth-masks.rst_
+++ b/doc/rst/source/datasets/earth-masks.rst_
@@ -17,8 +17,8 @@ via :doc:`/grdlandmask` but they can take a long time to compute for large regio
 the full GSHHG resolution, and small grid spacings. For these reasons we offer
 precalculated mask grids via the remote server mechanism.
 
-Usage
-~~~~~
+Usage - Global Earth Mask Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You access a global mask grid by specifying the special name
 
@@ -50,8 +50,8 @@ Code Dimensions        Reg Size     Description
 All of these data will, when downloaded, be placed in your ~/.gmt/server directory, with
 the Earth mask files being placed in an ``earth/earth_mask`` sub-directory.
 
-Technical Information
-~~~~~~~~~~~~~~~~~~~~~
+Technical Information - Global Earth Mask Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given that GSHHG contains 5 levels (ocean, land, lake, island-in-lake, pond-in-island-in-lake)
 corresponding to levels 0-4, the mask grids were computed to reflect those 5 levels.  This

--- a/doc/rst/source/datasets/earth-relief.rst_
+++ b/doc/rst/source/datasets/earth-relief.rst_
@@ -11,8 +11,8 @@ Global Earth Relief Grids
    :align: center
    :scale: 40 %
 
-Usage
-~~~~~
+Usage - Global Earth Relief Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You access a global relief grid by specifying the special name
 
@@ -47,8 +47,8 @@ All of these data will, when downloaded, be placed in your ~/.gmt/server directo
 the earth_relief files being placed in an ``earth/earth_relief`` sub-directory.  If you
 do not specify a CPT then this dataset default to the GMT master *geo*.
 
-Technical Information
-~~~~~~~~~~~~~~~~~~~~~
+Technical Information - Global Earth Relief Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As you see, the 30s and lower resolutions are all derivatives of Scripps' SRTM15+V2.1 grid
 (Tozer et al., 2019).  We have downsampled it via Cartesian Gaussian filtering to prevent
@@ -62,8 +62,8 @@ you may use the special names @srtm_relief_03s or @srtm_relief_01s instead. Almo
 are available in both gridline- and pixel-registered formats except the original pixel-registered
 SRTM15+V2.1 (here called @earth_relief_15s) and the gridline-registered SRTM tiles.
 
-Data References
-~~~~~~~~~~~~~~~
+Data References - Global Earth Relief Grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. SRTM15+V2.1 [http://dx.doi.org/10.1029/2019EA000658].
 #. SRTMGL3 tiles: [https://lpdaac.usgs.gov/products/srtmgl3v003].

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -308,8 +308,8 @@ These options are only used in classic mode and are listed here just for referen
 
 .. include:: explain_-P_full.rst_
 
-See Also
---------
+More information sources
+-------------------------
 
 Look up the individual man pages for more details and full syntax. Run
 ``gmt --help`` to list all GMT programs and to show all installation

--- a/doc/rst/source/gmt2kml.rst
+++ b/doc/rst/source/gmt2kml.rst
@@ -388,6 +388,13 @@ switching between folders and documents.  The gmt_shell_scripts.sh
 contains function gmt_build_kmz that can assist in building a KMZ file
 from any number of KML files (and optionally images they may refer to).
 
+If you have made a series of KML files (which may depend on other items
+like local PNG images), you can consolidate these into a single KMZ file
+for saving space and for grouping related files together.  The bash function
+**gmt_build_kmz** in the :doc:`gmt_shell_functions.sh` can be used to
+do this.  You need to source gmt_shell_functions.sh first before you can
+use it.
+
 Kml Hierarchy
 -------------
 
@@ -457,16 +464,6 @@ Segment Information
 **-L**"*some label*\ " [also see **-N** discussion] and **-T**"*some
 text description*\ ". If present, these are parsed to supply name and
 description tags, respectively, for the current feature.
-
-Making KMZ files
-----------------
-
-If you have made a series of KML files (which may depend on other items
-like local PNG images), you can consolidate these into a single KMZ file
-for saving space and for grouping related files together.  The bash function
-**gmt_build_kmz** in the :doc:`gmt_shell_functions.sh` can be used to
-do this.  You need to source gmt_shell_functions.sh first before you can
-use it.
 
 See Also
 --------

--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -39,8 +39,8 @@ that leaves off the scale or width then we supply a scale or width to fill the i
 as possible, given the inset size and margins (if selected).
 
 
-Required Arguments
-------------------
+Required Arguments (begin mode)
+-------------------------------
 
 .. _-D:
 
@@ -60,8 +60,8 @@ Required Arguments
     if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
     Specify inset box attributes via the **-F** option [outline only].
 
-Optional Arguments
-------------------
+Optional Arguments (begin mode)
+-------------------------------
 
 .. _-F:
 
@@ -103,8 +103,8 @@ The **end** directive finalizes the current inset, which returns the plotting en
 the state prior to the start of the inset.  The previous region and map projection will be
 in effect going forward.
 
-Optional Arguments
-------------------
+Optional Arguments (end mode)
+-----------------------------
 
 .. _inset_end-V:
 

--- a/doc/rst/source/psbasemap.rst
+++ b/doc/rst/source/psbasemap.rst
@@ -222,8 +222,8 @@ Another basemap for middle Europe may be created by
 
     gmt psbasemap -R0/90/25/55 -Jl45/20/32/45/0.1i -Bafg -B+t"Lambert Conformal Conic" -P > lambertc.ps
 
-Equidistant
-~~~~~~~~~~~
+Conic Equidistant
+~~~~~~~~~~~~~~~~~
 
 Yet another basemap of width 6 inch for middle Europe may be created by
 
@@ -257,8 +257,8 @@ Follow the instructions for stereographic projection if you want to
 impose rectangular boundaries on the azimuthal equal-area map but
 substitute **-Ja** for **-Js**.
 
-Equidistant
-~~~~~~~~~~~
+Azimuthal Equidistant
+~~~~~~~~~~~~~~~~~~~~~
 
 A 15-cm-wide global map in which distances from the center (here 125/10)
 to any point is true can be obtained by:

--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -40,8 +40,8 @@ Description
 The **begin** directive of subplot defines the layout of the entire multi-panel illustration.  Several
 options are available to specify the systematic layout, labeling, dimensions, and more for the subplots.
 
-Required Arguments
-------------------
+Required Arguments (begin mode)
+--------------------------------
 
 *nrows*\ **x**\ *ncols*
     Specifies the number of rows and columns of subplots.  Each row will have
@@ -81,8 +81,8 @@ Required Arguments
     subplots, add dividing lines between panels (**+w**\ *pen*), and even expand it via **+c**.  These are most
     useful if you supply **-B+n** to **subplot begin**, meaning no ticks or annotations will take place in the subplots.
 
-Optional Arguments
-------------------
+Optional Arguments (begin mode)
+-------------------------------
 
 .. _-A:
 
@@ -187,8 +187,8 @@ inside the subplot, then the scale of the map is automatically determined by the
 For Cartesian plots: If you want the scale to apply *equally* to both dimensions
 then you must specify **-Jx** [The default projection of **-JX** will fill the subplot by using unequal scales].
 
-Optional Arguments
-------------------
+Optional Arguments (set mode)
+-----------------------------
 
 *row,col*
     Sets the current subplot until further notice.  **Note**: First *row* or *col* is 0, not 1. If not given we go to the next subplot by order
@@ -237,8 +237,8 @@ outline. This allows subsequent commands, such as colorbar, to use **-DJ** to pl
 reference to the complete figure dimensions. We also reset
 the current plot location to where it was prior to the subplot.
 
-Optional Arguments
-------------------
+Optional Arguments (end mode)
+-----------------------------
 
 .. _subplot_end-V:
 


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the [sphinx autosection label](https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html), which is also described in the [sphinx documentation on cross-referencing](https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#automatically-label-sections). It will enable linking directly to section headers in various files, rather than needing to set up explicit, unique references.
For example, this:
```
:ref:`cookbook/features:The background panel`
```
Rather than adding ``.. _Background-panel:`` above 'The background panel' in cookbook/features.rst section and then linking using:
```
:ref:`The background panel <Background-panel>`
```
I think this will make adding cross-references easier moving forward. It also will make it more obvious where the references being linked to. The downside is that duplicate headers within individual files cause warnings. Those have been renamed as part of this pull request, notably adding the GMT version to each section header in the changelog.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
