### PR TITLE
Add psrose option to draw von Mises distribution

### DIFF
--- a/doc/rst/source/histogram_common.rst_
+++ b/doc/rst/source/histogram_common.rst_
@@ -107,7 +107,7 @@ Optional Arguments
 .. _-N:
 
 **-N**\ [*mode*][**+p**\ *pen*]
-    Draw the equivalent normal distribution; append desired pen [0.5p,black].
+    Draw the equivalent normal distribution; append desired pen [0.25p,black].
     The *mode* selects which central location and scale to use:
 
     * 0 = mean and standard deviation [Default];

--- a/doc/rst/source/psrose.rst
+++ b/doc/rst/source/psrose.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-K| ]
 [ |-L|\ [*wlabel*\ ,\ *elabel*\ ,\ *slabel*\ ,\ *nlabel*] ]
 [ |-M|\ *parameters* ]
-[ |-N|\ [*mode*][**+p**\ *pen*] ]
+[ |-N|\ *mode*\ [**+p**\ *pen*] ]
 [ |-O| ] [ |-P| ]
 [ |-Q|\ *alpha* ]
 [ |-R|\ *r0*/*r1*/*az0*/*az1* ]

--- a/doc/rst/source/psrose.rst
+++ b/doc/rst/source/psrose.rst
@@ -22,6 +22,7 @@ Synopsis
 [ |-K| ]
 [ |-L|\ [*wlabel*\ ,\ *elabel*\ ,\ *slabel*\ ,\ *nlabel*] ]
 [ |-M|\ *parameters* ]
+[ |-N|\ [*mode*][**+p**\ *pen*] ]
 [ |-O| ] [ |-P| ]
 [ |-Q|\ *alpha* ]
 [ |-R|\ *r0*/*r1*/*az0*/*az1* ]

--- a/doc/rst/source/rose.rst
+++ b/doc/rst/source/rose.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-J|\ **X**\ *diameter* ]
 [ |-L|\ [*wlabel*\ ,\ *elabel*\ ,\ *slabel*\ ,\ *nlabel*] ]
 [ |-M|\ *parameters* ]
-[ |-N|\ [*mode*][**+p**\ *pen*] ]
+[ |-N|\ *mode*\ [**+p**\ *pen*] ]
 [ |-Q|\ *alpha* ]
 [ |-R|\ *r0*/*r1*/*az0*/*az1* ]
 [ |-S|\ [**+a**] ]

--- a/doc/rst/source/rose.rst
+++ b/doc/rst/source/rose.rst
@@ -22,6 +22,7 @@ Synopsis
 [ |-J|\ **X**\ *diameter* ]
 [ |-L|\ [*wlabel*\ ,\ *elabel*\ ,\ *slabel*\ ,\ *nlabel*] ]
 [ |-M|\ *parameters* ]
+[ |-N|\ [*mode*][**+p**\ *pen*] ]
 [ |-Q|\ *alpha* ]
 [ |-R|\ *r0*/*r1*/*az0*/*az1* ]
 [ |-S|\ [**+a**] ]

--- a/doc/rst/source/rose_common.rst_
+++ b/doc/rst/source/rose_common.rst_
@@ -107,12 +107,12 @@ Optional Arguments
 
 .. _-N:
 
-**-N**\ [*mode*][**+p**\ *pen*]
+**-N**\ *mode*\ [**+p**\ *pen*]
     Draw the equivalent circular normal distribution, i.e., the *von Mises*
     distribution; append desired pen [0.25p,black].
     The *mode* selects which central location and scale to use:
 
-    * 0 = mean and standard deviation [Default];
+    * 0 = mean and standard deviation;
     * 1 = median and L1 scale (1.4826 \* median absolute deviation; MAD);
     * 2 = LMS (least median of squares) mode and scale.
 

--- a/doc/rst/source/rose_common.rst_
+++ b/doc/rst/source/rose_common.rst_
@@ -105,6 +105,19 @@ Optional Arguments
     using **-M** will add vector heads to all individual directions
     using the supplied attributes.
 
