### PR TITLE
Let colorbar handle CPTs with transparency

### DIFF
--- a/doc/rst/source/colorbar_notes.rst_
+++ b/doc/rst/source/colorbar_notes.rst_
@@ -11,3 +11,5 @@ Notes
 #. For cyclic (wrapping) color tables the cyclic symbol is plotted to the right
    of the color bar.  If annotations are specified there then we place the cyclic
    symbol at the left, unless **+n** was used in which case we center of the color bar instead.
+#. Discrete CPTs may have transparency applied to all or some individual slices.
+   Continuous CPTs may have transparency applied to all slices, but not just some.

--- a/test/psscale/transp_scale.ps
+++ b/test/psscale/transp_scale.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.3.0_fbe84c4-dirty_2021.06.11 [64-bit] Document from psscale
+%%Title: GMT v6.3.0_1321ce8_2021.06.11 [64-bit] Document from psscale
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Fri Jun 11 13:27:55 2021
+%%CreationDate: Fri Jun 11 13:57:58 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -118,39 +118,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -737,22 +737,22 @@ N 3780 0 M 0 -83 D S
 N 5669 0 M 0 -83 D S
 /MM {neg M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(-4000) sh mx
-(-3000) sh mx
-(-2000) sh mx
-(-1000) sh mx
+(”4000) sh mx
+(”3000) sh mx
+(”2000) sh mx
+(”1000) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
-(-4000) bc Z
+(”4000) bc Z
 1890 PSL_A0_y MM
-(-3000) bc Z
+(”3000) bc Z
 3780 PSL_A0_y MM
-(-2000) bc Z
+(”2000) bc Z
 5669 PSL_A0_y MM
-(-1000) bc Z
+(”1000) bc Z
 N 378 0 M 0 -42 D S
 N 756 0 M 0 -42 D S
 N 1134 0 M 0 -42 D S
@@ -807,22 +807,22 @@ N 3780 0 M 0 -83 D S
 N 5669 0 M 0 -83 D S
 /MM {neg M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(-4000) sh mx
-(-3000) sh mx
-(-2000) sh mx
-(-1000) sh mx
+(”4000) sh mx
+(”3000) sh mx
+(”2000) sh mx
+(”1000) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
-(-4000) bc Z
+(”4000) bc Z
 1890 PSL_A0_y MM
-(-3000) bc Z
+(”3000) bc Z
 3780 PSL_A0_y MM
-(-2000) bc Z
+(”2000) bc Z
 5669 PSL_A0_y MM
-(-1000) bc Z
+(”1000) bc Z
 N 378 0 M 0 -42 D S
 N 756 0 M 0 -42 D S
 N 1134 0 M 0 -42 D S
@@ -906,22 +906,22 @@ N 3780 0 M 0 -83 D S
 N 5669 0 M 0 -83 D S
 /MM {neg M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(-4000) sh mx
-(-3000) sh mx
-(-2000) sh mx
-(-1000) sh mx
+(”4000) sh mx
+(”3000) sh mx
+(”2000) sh mx
+(”1000) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
-(-4000) bc Z
+(”4000) bc Z
 1890 PSL_A0_y MM
-(-3000) bc Z
+(”3000) bc Z
 3780 PSL_A0_y MM
-(-2000) bc Z
+(”2000) bc Z
 5669 PSL_A0_y MM
-(-1000) bc Z
+(”1000) bc Z
 N 378 0 M 0 -42 D S
 N 756 0 M 0 -42 D S
 N 1134 0 M 0 -42 D S
@@ -1007,22 +1007,22 @@ N 3780 0 M 0 -83 D S
 N 5669 0 M 0 -83 D S
 /MM {neg M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(-4000) sh mx
-(-3000) sh mx
-(-2000) sh mx
-(-1000) sh mx
+(”4000) sh mx
+(”3000) sh mx
+(”2000) sh mx
+(”1000) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
-(-4000) bc Z
+(”4000) bc Z
 1890 PSL_A0_y MM
-(-3000) bc Z
+(”3000) bc Z
 3780 PSL_A0_y MM
-(-2000) bc Z
+(”2000) bc Z
 5669 PSL_A0_y MM
-(-1000) bc Z
+(”1000) bc Z
 N 378 0 M 0 -42 D S
 N 756 0 M 0 -42 D S
 N 1134 0 M 0 -42 D S
@@ -1047,7 +1047,7 @@ O0
 0 -2362 TM
 
 % PostScript produced by:
-%@GMT: gmt psscale -Ct.cpt -R0/10/0/10 -JX15c -Y-5c -O -Baf '-Bx+lDiscrete CPT Some Transparent'
+%@GMT: gmt psscale -Ct.cpt -R0/10/0/10 -JX15c -Y-5c -O -Baf '-Bx+lDiscrete CPT Odd Slices Transparent'
 %@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -1087,22 +1087,22 @@ N 3780 0 M 0 -83 D S
 N 5669 0 M 0 -83 D S
 /MM {neg M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
-(-4000) sh mx
-(-3000) sh mx
-(-2000) sh mx
-(-1000) sh mx
+(”4000) sh mx
+(”3000) sh mx
+(”2000) sh mx
+(”1000) sh mx
 def
 /PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
 0 PSL_A0_y MM
-(-4000) bc Z
+(”4000) bc Z
 1890 PSL_A0_y MM
-(-3000) bc Z
+(”3000) bc Z
 3780 PSL_A0_y MM
-(-2000) bc Z
+(”2000) bc Z
 5669 PSL_A0_y MM
-(-1000) bc Z
+(”1000) bc Z
 N 378 0 M 0 -42 D S
 N 756 0 M 0 -42 D S
 N 1134 0 M 0 -42 D S
@@ -1117,7 +1117,7 @@ N 4913 0 M 0 -42 D S
 N 5291 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 2835 -446 M 267 F0
-(Discrete CPT Some Transparent) tc Z
+(Discrete CPT Odd Slices Transparent) tc Z
 0 setlinecap
 -709 443 T
 %%EndObject

--- a/test/psscale/transp_scale.ps
+++ b/test/psscale/transp_scale.ps
@@ -1,0 +1,1136 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.3.0_fbe84c4-dirty_2021.06.11 [64-bit] Document from psscale
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Jun 11 13:27:55 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 12283 TM
+
+% PostScript produced by:
+%@GMT: gmt psscale -Ct.cpt -R0/10/0/10 -JX15c -Y26c -Baf '-Bx+lDiscrete CPT No Slices Transparent' -P -K
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%GMTBoundingBox: 72 737.007874016 425.196850394 425.196850394
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+709 -443 T
+25 W
+V N 0 0 T 5669 227 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 6 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [6 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter
+>> image
+6Vk<B]BiSpFkGb5qg]m%*Wc~>
+U
+2 setlinecap
+N 0 227 M 5669 0 D S
+N 0 0 M 0 227 D S
+N 5669 0 M 0 227 D S
+N 0 0 M 5669 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 3780 0 M 0 -83 D S
+N 5669 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-4000) sh mx
+(-3000) sh mx
+(-2000) sh mx
+(-1000) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-4000) bc Z
+1890 PSL_A0_y MM
+(-3000) bc Z
+3780 PSL_A0_y MM
+(-2000) bc Z
+5669 PSL_A0_y MM
+(-1000) bc Z
+N 378 0 M 0 -42 D S
+N 756 0 M 0 -42 D S
+N 1134 0 M 0 -42 D S
+N 1512 0 M 0 -42 D S
+N 2268 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 3024 0 M 0 -42 D S
+N 3402 0 M 0 -42 D S
+N 4157 0 M 0 -42 D S
+N 4535 0 M 0 -42 D S
+N 4913 0 M 0 -42 D S
+N 5291 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2835 -446 M 267 F0
+(Discrete CPT No Slices Transparent) tc Z
+0 setlinecap
+-709 443 T
+%%EndObject
+0 A
+FQ
+O0
+0 -2362 TM
+
+% PostScript produced by:
+%@GMT: gmt psscale -Ct.cpt -R0/10/0/10 -JX15c -Y-5c -Baf -O -K '-Bx+lDiscrete CPT All Slices Transparent'
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+709 -443 T
+25 W
+0.5 1 /Normal PSL_transp
+V N 0 0 T 5669 227 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 6 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [6 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter
+>> image
+6Vk<B]BiSpFkGb5qg]m%*Wc~>
+U
+1 1 /Normal PSL_transp
+2 setlinecap
+N 0 227 M 5669 0 D S
+N 0 0 M 0 227 D S
+N 5669 0 M 0 227 D S
+N 0 0 M 5669 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 3780 0 M 0 -83 D S
+N 5669 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-4000) sh mx
+(-3000) sh mx
+(-2000) sh mx
+(-1000) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-4000) bc Z
+1890 PSL_A0_y MM
+(-3000) bc Z
+3780 PSL_A0_y MM
+(-2000) bc Z
+5669 PSL_A0_y MM
+(-1000) bc Z
+N 378 0 M 0 -42 D S
+N 756 0 M 0 -42 D S
+N 1134 0 M 0 -42 D S
+N 1512 0 M 0 -42 D S
+N 2268 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 3024 0 M 0 -42 D S
+N 3402 0 M 0 -42 D S
+N 4157 0 M 0 -42 D S
+N 4535 0 M 0 -42 D S
+N 4913 0 M 0 -42 D S
+N 5291 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2835 -446 M 267 F0
+(Discrete CPT All Slices Transparent) tc Z
+0 setlinecap
+-709 443 T
+%%EndObject
+0 A
+FQ
+O0
+0 -2362 TM
+
+% PostScript produced by:
+%@GMT: gmt psscale -Ct.cpt -R0/10/0/10 -JX15c -Y-5c -O -K -Baf '-Bx+lContinuous CPT No Slices Transparent'
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+709 -443 T
+25 W
+V N 0 0 T 5669 227 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 2835 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [2835 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[=su"]U^h'EI'$Cp1HdK:pjK&i24`KAGA>h;-oCh-^I;FpBAHh$$>n%"$l]?iKYfc_6_]6SVAlia.Ya]sU%a-%)Cb#sY>N
+r_=aA["1uK@$"<d@-CiV`49tQd]1$f<<I)*B5?/@ft&mpP\FSTdo>)G?iul;Cg%Zl@7u5i.qgKgg/teC[]QeSChG<NhIm-U
+)!s@NQh$]SSR'B^EN&rM\l@nU;A"*(p2I.`;qoL';K(10Y`ES]^1<LXgA[tL"1//)<<nql_84hKVWr-!WVS<X)K<30KNh/1
+;EN%'(*'Fsj'I)6G+<n"3*n\_^!9#iHT2=XfMD4FTAi]a:A(PI9fq1K!RB';oQ5bm8>k.4:33d`4e;+*k[g-b>sK;EC);0+
+^r>"RhQCgsG+#fG0)%9+n90F7[B"]1iG.`u*tPk^]?\G1Xs^n@BK)+2E0GH$l*J@LB<*\rNV)&0h4`ZhlN_W"5QBR+*kq]b
+=1cd3&;JV!@G:[/_=3!KTO.seK`13WefO@b&!+$:r#<H3lj9s@%+h*CDhLp&JB"Lp&S.(]FORSMF"jiOH0kd@q*hm6-2)@e
+972G0Fd9WUfG\+0DZmM"2q_DdD=R"dFuYY$&+=3##'I`UaH#aRfa0jh4sW5--oO,b$[tKfIEVq?HU;q+.e\+aI89Kh0Bc^q
+fiQ#'q:B^1pkJ56<p]QUm/LB3n:CO/%tpRn6(`/<i%O)OYN!oIoW[fDn/odb1!5W`b#*0<kb%L7GidQ\rGd\RGaLlpi0-MT
+8ggIn@"*-r3!H2,;u-(DC!u5`qD0ml1LV%ZMpDm)Xe(/dkdfu(@aP$XH@^AcT1:Pt/f"PUR)PoMATRpe>e38o?^WRMP-1\\
+pbh?E[-p'?HDSplCrY<NeXJt1c0Q4Bk>jbWH>HMu(Ys;rME=89?$m,?m?[/P?2%rhqq083Qd@9EN&HE%)Y]/E"+1;r5,dpl
+-sc7c3)+ZDc%/*J$L>Q=lJj>G*hPu(L*tRZ:SLY5[8/*kCRn5IXVh^(T(uNA59#BY_fN*Bq&!@r^[OTsp#:2O.[Rju07U*_
+YC+0Oi76/rCS,!'rq].XLC-!8pTXQipeH,#/[iR+hl'o:7FL9A?dX((b0/XiTkf#D\Tn,lDtDndq!\UefHuJ.'D70AL=,"U
+./h0seISnWPP`dTd_"(+8Ls?Aq$]_BTAN\`\>?oRood'U^Uc&2B(_V-9##pYUmL>Tr$CSrX*=IFqE6qoIQ3+bq2]/?Sfp>g
+&aIiTbi_pQPB*-GiH!\V-S-=ZA\[26lD*ITo1-%@O2KC5I/0.^dK=lNR/M+X>qn6rY7qqu=,u%U=,G\T=8f[bh2SJS_d.Z_
+pmnoa_@F:l_KP1P=u^LPY"`fmlQgB1m?9He\k*idLSPBlA+Fs4Pe<$#:0su,!t?\u2)_>5_Cd8fH.UO\]I@t`G"Z+qh-o#8
+&(WOR$2-tqbV&H]`s\S:q?$"VcA-j&@ik9o#%Ys>"#K)tTZl):E98\kOuX3-bFF.LB26JV18j)cR8[N=S2I,t4h1mR1i!_?
+L9i6cB3SnB^b)n5Zf>5O@r^i$0t9sOB\XBcN,$DAcP_R$jG^kpF,"n_,s12uK:R(=i\':'fTdEb]4nn?%`1BMJZpNG)ZY64
+rHi>WOSrQo\o0gE:Ohb^]\[m@?8'a^CQQ(S*c17qLR>]kTldbPFP#L<#]geAP3tGi*Gt4ta-\sJZ"/W0m!*Su4Mfe_:PAO\
+-aAm,g[J/4>N;^YXnZW+/b*qo`=-o:fmFPsRqr;lOA4\=]#d'XIXYdU6%1&k0Y\dGLhs;_>sd+t9A*le4hR:jOWVHDbR_^o
+TK-[C]>bhHf9-/ZS`mh[h*ChqNM>kgl"5*3Se&S9]e.Q7^-0e8^-fIff+[V9mNt*d*nl%GH68d>L-qeGdeu0QrW%:AH77O5
+5:et7B=Zrql=92N9_!cmS3<9KjA2aNj)d=KI7AN@c%+->ch"-s"nb=KV%id3qF\'meKj[RoQm6V6[FqlTPpfJa4$1K:W"4G
+>oZAl;r<A8j9%Tcn5(.Es"M<'MiYU<5Q2unJR@Z>r"nBLl#Zj1$\"duq+:V:8*0%I]ISI&?N2U+8&)D*riPb/)uYi$Gn^,J
+9)nKUjd-e[?_?q-ptIUdpS[jPSg\(ilc21e8(2J*mW=]ak<o4C#8Zcl$2csb`4O0f3u0(*A:.TGjd(A\:%\rVNPDX17]5iZ
+eQ:rCrj)A5SU&UW]V%GaB(>%8SgC`=1DV5!S-TdRg>XR<Pru#U(NWB^d)X\W/0:&t&b?JO`C&(+]R`8>hG9WYSAe=t53t]+
+<UZ(<G,0=RG=m'=d+bDOUg*05>GRa^4hZ]UA)8Wi^t5I89@lbeee6S*=0nrBMCYMRf]>!/A^[EZ3m:gF=3Ff!>pN]XQ!PT(
+0BUQ\6I1qBJX,KQm&Wh=9JL0L7<(@M9ff\63/*n3bN%q\]Nt5!kla%_HoZ2:F=]MNX>jBEMU!2U.uo]$LGh,%(bV",<'!E@
++)FX^Oq&2T#$?`\fm[CFhpPsU[Poak;gRs[;gP`4`8p>4`,=#+FAeIb@V9g219jb4\tcihR*`Pqh+l\4BKY275PPo#<k"g`
+>5_+'PdV-5S,X]kP;]7IRMMTd8/iB@_)M30ItnK0%Hq_XIJpABn6br`LrEcuF7>f4OT).Cji7@Zrq$Hq5A3:CHXHbrr6@h.
+em&06QeIXPmJ.^gTmYt)s3aXAKaId:T=aAQF&>+Yl9@#m^VIn8qN%/2d>n'#%f-_%.Nd=7L%5+&b'UPhn((CniG6l(lJ"2k
+6MOT(j\8j:]YRZ$FBs<SY<lR'Gbm0&&72N8]EBb5(YK02Piql5oJu/=BLe]Rb8#ttT'"5EVpm)2l#>AYZqZ)blJoA_I8#&'
+>*DI$Wre'QLSP/Jdg)]GV.$4a;"_PcqKkkkH_e93Mn@W4dN-<FmHc`5PhsR_=($r.1V;mYEMIUX]D`mlSTHHqVMM`c\dJF2
+YJbo*=<UtQ?&&A1Y`rG1/s\-dUEI=5>p,^<]/YkB/"Q:$31HJXc@irq1UPW-e(CY7Lf;sJlm,]C&=gg:-sYtc$c2QT~>
+U
+2 setlinecap
+N 0 227 M 5669 0 D S
+N 0 0 M 0 227 D S
+N 5669 0 M 0 227 D S
+N 0 0 M 5669 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 3780 0 M 0 -83 D S
+N 5669 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-4000) sh mx
+(-3000) sh mx
+(-2000) sh mx
+(-1000) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-4000) bc Z
+1890 PSL_A0_y MM
+(-3000) bc Z
+3780 PSL_A0_y MM
+(-2000) bc Z
+5669 PSL_A0_y MM
+(-1000) bc Z
+N 378 0 M 0 -42 D S
+N 756 0 M 0 -42 D S
+N 1134 0 M 0 -42 D S
+N 1512 0 M 0 -42 D S
+N 2268 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 3024 0 M 0 -42 D S
+N 3402 0 M 0 -42 D S
+N 4157 0 M 0 -42 D S
+N 4535 0 M 0 -42 D S
+N 4913 0 M 0 -42 D S
+N 5291 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2835 -446 M 267 F0
+(Continuous CPT No Slices Transparent) tc Z
+0 setlinecap
+-709 443 T
+%%EndObject
+0 A
+FQ
+O0
+0 -2362 TM
+
+% PostScript produced by:
+%@GMT: gmt psscale -Ct.cpt -R0/10/0/10 -JX15c -Y-5c -O -K -Baf '-Bx+lContinuous CPT All Slices Transparent'
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+709 -443 T
+25 W
+0.5 1 /Normal PSL_transp
+V N 0 0 T 5669 227 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 2835 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [2835 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[=su"]U^h'EI'$Cp1HdK:pjK&i24`KAGA>h;-oCh-^I;FpBAHh$$>n%"$l]?iKYfc_6_]6SVAlia.Ya]sU%a-%)Cb#sY>N
+r_=aA["1uK@$"<d@-CiV`49tQd]1$f<<I)*B5?/@ft&mpP\FSTdo>)G?iul;Cg%Zl@7u5i.qgKgg/teC[]QeSChG<NhIm-U
+)!s@NQh$]SSR'B^EN&rM\l@nU;A"*(p2I.`;qoL';K(10Y`ES]^1<LXgA[tL"1//)<<nql_84hKVWr-!WVS<X)K<30KNh/1
+;EN%'(*'Fsj'I)6G+<n"3*n\_^!9#iHT2=XfMD4FTAi]a:A(PI9fq1K!RB';oQ5bm8>k.4:33d`4e;+*k[g-b>sK;EC);0+
+^r>"RhQCgsG+#fG0)%9+n90F7[B"]1iG.`u*tPk^]?\G1Xs^n@BK)+2E0GH$l*J@LB<*\rNV)&0h4`ZhlN_W"5QBR+*kq]b
+=1cd3&;JV!@G:[/_=3!KTO.seK`13WefO@b&!+$:r#<H3lj9s@%+h*CDhLp&JB"Lp&S.(]FORSMF"jiOH0kd@q*hm6-2)@e
+972G0Fd9WUfG\+0DZmM"2q_DdD=R"dFuYY$&+=3##'I`UaH#aRfa0jh4sW5--oO,b$[tKfIEVq?HU;q+.e\+aI89Kh0Bc^q
+fiQ#'q:B^1pkJ56<p]QUm/LB3n:CO/%tpRn6(`/<i%O)OYN!oIoW[fDn/odb1!5W`b#*0<kb%L7GidQ\rGd\RGaLlpi0-MT
+8ggIn@"*-r3!H2,;u-(DC!u5`qD0ml1LV%ZMpDm)Xe(/dkdfu(@aP$XH@^AcT1:Pt/f"PUR)PoMATRpe>e38o?^WRMP-1\\
+pbh?E[-p'?HDSplCrY<NeXJt1c0Q4Bk>jbWH>HMu(Ys;rME=89?$m,?m?[/P?2%rhqq083Qd@9EN&HE%)Y]/E"+1;r5,dpl
+-sc7c3)+ZDc%/*J$L>Q=lJj>G*hPu(L*tRZ:SLY5[8/*kCRn5IXVh^(T(uNA59#BY_fN*Bq&!@r^[OTsp#:2O.[Rju07U*_
+YC+0Oi76/rCS,!'rq].XLC-!8pTXQipeH,#/[iR+hl'o:7FL9A?dX((b0/XiTkf#D\Tn,lDtDndq!\UefHuJ.'D70AL=,"U
+./h0seISnWPP`dTd_"(+8Ls?Aq$]_BTAN\`\>?oRood'U^Uc&2B(_V-9##pYUmL>Tr$CSrX*=IFqE6qoIQ3+bq2]/?Sfp>g
+&aIiTbi_pQPB*-GiH!\V-S-=ZA\[26lD*ITo1-%@O2KC5I/0.^dK=lNR/M+X>qn6rY7qqu=,u%U=,G\T=8f[bh2SJS_d.Z_
+pmnoa_@F:l_KP1P=u^LPY"`fmlQgB1m?9He\k*idLSPBlA+Fs4Pe<$#:0su,!t?\u2)_>5_Cd8fH.UO\]I@t`G"Z+qh-o#8
+&(WOR$2-tqbV&H]`s\S:q?$"VcA-j&@ik9o#%Ys>"#K)tTZl):E98\kOuX3-bFF.LB26JV18j)cR8[N=S2I,t4h1mR1i!_?
+L9i6cB3SnB^b)n5Zf>5O@r^i$0t9sOB\XBcN,$DAcP_R$jG^kpF,"n_,s12uK:R(=i\':'fTdEb]4nn?%`1BMJZpNG)ZY64
+rHi>WOSrQo\o0gE:Ohb^]\[m@?8'a^CQQ(S*c17qLR>]kTldbPFP#L<#]geAP3tGi*Gt4ta-\sJZ"/W0m!*Su4Mfe_:PAO\
+-aAm,g[J/4>N;^YXnZW+/b*qo`=-o:fmFPsRqr;lOA4\=]#d'XIXYdU6%1&k0Y\dGLhs;_>sd+t9A*le4hR:jOWVHDbR_^o
+TK-[C]>bhHf9-/ZS`mh[h*ChqNM>kgl"5*3Se&S9]e.Q7^-0e8^-fIff+[V9mNt*d*nl%GH68d>L-qeGdeu0QrW%:AH77O5
+5:et7B=Zrql=92N9_!cmS3<9KjA2aNj)d=KI7AN@c%+->ch"-s"nb=KV%id3qF\'meKj[RoQm6V6[FqlTPpfJa4$1K:W"4G
+>oZAl;r<A8j9%Tcn5(.Es"M<'MiYU<5Q2unJR@Z>r"nBLl#Zj1$\"duq+:V:8*0%I]ISI&?N2U+8&)D*riPb/)uYi$Gn^,J
+9)nKUjd-e[?_?q-ptIUdpS[jPSg\(ilc21e8(2J*mW=]ak<o4C#8Zcl$2csb`4O0f3u0(*A:.TGjd(A\:%\rVNPDX17]5iZ
+eQ:rCrj)A5SU&UW]V%GaB(>%8SgC`=1DV5!S-TdRg>XR<Pru#U(NWB^d)X\W/0:&t&b?JO`C&(+]R`8>hG9WYSAe=t53t]+
+<UZ(<G,0=RG=m'=d+bDOUg*05>GRa^4hZ]UA)8Wi^t5I89@lbeee6S*=0nrBMCYMRf]>!/A^[EZ3m:gF=3Ff!>pN]XQ!PT(
+0BUQ\6I1qBJX,KQm&Wh=9JL0L7<(@M9ff\63/*n3bN%q\]Nt5!kla%_HoZ2:F=]MNX>jBEMU!2U.uo]$LGh,%(bV",<'!E@
++)FX^Oq&2T#$?`\fm[CFhpPsU[Poak;gRs[;gP`4`8p>4`,=#+FAeIb@V9g219jb4\tcihR*`Pqh+l\4BKY275PPo#<k"g`
+>5_+'PdV-5S,X]kP;]7IRMMTd8/iB@_)M30ItnK0%Hq_XIJpABn6br`LrEcuF7>f4OT).Cji7@Zrq$Hq5A3:CHXHbrr6@h.
+em&06QeIXPmJ.^gTmYt)s3aXAKaId:T=aAQF&>+Yl9@#m^VIn8qN%/2d>n'#%f-_%.Nd=7L%5+&b'UPhn((CniG6l(lJ"2k
+6MOT(j\8j:]YRZ$FBs<SY<lR'Gbm0&&72N8]EBb5(YK02Piql5oJu/=BLe]Rb8#ttT'"5EVpm)2l#>AYZqZ)blJoA_I8#&'
+>*DI$Wre'QLSP/Jdg)]GV.$4a;"_PcqKkkkH_e93Mn@W4dN-<FmHc`5PhsR_=($r.1V;mYEMIUX]D`mlSTHHqVMM`c\dJF2
+YJbo*=<UtQ?&&A1Y`rG1/s\-dUEI=5>p,^<]/YkB/"Q:$31HJXc@irq1UPW-e(CY7Lf;sJlm,]C&=gg:-sYtc$c2QT~>
+U
+1 1 /Normal PSL_transp
+2 setlinecap
+N 0 227 M 5669 0 D S
+N 0 0 M 0 227 D S
+N 5669 0 M 0 227 D S
+N 0 0 M 5669 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 3780 0 M 0 -83 D S
+N 5669 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-4000) sh mx
+(-3000) sh mx
+(-2000) sh mx
+(-1000) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-4000) bc Z
+1890 PSL_A0_y MM
+(-3000) bc Z
+3780 PSL_A0_y MM
+(-2000) bc Z
+5669 PSL_A0_y MM
+(-1000) bc Z
+N 378 0 M 0 -42 D S
+N 756 0 M 0 -42 D S
+N 1134 0 M 0 -42 D S
+N 1512 0 M 0 -42 D S
+N 2268 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 3024 0 M 0 -42 D S
+N 3402 0 M 0 -42 D S
+N 4157 0 M 0 -42 D S
+N 4535 0 M 0 -42 D S
+N 4913 0 M 0 -42 D S
+N 5291 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2835 -446 M 267 F0
+(Continuous CPT All Slices Transparent) tc Z
+0 setlinecap
+-709 443 T
+%%EndObject
+0 A
+FQ
+O0
+0 -2362 TM
+
+% PostScript produced by:
+%@GMT: gmt psscale -Ct.cpt -R0/10/0/10 -JX15c -Y-5c -O -Baf '-Bx+lDiscrete CPT Some Transparent'
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+709 -443 T
+25 W
+0.5 1 /Normal PSL_transp
+{0.264 0.309 0.734 C 0.5 0.5 /Normal PSL_transp} FS
+227 945 0 0 Sb
+1 1 /Normal PSL_transp
+{0.159 0.734 0.925 C} FS
+227 945 945 0 Sb
+0.5 1 /Normal PSL_transp
+{0.337 0.981 0.46 C 0.5 0.5 /Normal PSL_transp} FS
+227 945 1890 0 Sb
+1 1 /Normal PSL_transp
+{0.849 0.895 0.211 C} FS
+227 945 2835 0 Sb
+0.5 1 /Normal PSL_transp
+{0.984 0.503 0.132 C 0.5 0.5 /Normal PSL_transp} FS
+227 944 3780 0 Sb
+1 1 /Normal PSL_transp
+{0.728 0.12 0.00784 C} FS
+227 945 4724 0 Sb
+2 setlinecap
+N 0 227 M 5669 0 D S
+N 0 0 M 0 227 D S
+N 5669 0 M 0 227 D S
+N 0 0 M 5669 0 D S
+/PSL_A0_y 83 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -83 D S
+N 1890 0 M 0 -83 D S
+N 3780 0 M 0 -83 D S
+N 5669 0 M 0 -83 D S
+/MM {neg M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-4000) sh mx
+(-3000) sh mx
+(-2000) sh mx
+(-1000) sh mx
+def
+/PSL_A0_y PSL_A0_y 83 add PSL_AH0 add def
+0 PSL_A0_y MM
+(-4000) bc Z
+1890 PSL_A0_y MM
+(-3000) bc Z
+3780 PSL_A0_y MM
+(-2000) bc Z
+5669 PSL_A0_y MM
+(-1000) bc Z
+N 378 0 M 0 -42 D S
+N 756 0 M 0 -42 D S
+N 1134 0 M 0 -42 D S
+N 1512 0 M 0 -42 D S
+N 2268 0 M 0 -42 D S
+N 2646 0 M 0 -42 D S
+N 3024 0 M 0 -42 D S
+N 3402 0 M 0 -42 D S
+N 4157 0 M 0 -42 D S
+N 4535 0 M 0 -42 D S
+N 4913 0 M 0 -42 D S
+N 5291 0 M 0 -42 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2835 -446 M 267 F0
+(Discrete CPT Some Transparent) tc Z
+0 setlinecap
+-709 443 T
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/psscale/transp_scale.sh
+++ b/test/psscale/transp_scale.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Test CPTs with various levels of transparency
+ps=transp_scale.ps
+# 1. Discrete CPT with no transparenty
+gmt makecpt -Cturbo -T-4000/-1000/500 -D > t.cpt
+gmt psscale -Ct.cpt -R0/10/0/10 -JX15c -Y26c -Baf -Bx+l"Discrete CPT No Slices Transparent" -P -K > $ps
+# 2. Discrete CPT with all transparent colors
+gmt makecpt -A50 -Cturbo -T-4000/-1000/500 -D > t.cpt
+gmt psscale -Ct.cpt -R -J -Y-5c -Baf -O -K -Bx+l"Discrete CPT All Slices Transparent" >> $ps
+# 3. Continuous CPT with no transparency
+gmt makecpt -Cturbo -T-4000/-1000 -D > t.cpt
+gmt psscale -Ct.cpt -R -J -Y-5c -O -K -Baf -Bx+l"Continuous CPT No Slices Transparent" >> $ps
+# 4. Continuous CPT with all transparent colors
+gmt makecpt -A50 -Cturbo -T-4000/-1000 -D > t.cpt
+gmt psscale -Ct.cpt -R -J -Y-5c -O -K -Baf -Bx+l"Continuous CPT All Slices Transparent" >> $ps
+# 5. Discrete CPT with some transparent colors
+gmt makecpt -Cturbo -T-4000/-1000/500 -D | awk '{if (NF == 5 && NR%2) {printf "%s\t%s@50\t%s\t%s@50\t%s\n", $1, $2, $3, $4, $5} else {print $0}}'> t.cpt
+gmt psscale -Ct.cpt -R -J -Y-5c -O -Baf -Bx+l"Discrete CPT Odd Transparent" >> $ps

--- a/test/psscale/transp_scale.sh
+++ b/test/psscale/transp_scale.sh
@@ -15,4 +15,4 @@ gmt makecpt -A50 -Cturbo -T-4000/-1000 -D > t.cpt
 gmt psscale -Ct.cpt -R -J -Y-5c -O -K -Baf -Bx+l"Continuous CPT All Slices Transparent" >> $ps
 # 5. Discrete CPT with some transparent colors
 gmt makecpt -Cturbo -T-4000/-1000/500 -D | awk '{if (NF == 5 && NR%2) {printf "%s\t%s@50\t%s\t%s@50\t%s\n", $1, $2, $3, $4, $5} else {print $0}}'> t.cpt
-gmt psscale -Ct.cpt -R -J -Y-5c -O -Baf -Bx+l"Discrete CPT Odd Transparent" >> $ps
+gmt psscale -Ct.cpt -R -J -Y-5c -O -Baf -Bx+l"Discrete CPT Odd Slices Transparent" >> $ps


### PR DESCRIPTION
If the CPT has slices with specified transparency then we now honor that.  For discrete CPTs you may have all or individual slices be transparent, while for continuous CPTs you must either have all or no slices be transparent.  The only case we are not handling is continuous CPTs with a section that implies a change in transparency.  I added a test to demonstrate this capability:

![transp_scale](https://user-images.githubusercontent.com/26473567/121758588-a45b2b00-cabd-11eb-9afd-e4ab7c6aa00e.png)

Closes #5326.