### PR TITLE
Allow drop-down shade modifier in subplot tag option

### DIFF
--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -89,7 +89,7 @@ Optional Arguments (begin mode)
 
 .. _-A:
 
-**-A**\ [*autolabel*][**+c**\ *dx*\ [/*dy*]][**+g**\ *fill*][**+j**\|\ **J**\ *refpoint*][**+o**\ *dx*\ [/*dy*]][**+p**\ *pen*][**+r**\|\ **R**][**+s**\ [[*dx*/*dy*/][*shade*]]][**+v**]
+**-A**\ [*autolabel*][**+c**\ *dx*\ [/*dy*]][**+g**\ *fill*][**+j**\|\ **J**\ *refpoint*][**+o**\ *dx*\ [/*dy*]][**+p**\ *pen*][**+r**\|\ **R**][**+s**\ [[*dx*/*dy*][/*shade*]]][**+v**]
     Specify automatic tagging of each subplot.  Append either a number or letter [a].
     This sets the tag of the first, top-left subplot and others follow sequentially.
     Surround the number or letter by parentheses on any side if these should be typeset

--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -89,7 +89,7 @@ Optional Arguments (begin mode)
 
 .. _-A:
 
-**-A**\ [*autolabel*][**+c**\ *dx*\ [/*dy*]][**+g**\ *fill*][**+j**\|\ **J**\ *refpoint*][**+o**\ *dx*\ [/*dy*]][**+p**\ *pen*][**+r**\|\ **R**][**+v**]
+**-A**\ [*autolabel*][**+c**\ *dx*\ [/*dy*]][**+g**\ *fill*][**+j**\|\ **J**\ *refpoint*][**+o**\ *dx*\ [/*dy*]][**+p**\ *pen*][**+r**\|\ **R**][**+s**\ [[*dx*/*dy*/][*shade*]]][**+v**]
     Specify automatic tagging of each subplot.  Append either a number or letter [a].
     This sets the tag of the first, top-left subplot and others follow sequentially.
     Surround the number or letter by parentheses on any side if these should be typeset
@@ -105,6 +105,9 @@ Optional Arguments (begin mode)
     Append **+p**\ *pen* to draw the outline of the tag's text box using selected *pen* [no outline].
     Append **+r** to typeset your tag numbers using lowercase Roman numerals;
     use **+R** for uppercase Roman numerals [Arabic numerals].
+    Append **+s** to draw an offset background shaded rectangle. Here, *dx*/*dy* indicates the
+    shift relative to the tag box [default is **2p**\ /**-2p**] and *shade* sets the
+    fill style to use for shading [default is **gray50**].
     Append **+v** to increase tag numbers vertically down columns [horizontally across rows].
 
 .. |Add_-B| replace:: |Add_-B_links|

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13814,7 +13814,7 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 				fclose (fp);
 				return NULL;
 			}
-			if (P->fill[0] == '-') P->fill[0] = '\0';		/* - means no fill */
+			if (P->fill[0] == '-') P->fill[0] = '\0';	/* - means no fill */
 			if (P->shade[0] == '-') P->shade[0] = '\0';	/* - means no fill */
 			if (P->pen[0] == '-') P->pen[0] = '\0';		/* - means no pen */
 			P->first = first;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13808,13 +13808,14 @@ struct GMT_SUBPLOT *gmt_subplot_info (struct GMTAPI_CTRL *API, int fig) {
 			return NULL;
 		}
 		if (P->row == row && P->col == col) {	/* Found it */
-			if ((n = sscanf (line, "%*d %*d %*d %*d %*d %lg %lg %lg %lg %s %lg %lg %lg %lg %s %s %s %s",
-				&P->x, &P->y, &P->w, &P->h, P->tag, &P->off[GMT_X], &P->off[GMT_Y], &P->clearance[GMT_X], &P->clearance[GMT_Y], P->refpoint, P->justify, P->fill, P->pen)) != 13) {
+			if ((n = sscanf (line, "%*d %*d %*d %*d %*d %lg %lg %lg %lg %s %lg %lg %lg %lg %s %s %s %s %lg %lg %s",
+				&P->x, &P->y, &P->w, &P->h, P->tag, &P->off[GMT_X], &P->off[GMT_Y], &P->clearance[GMT_X], &P->clearance[GMT_Y], P->refpoint, P->justify, P->fill, P->pen, &P->soff[GMT_X], &P->soff[GMT_Y], P->shade)) != 16) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failure while decoding subplot information file %s.  Bad format? [%s] (n=%d)\n", file, line, n);
 				fclose (fp);
 				return NULL;
 			}
-			if (P->fill[0] == '-') P->fill[0] = '\0';	/* - means no fill */
+			if (P->fill[0] == '-') P->fill[0] = '\0';		/* - means no fill */
+			if (P->shade[0] == '-') P->shade[0] = '\0';	/* - means no fill */
 			if (P->pen[0] == '-') P->pen[0] = '\0';		/* - means no pen */
 			P->first = first;
 			gmt_M_memcpy (P->gap, gap, 4, double);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8817,9 +8817,12 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 					gmt_setpen (GMT, &pen);
 					outline = 1;
 				}
