### PR TITLE
Ensure font/stroke color is reset internally

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6251,7 +6251,10 @@ void gmt_map_title (struct GMT_CTRL *GMT, double x, double y) {
 			}
 		}
 	}
-
+	/* Since we are calling gmt_setfont inside a gsave/grestore block we must reset the font and stroke color to "not set" so it will be
+	 * correctly executed by the next gmt_setfont or gmt_setcolor calls elsewhere */
+	gmt_M_memcpy (PSL->current.rgb[PSL_IS_FONT], GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 since text setting must set the color desired */
+	gmt_M_memcpy (PSL->current.rgb[PSL_IS_STROKE], GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 since text setting must set the color desired */
 	PSL_command (PSL, "U\n");
 
 	GMT->current.map.frame.plotted_header = true;


### PR DESCRIPTION
GMT keeps track of the current colors for fill, font, and stroke in memory so that we don't keep sending the same color request in PostScript.  However, when some activities have been placed under a gsave/grestore branch then once we exit that branch, PostScript will revert to the previous color setting, which is not remembered inside GMT.  The solution to this problem is to set the relevant colors to "not set" (-1, -1, -1) so that the very next call for a color will always be executed.  This was missing in this new function related to subtitle and title.  I added some comments in the new _gmt_map_title_ function to remind us of this.
Closes #5156.
