### PR TITLE
Fix two warnings in animation scripts

### DIFF
--- a/doc/examples/anim08/anim08.sh
+++ b/doc/examples/anim08/anim08.sh
@@ -29,7 +29,7 @@ gmt begin
 	# Create standard seismicity cpt
 	gmt makecpt -Cred,green,blue -T0,70,300,10000 -H > q.cpt
 	# Make lons go from 160 to 240 with a pause at 200 mid movie
-	cat <<- 'EOF' | gmt sample1d -fT --TIME_UNIT=d -I1 -Fa > times.txt
+	cat <<- EOF | gmt sample1d -fT --TIME_UNIT=d -I1 -Fa > times.txt
 	2018-01-01T	160
 	2018-05-01T	200
 	2018-06-01T	200

--- a/doc/examples/anim13/anim13.sh
+++ b/doc/examples/anim13/anim13.sh
@@ -10,8 +10,8 @@
 #
 # DEM:  @earth_relief_06m
 # Data: @waveform_AV.DOL.txt
-# 
-# The data file @waveform_AV.DOL.txt contains 4 columns: 
+#
+# The data file @waveform_AV.DOL.txt contains 4 columns:
 # UTC times, and three-component movement in east-west, north-south and up-down directions
 #
 # The finished movie is available in our YouTube channel as well:
@@ -44,7 +44,7 @@ gmt begin
 		gmt plot @waveform_AV.DOL.txt -Bpxafg -Bsxa1D -Bpyaf -BWSrt -W0.5p,darkgray -i0,1+s1e-6
 	gmt subplot end
 	# 1d. Create location map and metadata
-	gmt text -R0/4.5/0/13 -Jx1c -F+j+f -B0 -X-5.25c -Y-0.5c <<- 'EOF'
+	gmt text -R0/4.5/0/13 -Jx1c -F+j+f -B0 -X-5.25c -Y-0.5c <<- EOF
 	2.25 12.5 CM 18p 2020-10-06
 	2.25 11.7 CM 9p SE of Sand Point, Alaska
 	2.25 11 CM 10p 54.851@.N, 159.851@.W
@@ -54,7 +54,7 @@ gmt begin
 	gmt grdimage -R190W/130W/30/75 @earth_relief_06m -Ba30+f -JM3.5c -I+d -Cterra --MAP_FRAME_TYPE=plain -X0.75c -Y0.5c -BWNbr --MAP_ANNOT_OBLIQUE=lat_parallel --FONT_ANNOT_PRIMARY=9p
 	echo 161.86W 55.15N | gmt plot -St0.2c -GBlack
 	echo 159.851W 54.851N | gmt plot -Sa0.25c -Gred -Wfaint
-	gmt meca -Sc2.5c -M -G110/168/255 -W0.5p -Yh+0.5c <<- 'EOF'
+	gmt meca -Sc2.5c -M -G110/168/255 -W0.5p -Yh+0.5c <<- EOF
 	-159.851 54.851 40.5 245 29 93 61 61 88 1.048 18
 	EOF
 gmt end


### PR DESCRIPTION
**Description of proposed changes**

The bash scripts are valid, but apparently sphinx doesn't like nested `'EOF'`.

Address the warnings in #5282.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
