### PR TITLE
Use correct architecture in bundle name

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -36,26 +36,22 @@ abort_build() {	# Called when we abort this script via Crtl-C
 }
 
 TOPDIR=$(pwd)
-if [ "${USER}" = "pwessel" ] || [ "${USER}" = "meghanj" ]; then	# Set ftp default action
+do_ftp=0
+if [ "X${1}" = "X-p" ]; then
 	do_ftp=1
-else
-	do_ftp=0
-fi
-
-if [ "X${1}" = "X-n" ]; then
-	do_ftp=0
 elif [ "X${1}" = "X-m" ]; then
 	do_ftp=2
 elif [ $# -gt 0 ]; then
 	cat <<- EOF  >&2
-	Usage: build-release.sh [-n]
+	Usage: build-release.sh [-p|m]
 	
 	build-release.sh must be run from top-level gmt directory.
 	Will create the release compressed tarballs and (under macOS) the bundle.
 	Requires you have set GMT_PACKAGE_VERSION_* and GMT_PUBLIC_RELEASE in cmake/ConfigDefaults.cmake.
 	Requires GMT_GSHHG_SOURCE and GMT_DCW_SOURCE to be set in the environment.
-	Passing -n means we do not copy the files to the SOEST ftp directory
+	Passing -p means we copy the files to the SOEST ftp directory
 	Passing -m means only copy the macOS bundle to the SOEST ftp directory
+	[Default places no files in the SOEST ftp directory]
 	EOF
 	exit 1
 fi

--- a/cmake/dist/CMakeLists.txt
+++ b/cmake/dist/CMakeLists.txt
@@ -42,7 +42,7 @@ if (WIN32)
     endif()
 endif (WIN32)
 if (APPLE)
-    set (CPACK_PACKAGE_FILE_NAME "gmt-${CPACK_PACKAGE_VERSION}-darwin-x86_64")
+    set (CPACK_PACKAGE_FILE_NAME "gmt-${CPACK_PACKAGE_VERSION}-darwin-${CMAKE_HOST_SYSTEM_PROCESSOR}")
 endif (APPLE)
 
 # Install components:


### PR DESCRIPTION
Also use -p to places the products instead of -n to NOT place products.
[Note: Maybe too hard to bet build-release to work under brew since there are several macports-path-specific things going on.  I will see if macports now will install under M1 since some time has passed since last attempt].

I am also not sure if we should wait for this effort.  With the installers working, is the plan to declare victory and rebuild installers as 6.2.0?  What is a suitable wait period for this?