### PR TITLE
Set geographic on the right direction (in or out)

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10712,7 +10712,7 @@ void * GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry,
 		if (this_dim == NULL) this_dim = zero_dim;	/* Provide dimensions set to zero */
 	}
 
-	if (mode & GMT_GRID_IS_GEO) gmt_set_geographic (API->GMT, GMT_OUT);	/* From API to tell a grid is geographic */
+	if (mode & GMT_GRID_IS_GEO) gmt_set_geographic (API->GMT, def_direction);	/* From API to tell a grid is geographic */
 
 	/* Below, data can only be non-NULL for Grids or Images passing back G or I to allocate the data array */
 


### PR DESCRIPTION
When **GMT_GRID_IS_GEO** is passed to _GMT_Create_Data_, we need to pay attention if it is for input or output.  This is step one in support of fixing a [pygmt](https://github.com/GenericMappingTools/pygmt/issues/1172) issue.