### PR TITLE
Only report a debug message if auto scaling is used

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9906,6 +9906,7 @@ void gmt_set_undefined_axes (struct GMT_CTRL *GMT, bool conf_update) {
 void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool conf_update) {
 	/* We must adjust all frame items with unspecified size according to plot dimension */
 	bool geo_frame = false;
+	bool auto_scale = false;
 	double fontsize, scale;
 	double const pt = 1.0/72.0;	/* points to inch */
 
@@ -9938,40 +9939,46 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 		scale = fontsize / 10.0;	/* scaling for offsets, pen widths and lengths normalized to the modern 10p size */
 	}
 
-	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Computed primary annotation font size: %g p  Dimension scaling: %g\n", fontsize, scale);
-
 	/* Only apply the automatic scaling to items NOT specifically set via a --PAR=value option */
 
 	if (gmt_M_is_dnan (GMT->current.setting.font_annot[GMT_PRIMARY].size)) {
 		GMT->current.setting.font_annot[GMT_PRIMARY].size = fontsize;
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_ANNOT_PRIMARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.font_annot[GMT_SECONDARY].size)) {
 		GMT->current.setting.font_annot[GMT_SECONDARY].size = scale * 12.0;	/* Modern 12p vs 10p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_ANNOT_SECONDARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.font_label.size)) {
 		GMT->current.setting.font_label.size = scale * 14.0;	/* Modern 14p vs 10p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_LABEL] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.font_heading.size)) {
 		GMT->current.setting.font_heading.size = scale * 28.0;	/* Modern 28p vs 10p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_HEADING] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.font_tag.size)) {
 		GMT->current.setting.font_tag.size = scale * 16.0;		/* Modern 16p vs 10p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_TAG] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.font_title.size)) {
 		GMT->current.setting.font_title.size = scale * 22.0;	/* Modern 22p vs 10p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_TITLE] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.font_subtitle.size)) {
 		GMT->current.setting.font_subtitle.size = scale * 18.0;	/* Modern 18p vs 10p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_SUBTITLE] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.font_logo.size)) {
 		GMT->current.setting.font_logo.size = scale * 8.0;		/* Classic 8p vs 10p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_LOGO] = true;
 	}
 
@@ -9979,26 +9986,32 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 
 	if (gmt_M_is_dnan (GMT->current.setting.map_annot_offset[GMT_PRIMARY])) {
 		GMT->current.setting.map_annot_offset[GMT_PRIMARY] = 3 * pt * scale; /* 3p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_ANNOT_OFFSET_PRIMARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_annot_offset[GMT_SECONDARY])) {
 		GMT->current.setting.map_annot_offset[GMT_SECONDARY] = 3 * pt * scale; /* 3p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_ANNOT_OFFSET_SECONDARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_label_offset)) {
 		GMT->current.setting.map_label_offset = 6 * pt * scale;	/* 6p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_LABEL_OFFSET] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_title_offset)) {
 		GMT->current.setting.map_title_offset = 12 * pt * scale;	/* 12p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_TITLE_OFFSET] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_heading_offset)) {
 		GMT->current.setting.map_heading_offset = 16 * pt * scale;	/* 16p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_HEADING_OFFSET] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_annot_min_spacing)) {
 		GMT->current.setting.map_annot_min_spacing = 28 * pt * scale; /* 28p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_ANNOT_MIN_SPACING] = true;
 		snprintf (GMT->current.setting.map_annot_min_spacing_txt, GMT_LEN16, "%.6gp", GMT->current.setting.map_annot_min_spacing / pt);
 	}
@@ -10007,6 +10020,7 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 
 	if (gmt_M_is_dnan (GMT->current.setting.map_frame_width)) {
 		GMT->current.setting.map_frame_width = 3 * pt * scale; /* 3p */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_FRAME_WIDTH] = true;
 	}
 
@@ -10022,6 +10036,7 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 			GMT->current.setting.map_tick_length[GMT_ANNOT_UPPER] = 4 * pt * scale;	/* 4p */
 			GMT->current.setting.map_tick_length[GMT_TICK_UPPER]  = 2 * pt * scale;	/* 2p */
 		}
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_TICK_LENGTH_PRIMARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_tick_length[GMT_ANNOT_LOWER])) {
@@ -10034,6 +10049,7 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 			GMT->current.setting.map_tick_length[GMT_ANNOT_LOWER] = 12 * pt * scale;	/* 12p */
 			GMT->current.setting.map_tick_length[GMT_TICK_LOWER]  = 3  * pt * scale;	/* 3p */
 		}
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_TICK_LENGTH_SECONDARY] = true;
 	}
 
@@ -10045,6 +10061,7 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 		if (reach < 1.0) reach *= 60.0, f *= 60.0;
 		reach = rint (reach) / f;	/* Integer degrees, minutes or seconds */
 		GMT->current.setting.map_polar_cap[0] = 90.0 - reach; /* Max 5 degrees from pole */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_POLAR_CAP] = true;
 	}
 
@@ -10052,29 +10069,37 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 
 	if (gmt_M_is_dnan (GMT->current.setting.map_frame_pen.width)) {
 		GMT->current.setting.map_frame_pen.width = 1.5 * scale; /* 1.5p (thicker) */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_FRAME_PEN] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_tick_pen[GMT_PRIMARY].width)) {
 		GMT->current.setting.map_tick_pen[GMT_PRIMARY].width = 0.5 * scale;	/* 0.5p (thinner) */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_TICK_PEN_PRIMARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_tick_pen[GMT_SECONDARY].width)) {
 		GMT->current.setting.map_tick_pen[GMT_SECONDARY].width = 0.5 * scale;	/* 0.5p (thinner) */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_TICK_PEN_SECONDARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_grid_pen[GMT_PRIMARY].width)) {
 		GMT->current.setting.map_grid_pen[GMT_PRIMARY].width = 0.25 * scale;	/* 0.25p (default) */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_GRID_PEN_PRIMARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_grid_pen[GMT_SECONDARY].width)) {
 		GMT->current.setting.map_grid_pen[GMT_SECONDARY].width = 0.5 * scale;	/* 0.5p (thinner) */
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_GRID_PEN_SECONDARY] = true;
 	}
 
 	if (gmt_M_is_dnan (GMT->current.setting.map_vector_shape)) {
 		GMT->current.setting.map_vector_shape = 0.5;
+		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_VECTOR_SHAPE] = true;
 	}
+
+	if (auto_scale) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Computed automatic parameters using dimension scaling: %g\n", scale);
 }
 
 GMT_LOCAL unsigned int gmtinit_parse_map_annot_oblique (struct GMT_CTRL *GMT, char *text) {


### PR DESCRIPTION
**Description of proposed changes**

The debug message about computing the primary annotation size was previously reported regardless of whether any automatic settings were changed. This PR keeps track of whether any automatic parameters were changed and reports the debug message only if true.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