+            if (P->shade[0] && gmt_getfill (GMT, P->shade, &fill)) {  /* Want to paint shade behind the tag box */
+               PSL_setfill (PSL, fill.rgb, 0);  /* Shade color */
+               PSL_plottextbox (PSL, plot_x+P->soff[GMT_X], plot_y+P->soff[GMT_Y], GMT->current.setting.font_tag.size, P->tag, 0.0, justify, P->clearance, 0);
+            }
 				if (P->fill[0] && gmt_getfill (GMT, P->fill, &fill))	/* Want to paint inside of tag box */
 					gmt_fill_syntax (GMT, 'g', NULL, " ");
-
 				PSL_setfill (PSL, fill.rgb, outline);	/* Box color */
 				PSL_plottextbox (PSL, plot_x, plot_y, GMT->current.setting.font_tag.size, P->tag, 0.0, justify, P->clearance, 0);
 				form = gmt_setfont (GMT, &GMT->current.setting.font_tag);	/* Set the tag font */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8805,27 +8805,27 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			PSL_command (PSL, " ");
 			PSL_setfont (PSL, GMT->current.setting.font_tag.id);
 			if (P->pen[0] || P->fill[0] || P->shade[0]) {	/* Must deal with textbox fill/outline/shade */
-            /* All fills and pens have already gone through a syntax check in subplot -A */
+				/* All fills and pens have already gone through a syntax check in subplot -A */
 				int outline = 0;
 				struct GMT_FILL fill;
-            struct GMT_PEN pen;
-            gmt_M_memset (&pen, 1, struct GMT_PEN);
+				struct GMT_PEN pen;
+				gmt_M_memset (&pen, 1, struct GMT_PEN);
 				gmt_init_fill (GMT, &fill, -1.0, -1.0, -1.0);	/* No fill */
 				PSL_command (PSL, "FQ O0\n");	/* Ensure fill/pen have been reset */
-            if (P->shade[0] && !gmt_getfill (GMT, P->shade, &fill)) {  /* Want to paint an offset, shaded rectangle behind the tag box */
-               PSL_setfill (PSL, fill.rgb, 0);  /* Shade color */
-               PSL_plottextbox (PSL, plot_x+P->soff[GMT_X], plot_y+P->soff[GMT_Y], GMT->current.setting.font_tag.size, P->tag, 0.0, justify, P->clearance, 0);
-            }
+				if (P->shade[0] && !gmt_getfill (GMT, P->shade, &fill)) {  /* Want to paint an offset, shaded rectangle behind the tag box */
+					PSL_setfill (PSL, fill.rgb, 0);  /* Shade color */
+					PSL_plottextbox (PSL, plot_x+P->soff[GMT_X], plot_y+P->soff[GMT_Y], GMT->current.setting.font_tag.size, P->tag, 0.0, justify, P->clearance, 0);
+				}
 				if (P->pen[0] && !gmt_getpen (GMT, P->pen, &pen)) {	/* Want to draw the outline of the tag box */
 					gmt_setpen (GMT, &pen);
 					outline = 1;
 				}
-            if (P->fill[0] && !gmt_getfill (GMT, P->fill, &fill)) {  /* Want to paint inside of tag box */
-               PSL_setfill (PSL, fill.rgb, outline);	/* Box color and possible outline */
-               PSL_plottextbox (PSL, plot_x, plot_y, GMT->current.setting.font_tag.size, P->tag, 0.0, justify, P->clearance, 0);
-            }
+				if (P->fill[0] && !gmt_getfill (GMT, P->fill, &fill)) {  /* Want to paint inside of tag box */
+					PSL_setfill (PSL, fill.rgb, outline);	/* Box color and possible outline */
+					PSL_plottextbox (PSL, plot_x, plot_y, GMT->current.setting.font_tag.size, P->tag, 0.0, justify, P->clearance, 0);
+				}
 				form = gmt_setfont (GMT, &GMT->current.setting.font_tag);	/* Set the tag font */
-            /* Finally place the tag text in the box */
+				/* Finally place the tag text in the box */
 				PSL_plottext (PSL, plot_x, plot_y, GMT->current.setting.font_tag.size, NULL, 0.0, justify, form);
 			}
 			else   /* Just place the tag text */

