### PR TITLE
Address limitation of slice annotations in colorbar

### DIFF
--- a/doc/rst/source/cookbook/cpts.rst
+++ b/doc/rst/source/cookbook/cpts.rst
@@ -103,10 +103,9 @@ are centered. The example below also shows how to annotate ranges using
 **-Li** (in which case no name labels should appear in the CPT),
 and how to switch the color bar around (by using a negative length).
 
-Finally, note that if the last slice should have both lower and upper
-custom labels then supply two semicolon-separated labels. Furthermore,
-the annotation code should be **L** for all slices except the last, which
-must be set to **B**.
+**Note**: If the last slice should have both lower and upper
+custom labels then you must supply *two* semicolon-separated labels and set the
+annotation code to **B**.
 
 .. figure:: /_images/GMT_App_M_2.*
    :width: 600 px

--- a/doc/rst/source/cookbook/cpts.rst
+++ b/doc/rst/source/cookbook/cpts.rst
@@ -104,7 +104,9 @@ are centered. The example below also shows how to annotate ranges using
 and how to switch the color bar around (by using a negative length).
 
 Finally, note that if the last slice should have both lower and upper
-custom labels then supply two semicolon-separated labels.
+custom labels then supply two semicolon-separated labels. Furthermore,
+the annotation code should be **L** for all slices except the last, which
+must be set to **B**.
 
 .. figure:: /_images/GMT_App_M_2.*
    :width: 600 px

--- a/doc/rst/source/cookbook/cpts.rst
+++ b/doc/rst/source/cookbook/cpts.rst
@@ -103,6 +103,9 @@ are centered. The example below also shows how to annotate ranges using
 **-Li** (in which case no name labels should appear in the CPT),
 and how to switch the color bar around (by using a negative length).
 
+Finally, note that if the last slice should have both lower and upper
+custom labels then supply two semicolon-separated labels.
+
 .. figure:: /_images/GMT_App_M_2.*
    :width: 600 px
    :align: center

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1294,7 +1294,9 @@ be omitted to determine the annotation and tick interval automatically
 make :doc:`/colorbar`, when used with the
 **-L** option, place the supplied label instead of formatted *z*-values.
 **Note**: The last slice may have two semicolon-separated labels to set
