### PR TITLE
Prevent subplot tag changes if not initiated

### DIFF
--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -203,7 +203,7 @@ Optional Arguments (set mode)
     Overrides the automatic labeling with the given string.  No modifiers are allowed.
     Placement, justification, etc. are all inherited from how **-A** was specified by the
     initial **subplot begin** command.  **Note**: Overriding means you initiate the tag
-    machinery with **-A** when subplot begin was called, otherwise the option is ignored.
+    machinery with **-A** when **subplot begin** was called, otherwise the option is ignored.
 
 .. _subplot_set-C2:
 

--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -202,7 +202,8 @@ Optional Arguments (set mode)
 **-A**\ *fixedlabel*
     Overrides the automatic labeling with the given string.  No modifiers are allowed.
     Placement, justification, etc. are all inherited from how **-A** was specified by the
-    initial **subplot begin** command.
+    initial **subplot begin** command.  **Note**: Overriding means you initiate the tag
+    machinery with **-A** when subplot begin was called, otherwise the option is ignored.
 
 .. _subplot_set-C2:
 

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1356,6 +1356,10 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		}
 		if (gmt_get_legend_info (API, &legend_width, &legend_scale, legend_justification, pen, fill, off)) {	/* Unplaced legend file */
 			char cmd[GMT_LEN128] = {""};
+			if ((P = gmt_subplot_info (API, fig)) == NULL) {
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "No subplot information file!\n");
+				Return (GMT_ERROR_ON_FOPEN);
+			}
 			/* Default to white legend with 1p frame offset 0.2 cm from selected justification point [TR] */
 			snprintf (cmd, GMT_LEN128, "-Dj%s+w%gi+o%s -F+p%s+g%s -S%g -Xa%gi -Ya%gi", legend_justification, legend_width, off, pen, fill, legend_scale, P->origin[GMT_X] + P->x, P->origin[GMT_Y] + P->y);
 			if ((error = GMT_Call_Module (API, "legend", GMT_MODULE_CMD, cmd))) {

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1349,7 +1349,7 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 
 		if (Ctrl->A.active) {	/* Can only override tag settings if subplot begin -A was used */
 			sprintf (file, "%s/gmt.tags.%d", API->gwf_dir, fig);
-			if (access (file, F_OK)) {
+			if (access (file, F_OK)) {	/* No such file */
 				GMT_Report (API, GMT_MSG_ERROR, "Cannot override tags with -A if it was not set during gmt subplot begin. -A ignored\n");
 				Ctrl->A.format[0] = '\0';
 			}


### PR DESCRIPTION
Since **subplot set -A** is used to override a specific tag for the specified panel, there has to be something to override, i.e., **subplot begin -A** must have been set.
Closes #4972.