### PR TITLE
Address regression on -I for dual geographic units

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7047,7 +7047,8 @@ GMT_LOCAL unsigned int gmtsupport_set_geo (struct GMT_CTRL *GMT) {
 /*! . */
 int gmt_getincn (struct GMT_CTRL *GMT, char *line, double inc[], unsigned int n) {
 	bool separate;
-	unsigned int last, i, pos, bit = 1, geo = gmtsupport_set_geo (GMT);	/* true unless clearly -R is Cartesian */
+	unsigned int last, i, pos, side = GMT_X, geo = gmtsupport_set_geo (GMT);	/* true unless clearly -R is Cartesian */
+	unsigned geo_bit[2] = {GMT_IS_LON, GMT_IS_LAT};
 	char p[GMT_BUFSIZ];
 	double scale = 1.0;
 
@@ -7081,7 +7082,7 @@ int gmt_getincn (struct GMT_CTRL *GMT, char *line, double inc[], unsigned int n)
 			if (i < 2) GMT->current.io.inc_code[i] |= GMT_INC_IS_NNODES;
 			if (last) last--;	/* Coverity rightly points out that if last == 0 it would become 4294967295 */
 		}
-		if (geo == 0 || (separate && (geo & bit) == 0) ) {	/* Gave a unit to a Cartesian axes that does not take any unit */
+		if (geo == 0 || (separate && (side <= GMT_Y && (geo & geo_bit[side]) == 0)) ) {	/* Gave a unit to a Cartesian axes that does not take any unit */
 			if (p[last] && strchr (GMT_LEN_UNITS "c", p[last])) {
 				if (separate) {	/* Report per axis since separate increments where given */
 					static char *A = "xyzvuw";
@@ -7149,7 +7150,7 @@ int gmt_getincn (struct GMT_CTRL *GMT, char *line, double inc[], unsigned int n)
 		}
 		inc[i] *= scale;
 		i++;	/* Goto next increment */
-		bit <<= 1;
+		side++;
 	}
 	if (geo) {
 		if (geo == (GMT_IS_LON+GMT_IS_LAT))	/* Regular lon/lat region presumably */


### PR DESCRIPTION
Addresses the silliness in reported on the [forum](https://forum.generic-mapping-tools.org/t/creating-a-zero-level-grid/1516/2).
All tests still pass and the original issue works as before:

```
gmt grdmath -R3/4/51/52 -I1s/1s 0 = t.grd
gmt grdinfo t.grd
t.grd: Title: Produced by grdmath
t.grd: Command: grdmath -R3/4/51/52 -I1s/1s 0 = t.grd
t.grd: Remark: 
t.grd: Gridline node registration used [Geographic grid]
t.grd: Grid file format: nf = GMT netCDF format (32-bit float), CF-1.7
t.grd: x_min: 3 x_max: 4 x_inc: 0.000277777777778 (1 sec) name: longitude n_columns: 3601
t.grd: y_min: 51 y_max: 52 y_inc: 0.000277777777778 (1 sec) name: latitude n_rows: 3601
t.grd: v_min: 0 v_max: 0 name: z
t.grd: scale_factor: 1 add_offset: 0
t.grd: format: netCDF-4 chunk_size: 129,129 shuffle: on deflation_level: 3
```
