### PR TITLE
Allow for a fixed label offset

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -363,6 +363,10 @@ equivalent of **WrStZ**. The default for the Gnomonic and general perspective
 projections is **WESNZ**. The default for non-perspective, non-Gnomonic, and
 non-polar plots using **MAP_FRAME_AXES**\ =\ **auto** is **WrStZ**.
 
+For **MAP_LABEL_OFFSET, **auto** will scale the offset based on figure size if
+**MAP_LABEL_MODE** is set to **annot**, but will default to **32p** if
+**MAP_LABEL_MODE** is set to **axis**.
+
 Changing GMT defaults
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -788,7 +788,10 @@ MAP Parameters
     **MAP_LABEL_OFFSET**
         Distance from base of axis annotations to the top of the axis label
         [default is :doc:`theme dependent <theme-settings>`]. Choose **auto**
-        for :ref:`automatic scaling with plot size <auto-scaling>`.
+        for :ref:`automatic scaling with plot size <auto-scaling>`. **Note**:
+        If a negative offset is given then it is interpreted as the absolute
+        offset from the axis to the base of the label; this is useful when
+        wishing to align several y-axis labels in stacked plots.
 
     **MAP_LINE_STEP**
         Determines the maximum length (> 0) of individual straight

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -795,10 +795,10 @@ MAP Parameters
     **MAP_LABEL_OFFSET**
         Distance from base of axis annotations to the top of the axis label
         [default is :doc:`theme dependent <theme-settings>`]. Choose **auto**
-        for :ref:`automatic scaling with plot size <auto-scaling>`. **Note**:
-        If a negative offset is given then it is interpreted as the absolute
-        offset from the axis to the base of the label; this is useful when
-        wishing to align several y-axis labels in stacked plots.
+        for :ref:`automatic scaling with plot size <auto-scaling>`. To
+        set different offsets for the *x* and *y* axes, separate distances
+        by a slash (e.g., **8p/12p** for 8p offset for the x-axis and 12p
+        offset for the y-axis)
 
     **MAP_LINE_STEP**
         Determines the maximum length (> 0) of individual straight

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -789,8 +789,8 @@ MAP Parameters
         Determines from where the label offset is measured: Choose **annot**
         to mean the distance from the end of the annotation or **axis**
         to mean the distance from the axis.  To set separate modes for the
-        *x* and *y* axes, separate modes by a slash [annot/annot]. Choose **axis**
-        if you need to align multiple axes labels across many rows or columns.
+        *x* and *y* axes, separate modes by a slash [default is **annot/annot**]. Choose
+        **axis** if you need to align multiple axes labels across many rows or columns.
 
     **MAP_LABEL_OFFSET**
         Distance from base of axis annotations to the top of the axis label

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -785,6 +785,13 @@ MAP Parameters
         [default is :doc:`theme dependent <theme-settings>`]. Choose **auto** for
         :ref:`automatic scaling with plot size <auto-scaling>`.
 
+    **MAP_LABEL_MODE**
+        Determines from where the label offset is measured: Choose **annot**
+        to mean the distance from the end of the annotation or **axis**
+        to mean the distance from the axis.  To set separate modes for the
+        *x* and *y* axes, separate modes by a slash [annot/annot]. Choose **axis**
+        if you need to align multiple axes labels across many rows or columns.
+
     **MAP_LABEL_OFFSET**
         Distance from base of axis annotations to the top of the axis label
         [default is :doc:`theme dependent <theme-settings>`]. Choose **auto**

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -387,6 +387,10 @@ enum GMT_enum_autolegend {
 	GMT_LEGEND_DRAW_D = 1, GMT_LEGEND_DRAW_V = 2, GMT_LEGEND_LABEL_FIXED = 0,
 	GMT_LEGEND_LABEL_FORMAT = 1, GMT_LEGEND_LABEL_LIST = 2, GMT_LEGEND_LABEL_HEADER = 3};
 
+/*! Various mode for label positioning */
+enum GMT_enum_maplabel {
+	GMT_LABEL_ANNOT = 0, GMT_LABEL_AXIS = 1};
+
 /*! Various mode for custom symbols */
 enum GMT_enum_customsymb {
 	GMT_CUSTOM_DEF  = 1,

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -140,7 +140,7 @@ struct GMT_DEFAULTS {
 	double map_frame_width;			/* Thickness of fancy map frame [5p] */
 	double map_grid_cross_size[2];	/* Size of primary & secondary gridcrosses.  0 means draw continuous gridlines */
 	double map_heading_offset;		/* Distance between top of panel title and base of subplot heading [18p] */
-	double map_label_offset;		/* Distance between lowermost annotation and top of label [8p] */
+	double map_label_offset[2];		/* Distance between lowermost annotation and top of label [8p/8p] */
 	double map_line_step;			/* Maximum straight linesegment length for arcuate lines [0.75p] */
 	double map_logo_pos[2];			/* Where to plot timestamp relative to origin [BL/-54p/-54p] */
 	double map_origin[2];			/* x- and y-origin of plot, i.e. where lower left corner plots on paper [1i/1i] */
@@ -149,12 +149,13 @@ struct GMT_DEFAULTS {
 	double map_tick_length[4];		/* Length of primary and secondary major and minor tickmarks [5p/2.5p/15p/3.75p] */
 	double map_title_offset;		/* Distance between lowermost annotation (or label) and base of plot title [14p] */
 	double map_vector_shape;		/* 0.0 = straight vectorhead, 1.0 = arrowshape, with continuous range in between */
-	double map_graph_extension;		/* If mapframetype is graph, how must longer to make axis length. [7.5%] */
+	double map_graph_extension;		/* If map_frame_type is graph, how must longer to make axis length. [7.5%] */
 	unsigned int map_annot_oblique;	/* Controls annotations and tick angles etc. [GMT_OBL_ANNOT_ANYWHERE] */
 	unsigned int map_grid_cross_type[2];	/* 0 = normal cross, 1 = symmetric tick, 2 = asymmetric tick */
 	unsigned int map_logo_justify;		/* Justification of the GMT timestamp box [1 (BL)] */
 	unsigned int map_frame_type;		/* Fancy (0), plain (1), or graph (2) [0] */
-	unsigned int map_graph_extension_unit;	/* If mapframetype is graph, the unit is GMT_CM, GMT_INCH, GMT_PT [%] */
+	unsigned int map_graph_extension_unit;	/* If map_frame_type is graph, the unit is GMT_CM, GMT_INCH, GMT_PT [%] */
+	double map_label_mode[2];		/* If label is relative to annotation (0) or axis (1) for x/t [0/0] */
 	bool map_annot_oblique_set;		/* true if user changed map_annot_oblique via a gmt.conf or --par=val */
 	bool map_logo;			/* Plot time and map projection on map [false] */
 	struct GMT_PEN map_default_pen;		/* Default pen for most pens [0.25p] */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10669,11 +10669,19 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_MAP_LABEL_MODE:
 			if ((i = sscanf (value, "%[^/]/%s", txt_a, txt_b)) == 2) {	/* Separate settings for x and y */
-				GMT->current.setting.map_label_mode[GMT_X] = (!strcmp (txt_a, "axis") ? GMT_LABEL_AXIS : GMT_LABEL_ANNOT);
-				GMT->current.setting.map_label_mode[GMT_Y] = (!strcmp (txt_b, "axis") ? GMT_LABEL_AXIS : GMT_LABEL_ANNOT);
+				if (strcmp (txt_a, "annot") && strcmp(txt_a,"axis") && strcmp(txt_b,"annot") && strcmp(txt_b,"axis"))
+					error = true;
+				else {
+					GMT->current.setting.map_label_mode[GMT_X] = (!strcmp (txt_a, "axis") ? GMT_LABEL_AXIS : GMT_LABEL_ANNOT);
+					GMT->current.setting.map_label_mode[GMT_Y] = (!strcmp (txt_b, "axis") ? GMT_LABEL_AXIS : GMT_LABEL_ANNOT);
+				}
 			}
-			else
-				GMT->current.setting.map_label_mode[GMT_X] = GMT->current.setting.map_label_mode[GMT_Y] = (!strcmp (value, "axis") ? GMT_LABEL_AXIS : GMT_LABEL_ANNOT);
+			else {
+				if (strcmp (value, "annot") && strcmp(value,"axis"))
+					error = true;
+				else
+					GMT->current.setting.map_label_mode[GMT_X] = GMT->current.setting.map_label_mode[GMT_Y] = (!strcmp (value, "axis") ? GMT_LABEL_AXIS : GMT_LABEL_ANNOT);
+			}
 			break;
 		case GMTCASE_LABEL_OFFSET:
 			GMT_COMPAT_TRANSLATE ("MAP_LABEL_OFFSET");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10018,12 +10018,18 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_ANNOT_OFFSET_SECONDARY] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_label_offset[GMT_X])) {
-		GMT->current.setting.map_label_offset[GMT_X] = 6 * pt * scale;	/* 6p */
+		if (GMT->current.setting.map_label_mode[GMT_X] == GMT_LABEL_AXIS)
+			GMT->current.setting.map_label_offset[GMT_X] = 32 * pt;
+		else
+			GMT->current.setting.map_label_offset[GMT_X] = 6 * pt * scale;	/* 6p */
 		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_LABEL_OFFSET] = true;
 	}
 	if (gmt_M_is_dnan (GMT->current.setting.map_label_offset[GMT_Y])) {
-		GMT->current.setting.map_label_offset[GMT_Y] = 6 * pt * scale;	/* 6p */
+		if (GMT->current.setting.map_label_mode[GMT_Y] == GMT_LABEL_AXIS)
+			GMT->current.setting.map_label_offset[GMT_Y] = 32 * pt;
+		else
+			GMT->current.setting.map_label_offset[GMT_Y] = 6 * pt * scale;	/* 6p */
 		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_MAP_LABEL_OFFSET] = true;
 	}

--- a/src/gmt_keywords.txt
+++ b/src/gmt_keywords.txt
@@ -116,6 +116,7 @@ MAP_GRID_PEN			# Pen for any grid-lines/crosses [does not go in gmt.conf]
 MAP_GRID_PEN_PRIMARY		# Pen for primary grid-lines/crosses
 MAP_GRID_PEN_SECONDARY		# Pen for secondary grid-lines/crosses
 MAP_HEADING_OFFSET		# Distance between a panel title and subplot heading
+MAP_LABEL_MODE			# Measure label distance from the annotation or axis
 MAP_LABEL_OFFSET		# Distance between an axis label and the annotations
 MAP_LINE_STEP			# Max step length when approximating curves on maps
 MAP_LOGO			# Plot the time stamp?

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5632,9 +5632,21 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		double label_angle;
 		char *this_label = (far_ && A->secondary_label[0]) ? A->secondary_label : A->label;	/* Get primary or secondary axis label */
 
-      if (GMT->current.setting.map_label_offset < 0.0) { /* Fixed distance from axis */
-         gmtplot_map_label (GMT, 0.0, fabs (GMT->current.setting.map_label_offset), this_label, label_angle, l_just, axis, below);
-     }
+      if (axis == GMT_Y && A->label_mode) {
+         l_just = (below) ? PSL_MR : PSL_ML;
+         label_angle = 0.0 + y_angle_add;
+      }
+      else {
+         double angle_add = (axis == GMT_X) ? x_angle_add : y_angle_add;
+         l_just = (axis == GMT_X) ? lx_just : ly_just;
+         label_angle = (horizontal ? 0.0 : 90.0) + angle_add;
+      }
+      if (GMT->current.setting.map_label_offset < 0.0) { /* Base of label is a fixed distance from axis */
+         double s = (below) ? -1.0 : 1.0;
+         double xc = (horizontal) ? 0.5 * length : s * fabs (GMT->current.setting.map_label_offset);
+         double yc = (horizontal) ? s * fabs (GMT->current.setting.map_label_offset) : 0.5 * length;
+         gmtplot_map_label (GMT, xc, yc, this_label, label_angle, l_just, axis, below);
+      }
       else {
    		if (!MM_set) PSL_command (PSL, "/MM {%s%sM} def\n", neg ? "neg " : "", (axis != GMT_X) ? "exch " : "");
    		form = gmt_setfont (GMT, &GMT->current.setting.font_label);
@@ -5649,15 +5661,6 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
    			PSL_command (PSL, "%d PSL_L_y PSL_slant_x add MM\n", PSL_IZ (PSL, 0.5 * length));
    		else
    			PSL_command (PSL, "%d PSL_L_y MM\n", PSL_IZ (PSL, 0.5 * length));
-   		if (axis == GMT_Y && A->label_mode) {
-   			l_just = (below) ? PSL_MR : PSL_ML;
-   			label_angle = 0.0 + y_angle_add;
-   		}
-   		else {
-   			double angle_add = (axis == GMT_X) ? x_angle_add : y_angle_add;
-   			l_just = (axis == GMT_X) ? lx_just : ly_just;
-   			label_angle = (horizontal ? 0.0 : 90.0) + angle_add;
-   		}
    		gmtplot_map_label (GMT, 0.0, 0.0, this_label, label_angle, l_just, axis, below);
       }
 	}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5631,29 +5631,35 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		unsigned int far_ = !below, l_just;
 		double label_angle;
 		char *this_label = (far_ && A->secondary_label[0]) ? A->secondary_label : A->label;	/* Get primary or secondary axis label */
-		if (!MM_set) PSL_command (PSL, "/MM {%s%sM} def\n", neg ? "neg " : "", (axis != GMT_X) ? "exch " : "");
-		form = gmt_setfont (GMT, &GMT->current.setting.font_label);
-		PSL_command (PSL, "/PSL_LH ");	/* PSL_LH is the height of the label text based on height of letter M */
-		PSL_deftextdim (PSL, "-h", GMT->current.setting.font_label.size, "M");
-		PSL_command (PSL, "def\n");
-		PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset), (neg == horizontal) ? "PSL_LH add " : "");
-		/* Move to new anchor point for label */
-		if (angled && axis == GMT_X)	/* Add offset due to angled x-annotations */
-			PSL_command (PSL, "%d PSL_L_y PSL_slant_y add MM\n", PSL_IZ (PSL, 0.5 * length));
-		else if (angled && axis == GMT_Y)
-			PSL_command (PSL, "%d PSL_L_y PSL_slant_x add MM\n", PSL_IZ (PSL, 0.5 * length));
-		else
-			PSL_command (PSL, "%d PSL_L_y MM\n", PSL_IZ (PSL, 0.5 * length));
-		if (axis == GMT_Y && A->label_mode) {
-			l_just = (below) ? PSL_MR : PSL_ML;
-			label_angle = 0.0 + y_angle_add;
-		}
-		else {
-			double angle_add = (axis == GMT_X) ? x_angle_add : y_angle_add;
-			l_just = (axis == GMT_X) ? lx_just : ly_just;
-			label_angle = (horizontal ? 0.0 : 90.0) + angle_add;
-		}
-		gmtplot_map_label (GMT, 0.0, 0.0, this_label, label_angle, l_just, axis, below);
+
+      if (GMT->current.setting.map_label_offset < 0.0) { /* Fixed distance from axis */
+         gmtplot_map_label (GMT, 0.0, fabs (GMT->current.setting.map_label_offset), this_label, label_angle, l_just, axis, below);
+     }
+      else {
+   		if (!MM_set) PSL_command (PSL, "/MM {%s%sM} def\n", neg ? "neg " : "", (axis != GMT_X) ? "exch " : "");
+   		form = gmt_setfont (GMT, &GMT->current.setting.font_label);
+   		PSL_command (PSL, "/PSL_LH ");	/* PSL_LH is the height of the label text based on height of letter M */
+   		PSL_deftextdim (PSL, "-h", GMT->current.setting.font_label.size, "M");
+   		PSL_command (PSL, "def\n");
+   		PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset), (neg == horizontal) ? "PSL_LH add " : "");
+   		/* Move to new anchor point for label */
+   		if (angled && axis == GMT_X)	/* Add offset due to angled x-annotations */
+   			PSL_command (PSL, "%d PSL_L_y PSL_slant_y add MM\n", PSL_IZ (PSL, 0.5 * length));
+   		else if (angled && axis == GMT_Y)
+   			PSL_command (PSL, "%d PSL_L_y PSL_slant_x add MM\n", PSL_IZ (PSL, 0.5 * length));
+   		else
+   			PSL_command (PSL, "%d PSL_L_y MM\n", PSL_IZ (PSL, 0.5 * length));
+   		if (axis == GMT_Y && A->label_mode) {
+   			l_just = (below) ? PSL_MR : PSL_ML;
+   			label_angle = 0.0 + y_angle_add;
+   		}
+   		else {
+   			double angle_add = (axis == GMT_X) ? x_angle_add : y_angle_add;
+   			l_just = (axis == GMT_X) ? lx_just : ly_just;
+   			label_angle = (horizontal ? 0.0 : 90.0) + angle_add;
+   		}
+   		gmtplot_map_label (GMT, 0.0, 0.0, this_label, label_angle, l_just, axis, below);
+      }
 	}
 	else
 		PSL_command (PSL, "/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def\n");

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5641,28 +5641,23 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
          l_just = (axis == GMT_X) ? lx_just : ly_just;
          label_angle = (horizontal ? 0.0 : 90.0) + angle_add;
       }
-      if (GMT->current.setting.map_label_offset < 0.0) { /* Base of label is a fixed distance from axis */
-         double s = (below) ? -1.0 : 1.0;
-         double xc = (horizontal) ? 0.5 * length : s * fabs (GMT->current.setting.map_label_offset);
-         double yc = (horizontal) ? s * fabs (GMT->current.setting.map_label_offset) : 0.5 * length;
-         gmtplot_map_label (GMT, xc, yc, this_label, label_angle, l_just, axis, below);
-      }
-      else {
-   		if (!MM_set) PSL_command (PSL, "/MM {%s%sM} def\n", neg ? "neg " : "", (axis != GMT_X) ? "exch " : "");
-   		form = gmt_setfont (GMT, &GMT->current.setting.font_label);
-   		PSL_command (PSL, "/PSL_LH ");	/* PSL_LH is the height of the label text based on height of letter M */
-   		PSL_deftextdim (PSL, "-h", GMT->current.setting.font_label.size, "M");
-   		PSL_command (PSL, "def\n");
-   		PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset), (neg == horizontal) ? "PSL_LH add " : "");
-   		/* Move to new anchor point for label */
-   		if (angled && axis == GMT_X)	/* Add offset due to angled x-annotations */
-   			PSL_command (PSL, "%d PSL_L_y PSL_slant_y add MM\n", PSL_IZ (PSL, 0.5 * length));
-   		else if (angled && axis == GMT_Y)
-   			PSL_command (PSL, "%d PSL_L_y PSL_slant_x add MM\n", PSL_IZ (PSL, 0.5 * length));
-   		else
-   			PSL_command (PSL, "%d PSL_L_y MM\n", PSL_IZ (PSL, 0.5 * length));
-   		gmtplot_map_label (GMT, 0.0, 0.0, this_label, label_angle, l_just, axis, below);
-      }
+		if (!MM_set) PSL_command (PSL, "/MM {%s%sM} def\n", neg ? "neg " : "", (axis != GMT_X) ? "exch " : "");
+		form = gmt_setfont (GMT, &GMT->current.setting.font_label);
+		PSL_command (PSL, "/PSL_LH ");	/* PSL_LH is the height of the label text based on height of letter M */
+		PSL_deftextdim (PSL, "-h", GMT->current.setting.font_label.size, "M");
+		PSL_command (PSL, "def\n");
+      if (GMT->current.setting.map_label_offset < 0.0) /* Base of label is a fixed distance from axis */
+         PSL_command (PSL, "/PSL_L_y %d %sdef\n", PSL_IZ (PSL, fabs (GMT->current.setting.map_label_offset)), (neg == horizontal) ? "PSL_LH add " : "");
+      else
+         PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset), (neg == horizontal) ? "PSL_LH add " : "");
+		/* Move to new anchor point for label */
+		if (angled && axis == GMT_X)	/* Add offset due to angled x-annotations */
+			PSL_command (PSL, "%d PSL_L_y PSL_slant_y add MM\n", PSL_IZ (PSL, 0.5 * length));
+		else if (angled && axis == GMT_Y)
+			PSL_command (PSL, "%d PSL_L_y PSL_slant_x add MM\n", PSL_IZ (PSL, 0.5 * length));
+		else
+			PSL_command (PSL, "%d PSL_L_y MM\n", PSL_IZ (PSL, 0.5 * length));
+		gmtplot_map_label (GMT, 0.0, 0.0, this_label, label_angle, l_just, axis, below);
 	}
 	else
 		PSL_command (PSL, "/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def\n");

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2611,7 +2611,7 @@ GMT_LOCAL void gmtplot_map_label (struct GMT_CTRL *GMT, double x, double y, char
 			if (fabs (angle) > 0.0) PSL_command (PSL, "currentpoint T %g R\n", angle); else PSL_command (PSL, "currentpoint T\n");
 			if (below) PSL_command (PSL, "0 %d PSL_LH sub neg M currentpoint T\n", (int)lrint (h * PSL->internal.y2iy));
 			/* I am somehow missing the label offset for y-axes so I need to account for it here in order to get correct result */
-			if (axis == GMT_Y) PSL_command (PSL, "0 %d M currentpoint T\n", (int)lrint (sgn[below]*GMT->current.setting.map_label_offset * PSL->internal.y2iy));
+			if (axis == GMT_Y) PSL_command (PSL, "0 %d M currentpoint T\n", (int)lrint (sgn[below]*GMT->current.setting.map_label_offset[GMT_Y] * PSL->internal.y2iy));
 		}
 		// PSL_command (PSL, "V currentpoint -2000 0 G 4000 0 D S U\n");	/* Debug line for base of label; keep for future debugging */
 		PSL_plotepsimage (PSL, x, y, w, h, PSL_BC, eps, &header);	/* Place the EPS plot */
