### PR TITLE
Let project -Z accept units for ellipse major axis

### DIFF
--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |-T|\ *px*/*py* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *wmin*/*wmax* ]
-[ |-Z|\ *major*/*minor*/*azimuth*\ [**+e**\|\ **n**] ]
+[ |-Z|\ *major*\ [*unit*][/*minor*/*azimuth*][**+e**\|\ **n**] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -193,18 +193,18 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *major*/*minor*/*azimuth*\ [**+e**\|\ **n**]
+**-Z**\ *major*\ [*unit*][/*minor*/*azimuth*][**+e**\|\ **n**]
     Create the coordinates of an ellipse with *major* and *minor* axes given in km (unless |-N| is given for a
     Cartesian ellipse) and the *azimuth* of the major axis in degrees; used in conjunction with |-C| (sets its center)
     and |-G| (sets the distance increment). **Note**: For the Cartesian ellipse (which requires |-N|), we expect
-    *direction* counter-clockwise from the horizontal instead of an *azimuth*. The following modifiers are supported:
+    *direction* counter-clockwise from the horizontal instead of an *azimuth*. A geographic *major* may be specified
+    in any desired unit [Default is km] by appending the unit (e.g., 3d for degrees); if so we assume the *minor* axis
+    and the increment are also given in the same unit (see `Units`_).  For degenerate ellipses you can just supply a
+    single *diameter* instead. The following modifiers are supported:
 
     - Append **+e** to adjust the increment set via |-G| so that the ellipse has equal distance increments [Default
       uses the given increment and closes the ellipse].
-    - Append **+n** to set a specific number of unique equidistant points via |-G|. For degenerate ellipses you can
-      just supply a single *diameter* instead.  A geographic diameter may be specified in any desired unit other than
-      km [Default is km] by appending the unit (e.g., 3d for degrees); if so we assume the increment is also given in
-      the same unit (see `Units`_).
+    - Append **+n** to set a specific number of unique equidistant points via |-G|.
 
 .. |Add_-bi| replace:: [Default is 2 input columns].
 .. include:: explain_-bi.rst_

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -190,6 +190,7 @@ enum GMT_time_period {
 #define GMT_DIM_UNITS	"cip"		/* Plot dimensions in cm, inch, or point */
 #define GMT_LEN_UNITS2	"efkMnu"	/* Distances in meter, foot, survey foot, km, Mile, nautical mile */
 #define GMT_LEN_UNITS	"dmsefkMnu"	/* Distances in arc-{degree,minute,second} or meter, foot, km, Mile, nautical mile, survey foot */
+#define GMT_ARC_UNITS	"dms"		/* Distances in arc-{degree,minute,second}t */
 #define GMT_TIME_UNITS	"yowdhms"	/* Time increments in year, month, week, day, hour, min, sec */
 #define GMT_TIME_VAR_UNITS	"yo"	/* Variable time increments in year or month*/
 #define GMT_WESN_UNITS	"WESN"		/* Sign-letters for geographic coordinates */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -5579,7 +5579,7 @@ GMT_LOCAL struct GMT_DATASET * gmtsupport_crosstracks_spherical (struct GMT_CTRL
 	cross_length = cross_length / GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in meters [or degrees] */
 	n_cross++;	/* Since one more node than increments */
 	n_half_cross = (n_cross % 2) ? (n_cross - 1) / 2 : n_cross / 2;	/* Half-width of points in a cross profile depending on odd/even */
-	if (unit && strchr ("dms", unit))	/* Gave increments in arc units (already in degrees at this point) */
+	if (unit && strchr (GMT_ARC_UNITS, unit))	/* Gave increments in arc units (already in degrees at this point) */
 		across_ds_radians = D2R * cross_length / (n_cross - 1);	/* Angular change from point to point */
 	else	/* Must convert distances to degrees */
 		across_ds_radians = D2R * (cross_length / GMT->current.proj.DIST_M_PR_DEG) / (n_cross - 1);	/* Angular change from point to point */


### PR DESCRIPTION
The **project -Z** option did not allow the use of units for the axes of ellipses, only for a circle.  This PR addresses this omission and clarifies the docs and formatting.
