### PR TITLE
Add VPDF for Von Mises PDF to grdmath

### DIFF
--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -151,11 +151,11 @@ Optional Arguments
 Operators
 ---------
 
-Choose among the following operators. "args" are the number of input
+Choose among the following operators. "Args" are the number of input
 and output arguments.
 
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
-| Operator      | args  | Returns                                                                                                |
+| Operator      | Args  | Returns                                                                                                |
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
 | **ABS**       | 1 1   | abs (A)                                                                                                |
 +---------------+-------+--------------------------------------------------------------------------------------------------------+

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -151,7 +151,7 @@ Optional Arguments
 Operators
 ---------
 
-Choose among the following 224 operators. "args" are the number of input
+Choose among the following operators. "args" are the number of input
 and output arguments.
 
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
@@ -559,6 +559,8 @@ and output arguments.
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
 | **VARW**      | 2 1   | Weighted variance of A for weights in B                                                                |
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
+| **VPDF**      | 3 1   | Von Mises density distribution P(x,mu,kappa), with x = A, mu = B, and kappa = C                        |
++---------------+-------+--------------------------------------------------------------------------------------------------------+
 | **WCDF**      | 3 1   | Weibull cumulative distribution function for x = A, scale = B, and shape = C                           |
 +---------------+-------+--------------------------------------------------------------------------------------------------------+
 | **WCRIT**     | 3 1   | Weibull distribution critical value for alpha = A, scale = B, and shape = C                            |
@@ -733,11 +735,13 @@ Notes On Operators
    only r,g,b and h,s,v triplet conversions, but also l,a,b (CIE L a b ) and
    sRGB (x, y, z) conversions between all four color spaces.
 
-#. The DAYNIGHT operator returns a grid with ones on the side facing the given
+#. The **DAYNIGHT** operator returns a grid with ones on the side facing the given
    sun location at (A,B).  If the transition width (C) is zero then we get
    either 1 or 0, but if C is nonzero then we approximate the step function
    using an atan-approximation instead.  Thus, the values are never exactly
    0 or 1, but close, and the smaller C the closer we get.
+
+#. The **VPDF** operator expects angles in degrees.
 
 .. include:: explain_float.rst_
 


### PR DESCRIPTION
**Description of proposed changes**

Allows evaluation of the Von Mises PDF.  Also removes the out-of-date number of operators and fixes formatting for **DAYNIGHT** operator.  It is simple enough that I did not bother to add another test for this.  Here is a case showing how the PDF is very broad (and wrapps over 360) when kappa is small then focuses on the mean (125) when kappa gets bigger:

```
gmt grdmath -R0/360/1/20 -I1 X 125 Y VPDF = t.grd
gmt grdimage t.grd -JX15cd/8c -Bxaf+l"Angle" -Byaf+l"@~k@~" -B+t"Von Mises PDF as function of @~k@~" --FORMAT_GEO_MAP=+D -png map
```

![map](https://user-images.githubusercontent.com/26473567/112706935-acef7e00-8e4b-11eb-9646-f2eefc6235dd.png)

