### PR TITLE
test: Improve the check of modern mode scripts

### DIFF
--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -12,8 +12,8 @@ local_script=$(basename "${script_name}")
 script="@GMT_SOURCE_DIR@/${script_name}"
 src="@GMT_SOURCE_DIR@/${script_dir}"
 
-# Is it a modern mode script?
-modern=$(grep "gmt begin" "$script" -c)
+# Is it a modern mode or one-liner script
+modern=$(grep "gmt begin\| -ps " "$script" -c)
 
 # Is it a script that is known to fail?
 if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then


### PR DESCRIPTION
**Description of proposed changes**

Address the issue found in #4952.

After this patch, I have the following failures locally (the last few failures may be unrelated):
```
	  7 - doc/scripts/GMT_-B_slanted.sh (Failed)
	 53 - doc/scripts/GMT_TM.sh (Failed)
	 61 - doc/scripts/GMT_az_equidistant.sh (Failed)
	 74 - doc/scripts/GMT_cassini.sh (Failed)
	 81 - doc/scripts/GMT_coverlogo.sh (Failed)
	 91 - doc/scripts/GMT_eckert4.sh (Failed)
	 93 - doc/scripts/GMT_equi_cyl.sh (Failed)
	 97 - doc/scripts/GMT_general_cyl.sh (Failed)
	 98 - doc/scripts/GMT_gnomonic.sh (Failed)
	100 - doc/scripts/GMT_grinten.sh (Failed)
	101 - doc/scripts/GMT_hammer.sh (Failed)
	106 - doc/scripts/GMT_lambert_az_hemi.sh (Failed)
	122 - doc/scripts/GMT_miller.sh (Failed)
	124 - doc/scripts/GMT_mollweide.sh (Failed)
	131 - doc/scripts/GMT_orthographic.sh (Failed)
	133 - doc/scripts/GMT_perspective.sh (Failed)
	135 - doc/scripts/GMT_polyconic.sh (Failed)
	140 - doc/scripts/GMT_robinson.sh (Failed)
	147 - doc/scripts/GMT_sinusoidal.sh (Failed)
	151 - doc/scripts/GMT_stereographic_polar.sh (Failed)
	155 - doc/scripts/GMT_transverse_merc.sh (Failed)
	180 - doc/scripts/GMT_winkel.sh (Failed)
	234 - doc/examples/ex49/ex49.sh (Failed)
	320 - test/gmt_core/testsuite.sh (Failed)
	508 - test/grdsample/straddle.sh (Failed)
	571 - test/modern/longbasemap.sh (Failed)
```