### PR TITLE
Another try at gmtlib_validate_id

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -7704,12 +7704,13 @@ int gmtlib_validate_id (struct GMTAPI_CTRL *API, int family, int object_ID, int 
 		if (direction != GMT_NOTSET && (int)S_obj->direction != direction) continue;	/* Not the requested direction */
 		if (direction == GMT_IN && S_obj->status != GMT_IS_UNUSED && object_ID == GMT_NOTSET) continue;	/* Already used this input object once */
 		/* Preliminary checks passed, no look at family */
-		if (!(family == GMT_NOTSET || (int)S_obj->family == family)) {		/* Not the required data type; check for exceptions... */
-			if (family == GMT_IS_GRID && S_obj->actual_family == GMT_IS_MATRIX)
+		//if (!(family == GMT_NOTSET || (int)S_obj->family == family)) {		/* Not the required data type; check for exceptions... */
+		if (family != GMT_NOTSET) {		/* Was specific about the family. */
+			if (family == GMT_IS_GRID && S_obj->actual_family == GMT_IS_MATRIX && S_obj->family != GMT_IS_DATASET)
 				S_obj->family = GMT_IS_GRID;	/* Matrix masquerading as grids is valid. Change the family here. */
 			else if (family == GMT_IS_DATASET && (S_obj->actual_family == GMT_IS_VECTOR || S_obj->actual_family == GMT_IS_MATRIX) && !(S_obj->family == GMT_IS_GRID || S_obj->family == GMT_IS_IMAGE))
 				S_obj->family = GMT_IS_DATASET;	/* Vectors or Matrix masquerading as dataset are valid. Change their family here. */
-			else if (family != GMT_NOTSET && family != S_obj->family)	/* We don't like your kind */
+			else if (family != S_obj->family)	/* We don't like your kind */
 				continue;
 		}
 		if (object_ID == GMT_NOTSET && (int)S_obj->direction == direction) item = i;	/* Pick the first object with the specified direction */


### PR DESCRIPTION
See  this [link](https://github.com/GenericMappingTools/pygmt/issues/1184) for background.  Whack-a-mole game in this function.  Hopefully this fixes it.  Please run all your PyGMT tests and let me know if it brakes other things - including what was fixed earlier today.  There are likely some assumptions in _gmtlib_validate_id_ that no longer are valid and that is tripping me up.  The code section that attempts to change S_ob->family is problematic since one would think these are always set.
