### PR TITLE
Fix spelling errors.

### DIFF
--- a/doc/rst/source/explain_-U.rst_
+++ b/doc/rst/source/explain_-U.rst_
@@ -12,7 +12,7 @@ The **-U** option
 
 The **-U** option draws the GMT system time stamp on the plot. The following modifiers are supported:
 
-- *label* to append the text string given in *label* (which must be surrounded by double qoutes if it contains spaces).
+- *label* to append the text string given in *label* (which must be surrounded by double quotes if it contains spaces).
 - **+c** to plot the current command string.
 - **+j**\ *justify* to specify the justification of the time stamp, where *justify* is a two-character
   :ref:`justification code <Reference_Points>` that is a combination of a horizontal (**L**\ (eft), **C**\ (enter), or

--- a/doc/rst/source/explain_-t_full.rst_
+++ b/doc/rst/source/explain_-t_full.rst_
@@ -18,5 +18,5 @@ Transparency may also be controlled on a feature by feature basis when setting c
 :ref:`-Gfill_attrib`). **Note**: The modules :doc:`/plot`, :doc:`/plot3d`, and :doc:`/text` can all change
 transparency on a record-by-record basis if **-t** is given without argument and the input file supplies variable
 transparencies as the last numerical column value(s). **Note**: The transparency is only visible when PDF or raster
-format ouput is selected because the PostScript language does not support transparency. Only the PNG format selection
+format output is selected because the PostScript language does not support transparency. Only the PNG format selection
 adds a transparency layer in the image (for further processing).


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build:

 * ouput  -> output
 * qoutes -> quotes
