### PR TITLE
Format links in common opts table

### DIFF
--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -338,6 +338,9 @@ modules. No space between the option flag and the associated arguments.
 
 .. include:: explain_colon_full.rst_
 
+Module help and configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. include:: explain_help.rst_
 
 .. include:: explain_color.rst_

--- a/doc/rst/source/std-opts-classic.rst
+++ b/doc/rst/source/std-opts-classic.rst
@@ -9,62 +9,62 @@ Common Options (Classic Mode)
    * - STANDARDIZED COMMAND LINE OPTIONS
      -
    * - **-B**\ *information*
-     - Specify map frame and axes parameters :ref:`(...) <-B_full>`
+     - :ref:`Specify map frame and axes parameters <-B_full>`
    * - **-J**\ *parameters*
-     - Select map projection :ref:`(...) <-J_full>`
+     - :ref:`Select map projection <-J_full>`
    * - **-K**
-     - Append more PS later :ref:`(...) <-K_full>`
+     - :ref:`Append more PS later <-K_full>`
    * - **-O**
-     - This is an overlay plot :ref:`(...) <-O_full>`
+     - :ref:`This is an overlay plot <-O_full>`
    * - **-P**
-     - Select Portrait orientation :ref:`(...) <-P_full>`
+     - :ref:`Select Portrait orientation <-P_full>`
    * - **-R**\ *west/east/south/north*\ [*/zmin/zmax*][**+r**][**+u**\ *unit*]
-     - Specify region of interest :ref:`(...) <-R_full>`
+     - :ref:`Specify region of interest <-R_full>`
    * - **-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*]
-     - Plot time-stamp on plot :ref:`(...) <-U_full>`
+     - :ref:`Plot time-stamp on plot <-U_full>`
    * - **-V**\ [*verbosity*]
-     - Run in verbose mode :ref:`(...) <-V_full>`
+     - :ref:`Run in verbose mode <-V_full>`
    * - **-X**\ [**a**\|\ **c**\|\ **f**\|\ **r**]\ *xshift*
-     - Shift plot origin in *x*-direction :ref:`(...) <-XY_full>`
+     - :ref:`Shift plot origin in x-direction <-XY_full>`
    * - **-Y**\ [**a**\|\ **c**\|\ **f**\|\ **r**]\ *yshift*
-     - Shift plot origin in *y*-direction :ref:`(...) <-XY_full>`
+     - :ref:`Shift plot origin in y-direction <-XY_full>`
    * - **-a**\ [*col*\ =]\ *name*\ [,\ *...*]
-     - Associates aspatial data with columns :ref:`(...) <-aspatial_full>`
+     - :ref:`Associates aspatial data with columns <-aspatial_full>`
    * - **-bi**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
-     - Select binary input :ref:`(...) <-bi_full>`
+     - :ref:`Select binary input <-bi_full>`
    * - **-bo**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
-     - Select binary output :ref:`(...) <-bo_full>`
+     - :ref:`Select binary output <-bo_full>`
    * - **-d**\ [**i**\|\ **o**]\ *nodata*
-     - Replace columns with *nodata* with NaN :ref:`(...) <-d_full>`
+     - :ref:`Replace columns with nodata with NaN <-d_full>`
    * - **-e**\ [**~**]\ *"pattern"* \| **-e**\ [**~**]/\ *regexp*/[**i**]
-     - Filter data records that match the given pattern :ref:`(...) <-e_full>`
+     - :ref:`Filter data records that match the given pattern <-e_full>`
    * - **-f**\ [**i**\|\ **o**]\ *colinfo*
-     - Set formatting of ASCII input or output :ref:`(...) <-f_full>`
+     - :ref:`Set formatting of ASCII input or output <-f_full>`
    * - **-g**\ [**a**]\ **x**\|\ **y**\|\ **d**\|\ **X**\|\ **Y**\|\ **D**\|[*col*]\ **z**\ *gap*\ [**+n**\|\ **p**]
-     - Segment data by detecting gaps :ref:`(...) <-g_full>`
+     - :ref:`Segment data by detecting gaps <-g_full>`
    * - **-h**\ [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\ *remark*][**+t**\ *title*]
-     - ASCII [*I*\|\ *O*] tables have header record[s] :ref:`(...) <-h_full>`
+     - :ref:`ASCII tables have header record[s] <-h_full>`
    * - **-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
-     - Selection of input columns :ref:`(...) <-icols_full>`
+     - :ref:`Selection of input columns <-icols_full>`
    * - **-je**\|\ **f**\|\ **g**
-     - Mode of spherical distance calculation :ref:`(...) <-distcalc_full>`
+     - :ref:`Mode of spherical distance calculation <-distcalc_full>`
    * - **-n**\ [**b**\|\ **c**\|\ **l**\|\ **n**][**+a**][**+b**\ *BC*][**+c**][**+t**\ *threshold*]
