### PR TITLE
Use stable mergesort in -i parsing

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9135,6 +9135,7 @@ int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 			}
 		}
 	}
+	/* Use mergesort since qsort is unstable (i.e., unpredictable order) when items are identical */
 	mergesort (GMT->current.io.col[GMT_IN], k, sizeof (struct GMT_COL_INFO), gmtinit_compare_cols);
 	GMT->common.i.n_cols = k;
 	if (k) {	/* Because the user may have repeated some columns we also determine how many unique columns were requested */


### PR DESCRIPTION
Since _qsort_ is unstable, especially on Windows.  Hopefully works and closes #5311.

