### PR TITLE
The -i for memory datasets via matrix used the wrong parameter

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -1316,7 +1316,7 @@ GMT_LOCAL unsigned int gmtapi_pick_in_col_number (struct GMT_CTRL *GMT, unsigned
 	/* Return the next column to be selected on input */
 	unsigned int col_pos;
 	if (GMT->common.i.select)	/* -i has selected some columns */
-		col_pos = GMT->current.io.col[GMT_IN][col].col;	/* Which data column to pick */
+        col_pos = GMT->current.io.col[GMT_IN][col].order; /* Which data column to pick */
 #if 0
 	else if (GMT->current.setting.io_lonlat_toggle[GMT_IN] && col < GMT_Z)	/* Worry about -: for lon,lat */
 		col_pos = 1 - col;	/* Read lat/lon instead of lon/lat */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -9567,11 +9567,26 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
 		S->status = GMT_IS_USING;				/* Mark as being read */
 		n_use = gmtapi_n_cols_needed_for_gaps (GMT, S->n_columns);
 		gmtapi_update_prev_rec (GMT, n_use);
-		for (col = 0; col < API->current_get_n_columns; col++) {	/* We know the number of columns from registration */
-			col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
-			ij = API->current_get_M_index (S->rec, col_pos, M->dim);
-			API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
-		}
+		//for (col = 0; col < API->current_get_n_columns; col++) {	/* We know the number of columns from registration */
+		//	col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
+		//	ij = API->current_get_M_index (S->rec, col_pos, M->dim);
+		//	API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
+		//}
+
+        col = 0;
+        while (col < API->current_get_n_columns) {
+            col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
+            ij = API->current_get_M_index (S->rec, col_pos, M->dim);
+            API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
+            col++;           
+            while (GMT->common.i.select && col < GMT->common.i.n_cols && GMT->current.io.col[GMT_IN][col].col == GMT->current.io.col[GMT_IN][col-1].col) {
+                /* This input column is requested more than once */
+                col_pos = GMT->current.io.col[GMT_IN][col].order;    /* The data column that will receive this value */
+                ij = API->current_get_M_index (S->rec, col_pos, M->dim);
+                API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
+                col++;
+            }
+       }
 		S->rec++;
 		if ((status = gmtapi_bin_input_memory (GMT, S->n_columns, n_use)) < 0) {	/* Process the data record */
 			if (status == GMTAPI_GOT_SEGGAP)	 /* Since we inserted a segment header we must revisit this record as first in next segment */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -9567,11 +9567,6 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
 		S->status = GMT_IS_USING;				/* Mark as being read */
 		n_use = gmtapi_n_cols_needed_for_gaps (GMT, S->n_columns);
 		gmtapi_update_prev_rec (GMT, n_use);
-		//for (col = 0; col < API->current_get_n_columns; col++) {	/* We know the number of columns from registration */
-		//	col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
-		//	ij = API->current_get_M_index (S->rec, col_pos, M->dim);
-		//	API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
-		//}
 
         col = 0;
         while (col < API->current_get_n_columns) {
@@ -9637,10 +9632,20 @@ struct GMT_RECORD *api_get_record_vector (struct GMTAPI_CTRL *API, unsigned int 
 		S->status = GMT_IS_USING;				/* Mark as being read */
 		n_use = gmtapi_n_cols_needed_for_gaps (GMT, S->n_columns);
 		gmtapi_update_prev_rec (GMT, n_use);
-		for (col = 0; col < API->current_get_n_columns; col++) {	/* We know the number of columns from registration */
-			col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
-			API->current_get_V_val[col] (&(V->data[col_pos]), S->rec, &(GMT->current.io.curr_rec[col]));
-		}
+
+        col = 0;
+        while (col < API->current_get_n_columns) {
+            col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
+            API->current_get_V_val[col_pos] (&(V->data[col_pos]), S->rec, &(GMT->current.io.curr_rec[col]));
+            col++;           
+            while (GMT->common.i.select && col < GMT->common.i.n_cols && GMT->current.io.col[GMT_IN][col].col == GMT->current.io.col[GMT_IN][col-1].col) {
+                /* This input column is requested more than once */
+                col_pos = GMT->current.io.col[GMT_IN][col].order;    /* The data column that will receive this value */
+                 API->current_get_V_val[col_pos] (&(V->data[col_pos]), S->rec, &(GMT->current.io.curr_rec[col]));
+                col++;
+            }
+        }
+
 		S->rec++;
 		if ((status = gmtapi_bin_input_memory (GMT, S->n_columns, n_use)) < 0) {	/* Process the data record */
 			if (status == GMTAPI_GOT_SEGGAP)	 /* Since we inserted a segment header we must revisit this record as first in next segment */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -9582,7 +9582,6 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
             while (GMT->common.i.select && col < GMT->common.i.n_cols && GMT->current.io.col[GMT_IN][col].col == GMT->current.io.col[GMT_IN][col-1].col) {
                 /* This input column is requested more than once */
                 col_pos = GMT->current.io.col[GMT_IN][col].order;    /* The data column that will receive this value */
-                ij = API->current_get_M_index (S->rec, col_pos, M->dim);
                 API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
                 col++;
             }


### PR DESCRIPTION
Instead of the column order it echoed back the column loop variable.  Addresses https://github.com/GenericMappingTools/pygmt/issues/1313, I hope.
