### PR TITLE
Use parameter settings in auto_scale

### DIFF
--- a/doc/examples/ex02/ex02.ps
+++ b/doc/examples/ex02/ex02.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from text
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from text
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:10:24 2021
+%%CreationDate: Wed Mar 17 16:19:07 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -9305,25 +9305,25 @@ N 0 0 M 0 121 D S
 N 3033 0 M 0 121 D S
 -90 R
 N 0 3033 M 0 -3033 D S
-/PSL_A0_y 60 def
+/PSL_A0_y 62 def
 /PSL_A1_y 0 def
 8 W
-N 0 426 M 60 0 D S
-N 0 1018 M 60 0 D S
-N 0 1610 M 60 0 D S
-N 0 2202 M 60 0 D S
-N 0 2795 M 60 0 D S
+N 0 426 M 62 0 D S
+N 0 1018 M 62 0 D S
+N 0 1610 M 62 0 D S
+N 0 2202 M 62 0 D S
+N 0 2795 M 62 0 D S
 /MM {exch M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-150 F0
+156 F0
 (-6) sw mx
 (-4) sw mx
 (-2) sw mx
 (0) sw mx
 (2) sw mx
 def
-/PSL_A0_y PSL_A0_y 45 add PSL_AH0 add def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
 426 PSL_A0_y MM
 (-6) mr Z
 1018 PSL_A0_y MM
@@ -9336,12 +9336,12 @@ def
 (2) mr Z
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 90 R
-1801 -463 M 211 F0
+1811 -480 M 218 F0
 V -90 R (T) mc Z U
-1611 -463 M V -90 R (O) mc Z U
-1422 -463 M V -90 R (P) mc Z U
-1232 -463 M V -90 R (O) mc Z U
-3078 61 M 150 F0
+1614 -480 M V -90 R (O) mc Z U
+1418 -480 M V -90 R (P) mc Z U
+1222 -480 M V -90 R (O) mc Z U
+3079 61 M 156 F0
 V -90 R (km) bc Z U
 -90 R
 -121 0 T
@@ -9628,22 +9628,22 @@ N 0 0 M 0 121 D S
 N 3033 0 M 0 121 D S
 -90 R
 N 0 3033 M 0 -3033 D S
-/PSL_A0_y 60 def
+/PSL_A0_y 62 def
 /PSL_A1_y 0 def
 8 W
-N 0 0 M 60 0 D S
-N 0 379 M 60 0 D S
-N 0 758 M 60 0 D S
-N 0 1137 M 60 0 D S
-N 0 1516 M 60 0 D S
-N 0 1895 M 60 0 D S
-N 0 2274 M 60 0 D S
-N 0 2654 M 60 0 D S
-N 0 3033 M 60 0 D S
+N 0 0 M 62 0 D S
+N 0 379 M 62 0 D S
+N 0 758 M 62 0 D S
+N 0 1137 M 62 0 D S
+N 0 1516 M 62 0 D S
+N 0 1895 M 62 0 D S
+N 0 2274 M 62 0 D S
+N 0 2654 M 62 0 D S
+N 0 3033 M 62 0 D S
 /MM {exch M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-150 F0
+156 F0
 (-2) sw mx
 (0) sw mx
 (2) sw mx
@@ -9654,7 +9654,7 @@ PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reenco
 (12) sw mx
 (14) sw mx
 def
-/PSL_A0_y PSL_A0_y 45 add PSL_AH0 add def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
 0 PSL_A0_y MM
 (-2) mr Z
 379 PSL_A0_y MM
@@ -9675,13 +9675,13 @@ def
 (14) mr Z
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 90 R
-1896 -463 M 211 F0
+1909 -480 M 218 F0
 V -90 R (G) mc Z U
-1706 -463 M V -90 R (E) mc Z U
-1516 -463 M V -90 R (O) mc Z U
-1327 -463 M V -90 R (I) mc Z U
-1137 -463 M V -90 R (D) mc Z U
-3138 61 M 150 F0
+1713 -480 M V -90 R (E) mc Z U
+1516 -480 M V -90 R (O) mc Z U
+1320 -480 M V -90 R (I) mc Z U
+1124 -480 M V -90 R (D) mc Z U
+3140 61 M 156 F0
 V -90 R (m) bc Z U
 -90 R
 -121 0 T

--- a/doc/examples/ex29/ex29.ps
+++ b/doc/examples/ex29/ex29.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from plot
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:11:23 2021
+%%CreationDate: Wed Mar 17 16:19:11 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -7466,7 +7466,7 @@ FQ
 O0
 0 4944 TM
 % PostScript produced by:
-%@GMT: gmt colorbar -DJBC+o0/0.4c+w6i/0.25c -I --FONT_ANNOT_PRIMARY=12p -Bx2f1 -By+lkm -Xa0i -Ya4.1198i -Rg -JH0/18c
+%@GMT: gmt colorbar -DJBC+o0/0.4c+w6i/0.25c -I --FONT_ANNOT_PRIMARY -Bx2f1 -By+lkm -Xa0i -Ya4.1198i -Rg -JH0/18c
 %@PROJ: hammer -180.00000000 180.00000000 -90.00000000 90.00000000 -18019929.522 18019929.522 -9009964.761 9009964.761 +unavailable +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -8711,7 +8711,7 @@ N 7057 0 M 0 -62 D S
 /MM {neg M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-156 F0
+200 F0
 (-6) sh mx
 (-4) sh mx
 (-2) sh mx

--- a/doc/scripts/GMT_colorbar.ps
+++ b/doc/scripts/GMT_colorbar.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from basemap
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from basemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 18:06:28 2021
+%%CreationDate: Wed Mar 17 16:13:56 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -805,68 +805,40 @@ N 0 0 M 4800 0 D S
 /PSL_A0_y 67 def
 /PSL_A1_y 0 def
 7 W
-N 0 0 M 0 -67 D S
 N 800 0 M 0 -67 D S
-N 1600 0 M 0 -67 D S
 N 2400 0 M 0 -67 D S
-N 3200 0 M 0 -67 D S
 N 4000 0 M 0 -67 D S
-N 4800 0 M 0 -67 D S
 /MM {neg M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-134 F0
-(-15\260) sh mx
+200 F0
 (-10\260) sh mx
-(-5\260) sh mx
 (0\260) sh mx
-(5\260) sh mx
 (10\260) sh mx
-(15\260) sh mx
 def
 /PSL_A0_y PSL_A0_y 40 add PSL_AH0 add def
-0 PSL_A0_y MM
-(-15\260) bc Z
 800 PSL_A0_y MM
 (-10\260) bc Z
-1600 PSL_A0_y MM
-(-5\260) bc Z
 2400 PSL_A0_y MM
 (0\260) bc Z
-3200 PSL_A0_y MM
-(5\260) bc Z
 4000 PSL_A0_y MM
 (10\260) bc Z
-4800 PSL_A0_y MM
-(15\260) bc Z
 N 160 0 M 0 -54 D S
-N 320 0 M 0 -54 D S
 N 480 0 M 0 -54 D S
-N 640 0 M 0 -54 D S
-N 960 0 M 0 -54 D S
 N 1120 0 M 0 -54 D S
-N 1280 0 M 0 -54 D S
 N 1440 0 M 0 -54 D S
 N 1760 0 M 0 -54 D S
-N 1920 0 M 0 -54 D S
 N 2080 0 M 0 -54 D S
-N 2240 0 M 0 -54 D S
-N 2560 0 M 0 -54 D S
 N 2720 0 M 0 -54 D S
-N 2880 0 M 0 -54 D S
 N 3040 0 M 0 -54 D S
 N 3360 0 M 0 -54 D S
-N 3520 0 M 0 -54 D S
 N 3680 0 M 0 -54 D S
-N 3840 0 M 0 -54 D S
-N 4160 0 M 0 -54 D S
 N 4320 0 M 0 -54 D S
-N 4480 0 M 0 -54 D S
 N 4640 0 M 0 -54 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-4936 96 M V MU 0 0 M 134 F12 (D) FP 134 F0 (T) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
-134 F12 (D) Z
-134 F0 (T) Z
+4936 96 M V MU 0 0 M 200 F12 (D) FP 200 F0 (T) FP pathbbox N 4 1 roll pop pop pop U -2 div 0 exch G
+200 F12 (D) Z
+200 F0 (T) Z
 0 setlinecap
 -600 342 T
 %%EndObject

--- a/doc/scripts/GMT_cycle_5.ps
+++ b/doc/scripts/GMT_cycle_5.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from grdimage
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 18:58:31 2021
+%%CreationDate: Wed Mar 17 16:13:57 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -933,7 +933,7 @@ N 0 2975 M 61 0 D S
 /MM {exch M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-152 F0
+200 F0
 (10) sw mx
 (20) sw mx
 (30) sw mx

--- a/doc/scripts/GMT_cyclic.ps
+++ b/doc/scripts/GMT_cyclic.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from basemap
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from basemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:09:14 2021
+%%CreationDate: Wed Mar 17 16:13:57 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -814,7 +814,7 @@ N 4800 0 M 0 -67 D S
 /MM {neg M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-134 F0
+200 F0
 (0) sh mx
 (20) sh mx
 (40) sh mx

--- a/doc/scripts/GMT_tut_15.ps
+++ b/doc/scripts/GMT_tut_15.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from grdimage
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:10:00 2021
+%%CreationDate: Wed Mar 17 16:19:04 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -700,7 +700,7 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt grdimage /Users/meghanj/.gmt/sessions/gmt_session.41163/=tiled_97_PX.000000 -R-108/-103/35/40 -JM6i -B -BWSnE
+%@GMT: gmt grdimage /Users/meghanj/.gmt/sessions/gmt_session.2013/=tiled_97_PX.000000 -R-108/-103/35/40 -JM6i -B -BWSnE
 %@PROJ: merc -108.00000000 -103.00000000 35.00000000 40.00000000 -278298.727 278298.727 4139372.762 4838471.398 +proj=merc +lon_0=-105.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -7528,7 +7528,7 @@ N 5760 0 M 0 83 D S
 /MM {M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-166 F0
+200 F0
 (1000) sh mx
 (2000) sh mx
 (3000) sh mx

--- a/doc/scripts/GMT_tut_16.ps
+++ b/doc/scripts/GMT_tut_16.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from grdimage
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:10:02 2021
+%%CreationDate: Wed Mar 17 16:19:06 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -700,7 +700,7 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt grdimage /Users/meghanj/.gmt/sessions/gmt_session.41206/=tiled_97_PX.000000 -R-108/-103/35/40 -Ius_i.nc -JM6i -B -BWSnE
+%@GMT: gmt grdimage /Users/meghanj/.gmt/sessions/gmt_session.2059/=tiled_97_PX.000000 -R-108/-103/35/40 -Ius_i.nc -JM6i -B -BWSnE
 %@PROJ: merc -108.00000000 -103.00000000 35.00000000 40.00000000 -278298.727 278298.727 4139372.762 4838471.398 +proj=merc +lon_0=-105.5 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -13461,7 +13461,7 @@ N 5760 0 M 0 83 D S
 /MM {M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-166 F0
+200 F0
 (1000) sh mx
 (2000) sh mx
 (3000) sh mx

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18890,7 +18890,7 @@ unsigned int gmt_file_type (struct GMT_CTRL *GMT, const char *file, unsigned int
 }
 #endif
 
-void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int justify) {
+void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int justify, struct GMT_OPTION *options) {
 	/* We wish to examine the previous -B setting for information as to which axes was
 	 * annotated and possibly labeled, and if the colorbar is requested to be placed on
 	 * such an axis side we need to make more space by increasing the offset. This is
@@ -18902,6 +18902,9 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 	unsigned int pos = 0, sides[5];
 	bool add_label = false, add_annot = false, axis_set = false, was;
 	double GMT_LETTER_HEIGHT = 0.736;
+	struct GMT_OPTION *opt = NULL;
+	char *c = NULL;
+	unsigned int n_errors = 0;
 	FILE *fp = NULL;
 	/* Initialize the default settings before considering any -B history */
 	gmt_set_undefined_defaults (GMT, 0.0, false);	/* Must set undefined to their reference values for now */
@@ -18951,6 +18954,13 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 	gmt_M_memcpy (sides, GMT->current.map.frame.side, 5U, unsigned int);
 	was = GMT->current.map.frame.draw;
 	gmtinit_conf_modern_override (GMT);	/* Reset */
+	(void)gmt_getdefaults (GMT, NULL);
+	for (opt = options; opt; opt = opt->next) {
+		if (opt->option != '-') continue;   /* Not a parameter setting */
+		c = strchr (opt->arg, '=');
+		c[0] = '\0';  /* Remove = */
+		n_errors += gmtlib_setparameter (GMT, opt->arg, &c[1], false);
+	}
 	gmt_M_memcpy (GMT->current.map.frame.side, sides, 5U, unsigned int);
 	GMT->current.map.frame.draw = was;
 }

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18957,7 +18957,7 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 	(void)gmt_getdefaults (GMT, NULL);
 	for (opt = options; opt; opt = opt->next) {
 		if (opt->option != '-') continue;   /* Not a parameter setting */
-		c = strchr (opt->arg, '=');
+		if ((c = strchr (opt->arg, '=')) == NULL) continue;
 		c[0] = '\0';  /* Remove = */
 		n_errors += gmtlib_setparameter (GMT, opt->arg, &c[1], false);
 	}

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -69,7 +69,7 @@ EXTERN_MSC int gmt_get_option_id (int start, char *this_option);
 EXTERN_MSC bool gmt_is_integer (char *L);
 EXTERN_MSC int gmt_get_next_panel (struct GMTAPI_CTRL *API, int fig, int *row, int *col);
 EXTERN_MSC int gmt_report_usage (struct GMTAPI_CTRL *API, struct GMT_OPTION *options, unsigned int special, int (*usage)(struct GMTAPI_CTRL *, int));
-EXTERN_MSC void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int justify);
+EXTERN_MSC void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int justify, struct GMT_OPTION *options);
 EXTERN_MSC struct GMT_SUBPLOT * gmt_subplot_info (struct GMTAPI_CTRL *API, int fig);
 EXTERN_MSC int gmt_get_V (char arg);
 EXTERN_MSC char gmt_set_V (int mode);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -443,7 +443,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT_OP
 	else if (Ctrl->D.refpoint->mode != GMT_REFPOINT_PLOT || strstr (Ctrl->D.refpoint->args, "+w")) {	/* New syntax: */
 		/* Args are +w<length>[/<width>][+e[b|f][<length>]][+h|v][+j<justify>][+ma|c|l|u][+n[<txt>]][+o<dx>[/<dy>]] */
 		double bar_offset[2];	/* Will be initialized in gmt_auto_offsets_for_colorbar */
-		gmt_auto_offsets_for_colorbar (GMT, bar_offset, Ctrl->D.refpoint->justify);
+		gmt_auto_offsets_for_colorbar (GMT, bar_offset, Ctrl->D.refpoint->justify, options);
 		if (gmt_get_modifier (Ctrl->D.refpoint->args, 'j', string))
 			Ctrl->D.justify = gmt_just_decode (GMT, string, PSL_NO_DEF);
 		else {	/* With -Dj or -DJ, set default to reference (mirrored) justify point, else BL */

--- a/test/grd2cpt/equalarea.ps
+++ b/test/grd2cpt/equalarea.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from text
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from text
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 17:34:26 2021
+%%CreationDate: Wed Mar 17 16:19:18 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -1224,7 +1224,7 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 756 4371 T
-23 W
+25 W
 V N 0 0 T 6047 242 scale /DeviceRGB setcolorspace
 << /ImageType 1 /Decode [0 1 0 1 0 1] /Width 10 /Height 1 /BitsPerComponent 8
    /ImageMatrix [10 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter
@@ -1237,19 +1237,19 @@ N 0 0 M 0 242 D S
 N 6047 0 M 0 242 D S
 0 242 T
 N 0 0 M 6047 0 D S
-/PSL_A0_y 77 def
+/PSL_A0_y 68 def
 /PSL_A1_y 0 def
 8 W
-N 724 0 M 0 77 D S
-N 1676 0 M 0 77 D S
-N 2629 0 M 0 77 D S
-N 3581 0 M 0 77 D S
-N 4534 0 M 0 77 D S
-N 5487 0 M 0 77 D S
+N 724 0 M 0 68 D S
+N 1676 0 M 0 68 D S
+N 2629 0 M 0 68 D S
+N 3581 0 M 0 68 D S
+N 4534 0 M 0 68 D S
+N 5487 0 M 0 68 D S
 /MM {M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-154 F0
+169 F0
 (”4000) sh mx
 (”2000) sh mx
 (0) sh mx
@@ -1257,7 +1257,7 @@ PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencod
 (4000) sh mx
 (6000) sh mx
 def
-/PSL_A0_y PSL_A0_y 46 add def
+/PSL_A0_y PSL_A0_y 51 add def
 724 PSL_A0_y MM
 (”4000) bc Z
 1676 PSL_A0_y MM
@@ -1271,13 +1271,13 @@ def
 5487 PSL_A0_y MM
 (6000) bc Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 247 0 M 0 62 D S
-N 1200 0 M 0 62 D S
-N 2152 0 M 0 62 D S
-N 3105 0 M 0 62 D S
-N 4058 0 M 0 62 D S
-N 5010 0 M 0 62 D S
-N 5963 0 M 0 62 D S
+N 247 0 M 0 34 D S
+N 1200 0 M 0 34 D S
+N 2152 0 M 0 34 D S
+N 3105 0 M 0 34 D S
+N 4058 0 M 0 34 D S
+N 5010 0 M 0 34 D S
+N 5963 0 M 0 34 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -242 T
 0 setlinecap
@@ -2118,7 +2118,7 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 756 4371 T
-23 W
+25 W
 {0.242 0.217 0.563 C} FS
 242 839 0 0 Sb
 {0.277 0.484 0.951 C} FS
@@ -2145,19 +2145,19 @@ N 0 0 M 0 242 D S
 N 6047 0 M 0 242 D S
 0 242 T
 N 0 0 M 6047 0 D S
-/PSL_A0_y 77 def
+/PSL_A0_y 68 def
 /PSL_A1_y 0 def
 8 W
-N 724 0 M 0 77 D S
-N 1676 0 M 0 77 D S
-N 2629 0 M 0 77 D S
-N 3581 0 M 0 77 D S
-N 4534 0 M 0 77 D S
-N 5487 0 M 0 77 D S
+N 724 0 M 0 68 D S
+N 1676 0 M 0 68 D S
+N 2629 0 M 0 68 D S
+N 3581 0 M 0 68 D S
+N 4534 0 M 0 68 D S
+N 5487 0 M 0 68 D S
 /MM {M} def
 /PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-154 F0
+169 F0
 (”4000) sh mx
 (”2000) sh mx
 (0) sh mx
@@ -2165,7 +2165,7 @@ PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencod
 (4000) sh mx
 (6000) sh mx
 def
-/PSL_A0_y PSL_A0_y 46 add def
+/PSL_A0_y PSL_A0_y 51 add def
 724 PSL_A0_y MM
 (”4000) bc Z
 1676 PSL_A0_y MM
@@ -2179,13 +2179,13 @@ def
 5487 PSL_A0_y MM
 (6000) bc Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 247 0 M 0 62 D S
-N 1200 0 M 0 62 D S
-N 2152 0 M 0 62 D S
-N 3105 0 M 0 62 D S
-N 4058 0 M 0 62 D S
-N 5010 0 M 0 62 D S
-N 5963 0 M 0 62 D S
+N 247 0 M 0 34 D S
+N 1200 0 M 0 34 D S
+N 2152 0 M 0 34 D S
+N 3105 0 M 0 34 D S
+N 4058 0 M 0 34 D S
+N 5010 0 M 0 34 D S
+N 5963 0 M 0 34 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 0 -242 T
 0 setlinecap

--- a/test/psscale/cbarfontsize.ps
+++ b/test/psscale/cbarfontsize.ps
@@ -1,0 +1,854 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 595 842
+%%HiResBoundingBox: 0 0 595.0000 842.0000
+%%Title: GMT v6.2.0_6fc7956_2021.03.17 [64-bit] Document from colorbar
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Wed Mar 17 16:11:45 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 9917 def
+/PSL_page_ysize 14033 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt colorbar -C -Dx0/12c+jBL+w15c/0.4c+h
+%@PROJ: xy 0.00000000 20.00000000 0.00000000 0.15748031 0.000 20.000 0.000 0.157 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 5669 T
+25 W
+V N 0 0 T 7087 189 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 5 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [5 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter
+>> image
+&3O;RBO$.@1>nHrrOBZ~>
+U
+2 setlinecap
+N 0 0 M 7087 0 D S
+N 0 189 M 7087 0 D S
+N 0 0 M 0 189 D S
+N 7087 0 M 0 189 D S
+4 W
+N 0 0 M 0 189 D S
+N 1417 0 M 0 189 D S
+N 2835 0 M 0 189 D S
+N 4252 0 M 0 189 D S
+N 5669 0 M 0 189 D S
+N 7087 0 M 0 189 D S
+8 W
+N 0 0 M 0 -67 D S
+N 1417 0 M 0 -67 D S
+N 2835 0 M 0 -67 D S
+N 4252 0 M 0 -67 D S
+N 5669 0 M 0 -67 D S
+N 7087 0 M 0 -67 D S
+0 -117 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+167 F0
+(0) tc Z
+1417 -117 M (4) tc Z
+2835 -117 M (8) tc Z
+4252 -117 M (12) tc Z
+5669 -117 M (16) tc Z
+7087 -117 M (20) tc Z
+0 setlinecap
+0 -5669 T
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt colorbar -C -Dx0/8c+jBL+w15c/0.4c+h
+%@PROJ: xy 0.00000000 20.00000000 0.00000000 0.15748031 0.000 20.000 0.000 0.157 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 3780 T
+25 W
+V N 0 0 T 7087 189 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 5 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [5 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter
+>> image
+&3O;RBO$.@1>nHrrOBZ~>
+U
+2 setlinecap
+N 0 0 M 7087 0 D S
+N 0 189 M 7087 0 D S
+N 0 0 M 0 189 D S
+N 7087 0 M 0 189 D S
+4 W
+N 0 0 M 0 189 D S
+N 1417 0 M 0 189 D S
+N 2835 0 M 0 189 D S
+N 4252 0 M 0 189 D S
+N 5669 0 M 0 189 D S
+N 7087 0 M 0 189 D S
+8 W
+N 0 0 M 0 -67 D S
+N 1417 0 M 0 -67 D S
+N 2835 0 M 0 -67 D S
+N 4252 0 M 0 -67 D S
+N 5669 0 M 0 -67 D S
+N 7087 0 M 0 -67 D S
+0 -117 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(0) tc Z
+1417 -117 M (4) tc Z
+2835 -117 M (8) tc Z
+4252 -117 M (12) tc Z
+5669 -117 M (16) tc Z
+7087 -117 M (20) tc Z
+0 setlinecap
+0 -3780 T
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt colorbar -C -Dx0/4c+jBL+w15c/0.4c+h --FONT_ANNOT_PRIMARY=32p
+%@PROJ: xy 0.00000000 20.00000000 0.00000000 0.15748031 0.000 20.000 0.000 0.157 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 1890 T
+25 W
+V N 0 0 T 7087 189 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 5 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [5 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter
+>> image
+&3O;RBO$.@1>nHrrOBZ~>
+U
+2 setlinecap
+N 0 0 M 7087 0 D S
+N 0 189 M 7087 0 D S
+N 0 0 M 0 189 D S
+N 7087 0 M 0 189 D S
+4 W
+N 0 0 M 0 189 D S
+N 1417 0 M 0 189 D S
+N 2835 0 M 0 189 D S
+N 4252 0 M 0 189 D S
+N 5669 0 M 0 189 D S
+N 7087 0 M 0 189 D S
+8 W
+N 0 0 M 0 -67 D S
+N 1417 0 M 0 -67 D S
+N 2835 0 M 0 -67 D S
+N 4252 0 M 0 -67 D S
+N 5669 0 M 0 -67 D S
+N 7087 0 M 0 -67 D S
+0 -117 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+533 F0
+(0) tc Z
+1417 -117 M (4) tc Z
+2835 -117 M (8) tc Z
+4252 -117 M (12) tc Z
+5669 -117 M (16) tc Z
+7087 -117 M (20) tc Z
+0 setlinecap
+0 -1890 T
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psscale/cbarfontsize.ps
+++ b/test/psscale/cbarfontsize.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_6fc7956_2021.03.17 [64-bit] Document from colorbar
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_dcb8743_2021.03.17 [64-bit] Document from colorbar
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Wed Mar 17 16:11:45 2021
+%%CreationDate: Wed Mar 17 16:19:20 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -117,39 +117,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -688,8 +688,8 @@ end
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-/PSL_page_xsize 9917 def
-/PSL_page_ysize 14033 def
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
 /PSL_movie_label_completion {} def
 /PSL_movie_prog_indicator_completion {} def
@@ -733,7 +733,7 @@ N 2835 0 M 0 -67 D S
 N 4252 0 M 0 -67 D S
 N 5669 0 M 0 -67 D S
 N 7087 0 M 0 -67 D S
-0 -117 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -117 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 167 F0
 (0) tc Z
 1417 -117 M (4) tc Z
@@ -782,7 +782,7 @@ N 2835 0 M 0 -67 D S
 N 4252 0 M 0 -67 D S
 N 5669 0 M 0 -67 D S
 N 7087 0 M 0 -67 D S
-0 -117 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -117 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 333 F0
 (0) tc Z
 1417 -117 M (4) tc Z
@@ -831,7 +831,7 @@ N 2835 0 M 0 -67 D S
 N 4252 0 M 0 -67 D S
 N 5669 0 M 0 -67 D S
 N 7087 0 M 0 -67 D S
-0 -117 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -117 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 533 F0
 (0) tc Z
 1417 -117 M (4) tc Z

--- a/test/psscale/cbarfontsize.sh
+++ b/test/psscale/cbarfontsize.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Test implementation of --PARAM=value with themes
+
+gmt begin cbarfontsize ps
+	gmt makecpt -Cbatlow -T0/20/4
+	gmt colorbar -C -Dx0/12c+jBL+w15c/0.4c+h
+	gmt set FONT_ANNOT_PRIMARY 20p
+	gmt colorbar -C -Dx0/8c+jBL+w15c/0.4c+h
+	gmt colorbar -C -Dx0/4c+jBL+w15c/0.4c+h --FONT_ANNOT_PRIMARY=32p
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a check for --PARAM=value and previous gmt.conf changes in ``gmt_auto_offsets_for_colorbar``.

Some PS files need to be updated, mostly because the constant font settings in GMT_THEME=cookbook were not honored by colorbar in modern mode.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #4978 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
