### PR TITLE
Cartesian -L case failed as distances are squared but +d is not

### DIFF
--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -3068,7 +3068,7 @@ GMT_LOCAL struct GMT_DATASET *grdmath_ASCII_read (struct GMT_CTRL *GMT, struct G
 	if (gmt_M_is_geographic (GMT, GMT_IN))
 		error = gmt_init_distaz (GMT, 'k', gmt_M_sph_mode (GMT), GMT_MAP_DIST);
 	else
-		error = gmt_init_distaz (GMT, 'X', 0, GMT_MAP_DIST);	/* Cartesian */
+		error = gmt_init_distaz (GMT, 'R', 0, GMT_MAP_DIST);	/* Cartesian squared distances */
 	if (error == GMT_NOT_A_VALID_TYPE) return NULL;
 	if (GMT_Set_Columns (GMT->parent, GMT_IN, 2, GMT_COL_FIX_NO_TEXT) != GMT_NOERROR) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in operator %s setting number of input columns\n", op);


### PR DESCRIPTION
See [forum](https://forum.generic-mapping-tools.org/t/questions-about-gmtselect-in-cartesian-coordinate/1716) for background.  The problem was that for simple Cartesian distances we save processing time by using the _squared_ distances instead of calling hypot.  But the **+d** distance was not squared, leading to huge mismatches.  We do the same for **-C** but here the squaring was taken care of.  Since _gmt_near_lines_ is called in other modules the squaring is now taken care of inside the _gmtmap_near_a_line_cartesian_ function.  Also **grdmath** needed to call the right _gmt_init_distaz_ so comparisons are correct.

Tests pass.  We will merge this after 6.2.0 release and approvals.