### PR TITLE
Fix a typo in debugging guides

### DIFF
--- a/doc/rst/source/debug.rst
+++ b/doc/rst/source/debug.rst
@@ -146,7 +146,7 @@ If you already have the dev version then you may just need to run `conda activat
    directory created by xcodebuild so that PyGMT can find the GMT library, and set $GMT_SHAREDIR to point to the full path that
    contains the share directory.
 
-#. Open Xcode, select scheme "libgmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
+#. Open Xcode, select scheme "gmtlib", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
 
 #. Type python in the terminal to get a python console, attach the process id or name to Xcode (menu item Debug->Attach to Process by PID or Name),
@@ -171,7 +171,7 @@ done you can proceed to installing the master GMT.jl:
 
 #. When done, end package install mode by hitting backspace.  Then, load and precompile GMT by typing "using GMT".
 
-#. Open Xcode, select scheme "libgmt", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
+#. Open Xcode, select scheme "gmtlib", navigate to gmt_api.c in the source listing, and set a stop point in the editor,
    say in *GMT_Call_Module* or *GMT_Create_Session* and Xcode will stop at the breakpoint when it is reached.
 
 #. Attach the Julia process id or name in Xcode (menu item Debug->Attach to Process by PID or Name), and run GMT.jl


### PR DESCRIPTION
**Description of proposed changes**

I only see scheme "gmtlib", not "libgmt". I think it's a typo.

@PaulWessel Please double-check it.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
