### PR TITLE
Honor subplot begin user labels

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13589,7 +13589,7 @@ GMT_LOCAL int gmtinit_get_current_panel (struct GMTAPI_CTRL *API, int fig, int *
 	}
 	fclose (fp);
 	if (*row < 0 || *col < 0) {
-		GMT_Report (API, GMT_MSG_ERROR, "Current panel has row or column outsiden range!\n");
+		GMT_Report (API, GMT_MSG_ERROR, "Current panel has row or column outside range!\n");
 		API->error = GMT_RUNTIME_ERROR;
 		return GMT_RUNTIME_ERROR;
 	}
@@ -13806,6 +13806,7 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 			while (*c != GMT_ASCII_GS) P->Byannot[k++] = *(c++);	/* Copy it over until end */
 			P->Byannot[k] = '\0';
 			found = true;	/* We are done */
+			fprintf (stderr, "GPT Bxannot = %s and BXlabel = %s\n", P->Bxannot, P->Bxlabel);
 		}
 	}
 	fclose (fp);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13806,7 +13806,6 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 			while (*c != GMT_ASCII_GS) P->Byannot[k++] = *(c++);	/* Copy it over until end */
 			P->Byannot[k] = '\0';
 			found = true;	/* We are done */
-			fprintf (stderr, "GPT Bxannot = %s and BXlabel = %s\n", P->Bxannot, P->Bxlabel);
 		}
 	}
 	fclose (fp);

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -644,7 +644,7 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 			}
 			if (Bx) {	/* Did get separate x-axis annotation settings */
 				if ((c = gmt_first_modifier (GMT, Bx->arg, "ls"))) {	/* Gave valid axes modifiers for custom labels */
-					pos = 0;
+					pos = error = 0;
 					while (gmt_getmodopt (GMT, 'B', c, "ls", &pos, p, &error) && error == 0) {
 						switch (p[0]) {
 							case 'l':	/* Regular x-axis label */
@@ -655,9 +655,8 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 								break;
 						}
 					}
-					fprintf (stderr, "GOT Xlabel Bx->arg = %s: %s\n", Bx->arg, Ctrl->S[GMT_X].label[GMT_PRIMARY]);
-					if (Ctrl->S[GMT_X].label[GMT_PRIMARY] || Ctrl->S[GMT_X].label[GMT_SECONDARY]) Ctrl->S[GMT_X].has_label = true;
 					c[0] = '\0';	/* Chop off for now */
+					if (Ctrl->S[GMT_X].label[GMT_PRIMARY] || Ctrl->S[GMT_X].label[GMT_SECONDARY]) Ctrl->S[GMT_X].has_label = true;
 				}
 				Ctrl->S[GMT_X].b = strdup (&Bx->arg[1]);
 				if (c) c[0] = '+';

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -261,9 +261,9 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, k, j, n = 0;
+	unsigned int n_errors = 0, error, k, j, n = 0, pos;
 	bool B_args = false, noB = false;
-	char *c = NULL, add[2] = {0, 0}, string[GMT_LEN128] = {""};
+	char *c = NULL, add[2] = {0, 0}, string[GMT_LEN128] = {""}, p[GMT_LEN128] = {""};
 	struct GMT_OPTION *opt = NULL, *Bframe = NULL, *Bx = NULL, *By = NULL, *Bxy = NULL;
 	struct GMT_PEN pen;	/* Only used to make sure any pen is given with correct syntax */
 	struct GMT_FILL fill;	/* Only used to make sure any fill is given with correct syntax */
@@ -642,10 +642,49 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 					n_errors++;
 				}
 			}
-			if (Bxy || Bx)	/* Did get x-axis annotation settings */
-				Ctrl->S[GMT_X].b = (Bx) ? strdup (Bx->arg) : strdup (Bxy->arg);
-			if (Bxy || By)	/* Did get y-axis annotation settings */
-				Ctrl->S[GMT_Y].b = (By) ? strdup (By->arg) : strdup (Bxy->arg);
+			if (Bx) {	/* Did get separate x-axis annotation settings */
+				if ((c = gmt_first_modifier (GMT, Bx->arg, "ls"))) {	/* Gave valid axes modifiers for custom labels */
+					pos = 0;
+					while (gmt_getmodopt (GMT, 'B', c, "ls", &pos, p, &error) && error == 0) {
+						switch (p[0]) {
+							case 'l':	/* Regular x-axis label */
+								Ctrl->S[GMT_X].label[GMT_PRIMARY] = strdup (&p[1]);	break;
+							case 's':	/* Secondary x-axis label */
+								Ctrl->S[GMT_X].label[GMT_SECONDARY] = strdup (&p[1]);	break;
+							default:	/* These are caught in gmt_getmodopt so break is just for Coverity */
+								break;
+						}
+					}
+					fprintf (stderr, "GOT Xlabel Bx->arg = %s: %s\n", Bx->arg, Ctrl->S[GMT_X].label[GMT_PRIMARY]);
+					if (Ctrl->S[GMT_X].label[GMT_PRIMARY] || Ctrl->S[GMT_X].label[GMT_SECONDARY]) Ctrl->S[GMT_X].has_label = true;
+					c[0] = '\0';	/* Chop off for now */
+				}
+				Ctrl->S[GMT_X].b = strdup (&Bx->arg[1]);
+				if (c) c[0] = '+';
+			}
+			else if (Bxy)	/* Did common x and y-axes annotation settings */
+				Ctrl->S[GMT_X].b = strdup (Bxy->arg);
+			if (By) {	/* Did get y-axis annotation settings */
+				if ((c = gmt_first_modifier (GMT, By->arg, "ls"))) {	/* Gave valid axes modifiers for custom labels */
+					pos = 0;
+					while (gmt_getmodopt (GMT, 'B', c, "ls", &pos, p, &error) && error == 0) {
+						switch (p[0]) {
+							case 'l':	/* Regular y-axis label */
+								Ctrl->S[GMT_Y].label[GMT_PRIMARY] = strdup (&p[1]);	break;
+							case 's':	/* Secondary y-axis label */
+								Ctrl->S[GMT_Y].label[GMT_SECONDARY] = strdup (&p[1]);	break;
+							default:	/* These are caught in gmt_getmodopt so break is just for Coverity */
+								break;
+						}
+					}
+					if (Ctrl->S[GMT_Y].label[GMT_PRIMARY] || Ctrl->S[GMT_Y].label[GMT_SECONDARY]) Ctrl->S[GMT_Y].has_label = true;
+					c[0] = '\0';	/* Chop off for now */
+				}
+				Ctrl->S[GMT_Y].b = strdup (&By->arg[1]);
+				if (c) c[0] = '+';
+			}
+			else if (Bxy)	/* Did common x and y-axes annotation settings */
+				Ctrl->S[GMT_Y].b = strdup (Bxy->arg);
 			if (noB) { /* Make sure we turn off everything */
 				Ctrl->S[GMT_X].extra = strdup ("+n");
 				Ctrl->In.no_B = true;

--- a/test/latex/subplotlatex.ps
+++ b/test/latex/subplotlatex.ps
@@ -1,0 +1,5815 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.2.0_4dac32f-dirty_2021.03.30 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Tue Mar 30 11:49:35 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/6.5381/0/8.1129 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.53810000 0.00000000 8.11290000 0.000 6.538 0.000 8.113 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 5011 TM
+% PostScript produced by:
+%@GMT: gmt basemap -BWens -Bxafg '-Byafg+l<math>\nabla G</math>' -Xa0i -Ya4.1759i -R-30/30/0/80 -JX10c
+%@PROJ: xy -30.00000000 30.00000000 0.00000000 80.00000000 -30.000 30.000 0.000 80.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+630 0 M
+0 4724 D
+S
+1890 0 M
+0 4724 D
+S
+3150 0 M
+0 4724 D
+S
+0 0 M
+3780 0 D
+S
+0 1181 M
+3780 0 D
+S
+0 2362 M
+3780 0 D
+S
+0 3543 M
+3780 0 D
+S
+0 4724 M
+3780 0 D
+S
+23 W
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -60 0 D S
+N 0 1181 M -60 0 D S
+N 0 2362 M -60 0 D S
+N 0 3543 M -60 0 D S
+N 0 4724 M -60 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+150 F0
+(0) sw mx
+(20) sw mx
+(40) sw mx
+(60) sw mx
+(80) sw mx
+def
+/PSL_A0_y PSL_A0_y 45 add def
+0 PSL_A0_y MM
+(0) mr Z
+1181 PSL_A0_y MM
+(20) mr Z
+2362 PSL_A0_y MM
+(40) mr Z
+3543 PSL_A0_y MM
+(60) mr Z
+4724 PSL_A0_y MM
+(80) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 591 M -30 0 D S
+N 0 1772 M -30 0 D S
+N 0 2953 M -30 0 D S
+N 0 4134 M -30 0 D S
+/PSL_LH 210 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 90 add def
+2362 PSL_L_y MM
+V
+currentpoint T 90 R
+0 189 PSL_LH sub neg M currentpoint T
+0 90 M currentpoint T
+PSL_eps_begin
+-210 0 T 21 21 scale
+-148 -656 T
+N 148 656 M 168 656 L 168 665 L 148 665 L P clip N
+%%BeginDocument: psimage.eps
+%!PS-Adobe-2.0 EPSF-2.0
+%%Creator: dvips(k) 2020.1 Copyright 2020 Radical Eye Software
+%%Title: gmt_eq.dvi
+%%CreationDate: Tue Mar 30 21:49:35 2021
+%%DocumentFonts: CMSY10 CMMI10
+%%EndComments
+%DVIPSWebPage: (www.radicaleye.com)
+%DVIPSCommandLine: dvips -q -E gmt_eq.dvi -o equation.eps
+%DVIPSParameters: dpi=600
+%DVIPSSource:  TeX output 2021.03.30:1149
+%%BeginProcSet: tex.pro 0 0
+%!
+/TeXDict 300 dict def TeXDict begin/N{def}def/B{bind def}N/S{exch}N/X{S
+N}B/A{dup}B/TR{translate}N/isls false N/vsize 11 72 mul N/hsize 8.5 72
+mul N/landplus90{false}def/@rigin{isls{[0 landplus90{1 -1}{-1 1}ifelse 0
+0 0]concat}if 72 Resolution div 72 VResolution div neg scale isls{
+landplus90{VResolution 72 div vsize mul 0 exch}{Resolution -72 div hsize
+mul 0}ifelse TR}if Resolution VResolution vsize -72 div 1 add mul TR[
+matrix currentmatrix{A A round sub abs 0.00001 lt{round}if}forall round
+exch round exch]setmatrix}N/@landscape{/isls true N}B/@manualfeed{
+statusdict/manualfeed true put}B/@copies{/#copies X}B/FMat[1 0 0 -1 0 0]
+N/FBB[0 0 0 0]N/nn 0 N/IEn 0 N/ctr 0 N/df-tail{/nn 8 dict N nn begin
+/FontType 3 N/FontMatrix fntrx N/FontBBox FBB N string/base X array
+/BitMaps X/BuildChar{CharBuilder}N/Encoding IEn N end A{/foo setfont}2
+array copy cvx N load 0 nn put/ctr 0 N[}B/sf 0 N/df{/sf 1 N/fntrx FMat N
+df-tail}B/dfs{div/sf X/fntrx[sf 0 0 sf neg 0 0]N df-tail}B/E{pop nn A
+definefont setfont}B/Cw{Cd A length 5 sub get}B/Ch{Cd A length 4 sub get
+}B/Cx{128 Cd A length 3 sub get sub}B/Cy{Cd A length 2 sub get 127 sub}
+B/Cdx{Cd A length 1 sub get}B/Ci{Cd A type/stringtype ne{ctr get/ctr ctr
+1 add N}if}B/CharBuilder{save 3 1 roll S A/base get 2 index get S
+/BitMaps get S get/Cd X pop/ctr 0 N Cdx 0 Cx Cy Ch sub Cx Cw add Cy
+setcachedevice Cw Ch true[1 0 0 -1 -.1 Cx sub Cy .1 sub]{Ci}imagemask
+restore}B/D{/cc X A type/stringtype ne{]}if nn/base get cc ctr put nn
+/BitMaps get S ctr S sf 1 ne{A A length 1 sub A 2 index S get sf div put
+}if put/ctr ctr 1 add N}B/I{cc 1 add D}B/bop{userdict/bop-hook known{
+bop-hook}if/SI save N @rigin 0 0 moveto/V matrix currentmatrix A 1 get A
+mul exch 0 get A mul add .99 lt{/QV}{/RV}ifelse load def pop pop}N/eop{
+SI restore userdict/eop-hook known{eop-hook}if showpage}N/@start{
+userdict/start-hook known{start-hook}if pop/VResolution X/Resolution X
+1000 div/DVImag X/IEn 256 array N 2 string 0 1 255{IEn S A 360 add 36 4
+index cvrs cvn put}for pop 65781.76 div/vsize X 65781.76 div/hsize X}N
+/dir 0 def/dyy{/dir 0 def}B/dyt{/dir 1 def}B/dty{/dir 2 def}B/dtt{/dir 3
+def}B/p{dir 2 eq{-90 rotate show 90 rotate}{dir 3 eq{-90 rotate show 90
+rotate}{show}ifelse}ifelse}N/RMat[1 0 0 -1 0 0]N/BDot 260 string N/Rx 0
+N/Ry 0 N/V{}B/RV/v{/Ry X/Rx X V}B statusdict begin/product where{pop
+false[(Display)(NeXT)(LaserWriter 16/600)]{A length product length le{A
+length product exch 0 exch getinterval eq{pop true exit}if}{pop}ifelse}
+forall}{false}ifelse end{{gsave TR -.1 .1 TR 1 1 scale Rx Ry false RMat{
+BDot}imagemask grestore}}{{gsave TR -.1 .1 TR Rx Ry scale 1 1 false RMat
+{BDot}imagemask grestore}}ifelse B/QV{gsave newpath transform round exch
+round exch itransform moveto Rx 0 rlineto 0 Ry neg rlineto Rx neg 0
+rlineto fill grestore}B/a{moveto}B/delta 0 N/tail{A/delta X 0 rmoveto}B
+/M{S p delta add tail}B/b{S p tail}B/c{-4 M}B/d{-3 M}B/e{-2 M}B/f{-1 M}
+B/g{0 M}B/h{1 M}B/i{2 M}B/j{3 M}B/k{4 M}B/w{0 rmoveto}B/l{p -4 w}B/m{p
+-3 w}B/n{p -2 w}B/o{p -1 w}B/q{p 1 w}B/r{p 2 w}B/s{p 3 w}B/t{p 4 w}B/x{
+0 S rmoveto}B/y{3 2 roll p a}B/bos{/SS save N}B/eos{SS restore}B end
+%%EndProcSet
+%%BeginProcSet: l3backend-dvips.pro 0 0
+%%
+%% This is file `l3backend-dvips.pro',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% l3backend-header.dtx  (with options: `header,dvips')
+%% 
+%% Copyright (C) 1990-2020 The LaTeX3 Project
+%% 
+%% It may be distributed and/or modified under the conditions of
+%% the LaTeX Project Public License (LPPL), either version 1.3c of
+%% this license or (at your option) any later version.  The latest
+%% version of this license is in the file:
+%% 
+%%    https://www.latex-project.org/lppl.txt
+%% 
+%% This file is part of the "l3backend bundle" (The Work in LPPL)
+%% and all files in that bundle must be distributed together.
+%% 
+%% File: l3backend-header.dtx
+true setglobal
+/pdf.globaldict 4 dict def
+false setglobal
+/pdf.cvs { 65534 string cvs } def
+/pdf.dvi.pt { 72.27 mul Resolution div } def
+/pdf.pt.dvi { 72.27 div Resolution mul } def
+/pdf.rect.ht { dup 1 get neg exch 3 get add } def
+/pdf.linkmargin { 1 pdf.pt.dvi } def
+/pdf.linkdp.pad { 0 } def
+/pdf.linkht.pad { 0 } def
+/pdf.rect
+  { /Rect [ pdf.llx pdf.lly pdf.urx pdf.ury ] } def
+/pdf.save.ll
+  {
+    currentpoint
+    /pdf.lly exch def
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.ur
+  {
+    currentpoint
+    /pdf.ury exch def
+    /pdf.urx exch def
+  }
+    def
+/pdf.save.linkll
+  {
+    currentpoint
+    pdf.linkmargin add
+    pdf.linkdp.pad add
+    /pdf.lly exch def
+    pdf.linkmargin sub
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.linkur
+  {
+    currentpoint
+    pdf.linkmargin sub
+    pdf.linkht.pad sub
+    /pdf.ury exch def
+    pdf.linkmargin add
+    /pdf.urx exch def
+  }
+    def
+/pdf.dest.anchor
+  {
+    currentpoint exch
+    pdf.dvi.pt 72 add
+    /pdf.dest.x exch def
+    pdf.dvi.pt
+    vsize 72 sub exch sub
+    /pdf.dest.y exch def
+  }
+    def
+/pdf.dest.point
+  { pdf.dest.x pdf.dest.y } def
+/pdf.dest2device
+  {
+    /pdf.dest.y exch def
+    /pdf.dest.x exch def
+    matrix currentmatrix
+    matrix defaultmatrix
+    matrix invertmatrix
+    matrix concatmatrix
+    cvx exec
+    /pdf.dev.y exch def
+    /pdf.dev.x exch def
+    /pdf.tmpd exch def
+    /pdf.tmpc exch def
+    /pdf.tmpb exch def
+    /pdf.tmpa exch def
+    pdf.dest.x pdf.tmpa mul
+      pdf.dest.y pdf.tmpc mul add
+      pdf.dev.x add
+    pdf.dest.x pdf.tmpb mul
+     pdf.dest.y pdf.tmpd mul add
+     pdf.dev.y add
+  }
+    def
+/pdf.bordertracking false def
+/pdf.bordertracking.begin
+  {
+    SDict /pdf.bordertracking true put
+    SDict /pdf.leftboundary undef
+    SDict /pdf.rightboundary undef
+    /a where
+      {
+        /a
+          {
+            currentpoint pop
+            SDict /pdf.rightboundary known dup
+              {
+                SDict /pdf.rightboundary get 2 index lt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.rightboundary exch put }
+            ifelse
+            moveto
+            currentpoint pop
+            SDict /pdf.leftboundary known dup
+              {
+                SDict /pdf.leftboundary get 2 index gt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.leftboundary exch put }
+            ifelse
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.bordertracking.end
+  {
+    /a where { /a { moveto } put } if
+    /x where { /x { 0 exch rmoveto } put } if
+    SDict /pdf.leftboundary known
+      { pdf.outerbox 0 pdf.leftboundary put }
+    if
+    SDict /pdf.rightboundary known
+      { pdf.outerbox 2 pdf.rightboundary put }
+    if
+    SDict /pdf.bordertracking false put
+  }
+    def
+  /pdf.bordertracking.endpage
+{
+  pdf.bordertracking
+    {
+      pdf.bordertracking.end
+      true setglobal
+      pdf.globaldict
+        /pdf.brokenlink.rect [ pdf.outerbox aload pop ] put
+      pdf.globaldict
+        /pdf.brokenlink.skip pdf.baselineskip put
+      pdf.globaldict
+        /pdf.brokenlink.dict
+          pdf.link.dict pdf.cvs put
+      false setglobal
+      mark pdf.link.dict cvx exec /Rect
+        [
+          pdf.llx
+          pdf.lly
+          pdf.outerbox 2 get pdf.linkmargin add
+          currentpoint exch pop
+          pdf.outerbox pdf.rect.ht sub pdf.linkmargin sub
+        ]
+      /ANN pdf.pdfmark
+    }
+  if
+}
+  def
+/pdf.bordertracking.continue
+  {
+    /pdf.link.dict pdf.globaldict
+      /pdf.brokenlink.dict get def
+    /pdf.outerbox pdf.globaldict
+      /pdf.brokenlink.rect get def
+    /pdf.baselineskip pdf.globaldict
+      /pdf.brokenlink.skip get def
+    pdf.globaldict dup dup
+    /pdf.brokenlink.dict undef
+    /pdf.brokenlink.skip undef
+    /pdf.brokenlink.rect undef
+    currentpoint
+    /pdf.originy exch def
+    /pdf.originx exch def
+    /a where
+      {
+        /a
+          {
+            moveto
+            SDict
+            begin
+            currentpoint pdf.originy ne exch
+              pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+    /x where
+      {
+        /x
+          {
+            0 exch rmoveto
+            SDict~
+            begin
+            currentpoint
+            pdf.originy ne exch pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.breaklink
+  {
+    pop
+    counttomark 2 mod 0 eq
+      {
+        counttomark /pdf.count exch def
+          {
+           pdf.count 0 eq { exit } if
+           counttomark 2 roll
+           1 index /Rect eq
+             {
+               dup 4 array copy
+               dup dup
+                 1 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add sub
+                 3 exch put
+               dup
+                 pdf.outerbox 2 get
+                 pdf.linkmargin add
+                 2 exch put
+               dup dup
+                 3 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add add
+                 1 exch put
+               /pdf.currentrect exch  def
+               pdf.breaklink.write
+                 {
+                   pdf.currentrect
+                   dup
+                     pdf.outerbox 0 get
+                     pdf.linkmargin sub
+                     0 exch put
+                   dup
+                     pdf.outerbox 2 get
+                     pdf.linkmargin add
+                     2 exch put
+                   dup dup
+                     1 get
+                     pdf.baselineskip add
+                     1 exch put
+                   dup dup
+                     3 get
+                     pdf.baselineskip add
+                     3 exch put
+                   /pdf.currentrect exch def
+                   pdf.breaklink.write
+                  }
+                1 index 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                2 index 1 get sub
+                pdf.baselineskip div round cvi 1 sub
+                exch
+              repeat
+              pdf.currentrect
+              dup
+                pdf.outerbox 0 get
+                pdf.linkmargin sub
+                0 exch put
+              dup dup
+                1 get
+                pdf.baselineskip add
+                1 exch put
+              dup dup
+                3 get
+                pdf.baselineskip add
+                3 exch put
+              dup 2 index 2 get  2 exch put
+              /pdf.currentrect exch def
+              pdf.breaklink.write
+              SDict /pdf.pdfmark.good false put
+              exit
+            }
+            { pdf.count 2 sub /pdf.count exch def }
+          ifelse
+        }
+      loop
+    }
+  if
+  /ANN
+}
+  def
+/pdf.breaklink.write
+  {
+    counttomark 1 sub
+    index /_objdef eq
+      {
+        counttomark -2 roll
+        dup wcheck
+          {
+            readonly
+            counttomark 2 roll
+          }
+          { pop pop }
+        ifelse
+      }
+    if
+    counttomark 1 add copy
+    pop pdf.currentrect
+    /ANN pdfmark
+  }
+    def
+/pdf.pdfmark
+  {
+    SDict /pdf.pdfmark.good true put
+    dup /ANN eq
+      {
+        pdf.pdfmark.store
+        pdf.pdfmark.dict
+          begin
+            Subtype /Link eq
+            currentdict /Rect known and
+            SDict /pdf.outerbox known and
+            SDict /pdf.baselineskip known and
+              {
+                Rect 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                Rect 1 get sub
+                pdf.baselineskip div round cvi 0 gt
+                  { pdf.breaklink }
+                if
+              }
+            if
+          end
+        SDict /pdf.outerbox undef
+        SDict /pdf.baselineskip undef
+        currentdict /pdf.pdfmark.dict undef
+      }
+    if
+    pdf.pdfmark.good
+      { pdfmark }
+      { cleartomark }
+    ifelse
+  }
+    def
+/pdf.pdfmark.store
+  {
+    /pdf.pdfmark.dict 65534 dict def
+    counttomark 1 add copy
+    pop
+      {
+        dup mark eq
+          {
+            pop
+            exit
+          }
+          {
+            pdf.pdfmark.dict
+            begin def end
+          }
+        ifelse
+      }
+    loop
+}
+  def
+%% 
+%%
+%% End of file `l3backend-dvips.pro'.
+%%EndProcSet
+%%BeginProcSet: texps.pro 0 0
+%!
+TeXDict begin/rf{findfont dup length 1 add dict begin{1 index/FID ne 2
+index/UniqueID ne and{def}{pop pop}ifelse}forall[1 index 0 6 -1 roll
+exec 0 exch 5 -1 roll VResolution Resolution div mul neg 0 0]FontType 0
+ne{/Metrics exch def dict begin Encoding{exch dup type/integertype ne{
+pop pop 1 sub dup 0 le{pop}{[}ifelse}{FontMatrix 0 get div Metrics 0 get
+div def}ifelse}forall Metrics/Metrics currentdict end def}{{1 index type
+/nametype eq{exit}if exch pop}loop}ifelse[2 index currentdict end
+definefont 3 -1 roll makefont/setfont cvx]cvx def}def/ObliqueSlant{dup
+sin S cos div neg}B/SlantFont{4 index mul add}def/ExtendFont{3 -1 roll
+mul exch}def/ReEncodeFont{CharStrings rcheck{/Encoding false def dup[
+exch{dup CharStrings exch known not{pop/.notdef/Encoding true def}if}
+forall Encoding{]exch pop}{cleartomark}ifelse}if/Encoding exch def}def
+end
+%%EndProcSet
+%%BeginProcSet: special.pro 0 0
+%!
+TeXDict begin/SDict 200 dict N SDict begin/@SpecialDefaults{/hs 612 N
+/vs 792 N/ho 0 N/vo 0 N/hsc 1 N/vsc 1 N/ang 0 N/CLIP 0 N/rwiSeen false N
+/rhiSeen false N/letter{}N/note{}N/a4{}N/legal{}N}B/@scaleunit 100 N
+/@hscale{@scaleunit div/hsc X}B/@vscale{@scaleunit div/vsc X}B/@hsize{
+/hs X/CLIP 1 N}B/@vsize{/vs X/CLIP 1 N}B/@clip{/CLIP 2 N}B/@hoffset{/ho
+X}B/@voffset{/vo X}B/@angle{/ang X}B/@rwi{10 div/rwi X/rwiSeen true N}B
+/@rhi{10 div/rhi X/rhiSeen true N}B/@llx{/llx X}B/@lly{/lly X}B/@urx{
+/urx X}B/@ury{/ury X}B/magscale true def end/@MacSetUp{userdict/md known
+{userdict/md get type/dicttype eq{userdict begin md length 10 add md
+maxlength ge{/md md dup length 20 add dict copy def}if end md begin
+/letter{}N/note{}N/legal{}N/od{txpose 1 0 mtx defaultmatrix dtransform S
+atan/pa X newpath clippath mark{transform{itransform moveto}}{transform{
+itransform lineto}}{6 -2 roll transform 6 -2 roll transform 6 -2 roll
+transform{itransform 6 2 roll itransform 6 2 roll itransform 6 2 roll
+curveto}}{{closepath}}pathforall newpath counttomark array astore/gc xdf
+pop ct 39 0 put 10 fz 0 fs 2 F/|______Courier fnt invertflag{PaintBlack}
+if}N/txpose{pxs pys scale ppr aload pop por{noflips{pop S neg S TR pop 1
+-1 scale}if xflip yflip and{pop S neg S TR 180 rotate 1 -1 scale ppr 3
+get ppr 1 get neg sub neg ppr 2 get ppr 0 get neg sub neg TR}if xflip
+yflip not and{pop S neg S TR pop 180 rotate ppr 3 get ppr 1 get neg sub
+neg 0 TR}if yflip xflip not and{ppr 1 get neg ppr 0 get neg TR}if}{
+noflips{TR pop pop 270 rotate 1 -1 scale}if xflip yflip and{TR pop pop
+90 rotate 1 -1 scale ppr 3 get ppr 1 get neg sub neg ppr 2 get ppr 0 get
+neg sub neg TR}if xflip yflip not and{TR pop pop 90 rotate ppr 3 get ppr
+1 get neg sub neg 0 TR}if yflip xflip not and{TR pop pop 270 rotate ppr
+2 get ppr 0 get neg sub neg 0 S TR}if}ifelse scaleby96{ppr aload pop 4
+-1 roll add 2 div 3 1 roll add 2 div 2 copy TR .96 dup scale neg S neg S
+TR}if}N/cp{pop pop showpage pm restore}N end}if}if}N/normalscale{
+Resolution 72 div VResolution 72 div neg scale magscale{DVImag dup scale
+}if 0 setgray}N/@beginspecial{SDict begin/SpecialSave save N gsave
+normalscale currentpoint TR @SpecialDefaults count/ocount X/dcount
+countdictstack N}N/@setspecial{CLIP 1 eq{newpath 0 0 moveto hs 0 rlineto
+0 vs rlineto hs neg 0 rlineto closepath clip}if ho vo TR hsc vsc scale
+ang rotate rwiSeen{rwi urx llx sub div rhiSeen{rhi ury lly sub div}{dup}
+ifelse scale llx neg lly neg TR}{rhiSeen{rhi ury lly sub div dup scale
+llx neg lly neg TR}if}ifelse CLIP 2 eq{newpath llx lly moveto urx lly
+lineto urx ury lineto llx ury lineto closepath clip}if/showpage{}N
+/erasepage{}N/setpagedevice{pop}N/copypage{}N newpath}N/@endspecial{
+count ocount sub{pop}repeat countdictstack dcount sub{end}repeat
+grestore SpecialSave restore end}N/@defspecial{SDict begin}N
+/@fedspecial{end}B/li{lineto}B/rl{rlineto}B/rc{rcurveto}B/np{/SaveX
+currentpoint/SaveY X N 1 setlinecap newpath}N/st{stroke SaveX SaveY
+moveto}N/fil{fill SaveX SaveY moveto}N/ellipse{/endangle X/startangle X
+/yrad X/xrad X/savematrix matrix currentmatrix N TR xrad yrad scale 0 0
+1 startangle endangle arc savematrix setmatrix}N end
+%%EndProcSet
+%%BeginFont: CMMI10
+%!PS-AdobeFont-1.0: CMMI10 003.002
+%%Title: CMMI10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMMI10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMMI10 known{/CMMI10 findfont dup/UniqueID known{dup
+/UniqueID get 5087385 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMMI10 def
+/FontBBox {-32 -250 1048 750 }readonly def
+/PaintType 0 def
+/FontInfo 10 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMMI10.) readonly def
+/FullName (CMMI10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+/ascent 750 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 71 /G put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3C05EF98F858322DCEA45E0874C5
+45D25FE192539D9CDA4BAA46D9C431465E6ABF4E4271F89EDED7F37BE4B31FB4
+7934F62D1F46E8671F6290D6FFF601D4937BF71C22D60FB800A15796421E3AA7
+72C500501D8B10C0093F6467C553250F7C27B2C3D893772614A846374A85BC4E
+BEC0B0A89C4C161C3956ECE25274B962C854E535F418279FE26D8F83E38C5C89
+974E9A224B3CBEF90A9277AF10E0C7CAC8DC11C41DC18B814A7682E5F0248674
+11453BC81C443407AF41AF8A831A85A700CFC65E2181BCBFBC7878DFBD546AC2
+1EF6CC527FEEA044B7C8E686367E920F575AD585387358FFF41BCB212922791C
+7B0BD3BED7C6D8F3D9D52D0F181CD4D164E75851D04F64309D810A0DEA1E257B
+0D7633CEFE93FEF9D2FB7901453A46F8ACA007358D904E0189AE7B7221545085
+EDD3D5A3CEACD6023861F13C8A345A68115425E94B8FDCCEC1255454EC3E7A37
+404F6C00A3BCCF851B929D4FE66B6D8FD1C0C80130541609759F18EF07BCD133
+78CBC4A0D8A796A2574260C6A952CA73D9EB5C28356F5C90D1A59DC788762BFF
+A1B6F0614958D09751C0DB2309406F6B4489125B31C5DD365B2F140CB5E42CEE
+88BE11C7176E6BBC90D24E40956279FBDC9D89A6C4A1F4D27EC57F496602FBC4
+C854143903A53EF1188D117C49F8B6F2498B4698C25F2C5E8D8BD833206F88FC
+BD5B495EB993A26B6055BD0BBA2B3DDFD462C39E022D4A1760C845EA448DED88
+98C44BAAB85CD0423E00154C4741240EB3A2290B67144A4C80C88BE3D59AD760
+E553DAC4E8BA00B06398B1D0DFE96FB89449D4AE18CE8B27AFE75D2B84EFDB44
+143FD887F8FB364D000651912E40B0BAEDDA5AD57A3BC0E411E1AD908C77DCE3
+981985F98E258A9BB3A1B845FC4A21BCC54559E51BC0E6C22F0C38540F8C9490
+88A0E23EA504FA79F8960CC9D58611C519D3ACDC63FB2FBCAE6674357D7F2285
+4BCC9F54D3DA421D744D3A341DA3B494BB526C0734E1A8FC71501745399F7683
+FD17EC3044419A88C3979FD2ABA5B0130907B145A8462AAF0A9B511D2C8A7C7F
+347FF6AC057E6512902BFD2918E2CD31DE615F5D643764E900B60287670AE18F
+FDE15545D8BC69591A8CBBB275AFFC9B14BD68DF0AAB32268FB84844D4DBC7BB
+C591C1AC5102C50A9C7BAAA848DA88B0519F0F5F0813BF055CF0E3C86F633A04
+B779D2E8E656DB1E09A66A85FE21CA8BA5523F472A229E83F2C4E91ABA46C733
+F3C7B5775B06C97782BC225C46385BEBDC61572458EFC5CF4190AB7A9C1C92DA
+29F84BAACF552089195966E3AD9E57CC914D20B6962BE80429A16D4DF1ECAA66
+36C4343FADF0B2B48F12E2EB8443C4AA29D00949255F3968617F98B8ABD4CC12
+048B838EE243A21AC808BD295195E4AE9027005F52258BFCA915C8D9AED9A2C0
+80814F79CF943FBE3594C530A22A92E11BE80FCEC1684C4F56712D5846B0749C
+9B54A979B315222F209DEE72583B03093EC38F7C5B9F9BCB21DBE8EDDAE9BE8B
+75ACE6B12A31083AC8348EC84D1D29D2297A266284B7E9734E207DAF59A25F4E
+4AA38509E993C5394FED76E6A2F25462685C4C86C6E8CFC9863338EC1428BDFC
+74616BB1BC8948B0ED4C87C15B4405F3A7796F9DB3798FFFE8BD0A94E834817B
+D5E9812E308D0CC920470A6F2CD088FCB80462BF7CB3F039A7DF3DAF5B2B5355
+E083A385CD2EAF0FC181E40E96DD7E9AB9EF5C7E6866A13B8A54718E950FE097
+EF0951A357114F18CE9933D28B3A77AA71E3CE884661F13284BCED5D5FD1A86D
+543E588FF473DC2CF9A4DC312500135F29C2D0174B32018C8DBD40EF9A232883
+710A1F2AB2CD11312300ACDF789A9B7B93D2035D81D1C84984D92D78A53A00C6
+EDA94B24BBAC1AD17774A4E07E6F74ABD90415965616AD540C8ECD8C3A44EE4F
+7F4F6BB6238C5062D63FA59B7BF08BE93FAEA70A2AB08FBEAAF7DBF56B95FD93
+03CA406543BA6C9527D0DF01F5108D31A51778A5EB1C93F27B72B46146A353A2
+01CACBC829603B9989A87CF64528682CCBA0562A8165B185C58A5C6BB72F5E89
+500ACCAAB8ECEFBB2640E99EAEEC4EA979AA793D013D61D8ACF8784FF8D9398F
+F6A252A709324FB39509F0B3A4E725E82F53543383C6765BE556CC897C758208
+AA3AD37B0406E4A79F8F0A6C1983FC73E71CD858C0DB66ED66D5D992978614EE
+1EA91EBE191E082EBA1FC040AF19A2202575C2EBEB8058833E3520FA03D2F915
+85C1ED337E457B9FEEB0C6EF2735EFDA6E0D05FA641BCF698AC6B97751E8306C
+4DF00A39B8581FF53DB8F8525FDB196D85950906CCB59B8EF171349AA3B567B1
+6A00819947A995FB383C3C1709C9A2C113B2E40BB832B7D4A0FBA0B16A2C455F
+55809CC425C403E9668DC66BE45B71A81C332FD4DB279D22A2959962304A8F18
+085893DAC61317D24A8F198FDAB95F3B86F0AFD35047B868A9A17037A2829A02
+BAB042F75F349E197A7EED41984C2859754CAFD0251439921C248B463B516951
+2E1322C80D73F9CBCAA63A585450275AC2492E4D3FB78E800F788254DB5E610D
+CF788DF5C70FF99892BCDF16133E34B24B77C8F097F546B87C603DDB8998B66E
+BACB68BA27462AF54AA405682EC96D701F0D474DECD5F95CA2102DF639EB169E
+D518162C2BAE45FF698B6DE15FC6E7DE48C336C40A670FD26952A6BAB09115E1
+991F0073419F2CC2A1C08BE91096936AA0C37E4ED3CCCEE235476074B8FF1125
+6BDE3701F85532D8BB64CCC927CC335281C95EA689706F0AC717DC2CF680C754
+E5EFD7FA4BB8880B2B727A964C876D4A223069D4E6001771F0E23EAD2A4BBC80
+E76675297B2EF05F52BF4E71B3EE2BE3048CF088C79540113C66AE98B2FD3CB1
+B0741A215FD070882C52765009D7D711DAA2508F19AE7DDA15229A856AC49BC3
+4DDF40814FF96500E4B9B02D412E94623C5FDCC76C0FB8E42DF56A904FE49D65
+1DA7C53901B2EA71AB658A464D3ABDE27D9DB8D9E0B48F64E61A2495AD5D8DAB
+B5E72424AD017DF37964AF911BD7FA21A5EB4775DC8E95EF0C0EB856B00D89D7
+8172A1DE8530767D317B8256103E53CFB877E10686A04F5A08F8DC58D843DEBA
+FD5F40597588663D103689F6EB3EB14D06E18C8078F2538B43E712DF491FC5C6
+AF639256C8C6134B64D560D8476DEA6329D995E46CC4BC78841C59E73648B47E
+BFA7DE0846422F738454AE77E822A083405289247BD7C478BE4974F742CD6051
+E99FBB1D1B3FBABFEE855174734EE45E87D0AADF32B1283B911162A9955847FD
+38944D70584FAA6B1A7191C5C134B73F98EB632B69E2F0C0F94156787C34C8A3
+7622A029D58F9626B74F8A8A1F3803E0BC20E0EADEB1E99B70F1BD9F980FB751
+2A842843DE42EB142A84D5D3138629AE9EAF6F3479C423E8829C8816FA6EFA27
+DCE5580E65AA9854B1C64163DC318420CD993C15BFD76A8BA1182860A6B03D6D
+22B8CF43CFE6C8AB27C64842E239CAE707D3086BADDE1D7C94E3BC96319470D6
+8D26915C575CFDD03271D6BB9DE86A0EB6EEA6E768B224A626C62A9AB48A6EDB
+44F70BB5AF991CDF9736D65933E81CC57A78F623F33EC9AF535F2F25FA4EEC90
+D50DB7E87F31E971A75A33A301CA6013EEC5A4E179D695B33DADF2C98364434A
+42926776000B610E17524162253F6FA638D6581C18F99EA0BD1D2E24D2424ADF
+C05010D08192485153DD03930C7BF45237593E484F9851E6D464FA10FECA5D9E
+0C8CCC97DE029030900CDBB491C5CF226DBF903CFE7735D939C3FDF3A20B70CE
+66579B28B99313FEE914E295388C7BC8E055A2E54EA3A8206D3C8F4F7C0BA5E6
+E519419FD8CE215F7B8E9BEC604A9E3FE272A0328A24E31997C8A91E0946BCF1
+6943A97CBED2AB9FC636B49828BBB8B89E0BBC2653796431224895ABA5DAC41E
+1854BD9764E86147FD7624F736F40DE3B7582EDDFD15C2BDE3F22B5A54D7DF10
+B87A1301CE85CFC061689A890A321412A13314AE96DCD3EDA75035FDD8F4AB9B
+897A2C68263A68457032C469987970648BA2D88B1C5375DFEAA35A917B8A952E
+EE670427942AEDB3CB599C5746180E392837D371E15D860620ABDB6AA7772C40
+A5E346661673ACA530BE3D8E3FFB895E5DA3DC23B1B43C080C77F7E47847F0F3
+F3AA5CA9E4BF75FC5EBD18D19F21A7DAA3B11CABC6E4070A15F7DBC8B05EB6AA
+A02EF1B078EB66D61D6AFE41DA9B36FE7EC9EF94D1EA26282A9871E2CACB3126
+2AD49C2D9B50A6E47D8F2CCAD50992D1B430979A45FD9E76182A19964BB2A1F6
+51779A2B258DC1DF4C2F3074621286831F3848AC152DDD2BA561E6586ADA88D3
+598A2CE2CD048F027CE0008B828BD915887D7785341E8305DF2346ADB76BE99F
+87B02173BDC334E9221C8DF54114A6B24C1C5340299512FA6C8C51AB4C8778CE
+178CEF531C6D1B5FF0A1BE8EFF767F959BD4C345C52699A29A17B2A230842BF6
+4B011217D6D24EDAC3F6D53482786F1CA33169B90ECD499407D37CE9B70DDF78
+7B7547B32952535BA9ACD1E244447AE3FCED3AF28717083CF9590A09780984D6
+AF0743C82AE4FB3E2BB2856A4153A3967A023FFC35382D6C22D84A924900B6A6
+3DDD400E6D2418DA6C27F2FA34C075C902B89EBAE658B3C9A18EEE449DA5A379
+337DE95CB7AB3F0970CF1A5D8FAD8090E495570FDFB2FBBA79244780D8035547
+C5A55BB21A2270F724BF5D442CDC5BB9F09BE0CAE59B1C2270F0BDACE698F2C5
+DE8F66BFB9634904B161F5BA2B1950048300D69BABD312D58D89C4ED527AF7BA
+7DA2478EDC2CDEE3473DD8A8ED9D891CD1FC21F23013228BB3281B71FCE959BD
+6F8E9059D682A7FCC5265A0620992D4FA8D78377EB34CE3ECA070EE3707239BC
+98907DB0120CE42ABA32CF97127E28382BDDFD685674279F588D4F951216C355
+821361790F64C2CC720DE97E8ECB57326C43EE47367628E05769E106868B54F4
+C33C9951908DF6FC4F5ED2C7787BD8FA591BBB3E9C6C1DA94CC5E38D9B20C886
+7D237572FF46DD896A4D6163408EA6CEFAC398EE041EAE29D577E75326CA17A6
+B072D47A7B13EC441CE6DAA042ECD02134CBFA6809A435050413817193DAEB16
+A5882C8AEA44BCF36E74E9ECCDFE7E19FF5A5DD7A94E5AB4F8702C3DA7F42325
+23C808670A0490F5B373DADE40814FF9650241D3D69C91FBC5ECE728F827D9BF
+C928602E05477903449E079164CA39859C4BCA60C579F490AA455F82B5050BB3
+969AFB478E0D4A257B3356EA3CD62051FCE6C6B1929CFF85BFDF166BEF658E10
+3A55E007F38EBBB248B3F0B8ED1925106B499B762E45113AE1AC9DE09644C84B
+9C08034B297314EE69BC32DB6E7D7FB9913CE5AC17E7335979E9DCCE2BAB3725
+1976155551F9706A576FE0E3ADCCF72C87683291528ECB749CB0ED291966E239
+B5E3630676BD409E08F85BC1AEC9A2D4135376284A96EA24431243BD6FE8B966
+95F11A4BB53F392E0AEFEA623064FF8A7002367B0A515635CB2D2DDFB9B4A8D7
+FE721754E81BBA548848A235B91AD4E4F7DB19CCE2F61D277FC00AB956EB93BE
+44AB4970CA56BF59506C94ED160FB1E25D3DF2988A532BDB787BFB8539D22986
+FDC378AC31444E63C4727FEE121A43751043849E6DCAC5B59D0FC703AAFBBFD4
+E8B7C268F21615AD02CE9DABEFA27B5FE6A6441B619539CAB1F810F1263447AA
+633F5DAF483752EF1A0421740E3A811D2D2898CBF53E7F686C9223FD7235F02D
+6F90D2D48CC20AB87778DE3C6FB335E0F0EC20B5DC5B65223FE117526DE2C72F
+FE839DF93CB2A7D66CD900CB325F891E311BEC932F703FB4FEFA29DB8B9C88DD
+375EC71B3D58C7BC59ADA91971A3BDA1ADEA629CE6CC92BD542CDDFAA7706FB2
+6CDDE2DF07E56D6741916AE8E8744339816F3E6C38062747AA9FDA2A2678A6B7
+EFEA870AA3A4D71B25EE3013EAB1DBA34401B867C7A41AE51E0421D41D3BB83C
+E120C8FEABA6E5DEC53A689C21426D4BBCB68CB37568761C360E6D4E3596FB7D
+F4DEC7918E58C0293D12D6DDA7E9DCDAAD7C939F55CD1BC4A228B31E9A904156
+DA6B40B08E6ACE674618B768DD681C772A3E55FE096CF949CF3B0460ABDCD891
+D17B37B355B29AB5137899C036F31DA026244FA25FB798FBE5105BDA29F46538
+D3D3AC1001A7BCECE64DE94FFE6C354166A0F97256137BDFA07F6E22A3D1D2F4
+9588DBAE95E895BC5E64DDCBBAA8D0A22C229B42CB717FC711E7E9DF793DF80B
+9F14754585A3C7E17F37B32924B9F9870DA8635E3E18BD1DCD81EDF01834D9C6
+B33F23C956C2FCBFA47D84422F583459D827D1E120B97694D12F1F54D02379C0
+D288F7104F3FFCF4F76E3494F4ACBD1BE3A15543CC680924C78A473F8E311ADF
+8FE00A04C6C393DE61AD3EDA5BC031E2353076A2489391B52632387CA28A7B93
+FBB065A6EF3658AE80B1ADA47E9B2539E73A71FA75645F85ED8ECC257FB4CF26
+B6C912DE9D0F9899E70BECCB934AD32CF49A093371A9F73DE6255EBC39DE1E7F
+00D0CBDABD4D0383977E694890E71FBE5C376BE5F3A80C28987417504F515C50
+909F3D31178BB9B1D085BE514F71B910A9085BD6122DDC72A150BFE266920E49
+5661BCB4BAB51D6DEFE32B616963DBD989FCDD1637B294CE4E288655FBEFA1BF
+7F25BBF8CF17C2D5FD161A7C2CC9CC7490D9BF15A1D35B3BFA43ADE256E88BDA
+BD490D92907C57BAC408A575EC84D6AEE070148C7C9A91C03B09FDBD792E8FF0
+C0B886AAD2EDD86541E5E579359D40E3AC312ACD3D8FD49F71BD533DDF8859B1
+BAF17F1884E331DD07CEEF93B71D492AEBAADF7A263450A7A72210CE630A0D37
+BF024BDC09ACC882816B8C22C62AE38A3A8D0F6EBC2B1B2C0B8161A8B076DD5D
+4B779C0788546BB4CF57332230D237856B00D79C28A7C01D11F44B7304F69075
+94B97A745DA43D1BE561372CE611C345A843834E46AD9DDB16CABCD3FA33D6F1
+F6B5C0497F5EE5400B305CDC16A7EC286AA4D45D0EEBB9DA06AC9C5294D68EC9
+E4DC3CA2B92CE8FC0526184A86EDC7AB34D67E60AC12D9CA8FD300235EC968BA
+92C6FBDA47572BC5600F25249F60AD287CBDAE980E747FCBE7EE5CD323E733F0
+63553B494D3DDEB9CC1480B5C3BB79A28E419AA65B18CB297AB383419E890E2A
+CE6F98C9900CCB4675280A10CF060B8D220DDA1BE55DFA65715EABCC1AFAA271
+B1F8732341613E17B231231A0D24D4D7FC198AE04D89A99C4536217769C6FBD9
+5EE24A6302F97438F7C0E311C878F674B4477A5ADA3952CDE4055AC408B8174E
+86F8FB797646DFFFE0ECA25D1BAB9A9F71F3926D3D85AA63E7A8C931D71E79E0
+AF1EAC26FADE468F4FF7F3861D14C10E3BE1F9EAFD6D3A544E8108D5DAB5B180
+3950C74818BC8AF4758A108F462EF1826647A49667F5E482038C54716856D9BC
+35F29922846D2148F92F943E951D7438C73D6A60459A8003174036C64E1629CD
+155D47FD04B03C023AD67CD5A70C98AB556EEAB8C48169706E5B352F6505D580
+AC945171BFE62E81F8F500438AC3B64D857BA5BC54C2C4BBB237F8FA51296255
+E66A92A61FE13FDE781D393557EB72CEBAD86511035F775FAC39A0479CCD400F
+226709118F887F47CC2ECC8F79816D4A945B2845F50AFD62D8C9A9BBF4739496
+9E644BC9F7B04803B7EE75A09EAE94365F6F374B4FCEB0B506C76297564B9B6B
+8B812BC3A33929AA94692572B010E6210AEAA312BDFC88BF302244AB9D587A9B
+919823FD01DE12438D960944D1977800FEB49E638C32E5B188B1CA033E0C37EE
+A142F746367888AA119535F0CCAF7EAA461B790EB089D2D6962E28A398439BB7
+9C9943654D7A2D765B46BC0DD1F915327F369162E1BA1BA83110B93F442905E0
+523BFF5E279508A98568CD5CFD18FABBE9D17265A9081E7BF64155A2CE3C0DF7
+88D00671AD65654709589BAD7EA65BBA811387ABA5CA0BC3F66D3D48597A0D1D
+2C268375DF47CCF62166262AE4840AB03BF49BE67A05EF66328EC729F03CA5FF
+AD3937FC053E223303565DC771ACF32E63DFB96D5030E787961D72D02C195C66
+B48E9AF0309DC169CFE8D16E2818DA94693A18F027DEA0D916672480464F7E22
+CA6E431FE38D3FC019BDD229E064B72C545C61C6EA55984565CCA88ACB01F744
+3B4593CC8973A8E56D0A5BBB31FA3647D2B01C752E21B8879522CCC8FB14C340
+CEE03251603F7B65066DDFC9669A99D6D639B30E82D5C11150E64286BF4E13E0
+C47E37C31F7F554CA03B1FB59225D5F11D16CB02740C4D7577D88DB9A080A864
+D6CD2A5A466549846A525AD43EF6358ACC6ABF95BC27EDF5BAF548A1553F660A
+2761A34A9B8E2B2E623EEA7EC7F95F9D383627F67FAE87A4AA5C1EC870A3B2A3
+585304A744579C0F6605973E95B48FF9395D1DFE4A04DE41B4E3093EFC4E3596
+6C3FB4DD4686E3E8B63DD1F82ADA5A0C2F518BA95197840C0CDB169CCDCE0CE6
+3B27C3890C9F13C14FFA8A0787C1703D519FBFA4364D0E2577AB7553DAA981EF
+FBC5896DBDC3A343ED0CCA7900196CB16F70AB30A7C216A2119217307D17A648
+91764AB6F5DBEA3FC694C826B45D3DA6BC8AF99B2F986D14E6297A48CF8EC20D
+CAB9A936A17635F9D1EBF6BE1E7BB633CC213076AD2E304E9A50DB0A87797758
+0C657A2DD37FE865E731DD6FC2DE58B4
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+%%BeginFont: CMSY10
+%!PS-AdobeFont-1.0: CMSY10 003.002
+%%Title: CMSY10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMSY10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMSY10 known{/CMSY10 findfont dup/UniqueID known{dup
+/UniqueID get 5096651 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMSY10 def
+/FontBBox {-29 -960 1116 775 }readonly def
+/PaintType 0 def
+/FontInfo 9 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMSY10.) readonly def
+/FullName (CMSY10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 114 /nabla put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CD06DFE1BE899059C588357426D7A0
+7B684C079A47D271426064AD18CB9750D8A986D1D67C1B2AEEF8CE785CC19C81
+DE96489F740045C5E342F02DA1C9F9F3C167651E646F1A67CF379789E311EF91
+511D0F605B045B279357D6FC8537C233E7AEE6A4FDBE73E75A39EB206D20A6F6
+1021961B748D419EBEEB028B592124E174CA595C108E12725B9875544955CFFD
+028B698EF742BC8C19F979E35B8E99CADDDDC89CC6C59733F2A24BC3AF36AD86
+1319147A4A219ECB92D0D9F6228B51A97C29547000FCC8A581BE543D73F1FED4
+3D08C53693138003C01E1D216B185179E1856E2A05AA6C66AABB68B7E4409021
+91AA9D8E4C5FBBDA55F1BB6BC679EABA06BE9795DB920A6343CE934B04D75DF2
+E0C30B8FD2E475FE0D66D4AA65821864C7DD6AC9939A04094EEA832EAD33DB7A
+11EE8D595FB0E543D0E80D31D584B97879B3C7B4A85CC6358A41342D70AD0B97
+C14123421FE8A7D131FB0D03900B392FDA0ABAFC25E946D2251F150EC595E857
+D17AE424DB76B431366086F377B2A0EEFD3909E3FA35E51886FC318989C1EF20
+B6F5990F1D39C22127F0A47BC8461F3AFDF87D9BDA4B6C1D1CFD7513F1E3C3D3
+93BEF764AA832316343F9FE869A720E4AA87AE76FA87A833BBC5892DE05B867F
+10FA225E233BCFA9BB51F46A6DF22ADCEACC01C3CD1F54C9AEFA25E92EFAC00D
+7E2BA427C25483BA42A199F4D2E43DFCE79A7156F7417ACF78E41FCA91E6C9EF
+B933450D851B73A6AB6AEA7EE4C710CB5C14270D1674FA334686653793FCB31B
+491E870D3C2BC654D2C1DE463EC9BA29D7371AA1078800EF93D3F66263A2EBBB
+F5723697BF7448BD0D2E301544BECF497FD475B85DFEF52AF4F8F8BE445CABE6
+019318806D10C5952157FF8F8286C1EE701545C8F60EFA854EAE66835A2046A6
+915D395F1E0366EFE0C0391583FE001FF16D82A2E2DA5F57754A2C6F69306E36
+356ECF8EFC3F1188AD6FCD2427E0580C97A5B69B4E0E09B85EEDE142F5ADD2F0
+5DE51D6DB72B127412A0D57106C19CA493048A4F815129ABE767D51715B1515D
+9C21067CB5BC88741B7298C83EAE36A866DFA87D8981F179B1C31292F56BBB64
+3C430779468AAF07C8A8B4934E1E775FE3F35186BD1FA6EE3689C1C750678AF1
+FBF9B23195A124C5C991FE670AC0C86FD39D2B07B9A319E74EFD498B45820252
+720ECDF7294F7B0B137CEB86D33BFCEB8606985A3260FD669E461C8BE94216C5
+D434FD8854F44EE66E5A289A9F9E32BC36AF645D53F96652602BAED418C8D726
+BD04A1B4617551FE4DEF54083D414F7DCE004E6BB2DC9C2EF7CE232B254BA2C5
+7DCBD36C2072ED46FF711F121A701E2284BF1B718B3164382B8F453D68FA0377
+DFE106503B8401D4DB87F5402A3AC9A442FA060B0610A9524D530C7157C26B56
+AC970FCC1D5655FFFFA39246E6420CF97D08ADFB7B05822679BD40C638DDF0E7
+A97BFE8918B611A145AC965C203F1428812F9D340AF499B3A915B22BE798594E
+0F520109FC81E452180AE45B170FF999C5FC2761C6CECD8742A5A6FC97F16743
+AD4EFCC6572A6D3F3E4E330C5CB2FF6FEA48A5B64DD3DBE943BD9918D4A18E18
+CBCF598AEFBB6AB3CD2CBC9BFD6099272F6543F3E532E0E21E614BD2880B1023
+0AC234CB705827BF016DB84E00E8C255FDEFA0101A842929540B7B4AA8A089BD
+5EFF05B72356B6BC3727817823B5CDBB1B963103000D7F2A4E2A1472FC3E614B
+5CBCB6D6D784023173DEFEBFA8F9ED87EC1A0A9EE98CA59CFC964CF943DC683F
+E9E00DA718C4425A705A69D99988EC6F152525C790912C2E46A2381A569424AB
+54DF4798BC2D7E7A361E7991641D4B756CE2A7FF4A2848927092C59C2C4B8809
+E13AB84FB6B111E680D7FB9F2FFC2C5C66B0B501E4447C2E46C10E2F6124476F
+A140C404CFE2DC9E0199BF61E035CEB481D438139A9630934E541D261FFD2906
+4CAD99E20655FA746AFB81EDBB5601F5FD6B1D6832A01D585E2C55053F6A7378
+4DAACCAC7608DBDADAAE732D66B3E7F87E79756337C1A961E53A4651BE7C77F4
+038B89C87F650C54A2A90EB7F1D525BB353F33318551EE8D84A6A83C718EA5A4
+B2AC0F7306B1E095819B87015A90CA3ED739B09061782C28CDB36BA4BD5E5308
+5CBB70414E4112193DAC4A1FA30996327230D1E021F3CD8115E12D239D93FFDC
+B645910EB29E40D830E7BAF2DB255FD7C4E776557BB38157917D993EAC245837
+A3B515147043574157B8342D829C7228CCEA843ABC89D1785A9672A5923FC4CD
+2F3FF27E6FCACF84E2D3136CA2C0FD3EF1EE7354CD04C38B5FB874553646ED2D
+CEDF7E362EADD04B18051F20A8FB0DE18E152385B9D05F98A3A7EF177824E246
+455ABE69E2F700EB78185CCFC07E3B4C6FA301112528D977367D30D0D5D59EDE
+FAEB706DDC970A9E296236C725B2B55B09B9C336B8E23CBA5FB8692D56F33B03
+16294E5FC7FAA42E96395A57CE51CA8DDD77442F142E2E576B778373FB31C81C
+16840BB422CA827E30A81829648BDF1CA36700EA32AD888D097C1FE0A05B2D9F
+483AEE40269DF09AF0D1AD3DF80C45DDC59C2A03FBB661C79B87853737C6D352
+67626B657321B16198DBD6DB98A092F17878AE4698121E1006E53D6F9B0A3BE2
+3FB68828EF854A0CDBAA68B37ABCA6AD4A3D809AAF0BAB1697A81FE59C98C472
+1E33CD70A75A22C249DD11D76C2575ED3370A25892A16D2FD569CDA70C130770
+93F493C7D47D6F9A5424A7A542BAD726BFC3AB225DCEBBE6AC4BE006F8C7C0EA
+051424B08305BF2D951AB2986AAFEA04E078CA79B399585BFF0F1ADCED02E15B
+8765EB6BF6A8E4D0901EFF2C3AA104924EAD9637A35D877E0C51A3C37DA78CD4
+8643C8CE6DCDDE3F116A6C2390F948E5371BEB5AD2E87B41C5F01FB5C196C436
+6E256A88D082E3F46E4EFFBF605B2EFF1E9D9AD5EE4DDC323A137CD9451EDEE0
+06F7D82898D71FAF2362C0FCF1F726F97F820305B7CE20728CA08C63575083A7
+84BA28B7DE2B916432475510E274C12FFD1660A717F51DACFDF0A102D85224E0
+D6DB607BB72569ABB8A7BC6A10354CBBC01732EFE35B72062DF269CB25EA3DE6
+DC603B04C90C5912D2C38D7A5ACDCDD3F6F116D884F0D8C528F69D5D47BA20DB
+0A9E585C7D8CC3C324FE8A1DF150279F7E8FB43BDB720E624E5E9918032C02CD
+8020636AE5C38DA2484B7F4B34163E0D0A561B43B80E97746DC05C871AB620EC
+C5D47101ECED4A7E25F291184BEF8B80024AA7BB456C1B83A907652B331DEA34
+754226C39C6889EBEEFDAD081E01EF8FE47751987667836FDE4C8BB8A3FD4406
+1E643B4EA37BD370734D1A2DB17C2F4B74B4ED75098B433601F75A88C9A37A05
+CCB157EF6E32023BFA33973F3E655A4D58289136996FCFA61EEABD70791B6523
+1FF5DE71AB8A17038923118A5EED8D59C4C58D246FFA9BB26472346B40C8741F
+153D19CAFF20DD2A86C6DB89154A630FB1761929FC3F0448EE2F089C1C953E02
+905BA8DE75D101A982A611056C4B237596C10951DD98BAB838B742D3CF7DE718
+617DB72E5268583223E37E029D1C8FD3F1D21690151F76B76C52C725CA135CA2
+8666553E863CE188BFC9B99AF56AC2DB5BFEBEB12FB563D00244EB89E478657A
+98AF2E1223C1ABC25A4500E8119B86EB3C26B8A2F3505A3E5610F89B7C34E278
+53FA0A54A7F46D84A35EFEC36AE660A9E3C37EE3864106702DE5AF6C45ABF64B
+888A4A51323138CE77DB935576FE6B4824B6942DF80625098CE1B5B32B234F1D
+052A9D6039697118A9D793793775D8729D8574A2E74D7109C7B7E23BC5E2E87A
+CA8E019203952A4892544E1AD3D4EDD22971611358AB230E9A2ABDF00A288501
+A01B67C42B33F6B78C39562DB50F4663B922D9BE0D8A150311AE44B83C1F129F
+07337323E9A23211EE58E16043E127C6F9574019179F5635648A011266677B56
+B5D0201A4E1470B952A1579B57AB2329CD4C615395023C653F784D36B5EE3672
+10D191F29EA508CE84763CA4CE7C2C5229E38E241255A5CABCD6C7CBAED901A2
+CA53B5E24111921CDDF83578D33D463D70EDACA0E470D8F592303FB6BFD68B4D
+3F3BE2D7C5EC8BBF10C90111A33E205F2649B56E8443F6FAA6C721C66575AE12
+D4C40F1F46CF9E9DA675AB5D5840D938780CD9E4AD6736ECBEB6A4397613586F
+849B51048AC5F9405E03E14540A5E5582F61CDCDB57EDDF95A8C6705F433EE16
+648F098C03DED8A2AD94AE3DE202D629B9422ABB031318D48F2C85F9DBFA17BE
+84708AA3B6C9F81F4508F7A5CB7B6646AB8722ECF817877B77D473F577556DAA
+2BA0ABACFCF5DEA7498C47328E873019A956FBB250FD9D8885D21D368FA70CBD
+2709D2DA44EE7A9869963EAB48789541906DE49FAE785ECE1F18A22C7E7ED204
+9768896B78E9EB7A2BD6EEC1B26083940656ECD689D92942CC8AF05CBF82AED0
+B45A7DF4DD7AA6526FB597322560B9ED3087A65B5EEF1371C328A021411BFE3B
+D9B5088B2F1AAE381FFED52D2D1E02CD0DA78683E3B06171CBE94BE9760005D7
+135893D7CC2DB097F6AC664D9594CF1C650F84DA80D2EDE04802DBA33CE3DAFE
+EB7A37E8AEFA4FDA6252FF21E8673DD98E67124D5DBC7BACF361E57077B71939
+C1D1FB923E4E35C075CD1BCBE0E80DAEA1320D55B43EAB45D9B26C366B278782
+7519FDC482D98839BF0DF2E7C3A56A1C1A3FC0E57A75CA414F6536C1FE8EB7A0
+4ADFEE3BEDA0F53BE8CF5F64230784A797133E8CD46BCCB3BF38BCE38A73CCE2
+9E073ADE792F7128231DDD1F63E6156ADB2609C200837C2E8A2D93D2A7BC9171
+050C709A71E44E32B1B03C92EB5CF1D3BAB1C38E027DC4ED9AED633D98CD7486
+3F773ACF8AE332631CF2ABE6D606607593FE862ADE31803964E3F4DC3CE3A271
+C76BDD95C87CDB3B87BC26FC7A16D567EEC62E6FF0D471B4853DB8A94D4CACF8
+843824F818083F10E88D52FC4253E8203292CB40F1414AE7E51DD7347007C342
+CD70E8E9F2D2A13D71213B841DDEAAB208AD9EA644591C15DEB084165F9DF24B
+B91D3BBEEC2E34E38EF16A0C3F00700A7BDCBBFED2EC0D09601AD6538288DB50
+3478B051B5E16B604A0341FE621A58718D960D699D3FAD284310DCF54EB13175
+19A75A539EE98E804AEA24689D3540F0F12951A3C01FACCE9A7BAF4D0DAFA946
+FF65A4D2A4C39969607272C6886F44E90ABE27CA3A1F12A29D9B32E60E8E34F0
+17C5FE43D0E69A99A922D98909B2BBCD145E59A5E7F5426B3988F73B09A525F6
+8BD4915663C1301323180E760BE81CB874B020FDA3AE63340E4261E4F3E4949B
+CC0966BDC4426190BE9F5D77F76A72AD925662E5FE1CEF9CCAB68F0BD33DA003
+F11EB91AC4502FBD6AE48DA0F9D07C35B96B103E379B8A83A05FE728F1716194
+1F650F75BEBADB2E3810388F3E2DC7B19F1BA9E32925F2FD9F19F4E8701F3E4E
+4069125D7C401144740691E7A460021A47B1E27997FC1DDABEC5BD0EE0B20194
+2D579C7D6727AA124083242BDA46D8E116E2751C5F298851A62B60AEBE82A929
+9B9F2492BA35690D1EFD16215B8EF14E7A3803B93C28FA41D971B05B6AF3B593
+E74AD1E68A5FCE12A86E63B78BFEA87D3949FD164F12277A4688BE96356791CB
+8671C49365608F3EDECC109321AF92B4C29CAF073DA3A7D73E913D0D83FAC5EB
+BD884D4C686056404DAAAD6F82F94F803FA1FB0DD8908D1DF08FB87A8BB83027
+04DE0CBB1C6FEB6B517FBD7CF065120079E608CE41893C2BC96A347826CCDFD5
+C69E161217F2127A59F1A6F22037641613F191F22D5B4CDCBCC2EE5615623404
+ABA7BE6C5FE475481615B2AC1A2412E54688DD21E44CC9AF5F16E634AFCA389C
+4D740B7B51BB141BFAD1080E7C726C1606A28ED492E6BDE9F800EFACD1513909
+84E98CEB6A0B7A2A6F3E1D1DCC3B2552795E0932673E59ECC56DDD37A1D52BA6
+C3F0E905978AB568941A163F4CE3AAB5C5B16F86016EC47BA6F3F7AAAA77C3B6
+09C8C3ABDB6D514A76ECD37C37AA88B5860630B3406B494F7725975596F84777
+D9CF48686EC9C5DBCC1D78513F591C7C10AB9D153B3D41426B7BF668B0D04503
+56BCB686258462C1DC61095724B9F3312316262FD7C1AEC6E54DE7E5A7BD8EFF
+035299B8FD8A4A7B0F51404F4A760F4D8B4C0FB7A32FA4B2383AB6E9C78FDEDB
+FE6A5788D38A6701B123630C2A6D820A684166FBBC83DB17069494FBD411B333
+CB37E2491C5BD035A33867A6D3A3D420CC31ACF43AA07182CAAE67E40EC63663
+B678F71D4C6E0EC3A0AAF904CD3AA66E0DE5E3CDE049E94249B39A1C06E3CE9A
+F974B2484BB2CDA14282B9511E505B3C89F9C802218AE40D1A7541335C5736DD
+CD565D4B9F4CC78F3A393737EDB4FBD0DA299E21CCFEBA5478EEF013F0552A8B
+0BB11FF46CCDB784E8BDCF730A16363E66572049E42C695886EAB42A9AD9094C
+B635DF4B5B9BD9B9AE8455DFA3EEFC77653190F9A8B1E93B7281C2A21EA7DDA9
+33484745BDF7E3DD63C7AC66C286C9A5A698A5E4D7A91710B7FF943FB23609B6
+4B442F83CB795788FAB5E9CF3F75D5487DA26170E4561C7941C910B088C3B86D
+F844B0F340CF82786A3FCF347048463EBD2006281A816627065DDA6CD4D3AC5E
+2024BC96C7D896381BBB567951E7A1F29D4E95351298B000D29E5F3D0448CB5A
+CFDAE1BADE9403B90371C3A07D208948AFA022A69C519434B6813086ADF518D5
+88E0B92072A44BA1B3EBB630A13B7AB90992E85B6D67361C8D96F3E0D826FF37
+17B67E4B1EB7BADFD98D7F4FD17BECE740ADF13C141EBF0A91CB105DABB32FE0
+55086D56A0D358841D15FD349E6B95512E4EDF4C430216FF85C2ABE995E4B40A
+A6044CC8820AD885C07E052B3F91C2E9A1D163BFFD210F7BE95B923E2500DB50
+2075106DB541C267BD450B25B670CE80BCD068D4DBFF2D82634175B61FBD3BC3
+406131F44C7D6F18D375D1F2270829DDF29DC14DBB58A30AC193245D18DE91F8
+AB88AB548D8138605BB5A50073295534E314366E26665AE70482B890E4101D6B
+60E4F3B37ABCA1346DAAE8FDB8DD9C832EFF3E73BA470E2BACE7B8515CB43388
+C27AF99FF9322175CF8D4947E6B3846AFF5163E972156847F58A66660EC8A3A6
+5FB47C9F637B4CBB4C73B6A080B0CF6FD1E9665E92032540570FFCC747C67C50
+822811AADC404BC7ECD1673E8AA6C3A2F1D82F39430B58C29145E2F1B679C46E
+94EDC711883F1E4EA84117A54757E8895A40401A26E1437B39A2F65CAADD6E02
+D71FA8AF7453668DC613F326A3344F74AD7AC67569AF399385500ABDA5EDD3BA
+343CC5EDD4B558467626850E752B9959FEF1454E53E7A3DCBC2255AD8F6AB4FE
+894455118A61C58840CB68A925ACCAD75CEACE863D806916228F0614191A1CD5
+DC9BAE256018615AA3725834519449B0A88B4F396654E74099C007930ADB1327
+DD119BF799FE3B0B223E1EDA04FE2DA7A1C879143E1C33B6C6344F4BA033AD6F
+8E88C33DEF1977796B454BAB2494C930F492A518E8198C708A75FFEF8C49C324
+A718AB59B889DED521229E741FFE53F98EBE88B0405AD523254FD3FA4BBE96DA
+DA1C27C1C979A0DD4E61C3B1F4C4DE01E42F1C4435EECFC02D97994BC8AF5270
+E7CB1458D76ED0229C5FFB4A23B8716018F9050970895D51722CDE8F2EA3D947
+DFF374D84915D5C5D16463A6FFCD079D1ED416C4347BF831FF0C4ADFB61295DC
+4D5785BB0852BF472CFC97EC174491CAF961AB90629F055E75DAA6D9898E8653
+5BCF379816CAE46FEA62E7BE8E9B953466E51828172C4DBD0E1BBAD1CE28B5B1
+02B3E36403BE80B49A47446A6677FCED438F01D60EB10F478C89528FA337D0D8
+88D3FC123C076507ACDAF783A9A6E24ED73BF24B6E0F11C13E532DE5F70EB02A
+60651FC2E263002D3986B7B20CC2AA08330B9FC2E26765CD52266969A86EE30E
+71E0B41B6C1C6DA423D3A7E1553D2FAF26EF40DC183099322D362E4965695C52
+9FC3E5BD7ABD743CDCB717DB10372A722A39CE53FABB454EADE2179C4CBFC016
+A8E893C28EF549CA1692C8D8ADFC471DCCDE266FB4E97A1F3035801F3F034D44
+AE6ADA0192657E8078A1D27420093FEBA111333314658021B90DA4E7A8D4B829
+F1795501020D5FF0AD25584C1D4A232CA299ACEE32C268C6BB20D3A28851A474
+B85F61F6B4F1E0DC1945FEEB21895CDA76F07D8EF689EBFDB9F9A6F4E566B666
+35A37B70D95A7C62FE3285AFDED7E43FC3F542CEB120323DFE2AE1E2C77721A3
+A7179550B8D6FE85D9FD08096938AF17FC898F6BFA73954D44F57FA1091E05BD
+76609739946CDE0C223FEB0A85286D5CA6122FA1C1062173F03813E491DD2151
+9DA56D9B60A825BD1E2064E7F69385803A17AAE63238226F5E08E925A2B2656D
+4E46664FD3E7CB0A
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+TeXDict begin 40258437 52099154 1000 600 600 (gmt_eq.dvi)
+@start /Fa 184[65 71[{}1 83.022 /CMMI10 rf /Fb 141[69
+114[{}1 83.022 /CMSY10 rf end
+%%EndProlog
+%%BeginSetup
+%%Feature: *Resolution 600dpi
+TeXDict begin
+ end
+%%EndSetup
+TeXDict begin 1 0 bop 639 523 a Fb(r)p Fa(G)p eop end
+%%Trailer
+userdict /end-hook known{end-hook}if
+%%EOF
+%%EndDocument
+PSL_eps_end
+U
+3780 0 T
+23 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 60 0 D S
+N 0 1181 M 60 0 D S
+N 0 2362 M 60 0 D S
+N 0 3543 M 60 0 D S
+N 0 4724 M 60 0 D S
+N 0 591 M 30 0 D S
+N 0 1772 M 30 0 D S
+N 0 2953 M 30 0 D S
+N 0 4134 M 30 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+23 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 630 0 M 0 -60 D S
+N 1890 0 M 0 -60 D S
+N 3150 0 M 0 -60 D S
+N 0 0 M 0 -30 D S
+N 1260 0 M 0 -30 D S
+N 2520 0 M 0 -30 D S
+N 3780 0 M 0 -30 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4724 T
+23 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 630 0 M 0 60 D S
+N 1890 0 M 0 60 D S
+N 3150 0 M 0 60 D S
+N 0 0 M 0 30 D S
+N 1260 0 M 0 30 D S
+N 2520 0 M 0 30 D S
+N 3780 0 M 0 30 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+0 A
+%%EndObject
+0 -5011 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4066 5011 TM
+% PostScript produced by:
+%@GMT: gmt basemap -Bwens -Bxafg -Byafg -Xa3.3885i -Ya4.1759i -R-30/30/0/80 -JX10c
+%@PROJ: xy -30.00000000 30.00000000 0.00000000 80.00000000 -30.000 30.000 0.000 80.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+630 0 M
+0 4724 D
+S
+1890 0 M
+0 4724 D
+S
+3150 0 M
+0 4724 D
+S
+0 0 M
+3780 0 D
+S
+0 1181 M
+3780 0 D
+S
+0 2362 M
+3780 0 D
+S
+0 3543 M
+3780 0 D
+S
+0 4724 M
+3780 0 D
+S
+23 W
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -60 0 D S
+N 0 1181 M -60 0 D S
+N 0 2362 M -60 0 D S
+N 0 3543 M -60 0 D S
+N 0 4724 M -60 0 D S
+N 0 591 M -30 0 D S
+N 0 1772 M -30 0 D S
+N 0 2953 M -30 0 D S
+N 0 4134 M -30 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+23 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 60 0 D S
+N 0 1181 M 60 0 D S
+N 0 2362 M 60 0 D S
+N 0 3543 M 60 0 D S
+N 0 4724 M 60 0 D S
+N 0 591 M 30 0 D S
+N 0 1772 M 30 0 D S
+N 0 2953 M 30 0 D S
+N 0 4134 M 30 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+23 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 630 0 M 0 -60 D S
+N 1890 0 M 0 -60 D S
+N 3150 0 M 0 -60 D S
+N 0 0 M 0 -30 D S
+N 1260 0 M 0 -30 D S
+N 2520 0 M 0 -30 D S
+N 3780 0 M 0 -30 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 4724 T
+23 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 630 0 M 0 60 D S
+N 1890 0 M 0 60 D S
+N 3150 0 M 0 60 D S
+N 0 0 M 0 30 D S
+N 1260 0 M 0 30 D S
+N 2520 0 M 0 30 D S
+N 3780 0 M 0 30 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+0 A
+%%EndObject
+-4066 -5011 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt basemap -BWenS '-Bxafg+l@[\int_{x} \int_{t} \tau_x@[' '-Byafg+l<math>\nabla G</math>' -Xa0i -Ya0i -R-30/30/0/80 -JX10c
+%@PROJ: xy -30.00000000 30.00000000 0.00000000 80.00000000 -30.000 30.000 0.000 80.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+630 0 M
+0 4724 D
+S
+1890 0 M
+0 4724 D
+S
+3150 0 M
+0 4724 D
+S
+0 0 M
+3780 0 D
+S
+0 1181 M
+3780 0 D
+S
+0 2362 M
+3780 0 D
+S
+0 3543 M
+3780 0 D
+S
+0 4724 M
+3780 0 D
+S
+23 W
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -60 0 D S
+N 0 1181 M -60 0 D S
+N 0 2362 M -60 0 D S
+N 0 3543 M -60 0 D S
+N 0 4724 M -60 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+150 F0
+(0) sw mx
+(20) sw mx
+(40) sw mx
+(60) sw mx
+(80) sw mx
+def
+/PSL_A0_y PSL_A0_y 45 add def
+0 PSL_A0_y MM
+(0) mr Z
+1181 PSL_A0_y MM
+(20) mr Z
+2362 PSL_A0_y MM
+(40) mr Z
+3543 PSL_A0_y MM
+(60) mr Z
+4724 PSL_A0_y MM
+(80) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 591 M -30 0 D S
+N 0 1772 M -30 0 D S
+N 0 2953 M -30 0 D S
+N 0 4134 M -30 0 D S
+/PSL_LH 210 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 90 add def
+2362 PSL_L_y MM
+V
+currentpoint T 90 R
+0 189 PSL_LH sub neg M currentpoint T
+0 90 M currentpoint T
+PSL_eps_begin
+-210 0 T 21 21 scale
+-148 -656 T
+N 148 656 M 168 656 L 168 665 L 148 665 L P clip N
+%%BeginDocument: psimage.eps
+%!PS-Adobe-2.0 EPSF-2.0
+%%Creator: dvips(k) 2020.1 Copyright 2020 Radical Eye Software
+%%Title: gmt_eq.dvi
+%%CreationDate: Tue Mar 30 21:49:36 2021
+%%DocumentFonts: CMSY10 CMMI10
+%%EndComments
+%DVIPSWebPage: (www.radicaleye.com)
+%DVIPSCommandLine: dvips -q -E gmt_eq.dvi -o equation.eps
+%DVIPSParameters: dpi=600
+%DVIPSSource:  TeX output 2021.03.30:1149
+%%BeginProcSet: tex.pro 0 0
+%!
+/TeXDict 300 dict def TeXDict begin/N{def}def/B{bind def}N/S{exch}N/X{S
+N}B/A{dup}B/TR{translate}N/isls false N/vsize 11 72 mul N/hsize 8.5 72
+mul N/landplus90{false}def/@rigin{isls{[0 landplus90{1 -1}{-1 1}ifelse 0
+0 0]concat}if 72 Resolution div 72 VResolution div neg scale isls{
+landplus90{VResolution 72 div vsize mul 0 exch}{Resolution -72 div hsize
+mul 0}ifelse TR}if Resolution VResolution vsize -72 div 1 add mul TR[
+matrix currentmatrix{A A round sub abs 0.00001 lt{round}if}forall round
+exch round exch]setmatrix}N/@landscape{/isls true N}B/@manualfeed{
+statusdict/manualfeed true put}B/@copies{/#copies X}B/FMat[1 0 0 -1 0 0]
+N/FBB[0 0 0 0]N/nn 0 N/IEn 0 N/ctr 0 N/df-tail{/nn 8 dict N nn begin
+/FontType 3 N/FontMatrix fntrx N/FontBBox FBB N string/base X array
+/BitMaps X/BuildChar{CharBuilder}N/Encoding IEn N end A{/foo setfont}2
+array copy cvx N load 0 nn put/ctr 0 N[}B/sf 0 N/df{/sf 1 N/fntrx FMat N
+df-tail}B/dfs{div/sf X/fntrx[sf 0 0 sf neg 0 0]N df-tail}B/E{pop nn A
+definefont setfont}B/Cw{Cd A length 5 sub get}B/Ch{Cd A length 4 sub get
+}B/Cx{128 Cd A length 3 sub get sub}B/Cy{Cd A length 2 sub get 127 sub}
+B/Cdx{Cd A length 1 sub get}B/Ci{Cd A type/stringtype ne{ctr get/ctr ctr
+1 add N}if}B/CharBuilder{save 3 1 roll S A/base get 2 index get S
+/BitMaps get S get/Cd X pop/ctr 0 N Cdx 0 Cx Cy Ch sub Cx Cw add Cy
+setcachedevice Cw Ch true[1 0 0 -1 -.1 Cx sub Cy .1 sub]{Ci}imagemask
+restore}B/D{/cc X A type/stringtype ne{]}if nn/base get cc ctr put nn
+/BitMaps get S ctr S sf 1 ne{A A length 1 sub A 2 index S get sf div put
+}if put/ctr ctr 1 add N}B/I{cc 1 add D}B/bop{userdict/bop-hook known{
+bop-hook}if/SI save N @rigin 0 0 moveto/V matrix currentmatrix A 1 get A
+mul exch 0 get A mul add .99 lt{/QV}{/RV}ifelse load def pop pop}N/eop{
+SI restore userdict/eop-hook known{eop-hook}if showpage}N/@start{
+userdict/start-hook known{start-hook}if pop/VResolution X/Resolution X
+1000 div/DVImag X/IEn 256 array N 2 string 0 1 255{IEn S A 360 add 36 4
+index cvrs cvn put}for pop 65781.76 div/vsize X 65781.76 div/hsize X}N
+/dir 0 def/dyy{/dir 0 def}B/dyt{/dir 1 def}B/dty{/dir 2 def}B/dtt{/dir 3
+def}B/p{dir 2 eq{-90 rotate show 90 rotate}{dir 3 eq{-90 rotate show 90
+rotate}{show}ifelse}ifelse}N/RMat[1 0 0 -1 0 0]N/BDot 260 string N/Rx 0
+N/Ry 0 N/V{}B/RV/v{/Ry X/Rx X V}B statusdict begin/product where{pop
+false[(Display)(NeXT)(LaserWriter 16/600)]{A length product length le{A
+length product exch 0 exch getinterval eq{pop true exit}if}{pop}ifelse}
+forall}{false}ifelse end{{gsave TR -.1 .1 TR 1 1 scale Rx Ry false RMat{
+BDot}imagemask grestore}}{{gsave TR -.1 .1 TR Rx Ry scale 1 1 false RMat
+{BDot}imagemask grestore}}ifelse B/QV{gsave newpath transform round exch
+round exch itransform moveto Rx 0 rlineto 0 Ry neg rlineto Rx neg 0
+rlineto fill grestore}B/a{moveto}B/delta 0 N/tail{A/delta X 0 rmoveto}B
+/M{S p delta add tail}B/b{S p tail}B/c{-4 M}B/d{-3 M}B/e{-2 M}B/f{-1 M}
+B/g{0 M}B/h{1 M}B/i{2 M}B/j{3 M}B/k{4 M}B/w{0 rmoveto}B/l{p -4 w}B/m{p
+-3 w}B/n{p -2 w}B/o{p -1 w}B/q{p 1 w}B/r{p 2 w}B/s{p 3 w}B/t{p 4 w}B/x{
+0 S rmoveto}B/y{3 2 roll p a}B/bos{/SS save N}B/eos{SS restore}B end
+%%EndProcSet
+%%BeginProcSet: l3backend-dvips.pro 0 0
+%%
+%% This is file `l3backend-dvips.pro',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% l3backend-header.dtx  (with options: `header,dvips')
+%% 
+%% Copyright (C) 1990-2020 The LaTeX3 Project
+%% 
+%% It may be distributed and/or modified under the conditions of
+%% the LaTeX Project Public License (LPPL), either version 1.3c of
+%% this license or (at your option) any later version.  The latest
+%% version of this license is in the file:
+%% 
+%%    https://www.latex-project.org/lppl.txt
+%% 
+%% This file is part of the "l3backend bundle" (The Work in LPPL)
+%% and all files in that bundle must be distributed together.
+%% 
+%% File: l3backend-header.dtx
+true setglobal
+/pdf.globaldict 4 dict def
+false setglobal
+/pdf.cvs { 65534 string cvs } def
+/pdf.dvi.pt { 72.27 mul Resolution div } def
+/pdf.pt.dvi { 72.27 div Resolution mul } def
+/pdf.rect.ht { dup 1 get neg exch 3 get add } def
+/pdf.linkmargin { 1 pdf.pt.dvi } def
+/pdf.linkdp.pad { 0 } def
+/pdf.linkht.pad { 0 } def
+/pdf.rect
+  { /Rect [ pdf.llx pdf.lly pdf.urx pdf.ury ] } def
+/pdf.save.ll
+  {
+    currentpoint
+    /pdf.lly exch def
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.ur
+  {
+    currentpoint
+    /pdf.ury exch def
+    /pdf.urx exch def
+  }
+    def
+/pdf.save.linkll
+  {
+    currentpoint
+    pdf.linkmargin add
+    pdf.linkdp.pad add
+    /pdf.lly exch def
+    pdf.linkmargin sub
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.linkur
+  {
+    currentpoint
+    pdf.linkmargin sub
+    pdf.linkht.pad sub
+    /pdf.ury exch def
+    pdf.linkmargin add
+    /pdf.urx exch def
+  }
+    def
+/pdf.dest.anchor
+  {
+    currentpoint exch
+    pdf.dvi.pt 72 add
+    /pdf.dest.x exch def
+    pdf.dvi.pt
+    vsize 72 sub exch sub
+    /pdf.dest.y exch def
+  }
+    def
+/pdf.dest.point
+  { pdf.dest.x pdf.dest.y } def
+/pdf.dest2device
+  {
+    /pdf.dest.y exch def
+    /pdf.dest.x exch def
+    matrix currentmatrix
+    matrix defaultmatrix
+    matrix invertmatrix
+    matrix concatmatrix
+    cvx exec
+    /pdf.dev.y exch def
+    /pdf.dev.x exch def
+    /pdf.tmpd exch def
+    /pdf.tmpc exch def
+    /pdf.tmpb exch def
+    /pdf.tmpa exch def
+    pdf.dest.x pdf.tmpa mul
+      pdf.dest.y pdf.tmpc mul add
+      pdf.dev.x add
+    pdf.dest.x pdf.tmpb mul
+     pdf.dest.y pdf.tmpd mul add
+     pdf.dev.y add
+  }
+    def
+/pdf.bordertracking false def
+/pdf.bordertracking.begin
+  {
+    SDict /pdf.bordertracking true put
+    SDict /pdf.leftboundary undef
+    SDict /pdf.rightboundary undef
+    /a where
+      {
+        /a
+          {
+            currentpoint pop
+            SDict /pdf.rightboundary known dup
+              {
+                SDict /pdf.rightboundary get 2 index lt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.rightboundary exch put }
+            ifelse
+            moveto
+            currentpoint pop
+            SDict /pdf.leftboundary known dup
+              {
+                SDict /pdf.leftboundary get 2 index gt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.leftboundary exch put }
+            ifelse
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.bordertracking.end
+  {
+    /a where { /a { moveto } put } if
+    /x where { /x { 0 exch rmoveto } put } if
+    SDict /pdf.leftboundary known
+      { pdf.outerbox 0 pdf.leftboundary put }
+    if
+    SDict /pdf.rightboundary known
+      { pdf.outerbox 2 pdf.rightboundary put }
+    if
+    SDict /pdf.bordertracking false put
+  }
+    def
+  /pdf.bordertracking.endpage
+{
+  pdf.bordertracking
+    {
+      pdf.bordertracking.end
+      true setglobal
+      pdf.globaldict
+        /pdf.brokenlink.rect [ pdf.outerbox aload pop ] put
+      pdf.globaldict
+        /pdf.brokenlink.skip pdf.baselineskip put
+      pdf.globaldict
+        /pdf.brokenlink.dict
+          pdf.link.dict pdf.cvs put
+      false setglobal
+      mark pdf.link.dict cvx exec /Rect
+        [
+          pdf.llx
+          pdf.lly
+          pdf.outerbox 2 get pdf.linkmargin add
+          currentpoint exch pop
+          pdf.outerbox pdf.rect.ht sub pdf.linkmargin sub
+        ]
+      /ANN pdf.pdfmark
+    }
+  if
+}
+  def
+/pdf.bordertracking.continue
+  {
+    /pdf.link.dict pdf.globaldict
+      /pdf.brokenlink.dict get def
+    /pdf.outerbox pdf.globaldict
+      /pdf.brokenlink.rect get def
+    /pdf.baselineskip pdf.globaldict
+      /pdf.brokenlink.skip get def
+    pdf.globaldict dup dup
+    /pdf.brokenlink.dict undef
+    /pdf.brokenlink.skip undef
+    /pdf.brokenlink.rect undef
+    currentpoint
+    /pdf.originy exch def
+    /pdf.originx exch def
+    /a where
+      {
+        /a
+          {
+            moveto
+            SDict
+            begin
+            currentpoint pdf.originy ne exch
+              pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+    /x where
+      {
+        /x
+          {
+            0 exch rmoveto
+            SDict~
+            begin
+            currentpoint
+            pdf.originy ne exch pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.breaklink
+  {
+    pop
+    counttomark 2 mod 0 eq
+      {
+        counttomark /pdf.count exch def
+          {
+           pdf.count 0 eq { exit } if
+           counttomark 2 roll
+           1 index /Rect eq
+             {
+               dup 4 array copy
+               dup dup
+                 1 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add sub
+                 3 exch put
+               dup
+                 pdf.outerbox 2 get
+                 pdf.linkmargin add
+                 2 exch put
+               dup dup
+                 3 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add add
+                 1 exch put
+               /pdf.currentrect exch  def
+               pdf.breaklink.write
+                 {
+                   pdf.currentrect
+                   dup
+                     pdf.outerbox 0 get
+                     pdf.linkmargin sub
+                     0 exch put
+                   dup
+                     pdf.outerbox 2 get
+                     pdf.linkmargin add
+                     2 exch put
+                   dup dup
+                     1 get
+                     pdf.baselineskip add
+                     1 exch put
+                   dup dup
+                     3 get
+                     pdf.baselineskip add
+                     3 exch put
+                   /pdf.currentrect exch def
+                   pdf.breaklink.write
+                  }
+                1 index 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                2 index 1 get sub
+                pdf.baselineskip div round cvi 1 sub
+                exch
+              repeat
+              pdf.currentrect
+              dup
+                pdf.outerbox 0 get
+                pdf.linkmargin sub
+                0 exch put
+              dup dup
+                1 get
+                pdf.baselineskip add
+                1 exch put
+              dup dup
+                3 get
+                pdf.baselineskip add
+                3 exch put
+              dup 2 index 2 get  2 exch put
+              /pdf.currentrect exch def
+              pdf.breaklink.write
+              SDict /pdf.pdfmark.good false put
+              exit
+            }
+            { pdf.count 2 sub /pdf.count exch def }
+          ifelse
+        }
+      loop
+    }
+  if
+  /ANN
+}
+  def
+/pdf.breaklink.write
+  {
+    counttomark 1 sub
+    index /_objdef eq
+      {
+        counttomark -2 roll
+        dup wcheck
+          {
+            readonly
+            counttomark 2 roll
+          }
+          { pop pop }
+        ifelse
+      }
+    if
+    counttomark 1 add copy
+    pop pdf.currentrect
+    /ANN pdfmark
+  }
+    def
+/pdf.pdfmark
+  {
+    SDict /pdf.pdfmark.good true put
+    dup /ANN eq
+      {
+        pdf.pdfmark.store
+        pdf.pdfmark.dict
+          begin
+            Subtype /Link eq
+            currentdict /Rect known and
+            SDict /pdf.outerbox known and
+            SDict /pdf.baselineskip known and
+              {
+                Rect 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                Rect 1 get sub
+                pdf.baselineskip div round cvi 0 gt
+                  { pdf.breaklink }
+                if
+              }
+            if
+          end
+        SDict /pdf.outerbox undef
+        SDict /pdf.baselineskip undef
+        currentdict /pdf.pdfmark.dict undef
+      }
+    if
+    pdf.pdfmark.good
+      { pdfmark }
+      { cleartomark }
+    ifelse
+  }
+    def
+/pdf.pdfmark.store
+  {
+    /pdf.pdfmark.dict 65534 dict def
+    counttomark 1 add copy
+    pop
+      {
+        dup mark eq
+          {
+            pop
+            exit
+          }
+          {
+            pdf.pdfmark.dict
+            begin def end
+          }
+        ifelse
+      }
+    loop
+}
+  def
+%% 
+%%
+%% End of file `l3backend-dvips.pro'.
+%%EndProcSet
+%%BeginProcSet: texps.pro 0 0
+%!
+TeXDict begin/rf{findfont dup length 1 add dict begin{1 index/FID ne 2
+index/UniqueID ne and{def}{pop pop}ifelse}forall[1 index 0 6 -1 roll
+exec 0 exch 5 -1 roll VResolution Resolution div mul neg 0 0]FontType 0
+ne{/Metrics exch def dict begin Encoding{exch dup type/integertype ne{
+pop pop 1 sub dup 0 le{pop}{[}ifelse}{FontMatrix 0 get div Metrics 0 get
+div def}ifelse}forall Metrics/Metrics currentdict end def}{{1 index type
+/nametype eq{exit}if exch pop}loop}ifelse[2 index currentdict end
+definefont 3 -1 roll makefont/setfont cvx]cvx def}def/ObliqueSlant{dup
+sin S cos div neg}B/SlantFont{4 index mul add}def/ExtendFont{3 -1 roll
+mul exch}def/ReEncodeFont{CharStrings rcheck{/Encoding false def dup[
+exch{dup CharStrings exch known not{pop/.notdef/Encoding true def}if}
+forall Encoding{]exch pop}{cleartomark}ifelse}if/Encoding exch def}def
+end
+%%EndProcSet
+%%BeginProcSet: special.pro 0 0
+%!
+TeXDict begin/SDict 200 dict N SDict begin/@SpecialDefaults{/hs 612 N
+/vs 792 N/ho 0 N/vo 0 N/hsc 1 N/vsc 1 N/ang 0 N/CLIP 0 N/rwiSeen false N
+/rhiSeen false N/letter{}N/note{}N/a4{}N/legal{}N}B/@scaleunit 100 N
+/@hscale{@scaleunit div/hsc X}B/@vscale{@scaleunit div/vsc X}B/@hsize{
+/hs X/CLIP 1 N}B/@vsize{/vs X/CLIP 1 N}B/@clip{/CLIP 2 N}B/@hoffset{/ho
+X}B/@voffset{/vo X}B/@angle{/ang X}B/@rwi{10 div/rwi X/rwiSeen true N}B
+/@rhi{10 div/rhi X/rhiSeen true N}B/@llx{/llx X}B/@lly{/lly X}B/@urx{
+/urx X}B/@ury{/ury X}B/magscale true def end/@MacSetUp{userdict/md known
+{userdict/md get type/dicttype eq{userdict begin md length 10 add md
+maxlength ge{/md md dup length 20 add dict copy def}if end md begin
+/letter{}N/note{}N/legal{}N/od{txpose 1 0 mtx defaultmatrix dtransform S
+atan/pa X newpath clippath mark{transform{itransform moveto}}{transform{
+itransform lineto}}{6 -2 roll transform 6 -2 roll transform 6 -2 roll
+transform{itransform 6 2 roll itransform 6 2 roll itransform 6 2 roll
+curveto}}{{closepath}}pathforall newpath counttomark array astore/gc xdf
+pop ct 39 0 put 10 fz 0 fs 2 F/|______Courier fnt invertflag{PaintBlack}
+if}N/txpose{pxs pys scale ppr aload pop por{noflips{pop S neg S TR pop 1
+-1 scale}if xflip yflip and{pop S neg S TR 180 rotate 1 -1 scale ppr 3
+get ppr 1 get neg sub neg ppr 2 get ppr 0 get neg sub neg TR}if xflip
+yflip not and{pop S neg S TR pop 180 rotate ppr 3 get ppr 1 get neg sub
+neg 0 TR}if yflip xflip not and{ppr 1 get neg ppr 0 get neg TR}if}{
+noflips{TR pop pop 270 rotate 1 -1 scale}if xflip yflip and{TR pop pop
+90 rotate 1 -1 scale ppr 3 get ppr 1 get neg sub neg ppr 2 get ppr 0 get
+neg sub neg TR}if xflip yflip not and{TR pop pop 90 rotate ppr 3 get ppr
+1 get neg sub neg 0 TR}if yflip xflip not and{TR pop pop 270 rotate ppr
+2 get ppr 0 get neg sub neg 0 S TR}if}ifelse scaleby96{ppr aload pop 4
+-1 roll add 2 div 3 1 roll add 2 div 2 copy TR .96 dup scale neg S neg S
+TR}if}N/cp{pop pop showpage pm restore}N end}if}if}N/normalscale{
+Resolution 72 div VResolution 72 div neg scale magscale{DVImag dup scale
+}if 0 setgray}N/@beginspecial{SDict begin/SpecialSave save N gsave
+normalscale currentpoint TR @SpecialDefaults count/ocount X/dcount
+countdictstack N}N/@setspecial{CLIP 1 eq{newpath 0 0 moveto hs 0 rlineto
+0 vs rlineto hs neg 0 rlineto closepath clip}if ho vo TR hsc vsc scale
+ang rotate rwiSeen{rwi urx llx sub div rhiSeen{rhi ury lly sub div}{dup}
+ifelse scale llx neg lly neg TR}{rhiSeen{rhi ury lly sub div dup scale
+llx neg lly neg TR}if}ifelse CLIP 2 eq{newpath llx lly moveto urx lly
+lineto urx ury lineto llx ury lineto closepath clip}if/showpage{}N
+/erasepage{}N/setpagedevice{pop}N/copypage{}N newpath}N/@endspecial{
+count ocount sub{pop}repeat countdictstack dcount sub{end}repeat
+grestore SpecialSave restore end}N/@defspecial{SDict begin}N
+/@fedspecial{end}B/li{lineto}B/rl{rlineto}B/rc{rcurveto}B/np{/SaveX
+currentpoint/SaveY X N 1 setlinecap newpath}N/st{stroke SaveX SaveY
+moveto}N/fil{fill SaveX SaveY moveto}N/ellipse{/endangle X/startangle X
+/yrad X/xrad X/savematrix matrix currentmatrix N TR xrad yrad scale 0 0
+1 startangle endangle arc savematrix setmatrix}N end
+%%EndProcSet
+%%BeginFont: CMMI10
+%!PS-AdobeFont-1.0: CMMI10 003.002
+%%Title: CMMI10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMMI10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMMI10 known{/CMMI10 findfont dup/UniqueID known{dup
+/UniqueID get 5087385 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMMI10 def
+/FontBBox {-32 -250 1048 750 }readonly def
+/PaintType 0 def
+/FontInfo 10 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMMI10.) readonly def
+/FullName (CMMI10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+/ascent 750 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 71 /G put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3C05EF98F858322DCEA45E0874C5
+45D25FE192539D9CDA4BAA46D9C431465E6ABF4E4271F89EDED7F37BE4B31FB4
+7934F62D1F46E8671F6290D6FFF601D4937BF71C22D60FB800A15796421E3AA7
+72C500501D8B10C0093F6467C553250F7C27B2C3D893772614A846374A85BC4E
+BEC0B0A89C4C161C3956ECE25274B962C854E535F418279FE26D8F83E38C5C89
+974E9A224B3CBEF90A9277AF10E0C7CAC8DC11C41DC18B814A7682E5F0248674
+11453BC81C443407AF41AF8A831A85A700CFC65E2181BCBFBC7878DFBD546AC2
+1EF6CC527FEEA044B7C8E686367E920F575AD585387358FFF41BCB212922791C
+7B0BD3BED7C6D8F3D9D52D0F181CD4D164E75851D04F64309D810A0DEA1E257B
+0D7633CEFE93FEF9D2FB7901453A46F8ACA007358D904E0189AE7B7221545085
+EDD3D5A3CEACD6023861F13C8A345A68115425E94B8FDCCEC1255454EC3E7A37
+404F6C00A3BCCF851B929D4FE66B6D8FD1C0C80130541609759F18EF07BCD133
+78CBC4A0D8A796A2574260C6A952CA73D9EB5C28356F5C90D1A59DC788762BFF
+A1B6F0614958D09751C0DB2309406F6B4489125B31C5DD365B2F140CB5E42CEE
+88BE11C7176E6BBC90D24E40956279FBDC9D89A6C4A1F4D27EC57F496602FBC4
+C854143903A53EF1188D117C49F8B6F2498B4698C25F2C5E8D8BD833206F88FC
+BD5B495EB993A26B6055BD0BBA2B3DDFD462C39E022D4A1760C845EA448DED88
+98C44BAAB85CD0423E00154C4741240EB3A2290B67144A4C80C88BE3D59AD760
+E553DAC4E8BA00B06398B1D0DFE96FB89449D4AE18CE8B27AFE75D2B84EFDB44
+143FD887F8FB364D000651912E40B0BAEDDA5AD57A3BC0E411E1AD908C77DCE3
+981985F98E258A9BB3A1B845FC4A21BCC54559E51BC0E6C22F0C38540F8C9490
+88A0E23EA504FA79F8960CC9D58611C519D3ACDC63FB2FBCAE6674357D7F2285
+4BCC9F54D3DA421D744D3A341DA3B494BB526C0734E1A8FC71501745399F7683
+FD17EC3044419A88C3979FD2ABA5B0130907B145A8462AAF0A9B511D2C8A7C7F
+347FF6AC057E6512902BFD2918E2CD31DE615F5D643764E900B60287670AE18F
+FDE15545D8BC69591A8CBBB275AFFC9B14BD68DF0AAB32268FB84844D4DBC7BB
+C591C1AC5102C50A9C7BAAA848DA88B0519F0F5F0813BF055CF0E3C86F633A04
+B779D2E8E656DB1E09A66A85FE21CA8BA5523F472A229E83F2C4E91ABA46C733
+F3C7B5775B06C97782BC225C46385BEBDC61572458EFC5CF4190AB7A9C1C92DA
+29F84BAACF552089195966E3AD9E57CC914D20B6962BE80429A16D4DF1ECAA66
+36C4343FADF0B2B48F12E2EB8443C4AA29D00949255F3968617F98B8ABD4CC12
+048B838EE243A21AC808BD295195E4AE9027005F52258BFCA915C8D9AED9A2C0
+80814F79CF943FBE3594C530A22A92E11BE80FCEC1684C4F56712D5846B0749C
+9B54A979B315222F209DEE72583B03093EC38F7C5B9F9BCB21DBE8EDDAE9BE8B
+75ACE6B12A31083AC8348EC84D1D29D2297A266284B7E9734E207DAF59A25F4E
+4AA38509E993C5394FED76E6A2F25462685C4C86C6E8CFC9863338EC1428BDFC
+74616BB1BC8948B0ED4C87C15B4405F3A7796F9DB3798FFFE8BD0A94E834817B
+D5E9812E308D0CC920470A6F2CD088FCB80462BF7CB3F039A7DF3DAF5B2B5355
+E083A385CD2EAF0FC181E40E96DD7E9AB9EF5C7E6866A13B8A54718E950FE097
+EF0951A357114F18CE9933D28B3A77AA71E3CE884661F13284BCED5D5FD1A86D
+543E588FF473DC2CF9A4DC312500135F29C2D0174B32018C8DBD40EF9A232883
+710A1F2AB2CD11312300ACDF789A9B7B93D2035D81D1C84984D92D78A53A00C6
+EDA94B24BBAC1AD17774A4E07E6F74ABD90415965616AD540C8ECD8C3A44EE4F
+7F4F6BB6238C5062D63FA59B7BF08BE93FAEA70A2AB08FBEAAF7DBF56B95FD93
+03CA406543BA6C9527D0DF01F5108D31A51778A5EB1C93F27B72B46146A353A2
+01CACBC829603B9989A87CF64528682CCBA0562A8165B185C58A5C6BB72F5E89
+500ACCAAB8ECEFBB2640E99EAEEC4EA979AA793D013D61D8ACF8784FF8D9398F
+F6A252A709324FB39509F0B3A4E725E82F53543383C6765BE556CC897C758208
+AA3AD37B0406E4A79F8F0A6C1983FC73E71CD858C0DB66ED66D5D992978614EE
+1EA91EBE191E082EBA1FC040AF19A2202575C2EBEB8058833E3520FA03D2F915
+85C1ED337E457B9FEEB0C6EF2735EFDA6E0D05FA641BCF698AC6B97751E8306C
+4DF00A39B8581FF53DB8F8525FDB196D85950906CCB59B8EF171349AA3B567B1
+6A00819947A995FB383C3C1709C9A2C113B2E40BB832B7D4A0FBA0B16A2C455F
+55809CC425C403E9668DC66BE45B71A81C332FD4DB279D22A2959962304A8F18
+085893DAC61317D24A8F198FDAB95F3B86F0AFD35047B868A9A17037A2829A02
+BAB042F75F349E197A7EED41984C2859754CAFD0251439921C248B463B516951
+2E1322C80D73F9CBCAA63A585450275AC2492E4D3FB78E800F788254DB5E610D
+CF788DF5C70FF99892BCDF16133E34B24B77C8F097F546B87C603DDB8998B66E
+BACB68BA27462AF54AA405682EC96D701F0D474DECD5F95CA2102DF639EB169E
+D518162C2BAE45FF698B6DE15FC6E7DE48C336C40A670FD26952A6BAB09115E1
+991F0073419F2CC2A1C08BE91096936AA0C37E4ED3CCCEE235476074B8FF1125
+6BDE3701F85532D8BB64CCC927CC335281C95EA689706F0AC717DC2CF680C754
+E5EFD7FA4BB8880B2B727A964C876D4A223069D4E6001771F0E23EAD2A4BBC80
+E76675297B2EF05F52BF4E71B3EE2BE3048CF088C79540113C66AE98B2FD3CB1
+B0741A215FD070882C52765009D7D711DAA2508F19AE7DDA15229A856AC49BC3
+4DDF40814FF96500E4B9B02D412E94623C5FDCC76C0FB8E42DF56A904FE49D65
+1DA7C53901B2EA71AB658A464D3ABDE27D9DB8D9E0B48F64E61A2495AD5D8DAB
+B5E72424AD017DF37964AF911BD7FA21A5EB4775DC8E95EF0C0EB856B00D89D7
+8172A1DE8530767D317B8256103E53CFB877E10686A04F5A08F8DC58D843DEBA
+FD5F40597588663D103689F6EB3EB14D06E18C8078F2538B43E712DF491FC5C6
+AF639256C8C6134B64D560D8476DEA6329D995E46CC4BC78841C59E73648B47E
+BFA7DE0846422F738454AE77E822A083405289247BD7C478BE4974F742CD6051
+E99FBB1D1B3FBABFEE855174734EE45E87D0AADF32B1283B911162A9955847FD
+38944D70584FAA6B1A7191C5C134B73F98EB632B69E2F0C0F94156787C34C8A3
+7622A029D58F9626B74F8A8A1F3803E0BC20E0EADEB1E99B70F1BD9F980FB751
+2A842843DE42EB142A84D5D3138629AE9EAF6F3479C423E8829C8816FA6EFA27
+DCE5580E65AA9854B1C64163DC318420CD993C15BFD76A8BA1182860A6B03D6D
+22B8CF43CFE6C8AB27C64842E239CAE707D3086BADDE1D7C94E3BC96319470D6
+8D26915C575CFDD03271D6BB9DE86A0EB6EEA6E768B224A626C62A9AB48A6EDB
+44F70BB5AF991CDF9736D65933E81CC57A78F623F33EC9AF535F2F25FA4EEC90
+D50DB7E87F31E971A75A33A301CA6013EEC5A4E179D695B33DADF2C98364434A
+42926776000B610E17524162253F6FA638D6581C18F99EA0BD1D2E24D2424ADF
+C05010D08192485153DD03930C7BF45237593E484F9851E6D464FA10FECA5D9E
+0C8CCC97DE029030900CDBB491C5CF226DBF903CFE7735D939C3FDF3A20B70CE
+66579B28B99313FEE914E295388C7BC8E055A2E54EA3A8206D3C8F4F7C0BA5E6
+E519419FD8CE215F7B8E9BEC604A9E3FE272A0328A24E31997C8A91E0946BCF1
+6943A97CBED2AB9FC636B49828BBB8B89E0BBC2653796431224895ABA5DAC41E
+1854BD9764E86147FD7624F736F40DE3B7582EDDFD15C2BDE3F22B5A54D7DF10
+B87A1301CE85CFC061689A890A321412A13314AE96DCD3EDA75035FDD8F4AB9B
+897A2C68263A68457032C469987970648BA2D88B1C5375DFEAA35A917B8A952E
+EE670427942AEDB3CB599C5746180E392837D371E15D860620ABDB6AA7772C40
+A5E346661673ACA530BE3D8E3FFB895E5DA3DC23B1B43C080C77F7E47847F0F3
+F3AA5CA9E4BF75FC5EBD18D19F21A7DAA3B11CABC6E4070A15F7DBC8B05EB6AA
+A02EF1B078EB66D61D6AFE41DA9B36FE7EC9EF94D1EA26282A9871E2CACB3126
+2AD49C2D9B50A6E47D8F2CCAD50992D1B430979A45FD9E76182A19964BB2A1F6
+51779A2B258DC1DF4C2F3074621286831F3848AC152DDD2BA561E6586ADA88D3
+598A2CE2CD048F027CE0008B828BD915887D7785341E8305DF2346ADB76BE99F
+87B02173BDC334E9221C8DF54114A6B24C1C5340299512FA6C8C51AB4C8778CE
+178CEF531C6D1B5FF0A1BE8EFF767F959BD4C345C52699A29A17B2A230842BF6
+4B011217D6D24EDAC3F6D53482786F1CA33169B90ECD499407D37CE9B70DDF78
+7B7547B32952535BA9ACD1E244447AE3FCED3AF28717083CF9590A09780984D6
+AF0743C82AE4FB3E2BB2856A4153A3967A023FFC35382D6C22D84A924900B6A6
+3DDD400E6D2418DA6C27F2FA34C075C902B89EBAE658B3C9A18EEE449DA5A379
+337DE95CB7AB3F0970CF1A5D8FAD8090E495570FDFB2FBBA79244780D8035547
+C5A55BB21A2270F724BF5D442CDC5BB9F09BE0CAE59B1C2270F0BDACE698F2C5
+DE8F66BFB9634904B161F5BA2B1950048300D69BABD312D58D89C4ED527AF7BA
+7DA2478EDC2CDEE3473DD8A8ED9D891CD1FC21F23013228BB3281B71FCE959BD
+6F8E9059D682A7FCC5265A0620992D4FA8D78377EB34CE3ECA070EE3707239BC
+98907DB0120CE42ABA32CF97127E28382BDDFD685674279F588D4F951216C355
+821361790F64C2CC720DE97E8ECB57326C43EE47367628E05769E106868B54F4
+C33C9951908DF6FC4F5ED2C7787BD8FA591BBB3E9C6C1DA94CC5E38D9B20C886
+7D237572FF46DD896A4D6163408EA6CEFAC398EE041EAE29D577E75326CA17A6
+B072D47A7B13EC441CE6DAA042ECD02134CBFA6809A435050413817193DAEB16
+A5882C8AEA44BCF36E74E9ECCDFE7E19FF5A5DD7A94E5AB4F8702C3DA7F42325
+23C808670A0490F5B373DADE40814FF9650241D3D69C91FBC5ECE728F827D9BF
+C928602E05477903449E079164CA39859C4BCA60C579F490AA455F82B5050BB3
+969AFB478E0D4A257B3356EA3CD62051FCE6C6B1929CFF85BFDF166BEF658E10
+3A55E007F38EBBB248B3F0B8ED1925106B499B762E45113AE1AC9DE09644C84B
+9C08034B297314EE69BC32DB6E7D7FB9913CE5AC17E7335979E9DCCE2BAB3725
+1976155551F9706A576FE0E3ADCCF72C87683291528ECB749CB0ED291966E239
+B5E3630676BD409E08F85BC1AEC9A2D4135376284A96EA24431243BD6FE8B966
+95F11A4BB53F392E0AEFEA623064FF8A7002367B0A515635CB2D2DDFB9B4A8D7
+FE721754E81BBA548848A235B91AD4E4F7DB19CCE2F61D277FC00AB956EB93BE
+44AB4970CA56BF59506C94ED160FB1E25D3DF2988A532BDB787BFB8539D22986
+FDC378AC31444E63C4727FEE121A43751043849E6DCAC5B59D0FC703AAFBBFD4
+E8B7C268F21615AD02CE9DABEFA27B5FE6A6441B619539CAB1F810F1263447AA
+633F5DAF483752EF1A0421740E3A811D2D2898CBF53E7F686C9223FD7235F02D
+6F90D2D48CC20AB87778DE3C6FB335E0F0EC20B5DC5B65223FE117526DE2C72F
+FE839DF93CB2A7D66CD900CB325F891E311BEC932F703FB4FEFA29DB8B9C88DD
+375EC71B3D58C7BC59ADA91971A3BDA1ADEA629CE6CC92BD542CDDFAA7706FB2
+6CDDE2DF07E56D6741916AE8E8744339816F3E6C38062747AA9FDA2A2678A6B7
+EFEA870AA3A4D71B25EE3013EAB1DBA34401B867C7A41AE51E0421D41D3BB83C
+E120C8FEABA6E5DEC53A689C21426D4BBCB68CB37568761C360E6D4E3596FB7D
+F4DEC7918E58C0293D12D6DDA7E9DCDAAD7C939F55CD1BC4A228B31E9A904156
+DA6B40B08E6ACE674618B768DD681C772A3E55FE096CF949CF3B0460ABDCD891
+D17B37B355B29AB5137899C036F31DA026244FA25FB798FBE5105BDA29F46538
+D3D3AC1001A7BCECE64DE94FFE6C354166A0F97256137BDFA07F6E22A3D1D2F4
+9588DBAE95E895BC5E64DDCBBAA8D0A22C229B42CB717FC711E7E9DF793DF80B
+9F14754585A3C7E17F37B32924B9F9870DA8635E3E18BD1DCD81EDF01834D9C6
+B33F23C956C2FCBFA47D84422F583459D827D1E120B97694D12F1F54D02379C0
+D288F7104F3FFCF4F76E3494F4ACBD1BE3A15543CC680924C78A473F8E311ADF
+8FE00A04C6C393DE61AD3EDA5BC031E2353076A2489391B52632387CA28A7B93
+FBB065A6EF3658AE80B1ADA47E9B2539E73A71FA75645F85ED8ECC257FB4CF26
+B6C912DE9D0F9899E70BECCB934AD32CF49A093371A9F73DE6255EBC39DE1E7F
+00D0CBDABD4D0383977E694890E71FBE5C376BE5F3A80C28987417504F515C50
+909F3D31178BB9B1D085BE514F71B910A9085BD6122DDC72A150BFE266920E49
+5661BCB4BAB51D6DEFE32B616963DBD989FCDD1637B294CE4E288655FBEFA1BF
+7F25BBF8CF17C2D5FD161A7C2CC9CC7490D9BF15A1D35B3BFA43ADE256E88BDA
+BD490D92907C57BAC408A575EC84D6AEE070148C7C9A91C03B09FDBD792E8FF0
+C0B886AAD2EDD86541E5E579359D40E3AC312ACD3D8FD49F71BD533DDF8859B1
+BAF17F1884E331DD07CEEF93B71D492AEBAADF7A263450A7A72210CE630A0D37
+BF024BDC09ACC882816B8C22C62AE38A3A8D0F6EBC2B1B2C0B8161A8B076DD5D
+4B779C0788546BB4CF57332230D237856B00D79C28A7C01D11F44B7304F69075
+94B97A745DA43D1BE561372CE611C345A843834E46AD9DDB16CABCD3FA33D6F1
+F6B5C0497F5EE5400B305CDC16A7EC286AA4D45D0EEBB9DA06AC9C5294D68EC9
+E4DC3CA2B92CE8FC0526184A86EDC7AB34D67E60AC12D9CA8FD300235EC968BA
+92C6FBDA47572BC5600F25249F60AD287CBDAE980E747FCBE7EE5CD323E733F0
+63553B494D3DDEB9CC1480B5C3BB79A28E419AA65B18CB297AB383419E890E2A
+CE6F98C9900CCB4675280A10CF060B8D220DDA1BE55DFA65715EABCC1AFAA271
+B1F8732341613E17B231231A0D24D4D7FC198AE04D89A99C4536217769C6FBD9
+5EE24A6302F97438F7C0E311C878F674B4477A5ADA3952CDE4055AC408B8174E
+86F8FB797646DFFFE0ECA25D1BAB9A9F71F3926D3D85AA63E7A8C931D71E79E0
+AF1EAC26FADE468F4FF7F3861D14C10E3BE1F9EAFD6D3A544E8108D5DAB5B180
+3950C74818BC8AF4758A108F462EF1826647A49667F5E482038C54716856D9BC
+35F29922846D2148F92F943E951D7438C73D6A60459A8003174036C64E1629CD
+155D47FD04B03C023AD67CD5A70C98AB556EEAB8C48169706E5B352F6505D580
+AC945171BFE62E81F8F500438AC3B64D857BA5BC54C2C4BBB237F8FA51296255
+E66A92A61FE13FDE781D393557EB72CEBAD86511035F775FAC39A0479CCD400F
+226709118F887F47CC2ECC8F79816D4A945B2845F50AFD62D8C9A9BBF4739496
+9E644BC9F7B04803B7EE75A09EAE94365F6F374B4FCEB0B506C76297564B9B6B
+8B812BC3A33929AA94692572B010E6210AEAA312BDFC88BF302244AB9D587A9B
+919823FD01DE12438D960944D1977800FEB49E638C32E5B188B1CA033E0C37EE
+A142F746367888AA119535F0CCAF7EAA461B790EB089D2D6962E28A398439BB7
+9C9943654D7A2D765B46BC0DD1F915327F369162E1BA1BA83110B93F442905E0
+523BFF5E279508A98568CD5CFD18FABBE9D17265A9081E7BF64155A2CE3C0DF7
+88D00671AD65654709589BAD7EA65BBA811387ABA5CA0BC3F66D3D48597A0D1D
+2C268375DF47CCF62166262AE4840AB03BF49BE67A05EF66328EC729F03CA5FF
+AD3937FC053E223303565DC771ACF32E63DFB96D5030E787961D72D02C195C66
+B48E9AF0309DC169CFE8D16E2818DA94693A18F027DEA0D916672480464F7E22
+CA6E431FE38D3FC019BDD229E064B72C545C61C6EA55984565CCA88ACB01F744
+3B4593CC8973A8E56D0A5BBB31FA3647D2B01C752E21B8879522CCC8FB14C340
+CEE03251603F7B65066DDFC9669A99D6D639B30E82D5C11150E64286BF4E13E0
+C47E37C31F7F554CA03B1FB59225D5F11D16CB02740C4D7577D88DB9A080A864
+D6CD2A5A466549846A525AD43EF6358ACC6ABF95BC27EDF5BAF548A1553F660A
+2761A34A9B8E2B2E623EEA7EC7F95F9D383627F67FAE87A4AA5C1EC870A3B2A3
+585304A744579C0F6605973E95B48FF9395D1DFE4A04DE41B4E3093EFC4E3596
+6C3FB4DD4686E3E8B63DD1F82ADA5A0C2F518BA95197840C0CDB169CCDCE0CE6
+3B27C3890C9F13C14FFA8A0787C1703D519FBFA4364D0E2577AB7553DAA981EF
+FBC5896DBDC3A343ED0CCA7900196CB16F70AB30A7C216A2119217307D17A648
+91764AB6F5DBEA3FC694C826B45D3DA6BC8AF99B2F986D14E6297A48CF8EC20D
+CAB9A936A17635F9D1EBF6BE1E7BB633CC213076AD2E304E9A50DB0A87797758
+0C657A2DD37FE865E731DD6FC2DE58B4
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+%%BeginFont: CMSY10
+%!PS-AdobeFont-1.0: CMSY10 003.002
+%%Title: CMSY10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMSY10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMSY10 known{/CMSY10 findfont dup/UniqueID known{dup
+/UniqueID get 5096651 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMSY10 def
+/FontBBox {-29 -960 1116 775 }readonly def
+/PaintType 0 def
+/FontInfo 9 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMSY10.) readonly def
+/FullName (CMSY10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 114 /nabla put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CD06DFE1BE899059C588357426D7A0
+7B684C079A47D271426064AD18CB9750D8A986D1D67C1B2AEEF8CE785CC19C81
+DE96489F740045C5E342F02DA1C9F9F3C167651E646F1A67CF379789E311EF91
+511D0F605B045B279357D6FC8537C233E7AEE6A4FDBE73E75A39EB206D20A6F6
+1021961B748D419EBEEB028B592124E174CA595C108E12725B9875544955CFFD
+028B698EF742BC8C19F979E35B8E99CADDDDC89CC6C59733F2A24BC3AF36AD86
+1319147A4A219ECB92D0D9F6228B51A97C29547000FCC8A581BE543D73F1FED4
+3D08C53693138003C01E1D216B185179E1856E2A05AA6C66AABB68B7E4409021
+91AA9D8E4C5FBBDA55F1BB6BC679EABA06BE9795DB920A6343CE934B04D75DF2
+E0C30B8FD2E475FE0D66D4AA65821864C7DD6AC9939A04094EEA832EAD33DB7A
+11EE8D595FB0E543D0E80D31D584B97879B3C7B4A85CC6358A41342D70AD0B97
+C14123421FE8A7D131FB0D03900B392FDA0ABAFC25E946D2251F150EC595E857
+D17AE424DB76B431366086F377B2A0EEFD3909E3FA35E51886FC318989C1EF20
+B6F5990F1D39C22127F0A47BC8461F3AFDF87D9BDA4B6C1D1CFD7513F1E3C3D3
+93BEF764AA832316343F9FE869A720E4AA87AE76FA87A833BBC5892DE05B867F
+10FA225E233BCFA9BB51F46A6DF22ADCEACC01C3CD1F54C9AEFA25E92EFAC00D
+7E2BA427C25483BA42A199F4D2E43DFCE79A7156F7417ACF78E41FCA91E6C9EF
+B933450D851B73A6AB6AEA7EE4C710CB5C14270D1674FA334686653793FCB31B
+491E870D3C2BC654D2C1DE463EC9BA29D7371AA1078800EF93D3F66263A2EBBB
+F5723697BF7448BD0D2E301544BECF497FD475B85DFEF52AF4F8F8BE445CABE6
+019318806D10C5952157FF8F8286C1EE701545C8F60EFA854EAE66835A2046A6
+915D395F1E0366EFE0C0391583FE001FF16D82A2E2DA5F57754A2C6F69306E36
+356ECF8EFC3F1188AD6FCD2427E0580C97A5B69B4E0E09B85EEDE142F5ADD2F0
+5DE51D6DB72B127412A0D57106C19CA493048A4F815129ABE767D51715B1515D
+9C21067CB5BC88741B7298C83EAE36A866DFA87D8981F179B1C31292F56BBB64
+3C430779468AAF07C8A8B4934E1E775FE3F35186BD1FA6EE3689C1C750678AF1
+FBF9B23195A124C5C991FE670AC0C86FD39D2B07B9A319E74EFD498B45820252
+720ECDF7294F7B0B137CEB86D33BFCEB8606985A3260FD669E461C8BE94216C5
+D434FD8854F44EE66E5A289A9F9E32BC36AF645D53F96652602BAED418C8D726
+BD04A1B4617551FE4DEF54083D414F7DCE004E6BB2DC9C2EF7CE232B254BA2C5
+7DCBD36C2072ED46FF711F121A701E2284BF1B718B3164382B8F453D68FA0377
+DFE106503B8401D4DB87F5402A3AC9A442FA060B0610A9524D530C7157C26B56
+AC970FCC1D5655FFFFA39246E6420CF97D08ADFB7B05822679BD40C638DDF0E7
+A97BFE8918B611A145AC965C203F1428812F9D340AF499B3A915B22BE798594E
+0F520109FC81E452180AE45B170FF999C5FC2761C6CECD8742A5A6FC97F16743
+AD4EFCC6572A6D3F3E4E330C5CB2FF6FEA48A5B64DD3DBE943BD9918D4A18E18
+CBCF598AEFBB6AB3CD2CBC9BFD6099272F6543F3E532E0E21E614BD2880B1023
+0AC234CB705827BF016DB84E00E8C255FDEFA0101A842929540B7B4AA8A089BD
+5EFF05B72356B6BC3727817823B5CDBB1B963103000D7F2A4E2A1472FC3E614B
+5CBCB6D6D784023173DEFEBFA8F9ED87EC1A0A9EE98CA59CFC964CF943DC683F
+E9E00DA718C4425A705A69D99988EC6F152525C790912C2E46A2381A569424AB
+54DF4798BC2D7E7A361E7991641D4B756CE2A7FF4A2848927092C59C2C4B8809
+E13AB84FB6B111E680D7FB9F2FFC2C5C66B0B501E4447C2E46C10E2F6124476F
+A140C404CFE2DC9E0199BF61E035CEB481D438139A9630934E541D261FFD2906
+4CAD99E20655FA746AFB81EDBB5601F5FD6B1D6832A01D585E2C55053F6A7378
+4DAACCAC7608DBDADAAE732D66B3E7F87E79756337C1A961E53A4651BE7C77F4
+038B89C87F650C54A2A90EB7F1D525BB353F33318551EE8D84A6A83C718EA5A4
+B2AC0F7306B1E095819B87015A90CA3ED739B09061782C28CDB36BA4BD5E5308
+5CBB70414E4112193DAC4A1FA30996327230D1E021F3CD8115E12D239D93FFDC
+B645910EB29E40D830E7BAF2DB255FD7C4E776557BB38157917D993EAC245837
+A3B515147043574157B8342D829C7228CCEA843ABC89D1785A9672A5923FC4CD
+2F3FF27E6FCACF84E2D3136CA2C0FD3EF1EE7354CD04C38B5FB874553646ED2D
+CEDF7E362EADD04B18051F20A8FB0DE18E152385B9D05F98A3A7EF177824E246
+455ABE69E2F700EB78185CCFC07E3B4C6FA301112528D977367D30D0D5D59EDE
+FAEB706DDC970A9E296236C725B2B55B09B9C336B8E23CBA5FB8692D56F33B03
+16294E5FC7FAA42E96395A57CE51CA8DDD77442F142E2E576B778373FB31C81C
+16840BB422CA827E30A81829648BDF1CA36700EA32AD888D097C1FE0A05B2D9F
+483AEE40269DF09AF0D1AD3DF80C45DDC59C2A03FBB661C79B87853737C6D352
+67626B657321B16198DBD6DB98A092F17878AE4698121E1006E53D6F9B0A3BE2
+3FB68828EF854A0CDBAA68B37ABCA6AD4A3D809AAF0BAB1697A81FE59C98C472
+1E33CD70A75A22C249DD11D76C2575ED3370A25892A16D2FD569CDA70C130770
+93F493C7D47D6F9A5424A7A542BAD726BFC3AB225DCEBBE6AC4BE006F8C7C0EA
+051424B08305BF2D951AB2986AAFEA04E078CA79B399585BFF0F1ADCED02E15B
+8765EB6BF6A8E4D0901EFF2C3AA104924EAD9637A35D877E0C51A3C37DA78CD4
+8643C8CE6DCDDE3F116A6C2390F948E5371BEB5AD2E87B41C5F01FB5C196C436
+6E256A88D082E3F46E4EFFBF605B2EFF1E9D9AD5EE4DDC323A137CD9451EDEE0
+06F7D82898D71FAF2362C0FCF1F726F97F820305B7CE20728CA08C63575083A7
+84BA28B7DE2B916432475510E274C12FFD1660A717F51DACFDF0A102D85224E0
+D6DB607BB72569ABB8A7BC6A10354CBBC01732EFE35B72062DF269CB25EA3DE6
+DC603B04C90C5912D2C38D7A5ACDCDD3F6F116D884F0D8C528F69D5D47BA20DB
+0A9E585C7D8CC3C324FE8A1DF150279F7E8FB43BDB720E624E5E9918032C02CD
+8020636AE5C38DA2484B7F4B34163E0D0A561B43B80E97746DC05C871AB620EC
+C5D47101ECED4A7E25F291184BEF8B80024AA7BB456C1B83A907652B331DEA34
+754226C39C6889EBEEFDAD081E01EF8FE47751987667836FDE4C8BB8A3FD4406
+1E643B4EA37BD370734D1A2DB17C2F4B74B4ED75098B433601F75A88C9A37A05
+CCB157EF6E32023BFA33973F3E655A4D58289136996FCFA61EEABD70791B6523
+1FF5DE71AB8A17038923118A5EED8D59C4C58D246FFA9BB26472346B40C8741F
+153D19CAFF20DD2A86C6DB89154A630FB1761929FC3F0448EE2F089C1C953E02
+905BA8DE75D101A982A611056C4B237596C10951DD98BAB838B742D3CF7DE718
+617DB72E5268583223E37E029D1C8FD3F1D21690151F76B76C52C725CA135CA2
+8666553E863CE188BFC9B99AF56AC2DB5BFEBEB12FB563D00244EB89E478657A
+98AF2E1223C1ABC25A4500E8119B86EB3C26B8A2F3505A3E5610F89B7C34E278
+53FA0A54A7F46D84A35EFEC36AE660A9E3C37EE3864106702DE5AF6C45ABF64B
+888A4A51323138CE77DB935576FE6B4824B6942DF80625098CE1B5B32B234F1D
+052A9D6039697118A9D793793775D8729D8574A2E74D7109C7B7E23BC5E2E87A
+CA8E019203952A4892544E1AD3D4EDD22971611358AB230E9A2ABDF00A288501
+A01B67C42B33F6B78C39562DB50F4663B922D9BE0D8A150311AE44B83C1F129F
+07337323E9A23211EE58E16043E127C6F9574019179F5635648A011266677B56
+B5D0201A4E1470B952A1579B57AB2329CD4C615395023C653F784D36B5EE3672
+10D191F29EA508CE84763CA4CE7C2C5229E38E241255A5CABCD6C7CBAED901A2
+CA53B5E24111921CDDF83578D33D463D70EDACA0E470D8F592303FB6BFD68B4D
+3F3BE2D7C5EC8BBF10C90111A33E205F2649B56E8443F6FAA6C721C66575AE12
+D4C40F1F46CF9E9DA675AB5D5840D938780CD9E4AD6736ECBEB6A4397613586F
+849B51048AC5F9405E03E14540A5E5582F61CDCDB57EDDF95A8C6705F433EE16
+648F098C03DED8A2AD94AE3DE202D629B9422ABB031318D48F2C85F9DBFA17BE
+84708AA3B6C9F81F4508F7A5CB7B6646AB8722ECF817877B77D473F577556DAA
+2BA0ABACFCF5DEA7498C47328E873019A956FBB250FD9D8885D21D368FA70CBD
+2709D2DA44EE7A9869963EAB48789541906DE49FAE785ECE1F18A22C7E7ED204
+9768896B78E9EB7A2BD6EEC1B26083940656ECD689D92942CC8AF05CBF82AED0
+B45A7DF4DD7AA6526FB597322560B9ED3087A65B5EEF1371C328A021411BFE3B
+D9B5088B2F1AAE381FFED52D2D1E02CD0DA78683E3B06171CBE94BE9760005D7
+135893D7CC2DB097F6AC664D9594CF1C650F84DA80D2EDE04802DBA33CE3DAFE
+EB7A37E8AEFA4FDA6252FF21E8673DD98E67124D5DBC7BACF361E57077B71939
+C1D1FB923E4E35C075CD1BCBE0E80DAEA1320D55B43EAB45D9B26C366B278782
+7519FDC482D98839BF0DF2E7C3A56A1C1A3FC0E57A75CA414F6536C1FE8EB7A0
+4ADFEE3BEDA0F53BE8CF5F64230784A797133E8CD46BCCB3BF38BCE38A73CCE2
+9E073ADE792F7128231DDD1F63E6156ADB2609C200837C2E8A2D93D2A7BC9171
+050C709A71E44E32B1B03C92EB5CF1D3BAB1C38E027DC4ED9AED633D98CD7486
+3F773ACF8AE332631CF2ABE6D606607593FE862ADE31803964E3F4DC3CE3A271
+C76BDD95C87CDB3B87BC26FC7A16D567EEC62E6FF0D471B4853DB8A94D4CACF8
+843824F818083F10E88D52FC4253E8203292CB40F1414AE7E51DD7347007C342
+CD70E8E9F2D2A13D71213B841DDEAAB208AD9EA644591C15DEB084165F9DF24B
+B91D3BBEEC2E34E38EF16A0C3F00700A7BDCBBFED2EC0D09601AD6538288DB50
+3478B051B5E16B604A0341FE621A58718D960D699D3FAD284310DCF54EB13175
+19A75A539EE98E804AEA24689D3540F0F12951A3C01FACCE9A7BAF4D0DAFA946
+FF65A4D2A4C39969607272C6886F44E90ABE27CA3A1F12A29D9B32E60E8E34F0
+17C5FE43D0E69A99A922D98909B2BBCD145E59A5E7F5426B3988F73B09A525F6
+8BD4915663C1301323180E760BE81CB874B020FDA3AE63340E4261E4F3E4949B
+CC0966BDC4426190BE9F5D77F76A72AD925662E5FE1CEF9CCAB68F0BD33DA003
+F11EB91AC4502FBD6AE48DA0F9D07C35B96B103E379B8A83A05FE728F1716194
+1F650F75BEBADB2E3810388F3E2DC7B19F1BA9E32925F2FD9F19F4E8701F3E4E
+4069125D7C401144740691E7A460021A47B1E27997FC1DDABEC5BD0EE0B20194
+2D579C7D6727AA124083242BDA46D8E116E2751C5F298851A62B60AEBE82A929
+9B9F2492BA35690D1EFD16215B8EF14E7A3803B93C28FA41D971B05B6AF3B593
+E74AD1E68A5FCE12A86E63B78BFEA87D3949FD164F12277A4688BE96356791CB
+8671C49365608F3EDECC109321AF92B4C29CAF073DA3A7D73E913D0D83FAC5EB
+BD884D4C686056404DAAAD6F82F94F803FA1FB0DD8908D1DF08FB87A8BB83027
+04DE0CBB1C6FEB6B517FBD7CF065120079E608CE41893C2BC96A347826CCDFD5
+C69E161217F2127A59F1A6F22037641613F191F22D5B4CDCBCC2EE5615623404
+ABA7BE6C5FE475481615B2AC1A2412E54688DD21E44CC9AF5F16E634AFCA389C
+4D740B7B51BB141BFAD1080E7C726C1606A28ED492E6BDE9F800EFACD1513909
+84E98CEB6A0B7A2A6F3E1D1DCC3B2552795E0932673E59ECC56DDD37A1D52BA6
+C3F0E905978AB568941A163F4CE3AAB5C5B16F86016EC47BA6F3F7AAAA77C3B6
+09C8C3ABDB6D514A76ECD37C37AA88B5860630B3406B494F7725975596F84777
+D9CF48686EC9C5DBCC1D78513F591C7C10AB9D153B3D41426B7BF668B0D04503
+56BCB686258462C1DC61095724B9F3312316262FD7C1AEC6E54DE7E5A7BD8EFF
+035299B8FD8A4A7B0F51404F4A760F4D8B4C0FB7A32FA4B2383AB6E9C78FDEDB
+FE6A5788D38A6701B123630C2A6D820A684166FBBC83DB17069494FBD411B333
+CB37E2491C5BD035A33867A6D3A3D420CC31ACF43AA07182CAAE67E40EC63663
+B678F71D4C6E0EC3A0AAF904CD3AA66E0DE5E3CDE049E94249B39A1C06E3CE9A
+F974B2484BB2CDA14282B9511E505B3C89F9C802218AE40D1A7541335C5736DD
+CD565D4B9F4CC78F3A393737EDB4FBD0DA299E21CCFEBA5478EEF013F0552A8B
+0BB11FF46CCDB784E8BDCF730A16363E66572049E42C695886EAB42A9AD9094C
+B635DF4B5B9BD9B9AE8455DFA3EEFC77653190F9A8B1E93B7281C2A21EA7DDA9
+33484745BDF7E3DD63C7AC66C286C9A5A698A5E4D7A91710B7FF943FB23609B6
+4B442F83CB795788FAB5E9CF3F75D5487DA26170E4561C7941C910B088C3B86D
+F844B0F340CF82786A3FCF347048463EBD2006281A816627065DDA6CD4D3AC5E
+2024BC96C7D896381BBB567951E7A1F29D4E95351298B000D29E5F3D0448CB5A
+CFDAE1BADE9403B90371C3A07D208948AFA022A69C519434B6813086ADF518D5
+88E0B92072A44BA1B3EBB630A13B7AB90992E85B6D67361C8D96F3E0D826FF37
+17B67E4B1EB7BADFD98D7F4FD17BECE740ADF13C141EBF0A91CB105DABB32FE0
+55086D56A0D358841D15FD349E6B95512E4EDF4C430216FF85C2ABE995E4B40A
+A6044CC8820AD885C07E052B3F91C2E9A1D163BFFD210F7BE95B923E2500DB50
+2075106DB541C267BD450B25B670CE80BCD068D4DBFF2D82634175B61FBD3BC3
+406131F44C7D6F18D375D1F2270829DDF29DC14DBB58A30AC193245D18DE91F8
+AB88AB548D8138605BB5A50073295534E314366E26665AE70482B890E4101D6B
+60E4F3B37ABCA1346DAAE8FDB8DD9C832EFF3E73BA470E2BACE7B8515CB43388
+C27AF99FF9322175CF8D4947E6B3846AFF5163E972156847F58A66660EC8A3A6
+5FB47C9F637B4CBB4C73B6A080B0CF6FD1E9665E92032540570FFCC747C67C50
+822811AADC404BC7ECD1673E8AA6C3A2F1D82F39430B58C29145E2F1B679C46E
+94EDC711883F1E4EA84117A54757E8895A40401A26E1437B39A2F65CAADD6E02
+D71FA8AF7453668DC613F326A3344F74AD7AC67569AF399385500ABDA5EDD3BA
+343CC5EDD4B558467626850E752B9959FEF1454E53E7A3DCBC2255AD8F6AB4FE
+894455118A61C58840CB68A925ACCAD75CEACE863D806916228F0614191A1CD5
+DC9BAE256018615AA3725834519449B0A88B4F396654E74099C007930ADB1327
+DD119BF799FE3B0B223E1EDA04FE2DA7A1C879143E1C33B6C6344F4BA033AD6F
+8E88C33DEF1977796B454BAB2494C930F492A518E8198C708A75FFEF8C49C324
+A718AB59B889DED521229E741FFE53F98EBE88B0405AD523254FD3FA4BBE96DA
+DA1C27C1C979A0DD4E61C3B1F4C4DE01E42F1C4435EECFC02D97994BC8AF5270
+E7CB1458D76ED0229C5FFB4A23B8716018F9050970895D51722CDE8F2EA3D947
+DFF374D84915D5C5D16463A6FFCD079D1ED416C4347BF831FF0C4ADFB61295DC
+4D5785BB0852BF472CFC97EC174491CAF961AB90629F055E75DAA6D9898E8653
+5BCF379816CAE46FEA62E7BE8E9B953466E51828172C4DBD0E1BBAD1CE28B5B1
+02B3E36403BE80B49A47446A6677FCED438F01D60EB10F478C89528FA337D0D8
+88D3FC123C076507ACDAF783A9A6E24ED73BF24B6E0F11C13E532DE5F70EB02A
+60651FC2E263002D3986B7B20CC2AA08330B9FC2E26765CD52266969A86EE30E
+71E0B41B6C1C6DA423D3A7E1553D2FAF26EF40DC183099322D362E4965695C52
+9FC3E5BD7ABD743CDCB717DB10372A722A39CE53FABB454EADE2179C4CBFC016
+A8E893C28EF549CA1692C8D8ADFC471DCCDE266FB4E97A1F3035801F3F034D44
+AE6ADA0192657E8078A1D27420093FEBA111333314658021B90DA4E7A8D4B829
+F1795501020D5FF0AD25584C1D4A232CA299ACEE32C268C6BB20D3A28851A474
+B85F61F6B4F1E0DC1945FEEB21895CDA76F07D8EF689EBFDB9F9A6F4E566B666
+35A37B70D95A7C62FE3285AFDED7E43FC3F542CEB120323DFE2AE1E2C77721A3
+A7179550B8D6FE85D9FD08096938AF17FC898F6BFA73954D44F57FA1091E05BD
+76609739946CDE0C223FEB0A85286D5CA6122FA1C1062173F03813E491DD2151
+9DA56D9B60A825BD1E2064E7F69385803A17AAE63238226F5E08E925A2B2656D
+4E46664FD3E7CB0A
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+TeXDict begin 40258437 52099154 1000 600 600 (gmt_eq.dvi)
+@start /Fa 184[65 71[{}1 83.022 /CMMI10 rf /Fb 141[69
+114[{}1 83.022 /CMSY10 rf end
+%%EndProlog
+%%BeginSetup
+%%Feature: *Resolution 600dpi
+TeXDict begin
+ end
+%%EndSetup
+TeXDict begin 1 0 bop 639 523 a Fb(r)p Fa(G)p eop end
+%%Trailer
+userdict /end-hook known{end-hook}if
+%%EOF
+%%EndDocument
+PSL_eps_end
+U
+3780 0 T
+23 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 60 0 D S
+N 0 1181 M 60 0 D S
+N 0 2362 M 60 0 D S
+N 0 3543 M 60 0 D S
+N 0 4724 M 60 0 D S
+N 0 591 M 30 0 D S
+N 0 1772 M 30 0 D S
+N 0 2953 M 30 0 D S
+N 0 4134 M 30 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+23 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 630 0 M 0 -60 D S
+N 1890 0 M 0 -60 D S
+N 3150 0 M 0 -60 D S
+/MM {neg M} def
+/PSL_AH0 0
+150 F0
+(”20) sh mx
+(0) sh mx
+(20) sh mx
+def
+/PSL_A0_y PSL_A0_y 45 add PSL_AH0 add def
+630 PSL_A0_y MM
+(”20) bc Z
+1890 PSL_A0_y MM
+(0) bc Z
+3150 PSL_A0_y MM
+(20) bc Z
+N 0 0 M 0 -30 D S
+N 1260 0 M 0 -30 D S
+N 2520 0 M 0 -30 D S
+N 3780 0 M 0 -30 D S
+/PSL_LH 210 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 90 add PSL_LH add def
+1890 PSL_L_y MM
+V
+currentpoint T
+0 273 PSL_LH sub neg M currentpoint T
+PSL_eps_begin
+-346 0 T 21 21 scale
+-148 -653 T
+N 148 653 M 181 653 L 181 666 L 148 666 L P clip N
+%%BeginDocument: psimage.eps
+%!PS-Adobe-2.0 EPSF-2.0
+%%Creator: dvips(k) 2020.1 Copyright 2020 Radical Eye Software
+%%Title: gmt_eq.dvi
+%%CreationDate: Tue Mar 30 21:49:36 2021
+%%DocumentFonts: CMEX10 CMMI7 CMMI10
+%%EndComments
+%DVIPSWebPage: (www.radicaleye.com)
+%DVIPSCommandLine: dvips -q -E gmt_eq.dvi -o equation.eps
+%DVIPSParameters: dpi=600
+%DVIPSSource:  TeX output 2021.03.30:1149
+%%BeginProcSet: tex.pro 0 0
+%!
+/TeXDict 300 dict def TeXDict begin/N{def}def/B{bind def}N/S{exch}N/X{S
+N}B/A{dup}B/TR{translate}N/isls false N/vsize 11 72 mul N/hsize 8.5 72
+mul N/landplus90{false}def/@rigin{isls{[0 landplus90{1 -1}{-1 1}ifelse 0
+0 0]concat}if 72 Resolution div 72 VResolution div neg scale isls{
+landplus90{VResolution 72 div vsize mul 0 exch}{Resolution -72 div hsize
+mul 0}ifelse TR}if Resolution VResolution vsize -72 div 1 add mul TR[
+matrix currentmatrix{A A round sub abs 0.00001 lt{round}if}forall round
+exch round exch]setmatrix}N/@landscape{/isls true N}B/@manualfeed{
+statusdict/manualfeed true put}B/@copies{/#copies X}B/FMat[1 0 0 -1 0 0]
+N/FBB[0 0 0 0]N/nn 0 N/IEn 0 N/ctr 0 N/df-tail{/nn 8 dict N nn begin
+/FontType 3 N/FontMatrix fntrx N/FontBBox FBB N string/base X array
+/BitMaps X/BuildChar{CharBuilder}N/Encoding IEn N end A{/foo setfont}2
+array copy cvx N load 0 nn put/ctr 0 N[}B/sf 0 N/df{/sf 1 N/fntrx FMat N
+df-tail}B/dfs{div/sf X/fntrx[sf 0 0 sf neg 0 0]N df-tail}B/E{pop nn A
+definefont setfont}B/Cw{Cd A length 5 sub get}B/Ch{Cd A length 4 sub get
+}B/Cx{128 Cd A length 3 sub get sub}B/Cy{Cd A length 2 sub get 127 sub}
+B/Cdx{Cd A length 1 sub get}B/Ci{Cd A type/stringtype ne{ctr get/ctr ctr
+1 add N}if}B/CharBuilder{save 3 1 roll S A/base get 2 index get S
+/BitMaps get S get/Cd X pop/ctr 0 N Cdx 0 Cx Cy Ch sub Cx Cw add Cy
+setcachedevice Cw Ch true[1 0 0 -1 -.1 Cx sub Cy .1 sub]{Ci}imagemask
+restore}B/D{/cc X A type/stringtype ne{]}if nn/base get cc ctr put nn
+/BitMaps get S ctr S sf 1 ne{A A length 1 sub A 2 index S get sf div put
+}if put/ctr ctr 1 add N}B/I{cc 1 add D}B/bop{userdict/bop-hook known{
+bop-hook}if/SI save N @rigin 0 0 moveto/V matrix currentmatrix A 1 get A
+mul exch 0 get A mul add .99 lt{/QV}{/RV}ifelse load def pop pop}N/eop{
+SI restore userdict/eop-hook known{eop-hook}if showpage}N/@start{
+userdict/start-hook known{start-hook}if pop/VResolution X/Resolution X
+1000 div/DVImag X/IEn 256 array N 2 string 0 1 255{IEn S A 360 add 36 4
+index cvrs cvn put}for pop 65781.76 div/vsize X 65781.76 div/hsize X}N
+/dir 0 def/dyy{/dir 0 def}B/dyt{/dir 1 def}B/dty{/dir 2 def}B/dtt{/dir 3
+def}B/p{dir 2 eq{-90 rotate show 90 rotate}{dir 3 eq{-90 rotate show 90
+rotate}{show}ifelse}ifelse}N/RMat[1 0 0 -1 0 0]N/BDot 260 string N/Rx 0
+N/Ry 0 N/V{}B/RV/v{/Ry X/Rx X V}B statusdict begin/product where{pop
+false[(Display)(NeXT)(LaserWriter 16/600)]{A length product length le{A
+length product exch 0 exch getinterval eq{pop true exit}if}{pop}ifelse}
+forall}{false}ifelse end{{gsave TR -.1 .1 TR 1 1 scale Rx Ry false RMat{
+BDot}imagemask grestore}}{{gsave TR -.1 .1 TR Rx Ry scale 1 1 false RMat
+{BDot}imagemask grestore}}ifelse B/QV{gsave newpath transform round exch
+round exch itransform moveto Rx 0 rlineto 0 Ry neg rlineto Rx neg 0
+rlineto fill grestore}B/a{moveto}B/delta 0 N/tail{A/delta X 0 rmoveto}B
+/M{S p delta add tail}B/b{S p tail}B/c{-4 M}B/d{-3 M}B/e{-2 M}B/f{-1 M}
+B/g{0 M}B/h{1 M}B/i{2 M}B/j{3 M}B/k{4 M}B/w{0 rmoveto}B/l{p -4 w}B/m{p
+-3 w}B/n{p -2 w}B/o{p -1 w}B/q{p 1 w}B/r{p 2 w}B/s{p 3 w}B/t{p 4 w}B/x{
+0 S rmoveto}B/y{3 2 roll p a}B/bos{/SS save N}B/eos{SS restore}B end
+%%EndProcSet
+%%BeginProcSet: l3backend-dvips.pro 0 0
+%%
+%% This is file `l3backend-dvips.pro',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% l3backend-header.dtx  (with options: `header,dvips')
+%% 
+%% Copyright (C) 1990-2020 The LaTeX3 Project
+%% 
+%% It may be distributed and/or modified under the conditions of
+%% the LaTeX Project Public License (LPPL), either version 1.3c of
+%% this license or (at your option) any later version.  The latest
+%% version of this license is in the file:
+%% 
+%%    https://www.latex-project.org/lppl.txt
+%% 
+%% This file is part of the "l3backend bundle" (The Work in LPPL)
+%% and all files in that bundle must be distributed together.
+%% 
+%% File: l3backend-header.dtx
+true setglobal
+/pdf.globaldict 4 dict def
+false setglobal
+/pdf.cvs { 65534 string cvs } def
+/pdf.dvi.pt { 72.27 mul Resolution div } def
+/pdf.pt.dvi { 72.27 div Resolution mul } def
+/pdf.rect.ht { dup 1 get neg exch 3 get add } def
+/pdf.linkmargin { 1 pdf.pt.dvi } def
+/pdf.linkdp.pad { 0 } def
+/pdf.linkht.pad { 0 } def
+/pdf.rect
+  { /Rect [ pdf.llx pdf.lly pdf.urx pdf.ury ] } def
+/pdf.save.ll
+  {
+    currentpoint
+    /pdf.lly exch def
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.ur
+  {
+    currentpoint
+    /pdf.ury exch def
+    /pdf.urx exch def
+  }
+    def
+/pdf.save.linkll
+  {
+    currentpoint
+    pdf.linkmargin add
+    pdf.linkdp.pad add
+    /pdf.lly exch def
+    pdf.linkmargin sub
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.linkur
+  {
+    currentpoint
+    pdf.linkmargin sub
+    pdf.linkht.pad sub
+    /pdf.ury exch def
+    pdf.linkmargin add
+    /pdf.urx exch def
+  }
+    def
+/pdf.dest.anchor
+  {
+    currentpoint exch
+    pdf.dvi.pt 72 add
+    /pdf.dest.x exch def
+    pdf.dvi.pt
+    vsize 72 sub exch sub
+    /pdf.dest.y exch def
+  }
+    def
+/pdf.dest.point
+  { pdf.dest.x pdf.dest.y } def
+/pdf.dest2device
+  {
+    /pdf.dest.y exch def
+    /pdf.dest.x exch def
+    matrix currentmatrix
+    matrix defaultmatrix
+    matrix invertmatrix
+    matrix concatmatrix
+    cvx exec
+    /pdf.dev.y exch def
+    /pdf.dev.x exch def
+    /pdf.tmpd exch def
+    /pdf.tmpc exch def
+    /pdf.tmpb exch def
+    /pdf.tmpa exch def
+    pdf.dest.x pdf.tmpa mul
+      pdf.dest.y pdf.tmpc mul add
+      pdf.dev.x add
+    pdf.dest.x pdf.tmpb mul
+     pdf.dest.y pdf.tmpd mul add
+     pdf.dev.y add
+  }
+    def
+/pdf.bordertracking false def
+/pdf.bordertracking.begin
+  {
+    SDict /pdf.bordertracking true put
+    SDict /pdf.leftboundary undef
+    SDict /pdf.rightboundary undef
+    /a where
+      {
+        /a
+          {
+            currentpoint pop
+            SDict /pdf.rightboundary known dup
+              {
+                SDict /pdf.rightboundary get 2 index lt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.rightboundary exch put }
+            ifelse
+            moveto
+            currentpoint pop
+            SDict /pdf.leftboundary known dup
+              {
+                SDict /pdf.leftboundary get 2 index gt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.leftboundary exch put }
+            ifelse
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.bordertracking.end
+  {
+    /a where { /a { moveto } put } if
+    /x where { /x { 0 exch rmoveto } put } if
+    SDict /pdf.leftboundary known
+      { pdf.outerbox 0 pdf.leftboundary put }
+    if
+    SDict /pdf.rightboundary known
+      { pdf.outerbox 2 pdf.rightboundary put }
+    if
+    SDict /pdf.bordertracking false put
+  }
+    def
+  /pdf.bordertracking.endpage
+{
+  pdf.bordertracking
+    {
+      pdf.bordertracking.end
+      true setglobal
+      pdf.globaldict
+        /pdf.brokenlink.rect [ pdf.outerbox aload pop ] put
+      pdf.globaldict
+        /pdf.brokenlink.skip pdf.baselineskip put
+      pdf.globaldict
+        /pdf.brokenlink.dict
+          pdf.link.dict pdf.cvs put
+      false setglobal
+      mark pdf.link.dict cvx exec /Rect
+        [
+          pdf.llx
+          pdf.lly
+          pdf.outerbox 2 get pdf.linkmargin add
+          currentpoint exch pop
+          pdf.outerbox pdf.rect.ht sub pdf.linkmargin sub
+        ]
+      /ANN pdf.pdfmark
+    }
+  if
+}
+  def
+/pdf.bordertracking.continue
+  {
+    /pdf.link.dict pdf.globaldict
+      /pdf.brokenlink.dict get def
+    /pdf.outerbox pdf.globaldict
+      /pdf.brokenlink.rect get def
+    /pdf.baselineskip pdf.globaldict
+      /pdf.brokenlink.skip get def
+    pdf.globaldict dup dup
+    /pdf.brokenlink.dict undef
+    /pdf.brokenlink.skip undef
+    /pdf.brokenlink.rect undef
+    currentpoint
+    /pdf.originy exch def
+    /pdf.originx exch def
+    /a where
+      {
+        /a
+          {
+            moveto
+            SDict
+            begin
+            currentpoint pdf.originy ne exch
+              pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+    /x where
+      {
+        /x
+          {
+            0 exch rmoveto
+            SDict~
+            begin
+            currentpoint
+            pdf.originy ne exch pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.breaklink
+  {
+    pop
+    counttomark 2 mod 0 eq
+      {
+        counttomark /pdf.count exch def
+          {
+           pdf.count 0 eq { exit } if
+           counttomark 2 roll
+           1 index /Rect eq
+             {
+               dup 4 array copy
+               dup dup
+                 1 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add sub
+                 3 exch put
+               dup
+                 pdf.outerbox 2 get
+                 pdf.linkmargin add
+                 2 exch put
+               dup dup
+                 3 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add add
+                 1 exch put
+               /pdf.currentrect exch  def
+               pdf.breaklink.write
+                 {
+                   pdf.currentrect
+                   dup
+                     pdf.outerbox 0 get
+                     pdf.linkmargin sub
+                     0 exch put
+                   dup
+                     pdf.outerbox 2 get
+                     pdf.linkmargin add
+                     2 exch put
+                   dup dup
+                     1 get
+                     pdf.baselineskip add
+                     1 exch put
+                   dup dup
+                     3 get
+                     pdf.baselineskip add
+                     3 exch put
+                   /pdf.currentrect exch def
+                   pdf.breaklink.write
+                  }
+                1 index 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                2 index 1 get sub
+                pdf.baselineskip div round cvi 1 sub
+                exch
+              repeat
+              pdf.currentrect
+              dup
+                pdf.outerbox 0 get
+                pdf.linkmargin sub
+                0 exch put
+              dup dup
+                1 get
+                pdf.baselineskip add
+                1 exch put
+              dup dup
+                3 get
+                pdf.baselineskip add
+                3 exch put
+              dup 2 index 2 get  2 exch put
+              /pdf.currentrect exch def
+              pdf.breaklink.write
+              SDict /pdf.pdfmark.good false put
+              exit
+            }
+            { pdf.count 2 sub /pdf.count exch def }
+          ifelse
+        }
+      loop
+    }
+  if
+  /ANN
+}
+  def
+/pdf.breaklink.write
+  {
+    counttomark 1 sub
+    index /_objdef eq
+      {
+        counttomark -2 roll
+        dup wcheck
+          {
+            readonly
+            counttomark 2 roll
+          }
+          { pop pop }
+        ifelse
+      }
+    if
+    counttomark 1 add copy
+    pop pdf.currentrect
+    /ANN pdfmark
+  }
+    def
+/pdf.pdfmark
+  {
+    SDict /pdf.pdfmark.good true put
+    dup /ANN eq
+      {
+        pdf.pdfmark.store
+        pdf.pdfmark.dict
+          begin
+            Subtype /Link eq
+            currentdict /Rect known and
+            SDict /pdf.outerbox known and
+            SDict /pdf.baselineskip known and
+              {
+                Rect 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                Rect 1 get sub
+                pdf.baselineskip div round cvi 0 gt
+                  { pdf.breaklink }
+                if
+              }
+            if
+          end
+        SDict /pdf.outerbox undef
+        SDict /pdf.baselineskip undef
+        currentdict /pdf.pdfmark.dict undef
+      }
+    if
+    pdf.pdfmark.good
+      { pdfmark }
+      { cleartomark }
+    ifelse
+  }
+    def
+/pdf.pdfmark.store
+  {
+    /pdf.pdfmark.dict 65534 dict def
+    counttomark 1 add copy
+    pop
+      {
+        dup mark eq
+          {
+            pop
+            exit
+          }
+          {
+            pdf.pdfmark.dict
+            begin def end
+          }
+        ifelse
+      }
+    loop
+}
+  def
+%% 
+%%
+%% End of file `l3backend-dvips.pro'.
+%%EndProcSet
+%%BeginProcSet: texps.pro 0 0
+%!
+TeXDict begin/rf{findfont dup length 1 add dict begin{1 index/FID ne 2
+index/UniqueID ne and{def}{pop pop}ifelse}forall[1 index 0 6 -1 roll
+exec 0 exch 5 -1 roll VResolution Resolution div mul neg 0 0]FontType 0
+ne{/Metrics exch def dict begin Encoding{exch dup type/integertype ne{
+pop pop 1 sub dup 0 le{pop}{[}ifelse}{FontMatrix 0 get div Metrics 0 get
+div def}ifelse}forall Metrics/Metrics currentdict end def}{{1 index type
+/nametype eq{exit}if exch pop}loop}ifelse[2 index currentdict end
+definefont 3 -1 roll makefont/setfont cvx]cvx def}def/ObliqueSlant{dup
+sin S cos div neg}B/SlantFont{4 index mul add}def/ExtendFont{3 -1 roll
+mul exch}def/ReEncodeFont{CharStrings rcheck{/Encoding false def dup[
+exch{dup CharStrings exch known not{pop/.notdef/Encoding true def}if}
+forall Encoding{]exch pop}{cleartomark}ifelse}if/Encoding exch def}def
+end
+%%EndProcSet
+%%BeginProcSet: special.pro 0 0
+%!
+TeXDict begin/SDict 200 dict N SDict begin/@SpecialDefaults{/hs 612 N
+/vs 792 N/ho 0 N/vo 0 N/hsc 1 N/vsc 1 N/ang 0 N/CLIP 0 N/rwiSeen false N
+/rhiSeen false N/letter{}N/note{}N/a4{}N/legal{}N}B/@scaleunit 100 N
+/@hscale{@scaleunit div/hsc X}B/@vscale{@scaleunit div/vsc X}B/@hsize{
+/hs X/CLIP 1 N}B/@vsize{/vs X/CLIP 1 N}B/@clip{/CLIP 2 N}B/@hoffset{/ho
+X}B/@voffset{/vo X}B/@angle{/ang X}B/@rwi{10 div/rwi X/rwiSeen true N}B
+/@rhi{10 div/rhi X/rhiSeen true N}B/@llx{/llx X}B/@lly{/lly X}B/@urx{
+/urx X}B/@ury{/ury X}B/magscale true def end/@MacSetUp{userdict/md known
+{userdict/md get type/dicttype eq{userdict begin md length 10 add md
+maxlength ge{/md md dup length 20 add dict copy def}if end md begin
+/letter{}N/note{}N/legal{}N/od{txpose 1 0 mtx defaultmatrix dtransform S
+atan/pa X newpath clippath mark{transform{itransform moveto}}{transform{
+itransform lineto}}{6 -2 roll transform 6 -2 roll transform 6 -2 roll
+transform{itransform 6 2 roll itransform 6 2 roll itransform 6 2 roll
+curveto}}{{closepath}}pathforall newpath counttomark array astore/gc xdf
+pop ct 39 0 put 10 fz 0 fs 2 F/|______Courier fnt invertflag{PaintBlack}
+if}N/txpose{pxs pys scale ppr aload pop por{noflips{pop S neg S TR pop 1
+-1 scale}if xflip yflip and{pop S neg S TR 180 rotate 1 -1 scale ppr 3
+get ppr 1 get neg sub neg ppr 2 get ppr 0 get neg sub neg TR}if xflip
+yflip not and{pop S neg S TR pop 180 rotate ppr 3 get ppr 1 get neg sub
+neg 0 TR}if yflip xflip not and{ppr 1 get neg ppr 0 get neg TR}if}{
+noflips{TR pop pop 270 rotate 1 -1 scale}if xflip yflip and{TR pop pop
+90 rotate 1 -1 scale ppr 3 get ppr 1 get neg sub neg ppr 2 get ppr 0 get
+neg sub neg TR}if xflip yflip not and{TR pop pop 90 rotate ppr 3 get ppr
+1 get neg sub neg 0 TR}if yflip xflip not and{TR pop pop 270 rotate ppr
+2 get ppr 0 get neg sub neg 0 S TR}if}ifelse scaleby96{ppr aload pop 4
+-1 roll add 2 div 3 1 roll add 2 div 2 copy TR .96 dup scale neg S neg S
+TR}if}N/cp{pop pop showpage pm restore}N end}if}if}N/normalscale{
+Resolution 72 div VResolution 72 div neg scale magscale{DVImag dup scale
+}if 0 setgray}N/@beginspecial{SDict begin/SpecialSave save N gsave
+normalscale currentpoint TR @SpecialDefaults count/ocount X/dcount
+countdictstack N}N/@setspecial{CLIP 1 eq{newpath 0 0 moveto hs 0 rlineto
+0 vs rlineto hs neg 0 rlineto closepath clip}if ho vo TR hsc vsc scale
+ang rotate rwiSeen{rwi urx llx sub div rhiSeen{rhi ury lly sub div}{dup}
+ifelse scale llx neg lly neg TR}{rhiSeen{rhi ury lly sub div dup scale
+llx neg lly neg TR}if}ifelse CLIP 2 eq{newpath llx lly moveto urx lly
+lineto urx ury lineto llx ury lineto closepath clip}if/showpage{}N
+/erasepage{}N/setpagedevice{pop}N/copypage{}N newpath}N/@endspecial{
+count ocount sub{pop}repeat countdictstack dcount sub{end}repeat
+grestore SpecialSave restore end}N/@defspecial{SDict begin}N
+/@fedspecial{end}B/li{lineto}B/rl{rlineto}B/rc{rcurveto}B/np{/SaveX
+currentpoint/SaveY X N 1 setlinecap newpath}N/st{stroke SaveX SaveY
+moveto}N/fil{fill SaveX SaveY moveto}N/ellipse{/endangle X/startangle X
+/yrad X/xrad X/savematrix matrix currentmatrix N TR xrad yrad scale 0 0
+1 startangle endangle arc savematrix setmatrix}N end
+%%EndProcSet
+%%BeginFont: CMMI10
+%!PS-AdobeFont-1.0: CMMI10 003.002
+%%Title: CMMI10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMMI10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMMI10 known{/CMMI10 findfont dup/UniqueID known{dup
+/UniqueID get 5087385 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMMI10 def
+/FontBBox {-32 -250 1048 750 }readonly def
+/PaintType 0 def
+/FontInfo 10 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMMI10.) readonly def
+/FullName (CMMI10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+/ascent 750 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 28 /tau put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3C05EF98F858322DCEA45E0874C5
+45D25FE192539D9CDA4BAA46D9C431465E6ABF4E4271F89EDED7F37BE4B31FB4
+7934F62D1F46E8671F6290D6FFF601D4937BF71C22D60FB800A15796421E3AA7
+72C500501D8B10C0093F6467C553250F7C27B2C3D893772614A846374A85BC4E
+BEC0B0A89C4C161C3956ECE25274B962C854E535F418279FE26D8F83E38C5C89
+974E9A224B3CBEF90A9277AF10E0C7CAC8DC11C41DC18B814A7682E5F0248674
+11453BC81C443407AF41AF8A831A85A700CFC65E2181BCBFBC7878DFBD546AC2
+1EF6CC527FEEA044B7C8E686367E920F575AD585387358FFF41BCB212922791C
+7B0BD3BED7C6D8F3D9D52D0F181CD4D164E75851D04F64309D810A0DEA1E257B
+0D7633CEFE93FEF9D2FB7901453A46F8ACA007358D904E0189AE7B7221545085
+EDD3D5A3CEACD6023861F13C8A345A68115425E94B8FDCCEC1255454EC3E7A37
+404F6C00A3BCCF851B929D4FE66B6D8FD1C0C80130541609759F18EF07BCD133
+78CBC4A0D8A796A2574260C6A952CA73D9EB5C28356F5C90D1A59DC788762BFF
+A1B6F0614958D09751C0DB2309406F6B4489125B31C5DD365B2F140CB5E42CEE
+88BE11C7176E6BBC90D24E40956279FBDC9D89A6C4A1F4D27EC57F496602FBC4
+C854143903A53EF1188D117C49F8B6F2498B4698C25F2C5E8D8BD833206F88FC
+BD5B495EB993A26B6055BD0BBA2B3DDFD462C39E022D4A1760C845EA448DED88
+98C44BAAB85CD0423E00154C4741240EB3A2290B67144A4C80C88BE3D59AD760
+E553DAC4E8BA00B06398B1D0DFE96FB89449D4AE18CE8B27AFE75D2B84EFDB44
+143FD887F8FB364D000651912E40B0BAEDDA5AD57A3BC0E411E1AD908C77DCE3
+981985F98E258A9BB3A1B845FC4A21BCC54559E51BC0E6C22F0C38540F8C9490
+88A0E23EA504FA79F8960CC9D58611C519D3ACDC63FB2FBCAE6674357D7F2285
+4BCC9F54D3DA421D744D3A341DA3B494BB526C0734E1A8FC71501745399F7683
+FD17EC3044419A88C3979FD2ABA5B0130907B145A8462AAF0A9B511D2C8A7C7F
+347FF6AC057E6512902BFD2918E2CD31DE615F5D643764E900B60287670AE18F
+FDE15545D8BC69591A8CBBB275AFFC9B14BD68DF0AAB32268FB84844D4DBC7BB
+C591C1AC5102C50A9C7BAAA848DA88B0519F0F5F0813BF055CF0E3C86F633A04
+B779D2E8E656DB1E09A66A85FE21CA8BA5523F472A229E83F2C4E91ABA46C733
+F3C7B5775B06C97782BC225C46385BEBDC61572458EFC5CF4190AB7A9C1C92DA
+29F84BAACF552089195966E3AD9E57CC914D20B6962BE80429A16D4DF1ECAA66
+36C4343FADF0B2B48F12E2EB8443C4AA29D00949255F3968617F98B8ABD4CC12
+048B838EE243A21AC808BD295195E4AE9027005F52258BFCA915C8D9AED9A2C0
+80814F79CF943FBE3594C530A22A92E11BE80FCEC1684C4F56712D5846B0749C
+9B54A979B315222F209DEE72583B03093EC38F7C5B9F9BCB21DBE8EDDAE9BE8B
+75ACE6B12A31083AC8348EC84D1D29D2297A266284B7E9734E207DAF59A25F4E
+4AA38509E993C5394FED76E6A2F25462685C4C86C6E8CFC9863338EC1428BDFC
+74616BB1BC8948B0ED4C87C15B4405F3A7796F9DB3798FFFE8BD0A94E834817B
+D5E9812E308D0CC920470A6F2CD088FCB80462BF7CB3F039A7DF3DAF5B2B5355
+E083A385CD2EAF0FC181E40E96DD7E9AB9EF5C7E6866A13B8A54718E950FE097
+EF0951A357114F18CE9933D28B3A77AA71E3CE884661F13284BCED5D5FD1A86D
+543E588FF473DC2CF9A4DC312500135F29C2D0174B32018C8DBD40EF9A232883
+710A1F2AB2CD11312300ACDF789A9B7B93D2035D81D1C84984D92D78A53A00C6
+EDA94B24BBAC1AD17774A4E07E6F74ABD90415965616AD540C8ECD8C3A44EE4F
+7F4F6BB6238C5062D63FA59B7BF08BE93FAEA70A2AB08FBEAAF7DBF56B95FD93
+03CA406543BA6C9527D0DF01F5108D31A51778A5EB1C93F27B72B46146A353A2
+01CACBC829603B9989A87CF64528682CCBA0562A8165B185C58A5C6BB72F5E89
+500ACCAAB8ECEFBB2640E99EAEEC4EA979AA793D013D61D8ACF8784FF8D9398F
+F6A252A709324FB39509F0B3A4E725E82F53543383C6765BE556CC897C758208
+AA3AD37B0406E4A79F8F0A6C1983FC73E71CD858C0DB66ED66D5D992978614EE
+1EA91EBE191E082EBA1FC040AF19A2202575C2EBEB8058833E3520FA03D2F915
+85C1ED337E457B9FEEB0C6EF2735EFDA6E0D05FA641BCF698AC6B97751E8306C
+4DF00A39B8581FF53DB8F8525FDB196D85950906CCB59B8EF171349AA3B567B1
+6A00819947A995FB383C3C1709C9A2C113B2E40BB832B7D4A0FBA0B16A2C455F
+55809CC425C403E9668DC66BE45B71A81C332FD4DB279D22A2959962304A8F18
+085893DAC61317D24A8F198FDAB95F3B86F0AFD35047B868A9A17037A2829A02
+BAB042F75F349E197A7EED41984C2859754CAFD0251439921C248B463B516951
+2E1322C80D73F9CBCAA63A585450275AC2492E4D3FB78E800F788254DB5E610D
+CF788DF5C70FF99892BCDF16133E34B24B77C8F097F546B87C603DDB8998B66E
+BACB68BA27462AF54AA405682EC96D701F0D474DECD5F95CA2102DF639EB169E
+D518162C2BAE45FF698B6DE15FC6E7DE48C336C40A670FD26952A6BAB09115E1
+991F0073419F2CC2A1C08BE91096936AA0C37E4ED3CCCEE235476074B8FF1125
+6BDE3701F85532D8BB64CCC927CC335281C95EA689706F0AC717DC2CF680C754
+E5EFD7FA4BB8880B2B727A964C876D4A223069D4E6001771F0E23EAD2A4BBC80
+E76675297B2EF05F52BF4E71B3EE2BE3048CF088C79540113C66AE98B2FD3CB1
+B0741A215FD070882C52765009D7D711DAA2508F19AE7DDA15229A856AC49BC3
+4DDF40814FF96500E4B9B02D412E94623C5FDCC76C0FB8E42DF56A904FE49D65
+1DA7C53901B2EA71AB658A464D3ABDE27D9DB8D9E0B48F64E61A2495AD5D8DAB
+B5E72424AD017DF37964AF911BD7FA21A5EB4775DC8E95EF0C0EB856B00D89D7
+8172A1DE8530767D317B8256103E53CFB877E10686A04F5A08F8DC58D843DEBA
+FD5F40597588663D103689F6EB3EB14D06E18C8078F2538B43E712DF491FC5C6
+AF639256C8C6134B64D560D8476DEA6329D995E46CC4BC78841C59E73648B47E
+BFA7DE0846422F738454AE77E822A083405289247BD7C478BE4974F742CD6051
+E99FBB1D1B3FBABFEE855174734EE45E87D0AADF32B1283B911162A9955847FD
+38944D70584FAA6B1A7191C5C134B73F98EB632B69E2F0C0F94156787C34C8A3
+7622A029D58F9626B74F8A8A1F3803E0BC20E0EADEB1E99B70F1BD9F980FB751
+2A842843DE42EB142A84D5D3138629AE9EAF6F3479C423E8829C8816FA6EFA27
+DCE5580E65AA9854B1C64163DC318420CD993C15BFD76A8BA1182860A6B03D6D
+22B8CF43CFE6C8AB27C64842E239CAE707D3086BADDE1D7C94E3BC96319470D6
+8D26915C575CFDD03271D6BB9DE86A0EB6EEA6E768B224A626C62A9AB48A6EDB
+44F70BB5AF991CDF9736D65933E81CC57A78F623F33EC9AF535F2F25FA4EEC90
+D50DB7E87F31E971A75A33A301CA6013EEC5A4E179D695B33DADF2C98364434A
+42926776000B610E17524162253F6FA638D6581C18F99EA0BD1D2E24D2424ADF
+C05010D08192485153DD03930C7BF45237593E484F9851E6D464FA10FECA5D9E
+0C8CCC97DE029030900CDBB491C5CF226DBF903CFE7735D939C3FDF3A20B70CE
+66579B28B99313FEE914E295388C7BC8E055A2E54EA3A8206D3C8F4F7C0BA5E6
+E519419FD8CE215F7B8E9BEC604A9E3FE272A0328A24E31997C8A91E0946BCF1
+6943A97CBED2AB9FC636B49828BBB8B89E0BBC2653796431224895ABA5DAC41E
+1854BD9764E86147FD7624F736F40DE3B7582EDDFD15C2BDE3F22B5A54D7DF10
+B87A1301CE85CFC061689A890A321412A13314AE96DCD3EDA75035FDD8F4AB9B
+897A2C68263A68457032C469987970648BA2D88B1C5375DFEAA35A917B8A952E
+EE670427942AEDB3CB599C5746180E392837D371E15D860620ABDB6AA7772C40
+A5E346661673ACA530BE3D8E3FFB895E5DA3DC23B1B43C080C77F7E47847F0F3
+F3AA5CA9E4BF75FC5EBD18D19F21A7DAA3B11CABC6E4070A15F7DBC8B05EB6AA
+A02EF1B078EB66D61D6AFE41DA9B36FE7EC9EF94D1EA26282A9871E2CACB3126
+2AD49C2D9B50A6E47D8F2CCAD50992D1B430979A45FD9E76182A19964BB2A1F6
+51779A2B258DC1DF4C2F3074621286831F3848AC152DDD2BA561E6586ADA88D3
+598A2CE2CD048F027CE0008B828BD915887D7785341E8305DF2346ADB76BE99F
+87B02173BDC334E9221C8DF54114A6B24C1C5340299512FA6C8C51AB4C8778CE
+178CEF531C6D1B5FF0A1BE8EFF767F959BD4C345C52699A29A17B2A230842BF6
+4B011217D6D24EDAC3F6D53482786F1CA33169B90ECD499407D37CE9B70DDF78
+7B7547B32952535BA9ACD1E244447AE3FCED3AF28717083CF9590A09780984D6
+AF0743C82AE4FB3E2BB2856A4153A3967A023FFC35382D6C22D84A924900B6A6
+3DDD400E6D2418DA6C27F2FA34C075C902B89EBAE658B3C9A18EEE449DA5A379
+337DE95CB7AB3F0970CF1A5D8FAD8090E495570FDFB2FBBA79244780D8035547
+C5A55BB21A2270F724BF5D442CDC5BB9F09BE0CAE59B1C2270F0BDACE698F2C5
+DE8F66BFB9634904B161F5BA2B1950048300D69BABD312D58D89C4ED527AF7BA
+7DA2478EDC2CDEE3473DD8A8ED9D891CD1FC21F23013228BB3281B71FCE959BD
+6F8E9059D682A7FCC5265A0620992D4FA8D78377EB34CE3ECA070EE3707239BC
+98907DB0120CE42ABA32CF97127E28382BDDFD685674279F588D4F951216C355
+821361790F64C2CC720DE97E8ECB57326C43EE47367628E05769E106868B54F4
+C33C9951908DF6FC4F5ED2C7787BD8FA591BBB3E9C6C1DA94CC5E38D9B20C886
+7D237572FF46DD896A4D6163408EA6CEFAC398EE041EAE29D577E75326CA17A6
+B072D47A7B13EC441CE6DAA042ECD02134CBFA6809A435050413817193DAEB16
+A5882C8AEA44BCF36E74E9ECCDFE7E19FF5A5DD7A94E5AB4F8702C3DA7F42325
+23C808670A0490F5B373DADE40814FF9650241D3D69C91FBC5ECE728F827D9BF
+C928602E05477903449E079164CA39859C4BCA60C579F490AA455F82B5050BB3
+969AFB478E0D4A257B3356EA3CD62051FCE6C6B1929CFF85BFDF166BEF658E10
+3A55E007F38EBBB248B3F0B8ED1925106B499B762E45113AE1AC9DE09644C84B
+9C08034B297314EE69BC32DB6E7D7FB9913CE5AC17E7335979E9DCCE2BAB3725
+1976155551F9706A576FE0E3ADCCF72C87683291528ECB749CB0ED291966E239
+B5E3630676BD409E08F85BC1AEC9A2D4135376284A96EA24431243BD6FE8B966
+95F11A4BB53F392E0AEFEA623064FF8A7002367B0A515635CB2D2DDFB9B4A8D7
+FE721754E81BBA548848A235B91AD4E4F7DB19CCE2F61D277FC00AB956EB93BE
+44AB4970CA56BF59506C94ED160FB1E25D3DF2988A532BDB787BFB8539D22986
+FDC378AC31444E63C4727FEE121A43751043849E6DCAC5B59D0FC703AAFBBFD4
+E8B7C268F21615AD02CE9DABEFA27B5FE6A6441B619539CAB1F810F1263447AA
+633F5DAF483752EF1A0421740E3A811D2D2898CBF53E7F686C9223FD7235F02D
+6F90D2D48CC20AB87778DE3C6FB335E0F0EC20B5DC5B65223FE117526DE2C72F
+FE839DF93CB2A7D66CD900CB325F891E311BEC932F703FB4FEFA29DB8B9C88DD
+375EC71B3D58C7BC59ADA91971A3BDA1ADEA629CE6CC92BD542CDDFAA7706FB2
+6CDDE2DF07E56D6741916AE8E8744339816F3E6C38062747AA9FDA2A2678A6B7
+EFEA870AA3A4D71B25EE3013EAB1DBA34401B867C7A41AE51E0421D41D3BB83C
+E120C8FEABA6E5DEC53A689C21426D4BBCB68CB37568761C360E6D4E3596FB7D
+F4DEC7918E58C0293D12D6DDA7E9DCDAAD7C939F55CD1BC4A228B31E9A904156
+DA6B40B08E6ACE674618B768DD681C772A3E55FE096CF949CF3B0460ABDCD891
+D17B37B355B29AB5137899C036F31DA026244FA25FB798FBE5105BDA29F46538
+D3D3AC1001A7BCECE64DE94FFE6C354166A0F97256137BDFA07F6E22A3D1D2F4
+9588DBAE95E895BC5E64DDCBBAA8D0A22C229B42CB717FC711E7E9DF793DF80B
+9F14754585A3C7E17F37B32924B9F9870DA8635E3E18BD1DCD81EDF01834D9C6
+B33F23C956C2FCBFA47D84422F583459D827D1E120B97694D12F1F54D02379C0
+D288F7104F3FFCF4F76E3494F4ACBD1BE3A15543CC680924C78A473F8E311ADF
+8FE00A04C6C393DE61AD3EDA5BC031E2353076A2489391B52632387CA28A7B93
+FBB065A6EF3658AE80B1ADA47E9B2539E73A71FA75645F85ED8ECC257FB4CF26
+B6C912DE9D0F9899E70BECCB934AD32CF49A093371A9F73DE6255EBC39DE1E7F
+00D0CBDABD4D0383977E694890E71FBE5C376BE5F3A80C28987417504F515C50
+909F3D31178BB9B1D085BE514F71B910A9085BD6122DDC72A150BFE266920E49
+5661BCB4BAB51D6DEFE32B616963DBD989FCDD1637B294CE4E288655FBEFA1BF
+7F25BBF8CF17C2D5FD161A7C2CC9CC7490D9BF15A1D35B3BFA43ADE256E88BDA
+BD490D92907C57BAC408A575EC84D6AEE070148C7C9A91C03B09FDBD792E8FF0
+C0B886AAD2EDD86541E5E579359D40E3AC312ACD3D8FD49F71BD533DDF8859B1
+BAF17F1884E331DD07CEEF93B71D492AEBAADF7A263450A7A72210CE630A0D37
+BF024BDC09ACC882816B8C22C62AE38A3A8D0F6EBC2B1B2C0B8161A8B076DD5D
+4B779C0788546BB4CF57332230D237856B00D79C28A7C01D11F44B7304F69075
+94B97A745DA43D1BE561372CE611C345A843834E46AD9DDB16CABCD3FA33D6F1
+F6B5C0497F5EE5400B305CDC16A7EC286AA4D45D0EEBB9DA06AC9C5294D68EC9
+E4DC3CA2B92CE8FC0526184A86EDC7AB34D67E60AC12D9CA8FD300235EC968BA
+92C6FBDA47572BC5600F25249F60AD287CBDAE980E747FCBE7EE5CD323E733F0
+63553B494D3DDEB9CC1480B5C3BB79A28E419AA65B18CB297AB383419E890E2A
+CE6F98C9900CCB4675280A10CF060B8D220DDA1BE55DFA65715EABCC1AFAA271
+B1F8732341613E17B231231A0D24D4D7FC198AE04D89A99C4536217769C6FBD9
+5EE24A6302F97438F7C0E311C878F674B4477A5ADA3952CDE4055AC408B8174E
+86F8FB797646DFFFE0ECA25D1BAB9A9F71F3926D3D85AA63E7A8C931D71E79E0
+AF1EAC26FADE468F4FF7F3861D14C10E3BE1F9EAFD6D3A544E8108D5DAB5B180
+3950C74818BC8AF4758A108F462EF1826647A49667F5E482038C54716856D9BC
+35F29922846D2148F92F943E951D7438C73D6A60459A8003174036C64E1629CD
+155D47FD04B03C023AD67CD5A70C98AB556EEAB8C48169706E5B352F6505D580
+AC945171BFE62E81F8F500438AC3B64D857BA5BC54C2C4BBB237F8FA51296255
+E66A92A61FE13FDE781D393557EB72CEBAD86511035F775FAC39A0479CCD400F
+226709118F887F47CC2ECC8F79816D4A945B2845F50AFD62D8C9A9BBF4739496
+9E644BC9F7B04803B7EE75A09EAE94365F6F374B4FCEB0B506C76297564B9B6B
+8B812BC3A33929AA94692572B010E6210AEAA312BDFC88BF302244AB9D587A9B
+919823FD01DE12438D960944D1977800FEB49E638C32E5B188B1CA033E0C37EE
+A142F746367888AA119535F0CCAF7EAA461B790EB089D2D6962E28A398439BB7
+9C9943654D7A2D765B46BC0DD1F915327F369162E1BA1BA83110B93F442905E0
+523BFF5E279508A98568CD5CFD18FABBE9D17265A9081E7BF64155A2CE3C0DF7
+88D00671AD65654709589BAD7EA65BBA811387ABA5CA0BC3F66D3D48597A0D1D
+2C268375DF47CCF62166262AE4840AB03BF49BE67A05EF66328EC729F03CA5FF
+AD3937FC053E223303565DC771ACF32E63DFB96D5030E787961D72D02C195C66
+B48E9AF0309DC169CFE8D16E2818DA94693A18F027DEA0D916672480464F7E22
+CA6E431FE38D3FC019BDD229E064B72C545C61C6EA55984565CCA88ACB01F744
+3B4593CC894009AAE9A490E3B99E03E117A041A381B8DACFFF20F6E5F293B58B
+0FAA86F132B8B59D102722B3E98E12F11EBC101AAE666271C93B6F7CF1AFE94B
+5826703D754B09055EBE0A53E46EF9829C7181974A374E6AD658B17D89EB88D1
+A80EF734BE6F686CCA917AA3AEF80A216B5E13C3626F2BE0093D2826CE4B3C25
+90E3189335FC4F3BDAA0F15652CF8B32364DEE4C7FE174CA2219BF865BE7DB62
+490D6C0BE2B1D2B889C0E1DAE9FC29B43AAA9C6A111C603B0ACF2AC6A7223A8A
+3F13D96291D22B09F4D89777
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+%%BeginFont: CMMI7
+%!PS-AdobeFont-1.0: CMMI7 003.002
+%%Title: CMMI7
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMMI7.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMMI7 known{/CMMI7 findfont dup/UniqueID known{dup
+/UniqueID get 5087382 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMMI7 def
+/FontBBox {-1 -250 1171 750 }readonly def
+/PaintType 0 def
+/FontInfo 10 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMMI7.) readonly def
+/FullName (CMMI7) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+/ascent 750 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 116 /t put
+dup 120 /x put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3C05EF98F858322DCEA45E0874C5
+45D25FE192539D9CDA4BAA46D9C431465E6ABF4E4271F89EDED7F37BE4B31FB4
+7934F62D1F46E8671F6290D6FFF601D4937BF71C22D60FB800A15796421E3AA7
+72C500501D8B10C0093F6467C553250F7C27B2C3D893772614A846374A85BC4E
+BEC0B0A89C4C161C3956ECE25274B962C854E535F418279FE26D8F83E38C5C89
+974E9A224B3CBEF90A9277AF10E0C7CAC8DC11C41DC18B814A7682E5F0248674
+11453BC81C443407AF41AF8A831A85A700CFC65E2181BCBFBBAAB71645535A2B
+6F0F22458E1429F4A67307E01F0BCF6F337E0E2AD89658D880B04C26306F8179
+C8121B958459B923AC3B05B594D8AB95F75870019130442FD29578D44F5690BC
+7281357A5041C8A809A59D0DEE108E2A07D406656BC74A9F3317CB887E712318
+46B2ECAA341F8692ACC2D14ABABDFBCAC6F35858355F1D3228B0223EC73AC56F
+3C987464DB829F243E304F4C59CDE3EF6EB53A4EF9BA91510CB89A3407261F58
+A2AE66880BA98FC1EF546112892494C85A2C39F9DCCAC5766725894A7AA148E9
+42360AE64BF3A4F1F9F0A0D0C1AAFDC4D50C52233AA595B7D0CE557D4A010D86
+6E6B76A7E9523E8A6633DA9348BC3F59302F72F492A30782AE7EF220516893D3
+DE836CDE311DED9262AF01C506040541EE84AAC539B404B23033EF56D4BCE6BE
+B05F79CD633FE75C6728114D2749E39FD7454050F67763AB636377BA8E1867C3
+996C7D7D4A4A02BC49D1AD7FF174C1F49F1F205BC9D5AE42BCB02CF8554E8F5A
+D1876C9285B6CCD7B8C165F75843B0AA11D8462B57077AFE75BAD086E9D9F91E
+30ACFF91776132F3CACAD1CA5E08B17B36A0E45ACBAC52393B9AF9089BD821D9
+CD5A9CD9BECA59F7445D63DECC1B4502D299DB85B6E2EE7C69A1DAB91E22A3A5
+89B524FA20AF6005E7A586B90A2C6E5A93C9EFA4ABEF5F7E4C7B81363FE8D2B3
+0AD637FA863DE787581ADD7CBE463F7866C40F4E280260ED0E9C8453E5C7E668
+FFF058B9742DD3F131C264F8FA102CD0DA05F3114D13D34D422799181453FE23
+2FC6EFB01BE420C930B879D671F3DFB036197874725220644A5A52DFB467BB75
+8089E4F40CE9401777B9FE1D0AEE02E782A6EB2A185A454AE9394094CDFE7CFA
+C03C23A78EAF242E4F811E4C83B59EF4DC5ACE4AD37B41616B46C263358710B2
+6137314545CA6CE89119B42A3518EC85C68DC07D26839C68B1FF55C4A9CD518B
+A1FB32F9C475BB6110839FCCB94156E7B3648F27245A00D2966FC4DDE3996BFA
+F463A663CB6935B596B1582ED0ABBC648AAA8A86068BF0038001C753C8BAFA0D
+2058041DFA720B528E2D4B16196DB1CF30C779D3F4800FE662D5B60B208341F2
+A66EFCB8448C2FCD12DF0DD899911A8BD96C9B670054D328790E5D388518B146
+8CE92E368EB1DB3CAAFCA4834CC9D9D9DCC80FB1F34F39DACDE643052C977A7E
+A95C5FA8DFED9B4DCE769E4E46256D6DA8FB18FD7FA4E4CED5D486803538F3B4
+6D3F5B3C03184F5C26C66DBB4C724918EBB6A89C4602E4EDDA81EEE2BD18B683
+FDB459F2CE0A9CED23DC208EAA8BEDB304B00E093DEE926A7B32FDB2EC70DD85
+94B9137856DDDABB402B2C76DBA87149051ADC6007018EBDD571BE1D092EBD95
+76D4E063AD7D5F62E6C26EDB88D38678F2806A1F4900B0ABC4ED034A818119A4
+E618F1A902315BC98F26775E59555A3DCEA1D0F8B20A9084920ECBE3F7F245AC
+1182A40B518B194669D95DE968542BFF80FDC89669BC256C44CB66A2AB8CD7A9
+E42C69956CCB6BDE8C09AD22EF3196939B3B84EB23A6E071A36D702909E019FF
+058F27562441EB5CAE87A4407F67C4390810BE89BBE867D636468E73677B84C8
+5A1228DD7DC8EADA221B1BAD5F43E832F20ADE7ADBFF170AB306F5B711816FD1
+39B7882556E30F002977FB88D8B28826A75DE0D20354A2D41F2DA8578376F7DD
+F27B0F59D4DDDF5790E11E3957491DC74EEB7625CA49FAD90FA47AD8E0BDE824
+FF326A84846A47A21B70FA549BEE307F9C6970009F963B49A504F0115777826F
+1D81203F655C242FFF15BA97E3BDDFBF435B10E74CE8543C98966223818839B3
+6BF3BC63F882B0AD0FDACA8C56A570277952E1D83F18BEDF084D2AC004E2B09D
+70DE1740D7D220E92B54D2FD0DDEAF1E08C41FD321A8D474982DD105B23166A7
+AA9E0129DC88065B1E0F9382BEB4B4E1DAAE3EA5489BDCA921AD5A8175F2841F
+9400478DFA99C5E5553F383882664D73FBDFA29BF32E52C28DCE80DAF4839434
+022FA515679DBC13FE98968D2894DF5DD69C49BD23D00F5D858B69D1F220F968
+F0700E13873579B3CFB658972098DC61F1DD580105BC27795DB4AF11A871CCD6
+2E1B9AF7F0DAAD4CE315379A7B42CECB983DAC5A2B9426B4E5E0A7F7978504C1
+DD7E30063AE3CBDFB24EA2BCCDC478AB82084FD30A4793F4707D9F8F9647B413
+F8A5C5AC6D5EA0E35628CE1096A434FB8286F4617CB4D0AD30A4A0B255A5A356
+25AA5A947FD3C4FA44B4AA80BAB44C48CC1E2C6D0A711365A37A58C3483D07ED
+301A83D2650A2E8CBA9EE62FF5C2736EC82C1402959F64527F9B640619F112D9
+8E0F4A8A3078C72ACF3F34AD855AA4008C96E30D9E8C414607C34E06E29AC5B9
+2EE5DDB823E8C3EEE6A8DE228313D476A7F39B5DFBFBDEDDF7C45C1C88EE6D01
+7FB4F7BB2CBBD5DF7F0CBD98DC287FA6940FBFE1B3B136613A3CF16634CA7B90
+53D5FD5776515EFF5D37F8FCC62D8BEC8EE2216503D54D6F2032D3C2BF861E15
+FD1B45B71576F15852EEA65DD372E911EF4CC18283CD2FF4196A3F1A9D81137F
+F1820EC604D6C61AF318C6C5AB6DA1EDF305CADEF7CC0183B86D31310A09972C
+A4BC37D110C77ECCA614D1A281EE1C2040B4A5ECB31A3FC61760F608E44332D1
+D2C53C7891B505A3020E9E4915F3618588FCEC80B9ECC5E637D8D0F3C94B1F2A
+C53FC46CAE0AFAA7E12266C212A73AAE60199752C042BD55A5DF1CD07FBDB830
+C83E7832D8554AD9C9CAEEC7CED1DAEE622090897641CF2E5B34A353D83264D4
+4687522DB290D3BA927BA315EA5D25B0D7B69350C6C180AB0C322B05E01F7C7D
+F2F48651567F0C1B49AF3950E43C94D78F7B184BF2946B924BC4279AED28F3A0
+17A7D8B235698A516D3FB5DF0B18A422B2410C385E7E9439C6D60917EB3299AD
+E31471616251FA40C9FA098109BB31A54D9C03B2F12947E4E9252A0851B81C4D
+F39E7FC44752504B589C3911571B1D3EC3BD1E1807F99CED1DB20270E483A805
+CA2A016E7283550D1B1D35C226FAB63F983CED41A4D02A2F228FA9EF065027B3
+CC69D6F2E278C0A2D238D3A37154B0D22281F62C61D9182A69657B027BBDED64
+11E261E47620602F865221A534C5A32E2BF5B93A187911A146F2E96538B47DBB
+7BFA7EF406FE940F4DAD17E6E4B80C4F031D71F65657C2F5C8233EEAC68DE8A7
+E1FC3055C122C1795D0C71A0284F89A9BF04837F61C9E08DB42644A490C97D34
+A5D3CEE475B8D578205005A0D68AF94AD27C0E855BB8EDB74775690A4EDD6543
+BCC10CF13283D6FA8A7CF3FE6C4F96470A11FF0B0160D3F9816B13B0BAE0D8F9
+B84C7631063FE658D13D108D6FE24A89799FABA72E6A6D1C943922CBE676C1B6
+11A4106ECB4F1A7F8A84B2783C2E6A109C58D63FC0B74D8C8A1CB62D527441AE
+E656D94B1AA8581B4F07B653ED6486AAE1F8ADB30FA8D8914AF24721C74B0908
+D84F2EBB91144ED4BD7EF533F2584048DEE37E17CDE5FBC2992A6F924FEBAF07
+B626F988599DECDAB43C931CFECF99FC6EBB72F8E542765C26295902DFF60B7C
+7B9ADDB4858BC9D808B7F0909690CF8DFBC59A786D48B891937C31A219842A43
+234425B4963062DB4C4E9F534C77F4243408805B5A6B8BBF428632CA4AC03A7A
+E336DD181CE0CF3E742079E2919EAFABE16A63299771BF276EFA8D85C920F995
+5B9D4E8F1ADFCC5C29AA89BF90C186C5DE7679906B2FD4DB279D245D27D08837
+D3A8D541FE37415B706EC585C05804108C1D938E543B8B63E275EE85CE9DD843
+0A8B9163144B77DA1A552A25D5E77E94F29CF252BE9950F4E627D5F72536B6F3
+3278D4A45D10759F16AE42BAE8460865FEE84537F8EC9BF4813570E883B826FD
+1ABF3F4E66DB6FEF8366E07BCF290EA67D39C9D81B2A7EA48E0A228FE3D5AA50
+1A56CCBF229C9AF2537A8FA70EEF41096ACED34CC7BEECA4EA1F23B39FBC39D8
+CCEA93E63F508CBE6722C11467A3D0D5C4C52031DE43C449333E4295104651CE
+E13B821D7904653346067E971BE0042C571ABF40C3A1079A675FE4264B784D46
+1B8FAA4CDE9851C4EBF69ADF51A7B68CC8706C08D13A44909D4C1D78DB0E0B2D
+0E0318304B229DD2FDC968027CDFF65722059C62154304D6F9C3F06DE22914EE
+928B7D1BF1FC7E74B4D882998D59BC086AA2D4EAD0AE39F6B75B5A3FB9994506
+E21731E1A15F0F2D12F88724BA72898197A80FDAC00243A3038871EBD2F2BAB1
+C616278BB78490CB86F552CBE5DD0862F3793D72C68AC16AF8E38FE1A523A5FA
+9B0428745B1455671CFA1F6BFBCCF9CA23C833113C2948E7A6AEFFF1A83509FF
+C559BB5EE7F92BB43F7F37A371E661C826F63DD0C1B25E34A8119E71EC82FB66
+23C7B126FB6554E7560B1B69F2EDBB742F3B20D1648C151C37A8570CBD330A9E
+7592A8607D2D727F3AAA0FF2057DF4E2A4C7D3B658C6CED38824A770420D89E7
+F6AD385DBCE9C9A9095CF0042052A67AB804A6675BB9373A99390CBDFB715984
+A069DE543E4C6ADD7F1EC7A15392EF834EAB4584679A43443953427DB13E6959
+0F2F5061C99C6D00FA5327FDB5330AEDE19A53DE3AE092634DC6AEEAF63A5BED
+990F8A117AEB1CA0E7F7DBE02CB3D86465F1613B976D1CF6F3A1E69740A2FDC8
+062ACC45EDA6B863B60015F276860FB79C31D28F97A799568E66D0A8757B2C41
+E939337B467303041D0F4C59390B2E41E5F298F275DCC699D27C459ED4D5ADBD
+02539F00095D7E1872862142B46BE06513D3EB1A406E6BAA64BE795122100F09
+C37E5D1834218EC1D11B031C7DFC9F5AB071A8F4DC08203821366959E9191D4B
+289682D915AF28CE5858F83338DC51B6B0DD052A181D9133FBA50CF18F70EE65
+C33726A0450EBA9D0E0C3662AF6C2121AB7911AA9880D6BB6811D6D7515888E7
+199A0E632104059A88C9D85B19BB35EDF4AB95E1515BB2339572928BD5FE8CBD
+2D4DAF55DCFE29FBC4C3D56336277BA0C9A889A129F9FA7052AD1420B8705163
+1A808EC1284C888D78CEA2B4BAB71AD76289F5F4986008FA9BF328E8537E6C91
+E11DBDD8447E1C9ACE18DB0EC3D5742C264C8EFA445C5D16C2930FB43669774F
+A2CA52144D99EFA8FC427DB4128CD4C036A8C611B087335C780740FAA419D39B
+5DD68EA89C95275F9254D947EB3683D0130255269B10C6CFF29EA0BE484C9949
+96188FCB747618A8044E2E37DFFD2DB8ABB621B34DC024259340677095B6937A
+78EDCF508AC91D4CEFD872AD73F50582DC8807143CEB9F109C84DC5DA30B64E2
+E56DE973088A9D32583D6946DB4F3523902FB1781D993B89D5F56D79D5D98CC1
+7FEE73FC3A7D1BCCE90179AE450829E228B4DEAD3B2B4C79A400CFF899AB26F9
+048B0875EBC871AD23BA96F88CDA8B87FE5809A13889A6AC349ABB25E54ACAA9
+C213C5DE2D01BCB9CC0D7BBD384D23AE12E289FF8FDF1F611F5E14D4B20B15A3
+42D9B3B37A83A9CA39B5DB6C8316C51B70F211530A56CFE54D63E88169CF5233
+D1A7B2388025B3EBD2BEE0716C3A2D589EBC7A42B3DA602AC4E2FD9C9052C922
+711E44408DEEA1FE0C9FD50A39AD46D437F61F284A2EFD42EF158EDD71A1486D
+4865D6B5E20E60F4F4FC3D646909FF1EE2D7573665E4CD8340A1B232CAC0202C
+C35BA9BB3D2267C7E78518F6711633F888EBEF72DC750AC2CB362D528CFC8B2E
+A1AE1C05456F50EED8CAA768DEF47FF85C4322F02D7F9D188C6F285C674EF589
+251B0B913339FD701FDB281338D96704ED7ED908BC113B4275A24D058955890B
+12CCDD5572D63688426B0E1E9A40D6AAECFA5555C1CF9DBEF8C04CE1E5A63F14
+969D39B6DAE8A91F6AF4CD1E2DA89A4661DA34E272B6032C442C031F081F5DF5
+858F4620885773D8A2B2F5EB6DDA74C1408DF279900450E4A3E80BA9A9B1295E
+F24EDC3F6EFD81A741EF74B0202820516C4FB720687BDD915EB2396128C3B262
+20E3075DA153D6FD36E1C05B855929DAA4DE694B6F15EF2145C63250B24B031A
+4CF0AFDB225E91D99828B83BD90F1702D3906D45872587A3A116B138AD9627CE
+E778A949C392202823C670FDBC56F1896FFFFBCF52C4B400F67BA36B5FCE44A5
+F18EEB8ADFC088C99DFF8E0A593E81A5ACA2E3693005F723C7D3E0AE2BDD3805
+8C6007A00542DEB2539709558A88B21003CE4B2C7817AF207ED576B25A41DEA0
+FC55A459BEB00ADB01309B35920F04F84B7B64F95AA99EBCB843A06CED900D99
+97BEFD7CCB9F4D85876F10160C8D63E2FDE82B7A8D945F37CC9933ABE0FD1D76
+268296B1A5AB06B2E814691128771694224781171DC6266BCC290FCE1AB59416
+85530368115BABD4F1DE45952918D1945D51EB713C283DAE8EDD559F437CD886
+A4B1DA6120D685C284673A3EE489FC1AE4297A3623B339B7D886B6B4B8F9F4A3
+7BF85E320A52FDC6323B51879B98A14C33C567BC069D9B44616514EE1BE36F90
+EC5FA33E1B6B0A46945D876EF0085E74935DF2560A03321861A752E59742B9FC
+5C501FBC64BFB1602459885B63873DC857ED37F8BE1A9C6E9517B9BF5A6161BD
+DEB6DB0381FFB34A8A96AB4AD48BEC40D4C198ABC599C3758AFF638AA75BBDA4
+8545D5F95FA426FB25587301A43E176F6CED7851E815AD907F2443E70740DD2D
+4FBD5D978B9B37F59D6DCF0ADD0F90825DD23558FCB858513602C8BC82BFA383
+7AA6DCEA4009961D06DF233C5381A7F9541259926446B2F03664BC5978A1B6CD
+EA6EBC9FE6100A65959513EEE32E69D47B55BAF30A893D77142F943982019C01
+715CE29923795EA01C58A798979939B507C5B29A32881877EF7EF0C5CB3DE591
+6B9A6C3F3FFA847F396A396F078860B59850BA4CA3115CA2376AEE6B30C05DC1
+6F9DB6781ED0F9D45D10E096C33B1B7CD12A9D57C6E49AD833C4B093DC82811F
+16B3BD902BE764A1680831EC5A6C1CED84AE0DC0A65678EA5270BF20931E6409
+7AA44EACB22CCA11098F8A51096BE83A1ABA56C9EED4195D5CCF24FDAD92E823
+C439DAAFBFD652157D728F2754F28304710D3CB33763156D76A259D446647A11
+493FAC70DD28063A4CDDA162F72542368E1AC2826C4BFF7109208F66371910C1
+068F21779FC39DE03AECF1C9FB2F417930C22791961D801284DCC89B0833B6A8
+D63F153ACBFB7B7D547924613BBCCAED37D90BAC5B0264ED31C7B9DA5A2BC620
+9B20CA48424D0FF58905BCD6190BF4B5FC6ECCA1BCEF13426920197CAB41C4E6
+E82E8EE7BCB23C6BA6F8B58001533B225ED721D6CE3D6E89116EC33CAA6E905A
+649F8C6A1AA187A48E20DB864596481976216DB78F0F57543DFAE3CDC0A6FC77
+2CAA49442527A5D94DC54BE93C875690CBE52EAA4EDD9F2A511361BC0F0807EE
+96AD0D26B62D809E82EC14EDB158EF48A748A6FE0C3A7EE5D4479B35425F35AD
+3EC7444F6FA75CEA5011AD571078293448A33C7647611CAEE87974B0A756DAC9
+4E1BA78DEE477FA59AD50BF5C52E068A5E044A4A4994D5B24CC5045F768A3C51
+D4F65E2A5AFD271A7666C6835E28C60751EE528C0742433165AFBE71562A3016
+F59676D56B0B5F7E4984D664BC3ADDAF24B4205752EE21D4B57057A943018466
+09C3FA5D2C5BCBFC22A643586BC9E7A965DC34C0A7D76A470B0602AE45106417
+0701ACD2C764DDE218B924E38B5A13CB82678372E743A8B3CC300BCBBB878978
+D9847F0640A031D5E76B5AD07699C3B2FC6C1DBBF79938BA649C152FFB2B5BBA
+D18B9570670B99907506494F362B124790A17D4F415D8447ECF70B67DBD46643
+91AD465A1852B804CBE65206EAAA38FFD2B4180AF00DBC62903A5E59ED93861B
+243B7A845469B9DC5E291C87011BB364ABF5FD618EDF8B9BB56654C1B8F9DE4C
+AAC5765BA2A249922863896E706D9DA2C2E4142ECCF3DC9F987AEADFDD401062
+31B6BBFE003A9CB49060506BA4EEB10B2AD453994CB13DBBE235F4AEF3EC5932
+56609E7975C2F2167CAF1E099A38128884D1E33AEEB94C6100E1D7E69C28BA96
+A99580199238E4480C94CFEF8A3F1EB41F376C83809D815905FAA7B94F42F905
+E1C0E77ADB73A70D220167038B1E62A1890728DD0994FA5A93980B445D980FBF
+7F66502B46F103BAD307528DF531938C754C57170F5342D00EBB933DB8D77759
+F0532A40F170B7DA29754551F61221DA3940AAD36488877127DE46DC61ADBD0D
+7BFE2746B21F40B526E56AB6135D2D23884855E1C146FBD00FD8CCEFD4E04C01
+043029291F12192EC2CCC7332ABF093037B65FFA6582B5D24108C276C6647423
+000BF48F1BF750F9D9ECB010D6D4155F1DFCBA208F316CBF9C936F84CEEE0020
+DE8DF99AC22146D6C9300E2ED3E9788BF2E2C7538066A658C5094011636D06C6
+5A725A6709BA11330B2346E5594CF7595E955966D5874AD581E6F0559ECABBB5
+B343140964953F4C3F372D27246DFC048E6216EFA3E53EB06FDB60AE5F5F40B4
+AB46C9FEAB4BBCE471A2F6F3436BBEE2E0F649FCE18349683D98D95FA47F7229
+94F4F16CB805AB393329A7463E88864037115426083D4BAF6B5135
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+%%BeginFont: CMEX10
+%!PS-AdobeFont-1.0: CMEX10 003.002
+%%Title: CMEX10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMEX10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMEX10 known{/CMEX10 findfont dup/UniqueID known{dup
+/UniqueID get 5092766 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMEX10 def
+/FontBBox {-24 -2960 1454 772 }readonly def
+/PaintType 0 def
+/FontInfo 9 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMEX10.) readonly def
+/FullName (CMEX10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle 0 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 82 /integraltext put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3DD325E55798292D7BD972BD75FA
+0E079529AF9C82DF72F64195C9C210DCE34528F540DA1FFD7BEBB9B40787BA93
+51BBFB7CFC5F9152D1E5BB0AD8D016C6CFA4EB41B3C51D091C2D5440E67CFD71
+7C56816B03B901BF4A25A07175380E50A213F877C44778B3C5AADBCC86D6E551
+E6AF364B0BFCAAD22D8D558C5C81A7D425A1629DD5182206742D1D082A12F078
+0FD4F5F6D3129FCFFF1F4A912B0A7DEC8D33A57B5AE0328EF9D57ADDAC543273
+C01924195A181D03F5054A93B71E5065F8D92FE23E7BC2A6E71BCF95FF3DA948
+1A27320759222BD7BC7C1A533E90058824F06942F0234C68671083E0E4708398
+D246C94F9C16DAB6563651BA33D86273FD2DB3C50C106F3CA95B1C79778D0BEB
+B99D9CFB38E41BDCB4261A86A23E2CDEE4837D9B6F0E85ACEAA984C344A63709
+EA35B61F08821338D363D172BD185A3658F43052AE1E61D879C99DED7F6D726E
+FAFEBD881BDDEA91FB09DB75675FC74AA2BEA8771027C7A51BF849F8E765B870
+8F7CC0871F301ADEF9B71EC3C607B2F51325AA5B3DD74A2C5426E7B329FAE84E
+94A159C8C9C35E27A0FC93FB98A4D616750DAD50068A5F0EB96B8228946E5CC6
+B69E93D262C92E3BC7161313156E380A2ABE27BE400A23DF95E65A4F76B3FFE4
+CF3CD141B006C487EBC73A5A101466D4388FB2CF1D9439D0714720BB58537B7D
+B3EE1F04AE117222CA5F0E5942F7A875D55D91D63958B1A02405D9DE08109B8C
+7104F2D109EF7074852DFD74CBE02E0F3704F2BACA14E05EB1D0D9021EFAC23F
+76C2389F8EA237D2E2AB6AFA83A725E16AECCAF025E05F1B1B5699D761F62A46
+EC6F31B0FE4769BD0D66821592ADBAEFA9EB454CF1402FE870F5F96D09980C1B
+8B6D2FE88BE56032C1959E6C3DC319B6A7353F3AC629CE5BCB947B4B235426E9
+4769302817AEC1ADF50E50265AB488017634AF824D44D3C8423FC7CAD97F6D6E
+6B34313637687FBDE3BDF6FC951CB41277D8EF49D14767B59656D214C9724DC4
+0523EF896F4E48434FCC5D8423F07194C54D48C62AC29001B10C9C8B514B24C5
+CEB60FF68D36749711E108DBB52738760FCF6571D5B04E58F24CC0247834B412
+D0F6F8D7F1573F23E3E399D5A3A3A37FCFFEAFA044A5694D2458EFF2BC1F7650
+8FB0A27C505A20C16776EDF94BEF9DF702F3C64DBC1939BEC0399B6AB283F832
+DD8FB358F701CC075C596FA7B0ED7A9304DC73274C8169337D55124CB748CE26
+A635B2704D8F65E23CC0FDA3C57ED451F8FDE7B6FBFCE2746F5AEA11B065A6DC
+C3D200D962A034DD6757991BA62D8DC0408F49083D48799B6097B61343365A5B
+30FB02E9CDFB5104FB751BE8A268EE55C1208DD8B29D5635014EDE9D0D94BB64
+ED5643B3049027925BF2FD7EFCB631E01269B731AE12AA6226B2656F035C7E92
+959C4A21BE40D7C138C8FF28C9FD4B768CF25F08859AE84FEE6EA18C033B3659
+D9EE250BA5FF2568E8BF7684A93BED7852251D1ADE5DB815AF3AAC36D1A500C9
+41D1BF3A1926828CD1F9E501ABE441A07B1B96612CF0728AD5FECF7480421F46
+0B18E06D2FF1A5B1183459C59517976474698BCE18A728515CD489A83C001AFA
+47BDA929F60D0FABCD8786AE16EE18615C37D18703571936A365D334BACA9BA3
+08E2523132887B5EE95ABCE8581C78C3E858DBF35ADD56A1F6C2489AFA73D1B2
+379C5064DAFD30FDA84581FDE268B470636EE35F21648955513714F6EAA08AF0
+249C937721DB0E93D95C4DDDFB0948051953F39C6D2D811D3FFDC25F786E072B
+2A8A1F4830F9CFC34666A1D3F13268980E9A26682CAB64817318A1E266F3D2D2
+DE4EBB3EDAF0E7B526C838CBD7F37E74A35B1C3EB96DA4099DE689A53970D4CB
+9AB355E93EB294B07DD09356C338BB4A61C147BEDC152E58DC92FA69846E4829
+551A5330006793CD88523F7B3AF7B4475C531C67A4B66A603597EE72C4ADA491
+BF13706F341125CABF37FADA554FDA0BA5534C7AC35F1829E250C885D9A9983C
+5D1FE8CE24458A8B13E5C7EA22BF1608AFA96B83C700889A2A6C9C4052DCB892
+6CAEEAA9E7D7F3E215019719B36A5DAFCCF2396FA0C04AD99A7C23772A7BAA64
+D1FABE8E476EAE9FC1A3E08CD6D1DDC6E087934E676BDFD1528652B6B9A50A35
+2029466364300AF4CA3C5883F6293A7104617D0858B3E43D43752F814654A938
+A44C33410BA0E5EA7BF55D4F1D57E27921DB05C059DE29BAC1BFC9B607D2C5CB
+1DDC47793984FBB18BD99E1DF7776B563A55E15DF024D6D8E6ADF62F16F602A6
+7DDE1C68637672AA9C7A1250161502ADDDC1B4F6011A9BD5605B73AEDC37CE4E
+4467C838B7692C4D541EF87DB41123F9DCCFFA971553A5D9B0E7EC539A28750C
+8554383585CD8B93DF731A301D85BA9ADC95B4A3A237794C30230A82300B6756
+AE5A46A090958109C5565EF60B0B16D6C0A16A56644B05D3371DABBB67ED9BB8
+9BD3983575D371419C7568B2556649402AFB9843106729E4EA87B3F9038218A1
+F820B098A1271E330708432567297CCDA332B555A40C62BAEB16330175D28AA6
+13AE6939CEFA2334E3E890B66A73277F0B63B1FA59F856ABECC5FC0A50571F5B
+0747FA554F5FC72A51E215304B2E44701A13E41D91397B204C66AAB3D101004C
+7FEF2D87DA558EA057BD492CD6EF93601CB63F78426B502CDC5C8E9EF4FF3692
+376601B1FAADD801602668370B5ACEFFDBACA8F8B3F4E850D07A20F6F47440FC
+FD39504F0FDFCA35AF2ED0DA8BAB63AD42EA8CDA912CE17F5E62192DDD912333
+3E9FA0884117F07221642490044A72E359D5F25D9591A8FAD568A3DEE435C354
+11995C0EFCFEA21735DF44A30F79F747510E28767A4266461D1394F81344F6DB
+1FA8D0B0D9E5F52FBB663C8F1E91192E5608FFEAA178B93F8298F70510A65BEE
+12ECB5D675311B5B3B19205476512D92B1D16262720484049370A76F78D9BDC3
+02EB96AC1E5B3CB078D2F219988FD0F36B043ABBF347B22D36CF541A8F80F791
+8E4F92D900B7E7B64DFD500882EFBBF23565FA470103B2E0D2D14E3E4D7827D1
+BAA0F84713A8CDE5904FFF2794850871DEADDDC53B77A502F5CA98B0744BB656
+2FC40ED2AEBCC5CACE2301E983E6C18CF16AFB9FD8CA49DE51B22F4259D43076
+DDC1BD4974CDF2E733EAB6334B1D5614288CC81FDCC722CEE193635D1088FB29
+F80AD5CB96394AE89D920DF8E1F271585AF019190F17DB51FEC9064B54C3A53E
+3FD33C3B553FC79F743BEC9674743BF0A821051261DE4527A2BEF4A04E293E97
+02B181EC5F5EED3E26060F2C9EF6852B7433CA1BC1690C30424B03C522A087EE
+92016EBDAC4B787133B4A22BFEF0B6CA564C6EB910E1DBF983CB4CFC3A1F8A26
+45329CED7F5A8704ACE9D4233583365A5A97342A053EF403F0567E9D0A62EBCD
+84B5D7145BBB11D31046BC2CF5B450CC68B85DA0E78EF8902F8D37DAAA9D4242
+455288C0D73748F9BFEB1B1769D6FB84B94993D5F7C2B9CBDF75AEF2C930F277
+210B3CCB8A0299F50AFE2548A4B8DF5ABB52F098ECDD56FCB8D3A406EFD95088
+92D7EC39FDC7EB1824ECA24D0CBC6EC6F4C6A7F9590D593B269D2CC0BFBD961C
+AA8BB4296B4E4411B54367A341A5EDA97288DAC370A015FDE6D7FB0A4CECEFBD
+1A67DF3A3703E922BEF2C414FDDA42482EB35D5DBB206B44C76C412A435A0842
+6845EAD204BDF87065CE2C99B05D2D4080D5D11CFC3316967472C7DA44CC1F9D
+51B83B4BE9B882D6E9ECB482F9855D024ABFBA502CCD624E0F88164A6F13CED4
+85F20DC01BB15C7D78B1C79FD9FF71F4B043F59DB5C297768115542BC7C8A99E
+ACE39A268D32122541FB441FF1364FCBA2B7627F12C49ED038BC044B6D9D533B
+A72D35317A5AB8D91A9AC56CA90D1DAE9F967605C63BC9F406FB3D5BAEB4B38F
+4934EE3D2F5FE434B45CF5C2D0E5E417EC279DCEC4F16504EE40E837B11620B7
+7526AFF23381ED3E9A92DA4DBF4EA2BE4FE444B9A74AB60EFC818E20DD8B852B
+DF8CB659C0A3956D0DA61F49A9DD467726E57E9B32EFF540D551A67213D40273
+AEAA6E319D92B4B406377D36DAB85662C755D76ADF5795C52D54ECCF0DE81E30
+B84F951233A0A400CB063911837F0AACF44AD2441A7CE08818D64705E1ACF7E0
+F59AEFC5DD812981C5508385274817056B2CDCCA4C9F3103C92838917EBFEC94
+21D5737AC634B23B6F7F63B166D60C6BAA8F33AF44379C5A7337E737190EB3EE
+14272B905D08C01EA118964D3444A03676FF3B62E7626168FA1DC6220699780A
+0BD5776DDFA26BF0BB335B3C978CDD5CF1A419D4B5C562B3974FECFCF0118199
+E547EB287CD92E32E881F344420FA3CD97333BFEF5D7E1BA31FD20622E5B4F95
+692DD0ACAF01D413B21C8608FA87B470191C3CC5AD333263C955B4ADF4370FCE
+D6667FC93495003F4B6AEE4F83603D55F19EFBF56F955FC9CC01E494804952CD
+D426FE706C13D41F87C5C668D8B6BE50AE0370E07F52AC0534ECAB1C19851099
+FC0BB1EC2A649795A62299F73CA606EDFB1D28183DC63ADF67294553115E8C57
+7CB603CC491A6065802B925E6DFBF42917EE6E44C714228AE452851D61BF70AC
+844B5D800EF029357FD659B8A648445CED0ECAE1474E443124F4B3644F54C556
+A330D92EABEC7F607C6B13FACF69CA928F835056BD1A8ADA20EFE6BD5CF4A1A0
+8B9E415E4A5FC6F209EF05ABF2E0C55F6E3060D1C72967E1E68791499F303C8B
+3960C5A1F2DF6306710DFA98C8D0815A06B5590374554DCCDBDC4C295B3BA6B8
+8BE3200CD4421A521C06BE39D4CA495BC63F3F982CAE3C82AD38DCB537E617D3
+34BD96EFDA7C6A0F6D97A6BC9F084645390E194E7A11399FCE4EEB9A965909BA
+6EC69D34DBA081BB3F18BD1ADB1AE1B7FBF96E4C546498667690857EB6931841
+46C427A5B7C7D99FF889582C4AD11A7D267B301C5A5AAD9DA99D5BFD438238DA
+62DEB899FF0F7B7997F781315B2CC328BE3572A3903A33EC901AC6BCC7F152A9
+8A6865C6CB17189A4EEB699006A5F9D4482D53A76E88438E444F9302C79F0DC4
+B3033D29D303B38F5959F020337EE6619DC8A8C3912101B02CF8AD113BF4BC29
+8C6B9D25AF6B6A787F222C05964475B49B6751E3A3A6EBBEA03677D5B136B9DC
+6D9AC20193BFB0759E89831C9E2AF68BD45ECC81175DFE80DC0879069ADFA8E5
+24CF3C84121CD9739A28BACB9891945FA4E72EC07136682E18FCA81938FA6A3B
+8CEFBAED60121530E33C1C0E698B5923D6AFC4E907A99B1367C3D435CAEDEF5F
+878237453B8DB2FE53073CF3319FD096343F42D68F097759D051AEE17E4FCFC9
+86E17099799DE82A38F22D870BF7AB90890E3B5264976700BAE594C8563A218C
+C985D9A5A7D7BD959F7E4E66286833C86E89203ECECD6FC4C6FE1F04010218FA
+A5714881C4C846E85F13BD68AC250CD0E488DBF60BB10B2CD7AE2E30F9C21DFA
+0E84F76B4E996AA1C5C056E64BAC85622C160B56DEFD4DEF86887C1201F7C20C
+076D4A27BA69572BE9C89FF3A9D3BAA5CAE0A6F2187AD01ED497798A305E3BD8
+422DBFBF45E3F4AD35240B07285128B59FA9E83D9F6A2E620CAF6DB05129D930
+44CB241CFF84E776315114C3AB61FBC0A8368D9154CC5066E2B162E89DA51165
+F9CC075F2524F9A8624D2B56ABE64AF93B9F0407CC770C1F2C76CCDC06345D03
+7B173C2FAA201D8E1F6C0315987A7A13902F4AA5ADF081C2B0A01C77E4F7A3E7
+6A4AAEDDC577E855D69D38AF6A1D271B02AB496D94D81996FB078FBED17F833D
+C6C0BCE141BCDE277D530951DD6574B9CB3CF0370D74211E9AC00C7CD3A67842
+0B4B72ED517E4906409DEA7993D0B8E92D418139960EBC86BE63A1B1D417C451
+8BA13C230DAE1EC4E466F23351D410D9FC4A7BBD477D5FA07659B71CE9921B1B
+6755C67AB3D4988064004CF75948879D16174E8097C91F7544352474C2D9A1F8
+A1813BC6F4BA13E952678F5707F19B4799ADB3BD186DF650821DF58CF3C78D67
+84E4E1DF8DACEC50D15647C3DBBC3C4355E602D3A03171FE1CB36FEB940211EE
+0A5300841DD7B7CF91C02B3FC5D89C691156BFF8A38C6C72789DF260B868AAA1
+895046E405661D97FA9A0048AF114A89E3ADAEBCE541753E4FFCD902391B5372
+6A97E32F0257FA9FA1DC15BD3140EC7F0CA5A68AABCEDBE73C38B35FDF195F96
+0F9DB0F592C188D72D73512F4DD92D2371D1A59254BC477CA084E68184AEAB6C
+266BB21DC3AAF874DE999AD2A17C79621AE322612EE4B6D5BDAC511418EDE90A
+AE75066AF19662C4AD855E4200A5D67BEE4ADA9A399192C74D35E59B15FB61E7
+BB167282D32D538029ED22CC5C9860C1F6B7BA7F33D5CF108D4BEEFAE7B37E67
+39391F9934DE17956303532ABB011540645DB8420749C9B9A019C3CE86ACD566
+1EE8D8D5E0D8D0DEAB33B5413EF10D4EE650F82417002E436E0B3B628A657F84
+074098C2E9F897D9AB692E0FB9F268E6728F94A79CF4D6B0A07C8DFDC1D67FD5
+EDD5863EA8949D180B1596D0009D662FC429449D76BF13D83F0D0CF165982443
+E9CC288CF7C5F2E17EB7F3736D1FB814196CCEAB8C833720E3733BF594E1B536
+BC0063080BC751F9DA1741522B2967D07DDDA169E7D3417B4A39EFAC15EA5E8E
+DE3473CC9DF991FAD2A971F44B09635085DB02D692F149F144F3DCDB69B72C53
+A2AF34C65DF0D5F35E82102E67B733750646EC03A4FF47138F7998607BD93AB2
+B63A0B82E8E225FFAD5DC468077FBE8C8C8E5B4BB10A8FE836B07367D742BD6B
+D36DF5304B9DF363120504C279453452EB177FBCDAA6F6FB78A24848F4A1D94D
+1E49F6C46CB36796F3F4C9739346381F28AF085C5EBDB2A02DC0570C7A21E097
+77522D4947B51182431BCBF3E55CCDDE93A916AA40CEB577277FA512380816DF
+9111C56F36341381D62368E70462577D0C135BB3CB4462B269AA8E0F03245BFA
+D01DB8E23F2DFD5DAA88FCAFDD51D48E562EC649DB1FFDA0FD8CC8C48E6A9207
+260ABE35733D75630053CC74A07E5AF6FE87BD5FEA69CB6AA20122276AD92853
+6B225BC9E3350D1B1362E04C7795D473F1266852B02C83D02D938C55D8F0C671
+7A9205F8CD058304DFA034D99A6BC16C582F02484A089602D42DF30D7A5716C1
+D42A4CE56C19E40C01DC7DED931FA13679CFD2700B3826A1E6539AAC12293DA8
+664DE251C5D1761BB45FE364CE3F7F7E9B67F86EB31D9626CCACE4DCE03EF3C1
+0D2FD1B12B5774510D46C5C5CBF0A34847418B9A1DF0C67789422D0EC2D49576
+9DDE72D63A4A98613461A6F730A05336C691583F96C3CAD2AF7C4BFD3AEB3814
+D909858B6598FE19397006C8C4D549AA1635968F47144E7861A2BCE8AB4CA7F0
+4D253949AA0127559FAE3161C810A8CE22A3079602E747C9398F9C8B2A868F23
+D77D7AD6B980FEB038E0557E58E1D7AE471036CBB96B83595D9C96A4895971CD
+C2A810651A045F876A1F5AE470BEF39F856808B1F8D736030A722E1576BDB3B4
+4DF06F73D38D313C8A0D3504EFBC774750C9F6E687ABCB1927FA1BB3882AABC1
+2306A030CEBB259AECAA646C6497712F6C1E9DB7E1365A60EEC5AEDD5147A77B
+1E3A10D73C477876D54FEE853D953EE75F7EDFB287550B93CFA8250D1FE2FE7D
+D34441F1224F3DB1D355188819EBB98A94DB193B9CA23803869DD10776647BF5
+5BB42031AC44A7339DC036AD0292AB9B732E6FB79BEE852A103C3788BB0F4B72
+EF37BB62356F9B2DF7F5899A26F1FE0A3D6469C1034B8AB14F52555EBF6DC592
+3F24D6DB395A3A182ED4B8ECEE8254661C19CC942F236CA40BAABE818EC312D8
+7F5762C210FCE8A3CB9A23A24D0A751A09F4FCFB72DD0FB3AAE0575CF97D126E
+1669203BE1C8F8FF626F49E8AFA7B29EF26618C6D8336D4471314D5D009BEC8C
+D914E74D0BE7D7C3A2511C0DDEB6FE04360D54FB3283AD67D9DCDE211FAFD19C
+449E201F2913232DDAFB2043F674EA73C9F043EB73CC9A96289B3CF819DB3E56
+5FE403D8C387C99979ED9F8EB2F5B970958CA554D9DB879786C39AAC8139A032
+6651A999D3927BB2A16D73BEA8CD512765A19BB5F5051B531D319F2C097655F8
+2301E3819F631129141AA5DB1D28EBEFBBBABC218C1DE7033C1E10608393137C
+FBC625528295185000819479C681C86FDB3D10D131949430AD8DFE38A5D62DE6
+FBE13CCDC34FD0CBF6E3A249B27E798E26A3EED8C3B278C163D72C417D978D20
+2D3290270F667D461FC2ED6F19B2A7DFE4099E483B72F8B85E18991AA5203CEF
+092B28FEF9F67C59DD19D5C9D2EE985CD3057F43DD47DE841D47BFBC859D1D07
+00DAC60E8905D87A43188F913603624FE23C8300CE998C4F14BC4DE5CD329D97
+AFD427F59C0A283CBBE47E05FB3E62E5D5741D3ABE666523F3564D7962FDB8FA
+91BA02B9E493B7A725FB492A44F2C0FE3714BEE2BD2DC7374865C456584F
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+TeXDict begin 40258437 52099154 1000 600 600 (gmt_eq.dvi)
+@start /Fa 227[36 28[{}1 83.022 /CMMI10 rf /Fb 135[38
+3[25 116[{}2 58.1154 /CMMI7 rf /Fc 173[39 82[{}1 83.022
+/CMEX10 rf end
+%%EndProlog
+%%BeginSetup
+%%Feature: *Resolution 600dpi
+TeXDict begin
+ end
+%%EndSetup
+TeXDict begin 1 0 bop 639 456 a Fc(R)678 553 y Fb(x)734
+456 y Fc(R)773 553 y Fb(t)816 523 y Fa(\034)852 535 y
+Fb(x)p eop end
+%%Trailer
+userdict /end-hook known{end-hook}if
+%%EOF
+%%EndDocument
+PSL_eps_end
+U
+0 4724 T
+23 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 630 0 M 0 60 D S
+N 1890 0 M 0 60 D S
+N 3150 0 M 0 60 D S
+N 0 0 M 0 30 D S
+N 1260 0 M 0 30 D S
+N 2520 0 M 0 30 D S
+N 3780 0 M 0 30 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+0 A
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4066 0 TM
+% PostScript produced by:
+%@GMT: gmt basemap -BwenS '-Bxafg+l@[\int_{x} \int_{t} \tau_x@[' -Byafg -Xa3.3885i -Ya0i -R-30/30/0/80 -JX10c
+%@PROJ: xy -30.00000000 30.00000000 0.00000000 80.00000000 -30.000 30.000 0.000 80.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+630 0 M
+0 4724 D
+S
+1890 0 M
+0 4724 D
+S
+3150 0 M
+0 4724 D
+S
+0 0 M
+3780 0 D
+S
+0 1181 M
+3780 0 D
+S
+0 2362 M
+3780 0 D
+S
+0 3543 M
+3780 0 D
+S
+0 4724 M
+3780 0 D
+S
+23 W
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -60 0 D S
+N 0 1181 M -60 0 D S
+N 0 2362 M -60 0 D S
+N 0 3543 M -60 0 D S
+N 0 4724 M -60 0 D S
+N 0 591 M -30 0 D S
+N 0 1772 M -30 0 D S
+N 0 2953 M -30 0 D S
+N 0 4134 M -30 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+23 W
+N 0 4724 M 0 -4724 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 60 0 D S
+N 0 1181 M 60 0 D S
+N 0 2362 M 60 0 D S
+N 0 3543 M 60 0 D S
+N 0 4724 M 60 0 D S
+N 0 591 M 30 0 D S
+N 0 1772 M 30 0 D S
+N 0 2953 M 30 0 D S
+N 0 4134 M 30 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+23 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 630 0 M 0 -60 D S
+N 1890 0 M 0 -60 D S
+N 3150 0 M 0 -60 D S
+/MM {neg M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+150 F0
+(”20) sh mx
+(0) sh mx
+(20) sh mx
+def
+/PSL_A0_y PSL_A0_y 45 add PSL_AH0 add def
+630 PSL_A0_y MM
+(”20) bc Z
+1890 PSL_A0_y MM
+(0) bc Z
+3150 PSL_A0_y MM
+(20) bc Z
+N 0 0 M 0 -30 D S
+N 1260 0 M 0 -30 D S
+N 2520 0 M 0 -30 D S
+N 3780 0 M 0 -30 D S
+/PSL_LH 210 F0
+(M) sh def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 90 add PSL_LH add def
+1890 PSL_L_y MM
+V
+currentpoint T
+0 273 PSL_LH sub neg M currentpoint T
+PSL_eps_begin
+-346 0 T 21 21 scale
+-148 -653 T
+N 148 653 M 181 653 L 181 666 L 148 666 L P clip N
+%%BeginDocument: psimage.eps
+%!PS-Adobe-2.0 EPSF-2.0
+%%Creator: dvips(k) 2020.1 Copyright 2020 Radical Eye Software
+%%Title: gmt_eq.dvi
+%%CreationDate: Tue Mar 30 21:49:37 2021
+%%DocumentFonts: CMEX10 CMMI7 CMMI10
+%%EndComments
+%DVIPSWebPage: (www.radicaleye.com)
+%DVIPSCommandLine: dvips -q -E gmt_eq.dvi -o equation.eps
+%DVIPSParameters: dpi=600
+%DVIPSSource:  TeX output 2021.03.30:1149
+%%BeginProcSet: tex.pro 0 0
+%!
+/TeXDict 300 dict def TeXDict begin/N{def}def/B{bind def}N/S{exch}N/X{S
+N}B/A{dup}B/TR{translate}N/isls false N/vsize 11 72 mul N/hsize 8.5 72
+mul N/landplus90{false}def/@rigin{isls{[0 landplus90{1 -1}{-1 1}ifelse 0
+0 0]concat}if 72 Resolution div 72 VResolution div neg scale isls{
+landplus90{VResolution 72 div vsize mul 0 exch}{Resolution -72 div hsize
+mul 0}ifelse TR}if Resolution VResolution vsize -72 div 1 add mul TR[
+matrix currentmatrix{A A round sub abs 0.00001 lt{round}if}forall round
+exch round exch]setmatrix}N/@landscape{/isls true N}B/@manualfeed{
+statusdict/manualfeed true put}B/@copies{/#copies X}B/FMat[1 0 0 -1 0 0]
+N/FBB[0 0 0 0]N/nn 0 N/IEn 0 N/ctr 0 N/df-tail{/nn 8 dict N nn begin
+/FontType 3 N/FontMatrix fntrx N/FontBBox FBB N string/base X array
+/BitMaps X/BuildChar{CharBuilder}N/Encoding IEn N end A{/foo setfont}2
+array copy cvx N load 0 nn put/ctr 0 N[}B/sf 0 N/df{/sf 1 N/fntrx FMat N
+df-tail}B/dfs{div/sf X/fntrx[sf 0 0 sf neg 0 0]N df-tail}B/E{pop nn A
+definefont setfont}B/Cw{Cd A length 5 sub get}B/Ch{Cd A length 4 sub get
+}B/Cx{128 Cd A length 3 sub get sub}B/Cy{Cd A length 2 sub get 127 sub}
+B/Cdx{Cd A length 1 sub get}B/Ci{Cd A type/stringtype ne{ctr get/ctr ctr
+1 add N}if}B/CharBuilder{save 3 1 roll S A/base get 2 index get S
+/BitMaps get S get/Cd X pop/ctr 0 N Cdx 0 Cx Cy Ch sub Cx Cw add Cy
+setcachedevice Cw Ch true[1 0 0 -1 -.1 Cx sub Cy .1 sub]{Ci}imagemask
+restore}B/D{/cc X A type/stringtype ne{]}if nn/base get cc ctr put nn
+/BitMaps get S ctr S sf 1 ne{A A length 1 sub A 2 index S get sf div put
+}if put/ctr ctr 1 add N}B/I{cc 1 add D}B/bop{userdict/bop-hook known{
+bop-hook}if/SI save N @rigin 0 0 moveto/V matrix currentmatrix A 1 get A
+mul exch 0 get A mul add .99 lt{/QV}{/RV}ifelse load def pop pop}N/eop{
+SI restore userdict/eop-hook known{eop-hook}if showpage}N/@start{
+userdict/start-hook known{start-hook}if pop/VResolution X/Resolution X
+1000 div/DVImag X/IEn 256 array N 2 string 0 1 255{IEn S A 360 add 36 4
+index cvrs cvn put}for pop 65781.76 div/vsize X 65781.76 div/hsize X}N
+/dir 0 def/dyy{/dir 0 def}B/dyt{/dir 1 def}B/dty{/dir 2 def}B/dtt{/dir 3
+def}B/p{dir 2 eq{-90 rotate show 90 rotate}{dir 3 eq{-90 rotate show 90
+rotate}{show}ifelse}ifelse}N/RMat[1 0 0 -1 0 0]N/BDot 260 string N/Rx 0
+N/Ry 0 N/V{}B/RV/v{/Ry X/Rx X V}B statusdict begin/product where{pop
+false[(Display)(NeXT)(LaserWriter 16/600)]{A length product length le{A
+length product exch 0 exch getinterval eq{pop true exit}if}{pop}ifelse}
+forall}{false}ifelse end{{gsave TR -.1 .1 TR 1 1 scale Rx Ry false RMat{
+BDot}imagemask grestore}}{{gsave TR -.1 .1 TR Rx Ry scale 1 1 false RMat
+{BDot}imagemask grestore}}ifelse B/QV{gsave newpath transform round exch
+round exch itransform moveto Rx 0 rlineto 0 Ry neg rlineto Rx neg 0
+rlineto fill grestore}B/a{moveto}B/delta 0 N/tail{A/delta X 0 rmoveto}B
+/M{S p delta add tail}B/b{S p tail}B/c{-4 M}B/d{-3 M}B/e{-2 M}B/f{-1 M}
+B/g{0 M}B/h{1 M}B/i{2 M}B/j{3 M}B/k{4 M}B/w{0 rmoveto}B/l{p -4 w}B/m{p
+-3 w}B/n{p -2 w}B/o{p -1 w}B/q{p 1 w}B/r{p 2 w}B/s{p 3 w}B/t{p 4 w}B/x{
+0 S rmoveto}B/y{3 2 roll p a}B/bos{/SS save N}B/eos{SS restore}B end
+%%EndProcSet
+%%BeginProcSet: l3backend-dvips.pro 0 0
+%%
+%% This is file `l3backend-dvips.pro',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% l3backend-header.dtx  (with options: `header,dvips')
+%% 
+%% Copyright (C) 1990-2020 The LaTeX3 Project
+%% 
+%% It may be distributed and/or modified under the conditions of
+%% the LaTeX Project Public License (LPPL), either version 1.3c of
+%% this license or (at your option) any later version.  The latest
+%% version of this license is in the file:
+%% 
+%%    https://www.latex-project.org/lppl.txt
+%% 
+%% This file is part of the "l3backend bundle" (The Work in LPPL)
+%% and all files in that bundle must be distributed together.
+%% 
+%% File: l3backend-header.dtx
+true setglobal
+/pdf.globaldict 4 dict def
+false setglobal
+/pdf.cvs { 65534 string cvs } def
+/pdf.dvi.pt { 72.27 mul Resolution div } def
+/pdf.pt.dvi { 72.27 div Resolution mul } def
+/pdf.rect.ht { dup 1 get neg exch 3 get add } def
+/pdf.linkmargin { 1 pdf.pt.dvi } def
+/pdf.linkdp.pad { 0 } def
+/pdf.linkht.pad { 0 } def
+/pdf.rect
+  { /Rect [ pdf.llx pdf.lly pdf.urx pdf.ury ] } def
+/pdf.save.ll
+  {
+    currentpoint
+    /pdf.lly exch def
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.ur
+  {
+    currentpoint
+    /pdf.ury exch def
+    /pdf.urx exch def
+  }
+    def
+/pdf.save.linkll
+  {
+    currentpoint
+    pdf.linkmargin add
+    pdf.linkdp.pad add
+    /pdf.lly exch def
+    pdf.linkmargin sub
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.linkur
+  {
+    currentpoint
+    pdf.linkmargin sub
+    pdf.linkht.pad sub
+    /pdf.ury exch def
+    pdf.linkmargin add
+    /pdf.urx exch def
+  }
+    def
+/pdf.dest.anchor
+  {
+    currentpoint exch
+    pdf.dvi.pt 72 add
+    /pdf.dest.x exch def
+    pdf.dvi.pt
+    vsize 72 sub exch sub
+    /pdf.dest.y exch def
+  }
+    def
+/pdf.dest.point
+  { pdf.dest.x pdf.dest.y } def
+/pdf.dest2device
+  {
+    /pdf.dest.y exch def
+    /pdf.dest.x exch def
+    matrix currentmatrix
+    matrix defaultmatrix
+    matrix invertmatrix
+    matrix concatmatrix
+    cvx exec
+    /pdf.dev.y exch def
+    /pdf.dev.x exch def
+    /pdf.tmpd exch def
+    /pdf.tmpc exch def
+    /pdf.tmpb exch def
+    /pdf.tmpa exch def
+    pdf.dest.x pdf.tmpa mul
+      pdf.dest.y pdf.tmpc mul add
+      pdf.dev.x add
+    pdf.dest.x pdf.tmpb mul
+     pdf.dest.y pdf.tmpd mul add
+     pdf.dev.y add
+  }
+    def
+/pdf.bordertracking false def
+/pdf.bordertracking.begin
+  {
+    SDict /pdf.bordertracking true put
+    SDict /pdf.leftboundary undef
+    SDict /pdf.rightboundary undef
+    /a where
+      {
+        /a
+          {
+            currentpoint pop
+            SDict /pdf.rightboundary known dup
+              {
+                SDict /pdf.rightboundary get 2 index lt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.rightboundary exch put }
+            ifelse
+            moveto
+            currentpoint pop
+            SDict /pdf.leftboundary known dup
+              {
+                SDict /pdf.leftboundary get 2 index gt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.leftboundary exch put }
+            ifelse
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.bordertracking.end
+  {
+    /a where { /a { moveto } put } if
+    /x where { /x { 0 exch rmoveto } put } if
+    SDict /pdf.leftboundary known
+      { pdf.outerbox 0 pdf.leftboundary put }
+    if
+    SDict /pdf.rightboundary known
+      { pdf.outerbox 2 pdf.rightboundary put }
+    if
+    SDict /pdf.bordertracking false put
+  }
+    def
+  /pdf.bordertracking.endpage
+{
+  pdf.bordertracking
+    {
+      pdf.bordertracking.end
+      true setglobal
+      pdf.globaldict
+        /pdf.brokenlink.rect [ pdf.outerbox aload pop ] put
+      pdf.globaldict
+        /pdf.brokenlink.skip pdf.baselineskip put
+      pdf.globaldict
+        /pdf.brokenlink.dict
+          pdf.link.dict pdf.cvs put
+      false setglobal
+      mark pdf.link.dict cvx exec /Rect
+        [
+          pdf.llx
+          pdf.lly
+          pdf.outerbox 2 get pdf.linkmargin add
+          currentpoint exch pop
+          pdf.outerbox pdf.rect.ht sub pdf.linkmargin sub
+        ]
+      /ANN pdf.pdfmark
+    }
+  if
+}
+  def
+/pdf.bordertracking.continue
+  {
+    /pdf.link.dict pdf.globaldict
+      /pdf.brokenlink.dict get def
+    /pdf.outerbox pdf.globaldict
+      /pdf.brokenlink.rect get def
+    /pdf.baselineskip pdf.globaldict
+      /pdf.brokenlink.skip get def
+    pdf.globaldict dup dup
+    /pdf.brokenlink.dict undef
+    /pdf.brokenlink.skip undef
+    /pdf.brokenlink.rect undef
+    currentpoint
+    /pdf.originy exch def
+    /pdf.originx exch def
+    /a where
+      {
+        /a
+          {
+            moveto
+            SDict
+            begin
+            currentpoint pdf.originy ne exch
+              pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+    /x where
+      {
+        /x
+          {
+            0 exch rmoveto
+            SDict~
+            begin
+            currentpoint
+            pdf.originy ne exch pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.breaklink
+  {
+    pop
+    counttomark 2 mod 0 eq
+      {
+        counttomark /pdf.count exch def
+          {
+           pdf.count 0 eq { exit } if
+           counttomark 2 roll
+           1 index /Rect eq
+             {
+               dup 4 array copy
+               dup dup
+                 1 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add sub
+                 3 exch put
+               dup
+                 pdf.outerbox 2 get
+                 pdf.linkmargin add
+                 2 exch put
+               dup dup
+                 3 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add add
+                 1 exch put
+               /pdf.currentrect exch  def
+               pdf.breaklink.write
+                 {
+                   pdf.currentrect
+                   dup
+                     pdf.outerbox 0 get
+                     pdf.linkmargin sub
+                     0 exch put
+                   dup
+                     pdf.outerbox 2 get
+                     pdf.linkmargin add
+                     2 exch put
+                   dup dup
+                     1 get
+                     pdf.baselineskip add
+                     1 exch put
+                   dup dup
+                     3 get
+                     pdf.baselineskip add
+                     3 exch put
+                   /pdf.currentrect exch def
+                   pdf.breaklink.write
+                  }
+                1 index 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                2 index 1 get sub
+                pdf.baselineskip div round cvi 1 sub
+                exch
+              repeat
+              pdf.currentrect
+              dup
+                pdf.outerbox 0 get
+                pdf.linkmargin sub
+                0 exch put
+              dup dup
+                1 get
+                pdf.baselineskip add
+                1 exch put
+              dup dup
+                3 get
+                pdf.baselineskip add
+                3 exch put
+              dup 2 index 2 get  2 exch put
+              /pdf.currentrect exch def
+              pdf.breaklink.write
+              SDict /pdf.pdfmark.good false put
+              exit
+            }
+            { pdf.count 2 sub /pdf.count exch def }
+          ifelse
+        }
+      loop
+    }
+  if
+  /ANN
+}
+  def
+/pdf.breaklink.write
+  {
+    counttomark 1 sub
+    index /_objdef eq
+      {
+        counttomark -2 roll
+        dup wcheck
+          {
+            readonly
+            counttomark 2 roll
+          }
+          { pop pop }
+        ifelse
+      }
+    if
+    counttomark 1 add copy
+    pop pdf.currentrect
+    /ANN pdfmark
+  }
+    def
+/pdf.pdfmark
+  {
+    SDict /pdf.pdfmark.good true put
+    dup /ANN eq
+      {
+        pdf.pdfmark.store
+        pdf.pdfmark.dict
+          begin
+            Subtype /Link eq
+            currentdict /Rect known and
+            SDict /pdf.outerbox known and
+            SDict /pdf.baselineskip known and
+              {
+                Rect 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                Rect 1 get sub
+                pdf.baselineskip div round cvi 0 gt
+                  { pdf.breaklink }
+                if
+              }
+            if
+          end
+        SDict /pdf.outerbox undef
+        SDict /pdf.baselineskip undef
+        currentdict /pdf.pdfmark.dict undef
+      }
+    if
+    pdf.pdfmark.good
+      { pdfmark }
+      { cleartomark }
+    ifelse
+  }
+    def
+/pdf.pdfmark.store
+  {
+    /pdf.pdfmark.dict 65534 dict def
+    counttomark 1 add copy
+    pop
+      {
+        dup mark eq
+          {
+            pop
+            exit
+          }
+          {
+            pdf.pdfmark.dict
+            begin def end
+          }
+        ifelse
+      }
+    loop
+}
+  def
+%% 
+%%
+%% End of file `l3backend-dvips.pro'.
+%%EndProcSet
+%%BeginProcSet: texps.pro 0 0
+%!
+TeXDict begin/rf{findfont dup length 1 add dict begin{1 index/FID ne 2
+index/UniqueID ne and{def}{pop pop}ifelse}forall[1 index 0 6 -1 roll
+exec 0 exch 5 -1 roll VResolution Resolution div mul neg 0 0]FontType 0
+ne{/Metrics exch def dict begin Encoding{exch dup type/integertype ne{
+pop pop 1 sub dup 0 le{pop}{[}ifelse}{FontMatrix 0 get div Metrics 0 get
+div def}ifelse}forall Metrics/Metrics currentdict end def}{{1 index type
+/nametype eq{exit}if exch pop}loop}ifelse[2 index currentdict end
+definefont 3 -1 roll makefont/setfont cvx]cvx def}def/ObliqueSlant{dup
+sin S cos div neg}B/SlantFont{4 index mul add}def/ExtendFont{3 -1 roll
+mul exch}def/ReEncodeFont{CharStrings rcheck{/Encoding false def dup[
+exch{dup CharStrings exch known not{pop/.notdef/Encoding true def}if}
+forall Encoding{]exch pop}{cleartomark}ifelse}if/Encoding exch def}def
+end
+%%EndProcSet
+%%BeginProcSet: special.pro 0 0
+%!
+TeXDict begin/SDict 200 dict N SDict begin/@SpecialDefaults{/hs 612 N
+/vs 792 N/ho 0 N/vo 0 N/hsc 1 N/vsc 1 N/ang 0 N/CLIP 0 N/rwiSeen false N
+/rhiSeen false N/letter{}N/note{}N/a4{}N/legal{}N}B/@scaleunit 100 N
+/@hscale{@scaleunit div/hsc X}B/@vscale{@scaleunit div/vsc X}B/@hsize{
+/hs X/CLIP 1 N}B/@vsize{/vs X/CLIP 1 N}B/@clip{/CLIP 2 N}B/@hoffset{/ho
+X}B/@voffset{/vo X}B/@angle{/ang X}B/@rwi{10 div/rwi X/rwiSeen true N}B
+/@rhi{10 div/rhi X/rhiSeen true N}B/@llx{/llx X}B/@lly{/lly X}B/@urx{
+/urx X}B/@ury{/ury X}B/magscale true def end/@MacSetUp{userdict/md known
+{userdict/md get type/dicttype eq{userdict begin md length 10 add md
+maxlength ge{/md md dup length 20 add dict copy def}if end md begin
+/letter{}N/note{}N/legal{}N/od{txpose 1 0 mtx defaultmatrix dtransform S
+atan/pa X newpath clippath mark{transform{itransform moveto}}{transform{
+itransform lineto}}{6 -2 roll transform 6 -2 roll transform 6 -2 roll
+transform{itransform 6 2 roll itransform 6 2 roll itransform 6 2 roll
+curveto}}{{closepath}}pathforall newpath counttomark array astore/gc xdf
+pop ct 39 0 put 10 fz 0 fs 2 F/|______Courier fnt invertflag{PaintBlack}
+if}N/txpose{pxs pys scale ppr aload pop por{noflips{pop S neg S TR pop 1
+-1 scale}if xflip yflip and{pop S neg S TR 180 rotate 1 -1 scale ppr 3
+get ppr 1 get neg sub neg ppr 2 get ppr 0 get neg sub neg TR}if xflip
+yflip not and{pop S neg S TR pop 180 rotate ppr 3 get ppr 1 get neg sub
+neg 0 TR}if yflip xflip not and{ppr 1 get neg ppr 0 get neg TR}if}{
+noflips{TR pop pop 270 rotate 1 -1 scale}if xflip yflip and{TR pop pop
+90 rotate 1 -1 scale ppr 3 get ppr 1 get neg sub neg ppr 2 get ppr 0 get
+neg sub neg TR}if xflip yflip not and{TR pop pop 90 rotate ppr 3 get ppr
+1 get neg sub neg 0 TR}if yflip xflip not and{TR pop pop 270 rotate ppr
+2 get ppr 0 get neg sub neg 0 S TR}if}ifelse scaleby96{ppr aload pop 4
+-1 roll add 2 div 3 1 roll add 2 div 2 copy TR .96 dup scale neg S neg S
+TR}if}N/cp{pop pop showpage pm restore}N end}if}if}N/normalscale{
+Resolution 72 div VResolution 72 div neg scale magscale{DVImag dup scale
+}if 0 setgray}N/@beginspecial{SDict begin/SpecialSave save N gsave
+normalscale currentpoint TR @SpecialDefaults count/ocount X/dcount
+countdictstack N}N/@setspecial{CLIP 1 eq{newpath 0 0 moveto hs 0 rlineto
+0 vs rlineto hs neg 0 rlineto closepath clip}if ho vo TR hsc vsc scale
+ang rotate rwiSeen{rwi urx llx sub div rhiSeen{rhi ury lly sub div}{dup}
+ifelse scale llx neg lly neg TR}{rhiSeen{rhi ury lly sub div dup scale
+llx neg lly neg TR}if}ifelse CLIP 2 eq{newpath llx lly moveto urx lly
+lineto urx ury lineto llx ury lineto closepath clip}if/showpage{}N
+/erasepage{}N/setpagedevice{pop}N/copypage{}N newpath}N/@endspecial{
+count ocount sub{pop}repeat countdictstack dcount sub{end}repeat
+grestore SpecialSave restore end}N/@defspecial{SDict begin}N
+/@fedspecial{end}B/li{lineto}B/rl{rlineto}B/rc{rcurveto}B/np{/SaveX
+currentpoint/SaveY X N 1 setlinecap newpath}N/st{stroke SaveX SaveY
+moveto}N/fil{fill SaveX SaveY moveto}N/ellipse{/endangle X/startangle X
+/yrad X/xrad X/savematrix matrix currentmatrix N TR xrad yrad scale 0 0
+1 startangle endangle arc savematrix setmatrix}N end
+%%EndProcSet
+%%BeginFont: CMMI10
+%!PS-AdobeFont-1.0: CMMI10 003.002
+%%Title: CMMI10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMMI10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMMI10 known{/CMMI10 findfont dup/UniqueID known{dup
+/UniqueID get 5087385 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMMI10 def
+/FontBBox {-32 -250 1048 750 }readonly def
+/PaintType 0 def
+/FontInfo 10 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMMI10.) readonly def
+/FullName (CMMI10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+/ascent 750 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 28 /tau put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3C05EF98F858322DCEA45E0874C5
+45D25FE192539D9CDA4BAA46D9C431465E6ABF4E4271F89EDED7F37BE4B31FB4
+7934F62D1F46E8671F6290D6FFF601D4937BF71C22D60FB800A15796421E3AA7
+72C500501D8B10C0093F6467C553250F7C27B2C3D893772614A846374A85BC4E
+BEC0B0A89C4C161C3956ECE25274B962C854E535F418279FE26D8F83E38C5C89
+974E9A224B3CBEF90A9277AF10E0C7CAC8DC11C41DC18B814A7682E5F0248674
+11453BC81C443407AF41AF8A831A85A700CFC65E2181BCBFBC7878DFBD546AC2
+1EF6CC527FEEA044B7C8E686367E920F575AD585387358FFF41BCB212922791C
+7B0BD3BED7C6D8F3D9D52D0F181CD4D164E75851D04F64309D810A0DEA1E257B
+0D7633CEFE93FEF9D2FB7901453A46F8ACA007358D904E0189AE7B7221545085
+EDD3D5A3CEACD6023861F13C8A345A68115425E94B8FDCCEC1255454EC3E7A37
+404F6C00A3BCCF851B929D4FE66B6D8FD1C0C80130541609759F18EF07BCD133
+78CBC4A0D8A796A2574260C6A952CA73D9EB5C28356F5C90D1A59DC788762BFF
+A1B6F0614958D09751C0DB2309406F6B4489125B31C5DD365B2F140CB5E42CEE
+88BE11C7176E6BBC90D24E40956279FBDC9D89A6C4A1F4D27EC57F496602FBC4
+C854143903A53EF1188D117C49F8B6F2498B4698C25F2C5E8D8BD833206F88FC
+BD5B495EB993A26B6055BD0BBA2B3DDFD462C39E022D4A1760C845EA448DED88
+98C44BAAB85CD0423E00154C4741240EB3A2290B67144A4C80C88BE3D59AD760
+E553DAC4E8BA00B06398B1D0DFE96FB89449D4AE18CE8B27AFE75D2B84EFDB44
+143FD887F8FB364D000651912E40B0BAEDDA5AD57A3BC0E411E1AD908C77DCE3
+981985F98E258A9BB3A1B845FC4A21BCC54559E51BC0E6C22F0C38540F8C9490
+88A0E23EA504FA79F8960CC9D58611C519D3ACDC63FB2FBCAE6674357D7F2285
+4BCC9F54D3DA421D744D3A341DA3B494BB526C0734E1A8FC71501745399F7683
+FD17EC3044419A88C3979FD2ABA5B0130907B145A8462AAF0A9B511D2C8A7C7F
+347FF6AC057E6512902BFD2918E2CD31DE615F5D643764E900B60287670AE18F
+FDE15545D8BC69591A8CBBB275AFFC9B14BD68DF0AAB32268FB84844D4DBC7BB
+C591C1AC5102C50A9C7BAAA848DA88B0519F0F5F0813BF055CF0E3C86F633A04
+B779D2E8E656DB1E09A66A85FE21CA8BA5523F472A229E83F2C4E91ABA46C733
+F3C7B5775B06C97782BC225C46385BEBDC61572458EFC5CF4190AB7A9C1C92DA
+29F84BAACF552089195966E3AD9E57CC914D20B6962BE80429A16D4DF1ECAA66
+36C4343FADF0B2B48F12E2EB8443C4AA29D00949255F3968617F98B8ABD4CC12
+048B838EE243A21AC808BD295195E4AE9027005F52258BFCA915C8D9AED9A2C0
+80814F79CF943FBE3594C530A22A92E11BE80FCEC1684C4F56712D5846B0749C
+9B54A979B315222F209DEE72583B03093EC38F7C5B9F9BCB21DBE8EDDAE9BE8B
+75ACE6B12A31083AC8348EC84D1D29D2297A266284B7E9734E207DAF59A25F4E
+4AA38509E993C5394FED76E6A2F25462685C4C86C6E8CFC9863338EC1428BDFC
+74616BB1BC8948B0ED4C87C15B4405F3A7796F9DB3798FFFE8BD0A94E834817B
+D5E9812E308D0CC920470A6F2CD088FCB80462BF7CB3F039A7DF3DAF5B2B5355
+E083A385CD2EAF0FC181E40E96DD7E9AB9EF5C7E6866A13B8A54718E950FE097
+EF0951A357114F18CE9933D28B3A77AA71E3CE884661F13284BCED5D5FD1A86D
+543E588FF473DC2CF9A4DC312500135F29C2D0174B32018C8DBD40EF9A232883
+710A1F2AB2CD11312300ACDF789A9B7B93D2035D81D1C84984D92D78A53A00C6
+EDA94B24BBAC1AD17774A4E07E6F74ABD90415965616AD540C8ECD8C3A44EE4F
+7F4F6BB6238C5062D63FA59B7BF08BE93FAEA70A2AB08FBEAAF7DBF56B95FD93
+03CA406543BA6C9527D0DF01F5108D31A51778A5EB1C93F27B72B46146A353A2
+01CACBC829603B9989A87CF64528682CCBA0562A8165B185C58A5C6BB72F5E89
+500ACCAAB8ECEFBB2640E99EAEEC4EA979AA793D013D61D8ACF8784FF8D9398F
+F6A252A709324FB39509F0B3A4E725E82F53543383C6765BE556CC897C758208
+AA3AD37B0406E4A79F8F0A6C1983FC73E71CD858C0DB66ED66D5D992978614EE
+1EA91EBE191E082EBA1FC040AF19A2202575C2EBEB8058833E3520FA03D2F915
+85C1ED337E457B9FEEB0C6EF2735EFDA6E0D05FA641BCF698AC6B97751E8306C
+4DF00A39B8581FF53DB8F8525FDB196D85950906CCB59B8EF171349AA3B567B1
+6A00819947A995FB383C3C1709C9A2C113B2E40BB832B7D4A0FBA0B16A2C455F
+55809CC425C403E9668DC66BE45B71A81C332FD4DB279D22A2959962304A8F18
+085893DAC61317D24A8F198FDAB95F3B86F0AFD35047B868A9A17037A2829A02
+BAB042F75F349E197A7EED41984C2859754CAFD0251439921C248B463B516951
+2E1322C80D73F9CBCAA63A585450275AC2492E4D3FB78E800F788254DB5E610D
+CF788DF5C70FF99892BCDF16133E34B24B77C8F097F546B87C603DDB8998B66E
+BACB68BA27462AF54AA405682EC96D701F0D474DECD5F95CA2102DF639EB169E
+D518162C2BAE45FF698B6DE15FC6E7DE48C336C40A670FD26952A6BAB09115E1
+991F0073419F2CC2A1C08BE91096936AA0C37E4ED3CCCEE235476074B8FF1125
+6BDE3701F85532D8BB64CCC927CC335281C95EA689706F0AC717DC2CF680C754
+E5EFD7FA4BB8880B2B727A964C876D4A223069D4E6001771F0E23EAD2A4BBC80
+E76675297B2EF05F52BF4E71B3EE2BE3048CF088C79540113C66AE98B2FD3CB1
+B0741A215FD070882C52765009D7D711DAA2508F19AE7DDA15229A856AC49BC3
+4DDF40814FF96500E4B9B02D412E94623C5FDCC76C0FB8E42DF56A904FE49D65
+1DA7C53901B2EA71AB658A464D3ABDE27D9DB8D9E0B48F64E61A2495AD5D8DAB
+B5E72424AD017DF37964AF911BD7FA21A5EB4775DC8E95EF0C0EB856B00D89D7
+8172A1DE8530767D317B8256103E53CFB877E10686A04F5A08F8DC58D843DEBA
+FD5F40597588663D103689F6EB3EB14D06E18C8078F2538B43E712DF491FC5C6
+AF639256C8C6134B64D560D8476DEA6329D995E46CC4BC78841C59E73648B47E
+BFA7DE0846422F738454AE77E822A083405289247BD7C478BE4974F742CD6051
+E99FBB1D1B3FBABFEE855174734EE45E87D0AADF32B1283B911162A9955847FD
+38944D70584FAA6B1A7191C5C134B73F98EB632B69E2F0C0F94156787C34C8A3
+7622A029D58F9626B74F8A8A1F3803E0BC20E0EADEB1E99B70F1BD9F980FB751
+2A842843DE42EB142A84D5D3138629AE9EAF6F3479C423E8829C8816FA6EFA27
+DCE5580E65AA9854B1C64163DC318420CD993C15BFD76A8BA1182860A6B03D6D
+22B8CF43CFE6C8AB27C64842E239CAE707D3086BADDE1D7C94E3BC96319470D6
+8D26915C575CFDD03271D6BB9DE86A0EB6EEA6E768B224A626C62A9AB48A6EDB
+44F70BB5AF991CDF9736D65933E81CC57A78F623F33EC9AF535F2F25FA4EEC90
+D50DB7E87F31E971A75A33A301CA6013EEC5A4E179D695B33DADF2C98364434A
+42926776000B610E17524162253F6FA638D6581C18F99EA0BD1D2E24D2424ADF
+C05010D08192485153DD03930C7BF45237593E484F9851E6D464FA10FECA5D9E
+0C8CCC97DE029030900CDBB491C5CF226DBF903CFE7735D939C3FDF3A20B70CE
+66579B28B99313FEE914E295388C7BC8E055A2E54EA3A8206D3C8F4F7C0BA5E6
+E519419FD8CE215F7B8E9BEC604A9E3FE272A0328A24E31997C8A91E0946BCF1
+6943A97CBED2AB9FC636B49828BBB8B89E0BBC2653796431224895ABA5DAC41E
+1854BD9764E86147FD7624F736F40DE3B7582EDDFD15C2BDE3F22B5A54D7DF10
+B87A1301CE85CFC061689A890A321412A13314AE96DCD3EDA75035FDD8F4AB9B
+897A2C68263A68457032C469987970648BA2D88B1C5375DFEAA35A917B8A952E
+EE670427942AEDB3CB599C5746180E392837D371E15D860620ABDB6AA7772C40
+A5E346661673ACA530BE3D8E3FFB895E5DA3DC23B1B43C080C77F7E47847F0F3
+F3AA5CA9E4BF75FC5EBD18D19F21A7DAA3B11CABC6E4070A15F7DBC8B05EB6AA
+A02EF1B078EB66D61D6AFE41DA9B36FE7EC9EF94D1EA26282A9871E2CACB3126
+2AD49C2D9B50A6E47D8F2CCAD50992D1B430979A45FD9E76182A19964BB2A1F6
+51779A2B258DC1DF4C2F3074621286831F3848AC152DDD2BA561E6586ADA88D3
+598A2CE2CD048F027CE0008B828BD915887D7785341E8305DF2346ADB76BE99F
+87B02173BDC334E9221C8DF54114A6B24C1C5340299512FA6C8C51AB4C8778CE
+178CEF531C6D1B5FF0A1BE8EFF767F959BD4C345C52699A29A17B2A230842BF6
+4B011217D6D24EDAC3F6D53482786F1CA33169B90ECD499407D37CE9B70DDF78
+7B7547B32952535BA9ACD1E244447AE3FCED3AF28717083CF9590A09780984D6
+AF0743C82AE4FB3E2BB2856A4153A3967A023FFC35382D6C22D84A924900B6A6
+3DDD400E6D2418DA6C27F2FA34C075C902B89EBAE658B3C9A18EEE449DA5A379
+337DE95CB7AB3F0970CF1A5D8FAD8090E495570FDFB2FBBA79244780D8035547
+C5A55BB21A2270F724BF5D442CDC5BB9F09BE0CAE59B1C2270F0BDACE698F2C5
+DE8F66BFB9634904B161F5BA2B1950048300D69BABD312D58D89C4ED527AF7BA
+7DA2478EDC2CDEE3473DD8A8ED9D891CD1FC21F23013228BB3281B71FCE959BD
+6F8E9059D682A7FCC5265A0620992D4FA8D78377EB34CE3ECA070EE3707239BC
+98907DB0120CE42ABA32CF97127E28382BDDFD685674279F588D4F951216C355
+821361790F64C2CC720DE97E8ECB57326C43EE47367628E05769E106868B54F4
+C33C9951908DF6FC4F5ED2C7787BD8FA591BBB3E9C6C1DA94CC5E38D9B20C886
+7D237572FF46DD896A4D6163408EA6CEFAC398EE041EAE29D577E75326CA17A6
+B072D47A7B13EC441CE6DAA042ECD02134CBFA6809A435050413817193DAEB16
+A5882C8AEA44BCF36E74E9ECCDFE7E19FF5A5DD7A94E5AB4F8702C3DA7F42325
+23C808670A0490F5B373DADE40814FF9650241D3D69C91FBC5ECE728F827D9BF
+C928602E05477903449E079164CA39859C4BCA60C579F490AA455F82B5050BB3
+969AFB478E0D4A257B3356EA3CD62051FCE6C6B1929CFF85BFDF166BEF658E10
+3A55E007F38EBBB248B3F0B8ED1925106B499B762E45113AE1AC9DE09644C84B
+9C08034B297314EE69BC32DB6E7D7FB9913CE5AC17E7335979E9DCCE2BAB3725
+1976155551F9706A576FE0E3ADCCF72C87683291528ECB749CB0ED291966E239
+B5E3630676BD409E08F85BC1AEC9A2D4135376284A96EA24431243BD6FE8B966
+95F11A4BB53F392E0AEFEA623064FF8A7002367B0A515635CB2D2DDFB9B4A8D7
+FE721754E81BBA548848A235B91AD4E4F7DB19CCE2F61D277FC00AB956EB93BE
+44AB4970CA56BF59506C94ED160FB1E25D3DF2988A532BDB787BFB8539D22986
+FDC378AC31444E63C4727FEE121A43751043849E6DCAC5B59D0FC703AAFBBFD4
+E8B7C268F21615AD02CE9DABEFA27B5FE6A6441B619539CAB1F810F1263447AA
+633F5DAF483752EF1A0421740E3A811D2D2898CBF53E7F686C9223FD7235F02D
+6F90D2D48CC20AB87778DE3C6FB335E0F0EC20B5DC5B65223FE117526DE2C72F
+FE839DF93CB2A7D66CD900CB325F891E311BEC932F703FB4FEFA29DB8B9C88DD
+375EC71B3D58C7BC59ADA91971A3BDA1ADEA629CE6CC92BD542CDDFAA7706FB2
+6CDDE2DF07E56D6741916AE8E8744339816F3E6C38062747AA9FDA2A2678A6B7
+EFEA870AA3A4D71B25EE3013EAB1DBA34401B867C7A41AE51E0421D41D3BB83C
+E120C8FEABA6E5DEC53A689C21426D4BBCB68CB37568761C360E6D4E3596FB7D
+F4DEC7918E58C0293D12D6DDA7E9DCDAAD7C939F55CD1BC4A228B31E9A904156
+DA6B40B08E6ACE674618B768DD681C772A3E55FE096CF949CF3B0460ABDCD891
+D17B37B355B29AB5137899C036F31DA026244FA25FB798FBE5105BDA29F46538
+D3D3AC1001A7BCECE64DE94FFE6C354166A0F97256137BDFA07F6E22A3D1D2F4
+9588DBAE95E895BC5E64DDCBBAA8D0A22C229B42CB717FC711E7E9DF793DF80B
+9F14754585A3C7E17F37B32924B9F9870DA8635E3E18BD1DCD81EDF01834D9C6
+B33F23C956C2FCBFA47D84422F583459D827D1E120B97694D12F1F54D02379C0
+D288F7104F3FFCF4F76E3494F4ACBD1BE3A15543CC680924C78A473F8E311ADF
+8FE00A04C6C393DE61AD3EDA5BC031E2353076A2489391B52632387CA28A7B93
+FBB065A6EF3658AE80B1ADA47E9B2539E73A71FA75645F85ED8ECC257FB4CF26
+B6C912DE9D0F9899E70BECCB934AD32CF49A093371A9F73DE6255EBC39DE1E7F
+00D0CBDABD4D0383977E694890E71FBE5C376BE5F3A80C28987417504F515C50
+909F3D31178BB9B1D085BE514F71B910A9085BD6122DDC72A150BFE266920E49
+5661BCB4BAB51D6DEFE32B616963DBD989FCDD1637B294CE4E288655FBEFA1BF
+7F25BBF8CF17C2D5FD161A7C2CC9CC7490D9BF15A1D35B3BFA43ADE256E88BDA
+BD490D92907C57BAC408A575EC84D6AEE070148C7C9A91C03B09FDBD792E8FF0
+C0B886AAD2EDD86541E5E579359D40E3AC312ACD3D8FD49F71BD533DDF8859B1
+BAF17F1884E331DD07CEEF93B71D492AEBAADF7A263450A7A72210CE630A0D37
+BF024BDC09ACC882816B8C22C62AE38A3A8D0F6EBC2B1B2C0B8161A8B076DD5D
+4B779C0788546BB4CF57332230D237856B00D79C28A7C01D11F44B7304F69075
+94B97A745DA43D1BE561372CE611C345A843834E46AD9DDB16CABCD3FA33D6F1
+F6B5C0497F5EE5400B305CDC16A7EC286AA4D45D0EEBB9DA06AC9C5294D68EC9
+E4DC3CA2B92CE8FC0526184A86EDC7AB34D67E60AC12D9CA8FD300235EC968BA
+92C6FBDA47572BC5600F25249F60AD287CBDAE980E747FCBE7EE5CD323E733F0
+63553B494D3DDEB9CC1480B5C3BB79A28E419AA65B18CB297AB383419E890E2A
+CE6F98C9900CCB4675280A10CF060B8D220DDA1BE55DFA65715EABCC1AFAA271
+B1F8732341613E17B231231A0D24D4D7FC198AE04D89A99C4536217769C6FBD9
+5EE24A6302F97438F7C0E311C878F674B4477A5ADA3952CDE4055AC408B8174E
+86F8FB797646DFFFE0ECA25D1BAB9A9F71F3926D3D85AA63E7A8C931D71E79E0
+AF1EAC26FADE468F4FF7F3861D14C10E3BE1F9EAFD6D3A544E8108D5DAB5B180
+3950C74818BC8AF4758A108F462EF1826647A49667F5E482038C54716856D9BC
+35F29922846D2148F92F943E951D7438C73D6A60459A8003174036C64E1629CD
+155D47FD04B03C023AD67CD5A70C98AB556EEAB8C48169706E5B352F6505D580
+AC945171BFE62E81F8F500438AC3B64D857BA5BC54C2C4BBB237F8FA51296255
+E66A92A61FE13FDE781D393557EB72CEBAD86511035F775FAC39A0479CCD400F
+226709118F887F47CC2ECC8F79816D4A945B2845F50AFD62D8C9A9BBF4739496
+9E644BC9F7B04803B7EE75A09EAE94365F6F374B4FCEB0B506C76297564B9B6B
+8B812BC3A33929AA94692572B010E6210AEAA312BDFC88BF302244AB9D587A9B
+919823FD01DE12438D960944D1977800FEB49E638C32E5B188B1CA033E0C37EE
+A142F746367888AA119535F0CCAF7EAA461B790EB089D2D6962E28A398439BB7
+9C9943654D7A2D765B46BC0DD1F915327F369162E1BA1BA83110B93F442905E0
+523BFF5E279508A98568CD5CFD18FABBE9D17265A9081E7BF64155A2CE3C0DF7
+88D00671AD65654709589BAD7EA65BBA811387ABA5CA0BC3F66D3D48597A0D1D
+2C268375DF47CCF62166262AE4840AB03BF49BE67A05EF66328EC729F03CA5FF
+AD3937FC053E223303565DC771ACF32E63DFB96D5030E787961D72D02C195C66
+B48E9AF0309DC169CFE8D16E2818DA94693A18F027DEA0D916672480464F7E22
+CA6E431FE38D3FC019BDD229E064B72C545C61C6EA55984565CCA88ACB01F744
+3B4593CC894009AAE9A490E3B99E03E117A041A381B8DACFFF20F6E5F293B58B
+0FAA86F132B8B59D102722B3E98E12F11EBC101AAE666271C93B6F7CF1AFE94B
+5826703D754B09055EBE0A53E46EF9829C7181974A374E6AD658B17D89EB88D1
+A80EF734BE6F686CCA917AA3AEF80A216B5E13C3626F2BE0093D2826CE4B3C25
+90E3189335FC4F3BDAA0F15652CF8B32364DEE4C7FE174CA2219BF865BE7DB62
+490D6C0BE2B1D2B889C0E1DAE9FC29B43AAA9C6A111C603B0ACF2AC6A7223A8A
+3F13D96291D22B09F4D89777
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+%%BeginFont: CMMI7
+%!PS-AdobeFont-1.0: CMMI7 003.002
+%%Title: CMMI7
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMMI7.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMMI7 known{/CMMI7 findfont dup/UniqueID known{dup
+/UniqueID get 5087382 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMMI7 def
+/FontBBox {-1 -250 1171 750 }readonly def
+/PaintType 0 def
+/FontInfo 10 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMMI7.) readonly def
+/FullName (CMMI7) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+/ascent 750 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 116 /t put
+dup 120 /x put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3C05EF98F858322DCEA45E0874C5
+45D25FE192539D9CDA4BAA46D9C431465E6ABF4E4271F89EDED7F37BE4B31FB4
+7934F62D1F46E8671F6290D6FFF601D4937BF71C22D60FB800A15796421E3AA7
+72C500501D8B10C0093F6467C553250F7C27B2C3D893772614A846374A85BC4E
+BEC0B0A89C4C161C3956ECE25274B962C854E535F418279FE26D8F83E38C5C89
+974E9A224B3CBEF90A9277AF10E0C7CAC8DC11C41DC18B814A7682E5F0248674
+11453BC81C443407AF41AF8A831A85A700CFC65E2181BCBFBBAAB71645535A2B
+6F0F22458E1429F4A67307E01F0BCF6F337E0E2AD89658D880B04C26306F8179
+C8121B958459B923AC3B05B594D8AB95F75870019130442FD29578D44F5690BC
+7281357A5041C8A809A59D0DEE108E2A07D406656BC74A9F3317CB887E712318
+46B2ECAA341F8692ACC2D14ABABDFBCAC6F35858355F1D3228B0223EC73AC56F
+3C987464DB829F243E304F4C59CDE3EF6EB53A4EF9BA91510CB89A3407261F58
+A2AE66880BA98FC1EF546112892494C85A2C39F9DCCAC5766725894A7AA148E9
+42360AE64BF3A4F1F9F0A0D0C1AAFDC4D50C52233AA595B7D0CE557D4A010D86
+6E6B76A7E9523E8A6633DA9348BC3F59302F72F492A30782AE7EF220516893D3
+DE836CDE311DED9262AF01C506040541EE84AAC539B404B23033EF56D4BCE6BE
+B05F79CD633FE75C6728114D2749E39FD7454050F67763AB636377BA8E1867C3
+996C7D7D4A4A02BC49D1AD7FF174C1F49F1F205BC9D5AE42BCB02CF8554E8F5A
+D1876C9285B6CCD7B8C165F75843B0AA11D8462B57077AFE75BAD086E9D9F91E
+30ACFF91776132F3CACAD1CA5E08B17B36A0E45ACBAC52393B9AF9089BD821D9
+CD5A9CD9BECA59F7445D63DECC1B4502D299DB85B6E2EE7C69A1DAB91E22A3A5
+89B524FA20AF6005E7A586B90A2C6E5A93C9EFA4ABEF5F7E4C7B81363FE8D2B3
+0AD637FA863DE787581ADD7CBE463F7866C40F4E280260ED0E9C8453E5C7E668
+FFF058B9742DD3F131C264F8FA102CD0DA05F3114D13D34D422799181453FE23
+2FC6EFB01BE420C930B879D671F3DFB036197874725220644A5A52DFB467BB75
+8089E4F40CE9401777B9FE1D0AEE02E782A6EB2A185A454AE9394094CDFE7CFA
+C03C23A78EAF242E4F811E4C83B59EF4DC5ACE4AD37B41616B46C263358710B2
+6137314545CA6CE89119B42A3518EC85C68DC07D26839C68B1FF55C4A9CD518B
+A1FB32F9C475BB6110839FCCB94156E7B3648F27245A00D2966FC4DDE3996BFA
+F463A663CB6935B596B1582ED0ABBC648AAA8A86068BF0038001C753C8BAFA0D
+2058041DFA720B528E2D4B16196DB1CF30C779D3F4800FE662D5B60B208341F2
+A66EFCB8448C2FCD12DF0DD899911A8BD96C9B670054D328790E5D388518B146
+8CE92E368EB1DB3CAAFCA4834CC9D9D9DCC80FB1F34F39DACDE643052C977A7E
+A95C5FA8DFED9B4DCE769E4E46256D6DA8FB18FD7FA4E4CED5D486803538F3B4
+6D3F5B3C03184F5C26C66DBB4C724918EBB6A89C4602E4EDDA81EEE2BD18B683
+FDB459F2CE0A9CED23DC208EAA8BEDB304B00E093DEE926A7B32FDB2EC70DD85
+94B9137856DDDABB402B2C76DBA87149051ADC6007018EBDD571BE1D092EBD95
+76D4E063AD7D5F62E6C26EDB88D38678F2806A1F4900B0ABC4ED034A818119A4
+E618F1A902315BC98F26775E59555A3DCEA1D0F8B20A9084920ECBE3F7F245AC
+1182A40B518B194669D95DE968542BFF80FDC89669BC256C44CB66A2AB8CD7A9
+E42C69956CCB6BDE8C09AD22EF3196939B3B84EB23A6E071A36D702909E019FF
+058F27562441EB5CAE87A4407F67C4390810BE89BBE867D636468E73677B84C8
+5A1228DD7DC8EADA221B1BAD5F43E832F20ADE7ADBFF170AB306F5B711816FD1
+39B7882556E30F002977FB88D8B28826A75DE0D20354A2D41F2DA8578376F7DD
+F27B0F59D4DDDF5790E11E3957491DC74EEB7625CA49FAD90FA47AD8E0BDE824
+FF326A84846A47A21B70FA549BEE307F9C6970009F963B49A504F0115777826F
+1D81203F655C242FFF15BA97E3BDDFBF435B10E74CE8543C98966223818839B3
+6BF3BC63F882B0AD0FDACA8C56A570277952E1D83F18BEDF084D2AC004E2B09D
+70DE1740D7D220E92B54D2FD0DDEAF1E08C41FD321A8D474982DD105B23166A7
+AA9E0129DC88065B1E0F9382BEB4B4E1DAAE3EA5489BDCA921AD5A8175F2841F
+9400478DFA99C5E5553F383882664D73FBDFA29BF32E52C28DCE80DAF4839434
+022FA515679DBC13FE98968D2894DF5DD69C49BD23D00F5D858B69D1F220F968
+F0700E13873579B3CFB658972098DC61F1DD580105BC27795DB4AF11A871CCD6
+2E1B9AF7F0DAAD4CE315379A7B42CECB983DAC5A2B9426B4E5E0A7F7978504C1
+DD7E30063AE3CBDFB24EA2BCCDC478AB82084FD30A4793F4707D9F8F9647B413
+F8A5C5AC6D5EA0E35628CE1096A434FB8286F4617CB4D0AD30A4A0B255A5A356
+25AA5A947FD3C4FA44B4AA80BAB44C48CC1E2C6D0A711365A37A58C3483D07ED
+301A83D2650A2E8CBA9EE62FF5C2736EC82C1402959F64527F9B640619F112D9
+8E0F4A8A3078C72ACF3F34AD855AA4008C96E30D9E8C414607C34E06E29AC5B9
+2EE5DDB823E8C3EEE6A8DE228313D476A7F39B5DFBFBDEDDF7C45C1C88EE6D01
+7FB4F7BB2CBBD5DF7F0CBD98DC287FA6940FBFE1B3B136613A3CF16634CA7B90
+53D5FD5776515EFF5D37F8FCC62D8BEC8EE2216503D54D6F2032D3C2BF861E15
+FD1B45B71576F15852EEA65DD372E911EF4CC18283CD2FF4196A3F1A9D81137F
+F1820EC604D6C61AF318C6C5AB6DA1EDF305CADEF7CC0183B86D31310A09972C
+A4BC37D110C77ECCA614D1A281EE1C2040B4A5ECB31A3FC61760F608E44332D1
+D2C53C7891B505A3020E9E4915F3618588FCEC80B9ECC5E637D8D0F3C94B1F2A
+C53FC46CAE0AFAA7E12266C212A73AAE60199752C042BD55A5DF1CD07FBDB830
+C83E7832D8554AD9C9CAEEC7CED1DAEE622090897641CF2E5B34A353D83264D4
+4687522DB290D3BA927BA315EA5D25B0D7B69350C6C180AB0C322B05E01F7C7D
+F2F48651567F0C1B49AF3950E43C94D78F7B184BF2946B924BC4279AED28F3A0
+17A7D8B235698A516D3FB5DF0B18A422B2410C385E7E9439C6D60917EB3299AD
+E31471616251FA40C9FA098109BB31A54D9C03B2F12947E4E9252A0851B81C4D
+F39E7FC44752504B589C3911571B1D3EC3BD1E1807F99CED1DB20270E483A805
+CA2A016E7283550D1B1D35C226FAB63F983CED41A4D02A2F228FA9EF065027B3
+CC69D6F2E278C0A2D238D3A37154B0D22281F62C61D9182A69657B027BBDED64
+11E261E47620602F865221A534C5A32E2BF5B93A187911A146F2E96538B47DBB
+7BFA7EF406FE940F4DAD17E6E4B80C4F031D71F65657C2F5C8233EEAC68DE8A7
+E1FC3055C122C1795D0C71A0284F89A9BF04837F61C9E08DB42644A490C97D34
+A5D3CEE475B8D578205005A0D68AF94AD27C0E855BB8EDB74775690A4EDD6543
+BCC10CF13283D6FA8A7CF3FE6C4F96470A11FF0B0160D3F9816B13B0BAE0D8F9
+B84C7631063FE658D13D108D6FE24A89799FABA72E6A6D1C943922CBE676C1B6
+11A4106ECB4F1A7F8A84B2783C2E6A109C58D63FC0B74D8C8A1CB62D527441AE
+E656D94B1AA8581B4F07B653ED6486AAE1F8ADB30FA8D8914AF24721C74B0908
+D84F2EBB91144ED4BD7EF533F2584048DEE37E17CDE5FBC2992A6F924FEBAF07
+B626F988599DECDAB43C931CFECF99FC6EBB72F8E542765C26295902DFF60B7C
+7B9ADDB4858BC9D808B7F0909690CF8DFBC59A786D48B891937C31A219842A43
+234425B4963062DB4C4E9F534C77F4243408805B5A6B8BBF428632CA4AC03A7A
+E336DD181CE0CF3E742079E2919EAFABE16A63299771BF276EFA8D85C920F995
+5B9D4E8F1ADFCC5C29AA89BF90C186C5DE7679906B2FD4DB279D245D27D08837
+D3A8D541FE37415B706EC585C05804108C1D938E543B8B63E275EE85CE9DD843
+0A8B9163144B77DA1A552A25D5E77E94F29CF252BE9950F4E627D5F72536B6F3
+3278D4A45D10759F16AE42BAE8460865FEE84537F8EC9BF4813570E883B826FD
+1ABF3F4E66DB6FEF8366E07BCF290EA67D39C9D81B2A7EA48E0A228FE3D5AA50
+1A56CCBF229C9AF2537A8FA70EEF41096ACED34CC7BEECA4EA1F23B39FBC39D8
+CCEA93E63F508CBE6722C11467A3D0D5C4C52031DE43C449333E4295104651CE
+E13B821D7904653346067E971BE0042C571ABF40C3A1079A675FE4264B784D46
+1B8FAA4CDE9851C4EBF69ADF51A7B68CC8706C08D13A44909D4C1D78DB0E0B2D
+0E0318304B229DD2FDC968027CDFF65722059C62154304D6F9C3F06DE22914EE
+928B7D1BF1FC7E74B4D882998D59BC086AA2D4EAD0AE39F6B75B5A3FB9994506
+E21731E1A15F0F2D12F88724BA72898197A80FDAC00243A3038871EBD2F2BAB1
+C616278BB78490CB86F552CBE5DD0862F3793D72C68AC16AF8E38FE1A523A5FA
+9B0428745B1455671CFA1F6BFBCCF9CA23C833113C2948E7A6AEFFF1A83509FF
+C559BB5EE7F92BB43F7F37A371E661C826F63DD0C1B25E34A8119E71EC82FB66
+23C7B126FB6554E7560B1B69F2EDBB742F3B20D1648C151C37A8570CBD330A9E
+7592A8607D2D727F3AAA0FF2057DF4E2A4C7D3B658C6CED38824A770420D89E7
+F6AD385DBCE9C9A9095CF0042052A67AB804A6675BB9373A99390CBDFB715984
+A069DE543E4C6ADD7F1EC7A15392EF834EAB4584679A43443953427DB13E6959
+0F2F5061C99C6D00FA5327FDB5330AEDE19A53DE3AE092634DC6AEEAF63A5BED
+990F8A117AEB1CA0E7F7DBE02CB3D86465F1613B976D1CF6F3A1E69740A2FDC8
+062ACC45EDA6B863B60015F276860FB79C31D28F97A799568E66D0A8757B2C41
+E939337B467303041D0F4C59390B2E41E5F298F275DCC699D27C459ED4D5ADBD
+02539F00095D7E1872862142B46BE06513D3EB1A406E6BAA64BE795122100F09
+C37E5D1834218EC1D11B031C7DFC9F5AB071A8F4DC08203821366959E9191D4B
+289682D915AF28CE5858F83338DC51B6B0DD052A181D9133FBA50CF18F70EE65
+C33726A0450EBA9D0E0C3662AF6C2121AB7911AA9880D6BB6811D6D7515888E7
+199A0E632104059A88C9D85B19BB35EDF4AB95E1515BB2339572928BD5FE8CBD
+2D4DAF55DCFE29FBC4C3D56336277BA0C9A889A129F9FA7052AD1420B8705163
+1A808EC1284C888D78CEA2B4BAB71AD76289F5F4986008FA9BF328E8537E6C91
+E11DBDD8447E1C9ACE18DB0EC3D5742C264C8EFA445C5D16C2930FB43669774F
+A2CA52144D99EFA8FC427DB4128CD4C036A8C611B087335C780740FAA419D39B
+5DD68EA89C95275F9254D947EB3683D0130255269B10C6CFF29EA0BE484C9949
+96188FCB747618A8044E2E37DFFD2DB8ABB621B34DC024259340677095B6937A
+78EDCF508AC91D4CEFD872AD73F50582DC8807143CEB9F109C84DC5DA30B64E2
+E56DE973088A9D32583D6946DB4F3523902FB1781D993B89D5F56D79D5D98CC1
+7FEE73FC3A7D1BCCE90179AE450829E228B4DEAD3B2B4C79A400CFF899AB26F9
+048B0875EBC871AD23BA96F88CDA8B87FE5809A13889A6AC349ABB25E54ACAA9
+C213C5DE2D01BCB9CC0D7BBD384D23AE12E289FF8FDF1F611F5E14D4B20B15A3
+42D9B3B37A83A9CA39B5DB6C8316C51B70F211530A56CFE54D63E88169CF5233
+D1A7B2388025B3EBD2BEE0716C3A2D589EBC7A42B3DA602AC4E2FD9C9052C922
+711E44408DEEA1FE0C9FD50A39AD46D437F61F284A2EFD42EF158EDD71A1486D
+4865D6B5E20E60F4F4FC3D646909FF1EE2D7573665E4CD8340A1B232CAC0202C
+C35BA9BB3D2267C7E78518F6711633F888EBEF72DC750AC2CB362D528CFC8B2E
+A1AE1C05456F50EED8CAA768DEF47FF85C4322F02D7F9D188C6F285C674EF589
+251B0B913339FD701FDB281338D96704ED7ED908BC113B4275A24D058955890B
+12CCDD5572D63688426B0E1E9A40D6AAECFA5555C1CF9DBEF8C04CE1E5A63F14
+969D39B6DAE8A91F6AF4CD1E2DA89A4661DA34E272B6032C442C031F081F5DF5
+858F4620885773D8A2B2F5EB6DDA74C1408DF279900450E4A3E80BA9A9B1295E
+F24EDC3F6EFD81A741EF74B0202820516C4FB720687BDD915EB2396128C3B262
+20E3075DA153D6FD36E1C05B855929DAA4DE694B6F15EF2145C63250B24B031A
+4CF0AFDB225E91D99828B83BD90F1702D3906D45872587A3A116B138AD9627CE
+E778A949C392202823C670FDBC56F1896FFFFBCF52C4B400F67BA36B5FCE44A5
+F18EEB8ADFC088C99DFF8E0A593E81A5ACA2E3693005F723C7D3E0AE2BDD3805
+8C6007A00542DEB2539709558A88B21003CE4B2C7817AF207ED576B25A41DEA0
+FC55A459BEB00ADB01309B35920F04F84B7B64F95AA99EBCB843A06CED900D99
+97BEFD7CCB9F4D85876F10160C8D63E2FDE82B7A8D945F37CC9933ABE0FD1D76
+268296B1A5AB06B2E814691128771694224781171DC6266BCC290FCE1AB59416
+85530368115BABD4F1DE45952918D1945D51EB713C283DAE8EDD559F437CD886
+A4B1DA6120D685C284673A3EE489FC1AE4297A3623B339B7D886B6B4B8F9F4A3
+7BF85E320A52FDC6323B51879B98A14C33C567BC069D9B44616514EE1BE36F90
+EC5FA33E1B6B0A46945D876EF0085E74935DF2560A03321861A752E59742B9FC
+5C501FBC64BFB1602459885B63873DC857ED37F8BE1A9C6E9517B9BF5A6161BD
+DEB6DB0381FFB34A8A96AB4AD48BEC40D4C198ABC599C3758AFF638AA75BBDA4
+8545D5F95FA426FB25587301A43E176F6CED7851E815AD907F2443E70740DD2D
+4FBD5D978B9B37F59D6DCF0ADD0F90825DD23558FCB858513602C8BC82BFA383
+7AA6DCEA4009961D06DF233C5381A7F9541259926446B2F03664BC5978A1B6CD
+EA6EBC9FE6100A65959513EEE32E69D47B55BAF30A893D77142F943982019C01
+715CE29923795EA01C58A798979939B507C5B29A32881877EF7EF0C5CB3DE591
+6B9A6C3F3FFA847F396A396F078860B59850BA4CA3115CA2376AEE6B30C05DC1
+6F9DB6781ED0F9D45D10E096C33B1B7CD12A9D57C6E49AD833C4B093DC82811F
+16B3BD902BE764A1680831EC5A6C1CED84AE0DC0A65678EA5270BF20931E6409
+7AA44EACB22CCA11098F8A51096BE83A1ABA56C9EED4195D5CCF24FDAD92E823
+C439DAAFBFD652157D728F2754F28304710D3CB33763156D76A259D446647A11
+493FAC70DD28063A4CDDA162F72542368E1AC2826C4BFF7109208F66371910C1
+068F21779FC39DE03AECF1C9FB2F417930C22791961D801284DCC89B0833B6A8
+D63F153ACBFB7B7D547924613BBCCAED37D90BAC5B0264ED31C7B9DA5A2BC620
+9B20CA48424D0FF58905BCD6190BF4B5FC6ECCA1BCEF13426920197CAB41C4E6
+E82E8EE7BCB23C6BA6F8B58001533B225ED721D6CE3D6E89116EC33CAA6E905A
+649F8C6A1AA187A48E20DB864596481976216DB78F0F57543DFAE3CDC0A6FC77
+2CAA49442527A5D94DC54BE93C875690CBE52EAA4EDD9F2A511361BC0F0807EE
+96AD0D26B62D809E82EC14EDB158EF48A748A6FE0C3A7EE5D4479B35425F35AD
+3EC7444F6FA75CEA5011AD571078293448A33C7647611CAEE87974B0A756DAC9
+4E1BA78DEE477FA59AD50BF5C52E068A5E044A4A4994D5B24CC5045F768A3C51
+D4F65E2A5AFD271A7666C6835E28C60751EE528C0742433165AFBE71562A3016
+F59676D56B0B5F7E4984D664BC3ADDAF24B4205752EE21D4B57057A943018466
+09C3FA5D2C5BCBFC22A643586BC9E7A965DC34C0A7D76A470B0602AE45106417
+0701ACD2C764DDE218B924E38B5A13CB82678372E743A8B3CC300BCBBB878978
+D9847F0640A031D5E76B5AD07699C3B2FC6C1DBBF79938BA649C152FFB2B5BBA
+D18B9570670B99907506494F362B124790A17D4F415D8447ECF70B67DBD46643
+91AD465A1852B804CBE65206EAAA38FFD2B4180AF00DBC62903A5E59ED93861B
+243B7A845469B9DC5E291C87011BB364ABF5FD618EDF8B9BB56654C1B8F9DE4C
+AAC5765BA2A249922863896E706D9DA2C2E4142ECCF3DC9F987AEADFDD401062
+31B6BBFE003A9CB49060506BA4EEB10B2AD453994CB13DBBE235F4AEF3EC5932
+56609E7975C2F2167CAF1E099A38128884D1E33AEEB94C6100E1D7E69C28BA96
+A99580199238E4480C94CFEF8A3F1EB41F376C83809D815905FAA7B94F42F905
+E1C0E77ADB73A70D220167038B1E62A1890728DD0994FA5A93980B445D980FBF
+7F66502B46F103BAD307528DF531938C754C57170F5342D00EBB933DB8D77759
+F0532A40F170B7DA29754551F61221DA3940AAD36488877127DE46DC61ADBD0D
+7BFE2746B21F40B526E56AB6135D2D23884855E1C146FBD00FD8CCEFD4E04C01
+043029291F12192EC2CCC7332ABF093037B65FFA6582B5D24108C276C6647423
+000BF48F1BF750F9D9ECB010D6D4155F1DFCBA208F316CBF9C936F84CEEE0020
+DE8DF99AC22146D6C9300E2ED3E9788BF2E2C7538066A658C5094011636D06C6
+5A725A6709BA11330B2346E5594CF7595E955966D5874AD581E6F0559ECABBB5
+B343140964953F4C3F372D27246DFC048E6216EFA3E53EB06FDB60AE5F5F40B4
+AB46C9FEAB4BBCE471A2F6F3436BBEE2E0F649FCE18349683D98D95FA47F7229
+94F4F16CB805AB393329A7463E88864037115426083D4BAF6B5135
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+%%BeginFont: CMEX10
+%!PS-AdobeFont-1.0: CMEX10 003.002
+%%Title: CMEX10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMEX10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMEX10 known{/CMEX10 findfont dup/UniqueID known{dup
+/UniqueID get 5092766 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMEX10 def
+/FontBBox {-24 -2960 1454 772 }readonly def
+/PaintType 0 def
+/FontInfo 9 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMEX10.) readonly def
+/FullName (CMEX10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle 0 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 82 /integraltext put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3DD325E55798292D7BD972BD75FA
+0E079529AF9C82DF72F64195C9C210DCE34528F540DA1FFD7BEBB9B40787BA93
+51BBFB7CFC5F9152D1E5BB0AD8D016C6CFA4EB41B3C51D091C2D5440E67CFD71
+7C56816B03B901BF4A25A07175380E50A213F877C44778B3C5AADBCC86D6E551
+E6AF364B0BFCAAD22D8D558C5C81A7D425A1629DD5182206742D1D082A12F078
+0FD4F5F6D3129FCFFF1F4A912B0A7DEC8D33A57B5AE0328EF9D57ADDAC543273
+C01924195A181D03F5054A93B71E5065F8D92FE23E7BC2A6E71BCF95FF3DA948
+1A27320759222BD7BC7C1A533E90058824F06942F0234C68671083E0E4708398
+D246C94F9C16DAB6563651BA33D86273FD2DB3C50C106F3CA95B1C79778D0BEB
+B99D9CFB38E41BDCB4261A86A23E2CDEE4837D9B6F0E85ACEAA984C344A63709
+EA35B61F08821338D363D172BD185A3658F43052AE1E61D879C99DED7F6D726E
+FAFEBD881BDDEA91FB09DB75675FC74AA2BEA8771027C7A51BF849F8E765B870
+8F7CC0871F301ADEF9B71EC3C607B2F51325AA5B3DD74A2C5426E7B329FAE84E
+94A159C8C9C35E27A0FC93FB98A4D616750DAD50068A5F0EB96B8228946E5CC6
+B69E93D262C92E3BC7161313156E380A2ABE27BE400A23DF95E65A4F76B3FFE4
+CF3CD141B006C487EBC73A5A101466D4388FB2CF1D9439D0714720BB58537B7D
+B3EE1F04AE117222CA5F0E5942F7A875D55D91D63958B1A02405D9DE08109B8C
+7104F2D109EF7074852DFD74CBE02E0F3704F2BACA14E05EB1D0D9021EFAC23F
+76C2389F8EA237D2E2AB6AFA83A725E16AECCAF025E05F1B1B5699D761F62A46
+EC6F31B0FE4769BD0D66821592ADBAEFA9EB454CF1402FE870F5F96D09980C1B
+8B6D2FE88BE56032C1959E6C3DC319B6A7353F3AC629CE5BCB947B4B235426E9
+4769302817AEC1ADF50E50265AB488017634AF824D44D3C8423FC7CAD97F6D6E
+6B34313637687FBDE3BDF6FC951CB41277D8EF49D14767B59656D214C9724DC4
+0523EF896F4E48434FCC5D8423F07194C54D48C62AC29001B10C9C8B514B24C5
+CEB60FF68D36749711E108DBB52738760FCF6571D5B04E58F24CC0247834B412
+D0F6F8D7F1573F23E3E399D5A3A3A37FCFFEAFA044A5694D2458EFF2BC1F7650
+8FB0A27C505A20C16776EDF94BEF9DF702F3C64DBC1939BEC0399B6AB283F832
+DD8FB358F701CC075C596FA7B0ED7A9304DC73274C8169337D55124CB748CE26
+A635B2704D8F65E23CC0FDA3C57ED451F8FDE7B6FBFCE2746F5AEA11B065A6DC
+C3D200D962A034DD6757991BA62D8DC0408F49083D48799B6097B61343365A5B
+30FB02E9CDFB5104FB751BE8A268EE55C1208DD8B29D5635014EDE9D0D94BB64
+ED5643B3049027925BF2FD7EFCB631E01269B731AE12AA6226B2656F035C7E92
+959C4A21BE40D7C138C8FF28C9FD4B768CF25F08859AE84FEE6EA18C033B3659
+D9EE250BA5FF2568E8BF7684A93BED7852251D1ADE5DB815AF3AAC36D1A500C9
+41D1BF3A1926828CD1F9E501ABE441A07B1B96612CF0728AD5FECF7480421F46
+0B18E06D2FF1A5B1183459C59517976474698BCE18A728515CD489A83C001AFA
+47BDA929F60D0FABCD8786AE16EE18615C37D18703571936A365D334BACA9BA3
+08E2523132887B5EE95ABCE8581C78C3E858DBF35ADD56A1F6C2489AFA73D1B2
+379C5064DAFD30FDA84581FDE268B470636EE35F21648955513714F6EAA08AF0
+249C937721DB0E93D95C4DDDFB0948051953F39C6D2D811D3FFDC25F786E072B
+2A8A1F4830F9CFC34666A1D3F13268980E9A26682CAB64817318A1E266F3D2D2
+DE4EBB3EDAF0E7B526C838CBD7F37E74A35B1C3EB96DA4099DE689A53970D4CB
+9AB355E93EB294B07DD09356C338BB4A61C147BEDC152E58DC92FA69846E4829
+551A5330006793CD88523F7B3AF7B4475C531C67A4B66A603597EE72C4ADA491
+BF13706F341125CABF37FADA554FDA0BA5534C7AC35F1829E250C885D9A9983C
+5D1FE8CE24458A8B13E5C7EA22BF1608AFA96B83C700889A2A6C9C4052DCB892
+6CAEEAA9E7D7F3E215019719B36A5DAFCCF2396FA0C04AD99A7C23772A7BAA64
+D1FABE8E476EAE9FC1A3E08CD6D1DDC6E087934E676BDFD1528652B6B9A50A35
+2029466364300AF4CA3C5883F6293A7104617D0858B3E43D43752F814654A938
+A44C33410BA0E5EA7BF55D4F1D57E27921DB05C059DE29BAC1BFC9B607D2C5CB
+1DDC47793984FBB18BD99E1DF7776B563A55E15DF024D6D8E6ADF62F16F602A6
+7DDE1C68637672AA9C7A1250161502ADDDC1B4F6011A9BD5605B73AEDC37CE4E
+4467C838B7692C4D541EF87DB41123F9DCCFFA971553A5D9B0E7EC539A28750C
+8554383585CD8B93DF731A301D85BA9ADC95B4A3A237794C30230A82300B6756
+AE5A46A090958109C5565EF60B0B16D6C0A16A56644B05D3371DABBB67ED9BB8
+9BD3983575D371419C7568B2556649402AFB9843106729E4EA87B3F9038218A1
+F820B098A1271E330708432567297CCDA332B555A40C62BAEB16330175D28AA6
+13AE6939CEFA2334E3E890B66A73277F0B63B1FA59F856ABECC5FC0A50571F5B
+0747FA554F5FC72A51E215304B2E44701A13E41D91397B204C66AAB3D101004C
+7FEF2D87DA558EA057BD492CD6EF93601CB63F78426B502CDC5C8E9EF4FF3692
+376601B1FAADD801602668370B5ACEFFDBACA8F8B3F4E850D07A20F6F47440FC
+FD39504F0FDFCA35AF2ED0DA8BAB63AD42EA8CDA912CE17F5E62192DDD912333
+3E9FA0884117F07221642490044A72E359D5F25D9591A8FAD568A3DEE435C354
+11995C0EFCFEA21735DF44A30F79F747510E28767A4266461D1394F81344F6DB
+1FA8D0B0D9E5F52FBB663C8F1E91192E5608FFEAA178B93F8298F70510A65BEE
+12ECB5D675311B5B3B19205476512D92B1D16262720484049370A76F78D9BDC3
+02EB96AC1E5B3CB078D2F219988FD0F36B043ABBF347B22D36CF541A8F80F791
+8E4F92D900B7E7B64DFD500882EFBBF23565FA470103B2E0D2D14E3E4D7827D1
+BAA0F84713A8CDE5904FFF2794850871DEADDDC53B77A502F5CA98B0744BB656
+2FC40ED2AEBCC5CACE2301E983E6C18CF16AFB9FD8CA49DE51B22F4259D43076
+DDC1BD4974CDF2E733EAB6334B1D5614288CC81FDCC722CEE193635D1088FB29
+F80AD5CB96394AE89D920DF8E1F271585AF019190F17DB51FEC9064B54C3A53E
+3FD33C3B553FC79F743BEC9674743BF0A821051261DE4527A2BEF4A04E293E97
+02B181EC5F5EED3E26060F2C9EF6852B7433CA1BC1690C30424B03C522A087EE
+92016EBDAC4B787133B4A22BFEF0B6CA564C6EB910E1DBF983CB4CFC3A1F8A26
+45329CED7F5A8704ACE9D4233583365A5A97342A053EF403F0567E9D0A62EBCD
+84B5D7145BBB11D31046BC2CF5B450CC68B85DA0E78EF8902F8D37DAAA9D4242
+455288C0D73748F9BFEB1B1769D6FB84B94993D5F7C2B9CBDF75AEF2C930F277
+210B3CCB8A0299F50AFE2548A4B8DF5ABB52F098ECDD56FCB8D3A406EFD95088
+92D7EC39FDC7EB1824ECA24D0CBC6EC6F4C6A7F9590D593B269D2CC0BFBD961C
+AA8BB4296B4E4411B54367A341A5EDA97288DAC370A015FDE6D7FB0A4CECEFBD
+1A67DF3A3703E922BEF2C414FDDA42482EB35D5DBB206B44C76C412A435A0842
+6845EAD204BDF87065CE2C99B05D2D4080D5D11CFC3316967472C7DA44CC1F9D
+51B83B4BE9B882D6E9ECB482F9855D024ABFBA502CCD624E0F88164A6F13CED4
+85F20DC01BB15C7D78B1C79FD9FF71F4B043F59DB5C297768115542BC7C8A99E
+ACE39A268D32122541FB441FF1364FCBA2B7627F12C49ED038BC044B6D9D533B
+A72D35317A5AB8D91A9AC56CA90D1DAE9F967605C63BC9F406FB3D5BAEB4B38F
+4934EE3D2F5FE434B45CF5C2D0E5E417EC279DCEC4F16504EE40E837B11620B7
+7526AFF23381ED3E9A92DA4DBF4EA2BE4FE444B9A74AB60EFC818E20DD8B852B
+DF8CB659C0A3956D0DA61F49A9DD467726E57E9B32EFF540D551A67213D40273
+AEAA6E319D92B4B406377D36DAB85662C755D76ADF5795C52D54ECCF0DE81E30
+B84F951233A0A400CB063911837F0AACF44AD2441A7CE08818D64705E1ACF7E0
+F59AEFC5DD812981C5508385274817056B2CDCCA4C9F3103C92838917EBFEC94
+21D5737AC634B23B6F7F63B166D60C6BAA8F33AF44379C5A7337E737190EB3EE
+14272B905D08C01EA118964D3444A03676FF3B62E7626168FA1DC6220699780A
+0BD5776DDFA26BF0BB335B3C978CDD5CF1A419D4B5C562B3974FECFCF0118199
+E547EB287CD92E32E881F344420FA3CD97333BFEF5D7E1BA31FD20622E5B4F95
+692DD0ACAF01D413B21C8608FA87B470191C3CC5AD333263C955B4ADF4370FCE
+D6667FC93495003F4B6AEE4F83603D55F19EFBF56F955FC9CC01E494804952CD
+D426FE706C13D41F87C5C668D8B6BE50AE0370E07F52AC0534ECAB1C19851099
+FC0BB1EC2A649795A62299F73CA606EDFB1D28183DC63ADF67294553115E8C57
+7CB603CC491A6065802B925E6DFBF42917EE6E44C714228AE452851D61BF70AC
+844B5D800EF029357FD659B8A648445CED0ECAE1474E443124F4B3644F54C556
+A330D92EABEC7F607C6B13FACF69CA928F835056BD1A8ADA20EFE6BD5CF4A1A0
+8B9E415E4A5FC6F209EF05ABF2E0C55F6E3060D1C72967E1E68791499F303C8B
+3960C5A1F2DF6306710DFA98C8D0815A06B5590374554DCCDBDC4C295B3BA6B8
+8BE3200CD4421A521C06BE39D4CA495BC63F3F982CAE3C82AD38DCB537E617D3
+34BD96EFDA7C6A0F6D97A6BC9F084645390E194E7A11399FCE4EEB9A965909BA
+6EC69D34DBA081BB3F18BD1ADB1AE1B7FBF96E4C546498667690857EB6931841
+46C427A5B7C7D99FF889582C4AD11A7D267B301C5A5AAD9DA99D5BFD438238DA
+62DEB899FF0F7B7997F781315B2CC328BE3572A3903A33EC901AC6BCC7F152A9
+8A6865C6CB17189A4EEB699006A5F9D4482D53A76E88438E444F9302C79F0DC4
+B3033D29D303B38F5959F020337EE6619DC8A8C3912101B02CF8AD113BF4BC29
+8C6B9D25AF6B6A787F222C05964475B49B6751E3A3A6EBBEA03677D5B136B9DC
+6D9AC20193BFB0759E89831C9E2AF68BD45ECC81175DFE80DC0879069ADFA8E5
+24CF3C84121CD9739A28BACB9891945FA4E72EC07136682E18FCA81938FA6A3B
+8CEFBAED60121530E33C1C0E698B5923D6AFC4E907A99B1367C3D435CAEDEF5F
+878237453B8DB2FE53073CF3319FD096343F42D68F097759D051AEE17E4FCFC9
+86E17099799DE82A38F22D870BF7AB90890E3B5264976700BAE594C8563A218C
+C985D9A5A7D7BD959F7E4E66286833C86E89203ECECD6FC4C6FE1F04010218FA
+A5714881C4C846E85F13BD68AC250CD0E488DBF60BB10B2CD7AE2E30F9C21DFA
+0E84F76B4E996AA1C5C056E64BAC85622C160B56DEFD4DEF86887C1201F7C20C
+076D4A27BA69572BE9C89FF3A9D3BAA5CAE0A6F2187AD01ED497798A305E3BD8
+422DBFBF45E3F4AD35240B07285128B59FA9E83D9F6A2E620CAF6DB05129D930
+44CB241CFF84E776315114C3AB61FBC0A8368D9154CC5066E2B162E89DA51165
+F9CC075F2524F9A8624D2B56ABE64AF93B9F0407CC770C1F2C76CCDC06345D03
+7B173C2FAA201D8E1F6C0315987A7A13902F4AA5ADF081C2B0A01C77E4F7A3E7
+6A4AAEDDC577E855D69D38AF6A1D271B02AB496D94D81996FB078FBED17F833D
+C6C0BCE141BCDE277D530951DD6574B9CB3CF0370D74211E9AC00C7CD3A67842
+0B4B72ED517E4906409DEA7993D0B8E92D418139960EBC86BE63A1B1D417C451
+8BA13C230DAE1EC4E466F23351D410D9FC4A7BBD477D5FA07659B71CE9921B1B
+6755C67AB3D4988064004CF75948879D16174E8097C91F7544352474C2D9A1F8
+A1813BC6F4BA13E952678F5707F19B4799ADB3BD186DF650821DF58CF3C78D67
+84E4E1DF8DACEC50D15647C3DBBC3C4355E602D3A03171FE1CB36FEB940211EE
+0A5300841DD7B7CF91C02B3FC5D89C691156BFF8A38C6C72789DF260B868AAA1
+895046E405661D97FA9A0048AF114A89E3ADAEBCE541753E4FFCD902391B5372
+6A97E32F0257FA9FA1DC15BD3140EC7F0CA5A68AABCEDBE73C38B35FDF195F96
+0F9DB0F592C188D72D73512F4DD92D2371D1A59254BC477CA084E68184AEAB6C
+266BB21DC3AAF874DE999AD2A17C79621AE322612EE4B6D5BDAC511418EDE90A
+AE75066AF19662C4AD855E4200A5D67BEE4ADA9A399192C74D35E59B15FB61E7
+BB167282D32D538029ED22CC5C9860C1F6B7BA7F33D5CF108D4BEEFAE7B37E67
+39391F9934DE17956303532ABB011540645DB8420749C9B9A019C3CE86ACD566
+1EE8D8D5E0D8D0DEAB33B5413EF10D4EE650F82417002E436E0B3B628A657F84
+074098C2E9F897D9AB692E0FB9F268E6728F94A79CF4D6B0A07C8DFDC1D67FD5
+EDD5863EA8949D180B1596D0009D662FC429449D76BF13D83F0D0CF165982443
+E9CC288CF7C5F2E17EB7F3736D1FB814196CCEAB8C833720E3733BF594E1B536
+BC0063080BC751F9DA1741522B2967D07DDDA169E7D3417B4A39EFAC15EA5E8E
+DE3473CC9DF991FAD2A971F44B09635085DB02D692F149F144F3DCDB69B72C53
+A2AF34C65DF0D5F35E82102E67B733750646EC03A4FF47138F7998607BD93AB2
+B63A0B82E8E225FFAD5DC468077FBE8C8C8E5B4BB10A8FE836B07367D742BD6B
+D36DF5304B9DF363120504C279453452EB177FBCDAA6F6FB78A24848F4A1D94D
+1E49F6C46CB36796F3F4C9739346381F28AF085C5EBDB2A02DC0570C7A21E097
+77522D4947B51182431BCBF3E55CCDDE93A916AA40CEB577277FA512380816DF
+9111C56F36341381D62368E70462577D0C135BB3CB4462B269AA8E0F03245BFA
+D01DB8E23F2DFD5DAA88FCAFDD51D48E562EC649DB1FFDA0FD8CC8C48E6A9207
+260ABE35733D75630053CC74A07E5AF6FE87BD5FEA69CB6AA20122276AD92853
+6B225BC9E3350D1B1362E04C7795D473F1266852B02C83D02D938C55D8F0C671
+7A9205F8CD058304DFA034D99A6BC16C582F02484A089602D42DF30D7A5716C1
+D42A4CE56C19E40C01DC7DED931FA13679CFD2700B3826A1E6539AAC12293DA8
+664DE251C5D1761BB45FE364CE3F7F7E9B67F86EB31D9626CCACE4DCE03EF3C1
+0D2FD1B12B5774510D46C5C5CBF0A34847418B9A1DF0C67789422D0EC2D49576
+9DDE72D63A4A98613461A6F730A05336C691583F96C3CAD2AF7C4BFD3AEB3814
+D909858B6598FE19397006C8C4D549AA1635968F47144E7861A2BCE8AB4CA7F0
+4D253949AA0127559FAE3161C810A8CE22A3079602E747C9398F9C8B2A868F23
+D77D7AD6B980FEB038E0557E58E1D7AE471036CBB96B83595D9C96A4895971CD
+C2A810651A045F876A1F5AE470BEF39F856808B1F8D736030A722E1576BDB3B4
+4DF06F73D38D313C8A0D3504EFBC774750C9F6E687ABCB1927FA1BB3882AABC1
+2306A030CEBB259AECAA646C6497712F6C1E9DB7E1365A60EEC5AEDD5147A77B
+1E3A10D73C477876D54FEE853D953EE75F7EDFB287550B93CFA8250D1FE2FE7D
+D34441F1224F3DB1D355188819EBB98A94DB193B9CA23803869DD10776647BF5
+5BB42031AC44A7339DC036AD0292AB9B732E6FB79BEE852A103C3788BB0F4B72
+EF37BB62356F9B2DF7F5899A26F1FE0A3D6469C1034B8AB14F52555EBF6DC592
+3F24D6DB395A3A182ED4B8ECEE8254661C19CC942F236CA40BAABE818EC312D8
+7F5762C210FCE8A3CB9A23A24D0A751A09F4FCFB72DD0FB3AAE0575CF97D126E
+1669203BE1C8F8FF626F49E8AFA7B29EF26618C6D8336D4471314D5D009BEC8C
+D914E74D0BE7D7C3A2511C0DDEB6FE04360D54FB3283AD67D9DCDE211FAFD19C
+449E201F2913232DDAFB2043F674EA73C9F043EB73CC9A96289B3CF819DB3E56
+5FE403D8C387C99979ED9F8EB2F5B970958CA554D9DB879786C39AAC8139A032
+6651A999D3927BB2A16D73BEA8CD512765A19BB5F5051B531D319F2C097655F8
+2301E3819F631129141AA5DB1D28EBEFBBBABC218C1DE7033C1E10608393137C
+FBC625528295185000819479C681C86FDB3D10D131949430AD8DFE38A5D62DE6
+FBE13CCDC34FD0CBF6E3A249B27E798E26A3EED8C3B278C163D72C417D978D20
+2D3290270F667D461FC2ED6F19B2A7DFE4099E483B72F8B85E18991AA5203CEF
+092B28FEF9F67C59DD19D5C9D2EE985CD3057F43DD47DE841D47BFBC859D1D07
+00DAC60E8905D87A43188F913603624FE23C8300CE998C4F14BC4DE5CD329D97
+AFD427F59C0A283CBBE47E05FB3E62E5D5741D3ABE666523F3564D7962FDB8FA
+91BA02B9E493B7A725FB492A44F2C0FE3714BEE2BD2DC7374865C456584F
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+TeXDict begin 40258437 52099154 1000 600 600 (gmt_eq.dvi)
+@start /Fa 227[36 28[{}1 83.022 /CMMI10 rf /Fb 135[38
+3[25 116[{}2 58.1154 /CMMI7 rf /Fc 173[39 82[{}1 83.022
+/CMEX10 rf end
+%%EndProlog
+%%BeginSetup
+%%Feature: *Resolution 600dpi
+TeXDict begin
+ end
+%%EndSetup
+TeXDict begin 1 0 bop 639 456 a Fc(R)678 553 y Fb(x)734
+456 y Fc(R)773 553 y Fb(t)816 523 y Fa(\034)852 535 y
+Fb(x)p eop end
+%%Trailer
+userdict /end-hook known{end-hook}if
+%%EOF
+%%EndDocument
+PSL_eps_end
+U
+0 4724 T
+23 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 60 def
+/PSL_A1_y 0 def
+8 W
+N 630 0 M 0 60 D S
+N 1890 0 M 0 60 D S
+N 3150 0 M 0 60 D S
+N 0 0 M 0 30 D S
+N 1260 0 M 0 30 D S
+N 2520 0 M 0 30 D S
+N 3780 0 M 0 30 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -4724 T
+0 setlinecap
+0 A
+%%EndObject
+-4066 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/latex/subplotlatex.sh
+++ b/test/latex/subplotlatex.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Test of user Latex labels in subplot settings
+gmt begin subplotlatex pdf
+  gmt subplot begin 2x2 -Fs8c -M5p -SCb -SRl -BeSWn -JX10c -R-30/30/0/80 -Bxafg+l"@[\int_{x} \int_{t} \tau_x@[" -Byafg+l"<math>\nabla G</math>" -T"Try @[\nabla G@[ and @[\int_0^x f(x)@["
+    gmt basemap -c
+    gmt basemap -c
+    gmt basemap -c
+    gmt basemap -c
+  gmt subplot end
+gmt end show

--- a/test/latex/subplotlatex.sh
+++ b/test/latex/subplotlatex.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test of user Latex labels in subplot settings
-gmt begin subplotlatex pdf
+gmt begin subplotlatex ps
   gmt subplot begin 2x2 -Fs8c -M5p -SCb -SRl -BeSWn -JX10c -R-30/30/0/80 -Bxafg+l"@[\int_{x} \int_{t} \tau_x@[" -Byafg+l"<math>\nabla G</math>" -T"Try @[\nabla G@[ and @[\int_0^x f(x)@["
     gmt basemap -c
     gmt basemap -c

--- a/test/latex/subplotlatex.sh
+++ b/test/latex/subplotlatex.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test of user Latex labels in subplot settings
 gmt begin subplotlatex ps
-  gmt subplot begin 2x2 -Fs8c -M5p -SCb -SRl -BeSWn -JX10c -R-30/30/0/80 -Bxafg+l"@[\int_{x} \int_{t} \tau_x@[" -Byafg+l"<math>\nabla G</math>" -T"Try @[\nabla G@[ and @[\int_0^x f(x)@["
+  gmt subplot begin 2x2 -Fs8c -M5p -SCb -SRl -BeSWn -JX10c -R-30/30/0/80 -Bxafg+l"@[\int_{x} \int_{t} \tau_x@[" -Byafg+l"<math>\nabla G</math>"
     gmt basemap -c
     gmt basemap -c
     gmt basemap -c


### PR DESCRIPTION
**Description of proposed changes**

See #5032 for background.  The subplot begin -B parsing did not allow for user-supplied labels and hence these where appended with annotations, causing trouble.  This PR looks for both primary and secondary labels and separates those from annotations.  A added a test to ensure this continues to work.
Closes #5032.