### PR TITLE
Use clang instead of gcc in build-release.sh script

### DIFF
--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -18,9 +18,8 @@ if [ $(which cmake) = "/opt/local/bin/cmake" ]; then
 elif [ $(which cmake) = "/usr/local/bin/cmake" ]; then
 	distro=HomeBrew
 	top=/usr/local
-else
-	distro=Fink
-	/sw
+else	# Requires either MacPorts of HomeBrew
+	exit 1
 fi
 
 # Set temporary directory
@@ -115,3 +114,4 @@ install (FILES
 	DESTINATION \${GMT_LIBDIR}/GraphicsMagick/config
 	COMPONENT Runtime)
 EOF
+exit 0

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -119,7 +119,11 @@ trap abort_build SIGINT
 rm -rf build
 mkdir build
 # 2b. Build list of external programs and shared libraries
-admin/build-macos-external-list.sh > build/add_macOS_cpack.txt
+answer=$(admin/build-macos-external-list.sh > build/add_macOS_cpack.txt)
+if [ $answer -ne 0 ]; then
+	echo 'build-release.sh: Error: Requires either MacPorts of HomeBrew' >&2
+	exit 1
+fi
 cd build
 # 2c. Set CMake cache for MP build:
 COMPC=$(which gcc-mp-9)

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 #
 # Script that builds a GMT release and makes the compressed tarballs.
-# If run under macOS it also builds the macOS Bundle.
+# If run under macOS it also builds the macOS Bundle.  For now it
+# must be run in a MacPort installation for the bundle to be built.
 #
 # Requirements in addition to libraries and tools to build GMT:
-#	1) pngquant for squeezing PNG files down in size
+#	1) pngquant for squeezing PNG files down in size (package pngquant)
 #	2) GMT_GSHHG_SOURCE and GMT_DCW_SOURCE environmental parameters set
 #	3) A ghostscript version we can include in the macOS bundle [MacPort]
 #	4) sphinx-build 
 #	5) grealpath (package coreutils)
 #	6) GNU tar (package gnutar)
-#	7) For OpenMP: gcc-mp-9 must be installed and in path
-#	8) For OpenMP: g++-mp-9 must be installed and in path
+#	7) For OpenMP: clang-mp-11 and clang++-mp-11 must be installed and in path (package clang-11)
 #
 #  Notes:
 #	1. CMAKE_INSTALL_PATH, EXEPLUSLIBS, and EXESHARED in build-macos-external-list.sh may need to be changed for different users.
 #	2. Settings for GS_LIB, PROJ_LIB etc in cmake/dist/startup_macosx.sh.in may need to be updated as new gs,proj.gm releases are issued
 
+CLANG_V=11	# Current Clang version to use
 # Temporary ftp site for pre-release files:
 GMT_FTP_URL=ftp.soest.hawaii.edu
 GMT_FTP_DIR=/export/ftp1/ftp/pub/gmtrelease
@@ -126,36 +127,36 @@ if [ $answer -ne 0 ]; then
 fi
 cd build
 # 2c. Set CMake cache for MP build:
-COMPC=$(which gcc-mp-9)
-COMPG=$(which g++-mp-9)
+COMPC=$(which clang-mp-${CLANG_V})
+COMPG=$(which clang++-mp-${CLANG_V})
 echo "build-release.sh: Configure and build tarballs" >&2
-if [ "X${COMPC}" = "X" ]; then	# No gcc support, no OpenMP
-	echo 'build-release.sh: Warning: gcc-mp-9 is not found in your search PATH - OpenMP will be disabled.' >&2
+if [ "X${COMPC}" = "X" ]; then	# No clang support, no OpenMP
+	echo 'build-release.sh: Warning: clang-mp-${CLANG_V} is not found in your search PATH - OpenMP will be disabled.' >&2
 	cmake -G Ninja ..
 else
-	# gcc-mp-9 is need to build with OpenMP
-	if ! [ -x "$(command -v gcc-mp-9)" ]; then
-		echo 'build-release.sh: Error: gcc-mp-9 is not found in your search PATH.' >&2
+	# clang-mp-${CLANG_V} is needed to build with OpenMP
+	if ! [ -x "$(command -v clang-mp-${CLANG_V})" ]; then
+		echo 'build-release.sh: Error: clang-mp-${CLANG_V} is not found in your search PATH.' >&2
 		exit 1
 	fi
-	# gcc-mp-9 is need to build with OpenMP
-	if ! [ -x "$(command -v g++-mp-9)" ]; then
-		echo 'build-release.sh: Error: g++-mp-9 is not found in your search PATH.' >&2
+	# clang++-mp-${CLANG_V} is needed to build with OpenMP
+	if ! [ -x "$(command -v clang++-mp-${CLANG_V})" ]; then
+		echo 'build-release.sh: Error: clang++-mp-${CLANG_V} is not found in your search PATH.' >&2
 		exit 1
 	fi
 
-	cat <<- EOF > cache-mp-gcc.cmake
-	# Cache settings for building the macOS release with GCC and OpenMP
+	cat <<- EOF > cache-mp-clang.cmake
+	# Cache settings for building the macOS release with Clang and OpenMP
 	# This cache file is set for the binary paths of macports
 	#
-	SET ( CMAKE_C_COMPILER "${COMPC}" CACHE STRING "GNU MP C compiler" )
-	SET ( CMAKE_CXX_COMPILER "${COMPG}" CACHE STRING "GNU MP C++ compiler" )
+	SET ( CMAKE_C_COMPILER "/opt/local/bin/clang-mp-${CLANG_V}" CACHE STRING "CLANG MP C compiler" )
+	SET ( CMAKE_CXX_COMPILER "/opt/local/bin/clang++-mp-${CLANG_V}" CACHE STRING "CLANG MP C++ compiler" )
 	SET ( CMAKE_C_FLAGS -flax-vector-conversions CACHE STRING "C FLAGS")
 	SET ( CMAKE_C_FLAGS_DEBUG -flax-vector-conversions CACHE STRING "C FLAGS DEBUG")
 	SET ( CMAKE_C_FLAGS_RELEASE -flax-vector-conversions CACHE STRING "C FLAGS RELEASE")
 	SET ( OpenMP_C_FLAGS -flax-vector-conversions CACHE STRING "C FLAGS OPENMP")
 	EOF
-	cmake -G Ninja  -C cache-mp-gcc.cmake ..
+	cmake -G Ninja  -C cache-mp-clang.cmake ..
 fi
 # 3. Build the release and the tarballs
 cmake --build . --target gmt_release


### PR DESCRIPTION
**Description of proposed changes**

Since gcc is not yet available for M1 arm64 chips but clang is, I have switched to clang-11 and we can now build Open-MP enabled GMT bundles for either Intel or ARM architectures.  I also added checks that only MacPorts or HomeBrew can be used (although only MacPorts have been verified to work)
