### PR TITLE
CI: Let docs workflow timeout in 45 minutes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,7 @@ jobs:
   docs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
 
     env:
       # directories


### PR DESCRIPTION
**Description of proposed changes**

Building docs usually takes 15 minutes on Linux and 30 minutes on macOS
and Windows.

Sometimes, it may take hours on Linux, likely because something wrong
with the animation building. This PR limits the workflow to less than 45
minutes.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
