### PR TITLE
Fix again the pesky gmt_geo_polarcap_segment memory issue

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -4375,15 +4375,17 @@ GMT_LOCAL uint64_t gmtplot_geo_polygon_segment (struct GMT_CTRL *GMT, struct GMT
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Path already had a detour to the pole, skip adding another detour\n");
 			add_pole = false;
 			n = gmt_geo_polarcap_segment (GMT, S, &plon, &plat);
-			free_memory = true;
+			if (plon != S->data[GMT_X])	/* Pointer changed so we allocated, must delete below */
+				free_memory = true;
 		}
 	}
 	if (add_pole) {	/* If we get here then a detour will be needed */
 		if ((n = gmt_geo_polarcap_segment (GMT, S, &plon, &plat)) == 0) {	/* Not a global map */
 			/* Here we must detour to the N or S pole, then resample the path */
 			n = S->n_rows + 2;	/* Add new first and last point to connect to the pole */
-			plon = gmt_M_memory (GMT, NULL, n, double);
+			plon = gmt_M_memory (GMT, NULL, n, double);	/* This memory must be freed below */
 			plat = gmt_M_memory (GMT, NULL, n, double);
+			free_memory = true;
 			t_lat = SH->pole * 90.0;	/* This is presumably the correct pole, but could fail if just touching the pole */
 			if (S->data[GMT_Y][0] * t_lat < 0.0) t_lat = -t_lat;	/* Well, I'll be damned... */
 			plat[0] = plat[n-1] = t_lat;
@@ -4397,7 +4399,7 @@ GMT_LOCAL uint64_t gmtplot_geo_polygon_segment (struct GMT_CTRL *GMT, struct GMT
 				return 0;
 			}
 		}
-		else
+		else if (plon != S->data[GMT_X])	/* Pointer changed so we allocated, must delete below */
 			free_memory = true;
 	}
 	k = gmtplot_geo_polygon (GMT, plon, plat, n, first, comment);	/* Plot filled polygon [no outline] */

--- a/src/pssolar.c
+++ b/src/pssolar.c
@@ -568,6 +568,7 @@ EXTERN_MSC int GMT_pssolar (void *V_API, int mode, void *args) {
 			Ctrl->T.which = n;
 			pssolar_params (Ctrl, Sun);
 			S = gmt_get_smallcircle (GMT, -Sun->HourAngle, Sun->SolarDec, Sun->radius, n_pts);
+			GMT_Report (API, GMT_MSG_INFORMATION, "Plot small circle with pole at %g/%g and radius %g degrees\n",  -Sun->HourAngle, Sun->SolarDec, Sun->radius);
 			if (Ctrl->G.clip) {	/* Set up a clip path */
 				bool must_free = true;
 				if ((n_pts = (int)gmt_geo_polarcap_segment (GMT, S, &lon, &lat)) == 0) {	/* No resampling took place */


### PR DESCRIPTION
A bit of bad design here as this function may or may not allocate new memory and if it does then we must free it since the original S->data is still there.  This fix seems to take care of the two cases that failed with memory leak before.

The PR also has an informational message added to pssolar under -V.