### PR TITLE
Fix misc warnings and bugs hiding in the gcc output

### DIFF
--- a/src/filter1d.c
+++ b/src/filter1d.c
@@ -620,7 +620,10 @@ GMT_LOCAL int filter1d_do_the_filter (struct GMTAPI_CTRL *C, struct FILTER1D_INF
 				k++;
 				continue;	/* Outside filter width array */
 			}
-			result = gmt_intpol (GMT, F->ft, F->fw, NULL, F->nw, 1, &(F->T.array[k]), &(F->filter_width), 0.0, GMT->current.setting.interpolant);
+			if ((result = gmt_intpol (GMT, F->ft, F->fw, NULL, F->nw, 1, &(F->T.array[k]), &(F->filter_width), 0.0, GMT->current.setting.interpolant))) {
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Interpolation failure in gmt_intpol (error %d) - skipping segment", result);
+				continue;
+			}
 			filter1d_set_up_filter (GMT, F);
 			if (F->T.array[k] < F->t_start || F->T.array[k] > F->t_stop) {
 				k++;

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -8608,14 +8608,12 @@ int GMT_Open_VirtualFile (void *V_API, unsigned int family, unsigned int geometr
 	 * name is the name given to the virtual file and is returned. */
 	int object_ID = GMT_NOTSET, item_s = 0;
 	unsigned int item, orig_family, actual_family = 0, via_type = 0, messenger = 0, module_input, the_mode = GMT_IS_DUPLICATE;
-	bool readonly = false;
 	struct GMTAPI_DATA_OBJECT *S_obj = NULL;
 	struct GMTAPI_CTRL *API = NULL;
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	module_input = (family & GMT_VIA_MODULE_INPUT);	/* Are we registering a resource that is a module input? */
 	family -= module_input;
 	if (direction & GMT_IS_REFERENCE) {	/* Treat this memory as read-only */
-		readonly = true;
 		direction -= GMT_IS_REFERENCE;
 		the_mode = GMT_IS_REFERENCE;
 	}
@@ -14935,7 +14933,7 @@ int GMT_Set_AllocMode (void *V_API, unsigned int family, void *object) {
 			break;
 		case GMT_IS_CUBE:	/* GMT cube */
 			UH = gmt_get_U_hidden (gmtapi_get_cube_data (object));
-			CH->alloc_mode = GMT_ALLOC_EXTERNALLY;
+			UH->alloc_mode = GMT_ALLOC_EXTERNALLY;
 			break;
 		case GMT_IS_POSTSCRIPT:		/* GMT PS */
 			PH = gmt_get_P_hidden (gmtapi_get_postscript_data (object));

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2977,7 +2977,7 @@ void gmt_hierarchy_tag (struct GMTAPI_CTRL *API, const char *kind, unsigned int 
 		if (!access (path, R_OK)) return;	/* Yes, found it */
 	}
 	/* Fall back is session level */
-	sprintf (tag, "");
+	tag[0] = '\0';
 	snprintf (path, PATH_MAX, "%s/%s%s", API->gwf_dir, kind, tag);
 }
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11444,7 +11444,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 					GMT->current.setting.auto_download = GMT_NO_DOWNLOAD;
 			}
 			else
-					error++;
+				error = true;
 			break;
 
 		case GMTCASE_GMT_CUSTOM_LIBS:

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1885,7 +1885,7 @@ nc_err:
 bool gmt_nc_is_cube (struct GMTAPI_CTRL *API, char *file) {
 	/* Return true if the file is a 3-D netCDF cube */
 	bool is_cube = false;
-	int i, ID = GMT_NOTSET, ncid, z_id = GMT_NOTSET, dim = 0, nvars, ndims = 0;
+	int i, ID = GMT_NOTSET, ncid, z_id = GMT_NOTSET, nvars, ndims = 0;
 	char varname[GMT_GRID_NAME_LEN256] = {""}, *c = NULL;
 	gmt_M_unused (API);
 
@@ -1916,10 +1916,8 @@ bool gmt_nc_is_cube (struct GMTAPI_CTRL *API, char *file) {
 			if (nc_inq_varndims (ncid, i, &ndims)) goto nc_cube_return;	/* Not good */
 			if (ndims == 3)	/* Found the first 3-D grid */
 				z_id = i;
-			else if (ID == GMT_NOTSET && ndims > 3 && ndims < 5) {	/* Also look for higher-dim grid in case no 3-D */
+			else if (ID == GMT_NOTSET && ndims > 3 && ndims < 5)	/* Also look for higher-dim grid in case no 3-D */
 				ID = i;
-				dim = ndims;
-			}
 			i++;
 		}
 	}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6079,7 +6079,7 @@ void gmt_map_title (struct GMT_CTRL *GMT, double x, double y) {
 	 * Note, when x = y = 0 it means current point has already been selected so we must store that and keep
 	 * moving up for each line in the multi-line title.
 	 */
-	bool pos_set = (gmt_M_is_zero (x) && gmt_M_is_zero (y)), many_lines = false, head_latex = false;
+	bool pos_set = (gmt_M_is_zero (x) && gmt_M_is_zero (y)), head_latex = false;
 	double sign = (pos_set) ? -1.0 : +1.0, y_next = 0.0, line_spacing;
 	unsigned int n_breaks_T = 0, n_breaks_S, k, form;
 	char *word = NULL, title[GMT_LEN256] = {""}, subtitle[GMT_LEN256] = {""}, sep[2] = {""};
@@ -6104,9 +6104,7 @@ void gmt_map_title (struct GMT_CTRL *GMT, double x, double y) {
 	n_breaks_T = gmt_char_count (title, GMT_ASCII_GS);		/* Is there a title spilling over several lines */
 	n_breaks_S = gmt_char_count (subtitle, GMT_ASCII_GS);	/* Is there a subtitle spilling over several lines */
 
-	if (n_breaks_T || n_breaks_S || subtitle[0])
-		many_lines = true;
-	else {	/* Just a single title string on one line */
+	if (!(n_breaks_T || n_breaks_S || subtitle[0])){	/* Just a single title string on one line */
 		if (gmt_text_is_latex (GMT, title)) {
 			/* Detected LaTeX commands, i.e., "....@[LaTeX...@[ ..." or  "....<math>LaTeX...</math> ..." */
 			(void)gmtplot_place_latex_eps (GMT, x, y, &GMT->current.setting.font_title, title);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12861,7 +12861,7 @@ cube_clean_up:
 	G->data = NULL;
 	gmt_free_grid (GMT, &G, true);
 
-	return (GMT_NOERROR);
+	return (error);
 }
 
 /*! . */

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -956,10 +956,10 @@ GMT_LOCAL void grdimage_img_gray_with_intensity (struct GMT_CTRL *GMT, struct GR
 GMT_LOCAL void grdimage_img_gray_no_intensity (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GRDIMAGE_CONF *Conf, unsigned char *image) {
 	/* Function that fills out the image in the special case of 1) image, 2) gray, 3) no intensity */
 	int64_t srow, scol;	/* Due to OPENMP on Windows requiring signed int loop variables */
-	gmt_M_unused (Ctrl);
 	uint64_t byte, kk_s, node_s;
 	struct GMT_GRID_HEADER *H_s = Conf->Image->header;	/* Pointer to the active data header */
 	gmt_M_unused (GMT);
+	gmt_M_unused (Ctrl);
 
 #ifdef _OPENMP
 #pragma omp parallel for private(srow,byte,kk_s,scol,node_s) shared(GMT,Conf,Ctrl,H_s,image)
@@ -1151,7 +1151,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 
 	struct GMT_GRID *Grid_orig = NULL, *Grid_proj = NULL;
 	struct GMT_GRID *Intens_orig = NULL, *Intens_proj = NULL;
-	struct GMT_GRID_HEADER_HIDDEN *HH = NULL, *IH = NULL;
+	struct GMT_GRID_HEADER_HIDDEN *HH = NULL;
 	struct GMT_PALETTE *P = NULL;
 	struct GRDIMAGE_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;	/* General GMT internal parameters */
@@ -1649,7 +1649,6 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 
 	/* From here, use Grid_proj or Img_proj plus optionally Intens_proj in making the (now) Cartesian rectangular image */
 
-	if (use_intensity_grid) IH = gmt_get_H_hidden (Intens_proj->header);
 	if (got_z_grid) { /* Dealing with a projected grid, so we only have one band [z]*/
 		Grid_proj->header->n_bands = 1;
 		header_work = Grid_proj->header;	/* Later when need to refer to the header, use this copy */

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -635,7 +635,7 @@ EXTERN_MSC int gmtlib_clock_C_format (struct GMT_CTRL *GMT, char *form, struct G
 
 EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 	char tmp_file_symbols[PATH_MAX] = {""}, tmp_file_labels[PATH_MAX] = {""}, cmd[BUFSIZ] = {""}, *c = NULL;
-	char string[GMT_LEN128] = {""}, header[GMT_BUFSIZ] = {""}, X[GMT_LEN32] = {""}, Y[GMT_LEN32] = {""},find;
+	char string[GMT_LEN128] = {""}, header[GMT_BUFSIZ] = {""}, X[GMT_LEN32] = {""}, Y[GMT_LEN32] = {""};
 
 	bool do_coda, finite_duration, out_segment = false;
 
@@ -884,7 +884,6 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 	finite_duration = (Ctrl->L.mode != PSEVENTS_INFINITE);
 	time_type = gmt_M_type (GMT, GMT_IN, t_in);
 	end_type = (Ctrl->L.mode == PSEVENTS_VAR_ENDTIME) ? time_type : GMT_IS_FLOAT;
-	find = (time_type == GMT_IS_ABSTIME) ? ',' : '/';
 	x_type = gmt_M_type (GMT, GMT_IN, GMT_X);
 	y_type = gmt_M_type (GMT, GMT_IN, GMT_Y);
 	if (x_type == GMT_IS_ABSTIME || y_type == GMT_IS_ABSTIME) {	/* Force precision of msec */

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -604,6 +604,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 							n_errors += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_b, GMT_IS_LAT, &Ctrl->A.lat1), txt_b);
 							Ctrl->A.PREF.str = atof (txt_c);
 							Ctrl->A.p_length = atof (txt_d);
+							break;
 						case 'c':
 							n_errors += gmt_verify_expectations (GMT, GMT_IS_FLOAT, gmt_scanf (GMT, txt_a, GMT_IS_FLOAT, &Ctrl->A.lon1), txt_a);
 							n_errors += gmt_verify_expectations (GMT, GMT_IS_FLOAT, gmt_scanf (GMT, txt_b, GMT_IS_FLOAT, &Ctrl->A.lat1), txt_b);
@@ -615,6 +616,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 							n_errors += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_b, GMT_IS_LAT, &Ctrl->A.lat1), txt_b);
 							Ctrl->A.PREF.str = atof (txt_c);
 							Ctrl->A.p_length = atof (txt_d);
+							break;
 						default:
 							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A: Unrecognized mode %c.\n", Ctrl->A.proj_type);
 							n_errors++;


### PR DESCRIPTION
Compiling for the bundle with gcc-mp yields 1000s of warnings so really hard to find the ones that are significant.  This PR fixes some of these, including a few bugs that did not affect our tests (but could cause trouble for other option choices).
