### PR TITLE
Fix minor annoyances in the API

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15152,7 +15152,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		opt_J = GMT_Find_Option (API, 'J', *options);
 
 		for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
-			if (opt->arg[0] != '@') continue;	/* No remote file argument given */
+			if (gmt_M_file_is_memory (opt->arg) || opt->arg[0] != '@') continue;	/* No remote file argument given */
 			if ((k_data = gmt_remote_no_extension (API, opt->arg)) != GMT_NOTSET) {	/* Remote file without file extension */
 				char *file = malloc (strlen(opt->arg)+1+strlen (API->remote_info[k_data].ext));
 				sprintf (file, "%s", opt->arg);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -374,6 +374,7 @@ void gmt_set_unspecified_remote_registration (struct GMTAPI_CTRL *API, char **fi
 	char newfile[GMT_LEN256] = {""}, reg[2] = {'p', 'g'}, *file = NULL, *infile = NULL, *ext = NULL, *c = NULL;
 	int k_data, k;
 	if (file_ptr == NULL || (file = *file_ptr) == NULL || file[0] == '\0') return;
+	if (gmt_M_file_is_memory (file)) return;	/* Not a remote file for sure */
 	if (file[0] != '@') return;
 	infile = strdup (file);
 	if ((c = strchr (infile, '+')))	/* Got modifiers, probably from grdimage or similar, chop off for now */


### PR DESCRIPTION
Adding a few more checks to skip actions when input is a memory file, and also attempt to update the type field in the API object container when a matrix of known type is added.  None of these are expected to fix anything but is the right thing to do.  Done as part of hunting down [this bug](https://github.com/GenericMappingTools/pygmt/issues/1177).
