### PR TITLE
Ensure geographic datasets passed by memory files are seen as geographic

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -1301,7 +1301,9 @@ directly (they either expect **GMT_IS_GRID** or **GMT_IS_DATASET**, for instance
 The solution is to specify the container type the GMT module expects but add in the special
 flags **GMT_VIA_MATRIX** or **GMT_VIA*VECTOR**.  This will create the **GMT_IS_MATRIX** or
 **GMT_IS_VECTOR** container the user needs to add the user data, but will also tell GMT how
-they should be considered by the module.
+they should be considered by the module. **Note**: When creating your own geographic data
+(dataset, grid, image, matrix, or vector) you may add ``GMT_DATA_IS_GEO`` to ``mode`` so that
+the structure that is created will retain this information.
 
 For grids and images you may pass ``pad`` to set the padding, or -1 to
 accept the prevailing GMT default. The ``mode`` determines what is actually

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2745,8 +2745,8 @@ GMT_LOCAL int gmtapi_decode_id (const char *filename) {
 
 /*! . */
 bool gmtlib_data_is_geographic (struct GMTAPI_CTRL *API, const char *file) {
-	/* Here file is a memory file. If grid, matrix, or dataset determine if geographic */
-	bool geo = false;
+	/* Here file is a memory file. If dataset, grid, image, matrix, or vector we determine if geographic */
+	bool geo = false;	/* Default is Cartesian */
 	int object_ID, item;
 	struct GMT_DATASET *D;
 	struct GMT_GRID *G;
@@ -2754,7 +2754,6 @@ bool gmtlib_data_is_geographic (struct GMTAPI_CTRL *API, const char *file) {
 	struct GMT_MATRIX *M;
 	struct GMT_VECTOR *V;
 	struct GMT_DATASET_HIDDEN *HD;
-	struct GMT_GRID_HIDDEN *GH;
 	struct GMT_GRID_HEADER_HIDDEN *HH;
 	struct GMT_MATRIX_HIDDEN *HM;
 	struct GMT_VECTOR_HIDDEN *HV;
@@ -2765,9 +2764,9 @@ bool gmtlib_data_is_geographic (struct GMTAPI_CTRL *API, const char *file) {
 
 	/* Must get pointer to the hidden structure */
 	if ((object_ID = gmtapi_decode_id (file)) == GMT_NOTSET)
-		return false;	/* Should not happen but return not geographic */
+		return false;	/* Should not happen but return as not geographic */
 	if ((item = gmtlib_validate_id (API, GMT_NOTSET, object_ID, GMT_NOTSET, GMT_NOTSET)) == GMT_NOTSET)
-		return false;	/* Should not happen but return not geographic */
+		return false;	/* Should not happen but return as not geographic */
 
 	switch (file[GMTAPI_OBJECT_FAMILY_START]) {
 		case 'D':	/* Memory dataset */
@@ -10789,7 +10788,7 @@ void * GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry,
 		if (this_dim == NULL) this_dim = zero_dim;	/* Provide dimensions set to zero */
 	}
 
-	if (mode & GMT_DATA_IS_GEO) gmt_set_geographic (API->GMT, def_direction);	/* From API to tell a grid is geographic */
+	if (mode & GMT_DATA_IS_GEO) gmt_set_geographic (API->GMT, def_direction);	/* From API to tell the data are geographic */
 
 	/* Below, data can only be non-NULL for Grids or Images passing back G or I to allocate the data array */
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5324,7 +5324,7 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 	if (S_obj->region) {	/* See if this is really a subset or just the same region as the grid */
 		if (G_obj->header->wesn[XLO] == S_obj->wesn[XLO] && G_obj->header->wesn[XHI] == S_obj->wesn[XHI] && G_obj->header->wesn[YLO] == S_obj->wesn[YLO] && G_obj->header->wesn[YHI] == S_obj->wesn[YHI]) S_obj->region = false;
 	}
-	if (mode & GMT_GRID_IS_GEO) gmt_set_geographic (GMT, GMT_OUT);	/* From API to tell grid is geographic */
+	if (mode & GMT_DATA_IS_GEO) gmt_set_geographic (GMT, GMT_OUT);	/* From API to tell grid is geographic */
 	gmtlib_grd_set_units (GMT, G_obj->header);	/* Ensure unit strings are set, regardless of destination */
 	method = gmtapi_set_method (S_obj);	/* Get the actual method to use since may be MATRIX or VECTOR masquerading as GRID */
 	switch (method) {
@@ -6054,7 +6054,7 @@ GMT_LOCAL int gmtapi_export_cube (struct GMTAPI_CTRL *API, int object_ID, unsign
 			U_obj->z_range[0] == S_obj->wesn[ZLO] && U_obj->z_range[1] == S_obj->wesn[ZHI])
 				S_obj->region = false;
 	}
-	if (mode & GMT_GRID_IS_GEO) gmt_set_geographic (GMT, GMT_OUT);	/* From API to tell cube is geographic */
+	if (mode & GMT_DATA_IS_GEO) gmt_set_geographic (GMT, GMT_OUT);	/* From API to tell cube is geographic */
 	gmtapi_cube_set_units (GMT, U_obj);	/* Ensure unit strings are set, regardless of destination */
 
 	method = gmtapi_set_method (S_obj);	/* Get the actual method to use since may be MATRIX or VECTOR masquerading as GRID */
@@ -10789,7 +10789,7 @@ void * GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry,
 		if (this_dim == NULL) this_dim = zero_dim;	/* Provide dimensions set to zero */
 	}
 
-	if (mode & GMT_GRID_IS_GEO) gmt_set_geographic (API->GMT, def_direction);	/* From API to tell a grid is geographic */
+	if (mode & GMT_DATA_IS_GEO) gmt_set_geographic (API->GMT, def_direction);	/* From API to tell a grid is geographic */
 
 	/* Below, data can only be non-NULL for Grids or Images passing back G or I to allocate the data array */
 

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 253
+#define GMT_N_API_ENUMS 254
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -75,6 +75,7 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_CPT_SOFT_HINGE", 8},
 	{"GMT_CPT_TIME", 16},
 	{"GMT_CUBE_IS_STACK", 64},
+	{"GMT_DATA_IS_GEO", 256},
 	{"GMT_DATA_ONLY", 2},
 	{"GMT_DATETIME", 32},
 	{"GMT_DOUBLE", 9},

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1267,6 +1267,45 @@ bool gmt_grd_pad_status (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, u
 	}
 }
 
+int gmtlib_get_matrixtype (struct GMT_CTRL *GMT, unsigned int direction, struct GMT_MATRIX *M) {
+	/* Determine if input or output matrix is Cartesian or geographic, and if so if longitude range is <360, ==360, or >360 */
+	char *dir[2] = {"input", "output"};
+	if (gmt_M_x_is_lon (GMT, direction)) {	/* Data set is geographic with x = longitudes */
+		if (fabs (M->range[XHI] - M->range[XLO] - 360.0) < GMT_CONV4_LIMIT) {
+			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Geographic %s matrix, longitudes span exactly 360\n", dir[direction]);
+			/* If w/e is 360 and gridline reg then we have a repeat entry for 360.  For pixel there are never repeat pixels */
+			return ((M->registration == GMT_GRID_NODE_REG) ? GMT_GRID_GEOGRAPHIC_EXACT360_REPEAT : GMT_GRID_GEOGRAPHIC_EXACT360_NOREPEAT);
+		}
+		else if (fabs (M->n_columns * M->inc[GMT_X] - 360.0) < GMT_CONV4_LIMIT) {
+			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Geographic %s matrix, longitude cells span exactly 360\n", dir[direction]);
+			/* If n*xinc = 360 and previous test failed then we do not have a repeat node */
+			return (GMT_GRID_GEOGRAPHIC_EXACT360_NOREPEAT);
+		}
+		else if ((M->range[XHI] - M->range[XLO]) > 360.0) {
+			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Geographic %s matrix, longitudes span more than 360\n", dir[direction]);
+			return (GMT_GRID_GEOGRAPHIC_MORE360);
+		}
+		else {
+			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Geographic %s matrix, longitudes span less than 360\n", dir[direction]);
+			return (GMT_GRID_GEOGRAPHIC_LESS360);
+		}
+	}
+	else if (M->range[YLO] >= -90.0 && M->range[YHI] <= 90.0) {	/* Here we simply advice the user if matrix looks like geographic but is not set as such */
+		if (fabs (M->range[XHI] - M->range[XLO] - 360.0) < GMT_CONV4_LIMIT) {
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Cartesian %s matrix, yet x spans exactly 360 and -90 <= y <= 90.\n", dir[direction]);
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "     To make sure the matrix is recognized as geographical and global, use the -fg option\n");
+			return (GMT_GRID_CARTESIAN);
+		}
+		else if (fabs (M->n_columns * M->inc[GMT_X] - 360.0) < GMT_CONV4_LIMIT) {
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Cartesian %s matrix, yet x cells span exactly 360 and -90 <= y <= 90.\n", dir[direction]);
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "     To make sure the matrix is recognized as geographical and global, use the -fg option\n");
+			return (GMT_GRID_CARTESIAN);
+		}
+	}
+	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Cartesian %s matrix\n", dir[direction]);
+	return (GMT_GRID_CARTESIAN);
+}
+
 int gmtlib_get_grdtype (struct GMT_CTRL *GMT, unsigned int direction, struct GMT_GRID_HEADER *h) {
 	/* Determine if input or output grid is Cartesian or geographic, and if so if longitude range is <360, ==360, or >360 */
 	char *dir[2] = {"input", "output"};

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -137,6 +137,7 @@ struct GMT_VECTOR_HIDDEN {	/* Supporting information hidden from the API */
 struct GMT_MATRIX_HIDDEN {	/* Supporting information hidden from the API */
 	uint64_t id;			/* The internal number of the data set */
 	int pad;			/* The internal number of the data set */
+	unsigned int grdtype;		/* 0 for Cartesian, > 0 for geographic and depends on 360 periodicity [see GMT_enum_grdtype in gmt_grd.h] */
 	unsigned int alloc_level;	/* The level it was allocated at */
 	enum GMT_enum_alloc alloc_mode;	/* Allocation mode [GMT_ALLOC_INTERNALLY] */
 	enum GMT_enum_alloc alloc_mode_text;	/* Allocation mode per text [GMT_ALLOC_INTERNALLY] */

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -97,6 +97,7 @@ struct GMT_DATASET_HIDDEN {	/* Supporting information hidden from the API */
 	size_t n_alloc;			/* The current allocation length of tables */
 	uint64_t dim[4];		/* Only used by GMT_Duplicate_Data to override dimensions */
 	unsigned int alloc_level;	/* The level it was allocated at */
+	unsigned int geographic;	/* 0 for Cartesian, 1 for geographic, mostly used for memory files */
 	enum GMT_enum_write io_mode;	/* -1 means write OGR format (requires proper -a),
 					 * 0 means write everything to one destination [Default],
 					 * 1 means use table->file[GMT_OUT] to write separate table,
@@ -130,6 +131,7 @@ struct GMT_POSTSCRIPT_HIDDEN {	/* Supporting information hidden from the API */
 struct GMT_VECTOR_HIDDEN {	/* Supporting information hidden from the API */
 	uint64_t id;			/* The internal number of the data set */
 	unsigned int alloc_level;	/* The level it was allocated at */
+	unsigned int geographic;	/* 0 for Cartesian, 1 for geographic, mostly used for memory files */
 	enum GMT_enum_alloc *alloc_mode;	/* Allocation mode per column [GMT_ALLOC_INTERNALLY] */
 	enum GMT_enum_alloc alloc_mode_text;	/* Allocation mode per text [GMT_ALLOC_INTERNALLY] */
 };
@@ -145,7 +147,7 @@ struct GMT_MATRIX_HIDDEN {	/* Supporting information hidden from the API */
 
 struct GMT_GRID_HEADER_HIDDEN {
 	/* ---- Variables "hidden" from the API ----
-	 * This section is flexible.  It is not copied to any grid header
+	 * This section is flexible.  It is not copied to any grid or image header
 	 * or stored in any file.  It is considered private */
 	unsigned int trendmode;          /* Holds status for detrending of grids.  0 if not detrended, 1 if mean, 2 if mid-value, and 3 if LS plane removed */
 	unsigned int arrangement;        /* Holds status for complex grid as how the read/imag is placed in the grid (interleaved, R only, etc.) */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14805,11 +14805,12 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 
 	GMT->current.ps.active = is_PS;		/* true if module will produce PS */
 
+	/* Check if there is an impute remote grid or memory file so we may set geographic to be true now before we must decide on auto-J */
 	if (options && (opt = GMT_Find_Option (API, GMT_OPT_INFILE, *options))) {
-		if (gmt_remote_dataset_id (API, opt->arg) != GMT_NOTSET)
-			gmt_set_geographic (GMT, GMT_IN);	/* Help parsing of -R in case geographic coordinates are given to tools like grdcut */
-		else if (gmtlib_grid_is_geographic (API, opt->arg))
-			gmt_set_geographic (GMT, GMT_IN);	/* Help parsing of -R in case geographic coordinates are given to tools like grdcut */
+		if (gmt_remote_dataset_id (API, opt->arg) != GMT_NOTSET)	/* All remote data grids/images are geographic */
+			gmt_set_geographic (GMT, GMT_IN);
+		else if (gmtlib_data_is_geographic (API, opt->arg))	/* This dataset, grid, image, matrix, or vector is geographic */
+			gmt_set_geographic (GMT, GMT_IN);
 	}
 
 	if (options && GMT->current.setting.run_mode == GMT_MODERN) {	/* Make sure options conform to this mode's harsh rules: */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14805,7 +14805,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 
 	GMT->current.ps.active = is_PS;		/* true if module will produce PS */
 
-	/* Check if there is an impute remote grid or memory file so we may set geographic to be true now before we must decide on auto-J */
+	/* Check if there is an input remote grid or memory file so we may set geographic to be true now before we must decide on auto-J */
 	if (options && (opt = GMT_Find_Option (API, GMT_OPT_INFILE, *options))) {
 		if (gmt_remote_dataset_id (API, opt->arg) != GMT_NOTSET)	/* All remote data grids/images are geographic */
 			gmt_set_geographic (GMT, GMT_IN);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14808,6 +14808,8 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	if (options && (opt = GMT_Find_Option (API, GMT_OPT_INFILE, *options))) {
 		if (gmt_remote_dataset_id (API, opt->arg) != GMT_NOTSET)
 			gmt_set_geographic (GMT, GMT_IN);	/* Help parsing of -R in case geographic coordinates are given to tools like grdcut */
+		else if (gmtlib_grid_is_geographic (API, opt->arg))
+			gmt_set_geographic (GMT, GMT_IN);	/* Help parsing of -R in case geographic coordinates are given to tools like grdcut */
 	}
 
 	if (options && GMT->current.setting.run_mode == GMT_MODERN) {	/* Make sure options conform to this mode's harsh rules: */

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -53,7 +53,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
-EXTERN_MSC bool gmtlib_grid_is_geographic (struct GMTAPI_CTRL *API, const char *file);
+EXTERN_MSC bool gmtlib_data_is_geographic (struct GMTAPI_CTRL *API, const char *file);
 EXTERN_MSC void gmtlib_set_case_and_kind (struct GMT_CTRL *GMT, char *format, bool *upper_case, unsigned int *flavor);
 EXTERN_MSC bool gmtlib_fixed_paper_size (struct GMTAPI_CTRL *API);
 EXTERN_MSC struct GMT_CUBE *gmtlib_create_cube (struct GMT_CTRL *GMT);

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -53,6 +53,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC bool gmtlib_grid_is_geographic (struct GMTAPI_CTRL *API, const char *file);
 EXTERN_MSC void gmtlib_set_case_and_kind (struct GMT_CTRL *GMT, char *format, bool *upper_case, unsigned int *flavor);
 EXTERN_MSC bool gmtlib_fixed_paper_size (struct GMTAPI_CTRL *API);
 EXTERN_MSC struct GMT_CUBE *gmtlib_create_cube (struct GMT_CTRL *GMT);
@@ -214,6 +215,7 @@ EXTERN_MSC bool gmtlib_is_gleap (int gyear);
 EXTERN_MSC char * gmtlib_cptfile_unitscale (struct GMTAPI_CTRL *API, char *name);
 EXTERN_MSC void gmtlib_set_oblique_pole_and_origin (struct GMT_CTRL *GMT, double plon, double plat, double olon, double olat);
 EXTERN_MSC int gmtlib_get_grdtype (struct GMT_CTRL *GMT, unsigned int direction, struct GMT_GRID_HEADER *h);
+EXTERN_MSC int gmtlib_get_matrixtype (struct GMT_CTRL *GMT, unsigned int direction, struct GMT_MATRIX *M);
 EXTERN_MSC void gmtlib_grd_real_interleave (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_grdfloat *data);
 EXTERN_MSC void gmtlib_grd_get_units (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header);
 EXTERN_MSC void gmtlib_grd_set_units (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header);

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -272,6 +272,10 @@ enum GMT_enum_header {
 	GMT_HEADER_ON = 1	/* Enable header blocks out as default */
 };
 
+enum GMT_enum_data {
+	GMT_DATA_IS_GEO = 256	/*  Data are geographic, not Cartesian */
+};
+
 enum GMT_enum_alloc {
 	GMT_ALLOC_EXTERNALLY = 0,	/* Allocated outside of GMT: We cannot reallocate or free this memory */
 	GMT_ALLOC_INTERNALLY = 1,	/* Allocated by GMT: We may reallocate as needed and free when no longer needed */
@@ -362,7 +366,7 @@ enum GMT_enum_gridio {
 	GMT_GRID_ROW_BY_ROW	   = 32U,   /* Read|write the grid array one row at the time sequentially */
 	GMT_GRID_ROW_BY_ROW_MANUAL = 64U,   /* Read|write the grid array one row at the time in any order */
 	GMT_GRID_XY		   = 128U,  /* Allocate and initialize x,y vectors */
-	GMT_GRID_IS_GEO		   = 256U,  /* Grid is a geographic grid, not Cartesian */
+	GMT_GRID_IS_GEO		   = 256U,  /* Grid is a geographic grid, not Cartesian [Deprecated, use GMT_DATA_IS_GEO instead] */
 	GMT_GRID_IS_IMAGE	   = 512U,   /* Grid may be an image, only allowed with GMT_CONTAINER_ONLY */
 	GMT_IMAGE_NO_INDEX	   = 4096,	/* If reading an indexed grid, convert to rgb so we can interpolate */
 	GMT_IMAGE_ALPHA_LAYER  = 8192	/* Place any alpha layer in the image band, not alpha array */


### PR DESCRIPTION
Externals (in this case [PyGMT](https://github.com/GenericMappingTools/pygmt/issues/1172)) may pass data into GMT modules.  These may be created and data added, and the creator may know the data are geographic and may flag that via the bit-flag **GMT_GRID_IS_GEO** in _GMT_Create_Data_.  Unfortunately, this was not honored.  Furthermore, this concept should not be restricted to grids: The user may know that the created dataset, grid, image, matrix, or vector is geographic and would like to pass that information into the data structure.  This PR allows for that while fixing the grid-specific bug.  Now,

1. **GMT_GRID_IS_GEO** is deprecated and we use **GMT_DATA_IS_GEO** instead for all the above data types (the old enum is kept for backwards compatibility)
2. The bit-flag, if set, calls _gmt_set_geographic_ for the chosen direction (input or output source)
3. When _GMT_Create_Data_ builds the various structures we check on that and add a _grdtype_ flag for grids, images, matrices (same value and meaning as in hidden grid header) and a _geographic_ = 0|1 flag for datasets and vectors
4. When _gmt_init_module_ checks if an input file (if found) is a remote data set (and hence sets geographic) we also check if given a memory file to see if it is known to be geographic.
5. When we call _GMT_Read_Data_ and the sources is a memory file we are now able to process the hidden geographic information.

With these changes, a memory file passed that is known to be geographic will trigger an automatic geographic projection if none had been selected explicitly with **-J**.

**Note**: Tested with the original PyGMT problem.  I assume it will work similarly for images and grids, as well as data sets and vectors, but there are no such external tests (yet).  I also updated the API doc to mention the purpose of the **GMT_DATA_IS_DATA** flag under _GMT_Create_Data_.