### PR TITLE
Add toggle-buttons showing source scripts to cookbook

### DIFF
--- a/doc/rst/_extensions/sphinx_togglebutton/_static/togglebutton.css_t
+++ b/doc/rst/_extensions/sphinx_togglebutton/_static/togglebutton.css_t
@@ -64,8 +64,8 @@ button.toggle-button {
         content: "{{ togglebutton_hint }}";
         position: absolute;
         font-size: .8em;
-        left: -6.5em;
-        bottom: .4em;
+        left: -13.5em;
+        bottom: .3em;
     }
 }
 

--- a/doc/rst/_extensions/sphinx_togglebutton/_static/togglebutton.css_t
+++ b/doc/rst/_extensions/sphinx_togglebutton/_static/togglebutton.css_t
@@ -65,7 +65,7 @@ button.toggle-button {
         position: absolute;
         font-size: .8em;
         left: -13.5em;
-        bottom: .3em;
+        bottom: .4em;
     }
 }
 

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -21,7 +21,7 @@ smartquotes_action = 'qe'
 highlight_language = 'bash'
 pygments_style = 'sphinx'
 autosectionlabel_prefix_document = True
-togglebutton_hint = "Click to show example"
+togglebutton_hint = "Click to show example script"
 
 # Disable sphinx_panels extension for manpage build
 if tags.has("nosphinxpanels"):

--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -21,6 +21,7 @@ smartquotes_action = 'qe'
 highlight_language = 'bash'
 pygments_style = 'sphinx'
 autosectionlabel_prefix_document = True
+togglebutton_hint = "Click to show example"
 
 # Disable sphinx_panels extension for manpage build
 if tags.has("nosphinxpanels"):

--- a/doc/rst/source/cookbook/colorspace.rst
+++ b/doc/rst/source/cookbook/colorspace.rst
@@ -234,6 +234,11 @@ terribly wrong when you do the interpolation in the other system.
    palette should be interpolated in HSV, since only hue should change between magenta (300) and red (0).
    Diamonds indicate which colors are defined in the palettes; they are fixed, the rest is interpolated.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_color_interpolate.txt
 
 Artificial illumination
 -----------------------
@@ -254,6 +259,12 @@ Artificial illumination
    no longer can easily be related to elevation. GMT thus only uses the directions of these
    vectors and normalizes the intensities to yield suitable shading; see :doc:`/grdgradient`
    for more details.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_slope2intensity.txt
 
 GMT uses the HSV system to achieve artificial illumination of colored
 images (e.g., **-I** option in :doc:`/grdimage`) by changing the saturation
@@ -291,6 +302,12 @@ obvious in RGB.
    B and W points as terminal points but instead end at the two white circles.  Their
    coordinates are given by (:term:`COLOR_HSV_MIN_S`, :term:`COLOR_HSV_MIN_V`) [1, 0.3]
    and (:term:`COLOR_HSV_MAX_S`, :term:`COLOR_HSV_MAX_V`) [0.1, 1].
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_color_hsv.txt
 
 Thinking in RGB or HSV
 ----------------------
@@ -340,6 +357,12 @@ achieved using *c/m/y/k* quadruplets.
    the amount of black in any particular color is removed from the color
    and painted with a specific black ink instead, leading to under-color
    removal of the remaining three pigments.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_cmyk.txt
 
 Obviously, there is no unique way to go from the 3-dimensional RGB
 system to the 4-dimensional CMYK system. So, again, there is a lot of

--- a/doc/rst/source/cookbook/cpts.rst
+++ b/doc/rst/source/cookbook/cpts.rst
@@ -28,6 +28,12 @@ Default ranges, if available, are indicated on the top-right of the scales.
 
    The standard 44 CPTs supported by GMT.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_M_1a.txt
+
 .. _CPT_files_b:
 
 .. figure:: /_images/GMT_App_M_1b.*
