### PR TITLE
fix two typos

### DIFF
--- a/doc/rst/source/grdimage_notes.rst_
+++ b/doc/rst/source/grdimage_notes.rst_
@@ -28,6 +28,6 @@ Image formats recognized
 ------------------------
 
 We automatically recognize image formats via their magic bytes.  For formats
-that could contain either an image of a data set (e.g., geotiff) we determine
+that could contain either an image or a data set (e.g., geotiff) we determine
 which case it is and act accordingly.  If your favorite image format is not
 automatically detected then please let us know its magic bytes so we can add it.

--- a/doc/rst/source/grdmix.rst
+++ b/doc/rst/source/grdmix.rst
@@ -34,7 +34,7 @@ Description
 -----------
 
 **grdmix** will perform various operations involving images and grids.
-We either use a *alpha* grid, image, or constant to add a new alpha
+We either use an *alpha* grid, image, or constant to add a new alpha
 (transparency) layer to the image given as *raster1*, or we will blend
 the two *raster1* and *raster2* (grids or images) using the *weights* for
 *raster1* and the complementary *1 - weights* for *raster2* and save to


### PR DESCRIPTION
Please revise the fix;

This is the change I made:
```
that could contain either an image or a data set (e.g., geotiff) we determine
```

But it could also be meant to say:
```
that could contain either an image of a data set (e.g., geotiff) or a data set we determine
```
