### PR TITLE
Use docutils version 0.16 to build gmt docs

### DIFF
--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y --no-install-recommends --no-install-suggests $packages
 # Install more packages for building documentation
 if [ "$BUILD_DOCS" = "true" ]; then
     sudo snap install pngquant
-    pip3 install --user sphinx
+    pip3 install --user docutils==0.16 phinx
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y --no-install-recommends --no-install-suggests $packages
 # Install more packages for building documentation
 if [ "$BUILD_DOCS" = "true" ]; then
     sudo snap install pngquant
-    pip3 install --user docutils==0.16 phinx
+    pip3 install --user docutils==0.16 sphinx
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -38,7 +38,7 @@ fi
 brew install ${packages}
 
 if [ "$BUILD_DOCS" = "true" ]; then
-	pip3 install --user sphinx
+	pip3 install --user docutils==0.16 sphinx
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -33,7 +33,7 @@ choco install ninja
 choco install ghostscript --version 9.50
 
 if [ "$BUILD_DOCS" = "true" ]; then
-    pip install --user sphinx
+    pip install --user docutils==0.16 sphinx
     # Add sphinx to PATH
     echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
 

--- a/ci/vercel-docs.sh
+++ b/ci/vercel-docs.sh
@@ -11,7 +11,7 @@ yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.r
 yum install cmake3 ninja-build libcurl-devel netcdf-devel
 # Install Python packages
 # importlib-resources is required for Python <3.7
-pip install sphinx importlib-resources
+pip install docutils==0.16 sphinx importlib-resources
 
 # Install latest gs
 curl -SLO https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9533/ghostscript-9.53.3-linux-x86_64.tgz


### PR DESCRIPTION
**Description of proposed changes**

The 0.17 docutils release broke much of the formatting for the sphinx_rtd_theme. This PR pins the docutils dependency of sphinx to v0.16.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #5097 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