@@ -35,6 +41,12 @@ Default ranges, if available, are indicated on the top-right of the scales.
    :align: center
 
    The 30 scientific color maps by Fabio Crameri supported by GMT.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_M_1b.txt
 
 .. _CPT_files_c:
 
@@ -45,6 +57,11 @@ Default ranges, if available, are indicated on the top-right of the scales.
    The 18 categorical CPTs (those ending in "S" are the categorical
    scientific color maps by Fabio Crameri) supported by GMT.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_M_1c.txt
 
 .. _CPT_files_d:
 
@@ -55,6 +72,12 @@ Default ranges, if available, are indicated on the top-right of the scales.
    The 5 cyclic scientific color maps by Fabio Crameri supported by GMT.
    **Note**: Any GMT CPT can be made cyclic by running :doc:`/makecpt`
    with the **-Ww** option (wrapped = cyclic).
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_M_1d.txt
 
 For additional color tables, visit
 `cpt-city <http://soliton.vm.bytemark.co.uk/pub/cpt-city/>`_ and
@@ -83,3 +106,10 @@ and how to switch the color bar around (by using a negative length).
 .. figure:: /_images/GMT_App_M_2.*
    :width: 600 px
    :align: center
+
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_M_2.txt

--- a/doc/rst/source/cookbook/custom-symbols.rst
+++ b/doc/rst/source/cookbook/custom-symbols.rst
@@ -34,6 +34,11 @@ Several custom symbol definitions comes included with GMT (see Figure :ref:`Cust
    Be aware that some symbols may have a hardwired fill or no-fill component,
    while others duplicate what is already available as standard built-in symbols.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_N_1.txt
 
 You may find it convenient to examine some of these and use them as a
 starting point for your own design; they can be found in GMT's

--- a/doc/rst/source/cookbook/data-filtering.rst
+++ b/doc/rst/source/cookbook/data-filtering.rst
@@ -38,6 +38,11 @@ diametrical cross-section through the filter weights
 
    Impulse responses for GMT filters.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_J_1.txt
 
 Although the impulse responses look the same in 1-D and 2-D, this is not
 true of the transfer functions; in 1-D the transfer function is the
@@ -64,6 +69,11 @@ they require more work (doubling the width to achieve the same cut-off wavelengt
 
    Transfer functions for 1-D GMT filters.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_J_2.txt
 
 One of the nice things about the gaussian filter is that its transfer
 functions are the same in 1-D and 2-D. Another nice property is that it
@@ -82,6 +92,12 @@ the wavelength at which the transfer function equals 0.5 is about 5.34
    :align: center
 
    Transfer functions for 2-D (radial) GMT filters.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_J_3.txt
 
 Footnote
 --------

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -240,6 +240,13 @@ E.g., if your ``gmt.conf`` file has *x* offset = 3\ **c** as default, the
 
    Some GMT parameters that affect plot appearance.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_Defaults_1a.txt
+
+
 .. _gmt_defaults_b:
 
 .. figure:: /_images/GMT_Defaults_1b.*
@@ -248,6 +255,12 @@ E.g., if your ``gmt.conf`` file has *x* offset = 3\ **c** as default, the
 
    More GMT parameters that affect plot appearance.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_Defaults_1b.txt
+
 .. _gmt_defaults_c:
 
 .. figure:: /_images/GMT_Defaults_1c.*
@@ -255,6 +268,12 @@ E.g., if your ``gmt.conf`` file has *x* offset = 3\ **c** as default, the
    :align: center
 
    Even more GMT parameters that affect plot appearance.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_Defaults_1c.txt
 
 There are at least two good reasons why the GMT default options are
 placed in a separate parameter file:
@@ -468,6 +487,12 @@ this check is only performed no more often than once a day.
    :align: center
 
    The 14297 1x1 degree tiles (red) for which SRTM 1 and 3 arc second data are available.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_SRTM.txt
 
 As a short example, we can make a quick map of Easter Island using the SRTM 1x1 arc second
 grid via
@@ -737,6 +762,12 @@ point, as shown in Figures :ref:`Cap <Cap_settings>` and :ref:`Miter <Miter_sett
    **ROUND**, or **BUTT**.  The circles and thin lines indicate the coordinates.  All lines
    where plotted with the same width and dash-spacing (-W10p,20_20:0).
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_cap.txt
+
 .. _Miter_settings:
 
 .. figure:: /_images/GMT_joint.*
@@ -747,6 +778,12 @@ point, as shown in Figures :ref:`Cap <Cap_settings>` and :ref:`Miter <Miter_sett
    meet that can be adjusted with :term:`PS_LINE_JOIN`.  There is **BEVEL**, **ROUND**, and
    **MITER**.  The last setting also depends on :term:`PS_MITER_LIMIT` which sets a limit on
    the angle at the mitered joint below which we apply a bevel.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_joint.txt
 
 By default, line segments have rectangular ends, but this can
 change to give rounded ends. When :term:`PS_LINE_CAP` is set to round the
@@ -766,6 +803,12 @@ different phase *offset* and color. See the :doc:`/gmt.conf` man page for more i
 
    Line appearance can be varied by using :term:`PS_LINE_CAP`
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_linecap.txt
+
 Experience has shown that the rendering of lines that are short relative to the pen thickness
 can sometimes appear wrong or downright ugly.  This is a feature of PostScript interpreters, such as
 Ghostscript.  By default, lines are rendered using a fast algorithm which is susceptible to
@@ -782,6 +825,12 @@ displays the difference in results.
 
    Very thick line appearance using the default (left) and round line cap and join (right).  The
    red line (1p width) illustrates the extent of the input coordinates.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_fatline.txt
 
 Specifying line attributes
 --------------------------
@@ -814,6 +863,12 @@ specification. The line attribute modifiers are:
    of plotting the same line while requesting offsets of 1 cm at the beginning and 500 km
    at the end, via **-W**\ 2p\ **+o**\ 1c/500k.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_lineoffset.txt
+
 * **+s**
     Normally, all PostScript line drawing is implemented as a linear spline, i.e., we simply
     draw straight line-segments between the map-projected data points.  Use this modifier to render the
@@ -828,6 +883,12 @@ specification. The line attribute modifiers are:
 
    (left) Normal plotting of line given input points (red circles) via **-W**\ 2p. (right) Letting
    the projected points be interpolated by a Bezier cubic spline via **-W**\ 2p\ **+s**.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_bezier.txt
 
 * **+v**\ [**b**\|\ **e**]\ *vspecs*
     By default, lines are normally drawn from start to end.  Using the **+v** modifier you can
@@ -847,6 +908,12 @@ specification. The line attribute modifiers are:
    Same line as above but now we have requested a blue vector head at the end of the line and a
    red circle at the beginning of the line with **-W**\ 2p\ **+o**\ 1c/500k\ **+vb**\ 0.2i\ **+g**\ red\ **+p**\ faint\ **+b**\ c\ **+ve**\ 0.3i\ **+g**\ blue.
    Note that we also prescribed the line offsets in addition to the symbol endings.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_linearrow.txt
 
 .. _-Gfill_attrib:
 
@@ -998,6 +1065,12 @@ discusses the various ways to do this.
    three letter codes for horizontal (**L**\ eft, **C**\ enter, **R**\ ight)
    and vertical (**T**\ op, **M**\ iddle, **B**\ ottom) alignments.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_pstext_justify.txt
+
 Notice how the anchor points refers to the text baseline and do not change
 for text whose letters extend below the baseline.
 
@@ -1023,6 +1096,12 @@ as illustrated in Figure :ref:`Text clearance <Text_clearance>`.
    bounding box can be modified as well, including rounded or convex
    rectangles.  Here we have chosen a rounded rectangle, requiring the
    additional specification of a corner radius, *r*.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_pstext_clearance.txt
 
 .. _CPT_section:
 
@@ -1272,6 +1351,12 @@ it from data tables while :doc:`/grd2cpt` can derive the range from one or more 
    Because of the hinge, the two sides of the CPT will be stretched separately
    to honor the desired range while utilizing the full color range.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_hinge.txt
+
 All CPT master tables can be found in Chapter :ref:`Of Colors and Color Legends`
 where those with hard or soft hinges are identified by triangles at their hinges.
 
@@ -1304,6 +1389,12 @@ color list to have the *min* and *max* values rounded down and up to nearest mul
 
    Lists of colors (here red,yellow,purple) can be turned into discrete or continuous CPT tables on the fly.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_colorlist.txt
+
 Cyclic (wrapped) CPTs
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -1324,6 +1415,12 @@ color tables are useful for highlighting small changes.
    :align: center
 
    Cyclic color bars are indicated by a cycle symbol on the left side of the bar.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_cyclic.txt
 
 .. _manipulating_CPTs:
 
@@ -1356,6 +1453,12 @@ applications only the last transformation is needed.
 
    Examples of two user CPTs for the range -0.5 to 3 created from the same master.  One (left) extracted a
    subset of the master before scaling while the other (right) used the entire range.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_CPTscale.txt
 
 Automatic CPTs
 ~~~~~~~~~~~~~~
@@ -1402,6 +1505,12 @@ between three types of vectors:
    for different attribute specifications. Note that both full and half
    arrow-heads can be specified, as well as no head at all.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_arrows.txt
+
 There are numerous attributes you can modify, including how the vector
 should be justified relative to the given point (beginning, center, or
 end), where heads (if any) should be placed, if the head should just be
@@ -1420,6 +1529,12 @@ relevant manual pages.
    Other vector heads are the circle (**c**), the terminal line (**t**), the
    arrow fin (**i**) and the plain head (**A**) and tail (**I**); the last two
    are line-drawings only and cannot be filled.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_arrows_types.txt
 
 .. _Char-esc-seq:
 
@@ -1568,6 +1683,12 @@ Reference and anchor point specification
    anchor point (red square).
    The feature is then placed such that its adjusted anchor point matches the reference point.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_anchor.txt
+
 Placing a feature on the map means selecting a *reference* point somewhere on the map, an
 *anchor* point somewhere on the feature, and then positioning the feature so that the two points overlap.
 It may be helpful to consider the analog of a boat dropping an anchor: The boat navigates to the
@@ -1696,6 +1817,12 @@ the attributes that are under your control:
    lower right was set with **-F+p**\ 1p\ **+i+s+g**\ white\ **+c**\ 0.1i (we added a light
    dashed box to indicate the effect of the clearance setting).
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_panel.txt
+
 .. _Placing-map-scales:
 
 Placing map scales
@@ -1745,6 +1872,12 @@ Here is a list of the attributes that is under your control:
    The left-most scale was placed with **-Lj**\ *ML*\ **+c**\ 53\ **+w**\ 1000k\ **+f+l**\ "Scale at 53\\232N"
    while the scale on the right was placed with **-Lj**\ *BR*\ **+c**\ 53\ **+w**\ 1000k\ **+l+f**.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_mapscale.txt
+
 Note that for the purpose of anchor justification (**+j**) the footprint of the map scale is
 considered the rectangle that contains the scale and all selected labels and annotations, i.e.,
 the map scale's *bounding box*.
@@ -1789,6 +1922,12 @@ The next two modifiers are optional:
    and a cross indicating the cardinal directions, specified by **-Tdg**\ 0/0\ **+w**\ 1i. (middle) Fancy rose
    obtained by adding **+f** and **+l**\ ,,,N to get the north label.  (right) Fancy directional rose
    at level 3 with labels by adding **+f**\ 3\ **+l**.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_dir_rose.txt
 
 .. _Placing-mag-map-roses:
 
@@ -1847,6 +1986,12 @@ The remaining modifiers are optional:
    was specified by **-Tmg**\ -2/0.5\ **+w**\ 2.5i\ **+d**\ -14.5\ **+t**\ 45/10/5\ **+i**\ 0.25p,blue\ **+p**\ 0.25p,red\ **+l+j**\ CM.
    See :doc:`/gmt.conf` for more details on the default parameters.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_mag_rose.txt
+
 Placing color scale bars
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1885,6 +2030,12 @@ supply suitable required and optional modifiers:
    colors, and used the frame-annotation machinery to add labels.  The bar was placed with
    **-D**\ *JBC*\ **+o**\ 0/0.35i\ **+w**\ 4.5i/0.1i\ **+h**.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_colorbar.txt
+
 Placing map legends
 ~~~~~~~~~~~~~~~~~~~
 
@@ -1915,6 +2066,12 @@ first, then supply suitable required and optional modifiers:
    here, :doc:`/legend` reads macro commands that specifies each item of the legend, including colors,
    widths of columns, the number of columns, and presents a broad selection of items.  Here, we
    simply used **-Dx**\ 0/0\ **+w**\ 14c\ **+j**\ *BL*.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_legend.txt
 
 Placing raster and EPS images on maps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1950,6 +2107,12 @@ In addition, we require one (of two) modifiers to determine the image size.
    The School of Ocean and Earth Science and Technology at the University of Hawaii at Manoa
    hosts the gmt server and its EPS logo is shown via **-Dj**\ *MR*\ **+o**\ 0.1i\ **+w**\ 2i.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_images.txt
+
 Placing a GMT logo on maps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1967,6 +2130,12 @@ In addition, we require one modifier to set the logo's size.
 
    Placement of the GMT logo. The logo itself only has a size modifier but the :doc:`/gmtlogo`
    module allows additional attributes such as a background map panel.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_coverlogo.txt
 
 Placing map insets
 ~~~~~~~~~~~~~~~~~~
@@ -2008,6 +2177,12 @@ instead (similar to how the **-R** option works), by adding **+r**\ .  Some opti
    right area with **-Dj**\ TR\ **+w**\ 3.8c\ **+o**\ 0.4c/0.25c.
    See Example :ref:`example_44` for more details.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_inset.txt
+
 Placing a vertical scale on maps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2035,6 +2210,11 @@ In addition, we offer a few modifier to set the scale bar's remaining attributes
    Placement of a vertical scale bar. As for other embellishments the :doc:`/wiggle`
    module allows additional attributes such as a background map panel.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_vertscale.txt
 
 .. _grid-file-format:
 

--- a/doc/rst/source/cookbook/gmt-latex.rst
+++ b/doc/rst/source/cookbook/gmt-latex.rst
@@ -18,6 +18,12 @@ location instead of the regular text.
 
    Example of using a LaTeX equation in the x-axis label via -Bxaf+l"@[\\nabla^4 \\psi - \\Delta \\sigma_{xx}^2@[ (MPa)".
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_latex.txt
+
 .. _gmt-latex-fonts:
 
 GMT fonts and LaTeX

--- a/doc/rst/source/cookbook/map-projections.rst
+++ b/doc/rst/source/cookbook/map-projections.rst
@@ -299,6 +299,13 @@ stereonet can be obtained by using the stereographic projection
 
    Equal-Area (Schmidt) and Equal-Angle (Wulff) stereo nets.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_stereonets.txt
+
+
 .. _-Js:
 
 Stereographic Equal-Angle (**-Js** **-JS**)
@@ -703,6 +710,11 @@ latitude bands but these are not needed to specify the projection for most cases
 
    Universal Transverse Mercator zone layout.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_utm_zones.txt
 
 In order to minimize the distortion in any given zone, a scale factor of 0.9996 has been factored into the formulae
 (although a standard, you can change this with :term:`PROJ_SCALE_FACTOR`). This makes the UTM projection a *secant*
@@ -802,6 +814,12 @@ corners internally.
    The projected coordinate system is still aligned as before but the Earth has been rotated 180 degrees.  The blue
    point now has projected coordinates (*x* = -426.2, *y* = 399.7).
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_obl_nz.txt
+
 The oblique Mercator projection will by default arrange the output so that the oblique Equator becomes the new
 horizontal, positive *x*-axis.  For features with an orientation more north-south than east-west, it may be preferable
 to align the oblique Equator with the vertical, positive *y*-axis instead.  This configuration is selected by appending
@@ -813,6 +831,12 @@ to align the oblique Equator with the vertical, positive *y*-axis instead.  This
 
    Oblique view of Baja California using the vertical oblique Equator modifier.  This plot
    resulted from the argument **-JOa**\ 120W/25N/-30/6c\ **+v**\ .
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_obl_baja.txt
 
 .. _-Jc:
 
@@ -1269,6 +1293,12 @@ The same script, with **s** instead of **f**, yields the Eckert VI map:
    :align: center
 
    World map using the Eckert VI projection.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_eckert6.txt
 
 .. _-Ji:
 

--- a/doc/rst/source/cookbook/octal-codes.rst
+++ b/doc/rst/source/cookbook/octal-codes.rst
@@ -18,6 +18,12 @@ characters (shown in the light green boxes) you need to set
 
    Octal codes and corresponding symbols for StandardEncoding (left) and ISOLatin1Encoding (right) fonts.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_F_stand+_iso+.txt
+
 The chart for the Symbol character set (GMT font number 12) and Pifont
 ZapfDingbats character set (font number 34) are presented in
 Figure :ref:`Octal codes for Symbol and ZapfDingbats <Octal_codes_symbol_zap>` below. The octal code
@@ -34,6 +40,12 @@ firmware will not know about the euro).
    :align: center
 
    Octal codes and corresponding symbols for Symbol (left) and ZapfDingbats (right) fonts.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_F_symbol_dingbats.txt
 
 Footnote
 --------

--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -134,6 +134,12 @@ and 2 are shown in panels a) and b) respectively of the Figure :ref:`Map region 
    The plot region can be specified in two different ways. (a) Extreme values for each dimension, or (b) coordinates of
    lower left and upper right corners.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-R.txt
+
 For rectilinear projections the first two forms give identical results. Depending on the selected map projection (or
 the kind of expected input data), the boundary coordinates may take on several different formats:
 
@@ -244,6 +250,12 @@ The over 30 map projections and coordinate transformations available in GMT are 
    :align: center
 
    The over-30 map projections and coordinate transformations available in GMT
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-J.txt
 
 .. _proj-codes:
 
@@ -467,6 +479,12 @@ is shown in Figure :ref:`Geographic map border <basemap_border>`.
    frame, and grid intervals.  Formatting of the annotation is controlled by
    the parameter :term:`FORMAT_GEO_MAP` in your :doc:`/gmt.conf`.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-B_geo_1.txt
+
 The machinery for primary and secondary annotations introduced for
 time-series axes can also be utilized for geographic basemaps. This may
 be used to separate degree annotations from minutes- and
@@ -482,6 +500,12 @@ attributes for grid lines and grid crosses, see Figure :ref:`Complex basemap
    :align: center
 
    Geographic map border with both primary (P) and secondary (S) components.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-B_geo_2.txt
 
 Cartesian linear axes
 ^^^^^^^^^^^^^^^^^^^^^
@@ -508,6 +532,12 @@ each annotation (see Figure :ref:`Axis label <axis_label_basemap>`).
    annotations, shorter ticks indicate frame interval. The axis label is
    optional. For this example we used ``-R0/12/0/0.95 -JX7.5c/0.75c -Ba4f2g1+lFrequency+u" %" -BS``
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-B_linear.txt
+
 There are occasions when the length of the annotations are such that placing them
 horizontally (which is the default) may lead to overprinting or too few annotations.
 One solution is to request slanted annotations for the x-axis (e.g., Figure :ref:`Axis label <axis_slanted_basemap>`)
@@ -524,6 +554,11 @@ via the **+a**\ *angle* modifier.
    For this example we used ``-R2000/2020/35/45 -JX12c -Bxa2f+a-30 -BS``.
    For the y-axis only the modifier **+ap** for parallel is allowed.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-B_slanted.txt
 
 Cartesian log\ :sub:`10` axes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -560,6 +595,12 @@ specific to log axes (see Figure :ref:`Logarithmic projection axis
    (bottom) We annotate every power of 10 using :math:`\log_{10}` of the actual
    values as exponents, with -Ba1f2g3p.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-B_log.txt
+
 Cartesian exponential axes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -584,6 +625,12 @@ labeled 1, 4, 9, ... will appear.
    in -R0/100/0/0.9 -JX3ip0.5/0.25i -Ba20f10g5.
    (bottom) Here, intervals refer to projected values, although the annotation
    uses the corresponding unprojected values, as in -Ba3f2g1p.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-B_pow.txt
 
 .. _cartesian_time_axes:
 
@@ -772,6 +819,12 @@ which will plot the current command string (Figure :ref:`Time stamp <fig_-U>`).
 
    The -U option makes it easy to date a plot.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-U.txt
+
 .. _option_-V:
 
 Verbose feedback: The **-V** option
@@ -819,6 +872,12 @@ To move the origin half the width to the right, use **-X**\ *w*\ /2.
    :align: center
 
    Plot origin can be translated freely with -X -Y.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-XY.txt
 
 .. _option_-a:
 
@@ -1297,6 +1356,11 @@ spacing by
    Gridline- and pixel-registration of data nodes.  The red shade indicates the
    areas represented by the value at the node (solid circle).
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_registration.txt
 
 .. math::
 
@@ -1336,6 +1400,12 @@ of the higher data frequencies, as shown in Figure :ref:`Registration resampling
    resampling data from a pixel-registered to a gridline-registered grid format illustrates the loss
    of amplitude that will occur.  There is also a linear change in phase from 0 to 90 degrees as a
    function of wavenumber :math:`k_j` [Marks and Smith, 2007 [15]_.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_grid2pix.txt
 
 .. _option_-s:
 

--- a/doc/rst/source/cookbook/postscript-fonts.rst
+++ b/doc/rst/source/cookbook/postscript-fonts.rst
@@ -12,6 +12,11 @@ usually Courier). The following is a list of the GMT fonts:
 
    The standard 35 PostScript fonts recognized by GMT.
 
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_G.txt
 
 For the special fonts Symbol (12) and ZapfDingbats (34), see the octal
 charts in Chapter :doc:`octal-codes`. When specifying fonts in GMT, you can

--- a/doc/rst/source/cookbook/predefined-patterns.rst
+++ b/doc/rst/source/cookbook/predefined-patterns.rst
@@ -10,3 +10,9 @@ below at 300 dpi using the default black and white shades.
 .. figure:: /_images/GMT_App_E.*
    :width: 500 px
    :align: center
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_App_E.txt


### PR DESCRIPTION
**Description of proposed changes**

This PR adds toggle-buttons to show the source scripts used to generate figures in the cookbook, when the source code isn't already included.

This is what it looks like:

<img width="972" alt="image" src="https://user-images.githubusercontent.com/14077947/110732965-23a53e00-81f3-11eb-94e9-36f5ec2c2df3.png">


And toggled open:

<img width="978" alt="image" src="https://user-images.githubusercontent.com/14077947/110731052-957b8880-81ef-11eb-8b21-aa0be7c71e16.png">

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