--- a/src/gmt_symbol.h
+++ b/src/gmt_symbol.h
@@ -41,6 +41,7 @@
 
 /* PANEL attributes are used by pslegend, psscale, psimage, gmtlogo */
 
+#define GMT_TAG_CLEARANCE	2.0	/* In points */
 #define GMT_FRAME_CLEARANCE	4.0	/* In points */
 #define GMT_FRAME_GAP		2.0	/* In points */
 #define GMT_FRAME_RADIUS	6.0	/* In points */

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -176,12 +176,14 @@ struct GMT_SUBPLOT {
 	double dim[2];			/* Dimension of entire subplot */
 	double origin[2];		/* Location of lower left figure origin set via -X -Y */
 	double off[2];			/* Offset from justification point of panel tag */
-	double clearance[4];		/* Space around text for surrounding textbox */
+	double soff[2];			/* Shade offset from justification point of panel tag */
+	double clearance[4];	/* Space around text for surrounding textbox */
 	double gap[4];			/* Shrink plottable region to make space for enhancements */
 	char refpoint[3];		/* Reference point for panel tag */
 	char justify[3];		/* Justification relative to refpoint */
 	char tag[GMT_LEN128];		/* Panel tag, e.g., a) */
 	char fill[GMT_LEN64];		/* Panel fill color */
+	char shade[GMT_LEN64];		/* Panel tag shade color */
 	char pen[GMT_LEN64];		/* Panel tag pen outline */
 	char Baxes[GMT_LEN128];		/* The -B setting for selected axes, including +color, tec */
 	char Btitle[GMT_LEN128];	/* The -B setting for any title */

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -228,7 +228,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +o<dx>[/<dy>] to offset tag in direction implied by <justify> [%d%% of font size].\n", GMT_TEXT_OFFSET);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +p to draw the outline of the textbox using selected pen [no outline].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +r to set number using Roman numerals; use +R for uppercase [arabic].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append +s[<dx>/<dy>/][<shade>] to plot a shadow behind the tag panel [Default is 2p/-2p/gray50].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +s[<dx>/<dy>][/<shade>] to plot a shadow behind the tag panel [Default is 2p/-2p/gray50].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +v to number down columns [subplots are numbered across rows].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Specify a gap of dimension <clearance> to the <side> (w|e|s|n) of the plottable subplot.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Shrinks the size for the main plot to make room for scales, bars, etc.\n");

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -95,10 +95,11 @@ struct SUBPLOT_CTRL {
 		unsigned int mode;	/* SUBPLOT_BEGIN|SUBPLOT_SET|SUBPLOT_END*/
 		int row, col;		/* Current (row,col) subplot */
 	} In;