@@ -2883,7 +2883,7 @@ GMT_LOCAL void gmtplot_map_annotate (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL,
 		/* May need to label radial axis */
 		struct GMT_PLOT_AXIS *A = &GMT->current.map.frame.axis[GMT_Y];
 		double x0, x1, y0, y1, xm, ym, line_angle, t_angle;
-		double off = GMT->current.setting.map_label_offset + MAX (0.0, GMT->current.setting.map_annot_offset[GMT_PRIMARY]) + MAX (0.0, GMT->current.setting.map_tick_length[GMT_PRIMARY]);
+		double off = GMT->current.setting.map_label_offset[GMT_Y] + MAX (0.0, GMT->current.setting.map_annot_offset[GMT_PRIMARY]) + MAX (0.0, GMT->current.setting.map_tick_length[GMT_PRIMARY]);
 		unsigned int just, we_side[2] = {W_SIDE, E_SIDE}, def_just[2] = {PSL_TC, PSL_BC};
 		char *neg;
 		if (GMT->current.map.frame.side[we_side[0]] & GMT_AXIS_ANNOT) {
@@ -5628,7 +5628,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 	/* Finally do axis label */
 
 	if (A->label[0] && annotate && !gmt_M_axis_is_geo_strict (GMT, axis)) {
-		unsigned int far_ = !below, l_just;
+		unsigned int far_ = !below, l_just, L_axis = (axis == GMT_Z) ? GMT_X : axis;
 		double label_angle;
 		char *this_label = (far_ && A->secondary_label[0]) ? A->secondary_label : A->label;	/* Get primary or secondary axis label */
 
@@ -5646,10 +5646,10 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		PSL_command (PSL, "/PSL_LH ");	/* PSL_LH is the height of the label text based on height of letter M */
 		PSL_deftextdim (PSL, "-h", GMT->current.setting.font_label.size, "M");
 		PSL_command (PSL, "def\n");
-      if (GMT->current.setting.map_label_offset < 0.0) /* Base of label is a fixed distance from axis */
-         PSL_command (PSL, "/PSL_L_y %d %sdef\n", PSL_IZ (PSL, fabs (GMT->current.setting.map_label_offset)), (neg == horizontal) ? "PSL_LH add " : "");
+      if (GMT->current.setting.map_label_mode[L_axis] == GMT_LABEL_AXIS) /* Base of label is a fixed distance from axis */
+         PSL_command (PSL, "/PSL_L_y %d %sdef\n", PSL_IZ (PSL, fabs (GMT->current.setting.map_label_offset[L_axis])), (neg == horizontal) ? "PSL_LH add " : "");
       else
-         PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset), (neg == horizontal) ? "PSL_LH add " : "");
+         PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset[L_axis]), (neg == horizontal) ? "PSL_LH add " : "");
 		/* Move to new anchor point for label */
 		if (angled && axis == GMT_X)	/* Add offset due to angled x-annotations */
 			PSL_command (PSL, "%d PSL_L_y PSL_slant_y add MM\n", PSL_IZ (PSL, 0.5 * length));
@@ -6820,8 +6820,8 @@ int gmt_draw_map_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 			dim[YLO] = dist_to_annot + GMT_LET_HEIGHT * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;
 			dim[YHI] = 0.0;	/* Normally nothing above the scale bar */
 			/* If label is above or below bar, add label offset and approximate label height to the space dim */
-			if (ms->do_label && ms->alignment == 'b') dim[YLO] += fabs (GMT->current.setting.map_label_offset) + l_height;
-			else if (ms->do_label && ms->alignment == 't') dim[YHI] += fabs (GMT->current.setting.map_label_offset) + l_height;
+			if (ms->do_label && ms->alignment == 'b') dim[YLO] += fabs (GMT->current.setting.map_label_offset[GMT_Y]) + l_height;
+			else if (ms->do_label && ms->alignment == 't') dim[YHI] += fabs (GMT->current.setting.map_label_offset[GMT_Y]) + l_height;
 			else if (ms->do_label && l_shift > dim[YHI]) dim[YHI] = l_shift;
 			/* Determine center of gravity for panel */
 			x_center = ms->refpoint->x + 0.5 * (dim[XHI] - dim[XLO]);
@@ -6866,12 +6866,12 @@ int gmt_draw_map_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 					break;
 				case 't':	/* Top */
 					tx = ms->refpoint->x;
-					ty = ms->refpoint->y + fabs (GMT->current.setting.map_label_offset);
+					ty = ms->refpoint->y + fabs (GMT->current.setting.map_label_offset[GMT_Y]);
 					justify = PSL_BC;
 					break;
 				default:	/* Bottom */
 					tx = ms->refpoint->x;
