### PR TITLE
CI: Only run DOS examples on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,6 +164,7 @@ jobs:
         run: |
           cd doc/examples
           call do_examples.bat
+        if: runner.os == 'Windows'
 
       - name: Upload build directory if failed
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
**Description of proposed changes**

The tests on the master branch fail because we try to run DOS examples
on Linux and macOS.

This PR fixes the bug.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
