### PR TITLE
Update the scm-check workflow using zenodo API

### DIFF
--- a/.github/workflows/scm-check.yml
+++ b/.github/workflows/scm-check.yml
@@ -6,6 +6,8 @@
 #
 name: SCM Check
 on:
+  # uncomment the 'pull_request' line to enable testing in PRs
+  # pull_request:
   schedule:
     # weekly cron job
     - cron: '0 0 * * 0'
@@ -19,48 +21,21 @@ jobs:
       - name: Check the latest release
         id: scm
         run: |
-          scm_output=scm_version_string.txt
           scm_version_in_gmt=7.0.0
 
-          # Crawl the version string for parsing
-          echo "Crawling the official site: http://www.fabiocrameri.ch/colourmaps.php"
-          curl -s http://www.fabiocrameri.ch/colourmaps.php | grep Version > ${scm_output}
+          # Get version string and date from Zenodo API
+          # https://doi.org/10.5281/zenodo.1243862
+          scm_version=$(curl -Ls https://zenodo.org/api/records/1243862 | jq '.metadata.version' | sed 's/"//g')
+          scm_version_date=$(curl -Ls https://zenodo.org/api/records/1243862 | jq '.metadata.publication_date' | sed 's/"//g')
+          echo "SCM version ${scm_version} (${scm_version_date})"
 
-          # The number of lines in ${scm_output} must be 1
-          nlines=$(wc ${scm_output} | awk '{print $1}')
-          echo "Number of matched version strings: ${nlines}"
-          if [ "$nlines" != 1 ]; then
-            echo "${nlines} mactched version strings found. Will create a bug report!"
-            echo "::set-output name=error_code::1"
-          fi
-
-          # parse version string and date
-          scm_version=$(awk -F'Version <strong>' '{print $2}' scm_version_string.txt | awk -F'</strong>' '{print $1}')
-          scm_version_date=$(awk -F'(' '{print $2}' scm_version_string.txt | awk -F')' '{print $1}' | awk -F, '{print $1}')
+          # Set output of the current step
           echo "::set-output name=scm_version::${scm_version}"
           echo "::set-output name=scm_version_date::${scm_version_date}"
-
-          echo "Find version ${scm_version} released on ${scm_version_date}"
           if [ "${scm_version}" != ${scm_version_in_gmt} ]; then
-            echo "The latest SCM version ${scm_version} is different the one in GMT ${scm_version_in_gmt}!"
-            echo "Will create a update request!"
+            echo "The latest SCM version (${scm_version}) is different the one in GMT (${scm_version_in_gmt})!"
             echo "::set-output name=error_code::2"
           fi
-
-      - name: Create a bug report
-        if: ${{ steps.scm.outputs.error_code == 1 }}
-        uses: nashmaniac/create-issue-action@v1.1
-        with:
-          title: Error in checking ScientificColourMap release
-          token: ${{secrets.GITHUB_TOKEN}}
-          assignees: seisman
-          labels: bug
-          body: |
-            The ["SCM check"](.github/workflows/scm-check.yml) has an error in
-            parsing the version string of Scientific Colour Maps from
-            http://www.fabiocrameri.ch/colourmaps.php.
-
-            Please manually check it and fix the workflow.
 
       - name: Create an update request
         if: ${{ steps.scm.outputs.error_code == 2 }}


### PR DESCRIPTION
**Description of proposed changes**

The scm-check workflow fails because the official site was redesigned which broke the codes to extract version string and release date. 

The old workflow is fragile and the new workflow parses the Zenodo record (https://doi.org/10.5281/zenodo.1243862) directly, so it's more stable (unless the author forgets to upload the SCM package to zenodo).

See https://github.com/GenericMappingTools/gmt/pull/5224/checks?check_run_id=2713863229 for an example run of the new workflow.

Fixes #5208.


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
