### PR TITLE
Set the correct return type for grdinterpolate for external calls

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12444,28 +12444,21 @@ GMT_LOCAL bool gmtapi_operator_takes_dataset (struct GMT_OPTION *opt, int *geome
 }
 
 GMT_LOCAL char gmtapi_grdinterpolate_type (struct GMTAPI_CTRL *API, struct GMT_OPTION *options) {
-	unsigned int n_files = 0;
-	char type = 'D';	/* For -S */
-	struct GMT_OPTION *opt = NULL, *E = NULL, *S = NULL, *T = NULL;
+	char type;
+	struct GMT_OPTION *opt = NULL, *E = NULL, *S = NULL;
 	gmt_M_unused (API);
 
-	for (opt = options; opt; opt = opt->next) {	/* Process all the options given */
-		if (opt->option == GMT_OPT_INFILE) n_files++;
-		else if (opt->option == 'E') E = opt;
+	for (opt = options; opt; opt = opt->next) {	/* Look for -E and -S */
+		if (opt->option == 'E') E = opt;
 		else if (opt->option == 'S') S = opt;
-		else if (opt->option == 'T') T = opt;
 	}
 	/* Now determine the various cases that yield different return types */
-	if (E == NULL && S == NULL) {	/* Interpolating onto a single grid or a new cube */
-		if (T == NULL && n_files > 1)	/* Repackaging multiple grids as a single cube */
-			type = 'U';
-		else if (T && (strchr (T->arg, '/') || strchr (T->arg, ',')))	/* Making more than one output layer */
-			type = 'U';
-		else
-			type = 'U';	/* Making a single grid layer but need to be cube */
-	}
-	else if (E)	/* Sample a vertical slice as a grid */
+	if (S)	/* Sample down lines and returning result via a dataset */
+		type = 'D';
+	else if (E)	/* Return a vertical slice via a grid */
 		type = 'G';
+	else	/* Interpolating onto a single or multilayer cube */
+		type = 'U';
 
 	return (type);
 }

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12462,7 +12462,7 @@ GMT_LOCAL char gmtapi_grdinterpolate_type (struct GMTAPI_CTRL *API, struct GMT_O
 		else if (T && (strchr (T->arg, '/') || strchr (T->arg, ',')))	/* Making more than one output layer */
 			type = 'U';
 		else
-			type = 'G';	/* Making a single grid layer */
+			type = 'U';	/* Making a single grid layer but need to be cube */
 	}
 	else if (E)	/* Sample a vertical slice as a grid */
 		type = 'G';

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -771,8 +771,11 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 			gmt_set_cartesian (GMT, GMT_OUT);
 		if (z_is_abstime) gmt_set_column_type (GMT, GMT_OUT, GMT_Z, GMT_IS_ABSTIME);
 	}
-	else if (C[GMT_IN] == NULL && (C[GMT_IN] = GMT_Read_Data (API, GMT_IS_CUBE, GMT_IS_FILE, GMT_IS_VOLUME, GMT_CONTAINER_AND_DATA, wesn, Ctrl->In.file[0], NULL)) == NULL)
-		Return (GMT_DATA_READ_ERROR);
+	else if (C[GMT_IN] == NULL) {	/* Read the cube */
+		gmt_M_free (GMT, level);	/* Free this one now since it will be re-read by GMT_Read_Data */
+		if ((C[GMT_IN] = GMT_Read_Data (API, GMT_IS_CUBE, GMT_IS_FILE, GMT_IS_VOLUME, GMT_CONTAINER_AND_DATA, wesn, Ctrl->In.file[0], NULL)) == NULL)
+			Return (GMT_DATA_READ_ERROR);
+	}
 
 	if (convert_to_cube) {	/* Just want to build cube from input stack */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Convert %" PRIu64 " grid layers to a single data cube %s.\n", n_layers, Ctrl->G.file);


### PR DESCRIPTION
**Description of proposed changes**

See #5202 for context.  One key problem was the case when we ran commands like `G = grdinterpolate("cube.nc", T=4)` in gmtmex or Julia it would crash because the KEYS in this case was changed to expect a **GMT_GRID** structure (single layer) but in fact we are still returning a **GMT_CUBE** structure.  The mismatch of the very similar structures caused crashes in one OS but not another.  This PR fixes this.  In the process I also fix a memory leak (both CLI and externals see this)

`Matlab (gmt_grdio.c:3499(gmtlib_free_cube_ptr)): Wrongly tries to free item
`

I am separately updating gmtmex to detect when the returned cube has a single layer only and then return a grid instead, but this switcharoo has to take place in the wrappers, not the GMT API.
