### PR TITLE
CI: Build docs and run tests based on changed files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
       - 6.[0-9]+
+    paths:
+      - 'doc/**'
+      - '.github/workflows/**'
+      - 'ci/**'
   release:
     types:
       - published

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - master
       - 6.[0-9]+
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'doc/examples/**'
+      - 'doc/scripts/**'
+      - '.github/workflows/**'
+      - 'ci/**'
 
 defaults:
   run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
     paths:
       - 'src/**'
       - 'test/**'
-      - 'share/cpt/**'
+      - 'share/**'
       - 'doc/examples/**'
       - 'doc/scripts/**'
       - '.github/workflows/**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'src/**'
       - 'test/**'
+      - 'share/cpt/**'
       - 'doc/examples/**'
       - 'doc/scripts/**'
       - '.github/workflows/**'


### PR DESCRIPTION
**Description of proposed changes**

We now have 4 CI workflows:

- `build.yml`: Build the GMT source for **every commit in PR and in master branch**
- `docker.yml`: Build the GMT source on other Ubuntu and Debian versions [**only runs in the master branch**]
- `docs.yml`: Build the GMT documentation and deploy it to gh-pages branch [**only runs in the master branch**]
- `tests.yml`: Run the full tests [**only runs in the master branch**]

As all the documentation (ReST files and images) are stored in the `doc` directory, it wastes CI resources to build the documentation if only GMT C files are changed. Similarly, if only ReST files are changed, we also don't need to run the full tests. 

This PR improves the `docs` and `tests` workflows, so that they only run if a changed file match the specified patterns.

The rules are:

- If any changed files match `doc/**`, the `docs` workflow will run
- If any changed files match `src/**`, 'test/**', 'doc/examples/**', and 'doc/scripts/**', the `tests` workflow will run.

Do the rules make sense to you? Do I miss anything?

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
