### PR TITLE
Ensure grdtrack -s -Z adjusts the default column

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -252,7 +252,7 @@ Optional Arguments
     Only write out the sampled z-values [Default writes all columns].
     **Note**: If used in conjunction with **-s** then the default
     column becomes 0 instead of 2.  If specifying specific columns
-    in **-s** then start numbering from 0 instead of 2.
+    in **-s** then start numbering the z-columns from 0 instead of 2.
 
 **-:**
     Toggles between (longitude,latitude) and (latitude,longitude)

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -250,6 +250,9 @@ Optional Arguments
 
 **-Z**
     Only write out the sampled z-values [Default writes all columns].
+    **Note**: If used in conjunction with **-s** then the default
+    column becomes 0 instead of 2.  If specifying specific columns
+    in **-s** then start numbering from 0 instead of 2.
 
 **-:**
     Toggles between (longitude,latitude) and (latitude,longitude)

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -1194,7 +1194,7 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 		if (Ctrl->Z.active) {	/* Special case were number of output columns is known before reading input records */
 			gmt_set_cartesian (GMT, GMT_OUT);	/* Since we are outputting z-columns only */
 			GMT->current.setting.io_lonlat_toggle[GMT_OUT] = false;	/* Since no x,y involved here */
-			if (GMT->common.s.active && GMT->current.io.io_nan_ncols == 1 && GMT->current.io.io_nan_col[0] == GMT_Z)	/* Shift z nan-col setting */
+			if (GMT->common.s.active && !isdigit (GMT->common.s.string[0]))	/* Shift z nan-col setting to first column */
 				GMT->current.io.io_nan_col[0] = GMT_X;
 			n_out = Ctrl->G.n_grids;
 			n_lead = 0;	/* None of the input columns will be used */

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -1194,6 +1194,8 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 		if (Ctrl->Z.active) {	/* Special case were number of output columns is known before reading input records */
 			gmt_set_cartesian (GMT, GMT_OUT);	/* Since we are outputting z-columns only */
 			GMT->current.setting.io_lonlat_toggle[GMT_OUT] = false;	/* Since no x,y involved here */
+			if (GMT->common.s.active && GMT->current.io.io_nan_ncols == 1 && GMT->current.io.io_nan_col[0] == GMT_Z)	/* Shift z nan-col setting */
+				GMT->current.io.io_nan_col[0] = GMT_X;
 			n_out = Ctrl->G.n_grids;
 			n_lead = 0;	/* None of the input columns will be used */
 			if ((error = GMT_Set_Columns (API, GMT_OUT, (unsigned int)n_out, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {


### PR DESCRIPTION
See [forum](https://forum.generic-mapping-tools.org/t/grdtrack-z-overrides-s/1745) for background.  Normally, **-s** means `skip if z = NaN`.  However, in **grdtrack -Z** the "z" values are coming without x and y, hence the default column needs to be 0 if not set specifically.