### PR TITLE
Ensure plot region needed for -Pf uses ISO formatting for absolute time

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -2010,7 +2010,10 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 							L_col = D->table[0]->segment[0]->data[I->col][use_frame];
 							if ((type = gmt_M_type (GMT, GMT_IN, I->col)) == GMT_IS_ABSTIME) {	/* Time formatting */
 								char date[GMT_LEN16] = {""}, clock[GMT_LEN16] = {""};
-								gmt_format_calendar (GMT, date, clock, &GMT->current.plot.calclock.date, &GMT->current.plot.calclock.clock, upper_case[k], flavor[k], L_col);
+								if (I->kind == 'F')	/* Must give a proper ISO region */
+									gmt_format_calendar (GMT, date, clock, &GMT->current.io.date_output, &GMT->current.io.clock_output, false, 1, L_col);
+								else
+									gmt_format_calendar (GMT, date, clock, &GMT->current.plot.calclock.date, &GMT->current.plot.calclock.clock, upper_case[k], flavor[k], L_col);
 								if (GMT->current.plot.calclock.clock.skip)
 									sprintf (string, "%s", date);
 								else if (GMT->current.plot.calclock.date.skip)


### PR DESCRIPTION
See struggles in #5019.  The problem was I used the prevailing **FORMAT_DATE_MAP** and **FORMAT_CLOCK_MAP** settings to make an **-R** string but that is just wrong, of course.  For this purpose (making a **-R** argument to a module) we need **FORMAT_DATE_OUT** and **FORMAT_CLOCK_OUT**, as implemented in this PR.
