### PR TITLE
Allow build-release -m to just place the bundle

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -17,6 +17,10 @@
 #	1. CMAKE_INSTALL_PATH, EXEPLUSLIBS, and EXESHARED in build-macos-external-list.sh may need to be changed for different users.
 #	2. Settings for GS_LIB, PROJ_LIB etc in cmake/dist/startup_macosx.sh.in may need to be updated as new gs,proj.gm releases are issued
 
+# Temporary ftp site for pre-release files:
+GMT_FTP_URL=ftp.soest.hawaii.edu
+GMT_FTP_DIR=/export/ftp1/ftp/pub/pwessel/release
+
 reset_config() {
 	rm -f ${TOPDIR}/cmake/ConfigUser.cmake
 	if [ -f ${TOPDIR}/cmake/ConfigUser.cmake.orig ]; then # Restore what we had
@@ -174,18 +178,18 @@ reset_config
 if [ $do_ftp -eq 1 ]; then	# Place file in pwessel SOEST ftp release directory and set permissions
 	type=$(uname -m)
 	echo "build-release.sh: Placing gmt-${Version}-src.tar.* on the ftp site" >&2
-	scp gmt-${Version}-src.tar.* ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
+	scp gmt-${Version}-src.tar.* ${GMT_FTP_URL}:${GMT_FTP_DIR}
 	if [ -f gmt-${Version}-darwin-${type}.dmg ]; then
 		echo "build-release.sh: Placing gmt-${Version}-darwin-${type}.dmg on the ftp site" >&2
-		scp gmt-${Version}-darwin-${type}.dmg ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
+		scp gmt-${Version}-darwin-${type}.dmg ${GMT_FTP_URL}:${GMT_FTP_DIR}
 	fi
-	ssh ${USER}@ftp.soest.hawaii.edu 'chmod og+r /export/ftp1/ftp/pub/pwessel/release/gmt-*'
+	ssh ${USER}@${GMT_FTP_URL} 'chmod og+r ${GMT_FTP_DIR}/gmt-*'
 fi
 if [ $do_ftp -eq 2 ]; then	# Place M1 bundle file on ftp
 	type=$(uname -m)
 	if [ -f gmt-${Version}-darwin-${type}.dmg ]; then
 		echo "build-release.sh: Placing gmt-${Version}-darwin-${type}.dmg on the ftp site" >&2
-		scp gmt-${Version}-darwin-${type}.dmg ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
+		scp gmt-${Version}-darwin-${type}.dmg ${GMT_FTP_URL}:${GMT_FTP_DIR}
 	fi
-	ssh ${USER}@ftp.soest.hawaii.edu 'chmod og+r /export/ftp1/ftp/pub/pwessel/release/gmt-*'
+	ssh ${USER}@${GMT_FTP_URL} 'chmod og+r ${GMT_FTP_DIR}/gmt-*'
 fi

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -40,6 +40,8 @@ fi
 
 if [ "X${1}" = "X-n" ]; then
 	do_ftp=0
+elif [ "X${1}" = "X-m" ]; then
+	do_ftp=2
 elif [ $# -gt 0 ]; then
 	cat <<- EOF  >&2
 	Usage: build-release.sh [-n]
@@ -49,6 +51,7 @@ elif [ $# -gt 0 ]; then
 	Requires you have set GMT_PACKAGE_VERSION_* and GMT_PUBLIC_RELEASE in cmake/ConfigDefaults.cmake.
 	Requires GMT_GSHHG_SOURCE and GMT_DCW_SOURCE to be set in the environment.
 	Passing -n means we do not copy the files to the SOEST ftp directory
+	Passing -m means only copy the macOS bundle to the SOEST ftp directory
 	EOF
 	exit 1
 fi
@@ -167,13 +170,22 @@ shasum -a 256 gmt-${Version}-*
 # 9. Replace temporary ConfigReleaseBuild.cmake file with the original file
 reset_config
 
-# 10. Paul or Meghan may palce the candidate products on the pwessel/release ftp site
+# 10. Paul or Meghan may place the candidate products on the pwessel/release ftp site
 if [ $do_ftp -eq 1 ]; then	# Place file in pwessel SOEST ftp release directory and set permissions
+	type=$(uname -m)
 	echo "build-release.sh: Placing gmt-${Version}-src.tar.* on the ftp site" >&2
 	scp gmt-${Version}-src.tar.* ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
-	if [ -f gmt-${Version}-darwin-x86_64.dmg ]; then
-		echo "build-release.sh: Placing gmt-${Version}-darwin-x86_64.dmg on the ftp site" >&2
-		scp gmt-${Version}-darwin-x86_64.dmg ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
+	if [ -f gmt-${Version}-darwin-${type}.dmg ]; then
+		echo "build-release.sh: Placing gmt-${Version}-darwin-${type}.dmg on the ftp site" >&2
+		scp gmt-${Version}-darwin-${type}.dmg ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
+	fi
+	ssh ${USER}@ftp.soest.hawaii.edu 'chmod og+r /export/ftp1/ftp/pub/pwessel/release/gmt-*'
+fi
+if [ $do_ftp -eq 2 ]; then	# Place M1 bundle file on ftp
+	type=$(uname -m)
+	if [ -f gmt-${Version}-darwin-${type}.dmg ]; then
+		echo "build-release.sh: Placing gmt-${Version}-darwin-${type}.dmg on the ftp site" >&2
+		scp gmt-${Version}-darwin-${type}.dmg ftp.soest.hawaii.edu:/export/ftp1/ftp/pub/pwessel/release
 	fi
 	ssh ${USER}@ftp.soest.hawaii.edu 'chmod og+r /export/ftp1/ftp/pub/pwessel/release/gmt-*'
 fi


### PR DESCRIPTION
1. Removes the hardwired **x86-64** tag and now uses `uname -m` output instead. 
2. Adds the **-m** option to our script is useful if we just want to build the macOS bundle on a machine  with different architecture and copy that over to the ftp site, but not do so for the source tarballs.
3. Uses parameters for the temporary ftp url and directory so it is easier to change down the road.
