### PR TITLE
Use non-scaled pen default for +p

### DIFF
--- a/doc/examples/ex22/ex22.ps
+++ b/doc/examples/ex22/ex22.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_6b09bc8_2021.03.13 [64-bit] Document from coast
+%%Title: GMT v6.2.0_eb9390f_2021.05.26 [64-bit] Document from coast
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica Helvetica-Bold
-%%CreationDate: Sat Mar 13 18:31:02 2021
+%%CreationDate: Wed May 26 14:11:47 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Landscape
@@ -744,11 +744,18 @@ PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold 
 6496 -114 M (90°W) tc Z
 7146 -114 M (45°W) tc Z
 7795 -114 M (0°) tc Z
+/PSL_AH1 0
 2415 0 M (90°S) mr Z
+(90°S) sw mx
 984 974 M (45°S) mr Z
+(45°S) sw mx
 -114 2598 M (0°) mr Z
+(0°) sw mx
 984 4223 M (45°N) mr Z
+(45°N) sw mx
 2415 5197 M (90°N) mr Z
+(90°N) sw mx
+def
 {0.678 0.847 0.902 C} FS
 O0
 7795 0 M
@@ -11769,7 +11776,7 @@ O5<NAD*lA1H<R_69Ia$2fYhGuq``0WqIT7smqmb0"W=h1V(3BnBE\GKY^osX%sSe%$-Yn!b](F*.,WQi
 n3cChW;&SFYY[s~>
 U
 %%EndObject
-0 W
+25 W
 O1
 1984 8504 4252 992 Sr
 0 A

--- a/doc/examples/ex31/ex31.ps
+++ b/doc/examples/ex31/ex31.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from coast
+%%Title: GMT v6.2.0_eb9390f_2021.05.26 [64-bit] Document from coast
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font LinBiolinumO LinLibertineOB
-%%CreationDate: Thu Mar 11 16:11:25 2021
+%%CreationDate: Wed May 26 14:11:48 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -753,13 +753,23 @@ PSL_font_encode 42 get 0 eq {ISO-8859-5_Encoding /LinLibertineOB /LinLibertineOB
 2953 -131 M (10E) tc Z
 4643 -131 M (20E) tc Z
 6363 -131 M (30E) tc Z
+/PSL_AH1 0
 -131 888 M V 90 R (35N) bc Z U
+(35N) sw mx
 -131 1938 M V 90 R (40N) bc Z U
+(40N) sw mx
 -131 2987 M V 90 R (45N) bc Z U
+(45N) sw mx
 -131 4046 M V 90 R (50N) bc Z U
+(50N) sw mx
 -131 5131 M V 90 R (55N) bc Z U
+(55N) sw mx
 -131 6262 M V 90 R (60N) bc Z U
+(60N) sw mx
 -131 7480 M V 90 R (65N) bc Z U
+(65N) sw mx
+(70N) sw mx
+def
 {0.678 0.847 0.902 C} FS
 O0
 -7559 0 0 7608 7559 0 3 0 0 SP
@@ -71015,7 +71025,7 @@ O0
 3732 5928 T
 {1 A} FS
 1632 3780 1890 816 Sr
-0 W
+25 W
 FQ
 O1
 1632 3780 1890 816 Sr

--- a/doc/examples/ex41/ex41.ps
+++ b/doc/examples/ex41/ex41.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from coast
+%%Title: GMT v6.2.0_eb9390f_2021.05.26 [64-bit] Document from coast
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:11:44 2021
+%%CreationDate: Wed May 26 14:11:50 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -250201,7 +250201,7 @@ N 3109 4687 M 0 -3000 D S
 N 4365 4687 M 0 -3000 D S
 N 5556 4687 M 0 -3000 D S
 N 6085 4687 M 0 -3000 D S
-0 W
+25 W
 FQ
 O1
 5293 6614 3307 2647 Sr

--- a/doc/examples/ex42/ex42.ps
+++ b/doc/examples/ex42/ex42.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from grdimage
+%%Title: GMT v6.2.0_eb9390f_2021.05.26 [64-bit] Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:11:49 2021
+%%CreationDate: Wed May 26 14:11:56 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -34336,7 +34336,7 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 5721 1089 T
-0 W
+25 W
 O1
 3416 1208 537 1586 Sr
 4 W
@@ -41922,7 +41922,7 @@ O0
 -2126 2154 T
 17 W
 N 118 612 M 1417 0 D S
-0 W
+25 W
 O1
 940 1654 827 470 Sr
 4 W

--- a/doc/scripts/GMT_legend.ps
+++ b/doc/scripts/GMT_legend.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from legend
+%%Title: GMT v6.2.0_eb9390f_2021.05.26 [64-bit] Document from legend
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:09:28 2021
+%%CreationDate: Wed May 26 14:05:38 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -759,7 +759,7 @@ N 2957 3900 M 0 -2400 D S
 N 4301 3900 M 0 -2400 D S
 N 5645 3900 M 0 -2400 D S
 N 6182 3900 M 0 -2400 D S
-0 W
+25 W
 FQ
 O1
 4500 6720 3360 2250 Sr

--- a/doc/scripts/GMT_mag_rose.ps
+++ b/doc/scripts/GMT_mag_rose.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from basemap
+%%Title: GMT v6.2.0_eb9390f_2021.05.26 [64-bit] Document from basemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:09:34 2021
+%%CreationDate: Wed May 26 14:05:38 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -792,8 +792,14 @@ N 0 4800 M 8400 0 D S
 2282 -105 M (5°W) tc Z
 4500 -105 M (0°) tc Z
 6679 -106 M (5°E) tc Z
+/PSL_AH1 0
+(10°S) sw mx
+(5°S) sw mx
 -99 865 M V 90 R (0°) bc Z U
+(0°) sw mx
 -99 3194 M V 90 R (5°N) bc Z U
+(5°N) sw mx
+def
 0 A
 %%EndObject
 0 A
@@ -1331,7 +1337,7 @@ O0
 0 setlinejoin
 3.32550952342 setmiterlimit
 V % Begin inset
-0 W
+25 W
 {0.949 A} FS
 O1
 4680 3480 6600 2400 Sr

--- a/doc/scripts/GMT_mapscale.ps
+++ b/doc/scripts/GMT_mapscale.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_2cec3a0_2021.03.18 [64-bit] Document from basemap
+%%Title: GMT v6.2.0_eb9390f_2021.05.26 [64-bit] Document from basemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 18 17:55:35 2021
+%%CreationDate: Wed May 26 14:05:39 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -808,8 +808,11 @@ N -43 1537 M 0 -1580 D S
 3000 -113 M (20°E) tc Z
 4500 -113 M (30°E) tc Z
 6000 -113 M (40°E) tc Z
+/PSL_AH1 0
 -113 0 M (50°N) mr Z
-0 W
+(50°N) sw mx
+def
+25 W
 {0.878 1 1 C} FS
 O1
 540 2667 1118 798 Sr

--- a/doc/scripts/GMT_seislegend.ps
+++ b/doc/scripts/GMT_seislegend.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.2.0_99b7aea-dirty_2021.03.11 [64-bit] Document from legend
+%%Title: GMT v6.2.0_eb9390f_2021.05.26 [64-bit] Document from legend
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Mar 11 16:09:46 2021
+%%CreationDate: Wed May 26 14:05:42 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -718,7 +718,7 @@ N 0 941 M 8504 0 D S
 N 0 666 M 8504 0 D S
 N 2835 941 M 0 -275 D S
 N 5669 941 M 0 -275 D S
-0 W
+25 W
 FQ
 O1
 1413 8571 4252 673 Sr

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13539,7 +13539,7 @@ int gmt_getpanel (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	P->radius = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_RADIUS;	/* 6 pt */
 	gmt_init_fill (GMT, &P->fill, -1.0, -1.0, -1.0);			/* Default is no fill unless specified */
 	gmt_init_fill (GMT, &P->sfill, gmt_M_is255 (127), gmt_M_is255 (127), gmt_M_is255 (127));	/* Default if gray shade is used */
-	P->pen1 = GMT->current.setting.map_frame_pen;			/* Heavier pen for main outline */
+	gmt_getpen (GMT, "thicker,black", &P->pen1 );			/* Heavier pen for main outline */
 	P->pen2 = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
 	P->debug_pen = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
 	P->gap = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_GAP;	/* Default is 2p */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13539,7 +13539,7 @@ int gmt_getpanel (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	P->radius = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_RADIUS;	/* 6 pt */
 	gmt_init_fill (GMT, &P->fill, -1.0, -1.0, -1.0);			/* Default is no fill unless specified */
 	gmt_init_fill (GMT, &P->sfill, gmt_M_is255 (127), gmt_M_is255 (127), gmt_M_is255 (127));	/* Default if gray shade is used */
-	gmt_getpen (GMT, "thicker,black", &P->pen1 );			/* Heavier pen for main outline */
+	gmt_getpen (GMT, "thicker,black", &P->pen1);			/* Heavier pen for main outline */
 	P->pen2 = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
 	P->debug_pen = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
 	P->gap = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_GAP;	/* Default is 2p */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13539,7 +13539,7 @@ int gmt_getpanel (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	P->radius = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_RADIUS;	/* 6 pt */
 	gmt_init_fill (GMT, &P->fill, -1.0, -1.0, -1.0);			/* Default is no fill unless specified */
 	gmt_init_fill (GMT, &P->sfill, gmt_M_is255 (127), gmt_M_is255 (127), gmt_M_is255 (127));	/* Default if gray shade is used */
-	gmt_getpen (GMT, "thicker,black", &P->pen1);			/* Heavier pen for main outline */
+	(void) gmt_getpen (GMT, "thicker,black", &P->pen1);			/* Heavier pen for main outline */
 	P->pen2 = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
 	P->debug_pen = GMT->current.setting.map_default_pen;			/* Thinner pen for optional inner outline */
 	P->gap = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_GAP;	/* Default is 2p */


### PR DESCRIPTION
**Description of proposed changes**

This PR changes the default pen for +p to be `thicker,black` rather than scaled based on the size. 

Several tests fail, but for the better. I can push new postscript files after review of the fixed default.

Fixes #4955 and relates to https://github.com/GenericMappingTools/pygmt/pull/1287.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
