### PR TITLE
Failed to detect lack of modifier for -E in GMT_Encode_Options

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12990,7 +12990,7 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 		else info[ku].pos -= nn[info[ku].direction][K_SECONDARY];	/* Move any primary objects to start of list for this direction */
 	}
 	GMT_Report (API, GMT_MSG_DEBUG, "GMT_Encode_Options: Found %d inputs and %d outputs that need memory hook-up\n", input_pos, output_pos);
-#if DEBUG
+#if 0
 	{	/* Left here for simple debugging with messages on the GMT side */
 		text = GMT_Create_Cmd (API, *head);
 		GMT_Report (API, GMT_MSG_NOTICE, "GMT_Encode_Options: Revised command before memory-substitution: %s\n", text);

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12357,7 +12357,7 @@ GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key,
 			code[1] = key[k][K_MODIFIER];
 			if ((c = strstr (optarg, code))) {	/* Found +<modifier> */
 				strcpy (argument, optarg);
-				if (!c[2]) *takes_mod = 2;	/* Flag that option had what KEY was looking for */
+				if (!c[2] || c[2] == '+') *takes_mod = 2;	/* Flag that option had no argument that KEY was looking for */
 				pos = (unsigned int) (c - optarg + 2);	/* Position of this modifier's argument. E.g., -E+f<file> will have pos = 2 as start of <file> */
 			}
 			else	/* No modifier involved */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12988,7 +12988,7 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 		else info[ku].pos -= nn[info[ku].direction][K_SECONDARY];	/* Move any primary objects to start of list for this direction */
 	}
 	GMT_Report (API, GMT_MSG_DEBUG, "GMT_Encode_Options: Found %d inputs and %d outputs that need memory hook-up\n", input_pos, output_pos);
