### PR TITLE
Update cmake/ConfigDefault.cmake for 6.2.0rc2

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -52,12 +52,12 @@ set (GMT_PACKAGE_VERSION_MAJOR 6)
 set (GMT_PACKAGE_VERSION_MINOR 2)
 set (GMT_PACKAGE_VERSION_PATCH 0)
 # If this is a beta version or similar, add a string suffix
-#set (GMT_PACKAGE_VERSION_SUFFIX "rc1")
+set (GMT_PACKAGE_VERSION_SUFFIX "rc2")
 
 # Whether to make a public release.
 # When making internal releases or just an ordinary developer build, it is set to FALSE.
 # When making *public* release, uncomment to set it to TRUE.
-#set (GMT_PUBLIC_RELEASE TRUE)
+set (GMT_PUBLIC_RELEASE TRUE)
 
 # The GMT package version.
 set (GMT_PACKAGE_VERSION "${GMT_PACKAGE_VERSION_MAJOR}.${GMT_PACKAGE_VERSION_MINOR}.${GMT_PACKAGE_VERSION_PATCH}${GMT_PACKAGE_VERSION_SUFFIX}")


### PR DESCRIPTION
**Description of proposed changes**

Addresses two pre-release checklist items:

>  set GMT_PACKAGE_VERSION_SUFFIX to rcx
> set GMT_PUBLIC_RELEASE to TRUE

Addresses #5191 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
