### PR TITLE
Add suitable shorthands for creating month and day labels

### DIFF
--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -131,7 +131,12 @@ Optional Arguments
     category names (you can skip a category by not giving a name), or give
     *start*[-], where we automatically build monotonically increasing labels
     from *start* (a single letter or an integer). Append - to build ranges
-    *start*-*start+1* instead.
+    *start*-*start+1* instead.  **Note**: If **+cM** is given and the number
+    of categories is 12, then we automatically create a list of month names.
+    Likewise, if **+cD** is given and the number of categories is 7 then we
+    make a list of weekday names.  The format of these labels will depend on the
+    :term:`FORMAT_TIME_PRIMARY_MAP`, :term:`GMT_LANGUAGE` and possibly
+    :term:`TIME_WEEK_START` settings.
 
 .. _-G:
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -125,7 +125,12 @@ Optional Arguments
     keys instead of numerical entries then append **+k**\ *keys*, where
     *keys* is either a file with one key per record or a single letter (e.g., D),
     then we build sequential letter keys (e.g., D, E, F, ...) starting at that point.
-    For comma-separated lists of keys, use **-T** instead.
+    For comma-separated lists of keys, use **-T** instead.  **Note**: If **+cM** is given and the number
+    of categories is 12, then we automatically create a list of month names.
+    Likewise, if **+cD** is given and the number of categories is 7 then we
+    make a list of weekday names.  The format of these labels will depend on the
+    :term:`FORMAT_TIME_PRIMARY_MAP`, :term:`GMT_LANGUAGE` and possibly
+    :term:`TIME_WEEK_START` settings.
 
 .. _-G:
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7589,14 +7589,44 @@ unsigned int gmt_validate_cpt_parameters (struct GMT_CTRL *GMT, struct GMT_PALET
 	return GMT_NOERROR;
 }
 
-char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *label, unsigned int n) {
-	/* Generate categorical labels for n categories from the label magic argument */
-	unsigned int k = 0;
-	char **Clabel = gmt_M_memory (GMT, NULL, n, char *);
+char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *in_label, unsigned int n) {
+	/* Generate categorical labels for n categories from the label magic argument.
+	 * Note: If n = 12 and label = M then we create month names.
+	 * Note: If n = 7 and label = D then we create day names
+	 */
+	unsigned int k = 0, kind = 0;
+	bool upper = false;
+	char all_items[12*GMT_LEN16] = {""};
+	char *label = NULL, **Clabel = gmt_M_memory (GMT, NULL, n, char *);
 
+	if (n == 12 && !strcmp (in_label, "M")) {	/* Create a month-list from current defaults */
+		gmtlib_set_case_and_kind (GMT, GMT->current.setting.format_time[GMT_PRIMARY], &upper, &kind);
+		strcpy (all_items, GMT->current.language.month_name[kind][0]);
+		for (k = 1; k < 12; k++) {	/* Append comma-separated list of months in current language, format */
+			strcat (all_items, ",");
+			strcat (all_items, GMT->current.language.month_name[kind][k]);
+		}
+		if (upper) gmt_str_toupper (all_items);
+		label = all_items;
+	}
+	else if (n == 7 && !strcmp (in_label, "D")) {	/* Create a weekday-list from current defaults */
+		unsigned int day;
+		gmtlib_set_case_and_kind (GMT, GMT->current.setting.format_time[GMT_PRIMARY], &upper, &kind);
+		day = (GMT->current.setting.time_week_start + GMT_WEEK2DAY_I) % GMT_WEEK2DAY_I;	/* Wrap around */
+		strcpy (all_items, GMT->current.language.day_name[kind][day]);
+		for (k = 1; k < 7; k++) {	/* Append comma-separated list of weekdays in current language, format */
+			day = (k + GMT->current.setting.time_week_start + GMT_WEEK2DAY_I) % GMT_WEEK2DAY_I;	/* Wrap around */
+			strcat (all_items, ",");
+			strcat (all_items, GMT->current.language.day_name[kind][day]);
+		}
+		if (upper) gmt_str_toupper (all_items);
+		label = all_items;
+	}
+	else 	/* Pass what we were given as is */
+		label = in_label;
 	if (strchr (label, ',')) {	/* Got list of category names */
 		char *word = NULL, *trail = NULL, *orig = strdup (label);
-		trail = orig;
+		trail = orig;	k = 0;
 		while ((word = strsep (&trail, ",")) != NULL && k < n) {
 			if (*word != '\0')	/* Skip empty strings */
 				Clabel[k] = strdup (word);

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -170,6 +170,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   The <label>, if present, sets the labels for each category. It may be a\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   comma-separated list of category names, or <start>[-], where we automatically build\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   labels from <start> (a letter or an integer). Append - to build ranges <start>-<start+1>.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If number of categories is 12 and label is M then we auto-create month name labels, and\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     if it is 7 and label is D then we auto-create weekday name labels.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If <keys> is a single letter then we build sequential alphabetical keys from that letter.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   To accept one of the incoming limits, set that limit to NaN.\n");

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -169,6 +169,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +k<keys> to set categorical keys rather than numerical values.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   <keys> may be a file with one key per line or a comma-separated list of keys.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   If <keys> is a single letter then we build sequential alphabetical keys from that letter.\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   If number of categories is 12 and label is M then we auto-create month name labels, and\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t     if it is 7 and label is D then we auto-create weekday name labels.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-G Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   To accept one of the incoming limits, set that limit to NaN.\n");
 	if (API->GMT->current.setting.run_mode == GMT_MODERN)


### PR DESCRIPTION
When building a categorical CPT for months or weekdays, we can now have GMT supply those labels based on current default settings for time and language by using **+cM** or **+cD**, respectively.  Available in **makecpt** and **grd2cpt**. Closes #5189 and we may merge into master after 6.2.0 release.

Examples of use:

**gmt makecpt -Crainbow -T1/12/1 -F+cM**

```
1	201.88/0/255	L	;January
2	95.625/0/255	L	;February
3	0/10.625/255	L	;March
4	0/116.88/255	L	;April
5	0/223.12/255	L	;May
6	0/255/180.63	L	;June
7	0/255/74.375	L	;July
8	31.875/255/0	L	;August
9	138.12/255/0	L	;September
10	244.37/255/0	L	;October
11	255/159.38/0	L	;November
12	255/53.125/0	B	;December
N	128
```

**gmt makecpt -Crainbow -T1/7/1 -F+cD --FORMAT_TIME_PRIMARY_MAP=Abbrev --GMT_LANGUAGE=es**

```
1	163.93/0/255	L	;LUN
2	0/18.214/255	L	;MAR
3	0/200.36/255	L	;MIE
4	0/255/127.5	L	;JUE
5	54.643/255/0	L	;VIE
6	236.79/255/0	L	;SAB
7	255/91.071/0	B	;DGO
N	128
```

For days we also check the setting of **TIME_WEEK_START**.