### PR TITLE
Fix failures with bash on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,26 +128,9 @@ jobs:
           echo "${INSTALLDIR}/bin" >> $GITHUB_PATH
 
       - name: Check a few simple commands
-        run: |
-          set -x -e
-          echo $SHELL
-          gmt --version
-          gmt-config --all
-          gmt defaults -Vd
-          gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-          gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
-          gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
+        run: bash ci/simple-gmt-tests.sh
 
       - name: Check a few simple commands (Windows)
         shell: cmd
-        run: |
-          gmt --version
-          echo $SHELL
-          bash %INSTALLDIR%/bin/gmt-config --all
-          gmt defaults -Vd
-          gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-          gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
-          gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
+        run: call ci/simple-gmt-tests.bat
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Check a few simple commands
         run: |
           set -x -e
+          echo $SHELL
           gmt --version
           gmt-config --all
           gmt defaults -Vd
@@ -142,6 +143,7 @@ jobs:
         shell: cmd
         run: |
           gmt --version
+          echo $SHELL
           bash %INSTALLDIR%/bin/gmt-config --all
           gmt defaults -Vd
           gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,12 +105,4 @@ jobs:
           echo "${INSTALLDIR}/bin" >> $GITHUB_PATH
 
       - name: Check a few simple commands
-        run: |
-          set -x -e
-          gmt --version
-          gmt-config --all
-          gmt defaults -Vd
-          gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-          gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
-          gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
+        run: bash ci/simple-gmt-tests.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,26 +133,11 @@ jobs:
           echo "${INSTALLDIR}/bin" >> $GITHUB_PATH
 
       - name: Check a few simple commands
-        run: |
-          set -x -e
-          gmt --version
-          gmt-config --all
-          gmt defaults -Vd
-          gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-          gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
-          gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
+        run: bash ci/simple-gmt-tests.sh
 
       - name: Check a few simple commands (Windows)
         shell: cmd
-        run: |
-          gmt --version
-          bash %INSTALLDIR%/bin/gmt-config --all
-          gmt defaults -Vd
-          gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
-          gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
-          gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
+        run: call ci/simple-gmt-tests.bat
         if: runner.os == 'Windows'
 
       # Run full tests and rerun failed tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,9 @@ jobs:
           gmt-config --all
           gmt defaults -Vd
           gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
+          gmt begin
+          gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd
+          gmt end
           gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
           gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
 
@@ -150,7 +152,9 @@ jobs:
           bash %INSTALLDIR%/bin/gmt-config --all
           gmt defaults -Vd
           gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
+          gmt begin
+          gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd
+          gmt end
           gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
           gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
         if: runner.os == 'Windows'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,9 +139,7 @@ jobs:
           gmt-config --all
           gmt defaults -Vd
           gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin
-          gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd
-          gmt end
+          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
           gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
           gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
 
@@ -152,9 +150,7 @@ jobs:
           bash %INSTALLDIR%/bin/gmt-config --all
           gmt defaults -Vd
           gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
-          gmt begin
-          gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd
-          gmt end
+          gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
           gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
           gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
         if: runner.os == 'Windows'

--- a/ci/simple-gmt-tests.bat
+++ b/ci/simple-gmt-tests.bat
@@ -1,0 +1,24 @@
+REM
+REM Run some simple GMT commands
+REM
+
+REM Check GMT version
+gmt --version
+
+REM Check GMT configuration
+bash %INSTALLDIR%/bin/gmt-config --all
+
+REM Check GMT defaults
+gmt defaults -Vd
+
+REM Check GMT classic mode, GSHHG and DCW
+gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
+
+REM Check GMT modern mode, GSHHG and DCW
+gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
+
+REM Check remote file and modern one-liner
+gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
+
+REM Check supplemental modules
+gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd

--- a/ci/simple-gmt-tests.sh
+++ b/ci/simple-gmt-tests.sh
@@ -18,7 +18,9 @@ gmt defaults -Vd
 gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
 
 # Check GMT modern mode, GSHHG and DCW
+if [ "${RUNNER_OS}" == "Windows" ]; then export GMT_SESSION_NAME=$$; fi
 gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
+if [ "${RUNNER_OS}" == "Windows" ]; then unset GMT_SESSION_NAME; fi
 
 # Check remote file and modern one-liner
 gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map

--- a/ci/simple-gmt-tests.sh
+++ b/ci/simple-gmt-tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Run some simple GMT commands
+#
+
+set -x -e
+
+# Check GMT version
+gmt --version
+
+# Check GMT configuration
+gmt-config --all
+
+# Check GMT defaults
+gmt defaults -Vd
+
+# Check GMT classic mode, GSHHG and DCW
+gmt pscoast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -P -Vd > test.ps
+
+# Check GMT modern mode, GSHHG and DCW
+gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
+
+# Check remote file and modern one-liner
+gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
+
+# Check supplemental modules
+gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
+
+set +x +e


### PR DESCRIPTION
**Description of proposed changes**

GMT fails in bash on Windows, because the PID changes (https://docs.generic-mapping-tools.org/dev/begin.html#note-on-unix-shells). To fix the issue, we need to run:
```
export GMT_SESSION_NAME=$$
```

This PR fixes the issue and also move the testing commands into two scripts 
`ci/simple-gmt-tests.bat` and `ci/simple-gmt-tests.sh` to simplify the CI 
workflows.

Fixes #4984


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
