### PR TITLE
Fix problems in gmt_parse_array exposed by makecpt

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -17190,7 +17190,7 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 		return GMT_PARSE_ERROR;
 	}
 	/* 3. Check if we are working with absolute time.  This means there must be a T in both min or max arguments */
-	if (ns > 1 && (strchr (txt[GMT_X], 'T') || strchr (txt[GMT_Y], 'T'))) {	/* Gave absolute time limits */
+	if (ns >= 1 && (strchr (txt[GMT_X], 'T') || strchr (txt[GMT_Y], 'T'))) {	/* Gave absolute time limits */
 		T->temporal = true;
 		if (!(flags & GMT_ARRAY_TIME)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option %c: Calendar time not allowed for this module\n", option);
@@ -17224,6 +17224,8 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 			/* Check if unit is a variable increment */
 			T->vartime = (strchr (GMT_TIME_VAR_UNITS, T->unit) != NULL);
 		}
+		else	/* Set assumed time unit */
+			T->unit = GMT->current.setting.time_system.unit;
 	}
 	/* 4. Consider spatial distances */
 	if (has_inc && !T->temporal && strchr (GMT_LEN_UNITS "c", txt[ns][len])) {	/* Geospatial or Cartesian distances */

--- a/test/makecpt/timecpt_noinc.sh
+++ b/test/makecpt/timecpt_noinc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Test makecpt with time array lacking an increament value
+
+cat << EOF > cpt-true.cpt
+2012-06-29T08:00:00	0/0/127	2012-08-27T20:22:30	blue	L	
+2012-08-27T20:22:30	blue	2012-12-24T21:07:30	cyan	L	
+2012-12-24T21:07:30	cyan	2013-04-22T21:52:30	yellow	L	
+2013-04-22T21:52:30	yellow	2013-08-19T22:37:30	red	L	
+2013-08-19T22:37:30	red	2013-10-18T11:00:00	127/0/0	B	
+EOF
+
+gmt makecpt -Cjet -T2012-06-29T08:00:00/2013-10-18T11:00:00 -N > cpt-test.cpt
+
+diff cpt-true.cpt cpt-test.cpt --strip-trailing-cr >> fail


### PR DESCRIPTION
A failed if-test in _gmt_parse_array_ meant that **-T**_date1_/_date2_ (with no increment, as used in **makecpt**) would not be seen as temporal arguments and hence output would be in Cartesian seconds, not as a datetime stamp. Once fixed, it became clear that we also need to set the default time unit to the same as the system default [s] unless the user specified in increment with a specific unit.  This PR relates to this [issue](https://forum.generic-mapping-tools.org/t/label-color-bars-with-date-time-strings/1802/4) posted on the forum.

`gmt makecpt -Cjet -T2012-06-29T08:00:00/2013-10-18T11:00:00 -N`

Output before PR:

```
1340956800	0/0/127	1346098950	blue	L	
1346098950	blue	1356383250	cyan	L	
1356383250	cyan	1366667550	yellow	L	
1366667550	yellow	1376951850	red	L	
1376951850	red	1382094000	127/0/0	B
```

Output after PR:

```
2012-06-29T08:00:00	0/0/127	2012-08-27T20:22:30	blue	L	
2012-08-27T20:22:30	blue	2012-12-24T21:07:30	cyan	L	
2012-12-24T21:07:30	cyan	2013-04-22T21:52:30	yellow	L	
2013-04-22T21:52:30	yellow	2013-08-19T22:37:30	red	L	
2013-08-19T22:37:30	red	2013-10-18T11:00:00	127/0/0	B
```	

Tests unaffected.