### PR TITLE
Let build-release handle case of no gcc present

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -10,8 +10,8 @@
 #	4) sphinx-build 
 #	5) grealpath (package coreutils)
 #	6) GNU tar (package gnutar)
-#	7) gcc-mp-9 must be installed and in path
-#	8) g++-mp-9 must be installed and in path
+#	7) For OpenMP: gcc-mp-9 must be installed and in path
+#	8) For OpenMP: g++-mp-9 must be installed and in path
 #
 #  Notes:
 #	1. CMAKE_INSTALL_PATH, EXEPLUSLIBS, and EXESHARED in build-macos-external-list.sh may need to be changed for different users.
@@ -84,18 +84,6 @@ if ! [ -x "$(command -v gnutar)" ]; then
 	exit 1
 fi
 
-# gcc-mp-9 is need to build with OpenMP
-if ! [ -x "$(command -v gcc-mp-9)" ]; then
-	echo 'build-release.sh: Error: gcc-mp-9 is not found in your search PATH.' >&2
-	exit 1
-fi
-
-# gcc-mp-9 is need to build with OpenMP
-if ! [ -x "$(command -v g++-mp-9)" ]; then
-	echo 'build-release.sh: Error: g++-mp-9 is not found in your search PATH.' >&2
-	exit 1
-fi
-
 # 0. Make sure GMT_GSHHG_SOURCE and GMT_DCW_SOURCE are set in the environment
 if [ "X${GMT_GSHHG_SOURCE}" = "X" ]; then
 	echo "build-release.sh: Need to setenv GMT_GSHHG_SOURCE to point to directory with GSHHG files" >&2
@@ -136,20 +124,35 @@ cd build
 # 2c. Set CMake cache for MP build:
 COMPC=$(which gcc-mp-9)
 COMPG=$(which g++-mp-9)
-cat << EOF > cache-mp-gcc.cmake
-# Cache settings for building the macOS release with GCC and OpenMP
-# This cache file is set for the binary paths of macports
-#
-SET ( CMAKE_C_COMPILER "${COMPC}" CACHE STRING "GNU MP C compiler" )
-SET ( CMAKE_CXX_COMPILER "${COMPG}" CACHE STRING "GNU MP C++ compiler" )
-SET ( CMAKE_C_FLAGS -flax-vector-conversions CACHE STRING "C FLAGS")
-SET ( CMAKE_C_FLAGS_DEBUG -flax-vector-conversions CACHE STRING "C FLAGS DEBUG")
-SET ( CMAKE_C_FLAGS_RELEASE -flax-vector-conversions CACHE STRING "C FLAGS RELEASE")
-SET ( OpenMP_C_FLAGS -flax-vector-conversions CACHE STRING "C FLAGS OPENMP")
-EOF
-
 echo "build-release.sh: Configure and build tarballs" >&2
-cmake -G Ninja  -C cache-mp-gcc.cmake ..
+if [ "X${COMPC}" = "X" ]; then	# No gcc support, no OpenMP
+	echo 'build-release.sh: Warning: gcc-mp-9 is not found in your search PATH - OpenMP will be disabled.' >&2
+	cmake -G Ninja ..
+else
+	# gcc-mp-9 is need to build with OpenMP
+	if ! [ -x "$(command -v gcc-mp-9)" ]; then
+		echo 'build-release.sh: Error: gcc-mp-9 is not found in your search PATH.' >&2
+		exit 1
+	fi
+	# gcc-mp-9 is need to build with OpenMP
+	if ! [ -x "$(command -v g++-mp-9)" ]; then
+		echo 'build-release.sh: Error: g++-mp-9 is not found in your search PATH.' >&2
+		exit 1
+	fi
+
+	cat <<- EOF > cache-mp-gcc.cmake
+	# Cache settings for building the macOS release with GCC and OpenMP
+	# This cache file is set for the binary paths of macports
+	#
+	SET ( CMAKE_C_COMPILER "${COMPC}" CACHE STRING "GNU MP C compiler" )
+	SET ( CMAKE_CXX_COMPILER "${COMPG}" CACHE STRING "GNU MP C++ compiler" )
+	SET ( CMAKE_C_FLAGS -flax-vector-conversions CACHE STRING "C FLAGS")
+	SET ( CMAKE_C_FLAGS_DEBUG -flax-vector-conversions CACHE STRING "C FLAGS DEBUG")
+	SET ( CMAKE_C_FLAGS_RELEASE -flax-vector-conversions CACHE STRING "C FLAGS RELEASE")
+	SET ( OpenMP_C_FLAGS -flax-vector-conversions CACHE STRING "C FLAGS OPENMP")
+	EOF
+	cmake -G Ninja  -C cache-mp-gcc.cmake ..
+fi
 # 3. Build the release and the tarballs
 cmake --build . --target gmt_release
 cmake --build . --target gmt_release_tar


### PR DESCRIPTION
Since gcc cannot yet be built for M1 we need to use Xcode on that platform if we want to test bundle building. This PR checks if gcc-9 is present and if not switches to Xcode build.