### PR TITLE
Configure ths ghostscript executable name and fix links

### DIFF
--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -6,9 +6,11 @@
 # List of executables whose shared libraries must also be included
 #
 # Exceptions:
-# For now (6.0.0), need to do a few things manually first, like
-# 1. Separate install command to avoid version number in GraphicsMagick directory name
-# 2. Build gs from 9.50 tarball and place in /opt (until 9.50 appears in port)
+# For now (6.2.0), need to do a few things manually first, like
+#   1. Separate install command to avoid version number in GraphicsMagick directory name
+#
+# Notes:
+#   1. This is tested on macports where gs is a symbolic link to gsc.
 
 if [ $(which cmake) = "/opt/local/bin/cmake" ]; then
 	distro=MacPorts
@@ -26,16 +28,16 @@ TMPDIR=${TMPDIR:-/tmp}
 
 # 1a. List of executables needed and whose shared libraries also are needed.
 #     Use full path if you need something not in your path
-EXEPLUSLIBS="/opt/bin/gs /opt/local/bin/gm /opt/local/bin/ffmpeg /opt/local/bin/ogr2ogr /opt/local/bin/gdal_translate /opt/local/lib/libfftw3f_threads.dylib"
+EXEPLUSLIBS="/opt/local/bin/gsc /opt/local/bin/gm /opt/local/bin/ffmpeg /opt/local/bin/ogr2ogr /opt/local/bin/gdal_translate /opt/local/lib/libfftw3f_threads.dylib"
 # 1b. List of any symbolic links needed
 #     Use full path if you need something not in your path
-EXELINKS=
+EXELINKS=/opt/local/bin/gs
 # 1c. List of executables whose shared libraries have already been included via other shared libraries
 #     Use full path if you need something not in your path
 EXEONLY=
 # 1d. Shared directories to be added
 #     Use full path if you need something not in your path
-EXESHARED="gdal /opt/share/ghostscript /opt/local/lib/proj7/share/proj"
+EXESHARED="gdal /opt/local/share/ghostscript /opt/local/lib/proj7/share/proj"
 #-----------------------------------------
 # 2a. Add the executables to the list given their paths
 rm -f ${TMPDIR}/raw.lis

--- a/admin/otoolr.c
+++ b/admin/otoolr.c
@@ -7,6 +7,8 @@
  *
  * The <builddir> is prepended if any of the executables or dylib files have relative paths,
  * otherwise not used.
+ *
+ * P. Wessel, August 2020
  */
 
 #include <stdio.h>

--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -144,6 +144,15 @@ if (NOT DEFINED GMT_DATA_SERVER)
 	set (GMT_DATA_SERVER "oceania")
 endif (NOT DEFINED GMT_DATA_SERVER)
 
+# Default name of ghostscript executable
+if (NOT DEFINED GMT_GS_EXECUTABLE)
+	if (WIN32)
+		set (GMT_GS_EXECUTABLE "gswin64c")
+	else (WIN32)
+		set (GMT_GS_EXECUTABLE "gs")
+	endif (WIN32)
+endif (NOT DEFINED GMT_GS_EXECUTABLE)
+
 # You can set the build configuration type as a command-line argument to 'cmake' using -DCMAKE_BUILD_TYPE:STRING=Debug for example.
 # If no build configuration type was given as a command-line option to 'cmake' then a default cache entry is set here.
 # A cache entry is what appears in the 'CMakeCache.txt' file that CMake generates - you can edit that file directly or use the CMake GUI to edit it.

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -61,6 +61,9 @@
 /* Name of core library */
 #define GMT_CORE_LIB_NAME "@GMT_CORE_LIB_NAME@"
 
+/* Name of gs executable */
+#define GMT_GS_EXECUTABLE "@GMT_GS_EXECUTABLE@"
+
 /* Name of supplemental library */
 #define GMT_SUPPL_LIBRARY "@GMT_SUPPL_LIBRARY@"
 

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -481,9 +481,9 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	/* Initialize values whose defaults are not 0/false/NULL */
 #ifdef WIN32
 	if (psconvert_ghostbuster(GMT->parent, C) != GMT_NOERROR)  /* Try first to find the gspath from registry */
-		C->G.file = strdup ("gswin64c");     /* Fall back to this default and expect a miracle */
+		C->G.file = strdup (GMT_GS_EXECUTABLE);     /* Fall back to this default and expect a miracle */
 #else
-	C->G.file = strdup ("gs");
+	C->G.file = strdup (GMT_GS_EXECUTABLE);
 #endif
 	C->D.dir = strdup (".");
 


### PR DESCRIPTION
This PR addresses the two issues related to ghostscript in the #5070 comments:

1. We use Cmake configure to set the ghostscript executable name [**gs** on *nix, **gswin64c** on Windows]
2. Now the **gs** symbolic link to **gsc** is created in the bundle (needed under macports).

Note: While the script has a check for brew versus macports, this has likely not been tested and the gs/gsc stuff would need to be under a similar test.