### PR TITLE
The -Gfill+n+p failed to set negative fill to active

### DIFF
--- a/doc/rst/source/wiggle_common.rst_
+++ b/doc/rst/source/wiggle_common.rst_
@@ -98,7 +98,8 @@ Optional Arguments
     wiggles [Default is no fill]. Optionally, append **+p** to fill
     positive areas (this is the default behavior). Append **+n** to fill
     negative areas. Append **+n+p** to fill both positive and negative
-    areas with the same fill.
+    areas with the same fill.  **Note**: You will need to repeat the **-G** option
+    to select different fills for the positive and negative wiggles.
 
 .. _-I:
 

--- a/src/pswiggle.c
+++ b/src/pswiggle.c
@@ -357,7 +357,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSWIGGLE_CTRL *Ctrl, struct GMT_O
 					n_errors++;
 				}
 				if (c) c[0] = '+';	/* Restore modifiers */
-				if (pos && neg) Ctrl->G.fill[1-k] = Ctrl->G.fill[k];	/* Duplicate fill */
+				if (pos && neg) Ctrl->G.active[PSWIGGLE_NEG] = true, Ctrl->G.fill[PSWIGGLE_NEG] = Ctrl->G.fill[PSWIGGLE_POS];	/* Duplicate fill */
 				break;
 			case 'I':
 				Ctrl->I.value = atof (opt->arg);


### PR DESCRIPTION
Also, the documentation did not specify that for separate positive and negative fills one must use **-G** twice: once with **+n** and once with **+p**.  Closes #5035.
