### PR TITLE
Improve -R geographic documentation

### DIFF
--- a/doc/rst/source/coast_common.rst_
+++ b/doc/rst/source/coast_common.rst_
@@ -28,7 +28,7 @@ Required Arguments
 
 .. _-R:
 
-.. |Add_-Rgeo| unicode:: 0x20 .. just an invisible code
+.. |Add_-Rgeo| replace:: Not required when |-E| is used.
 .. include:: explain_-Rgeo.rst_
 
 .. |Add_-Rz| unicode:: 0x20 .. just an invisible code

--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -23,6 +23,7 @@ and 2 are shown in panels a) and b) respectively of the Figure :ref:`Map region 
    making meridians and parallels poor choices for map boundaries. Here, we instead specify the lower left corner and
    upper right corner geographic coordinates, followed by the modifier **+r**. This form guarantees a rectangular map
    even though lines of equal longitude and latitude are not straight lines.
+
 #. **-R**\ **g** or **-R**\ **d**. These forms can be used to quickly specify the global domain (0/360 for **-Rg** and
    -180/+180 for **-Rd** in longitude, with -90/+90 in latitude).
 
@@ -57,4 +58,4 @@ and 2 are shown in panels a) and b) respectively of the Figure :ref:`Map region 
 #. **-R**\ *xmin*/*xmax*/*ymin*/*ymax*/*zmin*/*zmax*. This method can be used for perspective views with the **-Jz**
    and the :ref:`-p <option_-p>` option, where the z-range (*zmin*/*zmax*) is appended to the first method to indicate
    the third dimension. This is not used for :ref:`-p <option_-p>` without **-Jz**, in which case a perspective view of
-   the place is plotted with no third dimension
+   the place is plotted with no third dimension.

--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -31,7 +31,7 @@ and 2 are shown in panels a) and b) respectively of the Figure :ref:`Map region 
    the nature of the calling module, this mechanism will also set grid spacing and possibly the grid registration (see
    :ref:`cookbook/options:Grid registration: The **-r** option`\ ).
 
-#. **-R**\ *code1,code2,...*\ [**+e**\ \|\ **r**\ \|\ **R**\ *incs*]]. This indirectly supplies the region by consulting
+#. **-R**\ *code1,code2,...*\ [**+e**\ \|\ **r**\ \|\ **R**\ *incs*]. This indirectly supplies the region by consulting
    the DCW (Digital Chart of the World) database and derives the bounding regions for one or more countries given by
    the codes. Simply append one or more comma-separated countries using the two-character
    `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)>`_.

--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -17,7 +17,7 @@
     #. **-R**\ **g** or **-R**\ **d**. These forms can be used to quickly specify the global domain (0/360 for **-Rg**
        and -180/+180 for **-Rd** in longitude, with -90/+90 in latitude).
 
-    #. **-R**\ *code1,code2,...*\ [**+e**\ \|\ **r**\ \|\ **R**\ *incs*]]. This indirectly supplies the region by
+    #. **-R**\ *code1,code2,...*\ [**+e**\ \|\ **r**\ \|\ **R**\ *incs*]. This indirectly supplies the region by
        consulting the DCW (Digital Chart of the World) database and derives the bounding regions for one or more
        countries given by the codes. Simply append one or more comma-separated countries using the two-character
        `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)>`_. To select a state within a

--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -1,37 +1,46 @@
 **-R**\ *west*/*east*/*south*/*north*\ [/*zmin*/*zmax*][**+r**][**+u**\ *unit*]
-    *west*, *east*, *south*, and *north* specify the region of interest,
-    and you may specify them in decimal degrees or in
-    [±]dd:mm[:ss.xxx][**W**\|\ **E**\|\ **S**\|\ **N**] format
-    Append **+r** if lower left
-    and upper right map coordinates are given instead of w/e/s/n. The
-    two shorthands **-Rg** and **-Rd** stand for global domain (0/360
-    and -180/+180 in longitude respectively, with -90/+90 in latitude).
-    Set geographic regions by specifying ISO country codes from the Digital Chart of the World using
-    **-R**\ *code1,code2,...*\ [**+r**\|\ **R**\ [*incs*]] instead:
-    Append one or more comma-separated countries using the 2-character
-    `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_.  To select a state of a country
-    (if available), append .state, e.g, US.TX for Texas.  To specify a
-    whole continent, prepend = to any of the continent codes AF (Africa),
-    AN (Antarctica), AS (Asia), EU (Europe), OC (Oceania),
-    NA (North America), or SA (South America).  Use **+r** to modify the bounding box coordinates from the polygon(s):
-    Append *inc*, *xinc*/*yinc*, or *winc*/*einc*/*sinc*/*ninc* to adjust the
-    region to be a multiple of these steps [no adjustment]. Alternatively, use **+R** to extend the region
-    outward by adding these increments instead, or **+e** which is like **+r** but
-    it ensures that the bounding box extends by at least 0.25 times the increment [no extension].
-    Alternatively for grid creation, give **R**\ *code*\ *lon*/*lat*/*nx*/*ny*, where
-    *code* is a 2-character combination of L, C, R (for left, center, or right)
-    and T, M, B for top, middle, or bottom. e.g., BL for lower left.  This
-    indicates which point on a rectangular region the *lon*/*lat* coordinate
-    refers to, and the grid dimensions *nx* and *ny* with grid spacings via
-    **-I** is used to create the corresponding region.
-    Alternatively, specify the name of an existing grid file and the
-    **-R** settings (and grid spacing and registration, if applicable) are copied from
-    the grid. Appending **+u**\ *unit* expects projected (Cartesian)
-    coordinates compatible with chosen **-J** and we inversely project
-    to determine actual rectangular geographic region.
-    For perspective view (**-p**), optionally append /*zmin*/*zmax*.
-    In case of perspective view (**-p**), a z-range (*zmin*, *zmax*)
-    can be appended to indicate the third dimension. This needs to be
-    done only when using the **-Jz** option, not when using only the
-    **-p** option. In the latter case a perspective view of the plane is
-    plotted, with no third dimension. |Add_-Rgeo|
+
+    Specify the region of interest. |Add_-Rgeo| The region may be specified in one of six ways:
+
+    1. **-R**\ *west*/*east*/*south*/*north*\ [**+u**\ *unit*]. This is the standard way to specify geographic regions
+       when using map projections where meridians and parallels are rectilinear. The coordinates may be specified in
+       decimal degrees or in [±]dd:mm[:ss.xxx][**W**\|\ **E**\|\ **S**\|\ **N**] format. Optionally, append
+       **+u**\ *unit* to specify a region in projected units (e.g., UTM meters) where *west*/*east*/*south*/*north* are
+       Cartesian projected coordinates compatible with the chosen projection (**-J**) and *unit* is an allowable
+       :ref:`distance unit <dist-units>`; we inversely project to determine the actual rectangular geographic region.
+
+    #. **-R**\ *west*/*south*/*east*/*north*\ **+r**. This form is useful for map projections that are oblique,
+       making meridians and parallels poor choices for map boundaries. Here, we instead specify the lower left corner
+       and upper right corner geographic coordinates, followed by the modifier **+r**. This form guarantees a
+       rectangular map even though lines of equal longitude and latitude are not straight lines.
+
+    #. **-R**\ **g** or **-R**\ **d**. These forms can be used to quickly specify the global domain (0/360 for **-Rg**
+       and -180/+180 for **-Rd** in longitude, with -90/+90 in latitude).
+
+    #. **-R**\ *code1,code2,...*\ [**+e**\ \|\ **r**\ \|\ **R**\ *incs*]]. This indirectly supplies the region by
+       consulting the DCW (Digital Chart of the World) database and derives the bounding regions for one or more
+       countries given by the codes. Simply append one or more comma-separated countries using the two-character
+       `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)>`_. To select a state within a
+       country (if available), append .state, e.g, US.TX for Texas. To specify a whole continent, prepend **=** to any
+       of the continent codes **AF** (Africa), **AN** (Antarctica), **AS** (Asia), **EU** (Europe), **OC** (Oceania),
+       **NA** (North America), or **SA** (South America). The following modifiers can be appended:
+
+        - **+r** to adjust the region boundaries to be multiples of the steps indicated by *inc*, *xinc*/*yinc*, or
+          *winc*/*einc*/*sinc*/*ninc* [default is no adjustment]. For example, **-R**\ *FR*\ **+r**\ 1 will select the
+          national bounding box of France rounded to nearest integer degree.
+        - **+R** to extend the region outward by adding the amounts specified by *inc*, *xinc*/*yinc*, or
+          *winc*/*einc*/*sinc*/*ninc* [default is no extension].
+        - **+e** to adjust the region boundaries to be multiples of the steps indicated by *inc*, *xinc*/*yinc*, or
+          *winc*/*einc*/*sinc*/*ninc*, while ensuring that the bounding box extends by at least 0.25 times the increment
+          [default is no adjustment].
+
+    #. **-R**\ *justify*\ *lon0*/*lat0*/*nx*/*ny*, where *justify* is a 2-character combination of
+       **L**\|\ **C**\|\ **R** (for left, center, or right) and **T**\|\ **M**\|\ **B** (for top, middle, or bottom)
+       (e.g., **BL** for lower left). The two character code *justify* indicates which point on a rectangular region
+       region the *lon0*/*lat0* coordinates refer to and the grid dimensions *nx* and *ny* are used with grid spacings
+       given via **-I** to create the corresponding region. This method can be used when creating grids. For example,
+       **-RCM**\ *25*/*25*/*50*/*50* specifies a *50*\ x\ *50* grid centered on *25*\ ,\ *25*.
+
+    #. **-R**\ *gridfile*. This will copy the domain settings found for the grid in specified file. Note that depending
+       on the nature of the calling module, this mechanism will also set grid spacing and possibly the grid registration
+       (see :ref:`cookbook/options:Grid registration: The **-r** option`\ ).


### PR DESCRIPTION
**Description of proposed changes**

This PR improves the formatting for the documentation in explain_-Rgeo.rst and clarifies that -R is not needed for coast if -E is set.

**Preview**: https://gmt-s130m27da-gmt.vercel.app/coast.html#r
<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #5314


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