-#if 0
+#if DEBUG
 	{	/* Left here for simple debugging with messages on the GMT side */
 		text = GMT_Create_Cmd (API, *head);
 		GMT_Report (API, GMT_MSG_NOTICE, "GMT_Encode_Options: Revised command before memory-substitution: %s\n", text);

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12350,14 +12350,14 @@ GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key,
 			c[0] = 0;
 			strcpy (argument, optarg);
 			c[0] = '+';
-			*takes_mod = 2;	/* Flag that option had what KEY was looking for */
+			if (!argument[0]) *takes_mod = 2;	/* Flag that option is missing the arg and needs it later */
 		}
 		else if (key[k][K_MODIFIER]) {	/* Look for a specific +<mod> in the option */
 			char code[3] = {"+?"};
 			code[1] = key[k][K_MODIFIER];
 			if ((c = strstr (optarg, code))) {	/* Found +<modifier> */
 				strcpy (argument, optarg);
-				*takes_mod = 2;	/* Flag that option had what KEY was looking for */
+				if (!c[2]) *takes_mod = 2;	/* Flag that option had what KEY was looking for */
 				pos = (unsigned int) (c - optarg + 2);	/* Position of this modifier's argument. E.g., -E+f<file> will have pos = 2 as start of <file> */
 			}
 			else	/* No modifier involved */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12328,7 +12328,7 @@ GMT_LOCAL const char *gmtapi_retrieve_module_keys (void *V_API, char *module) {
 	return_null (V_API, GMT_NOT_A_VALID_MODULE);
 }
 
-GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key, int k, bool colon, int *n_pre, bool *takes_mod) {
+GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key, int k, bool colon, int *n_pre, unsigned int *takes_mod) {
 	/* Two separate actions:
 	 * 1) If key ends with "=" then we pull out the option argument after stripping off +<stuff>.
 	 * 2) If key ends with "=q" then we see if +q is given and return pos to this modifiers argument.
@@ -12342,23 +12342,25 @@ GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key,
 	char *c = NULL;
 	unsigned int pos = 0;
 	*n_pre = 0;
-	*takes_mod = false;
+	*takes_mod = 0;
 	if (k >= 0 && key[k][K_EQUAL] == '=') {	/* Special handling */
-		*takes_mod = true;
+		*takes_mod = 1;	/* Flag that KEY was special */
 		*n_pre = (key[k][K_MODIFIER] && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
 		if ((*n_pre || key[k][K_MODIFIER] == 0) && (c = strchr (optarg, '+'))) {	/* Strip off trailing +<modifiers> */
 			c[0] = 0;
 			strcpy (argument, optarg);
 			c[0] = '+';
+			*takes_mod = 2;	/* Flag that option had what KEY was looking for */
 		}
-		else if (key[k][K_MODIFIER]) {	/* Look for +<mod> */
+		else if (key[k][K_MODIFIER]) {	/* Look for a specific +<mod> in the option */
 			char code[3] = {"+?"};
 			code[1] = key[k][K_MODIFIER];
 			if ((c = strstr (optarg, code))) {	/* Found +<modifier> */
 				strcpy (argument, optarg);
-				pos = (unsigned int) (c - optarg + 2);	/* Position of this modifiers argument */
+				*takes_mod = 2;	/* Flag that option had what KEY was looking for */
+				pos = (unsigned int) (c - optarg + 2);	/* Position of this modifier's argument. E.g., -E+f<file> will have pos = 2 as start of <file> */
 			}
-			else
+			else	/* No modifier involved */
 				strcpy (argument, optarg);
 		}
 		else
@@ -12523,11 +12525,11 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 	 */
 
 	unsigned int n_keys, direction = 0, kind, pos = 0, n_items = 0, ku, n_out = 0, nn[2][2];
-	unsigned int output_pos = 0, input_pos = 0, mod_pos;
+	unsigned int output_pos = 0, input_pos = 0, mod_pos, takes_mod;
 	int family = GMT_NOTSET;	/* -1, or one of GMT_IS_DATASET, GMT_IS_GRID, GMT_IS_PALETTE, GMT_IS_IMAGE */
 	int geometry = GMT_NOTSET;	/* -1, or one of GMT_IS_NONE, GMT_IS_TEXT, GMT_IS_POINT, GMT_IS_LINE, GMT_IS_POLY, GMT_IS_SURFACE */
 	int sdir, k = 0, n_in_added = 0, n_to_add, e, n_pre_arg, n_per_family[GMT_N_FAMILIES];
-	bool deactivate_output = false, deactivate_input = false, strip_colon = false, strip = false, is_grdmath = false, takes_mod;
+	bool deactivate_output = false, deactivate_input = false, strip_colon = false, strip = false, is_grdmath = false;
 	size_t n_alloc, len;
 	const char *keys = NULL;	/* This module's option keys */
 	char **key = NULL;		/* Array of items in keys */
@@ -12849,9 +12851,9 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 		}
 		else if (k >= 0 && key[k][K_OPT] != GMT_OPT_INFILE && family != GMT_NOTSET && key[k][K_DIR] != '-') {	/* Got some option like -G or -Lu with further args */
 			bool implicit = true;
-			if ((len = strlen (argument)) == 0 && takes_mod)	/* Got some option like -E[+f] but no +f was given so no implicit file needed */
+			if (takes_mod == 1)	/* Got some option like -E[+f] but no +f was given so no implicit file needed */
 				implicit = false;
-			else if (len == (size_t)n_pre_arg)	/* Got some option like -G or -Lu with no further args */
+			else if ((len = strlen (argument)) == (size_t)n_pre_arg)	/* Got some option like -G or -Lu with no further args */
 				GMT_Report (API, GMT_MSG_DEBUG, "GMT_Encode_Options: Option -%c needs implicit arg [offset = %d]\n", opt->option, n_pre_arg);
 			else if (mod_pos && (argument[mod_pos] == '\0' || argument[mod_pos] == '+'))	/* Found an embedded +q<noarg> */
 				GMT_Report (API, GMT_MSG_DEBUG, "GMT_Encode_Options: Option -%c needs implicit arg via argument-less +%c modifier\n", opt->option, key[k][K_MODIFIER]);


### PR DESCRIPTION
The **grd2cpt -E** option takes an optional **+f**_file_ modifier, and for externals it is possible to just give **+f** and _GMT_Encode_Options_ will fill in the memory reference.  However, in this case **-**E was given with no argument yet the API failed to detect this case and added a memory reference.  This PR is more careful to check that an option that may take modifiers did in fact do so before we consider this hookup.  Works for me wiht a Julia example but need @joa-quim to run the full Julia tests to see if anything else broke.  I will run the mex 2017 paper tests.
PS. I am not sure how this regression came to be since it worked for the 2017 mex paper, but we must have added form sutbleties in dealing with modifiers and introduced this bug then.,