### PR TITLE
Incorrect number of output points in solar

### DIFF
--- a/doc/rst/source/solar_common.rst_
+++ b/doc/rst/source/solar_common.rst_
@@ -4,7 +4,7 @@ Description
 -----------
 
 **solar** calculates the day-night terminator and the civil, nautical and astronomical twilights
-and either writes them to standard output or uses then for clipping of filling on maps.
+and either writes them to standard output or uses them for clipping of filling on maps.
 
 
 Required Arguments

--- a/doc/rst/source/solar_common.rst_
+++ b/doc/rst/source/solar_common.rst_
@@ -3,8 +3,8 @@
 Description
 -----------
 
-**solar** calculates the day-night terminator and the civil, nautical and astronomical twilights
-and either writes them to standard output or uses them for clipping of filling on maps.
+**solar** calculates closed polygons for the day-night terminator and the civil, nautical and astronomical twilights
+and either writes them to standard output or uses them for clipping or filling on maps.
 
 
 Required Arguments

--- a/doc/rst/source/solar_common.rst_
+++ b/doc/rst/source/solar_common.rst_
@@ -3,7 +3,8 @@
 Description
 -----------
 
-**solar** Calculate and plot the day-night terminator and the civil, nautical and astronomical twilights.
+**solar** calculates the day-night terminator and the civil, nautical and astronomical twilights
+and either writes them to standard output or uses then for clipping of filling on maps.
 
 
 Required Arguments
@@ -50,7 +51,7 @@ Optional Arguments
 .. _-M:
 
 **-M**
-    Write terminator(s) as a multisegment ASCII (or binary, see **-b**\ *o*) file to standard output. No plotting occurs.
+    Write terminator(s) as a multisegment ASCII (or binary, see **-b**\ *o*) polygons to standard output. No plotting occurs.
 
 .. _-N:
 

--- a/src/pssolar.c
+++ b/src/pssolar.c
@@ -538,7 +538,7 @@ EXTERN_MSC int GMT_pssolar (void *V_API, int mode, void *args) {
 			S = gmt_get_smallcircle (GMT, -Sun->HourAngle, Sun->SolarDec, Sun->radius, n_pts);
 			sprintf (record, "%s terminator", terms[n]);
 			GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, record);
-			for (j = 0; j < n_pts; j++) {
+			for (j = 0; j < S->n_rows; j++) {
 				out[GMT_X] = S->data[GMT_X][j];	out[GMT_Y] = S->data[GMT_Y][j];
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			}

--- a/src/pssolar.c
+++ b/src/pssolar.c
@@ -135,7 +135,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Add +d<date> in ISO format, e.g, +d2000-04-25, to compute sun parameters\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   for this date. If necessary, append time zone via +z<TZ>.\n");
 	GMT_Option (API, "J,K");
-	GMT_Message (API, GMT_TIME_NONE, "\t-M Write terminator(s) as a multisegment ASCII (or binary, see -bo) file to standard output. No plotting occurs.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-M Write terminator(s) as a multisegment ASCII (or binary, see -bo) polygons to standard output. No plotting occurs.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-N Use the outside of the polygons and the map boundary as clip paths.\n");
 	GMT_Option (API, "O,P,R");
 	GMT_Message (API, GMT_TIME_NONE, "\t-T <dcna> Plot (or dump; see -M) one or more terminators defined via these flags:\n");
@@ -507,7 +507,7 @@ EXTERN_MSC int GMT_pssolar (void *V_API, int mode, void *args) {
 			}
 		}
 	}
-	else if (Ctrl->M.active) {						/* Dump terminator(s) to stdout, no plotting takes place */
+	else if (Ctrl->M.active) {						/* Dump terminator(s) polygons to stdout; no plotting takes place */
 		int n_items;
 		char  *terms[4] = {"Day/night", "Civil", "Nautical", "Astronomical"};
 		double out[2];


### PR DESCRIPTION
When **-M** is used we wish to dump the coordinates of the polygon.  However,  the _gmt_get_smallcircle_ function may add extra points if we cross Greenwhich or the Dateline, hence the input _npts_ points is the minimum returned.  Hence, the calling program must use _S->n_rows_ and not the initial _npts_ when writing the output.  No tests were affected though.
Also minor updates to the docs to clarify what solar does and that these are polygons.

