### PR TITLE
Fix mistake in config.h.in

### DIFF
--- a/src/gmt_config.h.in
+++ b/src/gmt_config.h.in
@@ -110,6 +110,7 @@
 #cmakedefine HAVE___FUNC__
 #cmakedefine HAVE___FUNCTION__
 #cmakedefine HAVE__GETCWD
+#cmakedefine HAVE__RMDIR
 #cmakedefine HAVE_GETPID
 #cmakedefine HAVE__GETPID
 #cmakedefine HAVE_GETPWUID

--- a/src/gmt_notposix.h
+++ b/src/gmt_notposix.h
@@ -498,7 +498,7 @@
 /* rmdir is usually in unistd.h; we use a macro here
  * since the same function under WIN32 is prefixed with _
  * and defined in direct.h */
-#ifdef HAVE__GETCWD
+#ifdef HAVE__RMDIR
 #	define rmdir _rmdir
 #endif
 


### PR DESCRIPTION
Copy/paste error where **HAVE__GETCDW** was used for checking for _rmdir (on Windows presumably).  This PR adds **HAVE__RMDIR**.
