### PR TITLE
pstext had a few problems in paragraph mode

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -359,7 +359,7 @@ static struct GMT_FONTSPEC GMT_standard_fonts[GMT_N_STANDARD_FONTS] = {
 #include "standard_adobe_fonts.h"
 };
 
-#define DEF_HEADER_MARKERS "#%!;\"\'"
+#define DEF_HEADER_MARKERS "#%!;\"\'"	/* Default accepts GMT or MATLAB header records or comments of quoted text */
 
 #define N_MAP_ANNOT_OBLIQUE_ITEMS 7
 
@@ -719,7 +719,8 @@ GMT_LOCAL void gmtinit_translate_to_long_options (struct GMTAPI_CTRL *API, struc
 GMT_LOCAL int gmtinit_check_markers (struct GMT_CTRL *GMT) {
 	int error = GMT_NOERROR;
 	/* Make sure segment header markers and header markers are not the same */
-	strcpy (GMT->current.setting.io_head_marker_in, "#%\"\'");	/* Accept GMT or MATLAB header records or comments or quoted text */
+	if (GMT->current.setting.io_head_marker_in[0] == '\0')	/* Nothing, set default before comparison */
+		strcpy (GMT->current.setting.io_head_marker_in, DEF_HEADER_MARKERS);
 
 	if (strchr (GMT->current.setting.io_head_marker_in, GMT->current.setting.io_seg_marker[GMT_IN])) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Conflict between the settings of IO_HEADER_MARKER and IO_SEGMENT_MARKER for input:\n");

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -802,7 +802,7 @@ EXTERN_MSC int GMT_pstext (void *V_API, int mode, void *args) {
 	char text[GMT_BUFSIZ] = {""}, cp_line[GMT_BUFSIZ] = {""}, label[GMT_BUFSIZ] = {""}, buffer[GMT_BUFSIZ] = {""};
 	char pjust_key[5] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_f[GMT_LEN256] = {""};
 	char *paragraph = NULL, *line = NULL, *curr_txt = NULL, *in_txt = NULL, **c_txt = NULL, *use_text = NULL;
-	char this_size[GMT_LEN256] = {""}, this_font[GMT_LEN256] = {""}, just_key[5] = {""};
+	char this_size[GMT_LEN256] = {""}, this_font[GMT_LEN256] = {""}, just_key[5] = {""}, save_h_chars[GMT_LEN32] = {""};
 
 	enum GMT_enum_geometry geometry;
 
@@ -960,6 +960,8 @@ EXTERN_MSC int GMT_pstext (void *V_API, int mode, void *args) {
 		rec_mode = GMT_READ_TEXT;
 		geometry = GMT_IS_TEXT;
 		GMT_Set_Columns (API, GMT_IN, 0, GMT_COL_FIX);
+		strncpy (save_h_chars, GMT->current.setting.io_head_marker_in, GMT_LEN32);	/* Must allow quotes and percentage signs in paragraph text */
+		strcpy (GMT->current.setting.io_head_marker_in, "#");
 	}
 	else {
 		unsigned int ncol = Ctrl->Z.active;	/* Input will have z */
@@ -1054,7 +1056,7 @@ EXTERN_MSC int GMT_pstext (void *V_API, int mode, void *args) {
 				pos = 0;
 
 				if (gmt_M_compat_check (GMT, 4)) {
-					if (input_format_version == GMT_NOTSET) input_format_version = pstext_get_input_format_version (GMT, line, 1);
+					if (input_format_version == GMT_NOTSET) input_format_version = pstext_get_input_format_version (GMT, buffer, 1);
 				}
 				if (input_format_version == 4) {	/* Old-style GMT 4 records */
 					nscan += sscanf (buffer, "%s %lf %s %s %s %s %s\n", this_size, &T.paragraph_angle, this_font, just_key, txt_a, txt_b, pjust_key);
@@ -1428,6 +1430,7 @@ EXTERN_MSC int GMT_pstext (void *V_API, int mode, void *args) {
 			n_paragraphs++;
 		}
 	 	gmt_M_free (GMT, paragraph);
+	 	strncpy (GMT->current.setting.io_head_marker_in, save_h_chars, GMT_LEN32);	/* Restore original default */
 	}
 	if (Ctrl->G.mode && m) {
 		int n_labels = m, form = (T.boxflag & 4) ? PSL_TXT_ROUND : 0;	/* PSL_TXT_ROUND = Rounded rectangle */


### PR DESCRIPTION
There were a few problems here:

1. The function that determines if it is a GMT4 or GMT 5 input format was passed the wrong variable (_line_ instead of _buffer_)
2. The code that checks to make sure the header and segment markers are never the same overwrote whatever the user may have selected via **IO_HEADER_MARKER**.
3. **pstext -M** must be allowed to read general text and hence only the GMT comment lines starting with `#` shall be honored. We thus reset the setting temporarily and reset at the end of the module.

All tests pass as does my example script.  Closes #5250.