### PR TITLE
Add generic GMT_Free function to API for freeing odd GMT memory

### DIFF
--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -782,6 +782,8 @@ The C/C++ API is deliberately kept small to make it easy to use.
     +--------------------------+-------------------------------------------------------+
     | GMT_Find_Option_         | Find an option in the linked list                     |
     +--------------------------+-------------------------------------------------------+
+    | GMT_Free_                | Free GMT-allocated non-container memory               |
+    +--------------------------+-------------------------------------------------------+
     | GMT_Get_Common_          | Determine if a GMT common option was set              |
     +--------------------------+-------------------------------------------------------+
     | GMT_Get_Coord_           | Create a coordinate array                             |
@@ -2610,6 +2612,23 @@ whose prototype is
 where ``data`` is the address of the array with data containers, i.e., not
 the array to the containers but the *address* of that array (e.g. &array),
 and ``n`` is the number of containers.
+
+Free other allocated memory
+---------------------------
+
+Some GMT functions may allocate memory that is not part of the containers
+and thus cannot be freed with GMT_Destroy_Data_.  For these cases there is
+the GMT_Free_ function, whose prototype is
+
+.. _GMT_Free:
+
+  ::
+
+    int GMT_Free (void *API, void *ptr);
+
+where ``ptr`` is the address of the pointer to arbitrary data allocated
+by the GMT API.  The most common use of this function is to free the
+resources returned by GMT_Encode_Options_.
 
 Terminate a GMT session
 -----------------------

--- a/doc/rst/source/api.rst
+++ b/doc/rst/source/api.rst
@@ -3205,7 +3205,8 @@ error number.  The GMT_RESOURCE structure is defined below:
 API developers will need to provide specific code to handle the registration of native
 structures in their language or application and to translate between the GMT resources
 and the corresponding native items.  Developers should look at an existing and working
-interface such as the GMT/MATLAB toolbox to see the required steps.
+interface such as the GMT/MATLAB toolbox to see the required steps. **Note**: The array
+of structures returned by GMT_Encode_Options_ should be freed by GMT_Free_.
 
 Expand an option with explicit memory references
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/gmt.h
+++ b/src/gmt.h
@@ -62,7 +62,7 @@ extern "C" {
  *=====================================================================================
  */
 
-/* 33 Primary API functions */
+/* 34 Primary API functions */
 EXTERN_MSC void * GMT_Create_Session   (const char *tag, unsigned int pad, unsigned int mode, int (*print_func) (FILE *, const char *));
 EXTERN_MSC void * GMT_Create_Data      (void *API, unsigned int family, unsigned int geometry, unsigned int mode, uint64_t dim[],
                                            double *wesn, double *inc, unsigned int registration, int pad, void *data);
@@ -86,6 +86,7 @@ EXTERN_MSC int GMT_Get_Row             (void *API, int rec_no, struct GMT_GRID *
 EXTERN_MSC int GMT_Put_Row             (void *API, int rec_no, struct GMT_GRID *G, gmt_grdfloat *row);
 EXTERN_MSC int GMT_Set_Comment         (void *API, unsigned int family, unsigned int mode, void *arg, void *data);
 EXTERN_MSC int GMT_Set_Geometry	       (void *API, unsigned int direction, unsigned int geometry);
+EXTERN_MSC int GMT_Free                (void *API, void *ptr);
 
 EXTERN_MSC int GMT_Open_VirtualFile    (void *API, unsigned int family, unsigned int geometry, unsigned int direction, void *data, char *string);
 EXTERN_MSC int GMT_Close_VirtualFile   (void *API, const char *string);


### PR DESCRIPTION
Such as what is returned by _GMT_Encode_Options_.  It expects the address of the pointer to the memory.  Currently the only case use is to free what _GMT_Encode_Options_ returns to an external environment.  Updated the docs as well returned _GMT_Encode_Options_ to using GMT memory management.  Fixed some odd return codes in _GMT_Destroy_Data_ as well.

_GMT_Free_ will next be used in gmtmex.c to free that memory, but I will add a version check since _GMT_Free_ is only 6.2.0 and onward.
