### PR TITLE
Better defense against filenames with spaces

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -15145,6 +15145,8 @@ int GMT_Get_FilePath (void *V_API, unsigned int family, unsigned int direction, 
 
 	if ((mode & GMT_FILE_CHECK) == 0) gmt_set_unspecified_remote_registration (API, file_ptr);	/* Complete remote filenames without registration information */
 
+	gmt_filename_get (file);	/* Replace any ASCII 29 with spaces (if filename had spaces they may now be ASCII 29) */
+
 	switch (family) {
 		case GMT_IS_GRID:
 			if (!gmt_file_is_tiled_list (API, file, NULL, NULL, NULL) && (c = strchr (file, '='))) {	/* Got filename=id[+modifiers] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13972,6 +13972,7 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 				if (opt->option != GMT_OPT_INFILE) continue;	/* Look for input files we can append to new list */
 				if ((tmp = GMT_Make_Option (API, GMT_OPT_INFILE, opt->arg)) == NULL || (head = GMT_Append_Option (API, tmp, head)) == NULL)
 					return API->error;	/* Failure to make new option and append to list */
+				gmt_filename_set (opt->arg);	/* Replace any spaces with ASCII 29, will be undone by GMT_Get_FilePath */
 			}
 			if (head == NULL) {	/* User gave no input so we must process stdin */
 				/* Make name for a temporary file */

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -441,6 +441,7 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "File %s is sampled using region %s\n", B[n].file, Rargs);
 		}
 		if (do_sample) {	/* One or more reasons to call upon grdsample before using this grid */
+			gmt_filename_set (B[n].file);	/* Replace any spaces in filename with ASCII 29 */
 			if (do_sample & 1) {	/* Resampling of the grid into a netcdf grid */
 				if (GMT->parent->tmp_dir)	/* Use the established temp directory */
 					sprintf (buffer, "%s/grdblend_resampled_%d_%d.nc", GMT->parent->tmp_dir, (int)getpid(), n);

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -913,7 +913,9 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 		 * overlay grdcontour arguments. These are built on the fly */
 
 		for (opt = options; opt; opt = opt->next) {
+			if (opt->option == GMT_OPT_INFILE) gmt_filename_set (opt->arg);	/* Replace any spaces with ASCII 29 */
 			sprintf (string, " -%c%s", opt->option, opt->arg);
+			if (opt->option == GMT_OPT_INFILE) gmt_filename_get (opt->arg);	/* Undo */
 			switch (opt->option) {
 				case 'A' : case 'D': case 'F': case 'G': case 'K': case 'L': case 'Q': case 'T': case 'U': case 'W': case 'Z':	/* Only for grdcontour */
 					strcat (cmd2, string); break;
@@ -976,10 +978,6 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 					else {
 						strcat (cmd1, string);	strcat (cmd2, string);
 					}
-					break;
-				case GMT_OPT_INFILE:
-					gmt_filename_set (string);	/* Replace any spaces with ASCII 29 */
-					strcat (cmd1, string);	strcat (cmd2, string);
 					break;
 
 				default:	/* These arguments go into both commands (may be -p -n, --, etc) */

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -977,6 +977,11 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 						strcat (cmd1, string);	strcat (cmd2, string);
 					}
 					break;
+				case GMT_OPT_INFILE:
+					gmt_filename_set (string);	/* Replace any spaces with ASCII 29 */
+					strcat (cmd1, string);	strcat (cmd2, string);
+					break;
+
 				default:	/* These arguments go into both commands (may be -p -n, --, etc) */
 					strcat (cmd1, string);	strcat (cmd2, string);
 					break;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -441,6 +441,8 @@ static int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GMT_O
 		char output[GMT_VF_LEN] = {""}, cmd[GMT_LEN512] = {""};
 		GMT_Report (API, GMT_MSG_COMPAT, "Passing three grids instead of an image is deprecated.  Please consider using an image instead.\n");
 		GMT_Open_VirtualFile (API, GMT_IS_IMAGE, GMT_IS_SURFACE, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
+		for (k = 0; k < 3; k++)
+			gmt_filename_set (file[k]);	/* Replace any spaces with ASCII 29 */
 		sprintf (cmd, "%s %s %s -C -N -G%s", file[0], file[1], file[2], output);
 		if (GMT_Call_Module (API, "grdmix", GMT_MODULE_CMD, cmd)) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to combine %s/%s/%s into an image - aborting.\n", file[0], file[1], file[2]);
@@ -1434,8 +1436,11 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			strcat (cmd, data_grd);
 		else if (got_int4_grid)	/* Use the virtual file just assigned a few lines above this call */
 			strcat (cmd, int4_grd);
-		else	/* Default is to use the data file */
+		else {	/* Default is to use the data file; we quote it in case there are spaces in the filename */
+			gmt_filename_set (Ctrl->In.file);	/* Replace any spaces with ASCII 29 */
 			strcat (cmd, Ctrl->In.file);
+			gmt_filename_get (Ctrl->In.file);	/* Replace any ASCII 29 with spaces */
+		}
 		/* Call the grdgradient module */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Calling grdgradient with args %s\n", cmd);
 		if (GMT_Call_Module (API, "grdgradient", GMT_MODULE_CMD, cmd))

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -923,6 +923,7 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 				strcpy (data_file, Ctrl->In.file);
 
 		/* Prepare the grdgradient arguments using selected -A -N */
+		gmt_filename_set (data_file);	/* Replace any spaces with ASCII 29 */
 		sprintf (cmd, "%s -G%s -A%s -N%s+a%s -R%.16g/%.16g/%.16g/%.16g --GMT_HISTORY=readonly",
 			data_file, int_grd, Ctrl->I.azimuth, Ctrl->I.method, Ctrl->I.ambient, wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
 		/* Call the grdgradient module */

--- a/src/spotter/backtracker.c
+++ b/src/spotter/backtracker.c
@@ -452,7 +452,9 @@ EXTERN_MSC int GMT_backtracker (void *V_API, int mode, void *args) {
 		if (Ctrl->M.active) {	/* Must convert to stage poles and adjust opening angles */
 			char tmpfile[GMT_LEN32] = {""}, cmd[GMT_LEN128] = {""};
 			sprintf (tmpfile, "gmt_half_rots.%d", (int)getpid());
+			gmt_filename_set (Ctrl->E.rot.file);	/* Replace any spaces in filename with ASCII 29 */
 			sprintf (cmd, "%s -M%g -Fs ->%s", Ctrl->E.rot.file, Ctrl->M.value, tmpfile);
+			gmt_filename_get (Ctrl->E.rot.file);	/* Replace any ASCII 29 with spaces */
 			if (GMT_Call_Module (API, "rotconverter", GMT_MODULE_CMD, cmd) != GMT_NOERROR) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to convert %s to half-rates\n", Ctrl->E.rot.file);
 				Return (API->error);

--- a/src/spotter/spotter.c
+++ b/src/spotter/spotter.c
@@ -399,7 +399,7 @@ void spotter_setrot (struct GMT_CTRL *GMT, struct EULER *e) {
 	e->lat_r = e->lat * D2R;
 }
 
-int spotter_init (struct GMT_CTRL *GMT, char *file, struct EULER **p, unsigned int flowline, bool total_out, bool invert, double *t_max) {
+int spotter_init (struct GMT_CTRL *GMT, char *infile, struct EULER **p, unsigned int flowline, bool total_out, bool invert, double *t_max) {
 	/* file;	Name of file with backward stage poles, always GEOCENTRIC */
 	/* p;		Pointer to stage pole array */
 	/* flowline;	1 if flowlines rather than hotspot-tracks are needed */
@@ -414,9 +414,11 @@ int spotter_init (struct GMT_CTRL *GMT, char *file, struct EULER **p, unsigned i
 	FILE *fp = NULL;
 	struct EULER *e = NULL;
 	char buffer[GMT_BUFSIZ] = {""}, A[GMT_LEN64] = {""}, B[GMT_LEN64] = {""}, txt[GMT_LEN64] = {""}, comment[GMT_BUFSIZ] = {""};
-	char Plates[GMT_BUFSIZ] = {""}, Rotations[GMT_BUFSIZ] = {""}, *this_c = NULL;
+	char file[PATH_MAX] = {""}, Plates[GMT_BUFSIZ] = {""}, Rotations[GMT_BUFSIZ] = {""}, *this_c = NULL;
 	double K[9];
 
+	strncpy (file, infile, PATH_MAX);
+	gmt_filename_get (file);	/* Replace any ASCII 29 with spaces */
 	if (gmt_file_is_cache (GMT->parent, file)) {	/* Must be a cache file */
 		gmt_download_file_if_not_found (GMT, file, 0);
 	}


### PR DESCRIPTION
**Description of proposed changes**

Some users, for whatever reason, end up creating or passing filenames that contain spaces.  This means they need to use quotes when passing these on the command line to GMT.  However, many GMT modules will create commands that involve these input file names and call _GMT_Call_Module_.  However, the filenames now have lost their quotes and the commands fail.  This PR makes an attempt to fix this:

1. Before a module calls _GMT_Call_Module_ with a filename, that filename is run via _gmt_filename_set_ which will replace any space with ASCII 29.
2. The _GMT_File_Path_ function now always does the reverse, replacing any ASCII 29 found with spaces
3. _spotter_init_ does the same thing in the spotter supplement.

Closes #5119 when we merge after 6.2.0 release, hence WIP.
