### PR TITLE
WIP Add release-drafter workflow for automated changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,7 +21,7 @@ exclude-labels:
 category-template: '### $TITLE'
 change-template: '* $TITLE ([#$NUMBER]($URL))'
 template: |
-  ## Release of GMT $RESOLVED_VERSION (20YY/MM/DD)
+  ## Release of GMT $RESOLVED_VERSION
 
   ### Highlights
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-resolver:
+  minor:
+    labels:
+      - 'feature'
+  default: patch
+categories:
+  - title: 'New Features'
+    label: 'new feature'
+  - title: 'Enhancements'
+    label: 'enhancement'
+  - title: 'Bug Fixes'
+    label: 'bug'
+  - title: 'Documentation'
+    label: 'documentation'
+  - title: 'Maintenance'
+    label: 'maintenance'
+exclude-labels:
+  - 'skip-changelog'
+category-template: '### $TITLE'
+change-template: '* $TITLE ([#$NUMBER]($URL))'
+template: |
+  ## Release of GMT $RESOLVED_VERSION (20YY/MM/DD)
+
+  ### Highlights
+
+  *
+
+  $CHANGES
+
+  ### Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5.15.0
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -13,6 +13,7 @@ Below are instructions for developers and advanced users.
 - [Debugging GMT](#debugging-gmt)
 - [Using build and test aliases](#using-build-and-test-aliases)
 - [Continuous Integration](#continuous-integration)
+- [Updating the changelog](#updating-the-changelog)
 
 ## Building the source code
 
@@ -287,3 +288,30 @@ There are 11 configuration files located in `.github/workflows/`:
     This workflow is run when Pull Requests are merged into the *master* branch, if the Pull Request involved changes
     to the folders that contain source code, workflows, tests, or scripts for generating documentation figures. It runs
     the full GMT test suite on Linux, macOS, and Windows.
+
+12. `release-drafter.yml` (Drafts the next release notes)
+
+    This workflow is run to update the next releases notes as pull requests are merged into master.
+
+## Updating the changelog
+
+The Release Drafter GitHub Action will automatically keep a draft changelog at
+https://github.com/GenericMappingTools/gmt/releases, adding a new entry every time a Pull Request (with a proper label)
+is merged into the master branch. This release drafter tool has two configuration files, one for the GitHub Action
+at .github/workflows/release-drafter.yml, and one for the changelog template at .github/release-drafter.yml.
+Configuration settings can be found at https://github.com/release-drafter/release-drafter. The documentation for the
+workflow is based on the [PyGMT Maintenance Documentation](https://www.pygmt.org/dev/maintenance.html).
+
+The drafted release notes are not perfect, so we will need to tidy it prior to publishing the actual release notes at
+https://docs.generic-mapping-tools.org/latest/changes.html.
+
+1. Go to https://github.com/GenericMappingTools/gmt/releases and click on the 'Edit' button next to the current draft
+   release note. Copy the text of the automatically drafted release notes under the 'Write' tab to
+   `doc/rst/source/changes.rst`.
+2. Open a new Pull Request using the title 'Changelog entry for vX.Y.Z' with the updated release notes, so that other
+   people can help to review and collaborate on the changelog curation process described next.
+3. Edit the change list to remove any trivial changes (updates to the README, typo fixes, CI configuration, etc).
+4. Edit the formatting to use [ReST style](https://docs.generic-mapping-tools.org/latest/rst-cheatsheet.html).
+5. Add links in the changelog to elements of the documentation as appropriate.
+4. Edit the list of people who contributed to the release, linking to their GitHub account. Sort their names by the
+   number of commits made since the last release (e.g., use `git shortlog HEAD...v0.1.2 -sne`).

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -299,8 +299,8 @@ The Release Drafter GitHub Action will automatically keep a draft changelog at
 https://github.com/GenericMappingTools/gmt/releases, adding a new entry every time a Pull Request (with a proper label)
 is merged into the master branch. This release drafter tool has two configuration files, one for the GitHub Action
 at .github/workflows/release-drafter.yml, and one for the changelog template at .github/release-drafter.yml.
-Configuration settings can be found at https://github.com/release-drafter/release-drafter. The documentation for the
-workflow is based on the [PyGMT Maintenance Documentation](https://www.pygmt.org/dev/maintenance.html).
+Configuration settings can be found at https://github.com/release-drafter/release-drafter. The maintenance documentation
+for this workflow is based on the [PyGMT Maintenance Documentation](https://www.pygmt.org/dev/maintenance.html).
 
 The drafted release notes are not perfect, so we will need to tidy it prior to publishing the actual release notes at
 https://docs.generic-mapping-tools.org/latest/changes.html.


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a workflow that will automatically draft a changelog for new releases when PRs have the necessary labels. Note, the sections in the automated changelog still need discussion.

Here is a summary of the workflow from https://github.com/GenericMappingTools/gmt/issues/304#issuecomment-654614911.

> The release drafter creates a draft release (only visible to developers). When a PR is correctly labelled and merged into master (or a specific branch), it will create an new entry in the draft release page using the title of the PR. See the PyGMT changelog for what the automatically generated changelog looks like.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #304 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
