### PR TITLE
Fix grdinterpolate KEYS for external use

### DIFF
--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -35,7 +35,7 @@
 #define THIS_MODULE_MODERN_NAME	"grdinterpolate"
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Interpolate a 3-D cube, 2-D grids or 1-D series from a 3-D data cube or stack of 2-D grids"
-#define THIS_MODULE_KEYS	"<G{+,>?}"
+#define THIS_MODULE_KEYS	"<G{+,G?}"
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS	"->RVfn"
 


### PR DESCRIPTION
The **-G** option sets the output file name for grids, cubes, or datasets.  Hopefully addresses Julia problems?
