### PR TITLE
Suppress annoying phase-shift messages when tiling 1s and 3s reliefs

### DIFF
--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -239,7 +239,7 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			}
 			/* Data record to process */
 
-			/* Data record to process.  We permint this kind of records:
+			/* Data record to process.  We permit this kind of records:
 			 * file [-Rinner_region ] [weight]
 			 * i.e., file is required but region [grid extent] and/or weight [1] are optional
 			 */


### PR DESCRIPTION
Because the 1 and 3 arc second grids are gridline registered and the 15s SRTM+ grid is pixel registered, anyone using @earth_relief_01 or 3 gets these messages about phase-shift and different increments., e.g.,

```
grdblend [WARNING]: File @S40W070.earth_relief_15s_p.nc has different increments (0.00416666666667/0.00416666666667) than the output grid (0.000833333333333/0.000833333333333) - must resample
grdblend [WARNING]: File @S40W070.earth_relief_15s_p.nc coordinates are phase-shifted w.r.t. the output grid - must resample
```

In this case when **grdblend** is called from gmtlib_assemble_tiles I pass **-Ve** to avoid these warnings unless **-Vi** or higher have been set by the user.
