### PR TITLE
Let gmt_parse_array look out for memory files

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -17023,13 +17023,19 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 		return (GMT_NOERROR);
 	}
 
-	/* 1b. Check if argument is a local file */
+	/* 1b. Check if argument is a memory file */
+	if (gmt_M_file_is_memory (argument)) {	/* Yep */
+		T->file = strdup (argument);
+		return (GMT_NOERROR);
+	}
+
+	/* 1c. Check if argument is a local file */
 	if (!gmt_access (GMT, argument, F_OK)) {	/* File exists */
 		T->file = strdup (argument);
 		return (GMT_NOERROR);
 	}
 
-	/* 1c. Check if we are given a list t1,t2,t3,... */
+	/* 1d. Check if we are given a list t1,t2,t3,... */
 	if (strchr (argument, ',')) {
 		T->list = strdup (argument);
 		if (strchr (argument, 'T')) {	/* Gave list of absolute times */


### PR DESCRIPTION
In the externals, the argument to **sample1d -T** may well be an in-memory array, but _gmt_parse_array_ had no check for that, just for regular files.  The next step is _gmt_create_array_ which uses _GMT_Read_Data_ so I have good hope this will fix #5266.
