### PR TITLE
Let grd2cpt -L have ability to only set one limit

### DIFF
--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -168,7 +168,8 @@ Optional Arguments
 
 **-L**\ *minlimit/maxlimit*
     Limit range of CPT to *minlimit/maxlimit*, and don't count data
-    outside this range when estimating CDF(Z). [Default uses min and max of data.]
+    outside this range when estimating CDF(Z). To set only one limit,
+    specify the other limit as "-" [Default uses min and max of data.]
 
 .. _-M:
 


### PR DESCRIPTION
If **-L**_min_/_max_ is given and either _min_ or _max_ is set as - then only the other limit applies.  Closes #5223.
