### PR TITLE
Properly set min/max, lat-lilmit for global small circle

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9854,7 +9854,7 @@ struct GMT_DATASEGMENT * gmt_get_smallcircle (struct GMT_CTRL *GMT, double plon,
 	S->data[GMT_X][n - 1] = S->data[GMT_X][0];		/* Make really sure the polygon is closed */
 	S->data[GMT_Y][n - 1] = S->data[GMT_Y][0];
 	S->n_rows = n;
-	gmt_set_seg_polar (GMT, S);				/* Prepare if a polar cap */
+	gmt_set_seg_minmax (GMT, GMT_IS_POLY, 2, S);
 	return (S);	/* Pass out the results */
 }
 


### PR DESCRIPTION
While this does not fix #4551 it fixes a minor bug that appears not to have caused any problems (yet). At least now, when checking if the four map corners are inside or outside the large solar polygon it returns the correct results.  We are just not handling the plotting correctly yet.