-     - Set grid interpolation mode :ref:`(...) <-n_full>`
+     - :ref:`Set grid interpolation mode <-n_full>`
    * - **-o**\ *cols*\ [,...][,\ **t**\ [*word*]]
-     - Selection of output columns :ref:`(...) <-ocols_full>`
+     - :ref:`Selection of output columns <-ocols_full>`
    * - **-p**\ [**x**\|\ **y**\|\ **z**]\ *azim*\ [/*elev*\ [/*zlevel*]][**+w**\ *lon0*/*lat0*\ [/*z0*]][**+v**\ *x0*/*y0*]
-     - Control 3-D perspective view :ref:`(...) <perspective_full>`
+     - :ref:`Control 3-D perspective view <perspective_full>`
    * - **-q**\ [**i**\|\ **o**][~]\ *rows*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**]
-     - Selection of input or output rows :ref:`(...) <-q_full>`
+     - :ref:`Selection of input or output rows <-q_full>`
    * - **-r**\ [**g**\|\ **p**]
-     - Sets grid registration :ref:`(...) <nodereg_full>`
+     - :ref:`Sets grid registration <nodereg_full>`
    * - **-s**\ [*cols*][**+a**\|\ **r**]
-     - Control treatment of NaN records :ref:`(...) <-s_full>`
+     - :ref:`Control treatment of NaN records <-s_full>`
    * - **-t**\ *transparency*
-     - Set layer transparency :ref:`(...) <-t_full>`
+     - :ref:`Set layer transparency <-t_full>`
    * - **-wy**\|\ **a**\|\ **w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**\|\ **c**\ *period*\ [/*phase*][**+c**\ *col*]
-     - Convert selected coordinate to repeating cycles :ref:`(...) <-w_full>`
+     - :ref:`Convert selected coordinate to repeating cycles <-w_full>`
    * - **-x**\ [[-]\ *n*]
-     - Set number of cores in multi-threaded modules :ref:`(...) <core_full>`
+     - :ref:`Set number of cores in multi-threaded modules <core_full>`
    * - **-:**\ [**i**\|\ **o**]
-     - Expect *y*/*x* input rather than *x*/*y* :ref:`(...) <colon_full>`
+     - :ref:`Expect y/x input rather than x/y <colon_full>`

--- a/doc/rst/source/std-opts.rst
+++ b/doc/rst/source/std-opts.rst
@@ -9,60 +9,60 @@ Common Options
    * - STANDARDIZED COMMAND LINE OPTIONS
      -
    * - **-B**\ *information*
-     - Specify map frame and axes parameters :ref:`(...) <-B_full>`
+     - :ref:`Specify map frame and axes parameters <-B_full>`
    * - **-J**\ *parameters*
-     - Select map projection :ref:`(...) <-J_full>`
+     - :ref:`Select map projection <-J_full>`
    * - **-R**\ *west/east/south/north*\ [*/zmin/zmax*][**+r**][**+u**\ *unit*]
-     - Specify region of interest :ref:`(...) <-R_full>`
+     - :ref:`Specify region of interest <-R_full>`
    * - **-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*]
-     - Plot time-stamp on plot :ref:`(...) <-U_full>`
+     - :ref:`Plot time-stamp on plot <-U_full>`
    * - **-V**\ [*verbosity*]
-     - Run in verbose mode :ref:`(...) <-V_full>`
+     - :ref:`Run in verbose mode <-V_full>`
    * - **-X**\ [**a**\|\ **c**\|\ **f**\|\ **r**]\ *xshift*
-     - Shift plot origin in *x*-direction :ref:`(...) <-XY_full>`
+     - :ref:`Shift plot origin in x-direction <-XY_full>`
    * - **-Y**\ [**a**\|\ **c**\|\ **f**\|\ **r**]\ *yshift*
-     - Shift plot origin in *y*-direction :ref:`(...) <-XY_full>`
+     - :ref:`Shift plot origin in y-direction <-XY_full>`
    * - **-a**\ [*col*\ =]\ *name*\ [,\ *...*]
-     - Associates aspatial data with columns :ref:`(...) <-aspatial_full>`
+     - :ref:`Associates aspatial data with columns <-aspatial_full>`
    * - **-bi**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
-     - Select binary input :ref:`(...) <-bi_full>`
+     - :ref:`Select binary input <-bi_full>`
    * - **-bo**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
-     - Select binary output :ref:`(...) <-bo_full>`
+     - :ref:`Select binary output <-bo_full>`
    * - **-c**\ [*row*\ ,\ *col*\|\ *index*]
-     - Advance plot focus to selected (or next) subplot panel :ref:`(...) <-c_full>`
+     - :ref:`Advance plot focus to selected (or next) subplot panel <-c_full>`
    * - **-d**\ [**i**\|\ **o**]\ *nodata*
