### PR TITLE
Let J parser tolerate static string

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4767,7 +4767,7 @@ GMT_LOCAL int gmtinit_autoscale (char *arg) {
 }
 
 /*! . */
-GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
+GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args_in) {
 	/* gmtinit_parse_J_option scans the arguments given and extracts the parameters needed
 	 * for the specified map projection. These parameters are passed through the
 	 * GMT->current.proj structure.  The function returns true if an error is encountered.
@@ -4779,13 +4779,15 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args) {
 	bool width_given = false;
 	double c, az, GMT_units[3] = {0.01, 0.0254, 1.0};      /* No of meters in a cm, inch, m */
 	char mod, args_cp[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""};
-	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char = 0, *d = NULL;
-	char txt_arr[11][GMT_LEN256];
+	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char = 0, *d = NULL, *args;
+	char txt_arr[11][GMT_LEN256], args_buf[GMT_LEN128] = {""};
 
-	if (args == NULL) {
+	if (args_in == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -J: No argument for parsing\n");
 		return (true);
 	}
+	strncpy (args_buf, args_in, GMT_LEN128);	/* Must duplicate since args_in may be a static string */
+	args = args_buf;	/* Start of arguments */
 	gmt_M_memset (l_pos, 3, int);	gmt_M_memset (p_pos, 3, int);
 	gmt_M_memset (t_pos, 3, int);	gmt_M_memset (d_pos, 3, int);
 	if (!GMT->common.J.active)	/* Down want to clobber this during -Jz/Z after the horizontal part has been set */


### PR DESCRIPTION
Not sure how recent this is, but when a static string is passed to the J parser it cannot make any changes to that string.  This adds more fault tolerance and closes #5034.
