### PR TITLE
Features.rst Issues in escape sequences examples

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1622,7 +1622,7 @@ of several types. The escape sequences recognized in GMT are listed in
 Table :ref:`escape <tbl-escape>`. Only one level of sub- or superscript is supported.
 Note that under Windows the percent symbol indicates a batch variable,
 hence you must use two percent-signs for each one required in the escape
-sequence for font switching.
+sequence for font switching. In bash scripts the brackets have special meaning, hence you must add double quotes.
 
 .. _tbl-escape:
 
@@ -1697,7 +1697,7 @@ GMT strings using the Standard+ encoding:
 | ``Stresses are @~s@~@+*@+@-xx@- MPa`` = Stresses are :math:`\sigma^{*}_{xx}` MPa
 | ``Se@nor Gar@con`` = Señor Garçon
 | ``M@!\305anoa stra@se`` = Manoa straße
-| ``A@\#cceleration@\# \(ms@+-2@+\)`` = ACCELERATION (ms\ :math:`^{-2}`)
+| ``A@\#cceleration@\# (ms@+-2@+)`` = ACCELERATION (ms\ :math:`^{-2}`)
 
 The option in :doc:`/text` to draw a
 rectangle surrounding the text will not work for strings with escape

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1697,7 +1697,7 @@ GMT strings using the Standard+ encoding:
 | ``Stresses are @~s@~@+*@+@-xx@- MPa`` = Stresses are :math:`\sigma^{*}_{xx}` MPa
 | ``Se@nor Gar@con`` = Señor Garçon
 | ``M@!\305anoa stra@se`` = Manoa straße
-| ``A@\#cceleration@\# (ms@+-2@+)`` = ACCELERATION (ms\ :math:`^{-2}`)
+| ``A@#cceleration@# (ms@+-2@+)`` = ACCELERATION (ms\ :math:`^{-2}`)
 
 The option in :doc:`/text` to draw a
 rectangle surrounding the text will not work for strings with escape

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1697,7 +1697,7 @@ GMT strings using the Standard+ encoding:
 | ``Stresses are @~s@~@+*@+@-xx@- MPa`` = Stresses are :math:`\sigma^{*}_{xx}` MPa
 | ``Se@nor Gar@con`` = Señor Garçon
 | ``M@!\305anoa stra@se`` = Manoa straße
-| ``A@\#cceleration@\# (ms@+-2@+)`` = ACCELERATION
+| ``A@\#cceleration@\# \(ms@+-2@+\)`` = ACCELERATION (ms\ :math:`^{-2}`)
 
 The option in :doc:`/text` to draw a
 rectangle surrounding the text will not work for strings with escape


### PR DESCRIPTION
In the escape sequence section there is a list with some example. The last is "Acceleration (ms-2)." I add the backslash so the brackets are shown when the code is used (I try it) and complete the result with the "(ms@+-2@+)" (not sure if I edit it well).

Also, in the previous example (Manoa Straße) it is not clear what the escape sequences does in "Manoa". It was  Månoa?