-labels for both the lower *and* upper boundary.
+labels for both the lower *and* upper boundary. Furthermore,
+the annotation code **A** should be **L** for all slices except the last,
+which must be set to **B**.
 
 The background color (for *z*-values < :math:`z_0`), foreground color (for *z*-values >
 :math:`z_{n-1}`), and not-a-number (NaN) color (for *z*-values =

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1293,10 +1293,10 @@ be omitted to determine the annotation and tick interval automatically
 (e.g., **-Baf**). The optional semicolon followed by a text label will
 make :doc:`/colorbar`, when used with the
 **-L** option, place the supplied label instead of formatted *z*-values.
-**Note**: The last slice may have two semicolon-separated labels to set
-labels for both the lower *and* upper boundary. Furthermore,
-the annotation code **A** should be **L** for all slices except the last,
-which must be set to **B**.
+**Note**: If the last slice should have both lower and upper
+custom labels then you must supply *two* semicolon-separated labels and set the
+annotation code to **B**.
+
 
 The background color (for *z*-values < :math:`z_0`), foreground color (for *z*-values >
 :math:`z_{n-1}`), and not-a-number (NaN) color (for *z*-values =

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1268,13 +1268,13 @@ Regular CPTs
 Suitable for continuous data types and allowing for color
 interpolations, the format of the regular CPTs is:
 
-+---------------+-------------------+---------------+-------------------+----------+--------------+
-| z\ :sub:`0`   | Color\ :sub:`min` | z\ :sub:`1`   | Color\ :sub:`max` | [**A**]  | [;\ *label*] |
-+---------------+-------------------+---------------+-------------------+----------+--------------+
-| ...                                                                                             |
-+---------------+-------------------+---------------+-------------------+----------+--------------+
-| z\ :sub:`n-2` | Color\ :sub:`min` | z\ :sub:`n-1` | Color\ :sub:`max` | [**A**]  | [;\ *label*] |
-+---------------+-------------------+---------------+-------------------+----------+--------------+
++---------------+-------------------+---------------+-------------------+----------+------------------------------+
+| z\ :sub:`0`   | Color\ :sub:`min` | z\ :sub:`1`   | Color\ :sub:`max` | [**A**]  | [;\ *label*]                 |
++---------------+-------------------+---------------+-------------------+----------+------------------------------+
+| ...                                                                                                             |
++---------------+-------------------+---------------+-------------------+----------+------------------------------+
+| z\ :sub:`n-2` | Color\ :sub:`min` | z\ :sub:`n-1` | Color\ :sub:`max` | [**A**]  | [;\ *labell*\ [;\ *labelu*]] |
++---------------+-------------------+---------------+-------------------+----------+------------------------------+
 
 
 Thus, for each "*z*-slice", defined as the interval between two
@@ -1293,6 +1293,8 @@ be omitted to determine the annotation and tick interval automatically
 (e.g., **-Baf**). The optional semicolon followed by a text label will
 make :doc:`/colorbar`, when used with the
 **-L** option, place the supplied label instead of formatted *z*-values.
+**Note**: The last slice may have two semicolon-separated labels to set
+labels for both the lower *and* upper boundary.
 
 The background color (for *z*-values < :math:`z_0`), foreground color (for *z*-values >
 :math:`z_{n-1}`), and not-a-number (NaN) color (for *z*-values =

--- a/doc/scripts/GMT_App_M_2.ps
+++ b/doc/scripts/GMT_App_M_2.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 792 612
 %%HiResBoundingBox: 0 0 792.0000 612.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from colorbar
+%%Title: GMT v6.2.0_c68e366-dirty_2021.03.15 [64-bit] Document from colorbar
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:08:37 2021
+%%CreationDate: Mon Mar 15 18:49:27 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -859,6 +859,7 @@ V -90 R (Neogene) ml Z U
 1031 -117 M V -90 R (Silurian) ml Z U
 687 -117 M V -90 R (Ordovician) ml Z U
 344 -117 M V -90 R (Cambrian) ml Z U
+0 -117 M V -90 R (Precambrian) ml Z U
 -90 R
 -236 0 T
 0 setlinecap
@@ -1062,6 +1063,7 @@ V -90 R (Neogene) ml Z U
 2749 -117 M V -90 R (Silurian) ml Z U
 3092 -117 M V -90 R (Ordovician) ml Z U
 3436 -117 M V -90 R (Cambrian) ml Z U
+3780 -117 M V -90 R (Precambrian) ml Z U
 -90 R
 -236 0 T
 0 setlinecap

--- a/doc/scripts/GMT_App_M_2.sh
+++ b/doc/scripts/GMT_App_M_2.sh
@@ -18,7 +18,7 @@ cat > ages.cpt <<END
 359	104	255	0	416	104	255	0	;Devonian
 416	220	255	0	444	220	255	0	;Silurian
 444	255	174	0	488	255	174	0	;Ordovician
-488	255	58	0	542	255	58	0	;Cambrian
+488	255	58	0	542	255	58	0	;Cambrian;Precambrian
 B	black
 F	white
 END

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -254,6 +254,7 @@ enum GMT_time_period {
 #define GMT_CPT_Z_REVERSE	2	/* Reverse CPT z-values */
 #define GMT_CPT_L_ANNOT		1	/* Annotate lower slice boundary */
 #define GMT_CPT_U_ANNOT		2	/* Annotate upper slice boundary */
+#define GMT_CPT_B_ANNOT		3	/* Annotate lower and upper slice boundary */
 #define GMT_CPT_CATEGORICAL_VAL		1	/* Categorical CPT with numerical value */
 #define GMT_CPT_CATEGORICAL_KEY		2	/* Categorical CPT with text key */
 #define GMT_COLOR_AUTO_TABLE		1	/* Flag in rgb for auto-color changing per table */

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -692,7 +692,6 @@ GMT_LOCAL unsigned int psscale_set_custom_annot (struct GMT_CTRL *GMT, struct GM
 			strncpy (text, &c[1], GMT_LEN256-1);
 		else
 			text[0] = '\0';
-			//strncpy (text, P->data[i-1].label, GMT_LEN256-1);
 		this_just = l_justify;
 	}
 	else if ((P->data[i].annot & GMT_CPT_L_ANNOT) && P->data[i].label) {

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1210,7 +1210,12 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 					do_annot = true;
 					if (use_labels && (no_B_mode & PSSCALE_ANNOT_CUSTOM)) {
 						if ((P->data[i].annot & GMT_CPT_L_ANNOT) && P->data[i].label) {
+							char *c = NULL;
+							fprintf (stderr,"L = %s\n", P->data[i].label);
+							if ((c = strchr (P->data[i].label, ';')))
+								c[0] = '\0';	/* Temporary hide second label */
 							strncpy (text, P->data[i].label, GMT_LEN256-1);
+							if (c) c[0] = ';';	/* Restore second label */
 							this_just = l_justify;
 						}
 						else if (i && (P->data[i-1].annot & GMT_CPT_U_ANNOT) && P->data[i-1].label) {
@@ -1246,7 +1251,11 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 					do_annot = true;
 					if (use_labels && (no_B_mode & PSSCALE_ANNOT_CUSTOM)) {
 						if (P->data[i].label) {
-							strncpy (text, P->data[i].label, GMT_LEN256-1);
+							char *c = NULL;
+							if ((c = strchr (P->data[i].label, ';')))
+								strncpy (text, &c[1], GMT_LEN256-1);
+							else
+								strncpy (text, P->data[i].label, GMT_LEN256-1);
 							this_just = l_justify;
 						}
 						else
@@ -1511,7 +1520,12 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 					do_annot = true;
 					if (use_labels && (no_B_mode & PSSCALE_ANNOT_CUSTOM)) {
 						if ((P->data[i].annot & GMT_CPT_L_ANNOT) && P->data[i].label) {
+							char *c = NULL;
+							fprintf (stderr,"L = %s\n", P->data[i].label);
+							if ((c = strchr (P->data[i].label, ';')))
+								c[0] = '\0';	/* Temporary hide second label */
 							strncpy (text, P->data[i].label, GMT_LEN256-1);
+							if (c) c[0] = ';';	/* Restore second label */
 							this_just = l_justify;
 						}
 						else if (i && P->data[i-1].annot & GMT_CPT_U_ANNOT && P->data[i-1].label) {
@@ -1547,7 +1561,19 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 				if (all || (P->data[i].annot & GMT_CPT_U_ANNOT)) {
 					this_just = justify;
 					do_annot = true;
-					if (Ctrl->Q.active) {
+					if (use_labels && (no_B_mode & PSSCALE_ANNOT_CUSTOM)) {
+						if (P->data[i].label) {
+							char *c = NULL;
+							if ((c = strchr (P->data[i].label, ';')))
+								strncpy (text, &c[1], GMT_LEN256-1);
+							else
+								strncpy (text, P->data[i].label, GMT_LEN256-1);
+							this_just = l_justify;
+						}
+						else
+							text[0] = '\0';
+					}
+					else if (Ctrl->Q.active) {
 						p_val = irint (P->data[i].z_high);
 						if (doubleAlmostEqualZero (P->data[i].z_high, (double)p_val))
 							sprintf (text, "10@+%d@+", p_val);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1211,7 +1211,6 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 					if (use_labels && (no_B_mode & PSSCALE_ANNOT_CUSTOM)) {
 						if ((P->data[i].annot & GMT_CPT_L_ANNOT) && P->data[i].label) {
 							char *c = NULL;
-							fprintf (stderr,"L = %s\n", P->data[i].label);
 							if ((c = strchr (P->data[i].label, ';')))
 								c[0] = '\0';	/* Temporary hide second label */
 							strncpy (text, P->data[i].label, GMT_LEN256-1);
@@ -1521,7 +1520,6 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 					if (use_labels && (no_B_mode & PSSCALE_ANNOT_CUSTOM)) {
 						if ((P->data[i].annot & GMT_CPT_L_ANNOT) && P->data[i].label) {
 							char *c = NULL;
-							fprintf (stderr,"L = %s\n", P->data[i].label);
 							if ((c = strchr (P->data[i].label, ';')))
 								c[0] = '\0';	/* Temporary hide second label */
 							strncpy (text, P->data[i].label, GMT_LEN256-1);
@@ -1556,7 +1554,8 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 				}
 				x1 += z_width[i];
 			}
-			if (!center && !use_labels) {
+			//if (!center && !use_labels) {
+			if (!center) {
 				i = P->n_colors-1;
 				if (all || (P->data[i].annot & GMT_CPT_U_ANNOT)) {
 					this_just = justify;

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1554,7 +1554,6 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 				}
 				x1 += z_width[i];
 			}
-			//if (!center && !use_labels) {
 			if (!center) {
 				i = P->n_colors-1;
 				if (all || (P->data[i].annot & GMT_CPT_U_ANNOT)) {


### PR DESCRIPTION
As pointed out on the [forum]( https://forum.generic-mapping-tools.org/t/colorbar-label-two-ends-with-different-texts/1464 ) we have no solution for annotating the end of the last slice when **-L** is used.  This PR addresses that shortcoming by allowing the last slice to have an optional _second_ label following a second semi-colon.  For instance, in the case of the forum example, the last slice would be

3000 43/30/80 4500 43/30/80 B ; 3000 ; >4500

This yields a plot like this with this PR:

`gmt colorbar -Cmy.cpt -Dx2i/2i+w4i+h -L -png t`

![t](https://user-images.githubusercontent.com/26473567/111258163-85352600-85c0-11eb-9eb3-eee20b78ae9b.png)

After implementing this feature, the _GMT_App_M_2_ test failed but by adding "Precambrian" as the 2nd label for the last slice we get a more consistent plot, and when **-L** is given an argument (e.g., **-L**i or **-L**0.1) the second annotation is not used since the single or first annotation is then centered on each slice.

![GMT_App_M_2](https://user-images.githubusercontent.com/26473567/111258387-fa086000-85c0-11eb-811b-a7e013aa6db0.png)

The documentation has been updated to explain this effect.  The implementation was chosen as it has no side-effects on the API.