-	struct SUBPLOT_A {	/* -A[<letter>|<number>][+c<clearance>][+g<fill>][+j|J<pos>][+o<offset>][+p<pen>][+r|R][+v] */
+	struct SUBPLOT_A {	/* -A[<letter>|<number>][+c<clearance>][+g<fill>][+j|J<pos>][+o<offset>][+p<pen>][+r|R][+s[<dx>/<dy>/][<shade>]][+v] */
 		bool active;			/* Want to plot subplot tags */
 		char format[GMT_LEN128];	/* Format for plotting tag (or constant string when done via subplot set) */
 		char fill[GMT_LEN64];		/* Color fill for optional rectangle behind the tag [none] */
+		char shade[GMT_LEN64];		/* Color fill for optional shade behind rectangle behind the tag [none] */
 		char pen[GMT_LEN64];		/* Outline pen for optional rectangle behind the tag [none] */
 		unsigned int mode;		/* Either letter (0) of number (1) tag */
 		unsigned int nstart;		/* Offset count number for first subplot (0) */
@@ -108,6 +109,7 @@ struct SUBPLOT_CTRL {
 		char placement[3];		/* Placement of tag [TL] */
 		char justify[3];		/* Justification of tag [TL] */
 		double off[2];			/* Offset from placement location [20% of font size] */
+		double soff[2];			/* Shade offset from tag location [20% of font size] */
 		double clearance[2];		/* Padding around text for rectangle behind the tag [15%] */
 	} A;
 	struct SUBPLOT_C {	/* -C[side]<clearance>  */
@@ -167,7 +169,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	sprintf (C->A.justify, "TL");
 	C->A.off[GMT_X] = C->A.off[GMT_Y] = 0.01 * GMT_TEXT_OFFSET * GMT->current.setting.font_tag.size / PSL_POINTS_PER_INCH; /* 20% */
 	C->A.clearance[GMT_X] = C->A.clearance[GMT_Y] = 0.01 * GMT_TEXT_CLEARANCE * GMT->current.setting.font_tag.size / PSL_POINTS_PER_INCH;	/* 15% */
-	C->A.fill[0] = C->A.pen[0] = '-';	/* No fill or outline */
+	C->A.fill[0] = C->A.shade[0] = C->A.pen[0] = '-';	/* No fills or outline */
 	C->F.fill[0] = C->F.pen[0] = '-';	/* No fill or outline */
 	for (unsigned int k = 0; k < 4; k++) C->M.margin[k] = 0.5 * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;	/* Split annot font across two sides */
 	return (C);
@@ -215,7 +217,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +p to draw the outline of the figure rectangle using selected pen [no outline].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +w to draw dividing lines between interior subplots using selected pen [no lines].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-A Specify automatic tagging of each subplot.  Append either a number or letter [a].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t-A Specify automatic tagging of each subplot. Append either a number or letter [a].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   This sets the tag of the top-left subplot and others follow sequentially.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Surround number or letter by parentheses on any side if these should be typeset.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Use +j|J<refpoint> to specify where the tag should be plotted in the subplot [TL].\n");
@@ -226,6 +228,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +o<dx>[/<dy>] to offset tag in direction implied by <justify> [%d%% of font size].\n", GMT_TEXT_OFFSET);
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +p to draw the outline of the textbox using selected pen [no outline].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +r to set number using Roman numerals; use +R for uppercase [arabic].\n");
+	GMT_Message (API, GMT_TIME_NONE, "\t   Append +s[<dx>/<dy>/][<shade>] to plot a shadow behind the tag panel [Default is 4p/-4p/gray50].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Append +v to number down columns [subplots are numbered across rows].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C Specify a gap of dimension <clearance> to the <side> (w|e|s|n) of the plottable subplot.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Shrinks the size for the main plot to make room for scales, bars, etc.\n");
@@ -365,8 +368,8 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 					}
 					if (c) {	/* Gave modifiers so we must parse those now */
 						c[0] = '+';	/* Restore modifiers */
-						/* Modifiers are [+c<dx/dy>][+g<fill>][+j|J<justify>][+o<dx/dy>][+p<pen>][+r|R][+v] */
-						if (gmt_validate_modifiers (GMT, opt->arg, 'A', "cgjJoprRv", GMT_MSG_ERROR)) n_errors++;
+						/* Modifiers are [+c<dx/dy>][+g<fill>][+j|J<justify>][+o<dx/dy>][+p<pen>][+r|R][+s[<dx>/<dy>/][<shade>]][+v] */
+						if (gmt_validate_modifiers (GMT, opt->arg, 'A', "cgjJoprsRv", GMT_MSG_ERROR)) n_errors++;
 						if (gmt_get_modifier (opt->arg, 'j', Ctrl->A.placement)) {	/* Inside placement */
 							gmt_just_validate (GMT, Ctrl->A.placement, "TL");
 							strncpy (Ctrl->A.justify, Ctrl->A.placement, 2);
@@ -391,6 +394,25 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 							Ctrl->A.roman = GMT_IS_ROMAN_LCASE;
 						else if (gmt_get_modifier (opt->arg, 'R', string))	/* Want upper-case roman numbering */
 							Ctrl->A.roman = GMT_IS_ROMAN_UCASE;
+						if (gmt_get_modifier (opt->arg, 's', string)) {	/* shading behind rectangle */
+							char txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, txt_c[GMT_LEN64] = {""};
+							n = sscanf (string, "%[^/]/%[^/]/%s", txt_a, txt_b, txt_c);
+							Ctrl->A.soff[GMT_X] = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_CLEARANCE;	/* Default is (4p,-4p) */
+							Ctrl->A.soff[GMT_Y] = -Ctrl->A.soff[GMT_X];
+							strcpy (Ctrl->A.shade, "127");	/* Default gray shade */
+							if (n == 1)	/* Just got a new shade */
+								strcpy (Ctrl->A.shade, txt_a);
+							else if (n == 2) {	/* Just got a new shade offset */
+								if (gmt_get_pair (GMT, string, GMT_PAIR_DIM_DUP, Ctrl->A.soff) < 0) n_errors++;
+							}
+							else if (n == 3) {	/* Got offset and shade */
+								Ctrl->A.soff[GMT_X] = gmt_M_to_inch (GMT, txt_a);
+								Ctrl->A.soff[GMT_Y] = gmt_M_to_inch (GMT, txt_b);
+								strcpy (Ctrl->A.shade, txt_c);
+							}
+							else n_errors++;
+							if (gmt_getfill (GMT, Ctrl->A.shade, &fill)) n_errors++;
+						}
 						if (gmt_get_modifier (opt->arg, 'v', string))	/* Tag order is vertical down columns */
 							Ctrl->A.way = GMT_IS_COL_FORMAT;
 					}
@@ -1224,7 +1246,7 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		if (GMT->common.J.active && GMT->current.proj.projection == GMT_LINEAR)	/* Write axes directions for Cartesian plots as +1 or -1 */
 			fprintf (fp, "# DIRECTION: %d %d\n", 2*GMT->current.proj.xyz_pos[GMT_X]-1, 2*GMT->current.proj.xyz_pos[GMT_Y]-1);
 		/* Write header record */
-		fprintf (fp, "#subplot\trow\tcol\tnrow\tncol\tx0\ty0\tw\th\ttag\ttag_dx\ttag_dy\ttag_clearx\ttag_cleary\ttag_pos\ttag_just\ttag_fill\ttag_pen\tBframe\tBx\tBy\tAx\tAy\n");
+		fprintf (fp, "#subplot\trow\tcol\tnrow\tncol\tx0\ty0\tw\th\ttag\ttag_dx\ttag_dy\ttag_clearx\ttag_cleary\ttag_pos\ttag_just\ttag_fill\ttag_pen\tshade_offx\tshade_offy\tshade\tBframe\tBx\tBy\tAx\tAy\n");
 		for (row = panel = 0; row < Ctrl->N.dim[GMT_Y]; row++) {	/* For each row of subplots */
 			for (col = 0; col < Ctrl->N.dim[GMT_X]; col++, panel++) {	/* For each col of subplots */
 				k = (Ctrl->A.way == GMT_IS_COL_FORMAT) ? col * Ctrl->N.dim[GMT_Y] + row : row * Ctrl->N.dim[GMT_X] + col;
@@ -1242,10 +1264,10 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 					else	/* A character, perhaps offset from a) */
 						fprintf (fp, Ctrl->A.format, Ctrl->A.cstart + k);
 					fprintf (fp, "\t%g\t%g\t%g\t%g\t%s\t%s", Ctrl->A.off[GMT_X], Ctrl->A.off[GMT_Y], Ctrl->A.clearance[GMT_X], Ctrl->A.clearance[GMT_Y], Ctrl->A.placement, Ctrl->A.justify);
-					fprintf (fp, "\t%s\t%s", Ctrl->A.fill, Ctrl->A.pen);
+					fprintf (fp, "\t%s\t%s\t%g\t%g\t%s", Ctrl->A.fill, Ctrl->A.pen, Ctrl->A.soff[GMT_X], Ctrl->A.soff[GMT_Y], Ctrl->A.shade);
 				}
 				else	/* No subplot tags, write default fillers */
-					fprintf (fp, "-\t0\t0\t0\t0\tBL\tBL\t-\t-");
+					fprintf (fp, "-\t0\t0\t0\t0\tBL\tBL\t-\t-\t0\t0\t-");
 				/* Now the four -B settings items placed between GMT_ASCII_GS characters since there may be spaces in them */
 				if (no_frame || Ctrl->D.active)	/* Default filler since we don't want any frames */
 					fprintf (fp, "\t%c+n%c%c%c%c%c\n", GMT_ASCII_GS, GMT_ASCII_GS, GMT_ASCII_GS, GMT_ASCII_GS, GMT_ASCII_GS, GMT_ASCII_GS);	/* Pass -B+n only */


### PR DESCRIPTION
**Description of proposed changes**

Similarly to the ability to specify a drop-down shade behind legends, this added modifier (with the same syntax) adds this capability to the subplot auto-tagging machinery: 

`Append +s[<dx>/<dy>/][<shade>] to plot a shadow behind the tag panel [Default is 2p/-2p/gray50].`

Here is an example with the dropped shade being black and transparent, allowing subtleties in the background image to remain visible:

![ex53](https://user-images.githubusercontent.com/26473567/121973102-46764f80-cd18-11eb-95d5-9e08bd4f0b4a.png)
