### PR TITLE
Need to check for +f0 in pscoupe

### DIFF
--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -863,8 +863,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 						Ctrl->S.angle = atof(word);
 					if (gmt_get_modifier (opt->arg, 'j', word) && strchr ("LCRBMT", word[0]) && strchr ("LCRBMT", word[1]))
 						Ctrl->S.justify = gmt_just_decode (GMT, word, Ctrl->S.justify);
-					if (gmt_get_modifier (opt->arg, 'f', word))
-						n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));
+					if (gmt_get_modifier (opt->arg, 'f', word)) {
+						if (strcmp (word, "0"))
+							n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));
+						else
+							Ctrl->S.font.size = 0.0;
+					}
 					if (gmt_get_modifier (opt->arg, 'o', word)) {
 						if (gmt_get_pair (GMT, word, GMT_PAIR_DIM_DUP, Ctrl->S.offset) < 0) n_errors++;
 					} else {	/* Set default offset */


### PR DESCRIPTION
We did this in **meca** but forgot to duplicate in **coupe**.  Closes #4986.
