### PR TITLE
Stronger checks before running build-release.sh

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -48,7 +48,7 @@ elif [ $# -gt 0 ]; then
 	EOF
 	exit 1
 fi
-if [ ! -d cmake ]; then
+if [ ! -d admin ]; then
 	echo "build-release.sh: Must be run from top-level gmt directory" >&2
 	exit 1
 fi

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -172,9 +172,4 @@ if [ $do_ftp -eq 1 ]; then	# Place file in pwessel SOEST ftp release directory a
 		scp gmt-${Version}-darwin-x86_64.dmg ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
 	fi
 	ssh ${USER}@ftp.soest.hawaii.edu 'chmod og+r /export/ftp1/ftp/pub/pwessel/release/gmt-*'
-else
-	echo "build-release.sh: Place gmt-${Version}-src.tar.* on the ftp site" >&2
-	if [ -f gmt-${Version}-darwin-x86_64.dmg ]; then
-		echo "build-release.sh: Place gmt-${Version}-darwin-x86_64.dmg on the ftp site" >&2
-	fi
 fi

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -12,6 +12,8 @@
 #	6) GNU tar (package gnutar)
 #	7) gcc-mp-9 must be installed and in path
 #	8) g++-mp-9 must be installed and in path
+#
+#  Note: CMAKE_INSTALL_PATH, EXEPLUSLIBS, and EXESHARED may need to be changed for different users.
 
 reset_config() {
 	rm -f ${TOPDIR}/cmake/ConfigUser.cmake

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -133,7 +133,7 @@ cat << EOF > cache-mp-gcc.cmake
 # Cache settings for building the macOS release with GCC and OpenMP
 # This cache file is set for the binary paths of macports
 #
-SET ( CMAKE_C_COMPILER "${COMP}" CACHE STRING "GNU MP C compiler" )
+SET ( CMAKE_C_COMPILER "${COMPC}" CACHE STRING "GNU MP C compiler" )
 SET ( CMAKE_CXX_COMPILER "${COMPG}" CACHE STRING "GNU MP C++ compiler" )
 SET ( CMAKE_C_FLAGS -flax-vector-conversions CACHE STRING "C FLAGS")
 SET ( CMAKE_C_FLAGS_DEBUG -flax-vector-conversions CACHE STRING "C FLAGS DEBUG")

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -166,7 +166,7 @@ reset_config
 # 10. Paul or Meghan may palce the candidate products on the pwessel/release ftp site
 if [ $do_ftp -eq 1 ]; then	# Place file in pwessel SOEST ftp release directory and set permissions
 	echo "build-release.sh: Placing gmt-${Version}-src.tar.* on the ftp site" >&2
-	scp gmt-${Version}-darwin-x86_64.dmg gmt-${Version}-src.tar.* ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
+	scp gmt-${Version}-src.tar.* ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
 	if [ -f gmt-${Version}-darwin-x86_64.dmg ]; then
 		echo "build-release.sh: Placing gmt-${Version}-darwin-x86_64.dmg on the ftp site" >&2
 		scp gmt-${Version}-darwin-x86_64.dmg ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -28,15 +28,23 @@ abort_build() {	# Called when we abort this script via Crtl-C
 }
 
 TOPDIR=$(pwd)
+if [ "${USER}" = "pwessel" ] || [ "${USER}" = "meghanj" ]; then	# Set ftp default action
+	do_ftp=1
+else
+	do_ftp=0
+fi
 
-if [ $# -gt 0 ]; then
+if [ "X${1}" = "X-n" ]; then
+	do_ftp=0
+elif [ $# -gt 0 ]; then
 	cat <<- EOF  >&2
-	Usage: build-release.sh
+	Usage: build-release.sh [-n]
 	
 	build-release.sh must be run from top-level gmt directory.
 	Will create the release compressed tarballs and (under macOS) the bundle.
 	Requires you have set GMT_PACKAGE_VERSION_* and GMT_PUBLIC_RELEASE in cmake/ConfigDefaults.cmake.
 	Requires GMT_GSHHG_SOURCE and GMT_DCW_SOURCE to be set in the environment.
+	Passing -n means we do not copy the files to the SOEST ftp directory
 	EOF
 	exit 1
 fi
@@ -154,8 +162,9 @@ echo "build-release.sh: Report sha256sum per file" >&2
 shasum -a 256 gmt-${Version}-*
 # 9. Replace temporary ConfigReleaseBuild.cmake file with the original file
 reset_config
+
 # 10. Paul or Meghan may palce the candidate products on the pwessel/release ftp site
-if [ "${USER}" = "pwessel" ] || [ "${USER}" = "meghanj" ]; then	# Place file in pwessel SOEST ftp release directory and set permissions
+if [ $do_ftp -eq 1 ]; then	# Place file in pwessel SOEST ftp release directory and set permissions
 	echo "build-release.sh: Placing gmt-${Version}-src.tar.* on the ftp site" >&2
 	scp gmt-${Version}-darwin-x86_64.dmg gmt-${Version}-src.tar.* ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
 	if [ -f gmt-${Version}-darwin-x86_64.dmg ]; then


### PR DESCRIPTION
Enforce that gcc9-mp, gnutar etc are all available, plus add _meghanj_ as user able to ftp to SOEST pwessel/release directory.
