### PR TITLE
Add a variable to GMT_LIB_SRCS to include extra codes.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -404,7 +404,7 @@ set (GMT_LIB_SRCS block_subs.h gmt_common_byteswap.h gmt_common_math.h
 	${CMAKE_CURRENT_BINARY_DIR}/gmt_${SHARED_LIB_NAME}_glue.c
 	kiss_fft/_kiss_fft_guts.h kiss_fft/kiss_fft.c kiss_fft/kiss_fft.h
 	kiss_fft/kiss_fftnd.c kiss_fft/kiss_fftnd.h
-	${GMT_TRIANGLE_SRCS} ${GMT_MBSYSTEM_SRCS})
+	${GMT_TRIANGLE_SRCS} ${GMT_MBSYSTEM_SRCS} ${EXTRA_SOURCES})
 
 # source codes for testing API
 if (DO_API_TESTS)


### PR DESCRIPTION
This allows us to add extra code just by defining a list of codes to include via ConfigUser.cmake. E.g.

set (EXTRA_SOURCES a.c b.c a.h ...)

Currently my use case for this is to allow calling new C functions to experiment them via Julia calls.