+.. _-N:
+
+**-N**\ [*mode*][**+p**\ *pen*]
+    Draw the equivalent circular normal distribution, i.e., the *von Mises*
+    distribution; append desired pen [0.25p,black].
+    The *mode* selects which central location and scale to use:
+
+    * 0 = mean and standard deviation [Default];
+    * 1 = median and L1 scale (1.4826 \* median absolute deviation; MAD);
+    * 2 = LMS (least median of squares) mode and scale.
+
+    **Note**: At the present time, only *mode* == 0 is supported.
+
 .. _-Q:
 
 **-Q**\ [*alpha*]

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -89,9 +89,11 @@ struct PSROSE_CTRL {	/* All control options for this program (except common args
 		bool active;
 		struct GMT_SYMBOL S;
 	} M;
-	//struct PSROSE_N {	/* -N [Deprecated to -S+a] */
-	//	bool active;
-	//} N;
+	struct PSROSE_N {	/* -N[<kind>]+p<pen>, <kind = 0 (for now) OR -N [Deprecated to -S+a] */
+		bool active;
+		bool selected;
+		struct GMT_PEN pen;
+	} N;
 	struct PSROSE_Q {	/* -Q<alpha> */
 		bool active;
 		double value;
@@ -158,7 +160,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A<sector_angle>[+r]] [%s] [-C<cpt>] [-D] [-E[m|[+w]<modefile>]] [-F] [-G<fill>] [-I]\n", name, GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-JX<diameter>] %s[-L[<wlab>,<elab>,<slab>,<nlab>]] [-M[<size>][<modifiers>]] %s%s[-Q<alpha>]\n", API->K_OPT, API->O_OPT, API->P_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-JX<diameter>] %s[-L[<wlab>,<elab>,<slab>,<nlab>]] [-M[<size>][<modifiers>]] [-N[<mode>][+p<pen>]] %s%s[-Q<alpha>]\n", API->K_OPT, API->O_OPT, API->P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-R<r0>/<r1>/<theta0>/<theta1>] [-S[+a]] [-T] [%s]\n", GMT_U_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-W[v]<pen>] [%s] [%s]\n\t[-Zu|<scale>] [%s] %s[%s] [%s]\n\t[%s] [%s]\n\t[%s]\n\t[%s] [%s] [%s] [%s] [%s] [%s]\n\n",
 		GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, GMT_bi_OPT, API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_s_OPT, GMT_t_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -190,6 +192,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Otherwise, if windrose mode is selected we apply vector attributes to individual directions.\n");
 	gmt_vector_syntax (API->GMT, 15);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Default is %gp+gblack+p1p.\n", VECTOR_HEAD_LENGTH);
+	GMT_Message (API, GMT_TIME_NONE, "\t-N Append <mode> to draw the equivalent von Mises distribution; append desired pen [0.25p,black].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   <mode> selects which central location and scale to use:\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     0 = mean and standard deviation [Default]\n");
 	GMT_Option (API, "O,P");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Set confidence level for Rayleigh test for uniformity [0.05].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-R Specifies the region (<r0> = 0, <r1> = max_radius).  For azimuth:\n");
@@ -363,6 +368,22 @@ static int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_OPT
 			case 'N':	/* Make sectors area be proportional to frequency instead of radius [DEPRECATED in 6.2] */
 				if (opt->arg[0] == '\0')	/* Only plain -N is accepted to be backwards compatible */
 					Ctrl->S.area_normalize = true;
+				else {	/* Modern -N to draw VPDF with a pen */
+					switch (opt->arg[0]) {	/* See which distribution to draw */
+						case '0': break;	/* Only allowed mode for now */
+						default:
+							GMT_Report (API, GMT_MSG_ERROR, "Option -N: mode %c unrecognized.\n", opt->arg[0]);
+							n_errors++;
+							break;
+					}
+					Ctrl->N.selected = true;
+					if ((c = strstr (opt->arg, "+p")) != NULL) {
+						if (gmt_getpen (GMT, &c[2], &Ctrl->N.pen)) {
+							gmt_pen_syntax (GMT, 'N', NULL, " ", 0);
+							n_errors++;
+						}
+					}
+				}
 				break;
 			case 'Q':	/* Set critical value [0.05] */
 				Ctrl->Q.active = true;
@@ -416,6 +437,8 @@ static int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_OPT
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->G.active, "Option -C: Cannot give both -C and -G\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->A.rose, "Option -C: Cannot be used with -A+r\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && !Ctrl->A.active, "Option -C: Requires -A\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && !Ctrl->A.active, "Option -N: Requires -A\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && !doubleAlmostEqual (range, 360.0), "Option -N: Requires the full circle in -R\n");
 	if (GMT->common.J.active) {	/* Impose our conditions on -JX */
 		n_errors += gmt_M_check_condition (GMT, GMT->common.J.string[0] != 'X', "Option -J: Must specify -JX<diameter>\n");
 		n_errors += gmt_M_check_condition (GMT, strchr (GMT->common.J.string, '/'), "Option -J: Must specify -JX<diameter>\n");
@@ -449,7 +472,7 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 	char text[GMT_BUFSIZ] = {""}, format[GMT_BUFSIZ] = {""};
 
 	double max = 0.0, radius, az, x_origin, y_origin, tmp, one_or_two = 1.0, s, c, f;
-	double angle1, angle2, angle, x, y, mean_theta, mean_radius, xr = 0.0, yr = 0.0;
+	double angle1, angle2, angle, x, y, mean_theta, mean_radius, xr = 0.0, yr = 0.0, area = 0.0;
 	double x1, x2, y1, y2, total = 0.0, total_arc, off, max_radius, az_offset, start_angle;
 	double asize, lsize, this_az, half_bin_width, diameter, wesn[4], mean_vector, mean_resultant;
 	double *xx = NULL, *yy = NULL, *in = NULL, *sum = NULL, *azimuth = NULL, critical_resultant;
@@ -652,6 +675,7 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 		for (bin = 0; bin < n_bins; bin++) if (sum[bin] > max) max = sum[bin];
 		if (Ctrl->S.normalize) for (bin = 0; bin < n_bins; bin++) sum[bin] /= max;
 		if (Ctrl->S.area_normalize) for (bin = 0; bin < n_bins; bin++) sum[bin] = sqrt (sum[bin]);
+		for (bin = 0; bin < n_bins; bin++) area += sum[bin];
 	}
 	else {	/* Find max length of individual vectors */
 		for (i = 0; i < n; i++) if (length[i] > max) max = length[i];
@@ -947,6 +971,27 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 			angle2 = angle1 + Ctrl->A.inc;
 			PSL_plotarc (PSL, 0.0, 0.0, sum[k] * Ctrl->S.scale, angle1, angle2, (k == 0) ? PSL_STROKE : PSL_DRAW);
 		}
