### PR TITLE
Improve grdblend checking of input arguments

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1041,7 +1041,7 @@ int gmt_grd_get_format (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEADER
 	int val;
 	unsigned int direction = (magic) ? GMT_IN : GMT_OUT, pos = 0;
 	char tmp[GMT_LEN512] = {""};	/* But it's copied at most 256 chars into header->name so 256 should do */
-	char *c = NULL, *f = NULL;	/* Various char pointers used to deal with file modifiers */
+	char *c = NULL, *f = NULL, *ext = NULL;	/* Various char pointers used to deal with file modifiers */
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 
 	if (file[0] == '@') pos = 1;	/* At this point we will already have downloaded any remote file so skip the @ */
@@ -1155,6 +1155,10 @@ int gmt_grd_get_format (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEADER
 		/* Then check for ESRI grid */
 		if (gmtlib_is_esri_grid (GMT, header) == GMT_NOERROR)
 			return (GMT_NOERROR);
+		/* Rule out dumb *.txt and *.lis files before GDAL checks to avoid dumb error message */
+		ext = gmt_get_ext (file);
+		if (ext && (!strcmp (ext, "txt") || !strcmp (ext, "lis")))
+			return (GMT_GRDIO_UNKNOWN_FORMAT);
 #ifdef HAVE_GDAL
 		/* Then check for GDAL grid */
 		if (gmtlib_is_gdal_grid (GMT, header) == GMT_NOERROR)

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -829,6 +829,18 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
 
 	if (Ctrl->In.n <= 1) {	/* Got a blend file (or stdin) */
+		if (Ctrl->In.n) {	/* Check if user mistakenly gave a single grid as input */
+			char test_file[PATH_MAX] = {""};
+			int ret_code;
+			struct GMT_GRID_HEADER *h_test = gmt_get_header (GMT);
+			strncpy (test_file, Ctrl->In.file[0], PATH_MAX);
+			if ((ret_code = gmt_grd_get_format (GMT, test_file, h_test, true)) == GMT_NOERROR) {
+				GMT_Report (API, GMT_MSG_ERROR, "Only a single grid found; no blending can take place\n");
+				gmt_free_header (API->GMT, &h_test);
+				Return (GMT_RUNTIME_ERROR);
+			}
+			gmt_free_header (API->GMT, &h_test);
+		}
 		if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {	/* Register data input */
 			Return (API->error);
 		}


### PR DESCRIPTION
See #4943 again.  Problem was that the user was giving a single file which we must assume is a blend file.  But it was not - it was a single grid.  Of course, it makes no sense to blend one grid, but trying to read it as a blendfile gave lots of irrelevant errors and warnings.
This PR checks for the special case of a single input file.  If it can be successfully determined to be a grid then we give an error message, otherwise we trust it is a blend file.  The final case not checked for is if no files are given and we read stdin.  However, having some user pipe a grid is very unlikely and derserves a bad ending.  Thanks to @anbj for helping us harden the interface!
