### PR TITLE
Let GMT_Encode_Option do its job for psternary

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12812,11 +12812,6 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 	else if (!strncmp (module, "grdinfo", 7U)) {
 		type = ((opt = GMT_Find_Option (API, 'Q', *head))) ? 'U' : 'G';	/* Giving -Q means we are reading 3-D cubes */
 	}
-    /* 1u. Check if psternary is plotting or dumping */
-    else if (!strncmp (module, "psternary", 9U)) {
-        /* PostScript output unless -M */
-        type = (GMT_Find_Option (API, 'M', *head)) ? 'D' : 'X';  /* -M means dump (x,b,c) data */
-    }
 
 	/* 2a. Get the option key array for this module */
 	key = gmtapi_process_keys (API, keys, type, *head, n_per_family, &n_keys);	/* This is the array of keys for this module, e.g., "<D{,GG},..." */

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -30,7 +30,7 @@
 #define THIS_MODULE_MODERN_NAME	"ternary"
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Plot data on ternary diagrams"
-#define THIS_MODULE_KEYS	"<D{,>?},>DM,C-("
+#define THIS_MODULE_KEYS	"<D{,>X},>DM,C-("
 #define THIS_MODULE_NEEDS	"Jd"
 #define THIS_MODULE_OPTIONS "-:>BJKOPRUVXYbdefghipqstxy"
 


### PR DESCRIPTION
No special code needed in gmt_api.c - the KEYS work as advertised.  The initial problem was lack the of an output file name for writing when -M was set, which I fixed and merged directly to master earlier (by mistake).  Only applies to Mex and Julia.
