### PR TITLE
Set the Ctrl-C interrupt before overwriting ConfigUser.cmake file

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -110,12 +110,12 @@ else
 	echo "build-release.sh: Ghostscript version $G_ver failed the test - install another gs" >&2
 	exit 1
 fi
+trap abort_build SIGINT
 # 1. Set basic ConfigUser.cmake file for a release build
 if [ -f cmake/ConfigUser.cmake ]; then
 	cp cmake/ConfigUser.cmake cmake/ConfigUser.cmake.orig
 fi
 cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
-trap abort_build SIGINT
 # 2a. Make build dir and configure it
 rm -rf build
 mkdir build


### PR DESCRIPTION
When developers like me start the _admin/build-release.sh_ script then change their mind and hit Ctrl-C, I find that my own cmake/ConfigUser.cmake file may have been corrupted.  Not sure, but moving the _abort_build_ up before changing those files cannot hurt.  We will merge this after the 6.2 release, hence WIP.