-					ty = ms->refpoint->y - dist_to_annot - GMT_LET_HEIGHT * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH - fabs (GMT->current.setting.map_label_offset);
+					ty = ms->refpoint->y - dist_to_annot - GMT_LET_HEIGHT * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH - fabs (GMT->current.setting.map_label_offset[GMT_Y]);
 					justify = PSL_TC;
 					break;
 			}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13357,8 +13357,8 @@ int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	else {	/* With -Dj or -DJ, set default to reference (mirrored) justify point, else MC */
 		ms->justify = gmt_M_just_default (GMT, ms->refpoint, PSL_MC);
 		if (vertical || ms->vertical || gmt_M_is_cartesian (GMT, GMT_IN)) {
-			double out_offset = GMT->current.setting.map_label_offset + GMT->current.setting.map_frame_width;
-			double in_offset  = GMT->current.setting.map_label_offset;
+			double out_offset = GMT->current.setting.map_label_offset[GMT_Y] + GMT->current.setting.map_frame_width;
+			double in_offset  = GMT->current.setting.map_label_offset[GMT_Y];
 			switch (ms->refpoint->justify) {        /* Autoset +a, +o when placed centered on a side: Note: +a, +o may overrule this later */
 				case PSL_TC:
 					ms->off[GMT_Y] = (ms->refpoint->mode == GMT_REFPOINT_JUST_FLIP) ? out_offset : in_offset;

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -681,7 +681,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 							/* Default assumes label is added on top */
 							just = 't';
 							gave_label = true;
-							d_off = FONT_HEIGHT_LABEL * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH + fabs(GMT->current.setting.map_label_offset);
+							d_off = FONT_HEIGHT_LABEL * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH + fabs(GMT->current.setting.map_label_offset[GMT_Y]);
 							if ((txt_d[0] == 'f' || txt_d[0] == 'p') && gmt_get_modifier (txt_c, 'j', string))	/* Specified alternate justification old-style */
 								just = string[0];
 							else if (gmt_get_modifier (txt_c, 'a', string))	/* Specified alternate alignment */
@@ -1270,7 +1270,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 							just = 't';
 							gave_label = true;
 							row_height = GMT->current.setting.map_scale_height + FONT_HEIGHT_PRIMARY * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH + GMT->current.setting.map_annot_offset[GMT_PRIMARY];
-							d_off = FONT_HEIGHT_LABEL * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH + fabs(GMT->current.setting.map_label_offset);
+							d_off = FONT_HEIGHT_LABEL * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH + fabs(GMT->current.setting.map_label_offset[GMT_Y]);
 							if ((txt_d[0] == 'f' || txt_d[0] == 'p') && gmt_get_modifier (txt_c, 'j', string))	/* Specified alternate justification old-style */
 								just = string[0];
 							else if (gmt_get_modifier (txt_c, 'a', string))	/* Specified alternate alignment */

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -950,7 +950,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 				if (!(flip & PSSCALE_FLIP_LABEL) && psscale_letter_hangs_down (GMT->current.map.frame.axis[GMT_X].label))
 					label_off += 0.3;	/* Add 30% hang below baseline */
 				label_off *= GMT_LET_HEIGHT * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH;	/* Scale to inches */
-				label_off += MAX (0.0, GMT->current.setting.map_label_offset);	/* Add offset */
+				label_off += MAX (0.0, GMT->current.setting.map_label_offset[GMT_Y]);	/* Add offset */
 			}
 			/* If a unit then add space on the right to deal with the unit */
 			if (GMT->current.map.frame.axis[GMT_Y].label[0]) {
@@ -998,7 +998,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 			annot_off += hor_annot_width;
 			/* Increase width if there is a label */
 			if (GMT->current.map.frame.axis[GMT_X].label[0])
-				label_off = MAX (0.0, GMT->current.setting.map_label_offset) + GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH;
+				label_off = MAX (0.0, GMT->current.setting.map_label_offset[GMT_Y]) + GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH;
 			/* If a unit then consider if its width exceeds the bar width; then use half the excess to adjust center and width of box, and its height to adjust the height of box */
 			if (GMT->current.map.frame.axis[GMT_Y].label[0]) {
 				/* u_off is ~half-width of the label placed on top of the vertical bar, while v_off is the extra height needed to accommodate the label */
@@ -1055,11 +1055,11 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 	}
 	if (flip & PSSCALE_FLIP_LABEL) {	/* Place label on the opposite side */
 		Label_justify = PSL_BC;
-		y_label = width + GMT->current.setting.map_label_offset;
+		y_label = width + GMT->current.setting.map_label_offset[GMT_Y];
 	}
 	else {	/* Leave label on the default side */
 		Label_justify = PSL_TC;
-		y_label = -GMT->current.setting.map_label_offset;
+		y_label = -GMT->current.setting.map_label_offset[GMT_Y];
 	}
 
 	if (Ctrl->D.emode) {	/* Adjustment to triangle base coordinates so pen abuts perfectly with bar */
@@ -1136,7 +1136,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 		}
 
 		annot_off = ((len > 0.0 && !center) ? len : 0.0) + GMT->current.setting.map_annot_offset[GMT_PRIMARY];
-		label_off = annot_off + GMT_LET_HEIGHT * GMT->current.setting.font_annot[GMT_PRIMARY].size * GMT->session.u2u[GMT_PT][GMT_INCH] + GMT->current.setting.map_label_offset;
+		label_off = annot_off + GMT_LET_HEIGHT * GMT->current.setting.font_annot[GMT_PRIMARY].size * GMT->session.u2u[GMT_PT][GMT_INCH] + GMT->current.setting.map_label_offset[GMT_Y];
 		if (no_B_mode & PSSCALE_ANNOT_ANGLED) {
 			y_annot = y_base + dir * (((len > 0.0) ? len : 0.0) + GMT->current.setting.map_annot_offset[GMT_PRIMARY] * fabs (sind (Ctrl->S.angle)));
 			justify = l_justify = PSL_ML;
@@ -1408,7 +1408,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 			hor_annot_width = GMT->current.setting.font_annot[GMT_PRIMARY].size * GMT->session.u2u[GMT_PT][GMT_INCH];	/* Annotations are orthogonal */
 
 		annot_off = ((len > 0.0 && !center) ? len : 0.0) + GMT->current.setting.map_annot_offset[GMT_PRIMARY] + hor_annot_width;
-		label_off = annot_off + GMT->current.setting.map_label_offset;
+		label_off = annot_off + GMT->current.setting.map_label_offset[GMT_Y];
 		if (use_labels || (flip & PSSCALE_FLIP_ANNOT) || Ctrl->Q.active) annot_off -= hor_annot_width;
 		if (no_B_mode & PSSCALE_ANNOT_ANGLED) {
 			y_annot = y_base + dir * (((len > 0.0) ? len : 0.0) + GMT->current.setting.map_annot_offset[GMT_PRIMARY] * cosd (Ctrl->S.angle));

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -475,7 +475,7 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 			PSL_plotline (PSL, &tri_x[2], &tri_y[2], 2, PSL_MOVE|PSL_STROKE);
 	}
 
-	L_off = 3.0 * GMT->current.setting.map_label_offset;	T_off = 2.0 * GMT->current.setting.map_title_offset;
+	L_off = 3.0 * GMT->current.setting.map_label_offset[GMT_X];	T_off = 2.0 * GMT->current.setting.map_title_offset;
 	if (GMT->current.map.frame.header[0]) {	/* Plot title */
 		PSL_comment (PSL, "Placing plot title\n");
 		gmt_map_title (GMT, tri_x[2], tri_y[2]+2.0*T_off);

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -899,7 +899,7 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		/* Compute dimensions such as ticks and distance from tick to top of annotation etc for outside annotticks.  If map_frame_type is inside then 0 */
 		tick_height   = master_scale * MAX(0,GMT->current.setting.map_tick_length[GMT_ANNOT_UPPER]);	/* Allow for axis ticks */
 		annot_height  = master_scale * (GMT_LETTER_HEIGHT * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH) + MAX (0.0, GMT->current.setting.map_annot_offset[GMT_PRIMARY]);	/* Allow for space between axis and annotations */
-		label_height  = master_scale * (GMT_LETTER_HEIGHT * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH) + MAX (0.0, GMT->current.setting.map_label_offset);
+		label_height  = master_scale * (GMT_LETTER_HEIGHT * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH) + MAX (0.0, GMT->current.setting.map_label_offset[GMT_Y]);
 		title_height = (GMT_LETTER_HEIGHT * GMT->current.setting.font_title.size / PSL_POINTS_PER_INCH) + GMT->current.setting.map_title_offset;
 		y_header_off = GMT->current.setting.map_heading_offset;
 		if (Ctrl->In.no_B) tick_height = annot_height = 0.0;	/* No tick or annotations on subplot frames */

--- a/test/psbasemap/fixed_labeldist.ps
+++ b/test/psbasemap/fixed_labeldist.ps
@@ -1,0 +1,1462 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.3.0_9e3dc79_2021.06.09 [64-bit] Document from psbasemap
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Wed Jun  9 16:56:39 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -BWSen '-Bxa2f1+lAge (Ma)' '-Bya10f5+lC@-4@- (%)' -JX16c/2.5c -R6/17/0/24.9 -P -K
+%@PROJ: xy 6.00000000 17.00000000 0.00000000 24.90000000 6.000 17.000 0.000 24.900 +xy
+%GMTBoundingBox: 72 72 453.543307087 70.8661417323
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -83 0 D S
+N 0 474 M -83 0 D S
+N 0 949 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+133 F0
+(0) sw mx
+(10) sw mx
+(20) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+0 PSL_A0_y MM
+(0) mr Z
+474 PSL_A0_y MM
+(10) mr Z
+949 PSL_A0_y MM
+(20) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 237 M -42 0 D S
+N 0 712 M -42 0 D S
+-533 591 M 167 F0
+V 90 R V MU 0 0 M (C) FP 0 -42 G 117 F0 (4) FP 0 42 G 167 F0 ( \(%\)) FP pathbbox N pop exch pop add U -2 div 0 G
+(C) Z
+0 -42 G 117 F0 (4) Z
+0 42 G 167 F0 ( \(%\)) Z
+U
+7559 0 T
+25 W
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 83 0 D S
+N 0 474 M 83 0 D S
+N 0 949 M 83 0 D S
+N 0 237 M 42 0 D S
+N 0 712 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1374 0 M 0 -83 D S
+N 2749 0 M 0 -83 D S
+N 4123 0 M 0 -83 D S
+N 5497 0 M 0 -83 D S
+N 6872 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+133 F0
+(6) sh mx
+(8) sh mx
+(10) sh mx
+(12) sh mx
+(14) sh mx
+(16) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(6) bc Z
+1374 PSL_A0_y MM
+(8) bc Z
+2749 PSL_A0_y MM
+(10) bc Z
+4123 PSL_A0_y MM
+(12) bc Z
+5497 PSL_A0_y MM
+(14) bc Z
+6872 PSL_A0_y MM
+(16) bc Z
+N 687 0 M 0 -42 D S
+N 2062 0 M 0 -42 D S
+N 3436 0 M 0 -42 D S
+N 4810 0 M 0 -42 D S
+N 6185 0 M 0 -42 D S
+N 7559 0 M 0 -42 D S
+3780 -533 M 167 F0
+(Age \(Ma\)) bc Z
+0 1181 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 83 D S
+N 1374 0 M 0 83 D S
+N 2749 0 M 0 83 D S
+N 4123 0 M 0 83 D S
+N 5497 0 M 0 83 D S
+N 6872 0 M 0 83 D S
+N 687 0 M 0 42 D S
+N 2062 0 M 0 42 D S
+N 3436 0 M 0 42 D S
+N 4810 0 M 0 42 D S
+N 6185 0 M 0 42 D S
+N 7559 0 M 0 42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 1181 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Y2.5c -BWsen '-Bya1f3p+lMC@-T@- (grain/g)' -JX16c/2.5cl -R6/17/80/12000 -P -K -O
+%@PROJ: xy 6.00000000 17.00000000 80.00000000 12000.00000000 6.000 17.000 1.903 4.079 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 53 M -83 0 D S
+N 0 595 M -83 0 D S
+N 0 1138 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+133 F0
+V MU 0 0 M (10) FP 0 47 G 93 F0 (2) FP 0 -47 G pathbbox N pop exch pop add U mx
+V MU 0 0 M (10) FP 0 47 G 93 F0 (3) FP 0 -47 G pathbbox N pop exch pop add U mx
+V MU 0 0 M (10) FP 0 47 G 93 F0 (4) FP 0 -47 G pathbbox N pop exch pop add U mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+53 PSL_A0_y MM
+V MU 0 0 M (10) FP 0 47 G 93 F0 (2) FP 0 -47 G pathbbox N 4 1 roll exch pop add exch U -2 div exch neg exch G
+(10) Z
+0 47 G 93 F0 (2) Z
+0 -47 G 595 PSL_A0_y MM
+133 F0
+V MU 0 0 M (10) FP 0 47 G 93 F0 (3) FP 0 -47 G pathbbox N 4 1 roll exch pop add exch U -2 div exch neg exch G
+(10) Z
+0 47 G 93 F0 (3) Z
+0 -47 G 1138 PSL_A0_y MM
+133 F0
+V MU 0 0 M (10) FP 0 47 G 93 F0 (4) FP 0 -47 G pathbbox N 4 1 roll exch pop add exch U -2 div exch neg exch G
+(10) Z
+0 47 G 93 F0 (4) Z
+0 -47 G /PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 28 M -42 0 D S
+N 0 216 M -42 0 D S
+N 0 312 M -42 0 D S
+N 0 379 M -42 0 D S
+N 0 432 M -42 0 D S
+N 0 475 M -42 0 D S
+N 0 511 M -42 0 D S
+N 0 543 M -42 0 D S
+N 0 571 M -42 0 D S
+N 0 759 M -42 0 D S
+N 0 854 M -42 0 D S
+N 0 922 M -42 0 D S
+N 0 975 M -42 0 D S
+N 0 1018 M -42 0 D S
+N 0 1054 M -42 0 D S
+N 0 1086 M -42 0 D S
+N 0 1113 M -42 0 D S
+-533 591 M 167 F0
+V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (T) FP 0 42 G 167 F0 ( \(grain/g\)) FP pathbbox N pop exch pop add U -2 div 0 G
+(MC) Z
+0 -42 G 117 F0 (T) Z
+0 42 G 167 F0 ( \(grain/g\)) Z
+U
+7559 0 T
+25 W
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 53 M 83 0 D S
+N 0 595 M 83 0 D S
+N 0 1138 M 83 0 D S
+N 0 0 M 42 0 D S
+N 0 28 M 42 0 D S
+N 0 216 M 42 0 D S
+N 0 312 M 42 0 D S
+N 0 379 M 42 0 D S
+N 0 432 M 42 0 D S
+N 0 475 M 42 0 D S
+N 0 511 M 42 0 D S
+N 0 543 M 42 0 D S
+N 0 571 M 42 0 D S
+N 0 759 M 42 0 D S
+N 0 854 M 42 0 D S
+N 0 922 M 42 0 D S
+N 0 975 M 42 0 D S
+N 0 1018 M 42 0 D S
+N 0 1054 M 42 0 D S
+N 0 1086 M 42 0 D S
+N 0 1113 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1181 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 1181 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Y2.5c -BWsen -Bya0.1f0.05+lMC@-L@-/MC@-R@- -JX16c/2.5c -R6/17/0.01/0.39 -P -O -K
+%@PROJ: xy 6.00000000 17.00000000 0.01000000 0.39000000 6.000 17.000 0.010 0.390 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 280 M -83 0 D S
+N 0 591 M -83 0 D S
+N 0 901 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+133 F0
+(0.1) sw mx
+(0.2) sw mx
+(0.3) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+280 PSL_A0_y MM
+(0.1) mr Z
+591 PSL_A0_y MM
+(0.2) mr Z
+901 PSL_A0_y MM
+(0.3) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 124 M -42 0 D S
+N 0 435 M -42 0 D S
+N 0 746 M -42 0 D S
+N 0 1057 M -42 0 D S
+-533 591 M 167 F0
+V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (L) FP 0 42 G 167 F0 (/MC) FP 0 -42 G 117 F0 (R) FP 0 42 G pathbbox N pop exch pop add U -2 div 0 G
+(MC) Z
+0 -42 G 117 F0 (L) Z
+0 42 G 167 F0 (/MC) Z
+0 -42 G 117 F0 (R) Z
+0 42 G U
+7559 0 T
+25 W
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 280 M 83 0 D S
+N 0 591 M 83 0 D S
+N 0 901 M 83 0 D S
+N 0 124 M 42 0 D S
+N 0 435 M 42 0 D S
+N 0 746 M 42 0 D S
+N 0 1057 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1181 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 1181 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Y2.5c -BWsen '-Bya20f10+lGrass (%)' -JX16c/2.5c -R6/17/0.1/99.9 -P -O -K
+%@PROJ: xy 6.00000000 17.00000000 0.10000000 99.90000000 6.000 17.000 0.100 99.900 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 236 M -83 0 D S
+N 0 472 M -83 0 D S
+N 0 709 M -83 0 D S
+N 0 946 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+133 F0
+(20) sw mx
+(40) sw mx
+(60) sw mx
+(80) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+236 PSL_A0_y MM
+(20) mr Z
+472 PSL_A0_y MM
+(40) mr Z
+709 PSL_A0_y MM
+(60) mr Z
+946 PSL_A0_y MM
+(80) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 117 M -42 0 D S
+N 0 354 M -42 0 D S
+N 0 591 M -42 0 D S
+N 0 827 M -42 0 D S
+N 0 1064 M -42 0 D S
+-533 591 M 167 F0
+V 90 R (Grass \(%\)) bc Z U
+7559 0 T
+25 W
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 236 M 83 0 D S
+N 0 472 M 83 0 D S
+N 0 709 M 83 0 D S
+N 0 946 M 83 0 D S
+N 0 117 M 42 0 D S
+N 0 354 M 42 0 D S
+N 0 591 M 42 0 D S
+N 0 827 M 42 0 D S
+N 0 1064 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1181 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 1181 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Y2.5c -BWsen '-Bya20f10+lGrass (%)' -JX16c/2.5c -R6/17/0.1/99.9 -P -O -K
+%@PROJ: xy 6.00000000 17.00000000 0.10000000 99.90000000 6.000 17.000 0.100 99.900 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 236 M -83 0 D S
+N 0 472 M -83 0 D S
+N 0 709 M -83 0 D S
+N 0 946 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+133 F0
+(20) sw mx
+(40) sw mx
+(60) sw mx
+(80) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+236 PSL_A0_y MM
+(20) mr Z
+472 PSL_A0_y MM
+(40) mr Z
+709 PSL_A0_y MM
+(60) mr Z
+946 PSL_A0_y MM
+(80) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 117 M -42 0 D S
+N 0 354 M -42 0 D S
+N 0 591 M -42 0 D S
+N 0 827 M -42 0 D S
+N 0 1064 M -42 0 D S
+-533 591 M 167 F0
+V 90 R (Grass \(%\)) bc Z U
+7559 0 T
+25 W
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 236 M 83 0 D S
+N 0 472 M 83 0 D S
+N 0 709 M 83 0 D S
+N 0 946 M 83 0 D S
+N 0 117 M 42 0 D S
+N 0 354 M 42 0 D S
+N 0 591 M 42 0 D S
+N 0 827 M 42 0 D S
+N 0 1064 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1181 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 1181 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Y2.5c -BWsen -Bxa100 -By+lFossils -JX16c/2.5c -R6/17/0/2 -P -K -O
+%@PROJ: xy 6.00000000 17.00000000 0.00000000 2.00000000 6.000 17.000 0.000 2.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+-533 591 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+167 F0
+V 90 R (Fossils) bc Z U
+7559 0 T
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1181 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 1181 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Y2.5c -BWsen -Bya400+200f100+lMSH -JX16c/2.5c -R6/17/2801/4099 -P -K -O
+%@PROJ: xy 6.00000000 17.00000000 2801.00000000 4099.00000000 6.000 17.000 2801.000 4099.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 181 M -83 0 D S
+N 0 545 M -83 0 D S
+N 0 909 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+133 F0
+(3000) sw mx
+(3400) sw mx
+(3800) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+181 PSL_A0_y MM
+(3000) mr Z
+545 PSL_A0_y MM
+(3400) mr Z
+909 PSL_A0_y MM
+(3800) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 90 M -42 0 D S
+N 0 272 M -42 0 D S
+N 0 363 M -42 0 D S
+N 0 454 M -42 0 D S
+N 0 636 M -42 0 D S
+N 0 727 M -42 0 D S
+N 0 818 M -42 0 D S
+N 0 1000 M -42 0 D S
+N 0 1091 M -42 0 D S
+-533 591 M 167 F0
+V 90 R (MSH) bc Z U
+7559 0 T
+25 W
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 181 M 83 0 D S
+N 0 545 M 83 0 D S
+N 0 909 M 83 0 D S
+N 0 90 M 42 0 D S
+N 0 272 M 42 0 D S
+N 0 363 M 42 0 D S
+N 0 454 M 42 0 D S
+N 0 636 M 42 0 D S
+N 0 727 M 42 0 D S
+N 0 818 M 42 0 D S
+N 0 1000 M 42 0 D S
+N 0 1091 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1181 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 1181 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Y2.5c -BWsen '-Bya100f25+lCO@-2@- (PPM)' -JX16c/2.5c -R6/17/50/399 -P -O -K
+%@PROJ: xy 6.00000000 17.00000000 50.00000000 399.00000000 6.000 17.000 50.000 399.000 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 169 M -83 0 D S
+N 0 508 M -83 0 D S
+N 0 846 M -83 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+133 F0
+(100) sw mx
+(200) sw mx
+(300) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add def
+169 PSL_A0_y MM
+(100) mr Z
+508 PSL_A0_y MM
+(200) mr Z
+846 PSL_A0_y MM
+(300) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -42 0 D S
+N 0 85 M -42 0 D S
+N 0 254 M -42 0 D S
+N 0 338 M -42 0 D S
+N 0 423 M -42 0 D S
+N 0 592 M -42 0 D S
+N 0 677 M -42 0 D S
+N 0 761 M -42 0 D S
+N 0 931 M -42 0 D S
+N 0 1015 M -42 0 D S
+N 0 1100 M -42 0 D S
+-533 591 M 167 F0
+V 90 R V MU 0 0 M (CO) FP 0 -42 G 117 F0 (2) FP 0 42 G 167 F0 ( \(PPM\)) FP pathbbox N pop exch pop add U -2 div 0 G
+(CO) Z
+0 -42 G 117 F0 (2) Z
+0 42 G 167 F0 ( \(PPM\)) Z
+U
+7559 0 T
+25 W
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 169 M 83 0 D S
+N 0 508 M 83 0 D S
+N 0 846 M 83 0 D S
+N 0 0 M 42 0 D S
+N 0 85 M 42 0 D S
+N 0 254 M 42 0 D S
+N 0 338 M 42 0 D S
+N 0 423 M 42 0 D S
+N 0 592 M 42 0 D S
+N 0 677 M 42 0 D S
+N 0 761 M 42 0 D S
+N 0 931 M 42 0 D S
+N 0 1015 M 42 0 D S
+N 0 1100 M 42 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1181 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 1181 TM
+
+% PostScript produced by:
+%@GMT: gmt psbasemap -Y2.5c -BWsen -Bxa100 -By+lTectonics -JX16c/2.5c -R6/17/0/1 -P -O
+%@PROJ: xy 6.00000000 17.00000000 0.00000000 1.00000000 6.000 17.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+-533 591 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+167 F0
+V 90 R (Tectonics) bc Z U
+7559 0 T
+N 0 1181 M 0 -1181 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 1181 T
+25 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -1181 T
+0 setlinecap
+0 A
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psbasemap/fixed_labeldist.ps
+++ b/test/psbasemap/fixed_labeldist.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.3.0_9e3dc79_2021.06.09 [64-bit] Document from psbasemap
+%%Title: GMT v6.3.0_1321ce8_2021.06.11 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Wed Jun  9 16:56:39 2021
+%%CreationDate: Fri Jun 11 17:14:37 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -13,6 +13,7 @@
 %%EndComments
 
 %%BeginProlog
+% Begin pslib header
 250 dict begin
 /! {bind def} bind def
 /# {load def}!
@@ -43,42 +44,71 @@
 /MS {/SMat matrix currentmatrix def}!
 /MR {SMat setmatrix}!
 /edef {exch def}!
+% Path fill
 /FS {/fc edef /fs {V fc F U} def}!
 /FQ {/fs {} def}!
+% Outline off or on
 /O0 {/os {N} def}!
 /O1 {/os {P S} def}!
+% Set both fill and outline
 /FO {fs os}!
+% Star: radius xc yc
 /Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+% Box: height width xll yll
 /Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+% Rounded box: height width radius xll yll
 /SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
   BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+% Circle: radius xc yc
 /Sc {N 3 -1 roll 0 360 arc FO}!
+% Diamond: radius xc yc
 /Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+% Ellipse: major minor angle xc yc
 /Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+% Octagon: radius xc yc
 /Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+% Hexagon: radius xc yc
 /Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+% Inverted triangle: radius xc yc
 /Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+% Rotated rectangle: height width angle xc yc
 /Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+% Pentagon: radius xc yc
 /Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+% Dot: radius xc yc [hardwired as circle with no outline]
 /Sp {N 3 -1 roll 0 360 arc fs N}!
+% Patch fill: x1 y1 ... xn yn n
 /SP {M {D} repeat FO}!
+% Rectangle: height width xc yc
 /Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+% Rounded rectangle: height width radius xc yc
 /SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
   BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+% Square: radius xc yc
 /Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+% Triangle: radius xc yc
 /St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+% Single-headed vector
 /SV {0 exch M 0 D D D D D 0 D FO}!
+% Double-headed vector
 /Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+% Pie Wedge: radius angle1 angle2 xc yc
 /Sw {2 copy M 5 2 roll arc FO}!
+% Cross: radius xc yc
 /Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+% Y-dash: radius xc yc
 /Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+% Plus: radius xc yc
 /S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+% X-dash: radius xc yc
 /S- {M dup 0 G dup -2 mul dup 0 D S}!
+% String width, height, depth and total height (height-depth)
 /sw {stringwidth pop}!
 /sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
 /sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
 /sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
 /sb {E exch sh}!
+% To align text {bottom,middle,top}{left,center,right}
 /bl {}!
 /bc {E -2 div 0 G}!
 /br {E neg 0 G}!
@@ -88,36 +118,40 @@
 /tl {dup 0 exch sh neg G}!
 /tc {dup E -2 div exch sh neg G}!
 /tr {dup E neg exch sh neg G}!
+% Maximum of two numbers
 /mx {2 copy lt {exch} if pop}!
+% Translate and memorize advance
 /PSL_xorig 0 def /PSL_yorig 0 def
 /TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+% To re-encode one font with the provided encoding vector
 /PSL_reencode {findfont dup length dict begin
   {1 index /FID ne {def}{pop pop} ifelse} forall
   exch /Encoding edef currentdict end definefont pop
 }!
-/PSL_eps_begin {
-  /PSL_eps_state save def
-  /PSL_dict_count countdictstack def
-  /PSL_op_count count 1 sub def
-  userdict begin
-  /showpage {} def
-  0 setgray 0 setlinecap 1 setlinewidth
+/PSL_eps_begin {					% Marks begin of EPSF inclusion
+  /PSL_eps_state save def				% Save state for cleanup
+  /PSL_dict_count countdictstack def			% Count objects on dict stack
+  /PSL_op_count count 1 sub def				% Count objects on operand stack
+  userdict begin					% Push userdict stack
+  /showpage {} def					% Deactivate showpage command
+  0 setgray 0 setlinecap 1 setlinewidth			% Prepare clean graphics state
   0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
-  /languagelevel where
+  /languagelevel where	% If level != 1, set strokeadjust and overprint to their defaults
   {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
 }!
-/PSL_eps_end {
-  count PSL_op_count sub {pop} repeat
-  countdictstack PSL_dict_count sub {end} repeat
-  PSL_eps_state restore
+/PSL_eps_end {						% Marks end of EPSF inclusion
+  count PSL_op_count sub {pop} repeat			% Clean up operand stack
+  countdictstack PSL_dict_count sub {end} repeat	% Clean up dict stack
+  PSL_eps_state restore					% Restore saved state
 }!
-/PSL_transp {
+/PSL_transp {             % Changes the transparency settings
   /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
   /.setfillconstantalpha where
-  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
-  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }  % Ghostscript
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if } % Or Adobe
   ifelse
 }!
+
 /ISOLatin1+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
@@ -152,7 +186,7 @@
 /eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
 /oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
 ] def
-/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def	% Initially zero
 /F0 {/Helvetica Y}!
 /F1 {/Helvetica-Bold Y}!
 /F2 {/Helvetica-Oblique Y}!
@@ -192,185 +226,320 @@
 /F36 {/Ryumin-Light-EUC-V Y}!
 /F37 {/GothicBBB-Medium-EUC-H Y}!
 /F38 {/GothicBBB-Medium-EUC-V Y}!
-/PSL_pathtextdict 26 dict def
-/PSL_pathtext
-  {PSL_pathtextdict begin
-    /ydepth exch def
-    /textheight exch def
-    /just exch def
-    /offset exch def
-    /str exch def
-    /pathdist 0 def
-    /setdist offset def
-    /charcount 0 def
-    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
-    V flattenpath
-	{movetoproc} {linetoproc}
-	{curvetoproc} {closepathproc}
-	pathforall
-    U N
+
+/PSL_pathtextdict 26 dict def			% Local storage for the procedure PSL_pathtext.
+
+/PSL_pathtext					% PSL_pathtext'' will place a string
+  {PSL_pathtextdict begin			% of text along any path. It takes
+    /ydepth exch def                            % a string and starting offset
+    /textheight exch def			% distance from the beginning of
+    /just exch def				% the path as its arguments. Note
+    /offset exch def				% that PSL_pathtext assumes that a
+    /str exch def				% path has already been defined
+						% and after it places the text
+						% along the path, it clears the
+						% current path like the ``stroke''
+						% and ``fill'' operators; it also
+						% assumes that a font has been
+						% set. ``pathtext'' begins placing
+						% the characters along the current
+						% path, starting at the offset
+						% distance and continuing until
+						% either the path length is
+						% exhausted or the entire string
+						% has been printed, whichever
+						% occurs first. The results will
+						% be more effective when a small
+						% point size font is used with
+						% sharp curves in the path.
+						
+
+    /pathdist 0 def				% Initialize the distance we have
+						% travelled along the path.
+    /setdist offset def				% Initialize the distance we have
+						% covered by setting characters.
+    /charcount 0 def				% Initialize the character count.
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def % Compute the y-shift
+    V flattenpath				% Reduce the path to a series of
+						% straight line segments. The
+						% characters will be placed along
+						% the line segments in the
+						% ``linetoproc.''
+	{movetoproc} {linetoproc}		% The basic strategy is to process
+	{curvetoproc} {closepathproc}		% the segments of the path,
+	pathforall				% keeping a running total of the
+						% distance we have travelled so
+						% far (pathdist). We also keep
+						% track of the distance taken up
+						% by the characters that have been
+						% set so far (setdist). When the
+						% distance we have travelled along
+						% the path is greater than the
+						% distance taken up by the set
+						% characters, we are ready to set
+						% the next character (if there are
+						% any left to be set). This
+						% process continues until we have
+						% exhausted the full length of the
+						% path.
+    U N						% Clear the current path.
     end
   } def
+
 PSL_pathtextdict begin
-/movetoproc
-  { /newy exch def /newx exch def
-    /firstx newx def /firsty newy def
+/movetoproc					% ``movetoproc'' is executed when
+  { /newy exch def /newx exch def		% a moveto component has been
+						% encountered in the pathforall
+						% operation.
+    /firstx newx def /firsty newy def		% Remember the ``first point'' in
+						% the path so that when we get a
+						% ``closepath'' component we can
+						% properly handle the text.
     /ovr 0 def
     newx newy transform
-    /cpy exch def /cpx exch def
+    /cpy exch def /cpx exch def			% Explicitly keep track of the
+						% current position in device
+						% space.
   } def
-/linetoproc
-  { /oldx newx def /oldy newy def
-    /newy exch def /newx exch def
+
+/linetoproc					% ``linetoproc'' is executed when
+						% a lineto component has been
+						% encountered in the pathforall
+						% operation.
+  { /oldx newx def /oldy newy def		% Update the old point.
+    /newy exch def /newx exch def		% Get the new point.
     /dx newx oldx sub def
     /dy newy oldy sub def
-    /dist dx dup mul dy dup mul add sqrt def
+    /dist dx dup mul dy dup mul add sqrt def	% Calculate the distance between
+						% the old and the new point.
     dist 0 ne
-    { /dsx dx dist div ovr mul def
-      /dsy dy dist div ovr mul def
+    { /dsx dx dist div ovr mul def		% dsx and dsy are used to update
+      /dsy dy dist div ovr mul def		% the current position to be just
+						% beyond the width of the previous
+						% character.
       oldx dsx add oldy dsy add transform
-      /cpy exch def /cpx exch def
-      /pathdist pathdist dist add def
-      {setdist pathdist le
-	  {charcount str length lt
-	      {setchar} {exit} ifelse}
-	  { /ovr setdist pathdist sub def
-	    exit}
-	  ifelse
+      /cpy exch def /cpx exch def		% Update the current position.
+      /pathdist pathdist dist add def		% Increment the distance we have
+						% travelled along the path.
+      {setdist pathdist le			% Keep setting characters along
+						% this path segment until we have
+						% exhausted its length.
+	  {charcount str length lt		% As long as there are still
+	      {setchar} {exit} ifelse}		% characters left in the string,
+						% set them.
+	  { /ovr setdist pathdist sub def		% Keep track of how much we have
+	    exit}				% overshot the path segment by
+	  ifelse					% setting the previous character.
+						% This enables us to position the
+						% origin of the following
+						% characters properly on the path.
       } loop
     } if
   } def
-/curvetoproc
-  { (ERROR: No curveto's after flattenpath!)
-    print
-  } def
-/closepathproc
-  {firstx firsty linetoproc
-    firstx firsty movetoproc
-  } def
-/setchar
-  { /char str charcount 1 getinterval def
-    /charcount charcount 1 add def
-    /charwidth char stringwidth pop def
-    V cpx cpy itransform T
-      dy dx atan R
+
+/curvetoproc					% ``curvetoproc'' is executed when
+  { (ERROR: No curveto's after flattenpath!)	% a curveto component has been
+    print					% encountered in the pathforall
+  } def						% operation. It prints an error
+						% message since there shouldn't be
+						% any curveto's in a path after
+						% the flattenpath operator has
+						% been executed.
+
+/closepathproc					% ``closepathproc'' is executed
+  {firstx firsty linetoproc			% when a closepath component has
+    firstx firsty movetoproc			% been encountered in the
+  } def						% pathforall operation. It
+						% simulates the action of the
+						% operator ``closepath'' by
+						% executing ``linetoproc'' with
+						% the coordinates of the most
+						% recent ``moveto'' and then
+						% executing ``movetoproc'' to the
+						% same point.
+
+/setchar					% ``setchar'' sets the next
+  { /char str charcount 1 getinterval def	% character in the string along
+						% the path and then updates the
+						% amount of path we have
+						% exhausted.
+    /charcount charcount 1 add def		% Increment the character count.
+    /charwidth char stringwidth pop def		% Find the width of the character.
+    V cpx cpy itransform T			% Translate to the current
+						% position in user space.
+      dy dx atan R				% Rotate the x-axis to coincide
+						% with the current segment.
       0 justy M
-      PSL_font_F {
+      PSL_font_F {  % Show text normally, if requested
         char show}
       if
-      PSL_font_FO {
+      PSL_font_FO { % Fill first then outline, if requested
         currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
       } if
-      PSL_font_OF {
+      PSL_font_OF { % Outline text then fill, if requested
         currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
       } if
       0 justy neg G currentpoint transform
-      /cpy exch def /cpx exch def
-    U /setdist setdist charwidth add def
-  } def
+      /cpy exch def /cpx exch def		% Update the current position
+    						% before we restore ourselves to
+						% the untransformed state.
+    U /setdist setdist charwidth add def	% Increment the distance we have
+  } def						% covered by setting characters.
 end
+
+% PSL LABEL CLIP FUNCTIONS
+
+% Two main functions deals with label placement and clipping:
+% PSL_curved_path_labels: 	handles texts that must follow curved baselines
+% PSL_straight_path_labels:	handles texts that have straight baselines
+%
+% Both functions assume that several variables have been predefined:
+%
+% First we have these two constant settings for all text boxes:
+%
+%   PSL_setboxpen  Function that sets the text box pen attributes (width, texture, color)
+%   PSL_setboxrgb  Function that sets the opaque text box color
+%
+% Then several arrays are placed.  Since a set of several lines segments may each
+% have many labels along them, we end up with these variables:
+%
+%   PSL_n_paths		Total number of segments
+%   PSL_path_x		x coordinates of the paths (all concatenated one after another)
+%   PSL_path_y		y coordinates of the paths (all concatenated one after another)
+%   PSL_path_n		Array with number of points per segment
+%   PSL_label_str  	Array with all the labels for all segments
+%   PSL_label_n		Array with number of labels per segment
+%   PSL_angle		The annotation angle for each label
+%
+% PSL_curved_path_labels expects those labels to be placed along several
+% lines and it needs the node numbers where to place text:
+%
+% PSL_node	Array with (x,y) node number of label position
+%
+% PSL_straight_path_labels are simpler and instead expects
+%
+% PSL_txt_x	(x,y) coordinates of the location of the m labels
+% PSL_txt_y
+
 /PSL_set_label_heights
-{
-  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
-  /PSL_heights PSL_n_labels array def
-  0 1 PSL_n_labels_minus_1
-  { /psl_k exch def
-    /psl_label PSL_label_str psl_k get def
-    PSL_label_font psl_k get cvx exec
-    psl_label sH /PSL_height edef
-    PSL_heights psl_k PSL_height put
+{	% Create array PSL_heights with full label heights
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def	% Upper limit in loop over labels
+  /PSL_heights PSL_n_labels array def		% Create array with text heights
+  0 1 PSL_n_labels_minus_1			% Loop psl_k = 0 < PSL_n_labels
+  { /psl_k exch def				% Current label index psl_k
+    /psl_label PSL_label_str psl_k get def	% Current text label
+    PSL_label_font psl_k get cvx exec		% Get and set this label's font attributes
+    psl_label sH /PSL_height edef		% Compute the height of this string
+    PSL_heights psl_k PSL_height put		% Store it in the array
   } for
 } def
+
+% Curved Baseline Text Placement Functions
+
 /PSL_curved_path_labels
-{ /psl_bits exch def
-  /PSL_placetext psl_bits 2 and 2 eq def
-  /PSL_clippath psl_bits 4 and 4 eq def
-  /PSL_strokeline false def
-  /PSL_fillbox psl_bits 128 and 128 eq def
-  /PSL_drawbox psl_bits 256 and 256 eq def
-  /PSL_font_F  psl_bits 1536 and 0 eq def
-  /PSL_font_FO psl_bits 512 and 512 eq def
-  /PSL_font_OF psl_bits 1024 and 1024 eq def
-  /PSL_n_paths1 PSL_n_paths 1 sub def
-  /PSL_usebox PSL_fillbox PSL_drawbox or def
-  PSL_clippath {clipsave N clippath} if
+{ /psl_bits exch def				% 4 on/of bit settings as indicated below
+  /PSL_placetext psl_bits 2 and 2 eq def		% true to place text, false to just make space
+  /PSL_clippath psl_bits 4 and 4 eq def		% false inactive, true creates clippath for labels
+  /PSL_strokeline false def			% true draws line, false skips
+  /PSL_fillbox psl_bits 128 and 128 eq def		% true to paint box opaque before placing text, false gives transparent box
+  /PSL_drawbox psl_bits 256 and 256 eq def		% true to draw box outline before placing text, false gives no outline
+  /PSL_font_F  psl_bits 1536 and 0 eq def     % true to paint regular text
+  /PSL_font_FO psl_bits 512 and 512 eq def    % true to fill text first then draw outline
+  /PSL_font_OF psl_bits 1024 and 1024 eq def  % true to draw outline of text first then fill inside
+  /PSL_n_paths1 PSL_n_paths 1 sub def		% one less is the upper limit in for loop over the paths
+  /PSL_usebox PSL_fillbox PSL_drawbox or def	% true if we need box outline for fill or stroke or both
+
+  PSL_clippath {clipsave N clippath} if		% Bracket with clipsave/cliprestore and start clip path
   /psl_k 0 def
   /psl_p 0 def
   0 1 PSL_n_paths1
-  { /psl_kk exch def
-    /PSL_n PSL_path_n  psl_kk get def
-    /PSL_m PSL_label_n psl_kk get def
-    /PSL_x PSL_path_x psl_k PSL_n getinterval def
-    /PSL_y PSL_path_y psl_k PSL_n getinterval def
-    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
-    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
-    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
-    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
-    PSL_curved_path_label
-    /psl_k psl_k PSL_n add def
-    /psl_p psl_p PSL_m add def
-  } for
-  PSL_clippath {PSL_eoclip} if N
+  { /psl_kk exch def						% Index into the PSL_n PSL_m arrays
+    /PSL_n PSL_path_n  psl_kk get def				% Get the number of points in this line segment
+    /PSL_m PSL_label_n psl_kk get def				% Get the number of labels for this line segment
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def		% Get the subset that is the current line segment x-coordinates
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def		% Get the subset that is the current line segment y-coordinates
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def	% Get the subset of node values for current line segment
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def	% Get the subset of angle values for current line segment
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def		% Get the subset of string values for current line segment
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def		% Get the subset of font settings for current line segment
+    PSL_curved_path_label					% Operate on this segment only
+    /psl_k psl_k PSL_n add def					% Go to next segment start index for path
+    /psl_p psl_p PSL_m add def					% Go to next segment start index for nodes
+  } for  % The loop over segments
+  			
+  PSL_clippath {PSL_eoclip} if N			% Activate clip path and return
+
 } def
+
 /PSL_curved_path_label
-{
-  /PSL_n1 PSL_n 1 sub def
-  /PSL_m1 PSL_m 1 sub def
-  PSL_CT_calcstringwidth
-  PSL_CT_calclinedist
-  PSL_CT_excludelabels
-  PSL_CT_addcutpoints
-  /PSL_nn1 PSL_nn 1 sub def
-  /n 0 def
-  /k 0 def
-  /j 0 def
-  /PSL_seg 0 def
+{	% Deals with a single line segment and its labels
+  /PSL_n1 PSL_n 1 sub def	% one less is the upper limit in for loops
+  /PSL_m1 PSL_m 1 sub def	% same
+
+  PSL_CT_calcstringwidth	% Calculate the width of each label string
+  PSL_CT_calclinedist		% Calculate along-track distances
+  PSL_CT_excludelabels		% Possibly eliminate labels outside of line domain
+  PSL_CT_addcutpoints		% Expand path to include the cut points
+
+% Now we have the final xx/yy array and we are ready to simply lay down the lines
+% and place the text along the line where there are labels.  We will use the
+% new array PSL_xp/yp to store the final points prior to use
+
+  /PSL_nn1 PSL_nn 1 sub def		% End index in for loop
+  /n 0 def				% Toggle: 0 means line, 1 means text
+  /k 0 def				% Index of the current text string
+  /j 0 def				% Output point number counter
+  /PSL_seg 0 def			% Line segment number
   /PSL_xp PSL_nn array def
   /PSL_yp PSL_nn array def
-  PSL_xp 0 PSL_xx 0 get put
+  PSL_xp 0 PSL_xx 0 get put		% Place first point in array
   PSL_yp 0 PSL_yy 0 get put
-  1 1 PSL_nn1
-  { /i exch def
-    /node_type PSL_kind i get def
-    /j j 1 add def
-    PSL_xp j PSL_xx i get put
+  1 1 PSL_nn1				% Loop over rest of points
+  { /i exch def				% Index into PSL_xx/yy arrays
+    /node_type PSL_kind i get def	% Check what kind of point the current point is
+    /j j 1 add def			% Update point count
+    PSL_xp j PSL_xx i get put		% Add this point to the path
     PSL_yp j PSL_yy i get put
-    node_type 1 eq
-    {n 0 eq
+    node_type 1 eq			% If this is a cut point we either stroke or place text
+    {n 0 eq		% n is 0 so this is the strokable segment
       {PSL_CT_drawline}
-      {
+      {   % here, n = 1 so this is the segment along which text should be placed
         PSL_CT_reversepath
 	      PSL_CT_textline}
-      ifelse
+      ifelse		% Reverse path if needed to place text correctly
       /j 0 def
-      PSL_xp j PSL_xx i get put
+      PSL_xp j PSL_xx i get put		% Place new first point in array
       PSL_yp j PSL_yy i get put
     } if
   } for
-  n 0 eq {PSL_CT_drawline} if
+  n 0 eq {PSL_CT_drawline} if	% Finish off the last line segment
+
 } def
+
 /PSL_CT_textline
-{ PSL_fnt k get cvx exec
-  /PSL_height PSL_heights k get def
-  PSL_placetext	{PSL_CT_placelabel} if
+{ PSL_fnt k get cvx exec		% Get and set this label's font attributes
+  /PSL_height PSL_heights k get def	% Recall the height of this text
+  PSL_placetext	{PSL_CT_placelabel} if	% If we want to place the text
   PSL_clippath {PSL_CT_clippath} if
-  /n 0 def /k k 1 add def
+  /n 0 def /k k 1 add def		% Set n back to 0, goto next label
 } def
-/PSL_CT_calcstringwidth
-{ /PSL_width_tmp PSL_m array def
+
+/PSL_CT_calcstringwidth			% Calculate the width of each label string
+{ /PSL_width_tmp PSL_m array def	% Assign space for distance
   0 1 PSL_m1
   { /i exch def
-    PSL_fnt_tmp i get cvx exec
-    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+    PSL_fnt_tmp i get cvx exec					% Get and set this label's font attributes
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put	% Compute width and store in the array
   } for
 } def
-/PSL_CT_calclinedist
+
+/PSL_CT_calclinedist			% Calculate the distance along the line
 { /PSL_newx PSL_x 0 get def
   /PSL_newy PSL_y 0 get def
-  /dist 0.0 def
-  /PSL_dist PSL_n array def
-  PSL_dist 0 0.0 put
-  1 1 PSL_n1
+  /dist 0.0 def			% Cumulative distance at first point is 0
+  /PSL_dist PSL_n array def	% Assign array space for distance
+  PSL_dist 0 0.0 put		% Distances start at 0 and the 'th point
+  1 1 PSL_n1			% Loop over the remaining points
   { /i exch def
     /PSL_oldx PSL_newx def
     /PSL_oldy PSL_newy def
@@ -382,86 +551,100 @@ end
     PSL_dist i dist put
   } for
 } def
+
+% Some labels (in particular first and last per segment) may be too long
+% to actually fit inside the length of the line.  We precalculate the
+% start and end distances for each label and those that exceed the length
+% of the line cannot be plotted and are thus skipped.  The surviving labels
+% and their information is copied to the final PSL arrays
+
 /PSL_CT_excludelabels
-{ /k 0 def
-  /PSL_width PSL_m array def
-  /PSL_angle PSL_m array def
-  /PSL_node PSL_m array def
-  /PSL_str PSL_m array def
-  /PSL_fnt PSL_m array def
-  /lastdist PSL_dist PSL_n1 get def
-  0 1 PSL_m1
-  { /i exch def
-    /dist PSL_dist PSL_node_tmp i get get def
-    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
-    /L_dist dist halfwidth sub def
-    /R_dist dist halfwidth add def
-    L_dist 0 gt R_dist lastdist lt and
-    {
-      PSL_width k PSL_width_tmp i get put
-      PSL_node k PSL_node_tmp i get put
-      PSL_angle k PSL_angle_tmp i get put
-      PSL_str k PSL_str_tmp i get put
-      PSL_fnt k PSL_fnt_tmp i get put
+{ /k 0 def				% Current cut point
+  /PSL_width PSL_m array def		% New array of distances
+  /PSL_angle PSL_m array def		% New array of angles
+  /PSL_node PSL_m array def		% New array of nodes
+  /PSL_str PSL_m array def		% New array of strings
+  /PSL_fnt PSL_m array def		% New array of fonts
+  /lastdist PSL_dist PSL_n1 get def	% Length of line 
+  0 1 PSL_m1				% For each of the m labels
+  { /i exch def						% Index for label distance
+    /dist PSL_dist PSL_node_tmp i get get def		% Recall the distance to this label center
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def	% Set the halfwidth + gap distance
+    /L_dist dist halfwidth sub def			% Distance at beginning of label gap
+    /R_dist dist halfwidth add def			% Distance at the end of label gap
+    L_dist 0 gt R_dist lastdist lt and		% Yes, label is inside line ends
+    { % These are the labels we will use
+      PSL_width k PSL_width_tmp i get put	% Copy over width
+      PSL_node k PSL_node_tmp i get put		% Copy over node
+      PSL_angle k PSL_angle_tmp i get put	% Copy over angle
+      PSL_str k PSL_str_tmp i get put		% Copy over text
+      PSL_fnt k PSL_fnt_tmp i get put		% Copy over font
       /k k 1 add def
     } if
   } for
-  /PSL_m k def
+  /PSL_m k def	% New number of labels
   /PSL_m1 PSL_m 1 sub def
 } def
+
+% Initialize an array with all the original line points plus the set of 2*m
+% points at the transition from line to labelspace at each label
+% At the end of this section, the PSL_xx/yy array will be the array to use.
+
 /PSL_CT_addcutpoints
-{ /k 0 def
-  /PSL_nc PSL_m 2 mul 1 add def
-  /PSL_cuts PSL_nc array def
-  /PSL_nc1 PSL_nc 1 sub def
-  0 1 PSL_m1
-  { /i exch def
-    /dist PSL_dist PSL_node i get get def
-    /halfwidth PSL_width i get 2 div PSL_gap_x add def
-    PSL_cuts k dist halfwidth sub put
-    /k k 1 add def
-    PSL_cuts k dist halfwidth add put
-    /k k 1 add def
+{ /k 0 def				% Current cut point
+  /PSL_nc PSL_m 2 mul 1 add def		% 2*m points + one last acting as infinity
+  /PSL_cuts PSL_nc array def		% The array of distances to each cut
+  /PSL_nc1 PSL_nc 1 sub def		% One less to use in for loop limits
+  0 1 PSL_m1				% For each of the m labels
+  { /i exch def						% Index for label distance
+    /dist PSL_dist PSL_node i get get def		% Recall the distance to this label center
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def	% Set the halfwidth + gap distance
+    PSL_cuts k dist halfwidth sub put			% Distance at beginning of label gap
+    /k k 1 add def					% Was at start, now go to end distance node
+    PSL_cuts k dist halfwidth add put			% Distance at the end of label gap
+    /k k 1 add def					% Was at end, move to next
   } for
-  PSL_cuts k 100000.0 put
-  /PSL_nn PSL_n PSL_m 2 mul add def
-  /PSL_xx PSL_nn array def
+  PSL_cuts k 100000.0 put				% Last cut has ~infinite distance
+
+  /PSL_nn PSL_n PSL_m 2 mul add def	% The total path will be 2*m points longer
+  /PSL_xx PSL_nn array def		% Assign new space for x and y
   /PSL_yy PSL_nn array def
-  /PSL_kind PSL_nn array def
-  /j 0 def
-  /k 0 def
-  /dist 0.0 def
-  0 1 PSL_n1
-  { /i exch def
-    /last_dist dist def
-    /dist PSL_dist i get def
-    k 1 PSL_nc1
-    { /kk exch def
-      /this_cut PSL_cuts kk get def
-      dist this_cut gt
-      { /ds dist last_dist sub def
-	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+  /PSL_kind PSL_nn array def		% 0 = ordinary point, 1 = added point for label gap
+  /j 0 def				% Index for new track array
+  /k 0 def				% Index for current cut distance
+  /dist 0.0 def				% Current distance along track, starting at zero
+  0 1 PSL_n1				% Loop over every original line point
+  { /i exch def				% Index into current point on original line xy array
+    /last_dist dist def			% Update distance to last point (initially zero)
+    /dist PSL_dist i get def		% Distance to current point
+    k 1 PSL_nc1				% Loop over remaining cuts (starting with all)
+    { /kk exch def			% Index into current cut distance
+      /this_cut PSL_cuts kk get def	% Distance to start of this label gap
+      dist this_cut gt			% Oh, oh, we just stepped over a cut point
+      { /ds dist last_dist sub def	% Change in distance
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def	% Get fractional change in distance
 	/i1 i 0 eq {0} {i 1 sub} ifelse def
-	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put	% Calc (x,y) at label start (or stop) point
 	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
-	PSL_kind j 1 put
-	/j j 1 add def
-	/k k 1 add def
+	PSL_kind j 1 put		% Set PSL_kind to 1 since it is an added cut point
+	/j j 1 add def			% Go to next output point
+	/k k 1 add def			% Done with this cut point
       } if
     } for
-    dist PSL_cuts k get le
+    dist PSL_cuts k get le		% Having dealt with the cut, we may add the regular point
     {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
-      PSL_kind j 0 put
-      /j j 1 add def
+      PSL_kind j 0 put			% Ordinary (original) coordinates
+      /j j 1 add def			% Go to next output point
     } if
   } for
 } def
+
 /PSL_CT_reversepath
-{PSL_xp j get PSL_xp 0 get lt
-  {0 1 j 2 idiv
-    { /left exch def
-      /right j left sub def
-      /tmp PSL_xp left get def
+{PSL_xp j get PSL_xp 0 get lt	% Path must first be reversed to avoid upside-down text
+  {0 1 j 2 idiv		% Loop over half the path and swap left/right points
+    { /left exch def		% Current left point
+      /right j left sub def	% Matching right point
+      /tmp PSL_xp left get def	% Swap left and right values for x then y
       PSL_xp left PSL_xp right get put
       PSL_xp right tmp put
       /tmp PSL_yp left get def
@@ -469,218 +652,252 @@ end
       PSL_yp right tmp put
     } for
   } if
+  % Now PSL_xp/yp has the correct order to give proper text angles
 } def
+
 /PSL_CT_placelabel
-{
-  /PSL_just PSL_label_justify k get def
-  /PSL_height PSL_heights k get def
-  /psl_label PSL_str k get def
-  /psl_depth psl_label sd def
-  PSL_usebox
-  {PSL_CT_clippath
-    PSL_fillbox
+{ % Places the curved text label on current segment
+  /PSL_just PSL_label_justify k get def	% Get this labels justification
+  /PSL_height PSL_heights k get def	% Recall the height of this string
+  /psl_label PSL_str k get def		% Get the current label
+  /psl_depth psl_label sd def		% Determine depth beneath baseline
+  PSL_usebox		% Want to lay down box outline or fill
+  {PSL_CT_clippath	% Box path now current path
+    PSL_fillbox		% Want to paint box
     {V PSL_setboxrgb fill U} if
-    PSL_drawbox
+    PSL_drawbox		% Want to draw outline of box
     {V PSL_setboxpen S U} if N
   } if
   PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
 } def
+
 /PSL_CT_clippath
-{
+{ % Lays down a curved clipbox for one label
   /H PSL_height 2 div PSL_gap_y add def
   /xoff j 1 add array def
   /yoff j 1 add array def
-  /angle 0 def
-  0 1 j {
-    /ii exch def
+  /angle 0 def	% So it is at least a defined variable
+  0 1 j {	% Loop over points along line to calculate angle and offsets
+    /ii exch def	% Index
     /x PSL_xp ii get def
     /y PSL_yp ii get def
-    ii 0 eq {
+    ii 0 eq {	% Are we at the first point and hence must calculate angle using 0 and 1?
       /x1 PSL_xp 1 get def
       /y1 PSL_yp 1 get def
       /dx x1 x sub def
       /dy y1 y sub def
     }
-    { /i1 ii 1 sub def
+    { /i1 ii 1 sub def	% Previous point
       /x1 PSL_xp i1 get def
       /y1 PSL_yp i1 get def
       /dx x x1 sub def
       /dy y y1 sub def
     } ifelse
     dx 0.0 eq dy 0.0 eq and not
-    { /angle dy dx atan 90 add def} if
+    { /angle dy dx atan 90 add def} if	% Only calculate new angle if not duplicates
     /sina angle sin def
     /cosa angle cos def
     xoff ii H cosa mul put
     yoff ii H sina mul put
   } for
+
+  % Lay down next clip segment
+
   PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
-  1 1 j {
+  1 1 j {	% Loop over the rest of the upper line
     /ii exch def
     PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
   } for
-  j -1 0 {
+  j -1 0 {	% Loop backwards over the rest of the lower line
     /ii exch def
     PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
   } for P
 } def
+
 /PSL_CT_drawline
 {
   /str 20 string def
-  PSL_strokeline
-  {PSL_CT_placeline S} if
-  /PSL_seg PSL_seg 1 add def
-  /n 1 def
+  % PSL_strokeline PSL_seg 0 eq and		% If we asked to draw lines...
+  PSL_strokeline				% If we asked to draw lines...
+  {PSL_CT_placeline S} if			% Lay down the rest of the path and stroke it
+  /PSL_seg PSL_seg 1 add def			% Goto next segment number
+  /n 1 def					% Set n to 1
 } def
+
 /PSL_CT_placeline
-{PSL_xp 0 get PSL_yp 0 get M
-  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+{PSL_xp 0 get PSL_yp 0 get M			% Set the anchor point of the path
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for	% Lay down the rest of the path
 } def
+
+% Draw Baseline Text Segment Lines
+% PSL_draw_path_lines will draw the lines that have been stored in the concatenated
+% PSL_path_x and PSL_path_y arrays using the pen attributes in the PSL_path_pen array
+
 /PSL_draw_path_lines
-{
-  /PSL_n_paths1 PSL_n_paths 1 sub def
+{	% Draws the lines already stored in the PSL_path_x|y arrays
+  /PSL_n_paths1 PSL_n_paths 1 sub def		% One less is the upper limit in for loop over the paths
   V
-  /psl_start 0 def
-  0 1 PSL_n_paths1
-  { /psl_k exch def
-    /PSL_n PSL_path_n psl_k get def
-    /PSL_n1 PSL_n 1 sub def
-    PSL_path_pen psl_k get cvx exec
-    N
-    PSL_path_x psl_start get PSL_path_y psl_start get M
-    1 1 PSL_n1
-    { /psl_i exch def
-      /psl_kk psl_i psl_start add def
-      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+  /psl_start 0 def					% Start index of segment in concatenated path array
+  0 1 PSL_n_paths1					% Loop over all segments
+  { /psl_k exch def					% Index into the PSL arrays
+    /PSL_n PSL_path_n psl_k get def			% Get the number of points in this line segment
+    /PSL_n1 PSL_n 1 sub def				% One less is the upper limit in for loop over points
+    PSL_path_pen psl_k get cvx exec			% Get and set this line's pen
+    N							% Clean path
+    PSL_path_x psl_start get PSL_path_y psl_start get M	% Place anchor point of this segment
+    1 1 PSL_n1						% Loop over points in this segment
+    { /psl_i exch def					% Local index of next point in segment
+      /psl_kk psl_i psl_start add def			% Equivalent index in concatenated array of all segments
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L	% Draw to next point
     } for
-    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
-    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
-    psl_xclose 0 eq psl_yclose 0 eq and { P } if
-    S
-    /psl_start psl_start PSL_n add def
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def	% Difference between first and last x coordinate
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def	% Difference between first and last y coordinate
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if	% Explicitly close the path
+    S							% Stroke this path
+    /psl_start psl_start PSL_n add def			% Go to next segment and update start index for path
   } for
   U
 } def
+
+% Straight Baseline Text Placement Functions
+% PSL_straight_path_labels deals with straight text labels w/wo textboxes (rect or rounded).
+% Only the (x,y) location of each label is needed.
+% Use <flags> PSL_straight_path_labels to paint|draw textboxes and place text
+% Use <flags> PSL_straight_path_clip to use textboxes to define and activate clipping
+% Subroutines of these functions are called PSL_ST_*
+% Local variables are called psl_*, global are called PSL_*
+
 /PSL_straight_path_labels
-{
-  /psl_bits exch def
-  /PSL_placetext psl_bits 2 and 2 eq def
-  /PSL_rounded psl_bits 32 and 32 eq def
-  /PSL_fillbox psl_bits 128 and 128 eq def
-  /PSL_drawbox psl_bits 256 and 256 eq def
-  /PSL_font_F  psl_bits 1536 and 0 eq def
-  /PSL_font_FO psl_bits 512 and 512 eq def
-  /PSL_font_OF psl_bits 1024 and 1024 eq def
-  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
-  /PSL_usebox PSL_fillbox PSL_drawbox or def
-  0 1 PSL_n_labels_minus_1
-  { /psl_k exch def
-    PSL_ST_prepare_text
-    PSL_usebox
-    {  PSL_rounded
+{	% This function will lay down (a) text box paint, (b) text box outline, and (c) text labels
+	% All of these are optionals specified by the bit flag.
+  /psl_bits exch def				% Single bitflag argument passed
+  /PSL_placetext psl_bits 2 and 2 eq def	% true to place text, false to just make space
+  /PSL_rounded psl_bits 32 and 32 eq def	% true for rounded box shape, false gives rectangular box
+  /PSL_fillbox psl_bits 128 and 128 eq def	% true to paint box opaque before placing text
+  /PSL_drawbox psl_bits 256 and 256 eq def  % true to draw box outline before placing text
+  /PSL_font_F  psl_bits 1536 and 0 eq def     % true to paint regular text
+  /PSL_font_FO psl_bits 512 and 512 eq def    % true to fill text first then draw outline
+  /PSL_font_OF psl_bits 1024 and 1024 eq def  % true to draw outline of text first then fill inside
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def	% Upper limit in loop over labels
+  /PSL_usebox PSL_fillbox PSL_drawbox or def	% true if we need box outline for fill or stroke or both
+  0 1 PSL_n_labels_minus_1			% Loop psl_k = 0 < PSL_n_labels
+  { /psl_k exch def				% Current label index psl_k
+    PSL_ST_prepare_text				% Get all dimensions, coordinates, etc. for this label
+    PSL_usebox					% If a text box is requested we go in here:
+    {  PSL_rounded				% Place text box path, either straight or rounded, on stack
         {PSL_ST_textbox_round}
         {PSL_ST_textbox_rect}
       ifelse
-      PSL_fillbox {V PSL_setboxrgb fill U} if
-      PSL_drawbox {V PSL_setboxpen S U} if
-      N
+      PSL_fillbox {V PSL_setboxrgb fill U} if	% Paint it, if requested
+      PSL_drawbox {V PSL_setboxpen S U} if	% Outline it, if requested
+      N						% Done, so remove path
     } if
-    PSL_font_F {
+    PSL_font_F {  % Show text normally, if requested
       PSL_placetext {PSL_ST_place_label} if
     } if
-    PSL_font_FO {
+    PSL_font_FO { % Fill first then outline, if requested
       PSL_placetext {PSL_ST_place_label_FO} if
     } if
-    PSL_font_OF {
+    PSL_font_OF { % Outline text then fill, if requested
       PSL_placetext {PSL_ST_place_label_OF} if
     } if
   } for
 } def
+
 /PSL_straight_path_clip
-{
-  /psl_bits exch def
-  /PSL_rounded psl_bits 32 and 32 eq def
-  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
-  N clipsave clippath
-  0 1 PSL_n_labels_minus_1
-  { /psl_k exch def
-    PSL_ST_prepare_text
-    PSL_rounded
+{	% This function will create a total clip path for all the labels in PSL_txt
+  /psl_bits exch def				% Single bit flag argument passed
+  /PSL_rounded psl_bits 32 and 32 eq def	% true for rounded box shape, false gives rectangular box
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def	% Upper limit in loop over labels
+
+  N clipsave clippath				% Start clip path by selecting the entire mappable area
+  0 1 PSL_n_labels_minus_1			% Loop over all labels
+  { /psl_k exch def				% Current label index psl_k
+    PSL_ST_prepare_text				% Get all dimensions, coordinates, etc. for this label
+    PSL_rounded					% Get either straight or rounded text box path
       {PSL_ST_textbox_round}
       {PSL_ST_textbox_rect}
     ifelse
   } for
-  PSL_eoclip N
+  PSL_eoclip N					% Set the new clip path, increment clip counter and clear path
 } def
-/PSL_ST_prepare_text
+
+/PSL_ST_prepare_text		% Compute various dimensions and coordinates for one label
+{ % The current label has index psl_k
+  /psl_xp PSL_txt_x psl_k get def		% Get text placement x coordinate
+  /psl_yp PSL_txt_y psl_k get def		% Get text placement y coordinate
+  /psl_label PSL_label_str psl_k get def	% Current text label
+  PSL_label_font psl_k get cvx exec		% Get and set this label's font attributes
+  /PSL_height PSL_heights psl_k get def		% Recall the height of this string
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def	% Set height of current label including clearance
+  /PSL_just PSL_label_justify psl_k get def	% Get text justification (1-11)
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def % This is 0, -0.5, or -1 for relative x-shift 
+  /PSL_justy PSL_just 4 idiv 2 div neg def	% This is 0, -0.5, or -1 for relative y-shift 
+  /psl_SW psl_label stringwidth pop def		% Width of current label space
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def	% Width of current label space including clearance
+  /psl_x0 psl_SW PSL_justx mul def		% (psl_x0,psl_y0) is rotated/adjusted text LL point on inside rectangle relative to psl_xp,psl_yp
+  /psl_y0 PSL_justy PSL_height mul def		%
+  /psl_angle PSL_label_angle psl_k get def	% The angle of text w.r.t. baseline
+} def
+
+/PSL_ST_textbox_rect	% Compute and place rectangular path for current label
 {
-  /psl_xp PSL_txt_x psl_k get def
-  /psl_yp PSL_txt_y psl_k get def
-  /psl_label PSL_label_str psl_k get def
-  PSL_label_font psl_k get cvx exec
-  /PSL_height PSL_heights psl_k get def
-  /psl_boxH PSL_height PSL_gap_y 2 mul add def
-  /PSL_just PSL_label_justify psl_k get def
-  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
-  /PSL_justy PSL_just 4 idiv 2 div neg def
-  /psl_SW psl_label stringwidth pop def
-  /psl_boxW psl_SW PSL_gap_x 2 mul add def
-  /psl_x0 psl_SW PSL_justx mul def
-  /psl_y0 PSL_justy PSL_height mul def
-  /psl_angle PSL_label_angle psl_k get def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T	% Rotate the coordinate system to follow baseline text and make (psl_x0,psl_y0) the new origin
+  PSL_gap_x neg PSL_gap_y neg M			% Set LL anchor point for rectangular box
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P	% Draw text box going CW
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T	% Unto trans/rot above
 } def
-/PSL_ST_textbox_rect
+
+/PSL_ST_textbox_round	% Compute and place rounded rectangular path for current label
 {
-  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
-  PSL_gap_x neg PSL_gap_y neg M
-  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
-  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def	% Smallest gap distance is our corner radius
+  /psl_xd PSL_gap_x psl_BoxR sub def 			% When x_gap exceeds y_gap there will be an adjustment in x, else 0
+  /psl_yd PSL_gap_y psl_BoxR sub def 			% When y_gap exceeds x_gap there will be an adjustment in y, else 0
+  /psl_xL PSL_gap_x neg def				% Left-most x coordinate of text box
+  /psl_yB PSL_gap_y neg def				% Bottom y coordinate of text box
+  /psl_yT psl_boxH psl_yB add def			% Top y coordinate of text box
+  /psl_H2 PSL_height psl_yd 2 mul add def		% Inner height when adjusting for any psl_yd offset
+  /psl_W2 psl_SW psl_xd 2 mul add def			% Inner width when adjusting for any psl_xd offset
+  /psl_xR psl_xL psl_boxW add def			% Right-most x coordinate of text box
+  /psl_x0 psl_SW PSL_justx mul def			% (psl_x0,psl_y0) is rotated/adjusted text LL point on inside rectangle relative to psl_xp,psl_yp
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T		% Rotate the coordinate system to follow baseline text and make (psl_x0,psl_y0) the new origin
+  psl_xL psl_yd M					% LL anchor point for rounded box is on lower left side just before rounded corner
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D	% Draw UL rounded corner and line to start of UR rounded corner
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D	% Draw UR rounded corner and line to LR rounded corner
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D	% Draw LR rounded corner and line to LL rounded corner
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P			% Draw LL rounded corner and close the clippath segment
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T	% Unto trans/rot above
 } def
-/PSL_ST_textbox_round
+
+/PSL_ST_place_label % Just place the current label normally
 {
-  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
-  /psl_xd PSL_gap_x psl_BoxR sub def
-  /psl_yd PSL_gap_y psl_BoxR sub def
-  /psl_xL PSL_gap_x neg def
-  /psl_yB PSL_gap_y neg def
-  /psl_yT psl_boxH psl_yB add def
-  /psl_H2 PSL_height psl_yd 2 mul add def
-  /psl_W2 psl_SW psl_xd 2 mul add def
-  /psl_xR psl_xL psl_boxW add def
-  /psl_x0 psl_SW PSL_justx mul def
-  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
-  psl_xL psl_yd M
-  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
-  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
-  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
-  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
-  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+    V psl_xp psl_yp T psl_angle R % Set origin at text point and rotate the coordinate system to follow baseline text
+    psl_SW PSL_justx mul psl_y0 M % Goto LL point on label
+    psl_label dup sd neg 0 exch G show  % Place the text, adjust vertically for any depth below baseline
+    U         % Undo damage to coordinate system
 } def
-/PSL_ST_place_label
+
+/PSL_ST_place_label_FO % Just place the current label by filling it, then outlining it
 {
-    V psl_xp psl_yp T psl_angle R
-    psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G show
-    U
+    V psl_xp psl_yp T psl_angle R % Set origin at text point and rotate the coordinate system to follow baseline text
+    psl_SW PSL_justx mul psl_y0 M % Goto LL point on label
+    psl_label dup sd neg 0 exch G false charpath V fs U S N % Place the text, adjust vertically for any depth below baseline
+    U         % Undo damage to coordinate system
 } def
-/PSL_ST_place_label_FO
+
+/PSL_ST_place_label_OF % Just place the current label by drawing outline, then filling it
 {
-    V psl_xp psl_yp T psl_angle R
-    psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G false charpath V fs U S N
-    U
+    V psl_xp psl_yp T psl_angle R % Set origin at text point and rotate the coordinate system to follow baseline text
+    psl_SW PSL_justx mul psl_y0 M % Goto LL point on label
+    psl_label dup sd neg 0 exch G false charpath V S U fs N % Place the text, adjust vertically for any depth below baseline
+    U         % Undo damage to coordinate system
 } def
-/PSL_ST_place_label_OF
-{
-    V psl_xp psl_yp T psl_angle R
-    psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G false charpath V S U fs N
-    U
-} def
-/PSL_nclip 0 def
-/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
-/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
-/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+
+/PSL_nclip 0 def							% The depth of clipping in effect
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def			% Clip and update PSL_nclip
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def			% Even-odd clip and update PSL_nclip
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def	% Cliprestore and update PSL_nclip
+
 %%EndProlog
 
 %%BeginSetup
@@ -692,9 +909,18 @@ PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%Page: 1 1
 
 %%BeginPageSetup
+%
+% Init coordinate system and scales
+%
+%
+% Scale initialized to 0.06, so 1 inch equals 1200 Postscript units
+%
 V 0.06 0.06 scale
 %%EndPageSetup
 
+%
+% End of PSL header
+%
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
@@ -705,20 +931,36 @@ gsave
 0 A
 FQ
 O0
+% Set plot origin:
 1200 1200 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -BWSen '-Bxa2f1+lAge (Ma)' '-Bya10f5+lC@-4@- (%)' -JX16c/2.5c -R6/17/0/24.9 -P -K
+%@GMT: gmt psbasemap -BWSEn '-Bxa2f1+lAge (Ma)' '-Bya10f5+lC@-4@- (%)' -JX16c/2.5c -R6/17/0/24.9 -P -K
 %@PROJ: xy 6.00000000 17.00000000 0.00000000 24.90000000 6.000 17.000 0.000 24.900 +xy
 %GMTBoundingBox: 72 72 453.543307087 70.8661417323
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -728,7 +970,7 @@ N 0 474 M -83 0 D S
 N 0 949 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 133 F0
 (0) sw mx
 (10) sw mx
@@ -744,13 +986,25 @@ def
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
 N 0 237 M -42 0 D S
 N 0 712 M -42 0 D S
--533 591 M 167 F0
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R V MU 0 0 M (C) FP 0 -42 G 117 F0 (4) FP 0 42 G 167 F0 ( \(%\)) FP pathbbox N pop exch pop add U -2 div 0 G
 (C) Z
 0 -42 G 117 F0 (4) Z
 0 42 G 167 F0 ( \(%\)) Z
 U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -759,10 +1013,41 @@ N 0 1181 M 0 -1181 D S
 N 0 0 M 83 0 D S
 N 0 474 M 83 0 D S
 N 0 949 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+133 F0
+(0) sw mx
+(10) sw mx
+(20) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) mr Z
+474 PSL_A0_y MM
+(10) mr Z
+949 PSL_A0_y MM
+(20) mr Z
 N 0 237 M 42 0 D S
 N 0 712 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R V MU 0 0 M (C) FP 0 -42 G 117 F0 (4) FP 0 42 G 167 F0 ( \(%\)) FP pathbbox N pop exch pop add U -2 div 0 G
+(C) Z
+0 -42 G 117 F0 (4) Z
+0 42 G 167 F0 ( \(%\)) Z
+U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
@@ -803,9 +1088,21 @@ N 3436 0 M 0 -42 D S
 N 4810 0 M 0 -42 D S
 N 6185 0 M 0 -42 D S
 N 7559 0 M 0 -42 D S
-3780 -533 M 167 F0
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 PSL_LH add def
+3780 PSL_L_y MM
 (Age \(Ma\)) bc Z
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
@@ -824,26 +1121,57 @@ N 4810 0 M 0 42 D S
 N 6185 0 M 0 42 D S
 N 7559 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 0 A
 FQ
 O0
+% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y2.5c -BWsen '-Bya1f3p+lMC@-T@- (grain/g)' -JX16c/2.5cl -R6/17/80/12000 -P -K -O
+%@GMT: gmt psbasemap -Y2.5c -BWsEn '-Bya1f3p+lMC@-T@- (grain/g)' -JX16c/2.5cl -R6/17/80/12000 -P -K -O
 %@PROJ: xy 6.00000000 17.00000000 80.00000000 12000.00000000 6.000 17.000 1.903 4.079 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -853,7 +1181,7 @@ N 0 595 M -83 0 D S
 N 0 1138 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 133 F0
 V MU 0 0 M (10) FP 0 47 G 93 F0 (2) FP 0 -47 G pathbbox N pop exch pop add U mx
 V MU 0 0 M (10) FP 0 47 G 93 F0 (3) FP 0 -47 G pathbbox N pop exch pop add U mx
@@ -893,13 +1221,25 @@ N 0 1018 M -42 0 D S
 N 0 1054 M -42 0 D S
 N 0 1086 M -42 0 D S
 N 0 1113 M -42 0 D S
--533 591 M 167 F0
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (T) FP 0 42 G 167 F0 ( \(grain/g\)) FP pathbbox N pop exch pop add U -2 div 0 G
 (MC) Z
 0 -42 G 117 F0 (T) Z
 0 42 G 167 F0 ( \(grain/g\)) Z
 U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -908,7 +1248,29 @@ N 0 1181 M 0 -1181 D S
 N 0 53 M 83 0 D S
 N 0 595 M 83 0 D S
 N 0 1138 M 83 0 D S
-N 0 0 M 42 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+133 F0
+V MU 0 0 M (10) FP 0 47 G 93 F0 (2) FP 0 -47 G pathbbox N pop exch pop add U mx
+V MU 0 0 M (10) FP 0 47 G 93 F0 (3) FP 0 -47 G pathbbox N pop exch pop add U mx
+V MU 0 0 M (10) FP 0 47 G 93 F0 (4) FP 0 -47 G pathbbox N pop exch pop add U mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+53 PSL_A0_y MM
+V MU 0 0 M (10) FP 0 47 G 93 F0 (2) FP 0 -47 G pathbbox N 4 1 roll exch pop add exch U -2 div exch neg exch G
+(10) Z
+0 47 G 93 F0 (2) Z
+0 -47 G 595 PSL_A0_y MM
+133 F0
+V MU 0 0 M (10) FP 0 47 G 93 F0 (3) FP 0 -47 G pathbbox N 4 1 roll exch pop add exch U -2 div exch neg exch G
+(10) Z
+0 47 G 93 F0 (3) Z
+0 -47 G 1138 PSL_A0_y MM
+133 F0
+V MU 0 0 M (10) FP 0 47 G 93 F0 (4) FP 0 -47 G pathbbox N 4 1 roll exch pop add exch U -2 div exch neg exch G
+(10) Z
+0 47 G 93 F0 (4) Z
+0 -47 G N 0 0 M 42 0 D S
 N 0 28 M 42 0 D S
 N 0 216 M 42 0 D S
 N 0 312 M 42 0 D S
@@ -926,38 +1288,95 @@ N 0 1018 M 42 0 D S
 N 0 1054 M 42 0 D S
 N 0 1086 M 42 0 D S
 N 0 1113 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (T) FP 0 42 G 167 F0 ( \(grain/g\)) FP pathbbox N pop exch pop add U -2 div 0 G
+(MC) Z
+0 -42 G 117 F0 (T) Z
+0 42 G 167 F0 ( \(grain/g\)) Z
+U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 0 A
 FQ
 O0
+% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y2.5c -BWsen -Bya0.1f0.05+lMC@-L@-/MC@-R@- -JX16c/2.5c -R6/17/0.01/0.39 -P -O -K
+%@GMT: gmt psbasemap -Y2.5c -BWsEn -Bya0.1f0.05+lMC@-L@-/MC@-R@- -JX16c/2.5c -R6/17/0.01/0.39 -P -O -K
 %@PROJ: xy 6.00000000 17.00000000 0.01000000 0.39000000 6.000 17.000 0.010 0.390 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -967,7 +1386,7 @@ N 0 591 M -83 0 D S
 N 0 901 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 133 F0
 (0.1) sw mx
 (0.2) sw mx
@@ -985,14 +1404,26 @@ N 0 124 M -42 0 D S
 N 0 435 M -42 0 D S
 N 0 746 M -42 0 D S
 N 0 1057 M -42 0 D S
--533 591 M 167 F0
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (L) FP 0 42 G 167 F0 (/MC) FP 0 -42 G 117 F0 (R) FP 0 42 G pathbbox N pop exch pop add U -2 div 0 G
 (MC) Z
 0 -42 G 117 F0 (L) Z
 0 42 G 167 F0 (/MC) Z
 0 -42 G 117 F0 (R) Z
 0 42 G U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1001,42 +1432,114 @@ N 0 1181 M 0 -1181 D S
 N 0 280 M 83 0 D S
 N 0 591 M 83 0 D S
 N 0 901 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+133 F0
+(0.1) sw mx
+(0.2) sw mx
+(0.3) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+280 PSL_A0_y MM
+(0.1) mr Z
+591 PSL_A0_y MM
+(0.2) mr Z
+901 PSL_A0_y MM
+(0.3) mr Z
 N 0 124 M 42 0 D S
 N 0 435 M 42 0 D S
 N 0 746 M 42 0 D S
 N 0 1057 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (L) FP 0 42 G 167 F0 (/MC) FP 0 -42 G 117 F0 (R) FP 0 42 G pathbbox N pop exch pop add U -2 div 0 G
+(MC) Z
+0 -42 G 117 F0 (L) Z
+0 42 G 167 F0 (/MC) Z
+0 -42 G 117 F0 (R) Z
+0 42 G U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 0 A
 FQ
 O0
+% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y2.5c -BWsen '-Bya20f10+lGrass (%)' -JX16c/2.5c -R6/17/0.1/99.9 -P -O -K
+%@GMT: gmt psbasemap -Y2.5c -BWsEn '-Bya20f10+lGrass (%)' -JX16c/2.5c -R6/17/0.1/99.9 -P -O -K
 %@PROJ: xy 6.00000000 17.00000000 0.10000000 99.90000000 6.000 17.000 0.100 99.900 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1047,7 +1550,7 @@ N 0 709 M -83 0 D S
 N 0 946 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 133 F0
 (20) sw mx
 (40) sw mx
@@ -1069,9 +1572,21 @@ N 0 354 M -42 0 D S
 N 0 591 M -42 0 D S
 N 0 827 M -42 0 D S
 N 0 1064 M -42 0 D S
--533 591 M 167 F0
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R (Grass \(%\)) bc Z U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1081,43 +1596,113 @@ N 0 236 M 83 0 D S
 N 0 472 M 83 0 D S
 N 0 709 M 83 0 D S
 N 0 946 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+133 F0
+(20) sw mx
+(40) sw mx
+(60) sw mx
+(80) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+236 PSL_A0_y MM
+(20) mr Z
+472 PSL_A0_y MM
+(40) mr Z
+709 PSL_A0_y MM
+(60) mr Z
+946 PSL_A0_y MM
+(80) mr Z
 N 0 117 M 42 0 D S
 N 0 354 M 42 0 D S
 N 0 591 M 42 0 D S
 N 0 827 M 42 0 D S
 N 0 1064 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R (Grass \(%\)) bc Z U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 0 A
 FQ
 O0
+% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y2.5c -BWsen '-Bya20f10+lGrass (%)' -JX16c/2.5c -R6/17/0.1/99.9 -P -O -K
+%@GMT: gmt psbasemap -Y2.5c -BWsEn '-Bya20f10+lGrass (%)' -JX16c/2.5c -R6/17/0.1/99.9 -P -O -K
 %@PROJ: xy 6.00000000 17.00000000 0.10000000 99.90000000 6.000 17.000 0.100 99.900 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1128,7 +1713,7 @@ N 0 709 M -83 0 D S
 N 0 946 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 133 F0
 (20) sw mx
 (40) sw mx
@@ -1150,9 +1735,21 @@ N 0 354 M -42 0 D S
 N 0 591 M -42 0 D S
 N 0 827 M -42 0 D S
 N 0 1064 M -42 0 D S
--533 591 M 167 F0
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R (Grass \(%\)) bc Z U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1162,87 +1759,223 @@ N 0 236 M 83 0 D S
 N 0 472 M 83 0 D S
 N 0 709 M 83 0 D S
 N 0 946 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+133 F0
+(20) sw mx
+(40) sw mx
+(60) sw mx
+(80) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+236 PSL_A0_y MM
+(20) mr Z
+472 PSL_A0_y MM
+(40) mr Z
+709 PSL_A0_y MM
+(60) mr Z
+946 PSL_A0_y MM
+(80) mr Z
 N 0 117 M 42 0 D S
 N 0 354 M 42 0 D S
 N 0 591 M 42 0 D S
 N 0 827 M 42 0 D S
 N 0 1064 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R (Grass \(%\)) bc Z U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 0 A
 FQ
 O0
+% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y2.5c -BWsen -Bxa100 -By+lFossils -JX16c/2.5c -R6/17/0/2 -P -K -O
+%@GMT: gmt psbasemap -Y2.5c -BWsEn -Bxa100 -By+lFossils -JX16c/2.5c -R6/17/0/2 -P -K -O
 %@PROJ: xy 6.00000000 17.00000000 0.00000000 2.00000000 6.000 17.000 0.000 2.000 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
--533 591 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_LH PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R (Fossils) bc Z U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/MM {exch M} def
+/PSL_LH (M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R (Fossils) bc Z U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 0 A
 FQ
 O0
+% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y2.5c -BWsen -Bya400+200f100+lMSH -JX16c/2.5c -R6/17/2801/4099 -P -K -O
+%@GMT: gmt psbasemap -Y2.5c -BWsEn -Bya400+200f100+lMSH -JX16c/2.5c -R6/17/2801/4099 -P -K -O
 %@PROJ: xy 6.00000000 17.00000000 2801.00000000 4099.00000000 6.000 17.000 2801.000 4099.000 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1252,7 +1985,7 @@ N 0 545 M -83 0 D S
 N 0 909 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 133 F0
 (3000) sw mx
 (3400) sw mx
@@ -1275,9 +2008,21 @@ N 0 727 M -42 0 D S
 N 0 818 M -42 0 D S
 N 0 1000 M -42 0 D S
 N 0 1091 M -42 0 D S
--533 591 M 167 F0
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R (MSH) bc Z U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1286,6 +2031,20 @@ N 0 1181 M 0 -1181 D S
 N 0 181 M 83 0 D S
 N 0 545 M 83 0 D S
 N 0 909 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+133 F0
+(3000) sw mx
+(3400) sw mx
+(3800) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+181 PSL_A0_y MM
+(3000) mr Z
+545 PSL_A0_y MM
+(3400) mr Z
+909 PSL_A0_y MM
+(3800) mr Z
 N 0 90 M 42 0 D S
 N 0 272 M 42 0 D S
 N 0 363 M 42 0 D S
@@ -1295,38 +2054,91 @@ N 0 727 M 42 0 D S
 N 0 818 M 42 0 D S
 N 0 1000 M 42 0 D S
 N 0 1091 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R (MSH) bc Z U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 0 A
 FQ
 O0
+% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y2.5c -BWsen '-Bya100f25+lCO@-2@- (PPM)' -JX16c/2.5c -R6/17/50/399 -P -O -K
+%@GMT: gmt psbasemap -Y2.5c -BWsEn '-Bya100f25+lCO@-2@- (PPM)' -JX16c/2.5c -R6/17/50/399 -P -O -K
 %@PROJ: xy 6.00000000 17.00000000 50.00000000 399.00000000 6.000 17.000 50.000 399.000 +xy
 %%BeginObject PSL_Layer_8
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1336,7 +2148,7 @@ N 0 508 M -83 0 D S
 N 0 846 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 133 F0
 (100) sw mx
 (200) sw mx
@@ -1361,13 +2173,25 @@ N 0 761 M -42 0 D S
 N 0 931 M -42 0 D S
 N 0 1015 M -42 0 D S
 N 0 1100 M -42 0 D S
--533 591 M 167 F0
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R V MU 0 0 M (CO) FP 0 -42 G 117 F0 (2) FP 0 42 G 167 F0 ( \(PPM\)) FP pathbbox N pop exch pop add U -2 div 0 G
 (CO) Z
 0 -42 G 117 F0 (2) Z
 0 42 G 167 F0 ( \(PPM\)) Z
 U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1376,6 +2200,20 @@ N 0 1181 M 0 -1181 D S
 N 0 169 M 83 0 D S
 N 0 508 M 83 0 D S
 N 0 846 M 83 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+133 F0
+(100) sw mx
+(200) sw mx
+(300) sw mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+169 PSL_A0_y MM
+(100) mr Z
+508 PSL_A0_y MM
+(200) mr Z
+846 PSL_A0_y MM
+(300) mr Z
 N 0 0 M 42 0 D S
 N 0 85 M 42 0 D S
 N 0 254 M 42 0 D S
@@ -1387,72 +2225,188 @@ N 0 761 M 42 0 D S
 N 0 931 M 42 0 D S
 N 0 1015 M 42 0 D S
 N 0 1100 M 42 0 D S
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/PSL_LH 167 F0
+(M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R V MU 0 0 M (CO) FP 0 -42 G 117 F0 (2) FP 0 42 G 167 F0 ( \(PPM\)) FP pathbbox N pop exch pop add U -2 div 0 G
+(CO) Z
+0 -42 G 117 F0 (2) Z
+0 42 G 167 F0 ( \(PPM\)) Z
+U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 0 A
 FQ
 O0
+% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
-%@GMT: gmt psbasemap -Y2.5c -BWsen -Bxa100 -By+lTectonics -JX16c/2.5c -R6/17/0/1 -P -O
+%@GMT: gmt psbasemap -Y2.5c -BWsEn -Bxa100 -By+lTectonics -JX16c/2.5c -R6/17/0/1 -P -O
 %@PROJ: xy 6.00000000 17.00000000 0.00000000 1.00000000 6.000 17.000 0.000 1.000 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
+%
+% Start of basemap (placed before the plot contents)
+%
+%
+% Start of gridlines - if any
+%
+%
+% Start of map frame
+%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
+%
+% Start of left y-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
--533 591 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_LH PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
 167 F0
+(M) sh def
+/PSL_L_y 533 def
+591 PSL_L_y MM
 V 90 R (Tectonics) bc Z U
+%
+% End of left y-axis
+%
+%
+% Start of right y-axis
+%
 7559 0 T
+%
+% Axis tick marks and annotations
+%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
-/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+/MM {exch M} def
+/PSL_LH (M) sh def
+/PSL_L_y 533 PSL_LH add def
+591 PSL_L_y MM
+V 90 R (Tectonics) bc Z U
+%
+% End of right y-axis
+%
 -7559 0 T
+%
+% Start of lower x-axis
+%
+%
+% Axis tick marks and annotations
+%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of lower x-axis
+%
+%
+% Start of upper x-axis
+%
 0 1181 T
+%
+% Axis tick marks and annotations
+%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+%
+% End of upper x-axis
+%
 0 -1181 T
 0 setlinecap
+%
+% End of map frame
+%
+%
+% End of basemap (placed before the plot contents)
+%
+%
+% Start of basemap (placed after the plot contents)
+%
+%
+% End of basemap (placed after the plot contents)
+%
 0 A
 %%EndObject
 
 grestore
+%
+% Run PSL movie label completion function, if defined
+%
 PSL_movie_label_completion /PSL_movie_label_completion {} def
+%
+% Run PSL movie progress indicator completion function, if defined
+%
 PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
+%
+% Reset transformations and call showpage
+%
 U
 showpage
 

--- a/test/psbasemap/fixed_labeldist.ps
+++ b/test/psbasemap/fixed_labeldist.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.3.0_1321ce8_2021.06.11 [64-bit] Document from psbasemap
+%%Title: GMT v6.3.0_a08f6c5-dirty_2021.06.11 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jun 11 17:14:37 2021
+%%CreationDate: Fri Jun 11 18:42:23 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -13,7 +13,6 @@
 %%EndComments
 
 %%BeginProlog
-% Begin pslib header
 250 dict begin
 /! {bind def} bind def
 /# {load def}!
@@ -44,71 +43,42 @@
 /MS {/SMat matrix currentmatrix def}!
 /MR {SMat setmatrix}!
 /edef {exch def}!
-% Path fill
 /FS {/fc edef /fs {V fc F U} def}!
 /FQ {/fs {} def}!
-% Outline off or on
 /O0 {/os {N} def}!
 /O1 {/os {P S} def}!
-% Set both fill and outline
 /FO {fs os}!
-% Star: radius xc yc
 /Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
-% Box: height width xll yll
 /Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
-% Rounded box: height width radius xll yll
 /SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
   BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
-% Circle: radius xc yc
 /Sc {N 3 -1 roll 0 360 arc FO}!
-% Diamond: radius xc yc
 /Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
-% Ellipse: major minor angle xc yc
 /Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
-% Octagon: radius xc yc
 /Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
-% Hexagon: radius xc yc
 /Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
-% Inverted triangle: radius xc yc
 /Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
-% Rotated rectangle: height width angle xc yc
 /Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
-% Pentagon: radius xc yc
 /Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
-% Dot: radius xc yc [hardwired as circle with no outline]
 /Sp {N 3 -1 roll 0 360 arc fs N}!
-% Patch fill: x1 y1 ... xn yn n
 /SP {M {D} repeat FO}!
-% Rectangle: height width xc yc
 /Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
-% Rounded rectangle: height width radius xc yc
 /SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
   BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
-% Square: radius xc yc
 /Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
-% Triangle: radius xc yc
 /St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
-% Single-headed vector
 /SV {0 exch M 0 D D D D D 0 D FO}!
-% Double-headed vector
 /Sv {0 0 M D D 0 D D D D D 0 D D FO}!
-% Pie Wedge: radius angle1 angle2 xc yc
 /Sw {2 copy M 5 2 roll arc FO}!
-% Cross: radius xc yc
 /Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
-% Y-dash: radius xc yc
 /Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
-% Plus: radius xc yc
 /S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
-% X-dash: radius xc yc
 /S- {M dup 0 G dup -2 mul dup 0 D S}!
-% String width, height, depth and total height (height-depth)
 /sw {stringwidth pop}!
 /sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
 /sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
 /sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
 /sb {E exch sh}!
-% To align text {bottom,middle,top}{left,center,right}
 /bl {}!
 /bc {E -2 div 0 G}!
 /br {E neg 0 G}!
@@ -118,75 +88,71 @@
 /tl {dup 0 exch sh neg G}!
 /tc {dup E -2 div exch sh neg G}!
 /tr {dup E neg exch sh neg G}!
-% Maximum of two numbers
 /mx {2 copy lt {exch} if pop}!
-% Translate and memorize advance
 /PSL_xorig 0 def /PSL_yorig 0 def
 /TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
-% To re-encode one font with the provided encoding vector
 /PSL_reencode {findfont dup length dict begin
   {1 index /FID ne {def}{pop pop} ifelse} forall
   exch /Encoding edef currentdict end definefont pop
 }!
-/PSL_eps_begin {					% Marks begin of EPSF inclusion
-  /PSL_eps_state save def				% Save state for cleanup
-  /PSL_dict_count countdictstack def			% Count objects on dict stack
-  /PSL_op_count count 1 sub def				% Count objects on operand stack
-  userdict begin					% Push userdict stack
-  /showpage {} def					% Deactivate showpage command
-  0 setgray 0 setlinecap 1 setlinewidth			% Prepare clean graphics state
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
   0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
-  /languagelevel where	% If level != 1, set strokeadjust and overprint to their defaults
+  /languagelevel where
   {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
 }!
-/PSL_eps_end {						% Marks end of EPSF inclusion
-  count PSL_op_count sub {pop} repeat			% Clean up operand stack
-  countdictstack PSL_dict_count sub {end} repeat	% Clean up dict stack
-  PSL_eps_state restore					% Restore saved state
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
 }!
-/PSL_transp {             % Changes the transparency settings
+/PSL_transp {
   /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
   /.setfillconstantalpha where
-  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }  % Ghostscript
-  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if } % Or Adobe
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
-/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def	% Initially zero
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
 /F1 {/Helvetica-Bold Y}!
 /F2 {/Helvetica-Oblique Y}!
@@ -226,320 +192,185 @@
 /F36 {/Ryumin-Light-EUC-V Y}!
 /F37 {/GothicBBB-Medium-EUC-H Y}!
 /F38 {/GothicBBB-Medium-EUC-V Y}!
-
-/PSL_pathtextdict 26 dict def			% Local storage for the procedure PSL_pathtext.
-
-/PSL_pathtext					% PSL_pathtext'' will place a string
-  {PSL_pathtextdict begin			% of text along any path. It takes
-    /ydepth exch def                            % a string and starting offset
-    /textheight exch def			% distance from the beginning of
-    /just exch def				% the path as its arguments. Note
-    /offset exch def				% that PSL_pathtext assumes that a
-    /str exch def				% path has already been defined
-						% and after it places the text
-						% along the path, it clears the
-						% current path like the ``stroke''
-						% and ``fill'' operators; it also
-						% assumes that a font has been
-						% set. ``pathtext'' begins placing
-						% the characters along the current
-						% path, starting at the offset
-						% distance and continuing until
-						% either the path length is
-						% exhausted or the entire string
-						% has been printed, whichever
-						% occurs first. The results will
-						% be more effective when a small
-						% point size font is used with
-						% sharp curves in the path.
-						
-
-    /pathdist 0 def				% Initialize the distance we have
-						% travelled along the path.
-    /setdist offset def				% Initialize the distance we have
-						% covered by setting characters.
-    /charcount 0 def				% Initialize the character count.
-    /justy just 4 idiv textheight mul 2 div neg ydepth sub def % Compute the y-shift
-    V flattenpath				% Reduce the path to a series of
-						% straight line segments. The
-						% characters will be placed along
-						% the line segments in the
-						% ``linetoproc.''
-	{movetoproc} {linetoproc}		% The basic strategy is to process
-	{curvetoproc} {closepathproc}		% the segments of the path,
-	pathforall				% keeping a running total of the
-						% distance we have travelled so
-						% far (pathdist). We also keep
-						% track of the distance taken up
-						% by the characters that have been
-						% set so far (setdist). When the
-						% distance we have travelled along
-						% the path is greater than the
-						% distance taken up by the set
-						% characters, we are ready to set
-						% the next character (if there are
-						% any left to be set). This
-						% process continues until we have
-						% exhausted the full length of the
-						% path.
-    U N						% Clear the current path.
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
     end
   } def
-
 PSL_pathtextdict begin
-/movetoproc					% ``movetoproc'' is executed when
-  { /newy exch def /newx exch def		% a moveto component has been
-						% encountered in the pathforall
-						% operation.
-    /firstx newx def /firsty newy def		% Remember the ``first point'' in
-						% the path so that when we get a
-						% ``closepath'' component we can
-						% properly handle the text.
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
     /ovr 0 def
     newx newy transform
-    /cpy exch def /cpx exch def			% Explicitly keep track of the
-						% current position in device
-						% space.
+    /cpy exch def /cpx exch def
   } def
-
-/linetoproc					% ``linetoproc'' is executed when
-						% a lineto component has been
-						% encountered in the pathforall
-						% operation.
-  { /oldx newx def /oldy newy def		% Update the old point.
-    /newy exch def /newx exch def		% Get the new point.
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
     /dx newx oldx sub def
     /dy newy oldy sub def
-    /dist dx dup mul dy dup mul add sqrt def	% Calculate the distance between
-						% the old and the new point.
+    /dist dx dup mul dy dup mul add sqrt def
     dist 0 ne
-    { /dsx dx dist div ovr mul def		% dsx and dsy are used to update
-      /dsy dy dist div ovr mul def		% the current position to be just
-						% beyond the width of the previous
-						% character.
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
       oldx dsx add oldy dsy add transform
-      /cpy exch def /cpx exch def		% Update the current position.
-      /pathdist pathdist dist add def		% Increment the distance we have
-						% travelled along the path.
-      {setdist pathdist le			% Keep setting characters along
-						% this path segment until we have
-						% exhausted its length.
-	  {charcount str length lt		% As long as there are still
-	      {setchar} {exit} ifelse}		% characters left in the string,
-						% set them.
-	  { /ovr setdist pathdist sub def		% Keep track of how much we have
-	    exit}				% overshot the path segment by
-	  ifelse					% setting the previous character.
-						% This enables us to position the
-						% origin of the following
-						% characters properly on the path.
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
       } loop
     } if
   } def
-
-/curvetoproc					% ``curvetoproc'' is executed when
-  { (ERROR: No curveto's after flattenpath!)	% a curveto component has been
-    print					% encountered in the pathforall
-  } def						% operation. It prints an error
-						% message since there shouldn't be
-						% any curveto's in a path after
-						% the flattenpath operator has
-						% been executed.
-
-/closepathproc					% ``closepathproc'' is executed
-  {firstx firsty linetoproc			% when a closepath component has
-    firstx firsty movetoproc			% been encountered in the
-  } def						% pathforall operation. It
-						% simulates the action of the
-						% operator ``closepath'' by
-						% executing ``linetoproc'' with
-						% the coordinates of the most
-						% recent ``moveto'' and then
-						% executing ``movetoproc'' to the
-						% same point.
-
-/setchar					% ``setchar'' sets the next
-  { /char str charcount 1 getinterval def	% character in the string along
-						% the path and then updates the
-						% amount of path we have
-						% exhausted.
-    /charcount charcount 1 add def		% Increment the character count.
-    /charwidth char stringwidth pop def		% Find the width of the character.
-    V cpx cpy itransform T			% Translate to the current
-						% position in user space.
-      dy dx atan R				% Rotate the x-axis to coincide
-						% with the current segment.
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
       0 justy M
-      PSL_font_F {  % Show text normally, if requested
+      PSL_font_F {
         char show}
       if
-      PSL_font_FO { % Fill first then outline, if requested
+      PSL_font_FO {
         currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
       } if
-      PSL_font_OF { % Outline text then fill, if requested
+      PSL_font_OF {
         currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
       } if
       0 justy neg G currentpoint transform
-      /cpy exch def /cpx exch def		% Update the current position
-    						% before we restore ourselves to
-						% the untransformed state.
-    U /setdist setdist charwidth add def	% Increment the distance we have
-  } def						% covered by setting characters.
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
 end
-
-% PSL LABEL CLIP FUNCTIONS
-
-% Two main functions deals with label placement and clipping:
-% PSL_curved_path_labels: 	handles texts that must follow curved baselines
-% PSL_straight_path_labels:	handles texts that have straight baselines
-%
-% Both functions assume that several variables have been predefined:
-%
-% First we have these two constant settings for all text boxes:
-%
-%   PSL_setboxpen  Function that sets the text box pen attributes (width, texture, color)
-%   PSL_setboxrgb  Function that sets the opaque text box color
-%
-% Then several arrays are placed.  Since a set of several lines segments may each
-% have many labels along them, we end up with these variables:
-%
-%   PSL_n_paths		Total number of segments
-%   PSL_path_x		x coordinates of the paths (all concatenated one after another)
-%   PSL_path_y		y coordinates of the paths (all concatenated one after another)
-%   PSL_path_n		Array with number of points per segment
-%   PSL_label_str  	Array with all the labels for all segments
-%   PSL_label_n		Array with number of labels per segment
-%   PSL_angle		The annotation angle for each label
-%
-% PSL_curved_path_labels expects those labels to be placed along several
-% lines and it needs the node numbers where to place text:
-%
-% PSL_node	Array with (x,y) node number of label position
-%
-% PSL_straight_path_labels are simpler and instead expects
-%
-% PSL_txt_x	(x,y) coordinates of the location of the m labels
-% PSL_txt_y
-
 /PSL_set_label_heights
-{	% Create array PSL_heights with full label heights
-  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def	% Upper limit in loop over labels
-  /PSL_heights PSL_n_labels array def		% Create array with text heights
-  0 1 PSL_n_labels_minus_1			% Loop psl_k = 0 < PSL_n_labels
-  { /psl_k exch def				% Current label index psl_k
-    /psl_label PSL_label_str psl_k get def	% Current text label
-    PSL_label_font psl_k get cvx exec		% Get and set this label's font attributes
-    psl_label sH /PSL_height edef		% Compute the height of this string
-    PSL_heights psl_k PSL_height put		% Store it in the array
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
   } for
 } def
-
-% Curved Baseline Text Placement Functions
-
 /PSL_curved_path_labels
-{ /psl_bits exch def				% 4 on/of bit settings as indicated below
-  /PSL_placetext psl_bits 2 and 2 eq def		% true to place text, false to just make space
-  /PSL_clippath psl_bits 4 and 4 eq def		% false inactive, true creates clippath for labels
-  /PSL_strokeline false def			% true draws line, false skips
-  /PSL_fillbox psl_bits 128 and 128 eq def		% true to paint box opaque before placing text, false gives transparent box
-  /PSL_drawbox psl_bits 256 and 256 eq def		% true to draw box outline before placing text, false gives no outline
-  /PSL_font_F  psl_bits 1536 and 0 eq def     % true to paint regular text
-  /PSL_font_FO psl_bits 512 and 512 eq def    % true to fill text first then draw outline
-  /PSL_font_OF psl_bits 1024 and 1024 eq def  % true to draw outline of text first then fill inside
-  /PSL_n_paths1 PSL_n_paths 1 sub def		% one less is the upper limit in for loop over the paths
-  /PSL_usebox PSL_fillbox PSL_drawbox or def	% true if we need box outline for fill or stroke or both
-
-  PSL_clippath {clipsave N clippath} if		% Bracket with clipsave/cliprestore and start clip path
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
   /psl_k 0 def
   /psl_p 0 def
   0 1 PSL_n_paths1
-  { /psl_kk exch def						% Index into the PSL_n PSL_m arrays
-    /PSL_n PSL_path_n  psl_kk get def				% Get the number of points in this line segment
-    /PSL_m PSL_label_n psl_kk get def				% Get the number of labels for this line segment
-    /PSL_x PSL_path_x psl_k PSL_n getinterval def		% Get the subset that is the current line segment x-coordinates
-    /PSL_y PSL_path_y psl_k PSL_n getinterval def		% Get the subset that is the current line segment y-coordinates
-    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def	% Get the subset of node values for current line segment
-    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def	% Get the subset of angle values for current line segment
-    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def		% Get the subset of string values for current line segment
-    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def		% Get the subset of font settings for current line segment
-    PSL_curved_path_label					% Operate on this segment only
-    /psl_k psl_k PSL_n add def					% Go to next segment start index for path
-    /psl_p psl_p PSL_m add def					% Go to next segment start index for nodes
-  } for  % The loop over segments
-  			
-  PSL_clippath {PSL_eoclip} if N			% Activate clip path and return
-
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
 } def
-
 /PSL_curved_path_label
-{	% Deals with a single line segment and its labels
-  /PSL_n1 PSL_n 1 sub def	% one less is the upper limit in for loops
-  /PSL_m1 PSL_m 1 sub def	% same
-
-  PSL_CT_calcstringwidth	% Calculate the width of each label string
-  PSL_CT_calclinedist		% Calculate along-track distances
-  PSL_CT_excludelabels		% Possibly eliminate labels outside of line domain
-  PSL_CT_addcutpoints		% Expand path to include the cut points
-
-% Now we have the final xx/yy array and we are ready to simply lay down the lines
-% and place the text along the line where there are labels.  We will use the
-% new array PSL_xp/yp to store the final points prior to use
-
-  /PSL_nn1 PSL_nn 1 sub def		% End index in for loop
-  /n 0 def				% Toggle: 0 means line, 1 means text
-  /k 0 def				% Index of the current text string
-  /j 0 def				% Output point number counter
-  /PSL_seg 0 def			% Line segment number
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
   /PSL_xp PSL_nn array def
   /PSL_yp PSL_nn array def
-  PSL_xp 0 PSL_xx 0 get put		% Place first point in array
+  PSL_xp 0 PSL_xx 0 get put
   PSL_yp 0 PSL_yy 0 get put
-  1 1 PSL_nn1				% Loop over rest of points
-  { /i exch def				% Index into PSL_xx/yy arrays
-    /node_type PSL_kind i get def	% Check what kind of point the current point is
-    /j j 1 add def			% Update point count
-    PSL_xp j PSL_xx i get put		% Add this point to the path
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
     PSL_yp j PSL_yy i get put
-    node_type 1 eq			% If this is a cut point we either stroke or place text
-    {n 0 eq		% n is 0 so this is the strokable segment
+    node_type 1 eq
+    {n 0 eq
       {PSL_CT_drawline}
-      {   % here, n = 1 so this is the segment along which text should be placed
+      {
         PSL_CT_reversepath
 	      PSL_CT_textline}
-      ifelse		% Reverse path if needed to place text correctly
+      ifelse
       /j 0 def
-      PSL_xp j PSL_xx i get put		% Place new first point in array
+      PSL_xp j PSL_xx i get put
       PSL_yp j PSL_yy i get put
     } if
   } for
-  n 0 eq {PSL_CT_drawline} if	% Finish off the last line segment
-
+  n 0 eq {PSL_CT_drawline} if
 } def
-
 /PSL_CT_textline
-{ PSL_fnt k get cvx exec		% Get and set this label's font attributes
-  /PSL_height PSL_heights k get def	% Recall the height of this text
-  PSL_placetext	{PSL_CT_placelabel} if	% If we want to place the text
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
-  /n 0 def /k k 1 add def		% Set n back to 0, goto next label
+  /n 0 def /k k 1 add def
 } def
-
-/PSL_CT_calcstringwidth			% Calculate the width of each label string
-{ /PSL_width_tmp PSL_m array def	% Assign space for distance
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
   0 1 PSL_m1
   { /i exch def
-    PSL_fnt_tmp i get cvx exec					% Get and set this label's font attributes
-    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put	% Compute width and store in the array
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
   } for
 } def
-
-/PSL_CT_calclinedist			% Calculate the distance along the line
+/PSL_CT_calclinedist
 { /PSL_newx PSL_x 0 get def
   /PSL_newy PSL_y 0 get def
-  /dist 0.0 def			% Cumulative distance at first point is 0
-  /PSL_dist PSL_n array def	% Assign array space for distance
-  PSL_dist 0 0.0 put		% Distances start at 0 and the 'th point
-  1 1 PSL_n1			% Loop over the remaining points
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
   { /i exch def
     /PSL_oldx PSL_newx def
     /PSL_oldy PSL_newy def
@@ -551,100 +382,86 @@ end
     PSL_dist i dist put
   } for
 } def
-
-% Some labels (in particular first and last per segment) may be too long
-% to actually fit inside the length of the line.  We precalculate the
-% start and end distances for each label and those that exceed the length
-% of the line cannot be plotted and are thus skipped.  The surviving labels
-% and their information is copied to the final PSL arrays
-
 /PSL_CT_excludelabels
-{ /k 0 def				% Current cut point
-  /PSL_width PSL_m array def		% New array of distances
-  /PSL_angle PSL_m array def		% New array of angles
-  /PSL_node PSL_m array def		% New array of nodes
-  /PSL_str PSL_m array def		% New array of strings
-  /PSL_fnt PSL_m array def		% New array of fonts
-  /lastdist PSL_dist PSL_n1 get def	% Length of line 
-  0 1 PSL_m1				% For each of the m labels
-  { /i exch def						% Index for label distance
-    /dist PSL_dist PSL_node_tmp i get get def		% Recall the distance to this label center
-    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def	% Set the halfwidth + gap distance
-    /L_dist dist halfwidth sub def			% Distance at beginning of label gap
-    /R_dist dist halfwidth add def			% Distance at the end of label gap
-    L_dist 0 gt R_dist lastdist lt and		% Yes, label is inside line ends
-    { % These are the labels we will use
-      PSL_width k PSL_width_tmp i get put	% Copy over width
-      PSL_node k PSL_node_tmp i get put		% Copy over node
-      PSL_angle k PSL_angle_tmp i get put	% Copy over angle
-      PSL_str k PSL_str_tmp i get put		% Copy over text
-      PSL_fnt k PSL_fnt_tmp i get put		% Copy over font
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
       /k k 1 add def
     } if
   } for
-  /PSL_m k def	% New number of labels
+  /PSL_m k def
   /PSL_m1 PSL_m 1 sub def
 } def
-
-% Initialize an array with all the original line points plus the set of 2*m
-% points at the transition from line to labelspace at each label
-% At the end of this section, the PSL_xx/yy array will be the array to use.
-
 /PSL_CT_addcutpoints
-{ /k 0 def				% Current cut point
-  /PSL_nc PSL_m 2 mul 1 add def		% 2*m points + one last acting as infinity
-  /PSL_cuts PSL_nc array def		% The array of distances to each cut
-  /PSL_nc1 PSL_nc 1 sub def		% One less to use in for loop limits
-  0 1 PSL_m1				% For each of the m labels
-  { /i exch def						% Index for label distance
-    /dist PSL_dist PSL_node i get get def		% Recall the distance to this label center
-    /halfwidth PSL_width i get 2 div PSL_gap_x add def	% Set the halfwidth + gap distance
-    PSL_cuts k dist halfwidth sub put			% Distance at beginning of label gap
-    /k k 1 add def					% Was at start, now go to end distance node
-    PSL_cuts k dist halfwidth add put			% Distance at the end of label gap
-    /k k 1 add def					% Was at end, move to next
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
   } for
-  PSL_cuts k 100000.0 put				% Last cut has ~infinite distance
-
-  /PSL_nn PSL_n PSL_m 2 mul add def	% The total path will be 2*m points longer
-  /PSL_xx PSL_nn array def		% Assign new space for x and y
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
   /PSL_yy PSL_nn array def
-  /PSL_kind PSL_nn array def		% 0 = ordinary point, 1 = added point for label gap
-  /j 0 def				% Index for new track array
-  /k 0 def				% Index for current cut distance
-  /dist 0.0 def				% Current distance along track, starting at zero
-  0 1 PSL_n1				% Loop over every original line point
-  { /i exch def				% Index into current point on original line xy array
-    /last_dist dist def			% Update distance to last point (initially zero)
-    /dist PSL_dist i get def		% Distance to current point
-    k 1 PSL_nc1				% Loop over remaining cuts (starting with all)
-    { /kk exch def			% Index into current cut distance
-      /this_cut PSL_cuts kk get def	% Distance to start of this label gap
-      dist this_cut gt			% Oh, oh, we just stepped over a cut point
-      { /ds dist last_dist sub def	% Change in distance
-	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def	% Get fractional change in distance
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
 	/i1 i 0 eq {0} {i 1 sub} ifelse def
-	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put	% Calc (x,y) at label start (or stop) point
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
 	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
-	PSL_kind j 1 put		% Set PSL_kind to 1 since it is an added cut point
-	/j j 1 add def			% Go to next output point
-	/k k 1 add def			% Done with this cut point
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
       } if
     } for
-    dist PSL_cuts k get le		% Having dealt with the cut, we may add the regular point
+    dist PSL_cuts k get le
     {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
-      PSL_kind j 0 put			% Ordinary (original) coordinates
-      /j j 1 add def			% Go to next output point
+      PSL_kind j 0 put
+      /j j 1 add def
     } if
   } for
 } def
-
 /PSL_CT_reversepath
-{PSL_xp j get PSL_xp 0 get lt	% Path must first be reversed to avoid upside-down text
-  {0 1 j 2 idiv		% Loop over half the path and swap left/right points
-    { /left exch def		% Current left point
-      /right j left sub def	% Matching right point
-      /tmp PSL_xp left get def	% Swap left and right values for x then y
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
       PSL_xp left PSL_xp right get put
       PSL_xp right tmp put
       /tmp PSL_yp left get def
@@ -652,252 +469,218 @@ end
       PSL_yp right tmp put
     } for
   } if
-  % Now PSL_xp/yp has the correct order to give proper text angles
 } def
-
 /PSL_CT_placelabel
-{ % Places the curved text label on current segment
-  /PSL_just PSL_label_justify k get def	% Get this labels justification
-  /PSL_height PSL_heights k get def	% Recall the height of this string
-  /psl_label PSL_str k get def		% Get the current label
-  /psl_depth psl_label sd def		% Determine depth beneath baseline
-  PSL_usebox		% Want to lay down box outline or fill
-  {PSL_CT_clippath	% Box path now current path
-    PSL_fillbox		% Want to paint box
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
     {V PSL_setboxrgb fill U} if
-    PSL_drawbox		% Want to draw outline of box
+    PSL_drawbox
     {V PSL_setboxpen S U} if N
   } if
   PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
 } def
-
 /PSL_CT_clippath
-{ % Lays down a curved clipbox for one label
+{
   /H PSL_height 2 div PSL_gap_y add def
   /xoff j 1 add array def
   /yoff j 1 add array def
-  /angle 0 def	% So it is at least a defined variable
-  0 1 j {	% Loop over points along line to calculate angle and offsets
-    /ii exch def	% Index
+  /angle 0 def
+  0 1 j {
+    /ii exch def
     /x PSL_xp ii get def
     /y PSL_yp ii get def
-    ii 0 eq {	% Are we at the first point and hence must calculate angle using 0 and 1?
+    ii 0 eq {
       /x1 PSL_xp 1 get def
       /y1 PSL_yp 1 get def
       /dx x1 x sub def
       /dy y1 y sub def
     }
-    { /i1 ii 1 sub def	% Previous point
+    { /i1 ii 1 sub def
       /x1 PSL_xp i1 get def
       /y1 PSL_yp i1 get def
       /dx x x1 sub def
       /dy y y1 sub def
     } ifelse
     dx 0.0 eq dy 0.0 eq and not
-    { /angle dy dx atan 90 add def} if	% Only calculate new angle if not duplicates
+    { /angle dy dx atan 90 add def} if
     /sina angle sin def
     /cosa angle cos def
     xoff ii H cosa mul put
     yoff ii H sina mul put
   } for
-
-  % Lay down next clip segment
-
   PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
-  1 1 j {	% Loop over the rest of the upper line
+  1 1 j {
     /ii exch def
     PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
   } for
-  j -1 0 {	% Loop backwards over the rest of the lower line
+  j -1 0 {
     /ii exch def
     PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
   } for P
 } def
-
 /PSL_CT_drawline
 {
   /str 20 string def
-  % PSL_strokeline PSL_seg 0 eq and		% If we asked to draw lines...
-  PSL_strokeline				% If we asked to draw lines...
-  {PSL_CT_placeline S} if			% Lay down the rest of the path and stroke it
-  /PSL_seg PSL_seg 1 add def			% Goto next segment number
-  /n 1 def					% Set n to 1
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
 } def
-
 /PSL_CT_placeline
-{PSL_xp 0 get PSL_yp 0 get M			% Set the anchor point of the path
-  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for	% Lay down the rest of the path
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
 } def
-
-% Draw Baseline Text Segment Lines
-% PSL_draw_path_lines will draw the lines that have been stored in the concatenated
-% PSL_path_x and PSL_path_y arrays using the pen attributes in the PSL_path_pen array
-
 /PSL_draw_path_lines
-{	% Draws the lines already stored in the PSL_path_x|y arrays
-  /PSL_n_paths1 PSL_n_paths 1 sub def		% One less is the upper limit in for loop over the paths
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
   V
-  /psl_start 0 def					% Start index of segment in concatenated path array
-  0 1 PSL_n_paths1					% Loop over all segments
-  { /psl_k exch def					% Index into the PSL arrays
-    /PSL_n PSL_path_n psl_k get def			% Get the number of points in this line segment
-    /PSL_n1 PSL_n 1 sub def				% One less is the upper limit in for loop over points
-    PSL_path_pen psl_k get cvx exec			% Get and set this line's pen
-    N							% Clean path
-    PSL_path_x psl_start get PSL_path_y psl_start get M	% Place anchor point of this segment
-    1 1 PSL_n1						% Loop over points in this segment
-    { /psl_i exch def					% Local index of next point in segment
-      /psl_kk psl_i psl_start add def			% Equivalent index in concatenated array of all segments
-      PSL_path_x psl_kk get PSL_path_y psl_kk get L	% Draw to next point
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
     } for
-    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def	% Difference between first and last x coordinate
-    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def	% Difference between first and last y coordinate
-    psl_xclose 0 eq psl_yclose 0 eq and { P } if	% Explicitly close the path
-    S							% Stroke this path
-    /psl_start psl_start PSL_n add def			% Go to next segment and update start index for path
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
   } for
   U
 } def
-
-% Straight Baseline Text Placement Functions
-% PSL_straight_path_labels deals with straight text labels w/wo textboxes (rect or rounded).
-% Only the (x,y) location of each label is needed.
-% Use <flags> PSL_straight_path_labels to paint|draw textboxes and place text
-% Use <flags> PSL_straight_path_clip to use textboxes to define and activate clipping
-% Subroutines of these functions are called PSL_ST_*
-% Local variables are called psl_*, global are called PSL_*
-
 /PSL_straight_path_labels
-{	% This function will lay down (a) text box paint, (b) text box outline, and (c) text labels
-	% All of these are optionals specified by the bit flag.
-  /psl_bits exch def				% Single bitflag argument passed
-  /PSL_placetext psl_bits 2 and 2 eq def	% true to place text, false to just make space
-  /PSL_rounded psl_bits 32 and 32 eq def	% true for rounded box shape, false gives rectangular box
-  /PSL_fillbox psl_bits 128 and 128 eq def	% true to paint box opaque before placing text
-  /PSL_drawbox psl_bits 256 and 256 eq def  % true to draw box outline before placing text
-  /PSL_font_F  psl_bits 1536 and 0 eq def     % true to paint regular text
-  /PSL_font_FO psl_bits 512 and 512 eq def    % true to fill text first then draw outline
-  /PSL_font_OF psl_bits 1024 and 1024 eq def  % true to draw outline of text first then fill inside
-  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def	% Upper limit in loop over labels
-  /PSL_usebox PSL_fillbox PSL_drawbox or def	% true if we need box outline for fill or stroke or both
-  0 1 PSL_n_labels_minus_1			% Loop psl_k = 0 < PSL_n_labels
-  { /psl_k exch def				% Current label index psl_k
-    PSL_ST_prepare_text				% Get all dimensions, coordinates, etc. for this label
-    PSL_usebox					% If a text box is requested we go in here:
-    {  PSL_rounded				% Place text box path, either straight or rounded, on stack
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
         {PSL_ST_textbox_round}
         {PSL_ST_textbox_rect}
       ifelse
-      PSL_fillbox {V PSL_setboxrgb fill U} if	% Paint it, if requested
-      PSL_drawbox {V PSL_setboxpen S U} if	% Outline it, if requested
-      N						% Done, so remove path
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
     } if
-    PSL_font_F {  % Show text normally, if requested
+    PSL_font_F {
       PSL_placetext {PSL_ST_place_label} if
     } if
-    PSL_font_FO { % Fill first then outline, if requested
+    PSL_font_FO {
       PSL_placetext {PSL_ST_place_label_FO} if
     } if
-    PSL_font_OF { % Outline text then fill, if requested
+    PSL_font_OF {
       PSL_placetext {PSL_ST_place_label_OF} if
     } if
   } for
 } def
-
 /PSL_straight_path_clip
-{	% This function will create a total clip path for all the labels in PSL_txt
-  /psl_bits exch def				% Single bit flag argument passed
-  /PSL_rounded psl_bits 32 and 32 eq def	% true for rounded box shape, false gives rectangular box
-  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def	% Upper limit in loop over labels
-
-  N clipsave clippath				% Start clip path by selecting the entire mappable area
-  0 1 PSL_n_labels_minus_1			% Loop over all labels
-  { /psl_k exch def				% Current label index psl_k
-    PSL_ST_prepare_text				% Get all dimensions, coordinates, etc. for this label
-    PSL_rounded					% Get either straight or rounded text box path
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
       {PSL_ST_textbox_round}
       {PSL_ST_textbox_rect}
     ifelse
   } for
-  PSL_eoclip N					% Set the new clip path, increment clip counter and clear path
+  PSL_eoclip N
 } def
-
-/PSL_ST_prepare_text		% Compute various dimensions and coordinates for one label
-{ % The current label has index psl_k
-  /psl_xp PSL_txt_x psl_k get def		% Get text placement x coordinate
-  /psl_yp PSL_txt_y psl_k get def		% Get text placement y coordinate
-  /psl_label PSL_label_str psl_k get def	% Current text label
-  PSL_label_font psl_k get cvx exec		% Get and set this label's font attributes
-  /PSL_height PSL_heights psl_k get def		% Recall the height of this string
-  /psl_boxH PSL_height PSL_gap_y 2 mul add def	% Set height of current label including clearance
-  /PSL_just PSL_label_justify psl_k get def	% Get text justification (1-11)
-  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def % This is 0, -0.5, or -1 for relative x-shift 
-  /PSL_justy PSL_just 4 idiv 2 div neg def	% This is 0, -0.5, or -1 for relative y-shift 
-  /psl_SW psl_label stringwidth pop def		% Width of current label space
-  /psl_boxW psl_SW PSL_gap_x 2 mul add def	% Width of current label space including clearance
-  /psl_x0 psl_SW PSL_justx mul def		% (psl_x0,psl_y0) is rotated/adjusted text LL point on inside rectangle relative to psl_xp,psl_yp
-  /psl_y0 PSL_justy PSL_height mul def		%
-  /psl_angle PSL_label_angle psl_k get def	% The angle of text w.r.t. baseline
-} def
-
-/PSL_ST_textbox_rect	% Compute and place rectangular path for current label
+/PSL_ST_prepare_text
 {
-  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T	% Rotate the coordinate system to follow baseline text and make (psl_x0,psl_y0) the new origin
-  PSL_gap_x neg PSL_gap_y neg M			% Set LL anchor point for rectangular box
-  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P	% Draw text box going CW
-  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T	% Unto trans/rot above
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
 } def
-
-/PSL_ST_textbox_round	% Compute and place rounded rectangular path for current label
+/PSL_ST_textbox_rect
 {
-  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def	% Smallest gap distance is our corner radius
-  /psl_xd PSL_gap_x psl_BoxR sub def 			% When x_gap exceeds y_gap there will be an adjustment in x, else 0
-  /psl_yd PSL_gap_y psl_BoxR sub def 			% When y_gap exceeds x_gap there will be an adjustment in y, else 0
-  /psl_xL PSL_gap_x neg def				% Left-most x coordinate of text box
-  /psl_yB PSL_gap_y neg def				% Bottom y coordinate of text box
-  /psl_yT psl_boxH psl_yB add def			% Top y coordinate of text box
-  /psl_H2 PSL_height psl_yd 2 mul add def		% Inner height when adjusting for any psl_yd offset
-  /psl_W2 psl_SW psl_xd 2 mul add def			% Inner width when adjusting for any psl_xd offset
-  /psl_xR psl_xL psl_boxW add def			% Right-most x coordinate of text box
-  /psl_x0 psl_SW PSL_justx mul def			% (psl_x0,psl_y0) is rotated/adjusted text LL point on inside rectangle relative to psl_xp,psl_yp
-  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T		% Rotate the coordinate system to follow baseline text and make (psl_x0,psl_y0) the new origin
-  psl_xL psl_yd M					% LL anchor point for rounded box is on lower left side just before rounded corner
-  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D	% Draw UL rounded corner and line to start of UR rounded corner
-  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D	% Draw UR rounded corner and line to LR rounded corner
-  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D	% Draw LR rounded corner and line to LL rounded corner
-  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P			% Draw LL rounded corner and close the clippath segment
-  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T	% Unto trans/rot above
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
 } def
-
-/PSL_ST_place_label % Just place the current label normally
+/PSL_ST_textbox_round
 {
-    V psl_xp psl_yp T psl_angle R % Set origin at text point and rotate the coordinate system to follow baseline text
-    psl_SW PSL_justx mul psl_y0 M % Goto LL point on label
-    psl_label dup sd neg 0 exch G show  % Place the text, adjust vertically for any depth below baseline
-    U         % Undo damage to coordinate system
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
 } def
-
-/PSL_ST_place_label_FO % Just place the current label by filling it, then outlining it
+/PSL_ST_place_label
 {
-    V psl_xp psl_yp T psl_angle R % Set origin at text point and rotate the coordinate system to follow baseline text
-    psl_SW PSL_justx mul psl_y0 M % Goto LL point on label
-    psl_label dup sd neg 0 exch G false charpath V fs U S N % Place the text, adjust vertically for any depth below baseline
-    U         % Undo damage to coordinate system
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
 } def
-
-/PSL_ST_place_label_OF % Just place the current label by drawing outline, then filling it
+/PSL_ST_place_label_FO
 {
-    V psl_xp psl_yp T psl_angle R % Set origin at text point and rotate the coordinate system to follow baseline text
-    psl_SW PSL_justx mul psl_y0 M % Goto LL point on label
-    psl_label dup sd neg 0 exch G false charpath V S U fs N % Place the text, adjust vertically for any depth below baseline
-    U         % Undo damage to coordinate system
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
 } def
-
-/PSL_nclip 0 def							% The depth of clipping in effect
-/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def			% Clip and update PSL_nclip
-/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def			% Even-odd clip and update PSL_nclip
-/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def	% Cliprestore and update PSL_nclip
-
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
 %%EndProlog
 
 %%BeginSetup
@@ -909,18 +692,9 @@ PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%Page: 1 1
 
 %%BeginPageSetup
-%
-% Init coordinate system and scales
-%
-%
-% Scale initialized to 0.06, so 1 inch equals 1200 Postscript units
-%
 V 0.06 0.06 scale
 %%EndPageSetup
 
-%
-% End of PSL header
-%
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
@@ -931,7 +705,6 @@ gsave
 0 A
 FQ
 O0
-% Set plot origin:
 1200 1200 TM
 
 % PostScript produced by:
@@ -942,25 +715,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -970,7 +728,7 @@ N 0 474 M -83 0 D S
 N 0 949 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 133 F0
 (0) sw mx
 (10) sw mx
@@ -995,16 +753,7 @@ V 90 R V MU 0 0 M (C) FP 0 -42 G 117 F0 (4) FP 0 42 G 167 F0 ( \(%\)) FP pathbbo
 0 -42 G 117 F0 (4) Z
 0 42 G 167 F0 ( \(%\)) Z
 U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1038,16 +787,7 @@ V 90 R V MU 0 0 M (C) FP 0 -42 G 117 F0 (4) FP 0 42 G 167 F0 ( \(%\)) FP pathbbo
 0 -42 G 117 F0 (4) Z
 0 42 G 167 F0 ( \(%\)) Z
 U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
@@ -1090,19 +830,10 @@ N 6185 0 M 0 -42 D S
 N 7559 0 M 0 -42 D S
 /PSL_LH 167 F0
 (M) sh def
-/PSL_L_y 533 PSL_LH add def
+/PSL_L_y PSL_A0_y PSL_A1_y mx 133 add PSL_LH add def
 3780 PSL_L_y MM
 (Age \(Ma\)) bc Z
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
@@ -1121,29 +852,13 @@ N 4810 0 M 0 42 D S
 N 6185 0 M 0 42 D S
 N 7559 0 M 0 42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 0 A
 FQ
 O0
-% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
@@ -1153,25 +868,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1181,7 +881,7 @@ N 0 595 M -83 0 D S
 N 0 1138 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 133 F0
 V MU 0 0 M (10) FP 0 47 G 93 F0 (2) FP 0 -47 G pathbbox N pop exch pop add U mx
 V MU 0 0 M (10) FP 0 47 G 93 F0 (3) FP 0 -47 G pathbbox N pop exch pop add U mx
@@ -1230,16 +930,7 @@ V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (T) FP 0 42 G 167 F0 ( \(grain/g\)) FP 
 0 -42 G 117 F0 (T) Z
 0 42 G 167 F0 ( \(grain/g\)) Z
 U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1297,58 +988,24 @@ V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (T) FP 0 42 G 167 F0 ( \(grain/g\)) FP 
 0 -42 G 117 F0 (T) Z
 0 42 G 167 F0 ( \(grain/g\)) Z
 U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 0 A
 FQ
 O0
-% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
@@ -1358,25 +1015,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1386,7 +1028,7 @@ N 0 591 M -83 0 D S
 N 0 901 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 133 F0
 (0.1) sw mx
 (0.2) sw mx
@@ -1414,16 +1056,7 @@ V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (L) FP 0 42 G 167 F0 (/MC) FP 0 -42 G 1
 0 42 G 167 F0 (/MC) Z
 0 -42 G 117 F0 (R) Z
 0 42 G U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1460,58 +1093,24 @@ V 90 R V MU 0 0 M (MC) FP 0 -42 G 117 F0 (L) FP 0 42 G 167 F0 (/MC) FP 0 -42 G 1
 0 42 G 167 F0 (/MC) Z
 0 -42 G 117 F0 (R) Z
 0 42 G U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 0 A
 FQ
 O0
-% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
@@ -1521,25 +1120,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1550,7 +1134,7 @@ N 0 709 M -83 0 D S
 N 0 946 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 133 F0
 (20) sw mx
 (40) sw mx
@@ -1577,16 +1161,7 @@ N 0 1064 M -42 0 D S
 /PSL_L_y 533 def
 591 PSL_L_y MM
 V 90 R (Grass \(%\)) bc Z U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1623,58 +1198,24 @@ N 0 1064 M 42 0 D S
 /PSL_L_y 533 PSL_LH add def
 591 PSL_L_y MM
 V 90 R (Grass \(%\)) bc Z U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 0 A
 FQ
 O0
-% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
@@ -1684,25 +1225,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1713,7 +1239,7 @@ N 0 709 M -83 0 D S
 N 0 946 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 133 F0
 (20) sw mx
 (40) sw mx
@@ -1740,16 +1266,7 @@ N 0 1064 M -42 0 D S
 /PSL_L_y 533 def
 591 PSL_L_y MM
 V 90 R (Grass \(%\)) bc Z U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -1786,58 +1303,24 @@ N 0 1064 M 42 0 D S
 /PSL_L_y 533 PSL_LH add def
 591 PSL_L_y MM
 V 90 R (Grass \(%\)) bc Z U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 0 A
 FQ
 O0
-% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
@@ -1847,45 +1330,21 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /MM {neg exch M} def
-/PSL_LH PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+/PSL_LH PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 167 F0
 (M) sh def
 /PSL_L_y 533 def
 591 PSL_L_y MM
 V 90 R (Fossils) bc Z U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
@@ -1894,60 +1353,26 @@ N 0 1181 M 0 -1181 D S
 /PSL_L_y 533 PSL_LH add def
 591 PSL_L_y MM
 V 90 R (Fossils) bc Z U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 0 A
 FQ
 O0
-% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
@@ -1957,25 +1382,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1985,7 +1395,7 @@ N 0 545 M -83 0 D S
 N 0 909 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 133 F0
 (3000) sw mx
 (3400) sw mx
@@ -2013,16 +1423,7 @@ N 0 1091 M -42 0 D S
 /PSL_L_y 533 def
 591 PSL_L_y MM
 V 90 R (MSH) bc Z U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -2059,58 +1460,24 @@ N 0 1091 M 42 0 D S
 /PSL_L_y 533 PSL_LH add def
 591 PSL_L_y MM
 V 90 R (MSH) bc Z U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 0 A
 FQ
 O0
-% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
@@ -2120,25 +1487,10 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -2148,7 +1500,7 @@ N 0 508 M -83 0 D S
 N 0 846 M -83 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 133 F0
 (100) sw mx
 (200) sw mx
@@ -2182,16 +1534,7 @@ V 90 R V MU 0 0 M (CO) FP 0 -42 G 117 F0 (2) FP 0 42 G 167 F0 ( \(PPM\)) FP path
 0 -42 G 117 F0 (2) Z
 0 42 G 167 F0 ( \(PPM\)) Z
 U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 83 def
@@ -2234,58 +1577,24 @@ V 90 R V MU 0 0 M (CO) FP 0 -42 G 117 F0 (2) FP 0 42 G 167 F0 ( \(PPM\)) FP path
 0 -42 G 117 F0 (2) Z
 0 42 G 167 F0 ( \(PPM\)) Z
 U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 0 A
 FQ
 O0
-% Set plot origin:
 0 1181 TM
 
 % PostScript produced by:
@@ -2295,45 +1604,21 @@ O0
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-%
-% Start of basemap (placed before the plot contents)
-%
-%
-% Start of gridlines - if any
-%
-%
-% Start of map frame
-%
 25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-%
-% Start of left y-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /MM {neg exch M} def
-/PSL_LH PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if	% Set this font
+/PSL_LH PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 167 F0
 (M) sh def
 /PSL_L_y 533 def
 591 PSL_L_y MM
 V 90 R (Tectonics) bc Z U
-%
-% End of left y-axis
-%
-%
-% Start of right y-axis
-%
 7559 0 T
-%
-% Axis tick marks and annotations
-%
 N 0 1181 M 0 -1181 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
@@ -2342,71 +1627,29 @@ N 0 1181 M 0 -1181 D S
 /PSL_L_y 533 PSL_LH add def
 591 PSL_L_y MM
 V 90 R (Tectonics) bc Z U
-%
-% End of right y-axis
-%
 -7559 0 T
-%
-% Start of lower x-axis
-%
-%
-% Axis tick marks and annotations
-%
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of lower x-axis
-%
-%
-% Start of upper x-axis
-%
 0 1181 T
-%
-% Axis tick marks and annotations
-%
 25 W
 N 0 0 M 7559 0 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
 8 W
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-%
-% End of upper x-axis
-%
 0 -1181 T
 0 setlinecap
-%
-% End of map frame
-%
-%
-% End of basemap (placed before the plot contents)
-%
-%
-% Start of basemap (placed after the plot contents)
-%
-%
-% End of basemap (placed after the plot contents)
-%
 0 A
 %%EndObject
 
 grestore
-%
-% Run PSL movie label completion function, if defined
-%
 PSL_movie_label_completion /PSL_movie_label_completion {} def
-%
-% Run PSL movie progress indicator completion function, if defined
-%
 PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
-%
-% Reset transformations and call showpage
-%
 U
 showpage
 

--- a/test/psbasemap/fixed_labeldist.sh
+++ b/test/psbasemap/fixed_labeldist.sh
@@ -23,7 +23,7 @@ ysubtick=5
 axis_label="C@-4@- (%)"
 J_options="-JX${plot_width}/${plot_height}"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
-gmt psbasemap -BWSen -Bxa2f1+l"Age (Ma)" -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -K > $ps
+gmt psbasemap -BWSEn -Bxa2f1+l"Age (Ma)" -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -K > $ps
 
 ############## MC total
 
@@ -33,7 +33,7 @@ ymax=12000
 axis_label="MC@-T@-"
 J_options="-JX${plot_width}/${plot_height}l"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
-gmt psbasemap -Y${plot_height} -BWsen -Bya1f3p+l"${axis_label} (grain/g)" ${J_options} ${R_options} -P -K -O >> $ps
+gmt psbasemap -Y${plot_height} -BWsEn -Bya1f3p+l"${axis_label} (grain/g)" ${J_options} ${R_options} -P -K -O >> $ps
 
 ############## MC_L / MC_R
 
@@ -45,7 +45,7 @@ ysubtick=0.05
 axis_label="MC@-L@-/MC@-R@-"
 J_options="-JX${plot_width}/${plot_height}"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
-gmt psbasemap -Y${plot_height} -BWsen -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
+gmt psbasemap -Y${plot_height} -BWsEn -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
 
 ############## Grasses Yanwan
 
@@ -57,7 +57,7 @@ ysubtick=10
 axis_label="Grass (%)"
 J_options="-JX${plot_width}/${plot_height}"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
-gmt psbasemap -Y${plot_height} -BWsen -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
+gmt psbasemap -Y${plot_height} -BWsEn -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
 
 ############## Grasses Yaodian
 
@@ -69,7 +69,7 @@ ysubtick=10
 axis_label="Grass (%)"
 J_options="-JX${plot_width}/${plot_height}"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
-gmt psbasemap -Y${plot_height} -BWsen -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
+gmt psbasemap -Y${plot_height} -BWsEn -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
 
 ############## Mammal fossils
 
@@ -82,7 +82,7 @@ axis_label="Fossils"
 parameter="mammal_fossils"
 J_options="-JX${plot_width}/${plot_height}"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
-gmt psbasemap -Y${plot_height} -BWsen -Bxa100 -By+l"${axis_label}" ${J_options} ${R_options} -P -K -O >> $ps
+gmt psbasemap -Y${plot_height} -BWsEn -Bxa100 -By+l"${axis_label}" ${J_options} ${R_options} -P -K -O >> $ps
 
 ############## Mammal fossils
 
@@ -95,7 +95,7 @@ axis_label="MSH"
 parameter="MSH"
 J_options="-JX${plot_width}/${plot_height}"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
-gmt psbasemap -Y${plot_height} -BWsen -Bya400+200f100+l"${axis_label}" ${J_options} ${R_options} -P -K -O >> $ps
+gmt psbasemap -Y${plot_height} -BWsEn -Bya400+200f100+l"${axis_label}" ${J_options} ${R_options} -P -K -O >> $ps
 
 ################## CO2
 
@@ -108,7 +108,7 @@ axis_label="CO@-2@- (PPM)"
 J_options="-JX${plot_width}/${plot_height}"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
 
-gmt psbasemap -Y${plot_height} -BWsen -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
+gmt psbasemap -Y${plot_height} -BWsEn -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
 
 ############ Tectonic
 
@@ -122,4 +122,4 @@ parameter="tectonic_events"
 J_options="-JX${plot_width}/${plot_height}"
 R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
 
-gmt psbasemap -Y${plot_height} -BWsen -Bxa100 -By+l"${axis_label}" ${J_options} ${R_options} -P -O >> $ps
+gmt psbasemap -Y${plot_height} -BWsEn -Bxa100 -By+l"${axis_label}" ${J_options} ${R_options} -P -O >> $ps

--- a/test/psbasemap/fixed_labeldist.sh
+++ b/test/psbasemap/fixed_labeldist.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 # Test a fixed label offset distance form all axes
 # Script from https://github.com/GenericMappingTools/gmt/issues/5182
-# A negative MAP_LABEL_OFFSET means the base of the map label will be set
-# at exactly the absolute value of the OFFSET, regardless of which side
-# of whatever axis it applies to. So while this mostly makes sense for
-# Cartesian y-axes, there are no limitations on it side (yet)
+# The defaults MAP_LABEL_MODE = axis means the distance to the map label
+# will be measured relative to the axis, not the top of the annotations.
+# 
 ps=fixed_labeldist.ps
-gmt set FONT_LABEL 10p MAP_LABEL_OFFSET -32p FONT_ANNOT_PRIMARY 8p
+gmt set FONT_LABEL 10p MAP_LABEL_OFFSET 8p/32p MAP_LABEL_MODE annot/axis FONT_ANNOT_PRIMARY 8p
 
 plot_width=16c
 plot_height=2.5c

--- a/test/psbasemap/fixed_labeldist.sh
+++ b/test/psbasemap/fixed_labeldist.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Test a fixed label offset distance form all axes
+# Script from https://github.com/GenericMappingTools/gmt/issues/5182
+# A negative MAP_LABEL_OFFSET means the base of the map label will be set
+# at exactly the absolute value of the OFFSET, regardless of which side
+# of whatever axis it applies to. So while this mostly makes sense for
+# Cartesian y-axes, there are no limitations on it side (yet)
+ps=fixed_labeldist.ps
+gmt set FONT_LABEL 10p MAP_LABEL_OFFSET -32p FONT_ANNOT_PRIMARY 8p
+
+plot_width=16c
+plot_height=2.5c
+xmin=6
+xmax=17
+
+############## C4
+
+parameter="C4"
+ymin=0
+ymax=24.9
+ytick=10
+ysubtick=5
+axis_label="C@-4@- (%)"
+J_options="-JX${plot_width}/${plot_height}"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+gmt psbasemap -BWSen -Bxa2f1+l"Age (Ma)" -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -K > $ps
+
+############## MC total
+
+parameter=MC_total
+ymin=80
+ymax=12000
+axis_label="MC@-T@-"
+J_options="-JX${plot_width}/${plot_height}l"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+gmt psbasemap -Y${plot_height} -BWsen -Bya1f3p+l"${axis_label} (grain/g)" ${J_options} ${R_options} -P -K -O >> $ps
+
+############## MC_L / MC_R
+
+parameter="Total_L_Total_R"
+ymin=0.01
+ymax=0.39
+ytick=0.1
+ysubtick=0.05
+axis_label="MC@-L@-/MC@-R@-"
+J_options="-JX${plot_width}/${plot_height}"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+gmt psbasemap -Y${plot_height} -BWsen -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
+
+############## Grasses Yanwan
+
+parameter="Yanwan_Grasses" 
+ymin=0.1
+ymax=99.9
+ytick=20
+ysubtick=10
+axis_label="Grass (%)"
+J_options="-JX${plot_width}/${plot_height}"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+gmt psbasemap -Y${plot_height} -BWsen -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
+
+############## Grasses Yaodian
+
+parameter="Yaodian_Grasses"
+ymin=0.1
+ymax=99.9
+ytick=20
+ysubtick=10
+axis_label="Grass (%)"
+J_options="-JX${plot_width}/${plot_height}"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+gmt psbasemap -Y${plot_height} -BWsen -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
+
+############## Mammal fossils
+
+ymin=0
+ymax=2
+y_half=1
+ytick=1
+ysubtick=5
+axis_label="Fossils"
+parameter="mammal_fossils"
+J_options="-JX${plot_width}/${plot_height}"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+gmt psbasemap -Y${plot_height} -BWsen -Bxa100 -By+l"${axis_label}" ${J_options} ${R_options} -P -K -O >> $ps
+
+############## Mammal fossils
+
+ymin=2801
+ymax=4099
+y_half=1
+ytick=1
+ysubtick=5
+axis_label="MSH"
+parameter="MSH"
+J_options="-JX${plot_width}/${plot_height}"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+gmt psbasemap -Y${plot_height} -BWsen -Bya400+200f100+l"${axis_label}" ${J_options} ${R_options} -P -K -O >> $ps
+
+################## CO2
+
+parameter="CO2"
+ymin=50
+ymax=399
+ytick=100
+ysubtick=25
+axis_label="CO@-2@- (PPM)"
+J_options="-JX${plot_width}/${plot_height}"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+
+gmt psbasemap -Y${plot_height} -BWsen -Bya${ytick}f${ysubtick}+l"${axis_label}" ${J_options} ${R_options} -P -O -K >> $ps
+
+############ Tectonic
+
+ymin=0
+ymax=1
+y_half=1
+ytick=1
+ysubtick=5
+axis_label="Tectonics"
+parameter="tectonic_events"
+J_options="-JX${plot_width}/${plot_height}"
+R_options="-R${xmin}/${xmax}/${ymin}/${ymax}"
+
+gmt psbasemap -Y${plot_height} -BWsen -Bxa100 -By+l"${axis_label}" ${J_options} ${R_options} -P -O >> $ps


### PR DESCRIPTION
**Description of proposed changes**

See issue #5182 for background.  This PR lets a negative **MAP_LABEL_OFFSET** be interpreted as the absolute distance from the axis to the base of the label [The default is that a positive offset is seen as a relative addition beyond the end of the annotations].  The use for this is to better align multiple y-axes plots that are stacked so that the labels align even if the annotations have different magnitudes and formats.  TO demonstrate this effect I added a test based on the original poster's issue.  This plot is found below this text.  One remaining issue is whether of not we restrict this mechanism to just the y-axis.  There are two different consequences depending on the answer:

- If applicable to all axis then the user may need to use separate **basemap** calls so that the effect only applies to the label they want.
- If only applicable to the y-axis then one cannot align x-labels on stacks of plots in several columns, and not just this example of one column.

For these reasons I favor not imposing any restriction on which axis it applies to.  Also note: The offset is the exact absolute distance between axis and base of label . That means it is the same on both left and right axis, but since the base is on the right there is a difference.  Another question is then if we need to ensure it works symmetrically on left and right, meaning on the right axis (and bottom) we must deal with the absolute distance to the _top_ of the label.

Comments please. 

![fixed_labeldist](https://user-images.githubusercontent.com/26473567/121458596-5ae7d000-c945-11eb-9d0b-d4978e82d362.png)
