### PR TITLE
Set GMT_keyword_update to false in gmt_begin

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -17616,6 +17616,8 @@ struct GMT_CTRL *gmt_begin (struct GMTAPI_CTRL *API, const char *session, unsign
 	int  local_count = 0;
 #endif
 
+	gmt_M_memset (GMT_keyword_updated, GMT_N_KEYS, bool); /* Need to start with all set as false */
+
 #ifdef __FreeBSD__
 #ifdef _i386_
 	/* allow divide by zero -- Inf */


### PR DESCRIPTION
**Description of proposed changes**

This PR implements @PaulWessel's suggestion to use `gmt_M_memset` on `GMT_keyword_updated` to fix the issue summarized in [this comment](https://github.com/GenericMappingTools/pygmt/issues/1217#issuecomment-827891555). 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
