### PR TITLE
Refine the trend formula in grdtrend using LaTex

### DIFF
--- a/doc/rst/source/grdtrend.rst
+++ b/doc/rst/source/grdtrend.rst
@@ -27,8 +27,9 @@ Description
 to these data by [optionally weighted] least-squares. The trend surface
 is defined by:
 
-   m1 + m2\*x + m3\*y + m4\*x\*y + m5\*x\*x + m6\*y\*y + m7\*x\*x\*x +
-   m8\*x\*x\*y + m9\*x\*y\*y + m10\*y\*y\*y.
+.. math::
+    m_1 + m_2x + m_3y + m_4xy + m_5x^2 + m_6y^2 + m_7x^3 +
+    m_8x^2y + m_9xy^2 + m_{10}y^3.
 
 The user must specify **-N**\ *n\_model*, the number of model parameters
 to use; thus, **-N**\ *3* fits a bilinear trend, **-N**\ *6* a quadratic

--- a/doc/rst/source/grdtrend.rst
+++ b/doc/rst/source/grdtrend.rst
@@ -28,8 +28,7 @@ to these data by [optionally weighted] least-squares. The trend surface
 is defined by:
 
 .. math::
-    m_1 + m_2x + m_3y + m_4xy + m_5x^2 + m_6y^2 + m_7x^3 +
-    m_8x^2y + m_9xy^2 + m_{10}y^3.
+    m_1 + m_2x + m_3y + m_4xy + m_5x^2 + m_6y^2 + m_7x^3 + m_8x^2y + m_9xy^2 + m_{10}y^3.
 
 The user must specify **-N**\ *n\_model*, the number of model parameters
 to use; thus, **-N**\ *3* fits a bilinear trend, **-N**\ *6* a quadratic


### PR DESCRIPTION
**Description of proposed changes**

Refine the formula for the trend surface in [grdtrend](https://docs.generic-mapping-tools.org/latest/grdtrend.html) (Originally posted in https://github.com/gmt-china/GMT_docs/issues/238). See the comparisons below:

Current formula:

![old](https://user-images.githubusercontent.com/50591376/115181849-5ce29f00-a10b-11eb-95a1-0318035d0a6e.png)

New style:
![new](https://user-images.githubusercontent.com/50591376/115181844-5c4a0880-a10b-11eb-9e56-ea930dec0606.png)

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