-     - Replace columns with *nodata* with NaN :ref:`(...) <-d_full>`
+     - :ref:`Replace columns with nodata with NaN <-d_full>`
    * - **-e**\ [**~**]\ *"pattern"* \| **-e**\ [**~**]/\ *regexp*/[**i**]
-     - Filter data records that match the given pattern :ref:`(...) <-e_full>`
+     - :ref:`Filter data records that match the given pattern <-e_full>`
    * - **-f**\ [**i**\|\ **o**]\ *colinfo*
-     - Set formatting of ASCII input or output :ref:`(...) <-f_full>`
+     - :ref:`Set formatting of ASCII input or output <-f_full>`
    * - **-g**\ [**a**]\ **x**\|\ **y**\|\ **d**\|\ **X**\|\ **Y**\|\ **D**\|[*col*]\ **z**\ *gap*\ [**+n**\|\ **p**]
-     - Segment data by detecting gaps :ref:`(...) <-g_full>`
+     - :ref:`Segment data by detecting gaps <-g_full>`
    * - **-h**\ [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\ *remark*][**+t**\ *title*]
-     - ASCII [*I*\|\ *O*] tables have header record[s] :ref:`(...) <-h_full>`
+     - :ref:`ASCII tables have header record[s] <-h_full>`
    * - **-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
-     - Selection of input columns :ref:`(...) <-icols_full>`
+     - :ref:`Selection of input columns <-icols_full>`
    * - **-je**\|\ **f**\|\ **g**
-     - Mode of spherical distance calculation :ref:`(...) <-distcalc_full>`
+     - :ref:`Mode of spherical distance calculation <-distcalc_full>`
    * - **-l**\ [*label*]\ [*modifiers*]
-     - Add an item to the automatic plot legend :ref:`(...) <-l_full>`
+     - :ref:`Add an item to the automatic plot legend <-l_full>`
    * - **-n**\ [**b**\|\ **c**\|\ **l**\|\ **n**][**+a**][**+b**\ *BC*][**+c**][**+t**\ *threshold*]
-     - Set grid interpolation mode :ref:`(...) <-n_full>`
+     - :ref:`Set grid interpolation mode <-n_full>`
    * - **-o**\ *cols*\ [,...][,\ **t**\ [*word*]]
-     - Selection of output columns :ref:`(...) <-ocols_full>`
+     - :ref:`Selection of output columns <-ocols_full>`
    * - **-p**\ [**x**\|\ **y**\|\ **z**]\ *azim*\ [/*elev*\ [/*zlevel*]][**+w**\ *lon0*/*lat0*\ [/*z0*]][**+v**\ *x0*/*y0*]
-     - Control 3-D perspective view :ref:`(...) <perspective_full>`
+     - :ref:`Control 3-D perspective view <perspective_full>`
    * - **-q**\ [**i**\|\ **o**][~]\ *rows*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**]
-     - Selection of input or output rows :ref:`(...) <-q_full>`
+     - :ref:`Selection of input or output rows <-q_full>`
    * - **-r**\ [**g**\|\ **p**]
-     - Sets grid registration :ref:`(...) <nodereg_full>`
+     - :ref:`Sets grid registration <nodereg_full>`
    * - **-s**\ [*cols*][**+a**\|\ **r**]
-     - Control treatment of NaN records :ref:`(...) <-s_full>`
+     - :ref:`Control treatment of NaN records <-s_full>`
    * - **-t**\ *transparency*
-     - Set layer transparency :ref:`(...) <-t_full>`
+     - :ref:`Set layer transparency <-t_full>`
    * - **-wy**\|\ **a**\|\ **w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**\|\ **c**\ *period*\ [/*phase*][**+c**\ *col*]
-     - Convert selected coordinate to repeating cycles :ref:`(...) <-w_full>`
+     - :ref:`Convert selected coordinate to repeating cycles <-w_full>`
    * - **-x**\ [[-]\ *n*]
-     - Set number of cores in multi-threaded modules :ref:`(...) <core_full>`
+     - :ref:`Set number of cores in multi-threaded modules <core_full>`
    * - **-:**\ [**i**\|\ **o**]
-     - Expect *y*/*x* input rather than *x*/*y* :ref:`(...) <colon_full>`
+     - :ref:`Expect y/x input rather than x/y <colon_full>`


### PR DESCRIPTION
**Description of proposed changes**

This PR formats the links in the common options tables to make them more obvious and adds a section header after common opts in gmt.rst. The docs still build locally without any warnings/errors.

Before (partial view):
<img width="829" alt="image" src="https://user-images.githubusercontent.com/14077947/113877409-adaadd00-9786-11eb-8f4f-a21a11efad99.png">

After (partial view):
<img width="807" alt="image" src="https://user-images.githubusercontent.com/14077947/113877355-a08dee00-9786-11eb-9588-73d347424207.png">


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
