### PR TITLE
Fix wrong end index for filenames without extension in psconvert

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1813,7 +1813,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 			if (pos_ext < 0 && ps_file[j] == '.') pos_ext = j;	/* Beginning of file extension */
 			if (pos_file < 0 && (ps_file[j] == '/' || ps_file[j] == '\\')) pos_file = j + 1;	/* Beginning of file name */
 		}
-		if (pos_ext == -1) pos_ext = (unsigned int)len - 1;	/* File has no extension */
+		if (pos_ext == -1) pos_ext = (unsigned int)len;	/* File has no extension */
 		if (!Ctrl->D.active || pos_file == -1) pos_file = 0;	/* File either has no leading directory or we want to use it */
 
 		/* Adjust to a tight BoundingBox if user requested so */


### PR DESCRIPTION
See #5323.  Probably never tested since who uses filenames without extensions?
Closes #5323.
