### PR TITLE
Check if annotation phase implies a wider annotation format

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5330,8 +5330,15 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		ortho = true;	/* Annotations are orthogonal for this axis */
 	if (GMT->current.setting.map_frame_type & GMT_IS_INSIDE) neg = !neg;	/* Annotations go either below or above the axis */
 	faro = (neg == (horizontal && !ortho));			/* Current point is at the far side of the tickmark? */
-	if (A->type != GMT_TIME)						/* Set the annotation format template */
-		gmt_get_format (GMT, gmtlib_get_map_interval (GMT, A->type, &A->item[GMT_ANNOT_UPPER]), A->unit, A->prefix, format);
+	if (A->type != GMT_TIME) {						/* Set the annotation format template */
+		int n_dec = gmt_get_format (GMT, gmtlib_get_map_interval (GMT, A->type, &A->item[GMT_ANNOT_UPPER]), A->unit, A->prefix, format);
+		if (!doubleAlmostEqualZero (A->phase, 0.0)) {	/* Phase is nonzero, must see if adding it gives more decimals */
+			char format_w_phase[GMT_LEN256] = {""};	/* Format used if phase is added */
+			int ndec_p = gmt_get_format (GMT, gmtlib_get_map_interval (GMT, A->type, &A->item[GMT_ANNOT_UPPER]) + A->phase, A->unit, A->prefix, format_w_phase);
+			if (ndec_p > n_dec)	/* Use the phase format which has more decimals */
+				strncpy (format, format_w_phase, GMT_LEN256);
+		}
+	}
 	text_angle = (ortho == horizontal) ? 90.0 : 0.0;
 	justify = (ortho) ? PSL_MR : PSL_BC;
 	if (A->use_angle && !skip) {	/* User override annotation angle */


### PR DESCRIPTION
When phase is specified it is possible that the phase-shifted annotation values may require more decimals than that we infer from the internal itself.  E.g., if interval is 0.5 and phase is 0.25 then annotations like 0.75, 1.25 etc will require 2 decimals, one more than inferred from the annotation interval.  This PR addresses this possibility and closes #5152.

Not sure if this is too late for rc1, @meghanrjones.  If approved and you need to build and set tags then you can merge it, otherwise we can wait for rc2.
