### PR TITLE
Only set undefined axes when drawn

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9876,7 +9876,7 @@ unsigned int gmt_setdefaults (struct GMT_CTRL *GMT, struct GMT_OPTION *options) 
 void gmt_set_undefined_axes (struct GMT_CTRL *GMT, bool conf_update) {
 	char axes[GMT_LEN32] = {""};
 	double az = (gmt_M_is_zero (GMT->common.p.z_rotation)) ? GMT->current.proj.z_project.view_azimuth : GMT->common.p.z_rotation;
-	if (strcmp (GMT->current.setting.map_frame_axes, "auto")) return;
+	if (strcmp (GMT->current.setting.map_frame_axes, "auto") || !GMT->current.map.frame.draw) return;
 
 	/* Determine suitable MAP_FRAME_AXES for plot */
 	if (GMT->current.proj.projection == GMT_POLAR) {	/* May need to switch what is south and north */


### PR DESCRIPTION
**Description of proposed changes**

Fixes these two examples:
```
gmt basemap -R0/1/0/1 -JX5c -B+t"ABC" -png map
```

```
gmt begin colorbar png
gmt makecpt -Cbatlow -T0/10/1
gmt basemap -R20/30/-10/10 -B
gmt colorbar
gmt end show
```

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #4955 (partly)


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