+	}
+
+	if (Ctrl->N.active) {	/* Draw best-fitting probability distribution curve */
+		unsigned int k, NP = 361;
+		double a, mu, kappa, pdf, inc = 360.0 / (NP - 1), scl = area * Ctrl->A.inc * D2R;
+		double *xp = gmt_M_memory (GMT, NULL, NP, double);
+		double *yp = gmt_M_memory (GMT, NULL, NP, double);
+
+		mu = gmt_von_mises_mu_and_kappa (GMT, azimuth, length, n, &kappa);
+		fprintf (stderr, "mu, kappa, scale: %g %g %g\n", mu, kappa, scl);
+		for (k = 0; k < NP; k++) {
+			a = inc * k;
+			pdf = scl * gmt_vonmises_pdf (GMT, a, mu, kappa);
+			sincosd (a, &s, &c);
+			xp[k] = c * pdf;
+			yp[k] = s * pdf;
+		}
+		gmt_setpen (GMT, &Ctrl->N.pen);
+		PSL_plotline (PSL, xp, yp, NP, PSL_MOVE|PSL_STROKE);
+		gmt_M_free (GMT, xp);
+		gmt_M_free (GMT, yp);
 	}
 
 	if (Ctrl->E.active) {

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -161,7 +161,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A<sector_angle>[+r]] [%s] [-C<cpt>] [-D] [-E[m|[+w]<modefile>]] [-F] [-G<fill>] [-I]\n", name, GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-JX<diameter>] %s[-L[<wlab>,<elab>,<slab>,<nlab>]] [-M[<size>][<modifiers>]] [-N[<mode>][+p<pen>]] %s%s[-Q<alpha>]\n", API->K_OPT, API->O_OPT, API->P_OPT);
+	GMT_Message (API, GMT_TIME_NONE, "\t[-JX<diameter>] %s[-L[<wlab>,<elab>,<slab>,<nlab>]] [-M[<size>][<modifiers>]] [-N<mode>[+p<pen>]] %s%s[-Q<alpha>]\n", API->K_OPT, API->O_OPT, API->P_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[-R<r0>/<r1>/<theta0>/<theta1>] [-S[+a]] [-T] [%s]\n", GMT_U_OPT);
 	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-W[v]<pen>] [%s] [%s]\n\t[-Zu|<scale>] [%s] %s[%s] [%s]\n\t[%s] [%s]\n\t[%s]\n\t[%s] [%s] [%s] [%s] [%s] [%s]\n\n",
 		GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, GMT_bi_OPT, API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_s_OPT, GMT_t_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -196,6 +196,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Append <mode> to draw the equivalent von Mises distribution; append desired pen [0.25p,black].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <mode> selects which central location and scale to use:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t     0 = mean and standard deviation [Default]\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     (Other modes may be added later).\n");
 	GMT_Option (API, "O,P");
 	GMT_Message (API, GMT_TIME_NONE, "\t-Q Set confidence level for Rayleigh test for uniformity [0.05].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-R Specifies the region (<r0> = 0, <r1> = max_radius).  For azimuth:\n");

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -369,6 +369,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_OPT
 				if (opt->arg[0] == '\0')	/* Only plain -N is accepted to be backwards compatible */
 					Ctrl->S.area_normalize = true;
 				else {	/* Modern -N to draw VPDF with a pen */
+					Ctrl->N.active = true;
 					switch (opt->arg[0]) {	/* See which distribution to draw */
 						case '0': break;	/* Only allowed mode for now */
 						default:
@@ -975,16 +976,15 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 
 	if (Ctrl->N.active) {	/* Draw best-fitting probability distribution curve */
 		unsigned int k, NP = 361;
-		double a, mu, kappa, pdf, inc = 360.0 / (NP - 1), scl = area * Ctrl->A.inc * D2R;
+		double a, mu, kappa, pdf, inc = 360.0 / (NP - 1), scl = 2.0 * area * Ctrl->A.inc * D2R;
 		double *xp = gmt_M_memory (GMT, NULL, NP, double);
 		double *yp = gmt_M_memory (GMT, NULL, NP, double);
 
 		mu = gmt_von_mises_mu_and_kappa (GMT, azimuth, length, n, &kappa);
-		fprintf (stderr, "mu, kappa, scale: %g %g %g\n", mu, kappa, scl);
 		for (k = 0; k < NP; k++) {
 			a = inc * k;
 			pdf = scl * gmt_vonmises_pdf (GMT, a, mu, kappa);
-			sincosd (a, &s, &c);
+			sincosd (start_angle - a, &s, &c);
 			xp[k] = c * pdf;
 			yp[k] = s * pdf;
 		}

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -125,6 +125,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 	gmt_init_fill (GMT, &C->G.fill, -1.0, -1.0, -1.0);
+	C->N.pen = GMT->current.setting.map_default_pen;
 	C->M.S.symbol = PSL_VECTOR;
 	C->W.pen[0] = C->W.pen[1] = GMT->current.setting.map_default_pen;
 	C->Q.value = 0.05;

--- a/test/psrose/sector_vpdf.ps
+++ b/test/psrose/sector_vpdf.ps
@@ -1,0 +1,1367 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.2.0_f8d36fb_2021.04.02 [64-bit] Document from psrose
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Apr  2 08:26:30 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-2400 PSL_xorig sub PSL_page_xsize 2 div add 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psrose /Users/pwessel/GMTdev/gmt-dev/test/psrose/a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Glightblue -W1p -: -S -N0+p1p -JX4i -P -K -Xc -Em
+%@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
+%GMTBoundingBox: -144 72 288 288
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+2400 2400 T
+{0.565 0.933 0.565 C} FS
+2400 0 0 Sc
+4 W
+N 0 0 M 2400 0 D S
+N 0 0 M 1200 2078 D S
+N 0 0 M -1200 2078 D S
+N 0 0 M -2400 0 D S
+N 0 0 M -1200 -2078 D S
+N 0 0 M 1200 -2078 D S
+N 0 0 M 2400 0 D S
+N 0 0 480 0 360 arc S
+N 0 0 960 0 360 arc S
+N 0 0 1440 0 360 arc S
+N 0 0 1920 0 360 arc S
+N 0 0 2400 0 360 arc S
+17 W
+{0.678 0.847 0.902 C} FS
+1000 85 90 0 0 Sw
+1600 80 85 0 0 Sw
+2400 75 80 0 0 Sw
+800 70 75 0 0 Sw
+1400 65 70 0 0 Sw
+1600 60 65 0 0 Sw
+2000 55 60 0 0 Sw
+800 50 55 0 0 Sw
+1200 45 50 0 0 Sw
+800 40 45 0 0 Sw
+1400 35 40 0 0 Sw
+1000 30 35 0 0 Sw
+800 25 30 0 0 Sw
+200 20 25 0 0 Sw
+200 15 20 0 0 Sw
+600 10 15 0 0 Sw
+0 5 10 0 0 Sw
+0 0 5 0 0 Sw
+0 -5 0 0 0 Sw
+0 -10 -5 0 0 Sw
+0 -15 -10 0 0 Sw
+0 -20 -15 0 0 Sw
+0 -25 -20 0 0 Sw
+0 -30 -25 0 0 Sw
+0 -35 -30 0 0 Sw
+0 -40 -35 0 0 Sw
+0 -45 -40 0 0 Sw
+0 -50 -45 0 0 Sw
+0 -55 -50 0 0 Sw
+0 -60 -55 0 0 Sw
+0 -65 -60 0 0 Sw
+0 -70 -65 0 0 Sw
+0 -75 -70 0 0 Sw
+0 -80 -75 0 0 Sw
+0 -85 -80 0 0 Sw
+0 -90 -85 0 0 Sw
+0 -95 -90 0 0 Sw
+0 -100 -95 0 0 Sw
+0 -105 -100 0 0 Sw
+0 -110 -105 0 0 Sw
+0 -115 -110 0 0 Sw
+0 -120 -115 0 0 Sw
+0 -125 -120 0 0 Sw
+0 -130 -125 0 0 Sw
+0 -135 -130 0 0 Sw
+0 -140 -135 0 0 Sw
+0 -145 -140 0 0 Sw
+0 -150 -145 0 0 Sw
+0 -155 -150 0 0 Sw
+0 -160 -155 0 0 Sw
+0 -165 -160 0 0 Sw
+0 -170 -165 0 0 Sw
+0 -175 -170 0 0 Sw
+0 -180 -175 0 0 Sw
+0 -185 -180 0 0 Sw
+0 -190 -185 0 0 Sw
+0 -195 -190 0 0 Sw
+0 -200 -195 0 0 Sw
+0 -205 -200 0 0 Sw
+0 -210 -205 0 0 Sw
+0 -215 -210 0 0 Sw
+0 -220 -215 0 0 Sw
+0 -225 -220 0 0 Sw
+0 -230 -225 0 0 Sw
+200 -235 -230 0 0 Sw
+0 -240 -235 0 0 Sw
+0 -245 -240 0 0 Sw
+400 -250 -245 0 0 Sw
+400 -255 -250 0 0 Sw
+400 -260 -255 0 0 Sw
+200 -265 -260 0 0 Sw
+600 -270 -265 0 0 Sw
+0 1000 M
+0 -400 D
+0 0 600 -270 -265 arc
+0 0 200 -265 -260 arc
+0 0 400 -260 -255 arc
+0 0 400 -255 -250 arc
+0 0 400 -250 -245 arc
+0 0 0 -245 -240 arc
+0 0 0 -240 -235 arc
+0 0 200 -235 -230 arc
+0 0 0 -230 -225 arc
+0 0 0 -225 -220 arc
+0 0 0 -220 -215 arc
+0 0 0 -215 -210 arc
+0 0 0 -210 -205 arc
+0 0 0 -205 -200 arc
+0 0 0 -200 -195 arc
+0 0 0 -195 -190 arc
+0 0 0 -190 -185 arc
+0 0 0 -185 -180 arc
+0 0 0 -180 -175 arc
+0 0 0 -175 -170 arc
+0 0 0 -170 -165 arc
+0 0 0 -165 -160 arc
+0 0 0 -160 -155 arc
+0 0 0 -155 -150 arc
+0 0 0 -150 -145 arc
+0 0 0 -145 -140 arc
+0 0 0 -140 -135 arc
+0 0 0 -135 -130 arc
+0 0 0 -130 -125 arc
+0 0 0 -125 -120 arc
+0 0 0 -120 -115 arc
+0 0 0 -115 -110 arc
+0 0 0 -110 -105 arc
+0 0 0 -105 -100 arc
+0 0 0 -100 -95 arc
+0 0 0 -95 -90 arc
+0 0 0 -90 -85 arc
+0 0 0 -85 -80 arc
+0 0 0 -80 -75 arc
+0 0 0 -75 -70 arc
+0 0 0 -70 -65 arc
+0 0 0 -65 -60 arc
+0 0 0 -60 -55 arc
+0 0 0 -55 -50 arc
+0 0 0 -50 -45 arc
+0 0 0 -45 -40 arc
+0 0 0 -40 -35 arc
+0 0 0 -35 -30 arc
+0 0 0 -30 -25 arc
+0 0 0 -25 -20 arc
+0 0 0 -20 -15 arc
+0 0 0 -15 -10 arc
+0 0 0 -10 -5 arc
+0 0 0 -5 0 arc
+0 0 0 0 5 arc
+0 0 0 5 10 arc
+0 0 600 10 15 arc
+0 0 200 15 20 arc
+0 0 200 20 25 arc
+0 0 800 25 30 arc
+0 0 1000 30 35 arc
+0 0 1400 35 40 arc
+0 0 800 40 45 arc
+0 0 1200 45 50 arc
+0 0 800 50 55 arc
+0 0 2000 55 60 arc
+0 0 1600 60 65 arc
+0 0 1400 65 70 arc
+0 0 800 70 75 arc
+0 0 2400 75 80 arc
+0 0 1600 80 85 arc
+0 0 1000 85 90 arc S
+0 860 M
+33 84 D
+39 84 D
+45 83 D
+24 40 D
+26 40 D
+56 75 D
+30 35 D
+62 64 D
+33 29 D
+33 27 D
+67 45 D
+34 18 D
+34 15 D
+34 12 D
+33 9 D
+33 5 D
+32 2 D
+31 -1 D
+30 -5 D
+29 -8 D
+27 -11 D
+26 -15 D
+24 -18 D
+21 -20 D
+20 -24 D
+18 -27 D
+15 -29 D
+13 -32 D
+10 -34 D
+8 -36 D
+6 -38 D
+3 -39 D
+1 -41 D
+-2 -43 D
+-4 -43 D
+-14 -88 D
+-24 -89 D
+-14 -44 D
+-35 -88 D
+-19 -43 D
+-43 -84 D
+-47 -79 D
+-50 -74 D
+-52 -68 D
+-53 -62 D
+-78 -81 D
+-75 -67 D
+-47 -38 D
+-65 -46 D
+-40 -25 D
+-35 -20 D
+-33 -17 D
+-28 -14 D
+-14 -5 D
+-12 -5 D
+-12 -5 D
+-11 -4 D
+-10 -3 D
+-9 -3 D
+-9 -3 D
+-8 -2 D
+-8 -2 D
+-7 -1 D
+-6 -2 D
+-6 -1 D
+-6 -1 D
+-5 -1 D
+-4 0 D
+-4 -1 D
+-4 0 D
+-4 0 D
+-3 -1 D
+-3 0 D
+-3 0 D
+-2 0 D
+-2 0 D
+-2 0 D
+-2 0 D
+-13 2 D
+0 1 D
+-1 0 D
+-1 0 D
+0 1 D
+-1 0 D
+-1 0 D
+0 1 D
+-1 0 D
+-1 0 D
+0 1 D
+-1 0 D
+-12 13 D
+-14 23 D
+-15 34 D
+-19 59 D
+-15 74 D
+-7 59 D
+-4 71 D
+1 82 D
+4 63 D
+13 103 D
+14 74 D
+19 79 D
+P S
+{0 A} FS
+O1
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
+17 W
+V 0 0 T 62.8891148382 R
+N 0 0 M 2044 0 D S
+U
+V 1000 1953 T 62.8891148382 R
+PSL_vecheadpen
+67 W
+0 0 M
+-150 40 D
+0 -80 D
+P clip fs P S 
+U
+0 -2567 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+267 F0
+(South) tc Z
+8 W
+2400 -2317 M
+0 -83 D
+-480 0 D
+0 83 D
+S
+2160 -2483 M 200 F0
+(0.2) tc Z
+2567 0 M 267 F0
+(East) ml Z
+-2567 0 M (West) mr Z
+0 2567 M (North) bc Z
+25 W
+FQ
+2400 0 0 Sc
+-2400 -2400 T
+%%EndObject
+0 A
+FQ
+O0
+0 5700 TM
+
+% PostScript produced by:
+%@GMT: gmt psrose t.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Glightblue -W1p -: -S -N0+p1p -JX4i -O -Y4.75i -Em
+%@PROJ: xy -2.00000000 2.00000000 -2.00000000 2.00000000 -2.000 2.000 -2.000 2.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+2400 2400 T
+{0.565 0.933 0.565 C} FS
+2400 0 0 Sc
+4 W
+N 0 0 M 2400 0 D S
+N 0 0 M 1200 2078 D S
+N 0 0 M -1200 2078 D S
+N 0 0 M -2400 0 D S
+N 0 0 M -1200 -2078 D S
+N 0 0 M 1200 -2078 D S
+N 0 0 M 2400 0 D S
+N 0 0 480 0 360 arc S
+N 0 0 960 0 360 arc S
+N 0 0 1440 0 360 arc S
+N 0 0 1920 0 360 arc S
+N 0 0 2400 0 360 arc S
+17 W
+{0.678 0.847 0.902 C} FS
+434 85 90 0 0 Sw
+491 80 85 0 0 Sw
+642 75 80 0 0 Sw
+824 70 75 0 0 Sw
+1033 65 70 0 0 Sw
+1264 60 65 0 0 Sw
+1508 55 60 0 0 Sw
+1752 50 55 0 0 Sw
+1979 45 50 0 0 Sw
+2172 40 45 0 0 Sw
+2314 35 40 0 0 Sw
+2393 30 35 0 0 Sw
+2400 25 30 0 0 Sw
+2335 20 25 0 0 Sw
+2205 15 20 0 0 Sw
+2021 10 15 0 0 Sw
+1799 5 10 0 0 Sw
+1557 0 5 0 0 Sw
+1312 -5 0 0 0 Sw
+1077 -10 -5 0 0 Sw
+863 -15 -10 0 0 Sw
+676 -20 -15 0 0 Sw
+519 -25 -20 0 0 Sw
+391 -30 -25 0 0 Sw
+289 -35 -30 0 0 Sw
+211 -40 -35 0 0 Sw
+152 -45 -40 0 0 Sw
+109 -50 -45 0 0 Sw
+77 -55 -50 0 0 Sw
+55 -60 -55 0 0 Sw
+39 -65 -60 0 0 Sw
+27 -70 -65 0 0 Sw
+19 -75 -70 0 0 Sw
+14 -80 -75 0 0 Sw
+10 -85 -80 0 0 Sw
+7 -90 -85 0 0 Sw
+5 -95 -90 0 0 Sw
+4 -100 -95 0 0 Sw
+3 -105 -100 0 0 Sw
+2 -110 -105 0 0 Sw
+2 -115 -110 0 0 Sw
+2 -120 -115 0 0 Sw
+1 -125 -120 0 0 Sw
+1 -130 -125 0 0 Sw
+1 -135 -130 0 0 Sw
+1 -140 -135 0 0 Sw
+1 -145 -140 0 0 Sw
+1 -150 -145 0 0 Sw
+1 -155 -150 0 0 Sw
+1 -160 -155 0 0 Sw
+1 -165 -160 0 0 Sw
+1 -170 -165 0 0 Sw
+1 -175 -170 0 0 Sw
+1 -180 -175 0 0 Sw
+1 -185 -180 0 0 Sw
+2 -190 -185 0 0 Sw
+2 -195 -190 0 0 Sw
+3 -200 -195 0 0 Sw
+4 -205 -200 0 0 Sw
+5 -210 -205 0 0 Sw
+7 -215 -210 0 0 Sw
+9 -220 -215 0 0 Sw
+13 -225 -220 0 0 Sw
+18 -230 -225 0 0 Sw
+25 -235 -230 0 0 Sw
+36 -240 -235 0 0 Sw
+51 -245 -240 0 0 Sw
+72 -250 -245 0 0 Sw
+102 -255 -250 0 0 Sw
+143 -260 -255 0 0 Sw
+198 -265 -260 0 0 Sw
+272 -270 -265 0 0 Sw
+0 434 M
+0 -162 D
+0 0 272 -270 -265 arc
+0 0 198 -265 -260 arc
+0 0 143 -260 -255 arc
+0 0 102 -255 -250 arc
+0 0 72 -250 -245 arc
+0 0 51 -245 -240 arc
+0 0 36 -240 -235 arc
+0 0 25 -235 -230 arc
+0 0 18 -230 -225 arc
+0 0 13 -225 -220 arc
+0 0 9 -220 -215 arc
+0 0 7 -215 -210 arc
+0 0 5 -210 -205 arc
+0 0 4 -205 -200 arc
+0 0 3 -200 -195 arc
+0 0 2 -195 -190 arc
+0 0 2 -190 -185 arc
+0 0 1 -185 -180 arc
+0 0 1 -180 -175 arc
+0 0 1 -175 -170 arc
+0 0 1 -170 -165 arc
+0 0 1 -165 -160 arc
+0 0 1 -160 -155 arc
+0 0 1 -155 -150 arc
+0 0 1 -150 -145 arc
+0 0 1 -145 -140 arc
+0 0 1 -140 -135 arc
+0 0 1 -135 -130 arc
+0 0 1 -130 -125 arc
+0 0 1 -125 -120 arc
+0 0 2 -120 -115 arc
+0 0 2 -115 -110 arc
+0 0 2 -110 -105 arc
+0 0 3 -105 -100 arc
+0 0 4 -100 -95 arc
+0 0 5 -95 -90 arc
+0 0 7 -90 -85 arc
+0 0 10 -85 -80 arc
+0 0 14 -80 -75 arc
+0 0 19 -75 -70 arc
+0 0 27 -70 -65 arc
+0 0 39 -65 -60 arc
+0 0 55 -60 -55 arc
+0 0 77 -55 -50 arc
+0 0 109 -50 -45 arc
+0 0 152 -45 -40 arc
+0 0 211 -40 -35 arc
+0 0 289 -35 -30 arc
+0 0 391 -30 -25 arc
+0 0 519 -25 -20 arc
+0 0 676 -20 -15 arc
+0 0 863 -15 -10 arc
+0 0 1077 -10 -5 arc
+0 0 1312 -5 0 arc
+0 0 1557 0 5 arc
+0 0 1799 5 10 arc
+0 0 2021 10 15 arc
+0 0 2205 15 20 arc
+0 0 2335 20 25 arc
+0 0 2400 25 30 arc
+0 0 2393 30 35 arc
+0 0 2314 35 40 arc
+0 0 2172 40 45 arc
+0 0 1979 45 50 arc
+0 0 1752 50 55 arc
+0 0 1508 55 60 arc
+0 0 1264 60 65 arc
+0 0 1033 65 70 arc
+0 0 824 70 75 arc
+0 0 642 75 80 arc
+0 0 491 80 85 arc
+0 0 434 85 90 arc S
+0 331 M
+29 86 D
+31 75 D
+41 83 D
+52 90 D
+65 96 D
+78 100 D
+93 103 D
+108 102 D
+39 34 D
+83 65 D
+44 32 D
+92 60 D
+97 55 D
+50 26 D
+52 24 D
+105 43 D
+107 35 D
+54 14 D
+54 12 D
+55 10 D
+54 7 D
+53 4 D
+53 2 D
+52 -1 D
+51 -3 D
+50 -6 D
+49 -9 D
+47 -12 D
+45 -14 D
+44 -17 D
+41 -19 D
+39 -22 D
+37 -25 D
+34 -27 D
+31 -29 D
+28 -32 D
+26 -34 D
+22 -35 D
+19 -38 D
+16 -39 D
+13 -40 D
+9 -42 D
+6 -43 D
+2 -45 D
+-1 -45 D
+-4 -45 D
+-7 -46 D
+-11 -47 D
+-14 -47 D
+-17 -46 D
+-20 -46 D
+-49 -92 D
+-29 -45 D
+-31 -44 D
+-69 -85 D
+-38 -41 D
+-40 -40 D
+-41 -38 D
+-43 -37 D
+-44 -35 D
+-46 -34 D
+-46 -32 D
+-48 -31 D
+-96 -56 D
+-98 -49 D
+-49 -22 D
+-50 -20 D
+-48 -19 D
+-49 -17 D
+-48 -15 D
+-47 -14 D
+-47 -12 D
+-46 -11 D
+-45 -10 D
+-44 -8 D
+-43 -7 D
+-41 -6 D
+-41 -4 D
+-39 -4 D
+-39 -3 D
+-37 -1 D
+-35 -1 D
+-99 2 D
+-114 11 D
+-72 12 D
+-97 25 D
+-32 10 D
+-63 26 D
+-52 28 D
+-29 19 D
+-22 19 D
+-8 7 D
+-7 9 D
+-2 1 D
+-9 14 D
+0 1 D
+-1 0 D
+-3 10 D
+-1 0 D
+0 4 D
+-1 0 D
+0 1 D
+-1 0 D
+-1 0 D
+0 1 D
+-1 0 D
+0 1 D
+-1 0 D
+0 1 D
+-1 0 D
+-1 3 D
+-1 0 D
+-1 3 D
+-1 0 D
+-8 18 D
+-5 18 D
+-5 27 D
+-4 41 D
+2 60 D
+10 68 D
+16 69 D
+P S
+{0 A} FS
+O1
+/PSL_vecheadpen {33 W 0 A [] 0 B} def
+17 W
+V 0 0 T 30.1042453729 R
+N 0 0 M 1921 0 D S
+U
+V 1792 1039 T 30.1042453729 R
+PSL_vecheadpen
+67 W
+0 0 M
+-150 40 D
+0 -80 D
+P clip fs P S 
+U
+0 -2567 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+267 F0
+(South) tc Z
+8 W
+2400 -2317 M
+0 -83 D
+-480 0 D
+0 83 D
+S
+2160 -2483 M 200 F0
+(0.2) tc Z
+2567 0 M 267 F0
+(East) ml Z
+-2567 0 M (West) mr Z
+0 2567 M (North) bc Z
+25 W
+FQ
+2400 0 0 Sc
+-2400 -2400 T
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psrose/sector_vpdf.sh
+++ b/test/psrose/sector_vpdf.sh
@@ -8,4 +8,4 @@ gmt math -T0/360/1 T 60 4 VPDF = t.txt
 # First plot the data set with best-fitting von Mises
 gmt psrose a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Glightblue -W1p -: -S -N0+p1p -JX4i -P -K -Xc -Em > $ps
 # Then plot the synthetic set with best-fitting von Mises
-gmt psrose t.txt -R -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Clightblue -W1p -: -S -N0+p1p -J -O -Y4.75i -Em >> $ps
+gmt psrose t.txt -R -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Glightblue -W1p -: -S -N0+p1p -J -O -Y4.75i -Em >> $ps

--- a/test/psrose/sector_vpdf.sh
+++ b/test/psrose/sector_vpdf.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Test gmt psrose with -Em and basemap amd -Ccpt
+
+ps=sector_vpdf.ps
+
+# Output a von Mises distribution centered on 60 with kappa = 4
+gmt math -T0/360/1 T 60 4 VPDF = t.txt
+# First plot the data set with best-fitting von Mises
+gmt psrose a.txt -R0/1/0/360 -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Glightblue -W1p -: -S -N0+p1p -JX4i -P -K -Xc -Em > $ps
+# Then plot the synthetic set with best-fitting von Mises
+gmt psrose t.txt -R -Bx0g0.2 -Byg60 -B+glightgreen -A5 -Clightblue -W1p -: -S -N0+p1p -J -O -Y4.75i -Em >> $ps


### PR DESCRIPTION
**Description of proposed changes**

This PR adds the **-N**_mode_[**+p**_pen_] option to rose so that the best-fitting von Mises distribution can be plotted when -A is used and angular range is 360.  At the present only *mode == 0* is supported, and to preserve backwards compatibility (for now) with the old **-N** option the mode argument is required.  I am leaving other modes available for future expansion.

A new test was added for this.  Top plot uses a synthetic data derived from **gmt math VPDF** as input (so giving an exact fit for **-N**) and the other uses the standard data in that test dir used for other tests. 

![sector_vpdf](https://user-images.githubusercontent.com/26473567/113444699-1b729580-9390-11eb-8694-5379f077a6b4.png)

 Also fixed minor issues in histogram docs related to the default pen for **-N**.  Closes #5064.

This is the last "new feature" PR from me for 6.2.  We will try to wrap up animation 14 and maybe a bug fix or two before RC1?
