### PR TITLE
Document that subplot cannot use -Bp -Bs yet

### DIFF
--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -285,8 +285,9 @@ To make a minimalistic 2x2 basemap layout called panels.pdf, try::
 Restrictions
 ------------
 
-#. Currently, nesting of subplots is not implemented. (2) If auto-legend option **-l**
-   is used then you must complete plotting in one panel before moving to another.
+#. Currently, nesting of subplots is not implemented. 
+#. If auto-legend option **-l** is used then you must complete plotting in one panel 
+   before moving to another.
 #. Specifying separate primary and secondary annotations via **-Bp** and **-Bs** have
    not yet been implemented.
 

--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -285,8 +285,10 @@ To make a minimalistic 2x2 basemap layout called panels.pdf, try::
 Restrictions
 ------------
 
-(1) Currently, nesting of subplots is not implemented. (2) If auto-legend option **-l**
-is used then you must complete plotting in one panel before moving to another.
+#. Currently, nesting of subplots is not implemented. (2) If auto-legend option **-l**
+   is used then you must complete plotting in one panel before moving to another.
+#. Specifying separate primary and secondary annotations via **-Bp** and **-Bs** have
+   not yet been implemented.
 
 See Also
 --------


### PR DESCRIPTION
This documents the restriction currently in **subplot** while we work on making it possible to have primary and secondary axes in those panels.  See #5139 for details.
