### PR TITLE
Enable docker builds for Ubuntu 20.04 and 20.10 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,8 +40,7 @@ jobs:
           - ubuntu:14.04  # CMake 2.8.12 + GNU 4.8.4
           - ubuntu:16.04  # CMake 3.5.1 + GNU 5.40
           - ubuntu:18.04  # CMake 3.10.2 + GNU 7.4.0
-          # ubuntu 20.04 is disabled due to an issue of the docker image
-          #- ubuntu:20.04  # CMake 3.16.3 + GNU 9.3.0
+          - ubuntu:20.04  # CMake 3.16.3 + GNU 9.3.0
           - ubuntu:20.10  # CMake 3.16.3 + GNU 10.2.0
           - ubuntu:21.04  # CMake 3.18.4 + GNU 10.3.0
           - debian:9      # CMake 3.7.2 + GNU 6.3.0
@@ -58,6 +57,8 @@ jobs:
       - name: Install GMT dependencies
         run: |
           apt-get update
+          # tzdata is required for Ubuntu>=20.04
+          DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get install -y tzdata
           apt-get install -y --no-install-recommends --no-install-suggests \
                build-essential cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev \
                ghostscript curl git \


### PR DESCRIPTION
**Description of proposed changes**

For docker images of Ubuntu 20.04 and 20.10, we have to install the
tzdata package first, otherwise they will be stuck.
