### PR TITLE
For now, restrict interpolation on grids with no pad to be bilinear

### DIFF
--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -765,8 +765,11 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 		}
 		GC[g].HH = gmt_get_H_hidden (GC[g].G->header);
 		/* Temporary fix for external grids with no pad; see discussion at https://github.com/GenericMappingTools/pygmt/issues/1309 */
-		if (GC[g].G->header->pad[XLO] < 2 || GC[g].G->header->pad[XHI] < 2 || GC[g].G->header->pad[YLO] < 2 || GC[g].G->header->pad[YHI] < 2)
+		if (GC[g].G->header->pad[XLO] < 2 || GC[g].G->header->pad[XHI] < 2 || GC[g].G->header->pad[YLO] < 2 || GC[g].G->header->pad[YHI] < 2) {
 			GMT->common.n.interpolant = MIN (GMT->common.n.interpolant, BCR_BILINEAR);	/* Can only do near-neighbor or bilinear without 2 pad */
+			GC[g].HH->bcr_interpolant = GMT->common.n.interpolant;
+			GC[g].HH->bcr_n = (GC[g].HH->bcr_interpolant == BCR_NEARNEIGHBOR) ? 1 : 2;
+		}
 	}
 
 	if (Ctrl->E.active) {	/* Create profiles rather than read them */

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -766,7 +766,7 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 		GC[g].HH = gmt_get_H_hidden (GC[g].G->header);
 		/* Temporary fix for external grids with no pad; see discussion at https://github.com/GenericMappingTools/pygmt/issues/1309 */
 		if (GC[g].G->header->pad[XLO] < 2 || GC[g].G->header->pad[XHI] < 2 || GC[g].G->header->pad[YLO] < 2 || GC[g].G->header->pad[YHI] < 2)
-			GMT->common.n.interpolant = MAX (GMT->common.n.interpolant, BCR_BILINEAR);	/* Can only do near-neighbor or bilinar without 2 pad */
+			GMT->common.n.interpolant = MIN (GMT->common.n.interpolant, BCR_BILINEAR);	/* Can only do near-neighbor or bilinar without 2 pad */
 	}
 
 	if (Ctrl->E.active) {	/* Create profiles rather than read them */

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -764,6 +764,9 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 			img_conv_needed = true;
 		}
 		GC[g].HH = gmt_get_H_hidden (GC[g].G->header);
+		/* Temporary fix for external grids with no pad; see discussion at https://github.com/GenericMappingTools/pygmt/issues/1309 */
+		if (GC[g].G->header->pad[XLO] < 2 || GC[g].G->header->pad[XHI] < 2 || GC[g].G->header->pad[YLO] < 2 || GC[g].G->header->pad[YHI] < 2)
+			GMT->common.n.interpolant = MAX (GMT->common.n.interpolant, BCR_BILINEAR);	/* Can only do near-neighbor or bilinar without 2 pad */
 	}
 
 	if (Ctrl->E.active) {	/* Create profiles rather than read them */


### PR DESCRIPTION
The cubic interpolation schemes requires padding. See this[ PyGMT post](https://github.com/GenericMappingTools/pygmt/issues/1309) for required solution; this PR is a band-aid to prevent crashes until the better solution has been implemented.
