### PR TITLE
Parsing of -W used wrong arg

### DIFF
--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -221,7 +221,7 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEDIAN_CTRL *Ctrl, struct GM
 				Ctrl->W.active = true;
 				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "s", GMT_MSG_ERROR)) n_errors++;
 				sigma = (gmt_get_modifier (opt->arg, 's', arg)) ? true : false;
-				switch (arg[0]) {
+				switch (opt->arg[0]) {
 					case '\0':
 						Ctrl->W.weighted[GMT_IN] = Ctrl->W.weighted[GMT_OUT] = true;
 						Ctrl->W.sigma[GMT_IN] = Ctrl->W.sigma[GMT_OUT] = sigma;

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -237,7 +237,7 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_
 				Ctrl->W.active = true;
 				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "s", GMT_MSG_ERROR)) n_errors++;
 				sigma = (gmt_get_modifier (opt->arg, 's', arg)) ? true : false;
-				switch (arg[0]) {
+				switch (opt->arg[0]) {
 					case '\0':
 						Ctrl->W.weighted[GMT_IN] = Ctrl->W.weighted[GMT_OUT] = true;
 						Ctrl->W.sigma[GMT_IN] = Ctrl->W.sigma[GMT_OUT] = sigma;


### PR DESCRIPTION
The result was that unless a modifier like **+s** was used both input and output weights would be set if either **-Wi** or **-Wo** were given.  Reported on the [old wiki site](http://gmt.soest.hawaii.edu/issues/1291).  Affected both **blockmedian** and **blockmode** but not **blockmean**.
