### PR TITLE
CI: Add docker build for Ubuntu 21.04 with CMake 3.18 + GCC 10.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,7 @@ jobs:
           # ubuntu 20.04 is disabled due to an issue of the docker image
           #- ubuntu:20.04  # CMake 3.16.3 + GNU 9.3.0
           - ubuntu:20.10  # CMake 3.16.3 + GNU 10.2.0
+          - ubuntu:21.04  # CMake 3.18.4 + GNU 10.3.0
           - debian:9      # CMake 3.7.2 + GNU 6.3.0
           - debian:10     # CMake 3.13.4 + GNU 8.3.0
           - debian:sid    # CMake 3.16.3 + GNU 10.1.0


### PR DESCRIPTION
**Description of proposed changes**

Add docker build for Ubuntu 21.04 with CMake 3.18 + GCC 10.3.

