### PR TITLE
Improve code readability using named PSL vector, wedge, and matharc dim indices

### DIFF
--- a/src/geodesy/psvelo.c
+++ b/src/geodesy/psvelo.c
@@ -389,9 +389,12 @@ GMT_LOCAL int psvelo_trace_cross (struct GMT_CTRL *GMT, double slon, double slat
 		vw = v_width;
 	}
 
-	dim[0] = x2, dim[1] = y2;
-	dim[2] = vw, dim[3] = hl, dim[4] = hw;
-	dim[5] = vector_shape, dim[6] = PSL_VEC_END | PSL_VEC_FILL;
+	dim[PSL_VEC_XTIP] = x2;
+	dim[PSL_VEC_YTIP] = y2;
+	dim[PSL_VEC_TAIL_WIDTH] = vw;
+	dim[PSL_VEC_HEAD_LENGTH] = hl;
+	dim[PSL_VEC_HEAD_WIDTH] = hw;
+	dim[PSL_VEC_HEAD_SHAPE] = vector_shape, dim[PSL_VEC_STATUS] = PSL_VEC_END | PSL_VEC_FILL;
 	PSL_plotsymbol (GMT->PSL, x1, y1, dim, PSL_VECTOR);
 
 	/* second, extensional arrow in opposite direction */
@@ -415,14 +418,17 @@ GMT_LOCAL int psvelo_trace_cross (struct GMT_CTRL *GMT, double slon, double slat
 		vw = v_width;
 	}
 
-	dim[0] = x2, dim[1] = y2;
-	dim[2] = vw, dim[3] = hl, dim[4] = hw;
+	dim[PSL_VEC_XTIP] = x2;
+	dim[PSL_VEC_YTIP] = y2;
+	dim[PSL_VEC_TAIL_WIDTH] = vw;
+	dim[PSL_VEC_HEAD_LENGTH] = hl;
+	dim[PSL_VEC_HEAD_WIDTH] = hw;
 	PSL_plotsymbol (GMT->PSL, x1, y1, dim, PSL_VECTOR);
 
 	/* compression component */
 	dx = eps2 * s;
 	dy = eps2 * c;
-	dim[6] = PSL_VEC_BEGIN | PSL_VEC_FILL;
+	dim[PSL_VEC_STATUS] = PSL_VEC_BEGIN | PSL_VEC_FILL;
 	psvelo_trace_arrow (GMT, slon, slat, dx, dy, sscale, &x1, &y1, &x2, &y2);
 
 	if (eps2 > 0.0) {
@@ -443,8 +449,11 @@ GMT_LOCAL int psvelo_trace_cross (struct GMT_CTRL *GMT, double slon, double slat
 		vw = v_width;
 	}
 
-	dim[0] = x2, dim[1] = y2;
-	dim[2] = vw, dim[3] = hl, dim[4] = hw;
+	dim[PSL_VEC_XTIP] = x2;
+	dim[PSL_VEC_YTIP] = y2;
+	dim[PSL_VEC_TAIL_WIDTH] = vw;
+	dim[PSL_VEC_HEAD_LENGTH] = hl;
+	dim[PSL_VEC_HEAD_WIDTH] = hw;
 	PSL_plotsymbol (GMT->PSL, x1, y1, dim, PSL_VECTOR);
 
 	/* second, compressional arrow in opposite direction */
@@ -470,8 +479,11 @@ GMT_LOCAL int psvelo_trace_cross (struct GMT_CTRL *GMT, double slon, double slat
 		vw = v_width;
 	}
 
-	dim[0] = x2, dim[1] = y2;
-	dim[2] = vw, dim[3] = hl, dim[4] = hw;
+	dim[PSL_VEC_XTIP] = x2;
+	dim[PSL_VEC_YTIP] = y2;
+	dim[PSL_VEC_TAIL_WIDTH] = vw;
+	dim[PSL_VEC_HEAD_LENGTH] = hl;
+	dim[PSL_VEC_HEAD_WIDTH] = hw;
 	PSL_plotsymbol (GMT->PSL, x1, y1, dim, PSL_VECTOR);
 
 	return 0;
@@ -1248,9 +1260,12 @@ EXTERN_MSC int GMT_psvelo (void *V_API, int mode, void *args) {
 						}
 						gmt_setpen (GMT, &current_pen);
 					}
-					dim[0] = plot_vx, dim[1] = plot_vy;
-					dim[2] = vw, dim[3] = hl, dim[4] = hw;
-					dim[5] = Ctrl->A.S.v.v_shape;
+					dim[PSL_VEC_XTIP]        = plot_vx;
+					dim[PSL_VEC_YTIP]        = plot_vy;
+					dim[PSL_VEC_TAIL_WIDTH]  = vw;
+					dim[PSL_VEC_HEAD_LENGTH] = hl;
+					dim[PSL_VEC_HEAD_WIDTH]  = hw;
+					dim[PSL_VEC_HEAD_SHAPE]  = Ctrl->A.S.v.v_shape;
 					if (Ctrl->L.active) {
 						current_pen = Ctrl->L.pen;
 						if (Ctrl->H.active) {
@@ -1264,9 +1279,10 @@ EXTERN_MSC int GMT_psvelo (void *V_API, int mode, void *args) {
 						psl_vector_v4 (PSL, plot_x, plot_y, dim, this_rgb, Ctrl->L.active);
 					}
 					else {
-						dim[6] = (double)Ctrl->A.S.v.status;
-						dim[7] = (double)Ctrl->A.S.v.v_kind[0];	dim[8] = (double)Ctrl->A.S.v.v_kind[1];
-						dim[11] = (headpen_width > 0.0) ? headpen_width : 0.5 * Ctrl->W.pen.width;
+						dim[PSL_VEC_STATUS]          = (double)Ctrl->A.S.v.status;
+						dim[PSL_VEC_HEAD_TYPE_BEGIN] = (double)Ctrl->A.S.v.v_kind[0];
+						dim[PSL_VEC_HEAD_TYPE_END]   = (double)Ctrl->A.S.v.v_kind[1];
+						dim[PSL_VEC_HEAD_PENWIDTH]   = (headpen_width > 0.0) ? headpen_width : 0.5 * Ctrl->W.pen.width;
 						if (Ctrl->A.S.v.status & PSL_VEC_FILL2)
 							gmt_setfill (GMT, &Ctrl->A.S.v.fill, Ctrl->L.active);
 						else if (set_g_fill)

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -91,7 +91,7 @@ static double *GMT_x_annotation[4] = {NULL, NULL, NULL, NULL}, *GMT_y_annotation
 void gmt_linearx_grid (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n, double dval);
 
 /* Get bitmapped 600 dpi GMT glyph for timestamp.  The glyph is a 90 x 220 pixel 1-bit image
-   and it is here represented as ceil (220 / 8) * 90 = 2520 bytes */
+	and it is here represented as ceil (220 / 8) * 90 = 2520 bytes */
 
 static unsigned char GMT_glyph[2520] = {
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -3116,7 +3116,7 @@ GMT_LOCAL void gmtplot_timestamp (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, do
 	PSL_deftextdim (PSL, "PSL_b", 8.0, label);	/* Size of the white [timestamp] box (use only length) */
 
 	/* When justification is not BL (justify == 1), add some PostScript code to move to the
-	   location where the lower left corner of the time stamp box is to be drawn */
+		location where the lower left corner of the time stamp box is to be drawn */
 
 	switch ((justify + 3) % 4) {
 		case 1:	/* Center */
@@ -3298,7 +3298,7 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 			angle = 90.0 - (offset + val[i]);	/* Since val is azimuth */
 			sincosd (ew_angle + angle, &s, &c);
 			x[0] = mr->refpoint->x + (R[level] + GMT->current.setting.map_annot_offset[level]) * c, y[0] =
-			       mr->refpoint->y + (R[level] + GMT->current.setting.map_annot_offset[level]) * s;
+					 mr->refpoint->y + (R[level] + GMT->current.setting.map_annot_offset[level]) * s;
 			if (GMT->current.setting.map_degree_symbol == gmt_none)
 				snprintf (label, GMT_LEN16, "%ld", lrint (val[i]));
 			else
@@ -3649,7 +3649,7 @@ GMT_LOCAL void gmtplot_flush_symbol_piece (struct GMT_CTRL *GMT, struct PSL_CTRL
 
 GMT_LOCAL void gmtplot_format_symbol_string (struct GMT_CTRL *GMT, struct GMT_CUSTOM_SYMBOL_ITEM *s, double size[], char *text) {
 	/* Returns the [possibly reformatted] string to use for the letter macro.
- 	 * These are the things that can happen:
+	 * These are the things that can happen:
 	 * 1. Action = GMT_SYMBOL_TEXT means we have a static fixed text string; just copy
 	 * 2. s->text is $t.  Then we use the trailing text from the input as the text.
 	 *    Optionally, a single word of the trailing text can be selected by appending
@@ -4613,7 +4613,7 @@ GMT_LOCAL double gmtplot_get_local_scale (struct GMT_CTRL *GMT, double lon0, dou
 
 GMT_LOCAL void gmtplot_circle_pen_poly (struct GMT_CTRL *GMT, double *A, double *B, bool longway, double rot, struct GMT_PEN *pen, struct GMT_SYMBOL *S, struct GMT_CIRCLE *C, double scale) {
 	/* Given vectors A and B, return a small circle polygon path sampled every step that approximates a pen of given width
- 	 * drawn on the map.  Use small circle pole and its opening rot */
+	 * drawn on the map.  Use small circle pole and its opening rot */
 	uint64_t k, n, n2;
 	double Ai[3], Ao[3], Px[3], X[3], R[3][3], R0[3][3], w, step;
 	struct GMT_DATASEGMENT *L = NULL;
@@ -5466,10 +5466,10 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		gmt_M_memset (dim, PSL_MAX_DIMS, double);
 		vector_width = rint (PSL_DOTS_PER_INCH * GMT->current.setting.map_frame_pen.width / PSL_POINTS_PER_INCH) / PSL_DOTS_PER_INCH;	/* Round off vector width same way as pen width */
 		dim[PSL_VEC_TAIL_WIDTH]    = vector_width;
-      dim[PSL_VEC_HEAD_LENGTH]   = 10.0 * vector_width;
-      dim[PSL_VEC_HEAD_WIDTH]    = 5.0 * vector_width;
+		dim[PSL_VEC_HEAD_LENGTH]   = 10.0 * vector_width;
+		dim[PSL_VEC_HEAD_WIDTH]    = 5.0 * vector_width;
 		dim[PSL_VEC_HEAD_SHAPE]    = GMT->current.setting.map_vector_shape;
-      dim[PSL_VEC_STATUS]        = PSL_VEC_END | PSL_VEC_FILL;
+		dim[PSL_VEC_STATUS]        = PSL_VEC_END | PSL_VEC_FILL;
 		dim[PSL_VEC_HEAD_PENWIDTH] = 0.5 * GMT->current.setting.map_frame_pen.width;
 		PSL_defpen (PSL, "PSL_vecheadpen", GMT->current.setting.map_frame_pen.width, GMT->current.setting.map_frame_pen.style, GMT->current.setting.map_frame_pen.offset, GMT->current.setting.map_frame_pen.rgb);
 
@@ -5531,7 +5531,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 
 		is_interval = (T->type == 'i' || T->type == 'I');	/* Interval or tick mark annotation? */
 		nx = gmtlib_coordinate_array (GMT, val0, val1, &A->item[k], &knots, &label_c);	/* Get all the annotation tick knots */
-      delta = (label_c) ? GMT->session.d_NaN : A->item[k].interval;
+		delta = (label_c) ? GMT->session.d_NaN : A->item[k].interval;
 		do_annot = (nx && k < GMT_TICK_UPPER && annotate && !gmt_M_axis_is_geo_strict (GMT, axis) && T->unit != 'r');	/* Cannot annotate a Gregorian week */
 		do_tick = !((T->unit == 'K' || T->unit == 'k') && T->interval > 1 && fmod (T->interval, 7.0) > 0.0);	/* Do we want tick marks? */
 		nx1 = (nx > 0 && is_interval) ? nx - 1 : nx;
@@ -5572,7 +5572,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 				if (!is_interval && gmtplot_skip_second_annot (k, knots[i], knots_p, np, primary)) continue;	/* Secondary annotation skipped when coinciding with primary annotation */
 				if (label_c && label_c[i] && label_c[i][0]) {
 					strncpy (string, label_c[i], GMT_LEN256-1);
-            }
+				}
 				else
 					gmtlib_get_coordinate_label (GMT, string, &GMT->current.plot.calclock, format, T, knots[i], delta);	/* Get annotation string */
 				PSL_deftextdim (PSL, ortho ? "-w" : "-h", font.size, string);
@@ -5642,24 +5642,24 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		double label_angle;
 		char *this_label = (far_ && A->secondary_label[0]) ? A->secondary_label : A->label;	/* Get primary or secondary axis label */
 
-      if (axis == GMT_Y && A->label_mode) {
-         l_just = (below) ? PSL_MR : PSL_ML;
-         label_angle = 0.0 + y_angle_add;
-      }
-      else {
-         double angle_add = (axis == GMT_X) ? x_angle_add : y_angle_add;
-         l_just = (axis == GMT_X) ? lx_just : ly_just;
-         label_angle = (horizontal ? 0.0 : 90.0) + angle_add;
-      }
+		if (axis == GMT_Y && A->label_mode) {
+			l_just = (below) ? PSL_MR : PSL_ML;
+			label_angle = 0.0 + y_angle_add;
+		}
+		else {
+			double angle_add = (axis == GMT_X) ? x_angle_add : y_angle_add;
+			l_just = (axis == GMT_X) ? lx_just : ly_just;
+			label_angle = (horizontal ? 0.0 : 90.0) + angle_add;
+		}
 		if (!MM_set) PSL_command (PSL, "/MM {%s%sM} def\n", neg ? "neg " : "", (axis != GMT_X) ? "exch " : "");
 		form = gmt_setfont (GMT, &GMT->current.setting.font_label);
 		PSL_command (PSL, "/PSL_LH ");	/* PSL_LH is the height of the label text based on height of letter M */
 		PSL_deftextdim (PSL, "-h", GMT->current.setting.font_label.size, "M");
 		PSL_command (PSL, "def\n");
-      if (GMT->current.setting.map_label_mode[L_axis] == GMT_LABEL_AXIS) /* Base of label is a fixed distance from axis */
-         PSL_command (PSL, "/PSL_L_y %d %sdef\n", PSL_IZ (PSL, fabs (GMT->current.setting.map_label_offset[L_axis])), (neg == horizontal) ? "PSL_LH add " : "");
-      else
-         PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset[L_axis]), (neg == horizontal) ? "PSL_LH add " : "");
+		if (GMT->current.setting.map_label_mode[L_axis] == GMT_LABEL_AXIS) /* Base of label is a fixed distance from axis */
+			PSL_command (PSL, "/PSL_L_y %d %sdef\n", PSL_IZ (PSL, fabs (GMT->current.setting.map_label_offset[L_axis])), (neg == horizontal) ? "PSL_LH add " : "");
+		else
+			PSL_command (PSL, "/PSL_L_y PSL_A0_y PSL_A1_y mx %d add %sdef\n", PSL_IZ (PSL, GMT->current.setting.map_label_offset[L_axis]), (neg == horizontal) ? "PSL_LH add " : "");
 		/* Move to new anchor point for label */
 		if (angled && axis == GMT_X)	/* Add offset due to angled x-annotations */
 			PSL_command (PSL, "%d PSL_L_y PSL_slant_y add MM\n", PSL_IZ (PSL, 0.5 * length));
@@ -5893,15 +5893,15 @@ void gmt_plot_line (struct GMT_CTRL *GMT, double *x, double *y, unsigned int *pe
 
 	/* Here we must check for jumps, pen changes etc */
 
-    if (GMT->common.R.oblique) {
-        double www = GMT->current.proj.rect[XHI] - GMT->current.proj.rect[XLO];
-        for (k = i+1; k < n; k++) {
-            if (doubleAlmostEqual (fabs (x[k-1] - x[k]), www) && pen[k] & PSL_CLIP) {
-                if (pen[k] == PSL_CLIP) /* Fix a mistake made earlier */
-                    pen[k] = PSL_MOVE;
-            }
-        }
-    }
+	 if (GMT->common.R.oblique) {
+		  double www = GMT->current.proj.rect[XHI] - GMT->current.proj.rect[XLO];
+		  for (k = i+1; k < n; k++) {
+				if (doubleAlmostEqual (fabs (x[k-1] - x[k]), www) && pen[k] & PSL_CLIP) {
+					 if (pen[k] == PSL_CLIP) /* Fix a mistake made earlier */
+						  pen[k] = PSL_MOVE;
+				}
+		  }
+	 }
 	start_pen = pen[i];
 	if (pen[i] & PSL_CLIP) { 	/* Must add extra extension point before the first point */
 		gmtplot_get_outside_point_extension (GMT, x[i], y[i], x[i+1], y[i+1], &x_ext, &y_ext);
@@ -7339,7 +7339,7 @@ int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double s
 				}
 				else {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR,
-					            "Unrecognized symbol code (%d = '%c') passed to gmt_draw_custom_symbol\n", action, (char)action);
+									"Unrecognized symbol code (%d = '%c') passed to gmt_draw_custom_symbol\n", action, (char)action);
 					return GMT_PARSE_ERROR;
 					break;
 				}
@@ -7442,7 +7442,7 @@ int gmt_draw_custom_symbol (struct GMT_CTRL *GMT, double x0, double y0, double s
 
 			default:
 				GMT_Report (GMT->parent, GMT_MSG_ERROR,
-				            "Unrecognized symbol code (%d = '%c') passed to gmt_draw_custom_symbol\n", action, (char)action);
+								"Unrecognized symbol code (%d = '%c') passed to gmt_draw_custom_symbol\n", action, (char)action);
 				return GMT_PARSE_ERROR;
 				break;
 		}
@@ -7598,7 +7598,7 @@ GMT_LOCAL void gmtplot_wipe_substr(char *str1, char *str2) {
 #ifdef HAVE_GDAL
 char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 	/* Take a PROJ.4 projection string or EPSG code and try to find the equivalent -J syntax
-	   scale_pos is position on the return string where starts the scale sub-string.
+		scale_pos is position on the return string where starts the scale sub-string.
 	*/
 	unsigned int pos = 0;
 	//bool got_lonlat = false;
@@ -7690,7 +7690,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 	}
 	/* Cylindrical projections */
 	else if (!strcmp(prjcode, "cea") || !strcmp(prjcode, "eqc") || !strcmp(prjcode, "tmerc") ||
-		     !strcmp(prjcode, "mill") || !strcmp(prjcode, "merc") || !strcmp(prjcode, "cass")) {
+			  !strcmp(prjcode, "mill") || !strcmp(prjcode, "merc") || !strcmp(prjcode, "cass")) {
 		if (!strcmp(prjcode, "tmerc"))     strcat (opt_J, "T");
 		else if (!strcmp(prjcode, "cea"))  strcat (opt_J, "Y");
 		else if (!strcmp(prjcode, "eqc"))  strcat (opt_J, "Q");
@@ -7708,7 +7708,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 			}
 		}
 		if (!strcmp(prjcode, "cea") || !strcmp(prjcode, "eqc") || !strcmp(prjcode, "cass") ||
-		    !strcmp(prjcode, "tmerc") || !strcmp(prjcode, "merc")) {
+			 !strcmp(prjcode, "tmerc") || !strcmp(prjcode, "merc")) {
 			if (!lon_0[0]) strcat(lon_0, "0");
 			if (!lat_0[0]) strcat(lat_0, "0");
 			strcat(opt_J, lon_0);	strcat (opt_J, "/");
@@ -7830,7 +7830,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 
 	/* Azimuthal projections */
 	else if (!strcmp(prjcode, "stere") || !strcmp(prjcode, "laea") || !strcmp(prjcode, "aeqd") || !strcmp(prjcode, "gnom") ||
-	         !strcmp(prjcode, "sterea") || !strcmp(prjcode, "stere")) {
+				!strcmp(prjcode, "sterea") || !strcmp(prjcode, "stere")) {
 		if (!strcmp(prjcode, "stere")) strcat (opt_J, "S");
 		else if (!strcmp(prjcode, "laea")) strcat (opt_J, "A");
 		else if (!strcmp(prjcode, "aeqd")) strcat (opt_J, "E");
@@ -7862,8 +7862,8 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 
 	/* Misc projections */
 	else if (!strcmp(prjcode, "moll") || !strcmp(prjcode, "sinu") || !strcmp(prjcode, "vandg") ||
-	         !strcmp(prjcode, "robin") || !strcmp(prjcode, "wintri") || !strcmp(prjcode, "hammer") ||
-	         !strcmp(prjcode, "eck4") || !strcmp(prjcode, "eck6")) {
+				!strcmp(prjcode, "robin") || !strcmp(prjcode, "wintri") || !strcmp(prjcode, "hammer") ||
+				!strcmp(prjcode, "eck4") || !strcmp(prjcode, "eck6")) {
 		if (!strcmp(prjcode, "moll")) strcat (opt_J, "W");
 		else if (!strcmp(prjcode, "sinu"))   strcat (opt_J, "I");
 		else if (!strcmp(prjcode, "vandg"))  strcat (opt_J, "V");
@@ -7974,8 +7974,8 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 
 		if (ename[0] == '\0' && (!got_a || !got_b)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR,
-			            " Cannot convert to WGS84 if you don't tell me the ellipsoid of origin\n"
-					    "(miss +ellips=xxxx OR +a=xxxx +b=xxxx)\n");
+							" Cannot convert to WGS84 if you don't tell me the ellipsoid of origin\n"
+						 "(miss +ellips=xxxx OR +a=xxxx +b=xxxx)\n");
 			return (pStrOut);
 		}
 		pos = 0;	gmt_strtok (pch, " \t+", &pos, token);
@@ -7984,7 +7984,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 			sprintf(t, "%s:%s", ename, txt);    /* Create an ellip:dx,dy,dz string */
 		else                                    /* Need to pass a,1/f */
 			sprintf(t, "%12g,%.10f:%s",
-			        GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].eq_radius,
+					  GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].eq_radius,
 					1 / GMT->current.setting.ref_ellipsoid[GMT->current.setting.proj_ellipsoid].flattening,
 					txt);
 
@@ -9124,7 +9124,7 @@ void gmt_plotend (struct GMT_CTRL *GMT) {
 
 	if (GMT->current.ps.nclip != PSL->current.nclip)
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
-		            "Module was expected to change clip level by %d, but clip level changed by %d\n", GMT->current.ps.nclip, PSL->current.nclip);
+						"Module was expected to change clip level by %d, but clip level changed by %d\n", GMT->current.ps.nclip, PSL->current.nclip);
 
 	if (!K_active) {
 		if (GMT->current.ps.clip_level > 0)
@@ -9302,8 +9302,8 @@ uint64_t gmt_geo_polarcap_segment (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT 
 
 void gmt_geo_polygons (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S) {
 	/* Deal with plotting of one or more polygons that may wrap across the map.
- 	 * Multi-polygons occur if composed of a perimeter and one or more holes.
- 	 * This is marked by S->next being set to point to the next hole.
+	 * Multi-polygons occur if composed of a perimeter and one or more holes.
+	 * This is marked by S->next being set to point to the next hole.
 	 * Also, if the perimeter is a polar cap we must add a helping line that
 	 * connects to the pole but this line should not be drawn.  This is why
 	 * we must lay down path twice (first for fill; then for line) since the
@@ -9311,7 +9311,7 @@ void gmt_geo_polygons (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S) {
 	 */
 	struct GMT_DATASEGMENT *S2 = NULL;
 	struct GMT_DATASEGMENT_HIDDEN *SH = gmt_get_DS_hidden (S);
- 	bool add_pole, separate;
+	bool add_pole, separate;
 	int outline = 0, P_handedness = GMT_NOTSET, H_handedness;
 	int geo = gmt_M_is_geographic (GMT, GMT_IN);
 	uint64_t used = 0;
@@ -9382,9 +9382,9 @@ void gmt_geo_polygons (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S) {
 
 void gmt_plot_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth) {
 	/* gmt_plot_geo_ellipse takes the location, axes (in km), and azimuth of an ellipse
-	   and draws an approximate ellipse using N-sided polygon and the chosen map projection.
-	   We determine N by looking at the spacing between successive points for a trial N and
-	   then scale N up or down to satisfy the minimum point spacing criteria. */
+		and draws an approximate ellipse using N-sided polygon and the chosen map projection.
+		We determine N by looking at the spacing between successive points for a trial N and
+		then scale N up or down to satisfy the minimum point spacing criteria. */
 
 	struct GMT_DATASEGMENT *S = gmt_get_geo_ellipse (GMT, lon, lat, major, minor, azimuth, 0);
 
@@ -9407,10 +9407,10 @@ GMT_LOCAL void gmtplot_get_far_point (struct GMT_CTRL *GMT, double lon, double l
 
 GMT_LOCAL void gmtplot_geo_spider (struct GMT_CTRL *GMT, double xlon, double xlat, double radius_i, double radius_o, double dr, double az_start, double az_stop, double da, unsigned int wmode) {
 	/* gmtplot_geo_spider takes the location, radius_i (in unit), radius_o, dr, and start/stop azimuths of an geo-wedge and da
-	   and draws an approximate circular spider-web using N-sided polygon.
-	   mode & 1: Just draw arc(s)
-	   mode & 2: Just draw radii(s)
- 	*/
+		and draws an approximate circular spider-web using N-sided polygon.
+		mode & 1: Just draw arc(s)
+		mode & 2: Just draw radii(s)
+	*/
 
 	int n_arc, k, ko, n_seg;
 	uint64_t n_new;
@@ -9526,11 +9526,11 @@ GMT_LOCAL void gmtplot_geo_spider (struct GMT_CTRL *GMT, double xlon, double xla
 
 GMT_LOCAL void gmtplot_geo_wedge_fill (struct GMT_CTRL *GMT, double xlon, double xlat, double radius_i, double radius_o, double az_start, double az_stop, bool fill, bool outline) {
 	/* gmt_geo_wedge takes the location, radius_i (in unit), radius_o (in unit), and start/stop azimuths of an geo-wedge
-	   and draws an approximate circluar wedge using N-sided polygon.
-	   mode = 3: Draw the entire closed wedge.
-	   mode = 1: Just draw arc [no fill possible]
-	   mode = 2: Just draw jaw [no fill possible]
- 	*/
+		and draws an approximate circluar wedge using N-sided polygon.
+		mode = 3: Draw the entire closed wedge.
+		mode = 1: Just draw arc [no fill possible]
+		mode = 2: Just draw jaw [no fill possible]
+	*/
 
 	int n_arc, k, ki, ko, n_path;
 	uint64_t n_new;
@@ -9617,11 +9617,11 @@ GMT_LOCAL void gmtplot_geo_wedge_fill (struct GMT_CTRL *GMT, double xlon, double
 
 void gmt_geo_wedge (struct GMT_CTRL *GMT, double xlon, double xlat, double radius_i, double radius_o, double dr, double az_start, double az_stop, double da, unsigned int wmode, bool fill, bool outline) {
 	/* gmt_geo_wedge takes the location, radius_i (in km), radius_o (in km), dr (in km) and start/stop/da azimuths of an geo-wedge
-	   and draws an approximate circular wedge or windshield using N-sided polygon.
-	   If fill is true then we paint this polygon.
-	   If mode is not GMT_WEDGE_NORMAL then we draw the spider web on top.
-	   The form of that depends on dr > 0 and da > 0, otherwise we just do the outline.
- 	*/
+		and draws an approximate circular wedge or windshield using N-sided polygon.
+		If fill is true then we paint this polygon.
+		If mode is not GMT_WEDGE_NORMAL then we draw the spider web on top.
+		The form of that depends on dr > 0 and da > 0, otherwise we just do the outline.
+	*/
 
 	enum GMT_enum_wedgetype mode = wmode;
 
@@ -9639,11 +9639,11 @@ void gmt_geo_wedge (struct GMT_CTRL *GMT, double xlon, double xlat, double radiu
 
 unsigned int gmt_geo_vector (struct GMT_CTRL *GMT, double lon0, double lat0, double azimuth, double length, struct GMT_PEN *pen, struct GMT_SYMBOL *S) {
 	/* gmt_geo_vector takes the location lon0, lat0, azimuth of the vector at that point, and the
-	   length (in km), and and draws the vector using the chosen map projection.  If arrow heads
-	   have been requested we compute an arc length in degrees that is equivalent to the chosen
-	   symbol size.  With arrow heads we also shorten the vector arc so that unfilled vector heads
-	   are possible. If a small-circle vector is chosen then azimuth, length may be opening angles
-	   1 and 2 if PSL_VEC_ANGLES is set as well. */
+		length (in km), and and draws the vector using the chosen map projection.  If arrow heads
+		have been requested we compute an arc length in degrees that is equivalent to the chosen
+		symbol size.  With arrow heads we also shorten the vector arc so that unfilled vector heads
+		are possible. If a small-circle vector is chosen then azimuth, length may be opening angles
+		1 and 2 if PSL_VEC_ANGLES is set as well. */
 	unsigned int warn;
 	if ((S->v.status & PSL_VEC_SCALE) == 0) {	/* Must determine the best inch to degree scale for this map */
 		if (gmt_M_is_perspective (GMT)) {
@@ -9668,7 +9668,7 @@ unsigned int gmt_geo_vector (struct GMT_CTRL *GMT, double lon0, double lat0, dou
 
 void gmt_geo_rectangle (struct GMT_CTRL *GMT, double lon, double lat, double width, double height, double azimuth) {
 	/* gmt_geo_rectangle takes the location, axes (in km), and azimuth of a rectangle
-	   and draws the rectangle using the chosen map projection */
+		and draws the rectangle using the chosen map projection */
 
 	int jump;
 	double sin_azimuth, cos_azimuth, sinp, cosp, x, y, x_prime, y_prime, rho, c, dim[3];

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3354,9 +3354,13 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 		L = R[GMT_ROSE_PRIMARY] - 2.0 * tlen[2];
 		x[0] = mr->refpoint->x - L * c, y[0] = mr->refpoint->y - L * s;
 		x[1] = mr->refpoint->x + L * c, y[1] = mr->refpoint->y + L * s;
-		dim[0] = x[1], dim[1] = y[1],
-		dim[2] = M_VW * mr->size, dim[3] = M_HL * mr->size, dim[4] = M_HW * mr->size,
-		dim[5] = GMT->current.setting.map_vector_shape, dim[6] = PSL_VEC_END | PSL_VEC_FILL;
+		dim[PSL_VEC_XTIP]        = x[1];
+      dim[PSL_VEC_YTIP]        = y[1];
+		dim[PSL_VEC_TAIL_WIDTH]  = M_VW * mr->size;
+      dim[PSL_VEC_HEAD_LENGTH] = M_HL * mr->size;
+      dim[PSL_VEC_HEAD_WIDTH]  = M_HW * mr->size,
+		dim[PSL_VEC_HEAD_SHAPE]  = GMT->current.setting.map_vector_shape;
+      dim[PSL_VEC_STATUS]      = PSL_VEC_END | PSL_VEC_FILL;
 		gmt_setpen (GMT, &GMT->current.setting.map_default_pen);
 		gmt_setfill (GMT, &f, 1);
 		PSL_plotsymbol (PSL, x[0], y[0], dim, PSL_VECTOR);
@@ -3378,9 +3382,12 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 		x[0] = x[1] = x[4] = 0.0,	x[2] = -0.25 * mr->size,		x[3] = -x[2];
 		y[0] = -0.5 * L,		y[1] = -y[0], y[2] = y[3] = 0.0,	y[4] = y[1] + GMT->current.setting.map_annot_offset[GMT_PRIMARY];
 		gmtlib_rotate2D (GMT, x, y, 5, mr->refpoint->x, mr->refpoint->y, ew_angle, xp, yp);	/* Coordinate transformation and placement of the 4 labels */
-		dim[0] = xp[1], dim[1] = yp[1];
-		dim[2] = F_VW * mr->size, dim[3] = F_HL * mr->size, dim[4] = F_HW * mr->size;
-		dim[5] = GMT->current.setting.map_vector_shape, dim[6] = PSL_VEC_END | PSL_VEC_FILL;
+		dim[PSL_VEC_XTIP]        = xp[1];
+      dim[PSL_VEC_YTIP]        = yp[1];
+		dim[PSL_VEC_TAIL_WIDTH]  = F_VW * mr->size;
+      dim[PSL_VEC_HEAD_LENGTH] = F_HL * mr->size;dim[PSL_VEC_HEAD_WIDTH] = F_HW * mr->size;
+		dim[PSL_VEC_HEAD_SHAPE]  = GMT->current.setting.map_vector_shape;
+      dim[PSL_VEC_STATUS]      = PSL_VEC_END | PSL_VEC_FILL;
 		gmt_setfill (GMT, &f, 1);
 		PSL_defpen (PSL, "PSL_vecheadpen", GMT->current.setting.map_frame_pen.width, "", 0, f.rgb);
 		PSL_plotsymbol (PSL, xp[0], yp[0], dim, PSL_VECTOR);
@@ -5458,9 +5465,12 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		gmt_setfill (GMT, &arrow, 0);
 		gmt_M_memset (dim, PSL_MAX_DIMS, double);
 		vector_width = rint (PSL_DOTS_PER_INCH * GMT->current.setting.map_frame_pen.width / PSL_POINTS_PER_INCH) / PSL_DOTS_PER_INCH;	/* Round off vector width same way as pen width */
-		dim[2] = vector_width; dim[3] = 10.0 * vector_width; dim[4] = 5.0 * vector_width;
-		dim[5] = GMT->current.setting.map_vector_shape; dim[6] = PSL_VEC_END | PSL_VEC_FILL;
-		dim[11] = 0.5 * GMT->current.setting.map_frame_pen.width;
+		dim[PSL_VEC_TAIL_WIDTH]    = vector_width;
+      dim[PSL_VEC_HEAD_LENGTH]   = 10.0 * vector_width;
+      dim[PSL_VEC_HEAD_WIDTH]    = 5.0 * vector_width;
+		dim[PSL_VEC_HEAD_SHAPE]    = GMT->current.setting.map_vector_shape;
+      dim[PSL_VEC_STATUS]        = PSL_VEC_END | PSL_VEC_FILL;
+		dim[PSL_VEC_HEAD_PENWIDTH] = 0.5 * GMT->current.setting.map_frame_pen.width;
 		PSL_defpen (PSL, "PSL_vecheadpen", GMT->current.setting.map_frame_pen.width, GMT->current.setting.map_frame_pen.style, GMT->current.setting.map_frame_pen.offset, GMT->current.setting.map_frame_pen.rgb);
 
 		/* The start of the vector at the end of a positive axis is computed as x = g_scale_end * length + g_ext;
@@ -8316,14 +8326,17 @@ GMT_LOCAL void gmtplot_prog_indicator_C (struct GMT_CTRL *GMT, double x, double 
 	gmt_getpen (GMT, P1, &pen);	/* Always draw foreground circle */
 	gmt_setpen (GMT, &pen);	/* Front circle pen */
 	PSL_setfill (GMT->PSL, pen.rgb, 1);
-	dim[0] = 0.5 * w;	/* Apparently we take radius for wedge */
-	dim[1] = 90.0 - 360 * t;	/* Go clockwise. Convert t to 0-360 degrees */
-	dim[2] = 90.0;	/* Start is 12 'oclock */
-	dim[3] = 0.2 * w, dim[4] = 0.2 * w, dim[5] = pen.width / PSL_POINTS_PER_INCH;
-	dim[6] = 0.75;	/* Fixed shape setting */
-	dim[7] = (double)(PSL_VEC_BEGIN | PSL_VEC_FILL);
-	dim[8] = (double)PSL_VEC_ARROW;	dim[9] = (double)PSL_VEC_ARROW;
-	dim[12] = 0.5 * pen.width;
+	dim[PSL_MATHARC_RADIUS]          = 0.5 * w;	/* Apparently we take radius for wedge */
+	dim[PSL_MATHARC_ANGLE_BEGIN]     = 90.0 - 360 * t;	/* Go clockwise. Convert t to 0-360 degrees */
+	dim[PSL_MATHARC_ANGLE_END]       = 90.0;	/* Start is 12 'oclock */
+	dim[PSL_MATHARC_HEAD_LENGTH]     = 0.2 * w;
+   dim[PSL_MATHARC_HEAD_WIDTH]      = 0.2 * w;
+   dim[PSL_MATHARC_ARC_PENWIDTH]    = pen.width / PSL_POINTS_PER_INCH;
+	dim[PSL_MATHARC_HEAD_SHAPE]      = 0.75;	/* Fixed shape setting */
+	dim[PSL_MATHARC_STATUS]          = (double)(PSL_VEC_BEGIN | PSL_VEC_FILL);
+	dim[PSL_MATHARC_HEAD_TYPE_BEGIN] = (double)PSL_VEC_ARROW;
+   dim[PSL_MATHARC_HEAD_TYPE_END]   = (double)PSL_VEC_ARROW;
+	dim[PSL_MATHARC_HEAD_PENWIDTH]   = 0.5 * pen.width;
 	PSL_command (GMT->PSL, "/PSL_vecheadpen {} def\n");	/* So wedge won't fuss about not being set (like in psxy) */
 	PSL_plotsymbol (GMT->PSL, x, y, dim, PSL_MARC);
 }

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3355,12 +3355,12 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 		x[0] = mr->refpoint->x - L * c, y[0] = mr->refpoint->y - L * s;
 		x[1] = mr->refpoint->x + L * c, y[1] = mr->refpoint->y + L * s;
 		dim[PSL_VEC_XTIP]        = x[1];
-      dim[PSL_VEC_YTIP]        = y[1];
+		dim[PSL_VEC_YTIP]        = y[1];
 		dim[PSL_VEC_TAIL_WIDTH]  = M_VW * mr->size;
-      dim[PSL_VEC_HEAD_LENGTH] = M_HL * mr->size;
-      dim[PSL_VEC_HEAD_WIDTH]  = M_HW * mr->size,
+		dim[PSL_VEC_HEAD_LENGTH] = M_HL * mr->size;
+		dim[PSL_VEC_HEAD_WIDTH]  = M_HW * mr->size,
 		dim[PSL_VEC_HEAD_SHAPE]  = GMT->current.setting.map_vector_shape;
-      dim[PSL_VEC_STATUS]      = PSL_VEC_END | PSL_VEC_FILL;
+		dim[PSL_VEC_STATUS]      = PSL_VEC_END | PSL_VEC_FILL;
 		gmt_setpen (GMT, &GMT->current.setting.map_default_pen);
 		gmt_setfill (GMT, &f, 1);
 		PSL_plotsymbol (PSL, x[0], y[0], dim, PSL_VECTOR);
@@ -3383,11 +3383,11 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 		y[0] = -0.5 * L,		y[1] = -y[0], y[2] = y[3] = 0.0,	y[4] = y[1] + GMT->current.setting.map_annot_offset[GMT_PRIMARY];
 		gmtlib_rotate2D (GMT, x, y, 5, mr->refpoint->x, mr->refpoint->y, ew_angle, xp, yp);	/* Coordinate transformation and placement of the 4 labels */
 		dim[PSL_VEC_XTIP]        = xp[1];
-      dim[PSL_VEC_YTIP]        = yp[1];
+		dim[PSL_VEC_YTIP]        = yp[1];
 		dim[PSL_VEC_TAIL_WIDTH]  = F_VW * mr->size;
-      dim[PSL_VEC_HEAD_LENGTH] = F_HL * mr->size;dim[PSL_VEC_HEAD_WIDTH] = F_HW * mr->size;
+		dim[PSL_VEC_HEAD_LENGTH] = F_HL * mr->size;dim[PSL_VEC_HEAD_WIDTH] = F_HW * mr->size;
 		dim[PSL_VEC_HEAD_SHAPE]  = GMT->current.setting.map_vector_shape;
-      dim[PSL_VEC_STATUS]      = PSL_VEC_END | PSL_VEC_FILL;
+		dim[PSL_VEC_STATUS]      = PSL_VEC_END | PSL_VEC_FILL;
 		gmt_setfill (GMT, &f, 1);
 		PSL_defpen (PSL, "PSL_vecheadpen", GMT->current.setting.map_frame_pen.width, "", 0, f.rgb);
 		PSL_plotsymbol (PSL, xp[0], yp[0], dim, PSL_VECTOR);
@@ -8330,12 +8330,12 @@ GMT_LOCAL void gmtplot_prog_indicator_C (struct GMT_CTRL *GMT, double x, double 
 	dim[PSL_MATHARC_ANGLE_BEGIN]     = 90.0 - 360 * t;	/* Go clockwise. Convert t to 0-360 degrees */
 	dim[PSL_MATHARC_ANGLE_END]       = 90.0;	/* Start is 12 'oclock */
 	dim[PSL_MATHARC_HEAD_LENGTH]     = 0.2 * w;
-   dim[PSL_MATHARC_HEAD_WIDTH]      = 0.2 * w;
-   dim[PSL_MATHARC_ARC_PENWIDTH]    = pen.width / PSL_POINTS_PER_INCH;
+	dim[PSL_MATHARC_HEAD_WIDTH]      = 0.2 * w;
+	dim[PSL_MATHARC_ARC_PENWIDTH]    = pen.width / PSL_POINTS_PER_INCH;
 	dim[PSL_MATHARC_HEAD_SHAPE]      = 0.75;	/* Fixed shape setting */
 	dim[PSL_MATHARC_STATUS]          = (double)(PSL_VEC_BEGIN | PSL_VEC_FILL);
 	dim[PSL_MATHARC_HEAD_TYPE_BEGIN] = (double)PSL_VEC_ARROW;
-   dim[PSL_MATHARC_HEAD_TYPE_END]   = (double)PSL_VEC_ARROW;
+	dim[PSL_MATHARC_HEAD_TYPE_END]   = (double)PSL_VEC_ARROW;
 	dim[PSL_MATHARC_HEAD_PENWIDTH]   = 0.5 * pen.width;
 	PSL_command (GMT->PSL, "/PSL_vecheadpen {} def\n");	/* So wedge won't fuss about not being set (like in psxy) */
 	PSL_plotsymbol (GMT->PSL, x, y, dim, PSL_MARC);

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -552,9 +552,10 @@ EXTERN_MSC int GMT_grdvector (void *V_API, int mode, void *args) {
 		col_0 = urint ((tmp - Grid[0]->header->wesn[XLO]) * HH->r_inc[GMT_X]);
 	}
 
-	dim[5] = Ctrl->Q.S.v.v_shape;	/* dim[5-8] do not change inside the loop */
-	dim[6] = (double)Ctrl->Q.S.v.status;
-	dim[7] = (double)Ctrl->Q.S.v.v_kind[0];	dim[8] = (double)Ctrl->Q.S.v.v_kind[1];
+	dim[PSL_VEC_HEAD_SHAPE]      = Ctrl->Q.S.v.v_shape;	/* head shape, type, and status do not change inside the loop */
+	dim[PSL_VEC_STATUS]          = (double)Ctrl->Q.S.v.status;
+	dim[PSL_VEC_HEAD_TYPE_BEGIN] = (double)Ctrl->Q.S.v.v_kind[0];
+	dim[PSL_VEC_HEAD_TYPE_END]   = (double)Ctrl->Q.S.v.v_kind[1];
 
 	if (Ctrl->Q.S.v.status & PSL_VEC_OUTLINE2) {	/* Vector head outline pen specified separately */
 		PSL_defpen (PSL, "PSL_vecheadpen", Ctrl->Q.S.v.pen.width, Ctrl->Q.S.v.pen.style, Ctrl->Q.S.v.pen.offset, Ctrl->Q.S.v.pen.rgb);
@@ -722,13 +723,16 @@ EXTERN_MSC int GMT_grdvector (void *V_API, int mode, void *args) {
 					continue;
 				}
 				/* Must plot a vector head */
-				dim[0] = x2; dim[1] = y2;
-				dim[2] = Ctrl->Q.S.v.v_width;	dim[3] = Ctrl->Q.S.v.h_length;	dim[4] = Ctrl->Q.S.v.h_width;
-				dim[11] = headpen_width;	/* Possibly shrunk head pen width */
+				dim[PSL_VEC_XTIP]          = x2;
+				dim[PSL_VEC_YTIP]          = y2;
+				dim[PSL_VEC_TAIL_WIDTH]    = Ctrl->Q.S.v.v_width;
+				dim[PSL_VEC_HEAD_LENGTH]   = Ctrl->Q.S.v.h_length;
+				dim[PSL_VEC_HEAD_WIDTH]    = Ctrl->Q.S.v.h_width;
+				dim[PSL_VEC_HEAD_PENWIDTH] = headpen_width;	/* Possibly shrunk head pen width */
 				if (scaled_vec_length < Ctrl->Q.S.v.v_norm) {	/* Scale arrow attributes down with length */
 					f = scaled_vec_length / Ctrl->Q.S.v.v_norm;
 					for (k = 2; k <= 4; k++) dim[k] *= f;
-					dim[11] *= f;
+					dim[PSL_VEC_HEAD_PENWIDTH] *= f;
 				}
 				if (Ctrl->Q.S.symbol == GMT_SYMBOL_VECTOR_V4) {	/* Do the deprecated GMT4 vector polygon instead */
 					int v4_outline = Ctrl->W.active;

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -2389,13 +2389,20 @@ static int psl_matharc (struct PSL_CTRL *PSL, double x, double y, double param[]
 	 * the straight angle symbol when the angles subtend 90 degrees.
 	 *
 	 * param must hold up to 8 values:
-	 * param[0] = radius, param[1] = angle1, param[2] = angle2,
-	 * param[3] = headlength, param[4] = headwidth, param[5] = penwidth(inch)
- 	 * param[6] = vector-shape (0-1), param[7] = status bit flags
-	 * param[8] = begin head type;	param[9] = end head type)
-	 * param[10] = begin trim (degrees);	param[11] = end trim (degrees)
-	 * param[12] = head penwidth
-	 * add 4 to param[6] if you want to use a straight angle
+	 * param[PSL_MATHARC_RADIUS] = radius,
+    * param[PSL_MATHARC_ANGLE_BEGIN] = begin angle1,
+    * param[PSL_MATHARC_ANGLE_END] = end angle2,
+	 * param[PSL_MATHARC_HEAD_LENGTH] = headlength,
+    * param[PSL_MATHARC_HEAD_WIDTH] = headwidth,
+    * param[PSL_MATHARC_ARC_PENWIDTH] = penwidth(inch)
+ 	 * param[PSL_MATHARC_HEAD_SHAPE] = vector-shape (0-2),
+    * param[PSL_MATHARC_STATUS] = status bit flags
+	 * param[PSL_MATHARC_HEAD_TYPE_BEGIN] = begin head type;
+    * param[PSL_MATHARC_HEAD_TYPE_END] = end head type)
+	 * param[PSL_MATHARC_TRIM_BEGIN] = begin trim (degrees);
+    * param[PSL_MATHARC_TRIM_END] = end trim (degrees)
+	 * param[PSL_MATHARC_HEAD_PENWIDTH] = head penwidth
+	 * add 4 to param[PSL_MATHARC_HEAD_SHAPE] if you want to use a straight angle
 	 * symbol if the opening is 90.  */
 
 	int i, side[2], heads, outline, fill, sign[2] = {+1, -1};
@@ -2404,24 +2411,25 @@ static int psl_matharc (struct PSL_CTRL *PSL, double x, double y, double param[]
 	double angle[2], tangle[2], off[2], A, B, bo1, bo2, xi, yi, bi1, bi2, xv, yv, rshift[2] = {0.0, 0.0}, circ_r, xx[2], yy[2], trim[2];
 	char *line[2] = {"N", "P S"}, *dump[2] = {"", "fs"}, *end[2] = {"start", "end"};
 
-	status = (unsigned int)lrint (param[7]);
-	if (status & PSL_VEC_MARC90 && fabs (90.0 - fabs (param[2]-param[1])) < 1.0e-8) {	/* Right angle */
+	status = (unsigned int)lrint (param[PSL_MATHARC_STATUS]);
+	if (status & PSL_VEC_MARC90 && fabs (90.0 - fabs (param[PSL_MATHARC_ANGLE_END]-param[PSL_MATHARC_ANGLE_BEGIN])) < 1.0e-8) {	/* Right angle */
 		return (psl_mathrightangle (PSL, x, y, param));
 	}
 	PSL_comment (PSL, "Start of Math arc\n");
 	/* Make any adjustments caused by trim */
-	trim[PSL_BEGIN] = (status & PSL_VEC_OFF_BEGIN) ? param[10] : 0.0;
-	trim[PSL_END]   = (status & PSL_VEC_OFF_END)   ? param[11] : 0.0;
+	trim[PSL_BEGIN] = (status & PSL_VEC_OFF_BEGIN) ? param[PSL_MATHARC_TRIM_BEGIN] : 0.0;
+	trim[PSL_END]   = (status & PSL_VEC_OFF_END)   ? param[PSL_MATHARC_TRIM_END]   : 0.0;
 	PSL_command (PSL, "V %d %d T\n", psl_ix (PSL, x), psl_iy (PSL, y));
-	kind[PSL_BEGIN] = (unsigned int)lrint (param[8]);
-	kind[PSL_END] = (unsigned int)lrint (param[9]);
-	r = param[0];				  /* Radius of arc in inch */
-	angle[PSL_BEGIN] = param[1] + trim[PSL_BEGIN]; angle[PSL_END] = param[2] - trim[PSL_END]; /* Start/stop angles of arc, possibly adjusted */
-	head_arc_length = param[3];		  /* Head length in inch */
-	head_half_width = 0.5 * param[4];	  /* Head half-width in inch */
-	arc_width = param[5];			  /* Arc width in inch */
-	shape = param[6];			  /* Vector head shape (0-1) */
-	h_penwidth = param[12];
+	kind[PSL_BEGIN] = (unsigned int)lrint (param[PSL_MATHARC_HEAD_TYPE_BEGIN]);
+	kind[PSL_END]   = (unsigned int)lrint (param[PSL_MATHARC_HEAD_TYPE_END]);
+	r = param[PSL_MATHARC_RADIUS];				  /* Radius of arc in inch */
+	angle[PSL_BEGIN] = param[PSL_MATHARC_ANGLE_BEGIN] + trim[PSL_BEGIN];
+   angle[PSL_END]   = param[PSL_MATHARC_ANGLE_END] - trim[PSL_END]; /* Start/stop angles of arc, possibly adjusted */
+	head_arc_length  = param[PSL_MATHARC_HEAD_LENGTH];		  /* Head length in inch */
+	head_half_width  = 0.5 * param[PSL_MATHARC_HEAD_WIDTH];	  /* Head half-width in inch */
+	arc_width = param[PSL_MATHARC_ARC_PENWIDTH];			  /* Arc width in inch */
+	shape = param[PSL_MATHARC_HEAD_SHAPE];			  /* Vector head shape (0-1) */
+	h_penwidth = param[PSL_MATHARC_HEAD_PENWIDTH];
 	heads = PSL_vec_head (status);		  /* 1 = at beginning, 2 = at end, 3 = both */
 	outline = ((status & PSL_VEC_OUTLINE) > 0);
 	fill = ((status & PSL_VEC_FILL) > 0);
@@ -2443,7 +2451,7 @@ static int psl_matharc (struct PSL_CTRL *PSL, double x, double y, double param[]
 	 * for this half-thickness by adding/subtracting from the radius accordingly, using r2,
 	 * but only if the two heads agree. */
 	rshift[PSL_BEGIN] = 0.5 * side[PSL_BEGIN] * arc_width;
-	rshift[PSL_END] = 0.5 * side[PSL_END] * arc_width;
+	rshift[PSL_END]   = 0.5 * side[PSL_END]   * arc_width;
 
 	PSL_setlinewidth (PSL, arc_width * PSL_POINTS_PER_INCH);
 	PSL_plotarc (PSL, 0.0, 0.0, r, tangle[PSL_BEGIN], tangle[PSL_END], PSL_MOVE | PSL_STROKE);	/* Draw the (possibly shortened) arc */
@@ -2600,25 +2608,27 @@ static int psl_pattern_init (struct PSL_CTRL *PSL, int image_no, char *imagefile
 void psl_vector_v4 (struct PSL_CTRL *PSL, double x, double y, double param[], double rgb[], int outline)
 {
 	/* Old GMT4 vector symbol:
-	 * param[0] = xtip;
-	 * param[1] = ytip;
-	 * param[2] = tailwidth;
-	 * param[3] = headlength;
-	 * param[4] = headwidth;
-	 * param[5] = headshape;
+	 * param[PSL_VEC_XTIP] = xtip;
+	 * param[PSL_VEC_YTIP] = ytip;
+	 * param[PSL_VEC_TAIL_WIDTH] = tailwidth;
+	 * param[PSL_VEC_HEAD_LENGTH] = headlength;
+	 * param[PSL_VEC_HEAD_WIDTH] = headwidth;
+	 * param[PSL_VEC_HEAD_SHAPE] = headshape;
 	 * Will make sure that arrow has a finite width in PS coordinates */
 
 	double angle, xtail, ytail, xtip, ytip, tailwidth, headlength, headwidth, headshape;
 	int w2, length, hw, hl, hl2, hw2, l2;
 
-	xtail = x;	ytail = y;	xtip = param[0];	ytip = param[1];
+	xtail = x;	ytail = y;
+   xtip = param[PSL_VEC_XTIP];
+   ytip = param[PSL_VEC_YTIP];
 	length = psl_iz (PSL, hypot (xtail-xtip, ytail-ytip));	/* Vector length in PS units */
 	if (length == 0) return;	/* NULL vector */
 
-	tailwidth  = param[2];
-	headlength = param[3];
-	headwidth  = param[4];
-	headshape  = param[5];
+	tailwidth  = param[PSL_VEC_TAIL_WIDTH];
+	headlength = param[PSL_VEC_HEAD_LENGTH];
+	headwidth  = param[PSL_VEC_HEAD_WIDTH];
+	headshape  = param[PSL_VEC_HEAD_SHAPE];
 	if (outline & 8)
 		PSL_setfill (PSL, rgb, outline - 8);
 	else
@@ -2651,12 +2661,18 @@ void psl_vector_v4 (struct PSL_CTRL *PSL, double x, double y, double param[], do
 static int psl_vector (struct PSL_CTRL *PSL, double x, double y, double param[]) {
 	/* Will make sure that arrow has a finite width in PS coordinates.
 	 * param must hold up to 12 values:
-	 * param[0] = xtip;		param[1] = ytip;
-	 * param[2] = tailwidth;	param[3] = headlength;	param[4] = headwidth;
-	 * param[5] = headshape;	param[6] = status bit flags
-	 * param[7] = begin head type;	param[8] = end head type
-	 * param[9] = begin trim value;	param[10] = end trim value.
-	 * param[11] = head penwidth
+	 * param[PSL_VEC_XTIP] = xtip;
+    * param[PSL_VEC_YTIP] = ytip;
+	 * param[PSL_VEC_TAIL_WIDTH] = tailwidth;
+    * param[PSL_VEC_HEAD_LENGTH] = headlength;
+    * param[PSL_VEC_HEAD_WIDTH] = headwidth;
+	 * param[5PSL_VEC_HEAD_SHAPE] = headshape;
+    * param[PSL_VEC_STATUS] = status bit flags
+	 * param[PSL_VEC_HEAD_TYPE_BEGIN] = begin head type;
+    * param[PSL_VEC_HEAD_TYPE_END] = end head type
+	 * param[PSL_VEC_TRIM_BEGIN] = begin trim value;
+    * param[PSL_VEC_TRIM_END] = end trim value.
+	 * param[PSL_VEC_HEAD_PENWIDTH] = head penwidth
 	 */
 
 	double angle, xtip, ytip, r, s, tailwidth, headlength, headwidth, headshape, length_inch;
@@ -2665,16 +2681,16 @@ static int psl_vector (struct PSL_CTRL *PSL, double x, double y, double param[])
 	unsigned int kind[2];
 	char *line[2] = {"N", "P S"}, *dump[2] = {"", "fs"};
 
-	xtip = param[0];	ytip = param[1];
+	xtip = param[PSL_VEC_XTIP];	ytip = param[PSL_VEC_YTIP];
 	length_inch = hypot (x-xtip, y-ytip);					/* Vector length in inches */
 	length = psl_iz (PSL, length_inch);					/* Vector length in PS units */
 	if (length == 0) return (PSL_NO_ERROR);					/* NULL vector */
 	angle = atan2 (ytip-y, xtip-x) * R2D;					/* Angle vector makes with horizontal, in degrees */
-	status = lrint (param[6]);
-	h_penwidth = param[11];
+	status = lrint (param[PSL_VEC_STATUS]);
+	h_penwidth = param[PSL_VEC_HEAD_PENWIDTH];
 	/* Make any adjustments caused by trim */
-	trim[PSL_BEGIN] = (status & PSL_VEC_OFF_BEGIN) ? param[9]  : 0.0;
-	trim[PSL_END]   = (status & PSL_VEC_OFF_END)   ? param[10] : 0.0;
+	trim[PSL_BEGIN] = (status & PSL_VEC_OFF_BEGIN) ? param[PSL_VEC_TRIM_BEGIN] : 0.0;
+	trim[PSL_END]   = (status & PSL_VEC_OFF_END)   ? param[PSL_VEC_TRIM_END]   : 0.0;
 	if (fabs (angle) == 90.0) {	/* Vertical segment; only adjust y coordinates */
 		y += copysign (trim[PSL_BEGIN], angle);	ytip -= copysign (trim[PSL_END], angle);
 	}
@@ -2687,12 +2703,12 @@ static int psl_vector (struct PSL_CTRL *PSL, double x, double y, double param[])
 	length_inch = hypot (x-xtip, y-ytip);					/* Recalculate vector length in inches */
 	length = psl_iz (PSL, length_inch);					/* Vector length in PS units */
 	if (length == 0) return (PSL_NO_ERROR);					/* NULL vector */
-	tailwidth = param[2];
-	headlength = param[3];	headwidth = 0.5 * param[4];	headshape = param[5];
-	kind[PSL_BEGIN] = (unsigned int)lrint (param[7]);
-	kind[PSL_END] = (unsigned int)lrint (param[8]);
+	tailwidth = param[PSL_VEC_TAIL_WIDTH];
+	headlength = param[PSL_VEC_HEAD_LENGTH];	headwidth = 0.5 * param[PSL_VEC_HEAD_WIDTH];	headshape = param[PSL_VEC_HEAD_SHAPE];
+	kind[PSL_BEGIN] = (unsigned int)lrint (param[PSL_VEC_HEAD_TYPE_BEGIN]);
+	kind[PSL_END]   = (unsigned int)lrint (param[PSL_VEC_HEAD_TYPE_END]);
 	off[PSL_BEGIN] = (kind[PSL_BEGIN] == PSL_VEC_ARROW) ? 0.5 * (2.0 - headshape) * headlength : 0.0;
-	off[PSL_END] = (kind[PSL_END] == PSL_VEC_ARROW) ? 0.5 * (2.0 - headshape) * headlength : 0.0;
+	off[PSL_END]   = (kind[PSL_END] == PSL_VEC_ARROW)   ? 0.5 * (2.0 - headshape) * headlength : 0.0;
 	if (kind[PSL_BEGIN] == PSL_VEC_ARROW_PLAIN) off[PSL_BEGIN] = 0.5 * tailwidth *  headlength / headwidth;
 	else if (kind[PSL_BEGIN] == PSL_VEC_TAIL) off[PSL_BEGIN] = FIN_SLANT_COS * headwidth + FIN_LENGTH_SCALE * headlength - tailwidth;
 	if (kind[PSL_END] == PSL_VEC_ARROW_PLAIN) off[PSL_END] = 0.5 * tailwidth *  headlength / headwidth;
@@ -2701,8 +2717,8 @@ static int psl_vector (struct PSL_CTRL *PSL, double x, double y, double param[])
 	PSL_setlinewidth (PSL, tailwidth * PSL_POINTS_PER_INCH);	/* Inherits color from current pen */
 	outline = ((status & PSL_VEC_OUTLINE) > 0);
 	fill = ((status & PSL_VEC_FILL) > 0);
-	asymmetry[PSL_BEGIN] = -PSL_vec_side (status, 0);	  /* -1 = left-only, +1 = right-only, 0 = normal head at beginning */
-	asymmetry[PSL_END] = PSL_vec_side (status, 1);		  /* -1 = left-only, +1 = right-only, 0 = normal head at beginning */
+	asymmetry[PSL_BEGIN] = -PSL_vec_side (status, 0);	/* -1 = left-only, +1 = right-only, 0 = normal head at beginning */
+	asymmetry[PSL_END]   = PSL_vec_side (status, 1);	/* -1 = left-only, +1 = right-only, 0 = normal head at beginning */
 	r = sqrt (headlength * headwidth / M_PI);	/* Same circle area as vector head */
 	s = sqrt (headlength * headwidth)/2;		/* Same square 	area as vector head */
 	PSL_comment (PSL, "Start of Cartesian vector\n");
@@ -2712,7 +2728,7 @@ static int psl_vector (struct PSL_CTRL *PSL, double x, double y, double param[])
 	xx[0] = (heads & 1) ? off[PSL_BEGIN] : 0.0;
 	xx[1] = (heads & 2) ? length_inch - off[PSL_END] : length_inch;
 	if (heads & 1 && asymmetry[PSL_BEGIN] && kind[PSL_BEGIN] == PSL_VEC_CIRCLE) xx[0] = -r;
-	if (heads & 2 && asymmetry[PSL_END] && kind[PSL_END] == PSL_VEC_CIRCLE) xx[1] += r;
+	if (heads & 2 && asymmetry[PSL_END]   && kind[PSL_END]   == PSL_VEC_CIRCLE) xx[1] += r;
 	if (xx[1] > xx[0]) PSL_plotsegment (PSL, xx[0], 0.0, xx[1], 0.0);		/* Draw vector line body unless head length equals or exceeds total length */
 
 	if (status & PSL_VEC_MID_FWD) {	/* Want forward-pointing mid-point head instead of at end */
@@ -2731,7 +2747,7 @@ static int psl_vector (struct PSL_CTRL *PSL, double x, double y, double param[])
 
 	/* Must switch asymmetry for start head since implemented backwards */
 	yshift[PSL_BEGIN] = 0.5 * asymmetry[PSL_BEGIN] * tailwidth;
-	yshift[PSL_END] = 0.5 * asymmetry[PSL_END] * tailwidth;
+	yshift[PSL_END]   = 0.5 * asymmetry[PSL_END]   * tailwidth;
 
 	if (heads & 1) {	/* Need head at beginning, pointing backwards */
 		double f = (kind[PSL_BEGIN] == PSL_VEC_ARROW_PLAIN) ? 4.0 : 2.0;
@@ -2966,69 +2982,77 @@ static int psl_vector (struct PSL_CTRL *PSL, double x, double y, double param[])
 static int psl_wedge (struct PSL_CTRL *PSL, double x, double y, double param[]) {
 	/* Takes care of plotting a wedge.
 	 * param may hold up to 11 values; only 8 used here.
-	 * param[0] = radius;
-	 * param[1] = start angle;	param[2] = end angle;
-	 * param[3] = status bit flags;	param[4] = inner_radius [0]
-	 * param[5] = dr [0];		param[6] = da [0]
-	 * param[7] = do_fill (1) | do_outline (2)
+	 * param[PSL_WEDGE_RADIUS_O] = radius;
+	 * param[PSL_WEDGE_ANGLE_BEGIN] = start angle;
+    * param[PSL_WEDGE_ANGLE_END] = end angle;
+	 * param[PSL_WEDGE_STATUS] = status bit flags;
+    * param[PSL_WEDGE_RADIUS_I] = inner_radius [0]
+	 * param[PSL_WEDGE_DR] = dr [0];
+    * param[PSL_WEDGE_DA] = da [0]
+	 * param[PSL_WEDGE_ACTION] = do_fill (1) | do_outline (2)
 	 */
 
-	double xx[3], yy[3];
-	int status = lrint (param[3]), flags = lrint (param[7]);
-	bool windshield = (param[4] > 0.0);	/* Flag that we have an inner-tube */
+	double xx[3], yy[3], sa, ca;
+	int status = lrint (param[PSL_WEDGE_STATUS]), flags = lrint (param[PSL_WEDGE_ACTION]);
+	bool windshield = (param[PSL_WEDGE_RADIUS_I] > 0.0);	/* Flag that we have an inner-tube */
 	bool fill = flags & 1, outline = flags & 2;
 
 	if (status == 0 && !windshield) {	/* Good old plain pie wedge */
-		PSL_command (PSL, "%d %.12g %.12g %d %d Sw\n", psl_iz (PSL, param[0]), param[1], param[2], psl_ix (PSL, x), psl_iy (PSL, y));
+		PSL_command (PSL, "%d %.12g %.12g %d %d Sw\n", psl_iz (PSL, param[PSL_WEDGE_RADIUS_O]), param[PSL_WEDGE_ANGLE_BEGIN], param[PSL_WEDGE_ANGLE_END], psl_ix (PSL, x), psl_iy (PSL, y));
 		return (PSL_NO_ERROR);
 	}
 	/* Somewhat more involved */
 	if (fill) {	/* Paint wedge given fill first but not outline (if desired) */
 		if (windshield)
 			PSL_command (PSL, "V %d %d T 0 0 %d %.12g %.12g arc 0 0 %d %.12g %.12g arcn P fs U\n", psl_ix (PSL, x), psl_iy (PSL, y),
-				psl_iz (PSL, param[0]), param[1], param[2], psl_iz (PSL, param[4]), param[2], param[1]);
+				psl_iz (PSL, param[PSL_WEDGE_RADIUS_O]), param[PSL_WEDGE_ANGLE_BEGIN], param[PSL_WEDGE_ANGLE_END], psl_iz (PSL, param[PSL_WEDGE_RADIUS_I]), param[PSL_WEDGE_ANGLE_END], param[PSL_WEDGE_ANGLE_BEGIN]);
 		else
-			PSL_command (PSL, "%d %.12g %.12g %d %d 2 copy M 5 2 roll arc fs\n", psl_iz (PSL, param[0]), param[1], param[2], psl_ix (PSL, x), psl_iy (PSL, y));
+			PSL_command (PSL, "%d %.12g %.12g %d %d 2 copy M 5 2 roll arc fs\n", psl_iz (PSL, param[PSL_WEDGE_RADIUS_O]), param[PSL_WEDGE_ANGLE_BEGIN], param[PSL_WEDGE_ANGLE_END], psl_ix (PSL, x), psl_iy (PSL, y));
 	}
 	/* Next, if spiderweb is desired we need to set up a save/restore section and change the pen to PSL_spiderpen */
 	if (status) PSL_command (PSL, "V PSL_spiderpen\n");
 	if (status & 1) {	/* Draw one or more arcs */
-		if (param[5] > 0.0) {	/* Array of arcs requested */
-			double r = (windshield) ? ceil (param[4] / param[5]) * param[5] : param[5];	/* Either start at first arc inside windshield or the first zero-length arc of wedge */
-			while (r <= (param[0]+PSL_SMALL)) {
-				PSL_plotarc (PSL, x, y, r, param[1], param[2], PSL_MOVE | PSL_STROKE);	/* Draw the arcs */
-				r += param[5];	/* Go to next radial distance */
+		if (param[PSL_WEDGE_DR] > 0.0) {	/* Array of arcs requested */
+			double r = (windshield) ? ceil (param[PSL_WEDGE_RADIUS_I] / param[PSL_WEDGE_DR]) * param[PSL_WEDGE_DR] : param[PSL_WEDGE_DR];	/* Either start at first arc inside windshield or the first zero-length arc of wedge */
+			while (r <= (param[PSL_WEDGE_RADIUS_O]+PSL_SMALL)) {
+				PSL_plotarc (PSL, x, y, r, param[PSL_WEDGE_ANGLE_BEGIN], param[PSL_WEDGE_ANGLE_END], PSL_MOVE | PSL_STROKE);	/* Draw the arcs */
+				r += param[PSL_WEDGE_DR];	/* Go to next radial distance */
 			}
 		}
 		else {	/* Just draw outer and possibly inner arcs */
-			PSL_plotarc (PSL, x, y, param[0], param[1], param[2], PSL_MOVE | PSL_STROKE);	/* Draw the outer arc */
+			PSL_plotarc (PSL, x, y, param[PSL_WEDGE_RADIUS_O], param[PSL_WEDGE_ANGLE_BEGIN], param[PSL_WEDGE_ANGLE_END], PSL_MOVE | PSL_STROKE);	/* Draw the outer arc */
 			if (windshield)	/* Draw the inner arc */
-				PSL_plotarc (PSL, x, y, param[4], param[1], param[2], PSL_MOVE | PSL_STROKE);
+				PSL_plotarc (PSL, x, y, param[PSL_WEDGE_RADIUS_I], param[PSL_WEDGE_ANGLE_BEGIN], param[PSL_WEDGE_ANGLE_END], PSL_MOVE | PSL_STROKE);
 		}
 	}
 	if (status & 2) {	/* Draw one or more radial lines */
-		if (param[6] > 0.0) {	/* Array of lines requestedii */
-			double a = ceil (param[1] / param[6]) * param[6];	/* First angle of desired multiple inside range */
-			while (a <= (param[2]+PSL_SMALL)) {
-				xx[0] = x + param[4] * cos (D2R * a);	yy[0] = y + param[4] * sin (D2R * a);
-				xx[1] = x + param[0] * cos (D2R * a);	yy[1] = y + param[0] * sin (D2R * a);
+		if (param[PSL_WEDGE_DA] > 0.0) {	/* Array of lines requested */
+			double a = ceil (param[PSL_WEDGE_ANGLE_BEGIN] / param[PSL_WEDGE_DA]) * param[PSL_WEDGE_DA];	/* First angle of desired multiple inside range */
+			while (a <= (param[PSL_WEDGE_ANGLE_END]+PSL_SMALL)) {
+            sa = sin (D2R * a);   ca = cos (D2R * a);
+				xx[0] = x + param[PSL_WEDGE_RADIUS_I] * ca;	yy[0] = y + param[PSL_WEDGE_RADIUS_I] * sa;
+				xx[1] = x + param[PSL_WEDGE_RADIUS_O] * ca;	yy[1] = y + param[PSL_WEDGE_RADIUS_O] * sa;
 				PSL_plotline (PSL, xx, yy, 2, PSL_MOVE+PSL_STROKE);	/* Plot radial line */
-				a += param[6];	/* Go to next angle */
+				a += param[PSL_WEDGE_DA];	/* Go to next angle */
 			}
 		}
 		else {	/* Just draw the start and stop radii */
 			if (windshield) {	/* These are two separate lines not connecting */
-				xx[0] = x + param[4] * cos (D2R * param[1]);	yy[0] = y + param[4] * sin (D2R * param[1]);
-				xx[1] = x + param[0] * cos (D2R * param[1]);	yy[1] = y + param[0] * sin (D2R * param[1]);
+				sa = sin (D2R * param[PSL_WEDGE_ANGLE_BEGIN]);   ca = cos (D2R * param[PSL_WEDGE_ANGLE_BEGIN]);
+				xx[0] = x + param[PSL_WEDGE_RADIUS_I] * ca;	yy[0] = y + param[PSL_WEDGE_RADIUS_I] * sa;
+				xx[1] = x + param[PSL_WEDGE_RADIUS_O] * ca;	yy[1] = y + param[PSL_WEDGE_RADIUS_O] * sa;
 				PSL_plotline (PSL, xx, yy, 2, PSL_MOVE+PSL_STROKE);	/* Plot jaw */
-				xx[0] = x + param[4] * cos (D2R * param[2]);	yy[0] = y + param[4] * sin (D2R * param[2]);
-				xx[1] = x + param[0] * cos (D2R * param[2]);	yy[1] = y + param[0] * sin (D2R * param[2]);
+				sa = sin (D2R * param[PSL_WEDGE_ANGLE_END]);   ca = cos (D2R * param[PSL_WEDGE_ANGLE_END]);
+				xx[0] = x + param[PSL_WEDGE_RADIUS_I] * ca;	yy[0] = y + param[PSL_WEDGE_RADIUS_I] * sa;
+				xx[1] = x + param[PSL_WEDGE_RADIUS_O] * ca;	yy[1] = y + param[PSL_WEDGE_RADIUS_O] * sa;
 				PSL_plotline (PSL, xx, yy, 2, PSL_MOVE+PSL_STROKE);	/* Plot jaw */
 			}
 			else {	/* Open triangular jaw */
-				xx[0] = x + param[0] * cos (D2R * param[1]);	yy[0] = y + param[0] * sin (D2R * param[1]);
+				xx[0] = x + param[PSL_WEDGE_RADIUS_O] * cos (D2R * param[PSL_WEDGE_ANGLE_BEGIN]);
+				yy[0] = y + param[PSL_WEDGE_RADIUS_O] * sin (D2R * param[PSL_WEDGE_ANGLE_BEGIN]);
 				xx[1] = x;				yy[1] = y;
-				xx[2] = x + param[0] * cos (D2R * param[2]);	yy[2] = y + param[0] * sin (D2R * param[2]);
+				xx[2] = x + param[PSL_WEDGE_RADIUS_O] * cos (D2R * param[PSL_WEDGE_ANGLE_END]);
+				yy[2] = y + param[PSL_WEDGE_RADIUS_O] * sin (D2R * param[PSL_WEDGE_ANGLE_END]);
 				PSL_plotline (PSL, xx, yy, 3, PSL_MOVE+PSL_STROKE);	/* Plot jaw */
 			}
 		}
@@ -3037,9 +3061,9 @@ static int psl_wedge (struct PSL_CTRL *PSL, double x, double y, double param[]) 
 	if (outline) {	/* Draw wedge outline on top */
 		if (windshield)
 			PSL_command (PSL, "V %d %d T 0 0 %d %.12g %.12g arc 0 0 %d %.12g %.12g arcn P os U\n", psl_ix (PSL, x), psl_iy (PSL, y),
-				psl_iz (PSL, param[0]), param[1], param[2], psl_iz (PSL, param[4]), param[2], param[1]);
+				psl_iz (PSL, param[PSL_WEDGE_RADIUS_O]), param[PSL_WEDGE_ANGLE_BEGIN], param[PSL_WEDGE_ANGLE_END], psl_iz (PSL, param[PSL_WEDGE_RADIUS_I]), param[PSL_WEDGE_ANGLE_END], param[PSL_WEDGE_ANGLE_BEGIN]);
 		else
-			PSL_command (PSL, "%d %.12g %.12g %d %d 2 copy M 5 2 roll arc os\n", psl_iz (PSL, param[0]), param[1], param[2], psl_ix (PSL, x), psl_iy (PSL, y));
+			PSL_command (PSL, "%d %.12g %.12g %d %d 2 copy M 5 2 roll arc os\n", psl_iz (PSL, param[PSL_WEDGE_RADIUS_O]), param[PSL_WEDGE_ANGLE_BEGIN], param[PSL_WEDGE_ANGLE_END], psl_ix (PSL, x), psl_iy (PSL, y));
 	}
 	return (PSL_NO_ERROR);
 }

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -89,7 +89,7 @@ enum PSL_enum_vecattr {
 	PSL_VEC_ARROW_PLAIN	= 5,		/* Stylized vector head (just triangle lines; cannot be filled) */
 	PSL_VEC_TAIL_PLAIN	= 6,		/* Stylized vector tail (just inward triangle lines; cannot be filled) */
 	PSL_VEC_BEGIN		= 1,		/* Place vector head at beginning of vector. Add PSL_VEC_BEGIN_L for left only, PSL_VEC_BEGIN_R for right only */
-	PSL_VEC_END		= 2,		/* Place vector head at end of vector.  Add PSL_VEC_END_L for left only, and PSL_VEC_END_R for right only */
+	PSL_VEC_END			= 2,		/* Place vector head at end of vector.  Add PSL_VEC_END_L for left only, and PSL_VEC_END_R for right only */
 	PSL_VEC_HEADS		= 3,		/* Mask for either head end */
 	PSL_VEC_BEGIN_L		= 4,		/* Left-half head at beginning */
 	PSL_VEC_BEGIN_R		= 8,		/* Right-half head at beginning */
@@ -114,18 +114,43 @@ enum PSL_enum_vecattr {
 	PSL_VEC_SCALE		= 2097152};	/* Not yet needed in postscriptlight: If not set we determine the required inch-to-degree scale */
 
 enum PSL_enum_vecdim {	/* Indices into the dim[] array passed to psl_vector */
-	PSL_VEC_XTIP 		= 0,	/* x-coordinate of tip of vector in inches */
-	PSL_VEC_YTIP 		= 1,	/* y-coordinate of tip of vector in inches */
-	PSL_VEC_TAIL_WIDTH	= 2,	/* Width of tail stem (pen width) in inches */
-	PSL_VEC_HEAD_LENGTH	= 3,	/* Length of the vector head in inches */
-	PSL_VEC_HEAD_WIDTH	= 4,	/* Width of the vector head in inches */
-	PSL_VEC_HEAD_SHAPE	= 5,	/* Shape (0-2) of the vector head */
-	PSL_VEC_STATUS		= 6,	/* Sum of all vector bit flags */
-	PSL_VEC_HEAD_TYPE_B	= 7,	/* Type of vector head at beginning of vector */
-	PSL_VEC_HEAD_TYPE_E	= 8,	/* Type of vector head at end of vector */
-	PSL_VEC_TRIM_B		= 9,	/* Amount of line trim at beginning of vector in inches*/
-	PSL_VEC_TRIM_E		= 10,	/* Amount of line trim at end of vector in inches*/
-	PSL_VEC_HEAD_PEN	= 11};	/* Pen width of vector head outline */
+	PSL_VEC_XTIP 			= 0,	/* x-coordinate of tip of vector in inches */
+	PSL_VEC_YTIP 			= 1,	/* y-coordinate of tip of vector in inches */
+	PSL_VEC_TAIL_WIDTH		= 2,	/* Width of tail stem (pen width) in inches */
+	PSL_VEC_HEAD_LENGTH		= 3,	/* Length of the vector head in inches */
+	PSL_VEC_HEAD_WIDTH		= 4,	/* Width of the vector head in inches */
+	PSL_VEC_HEAD_SHAPE		= 5,	/* Shape (0-2) of the vector head */
+	PSL_VEC_STATUS			= 6,	/* Sum of all vector bit flags */
+	PSL_VEC_HEAD_TYPE_BEGIN	= 7,	/* Type of vector head at beginning of vector */
+	PSL_VEC_HEAD_TYPE_END	= 8,	/* Type of vector head at end of vector */
+	PSL_VEC_TRIM_BEGIN		= 9,	/* Amount of line trim at beginning of vector in inches*/
+	PSL_VEC_TRIM_END		= 10,	/* Amount of line trim at end of vector in inches*/
+	PSL_VEC_HEAD_PENWIDTH	= 11};	/* Pen width of vector head outline */
+
+enum PSL_enum_wedgedim {	/* Indices into the dim[] array passed to psl_wedge */
+	 PSL_WEDGE_RADIUS_O    = 0,	/* Outer radius of wedge in inches */
+	 PSL_WEDGE_ANGLE_BEGIN = 1,	/* Begin angle in degrees */
+	 PSL_WEDGE_ANGLE_END   = 2,	/* End angle in degrees */
+	 PSL_WEDGE_STATUS      = 3,	/* Status bit flags */
+	 PSL_WEDGE_RADIUS_I    = 4, 	/* Inner radius of wedge in inches */
+	 PSL_WEDGE_DR          = 5, 	/* Radial increment in inches */
+	 PSL_WEDGE_DA          = 6, 	/* Azimuthal increment in degrees */
+	 PSL_WEDGE_ACTION      = 7 };	/* Sets filling (1) and/or outline (2) */
+
+enum PSL_enum_matharcdim {	/* Indices into the dim[] array passed to psl_matharc */
+	 PSL_MATHARC_RADIUS			= 0,	/* Radius of arc in inches */
+	 PSL_MATHARC_ANGLE_BEGIN	= 1,	/* Begin angle in degrees */
+	 PSL_MATHARC_ANGLE_END		= 2,	/* End angle in degrees */
+	 PSL_MATHARC_HEAD_LENGTH	= 3,	/* Length of the vector head in inches */
+	 PSL_MATHARC_HEAD_WIDTH		= 4,	/* Width of the vector head in inches */
+	 PSL_MATHARC_ARC_PENWIDTH	= 5,	/* Pen width of arc in inches  */
+	 PSL_MATHARC_HEAD_SHAPE		= 6,	/* Shape (0-2) of the vector head */
+	 PSL_MATHARC_STATUS			= 7,	/* Sum of all vector bit flags */
+	 PSL_MATHARC_HEAD_TYPE_BEGIN= 8,	/* Type of vector head at beginning of vector */
+	 PSL_MATHARC_HEAD_TYPE_END	= 9,	/* Type of vector head at end of vector */
+	 PSL_MATHARC_TRIM_BEGIN		= 10,	/* Amount of line trim at beginning of vector in degrees */
+	 PSL_MATHARC_TRIM_END		= 11,	/* Amount of line trim at end of vector in degrees */
+	 PSL_MATHARC_HEAD_PENWIDTH	= 12};	/* Pen width of vector head outline in inches  */
 
 /* PSL macros for dealing with vector attributes */
 

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -113,6 +113,20 @@ enum PSL_enum_vecattr {
 	PSL_VEC_COMPONENTS	= 1048576,	/* Not yet needed in postscriptlight: Got vector dx, dy Cartesian components */
 	PSL_VEC_SCALE		= 2097152};	/* Not yet needed in postscriptlight: If not set we determine the required inch-to-degree scale */
 
+enum PSL_enum_vecdim {	/* Indices into the dim[] array passed to psl_vector */
+	PSL_VEC_XTIP 		= 0,	/* x-coordinate of tip of vector in inches */
+	PSL_VEC_YTIP 		= 1,	/* y-coordinate of tip of vector in inches */
+	PSL_VEC_TAIL_WIDTH	= 2,	/* Width of tail stem (pen width) in inches */
+	PSL_VEC_HEAD_LENGTH	= 3,	/* Length of the vector head in inches */
+	PSL_VEC_HEAD_WIDTH	= 4,	/* Width of the vector head in inches */
+	PSL_VEC_HEAD_SHAPE	= 5,	/* Shape (0-2) of the vector head */
+	PSL_VEC_STATUS		= 6,	/* Sum of all vector bit flags */
+	PSL_VEC_HEAD_TYPE_B	= 7,	/* Type of vector head at beginning of vector */
+	PSL_VEC_HEAD_TYPE_E	= 8,	/* Type of vector head at end of vector */
+	PSL_VEC_TRIM_B		= 9,	/* Amount of line trim at beginning of vector in inches*/
+	PSL_VEC_TRIM_E		= 10,	/* Amount of line trim at end of vector in inches*/
+	PSL_VEC_HEAD_PEN	= 11};	/* Pen width of vector head outline */
+
 /* PSL macros for dealing with vector attributes */
 
 #define PSL_vec_justify(status) ((status>>6)&3)			/* Return justification as 0-3 */

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -847,19 +847,20 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 	gmt_setpen (GMT, &Ctrl->W.pen[0]);
 	if (Ctrl->M.S.v.status & PSL_VEC_OUTLINE2) {	/* Gave specific head outline pen */
 		PSL_defpen (GMT->PSL, "PSL_vecheadpen", Ctrl->M.S.v.pen.width, Ctrl->M.S.v.pen.style, Ctrl->M.S.v.pen.offset, Ctrl->M.S.v.pen.rgb);
-		dim[11] = Ctrl->M.S.v.pen.width;
+		dim[PSL_VEC_HEAD_PENWIDTH] = Ctrl->M.S.v.pen.width;
 	}
 	else if (Ctrl->M.active) {
 		PSL_defpen (GMT->PSL, "PSL_vecheadpen", 0.5 * Ctrl->W.pen[1].width, Ctrl->W.pen[1].style, Ctrl->W.pen[1].offset, Ctrl->W.pen[1].rgb);
-		dim[11] = 0.5 * Ctrl->W.pen[1].width;
+		dim[PSL_VEC_HEAD_PENWIDTH] = 0.5 * Ctrl->W.pen[1].width;
 	}
 	if (windrose) {	/* Here we draw individual vectors */
 		if (Ctrl->M.active) { /* Initialize vector head settings */
 			gmt_init_vector_param (GMT, &Ctrl->M.S, false, false, NULL, false, NULL);
 			if (Ctrl->M.S.symbol == PSL_VECTOR) Ctrl->M.S.v.v_width = (float)(Ctrl->W.pen[1].width * GMT->session.u2u[GMT_PT][GMT_INCH]);
-			dim[5] = Ctrl->M.S.v.v_shape;
-			dim[6] = (double)Ctrl->M.S.v.status;
-			dim[7] = (double)Ctrl->M.S.v.v_kind[0];	dim[8] = (double)Ctrl->M.S.v.v_kind[1];
+			dim[PSL_VEC_HEAD_SHAPE]      = Ctrl->M.S.v.v_shape;
+			dim[PSL_VEC_STATUS]          = (double)Ctrl->M.S.v.status;
+			dim[PSL_VEC_HEAD_TYPE_BEGIN] = (double)Ctrl->M.S.v.v_kind[0];
+			dim[PSL_VEC_HEAD_TYPE_END]   = (double)Ctrl->M.S.v.v_kind[1];
 			if (Ctrl->M.S.v.status & PSL_VEC_OUTLINE) gmt_setpen (GMT, &Ctrl->W.pen[1]);
 			if (Ctrl->M.S.v.status & PSL_VEC_FILL2) gmt_setfill (GMT, &Ctrl->M.S.v.fill, 1);       /* Use fill structure */
 		}
@@ -867,9 +868,12 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 			sincosd (start_angle - azimuth[i], &s, &c);
 			radius = length[i] * Ctrl->S.scale;
 			if (Ctrl->M.active) {	/* Set end point of vector */
-				dim[0] = radius * c, dim[1] = radius * s;
+				dim[PSL_VEC_XTIP] = radius * c;
+				dim[PSL_VEC_YTIP] = radius * s;
 				f = (radius < Ctrl->M.S.v.v_norm) ? radius / Ctrl->M.S.v.v_norm : 1.0;
-				dim[2] = f * Ctrl->M.S.v.v_width, dim[3] = f * Ctrl->M.S.v.h_length, dim[4] = f * Ctrl->M.S.v.h_width;
+				dim[PSL_VEC_TAIL_WIDTH]  = f * Ctrl->M.S.v.v_width;
+				dim[PSL_VEC_HEAD_LENGTH] = f * Ctrl->M.S.v.h_length;
+				dim[PSL_VEC_HEAD_WIDTH]  = f * Ctrl->M.S.v.h_width;
 			}
 			if (Ctrl->T.active) {
 				if (Ctrl->M.active)	{	/* Draw two-headed vectors */
@@ -882,7 +886,7 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 							this_rgb = GMT->session.no_rgb;
 						if (v4_outline) gmt_setpen (GMT, &Ctrl->W.pen[1]);
 						v4_outline += 8;	/* Double-headed */
-						dim[5] = GMT->current.setting.map_vector_shape;
+						dim[PSL_VEC_HEAD_SHAPE] = GMT->current.setting.map_vector_shape;
 						psl_vector_v4 (PSL, -radius * c, -radius * s, dim, this_rgb, v4_outline);
 					}
 					else
@@ -901,7 +905,7 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 						else
 							this_rgb = GMT->session.no_rgb;
 						if (v4_outline) gmt_setpen (GMT, &Ctrl->W.pen[1]);
-						dim[5] = GMT->current.setting.map_vector_shape;
+						dim[PSL_VEC_HEAD_SHAPE] = GMT->current.setting.map_vector_shape;
 						psl_vector_v4 (PSL, 0.0, 0.0, dim, this_rgb, v4_outline);
 					}
 					else
@@ -1054,14 +1058,17 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 		}
 		gmt_init_vector_param (GMT, &Ctrl->M.S, false, false, NULL, false, NULL);
 		if (Ctrl->M.S.symbol == PSL_VECTOR) Ctrl->M.S.v.v_width = (float)(Ctrl->W.pen[1].width * GMT->session.u2u[GMT_PT][GMT_INCH]);
-		dim[2] = Ctrl->M.S.v.v_width, dim[3] = Ctrl->M.S.v.h_length, dim[4] = Ctrl->M.S.v.h_width;
-		dim[5] = Ctrl->M.S.v.v_shape;
-		dim[6] = (double)Ctrl->M.S.v.status;
-		dim[7] = (double)Ctrl->M.S.v.v_kind[0];	dim[8] = (double)Ctrl->M.S.v.v_kind[1];
+		dim[PSL_VEC_TAIL_WIDTH]      = Ctrl->M.S.v.v_width;
+		dim[PSL_VEC_HEAD_LENGTH]     = Ctrl->M.S.v.h_length;
+		dim[PSL_VEC_HEAD_WIDTH]      = Ctrl->M.S.v.h_width;
+		dim[PSL_VEC_HEAD_SHAPE]      = Ctrl->M.S.v.v_shape;
+		dim[PSL_VEC_STATUS]          = (double)Ctrl->M.S.v.status;
+		dim[PSL_VEC_HEAD_TYPE_BEGIN] = (double)Ctrl->M.S.v.v_kind[0];
+		dim[PSL_VEC_HEAD_TYPE_END]   = (double)Ctrl->M.S.v.v_kind[1];
 		if (Ctrl->M.S.v.status & PSL_VEC_OUTLINE) gmt_setpen (GMT, &Ctrl->W.pen[1]);
 		if (Ctrl->M.S.v.status & PSL_VEC_FILL2) gmt_setfill (GMT, &Ctrl->M.S.v.fill, 1);       /* Use fill structure */
 		if (Ctrl->M.S.symbol == GMT_SYMBOL_VECTOR_V4) {
-			dim[5] = GMT->current.setting.map_vector_shape;
+			dim[PSL_VEC_HEAD_SHAPE] = GMT->current.setting.map_vector_shape;
 			if (Ctrl->M.S.v.status & PSL_VEC_FILL2)
 				this_rgb = Ctrl->M.S.v.fill.rgb;
 			else
@@ -1071,11 +1078,11 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 		else {
 			if (Ctrl->M.S.v.status & PSL_VEC_OUTLINE2) {	/* Gave specific head outline pen */
 				PSL_defpen (GMT->PSL, "PSL_vecheadpen", Ctrl->M.S.v.pen.width, Ctrl->M.S.v.pen.style, Ctrl->M.S.v.pen.offset, Ctrl->M.S.v.pen.rgb);
-				dim[11] = Ctrl->M.S.v.pen.width;
+				dim[PSL_VEC_HEAD_PENWIDTH] = Ctrl->M.S.v.pen.width;
 			}
 			else if (Ctrl->M.active) {
 				PSL_defpen (GMT->PSL, "PSL_vecheadpen", 0.5 * Ctrl->W.pen[1].width, Ctrl->W.pen[1].style, Ctrl->W.pen[1].offset, Ctrl->W.pen[1].rgb);
-				dim[11] = 0.5 * Ctrl->W.pen[1].width;
+				dim[PSL_VEC_HEAD_PENWIDTH] = 0.5 * Ctrl->W.pen[1].width;
 			}
 		}
 		for (this_mode = 0; this_mode < n_modes; this_mode++) {
@@ -1085,7 +1092,7 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 			sincosd (angle, &s, &c);
 			xr = Ctrl->S.scale * mode_length[this_mode] * c;
 			yr = Ctrl->S.scale * mode_length[this_mode] * s;
-			dim[0] = xr, dim[1] = yr;
+			dim[PSL_VEC_XTIP] = xr, dim[PSL_VEC_YTIP] = yr;
 			if (Ctrl->M.S.symbol == GMT_SYMBOL_VECTOR_V4)
 				psl_vector_v4 (PSL, 0.0, 0.0, dim, this_rgb, v4_outline);
 			else

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -656,23 +656,25 @@ GMT_LOCAL void psscale_plot_cycle (struct GMT_CTRL *GMT, double x, double y, dou
 	gmt_init_fill (GMT, &head, pen.rgb[0], pen.rgb[1], pen.rgb[2]);	/* Default fill for points, if needed */
 	gmt_init_vector_param (GMT, &S, false, false, NULL, false, NULL);	/* Update vector head parameters */
 	gmt_M_memset (vdim, PSL_MAX_DIMS, double);
-	circum = 2.0 * M_PI * width;		/* Circumference of symbol in inches */
+	circum = 2.0 * M_PI * width;	/* Circumference of symbol in inches */
 	p_width = (float)(s * pen.width * GMT->session.u2u[GMT_PT][GMT_INCH]);
 	pen.width = p_width * GMT->session.u2u[GMT_INCH][GMT_PT];
-	vdim[0] = width;					/* Circular symbol radius is 0.45 of bar width */
-	vdim[1] = 50.0;	vdim[2] = 210.0;	/* Angular start and stop for one arrow */
-	vdim[3] = circum / 6.0;				/* Head-length is 1/6 of circumference */
-	vdim[4] = vdim[3] * tand (25.0);	/* Head width assumes 25 degree apex */
-	vdim[5] = p_width;					/* Passing in pen width */
-	vdim[6] = 0.75;						/* Vector shape */
-	vdim[7] = (double)(PSL_VEC_END|PSL_VEC_FILL);
-	vdim[9] = (double)PSL_VEC_ARROW;
+	vdim[PSL_MATHARC_RADIUS] = width;	/* Circular symbol radius is 0.45 of bar width */
+	vdim[PSL_MATHARC_ANGLE_BEGIN] = 50.0;	/* Angular start and stop for one arrow */
+	vdim[PSL_MATHARC_ANGLE_END]   = 210.0;
+	vdim[PSL_MATHARC_HEAD_LENGTH] = circum / 6.0;	/* Head-length is 1/6 of circumference */
+	vdim[PSL_MATHARC_HEAD_WIDTH] = vdim[PSL_MATHARC_HEAD_LENGTH] * tand (25.0);	/* Head width assumes 25 degree apex */
+	vdim[PSL_MATHARC_ARC_PENWIDTH] = p_width;	/* Passing in pen width */
+	vdim[PSL_MATHARC_HEAD_SHAPE] = 0.75;		/* Vector shape */
+	vdim[PSL_MATHARC_STATUS] = (double)(PSL_VEC_END|PSL_VEC_FILL);
+	vdim[PSL_MATHARC_HEAD_TYPE_END] = (double)PSL_VEC_ARROW;
 	gmt_setfill (GMT, &head, 0);
 	gmt_setpen (GMT, &pen);
 	PSL_defpen (GMT->PSL, "PSL_vecheadpen", 0.0, "", 0, head.rgb);
 	x += 0.15 * vdim[3];	/* Shift center to account for the width of the circular arrow */
 	PSL_plotsymbol (GMT->PSL, x, y, vdim, PSL_MARC);
-	vdim[1] = 230.0;	vdim[2] = 390.0;	/* Angular start and stop for the other circular arrow */
+	vdim[PSL_MATHARC_ANGLE_BEGIN] = 230.0;	/* Angular start and stop for the other circular arrow */
+	vdim[PSL_MATHARC_ANGLE_END]   = 390.0;
 	PSL_plotsymbol (GMT->PSL, x, y, vdim, PSL_MARC);
 }
 
@@ -685,8 +687,8 @@ GMT_LOCAL unsigned int psscale_cpt_transparency (struct GMT_CTRL *GMT, struct GM
 	unsigned int k, status = 0;
 	for (k = 0; k < P->n_colors; k++) {
 		if (P->data[k].rgb_low[3] > 0.0 || P->data[k].rgb_high[3] > 0.0) status |= 1;	/* Transparency detected */
-		if (k && !doubleAlmostEqualZero (P->data[k].rgb_low[3], P->data[k-1].rgb_low[3]))   status |= 2;	/* Unequal transparencies between slices */
-		if (k && !doubleAlmostEqualZero (P->data[k].rgb_high[3], P->data[k-1].rgb_high[3])) status |= 2;	/* Unequal transparencies between slices */
+		if (k && !doubleAlmostEqualZero (P->data[k].rgb_low[3], P->data[k-1].rgb_low[3]))     status |= 2;	/* Unequal transparencies between slices */
+		if (k && !doubleAlmostEqualZero (P->data[k].rgb_high[3], P->data[k-1].rgb_high[3]))   status |= 2;	/* Unequal transparencies between slices */
 		if (status && !doubleAlmostEqualZero (P->data[k].rgb_low[3], P->data[k].rgb_high[3])) status |= 4;	/* Unequal transparencies within slice */
 	}
 	return (status);

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1420,22 +1420,25 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 							x_2 -= dx;		y_2 -= dy;
 						}
 					}
-					data[n].dim[0] = x_2, data[n].dim[1] = y_2;
+					data[n].dim[PSL_VEC_XTIP] = x_2;
+					data[n].dim[PSL_VEC_YTIP] = y_2;
 					s = (data[n].dim[1] < S.v.v_norm) ? data[n].dim[1] / S.v.v_norm : 1.0;
-					data[n].dim[2] = s * S.v.v_width;
-					data[n].dim[3] = s * S.v.h_length;
-					data[n].dim[4] = s * S.v.h_width;
+					data[n].dim[PSL_VEC_TAIL_WIDTH]  = s * S.v.v_width;
+					data[n].dim[PSL_VEC_HEAD_LENGTH] = s * S.v.h_length;
+					data[n].dim[PSL_VEC_HEAD_WIDTH]  = s * S.v.h_width;
 					if (S.v.parsed_v4) {	/* Parsed the old ways so plot the old ways... */
-						data[n].dim[4] *= 0.5;	/* Since it was double in the parsing */
+						data[n].dim[PSL_VEC_HEAD_WIDTH] *= 0.5;	/* Since it was double in the parsing */
 						data[n].symbol = GMT_SYMBOL_VECTOR_V4;
-						data[n].dim[5] = GMT->current.setting.map_vector_shape;
+						data[n].dim[PSL_VEC_HEAD_SHAPE] = GMT->current.setting.map_vector_shape;
 					}
 					else {
-						data[n].dim[5] = S.v.v_shape;
-						data[n].dim[6] = (double)S.v.status;
-						data[n].dim[7] = (double)S.v.v_kind[0];	data[n].dim[8] = (double)S.v.v_kind[1];
-						data[n].dim[9] = (double)S.v.v_trim[0];	data[n].dim[10] = (double)S.v.v_trim[1];
-						data[n].dim[11] = s * data[n].h.width;	/* Possibly shrunk head pen width */
+						data[n].dim[PSL_VEC_HEAD_SHAPE]      = S.v.v_shape;
+						data[n].dim[PSL_VEC_STATUS]          = (double)S.v.status;
+						data[n].dim[PSL_VEC_HEAD_TYPE_BEGIN] = (double)S.v.v_kind[0];
+						data[n].dim[PSL_VEC_HEAD_TYPE_END]   = (double)S.v.v_kind[1];
+						data[n].dim[PSL_VEC_TRIM_BEGIN]      = (double)S.v.v_trim[0];
+						data[n].dim[PSL_VEC_TRIM_END]        = (double)S.v.v_trim[1];
+						data[n].dim[PSL_VEC_HEAD_PENWIDTH]   = s * data[n].h.width;	/* Possibly shrunk head pen width */
 					}
 					break;
 				case GMT_SYMBOL_GEOVECTOR:
@@ -1461,23 +1464,25 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 				case PSL_MARC:
 					gmt_init_vector_param (GMT, &S, false, false, NULL, false, NULL);	/* Update vector head parameters */
 					S.v.v_width = (float)(current_pen.width * GMT->session.u2u[GMT_PT][GMT_INCH]);
-					data[n].dim[0] = in[ex1+S.read_size];	/* Radius */
-					data[n].dim[1] = in[ex2+S.read_size];	/* Start direction in degrees */
-					data[n].dim[2] = in[ex3+S.read_size];	/* Stop direction in degrees */
-					length = fabs (data[n].dim[2]-data[n].dim[1]);	/* Arc length in degrees */
+					data[n].dim[PSL_MATHARC_RADIUS]      = in[ex1+S.read_size];	/* Radius */
+					data[n].dim[PSL_MATHARC_ANGLE_BEGIN] = in[ex2+S.read_size];	/* Start direction in degrees */
+					data[n].dim[PSL_MATHARC_ANGLE_END]   = in[ex3+S.read_size];	/* Stop direction in degrees */
+					length = fabs (data[n].dim[PSL_MATHARC_ANGLE_END]-data[n].dim[PSL_MATHARC_ANGLE_BEGIN]);	/* Arc length in degrees */
 					if (gmt_M_is_dnan (length)) {
 						GMT_Report (API, GMT_MSG_WARNING, "Math angle arc length = NaN near line %d. Skipped\n", n_total_read);
 						continue;
 					}
 					s = (length < S.v.v_norm) ? length / S.v.v_norm : 1.0;
-					data[n].dim[3] = s * S.v.h_length;	/* Length of (shrunk) vector head */
-					data[n].dim[4] = s * S.v.h_width;	/* Width of (shrunk) vector head */
-					data[n].dim[5] = s * S.v.v_width;	/* Thickness of (shrunk) vector */
-					data[n].dim[6] = S.v.v_shape;
-					data[n].dim[7] = (double)S.v.status;	/* Vector tributes */
-					data[n].dim[8] = (double)S.v.v_kind[0];	data[n].dim[9] = (double)S.v.v_kind[1];
-					data[n].dim[10] = (double)S.v.v_trim[0];	data[n].dim[11] = (double)S.v.v_trim[1];
-					data[n].dim[12] = s * data[n].h.width;	/* Possibly shrunk head pen width */
+					data[n].dim[PSL_MATHARC_HEAD_LENGTH]     = s * S.v.h_length;	/* Length of (shrunk) vector head */
+					data[n].dim[PSL_MATHARC_HEAD_WIDTH]      = s * S.v.h_width;	/* Width of (shrunk) vector head */
+					data[n].dim[PSL_MATHARC_ARC_PENWIDTH]    = s * S.v.v_width;	/* Thickness of (shrunk) vector */
+					data[n].dim[PSL_MATHARC_HEAD_SHAPE]      = S.v.v_shape;
+					data[n].dim[PSL_MATHARC_STATUS]          = (double)S.v.status;	/* Vector tributes */
+					data[n].dim[PSL_MATHARC_HEAD_TYPE_BEGIN] = (double)S.v.v_kind[0];
+					data[n].dim[PSL_MATHARC_HEAD_TYPE_END]   = (double)S.v.v_kind[1];
+					data[n].dim[PSL_MATHARC_TRIM_BEGIN]      = (double)S.v.v_trim[0];
+					data[n].dim[PSL_MATHARC_TRIM_END]        = (double)S.v.v_trim[1];
+					data[n].dim[PSL_MATHARC_HEAD_PENWIDTH]   = s * data[n].h.width;	/* Possibly shrunk head pen width */
 					break;
 				case PSL_WEDGE:
 					col = ex1+S.read_size;
@@ -1486,25 +1491,25 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 							GMT_Report (API, GMT_MSG_WARNING, "Wedge outer diameter = NaN near line %d. Skipped\n", n_total_read);
 								continue;
 						}
-						data[n].dim[0] = in[col++];
+						data[n].dim[PSL_WEDGE_RADIUS_O] = in[col++];
 					}
 					else	/* Set during -S parsing */
-						data[n].dim[0] = S.w_radius;
+						data[n].dim[PSL_WEDGE_RADIUS_O] = S.w_radius;
 					if (S.w_get_a) {	/* Must read from file */
 						if (gmt_M_is_dnan (in[col])) {
 							GMT_Report (API, GMT_MSG_WARNING, "Wedge start angle = NaN near line %d. Skipped\n", n_total_read);
 								continue;
 						}
-						data[n].dim[1] = in[col++];
+						data[n].dim[PSL_WEDGE_ANGLE_BEGIN] = in[col++];
 						if (gmt_M_is_dnan (in[col])) {
 							GMT_Report (API, GMT_MSG_WARNING, "Wedge stop angle = NaN near line %d. Skipped\n", n_total_read);
 								continue;
 						}
-						data[n].dim[2] = in[col++];
+						data[n].dim[PSL_WEDGE_ANGLE_END] = in[col++];
 					}
 					else {	/* Angles were set during -S parsing */
-						data[n].dim[1] = S.size_x;
-						data[n].dim[2] = S.size_y;
+						data[n].dim[PSL_WEDGE_ANGLE_BEGIN] = S.size_x;
+						data[n].dim[PSL_WEDGE_ANGLE_END]   = S.size_y;
 					}
 					if (S.w_get_di) {	/* Must read from file else it was set during -S parsing */
 						if (gmt_M_is_dnan (in[col])) {
@@ -1516,26 +1521,26 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 					if (S.convert_angles) {
 						if (gmt_M_is_cartesian (GMT, GMT_IN)) {
 							/* Note that the direction of the arc gets swapped when converting from azimuth */
-							data[n].dim[2] = 90.0 - data[n].dim[2];
-							data[n].dim[1] = 90.0 - data[n].dim[1];
+							data[n].dim[PSL_WEDGE_ANGLE_END]   = 90.0 - data[n].dim[PSL_WEDGE_ANGLE_END];
+							data[n].dim[PSL_WEDGE_ANGLE_BEGIN] = 90.0 - data[n].dim[PSL_WEDGE_ANGLE_BEGIN];
 						}
 						else {
-							data[n].dim[2] = gmt_azim_to_angle (GMT, in[GMT_X], in[GMT_Y], 0.1, data[n].dim[2]);
-							data[n].dim[1] = gmt_azim_to_angle (GMT, in[GMT_X], in[GMT_Y], 0.1, data[n].dim[1]);
+							data[n].dim[PSL_WEDGE_ANGLE_END] = gmt_azim_to_angle (GMT, in[GMT_X], in[GMT_Y], 0.1, data[n].dim[PSL_WEDGE_ANGLE_END]);
+							data[n].dim[PSL_WEDGE_ANGLE_BEGIN] = gmt_azim_to_angle (GMT, in[GMT_X], in[GMT_Y], 0.1, data[n].dim[PSL_WEDGE_ANGLE_BEGIN]);
 						}
 						gmt_M_double_swap (data[n].dim[1], data[n].dim[2]);	/* Must switch the order of the angles */
 					}
 					/* Load up the rest of the settings */
-					data[n].dim[3] = S.w_type;
-					data[n].dim[4] = S.w_radius_i;
-					data[n].dim[5] = S.w_dr;	/* In case there is a request for radially spaced arcs */
-					data[n].dim[6] = S.w_da;	/* In case there is a request for angularly spaced radial lines */
-					data[n].dim[7] = 0.0;	/* Reset */
-					if (fill_active || get_rgb) data[n].dim[7] = 1;	/* Lay down filled wedge */
-					if (outline_active) data[n].dim[7] += 2;	/* Draw wedge outline */
+					data[n].dim[PSL_WEDGE_STATUS]   = S.w_type;
+					data[n].dim[PSL_WEDGE_RADIUS_I] = S.w_radius_i;
+					data[n].dim[PSL_WEDGE_DR]       = S.w_dr;	/* In case there is a request for radially spaced arcs */
+					data[n].dim[PSL_WEDGE_DA]       = S.w_da;	/* In case there is a request for angularly spaced radial lines */
+					data[n].dim[PSL_WEDGE_ACTION]   = 0.0;	/* Reset */
+					if (fill_active || get_rgb) data[n].dim[PSL_WEDGE_ACTION] = 1;	/* Lay down filled wedge */
+					if (outline_active) data[n].dim[PSL_WEDGE_ACTION] += 2;	/* Draw wedge outline */
 					if (!S.w_active) {	/* Not geowedge so scale to radii */
-						data[n].dim[0] *= 0.5;
-						data[n].dim[4] *= 0.5;
+						data[n].dim[PSL_WEDGE_RADIUS_O] *= 0.5;
+						data[n].dim[PSL_WEDGE_RADIUS_I] *= 0.5;
 					}
 					break;
 				case GMT_SYMBOL_CUSTOM:
@@ -1771,7 +1776,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 						else
 							v4_rgb = GMT->session.no_rgb;
 						if (v4_outline) gmt_setpen (GMT, &Ctrl->W.pen);
-						v4_status = lrint (data[n].dim[6]);
+						v4_status = lrint (data[n].dim[PSL_VEC_STATUS]);
 						if (v4_status & PSL_VEC_BEGIN) v4_outline += 8;	/* Double-headed */
 						gmt_plane_perspective (GMT, GMT_Z, data[i].z);
 						psl_vector_v4 (PSL, xpos[item], data[i].y, data[i].dim, v4_rgb, v4_outline);
@@ -1790,9 +1795,10 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 					case PSL_WEDGE:
 						gmt_plane_perspective (GMT, GMT_Z, data[i].z);
 						if (S.w_active)	{	/* Geo-wedge */
-							unsigned int status = lrint (data[i].dim[3]);
+							unsigned int status = lrint (data[i].dim[PSL_WEDGE_STATUS]);
 							gmt_xy_to_geo (GMT, &dx, &dy, data[i].y, data[i].y);	/* Just recycle dx, dy here */
-							gmt_geo_wedge (GMT, dx, dy, data[n].dim[4], S.w_radius, data[n].dim[5], data[i].dim[1], data[i].dim[2], data[n].dim[6], status, fill_active || get_rgb, outline_active);
+							gmt_geo_wedge (GMT, dx, dy, data[n].dim[PSL_WEDGE_RADIUS_I], S.w_radius, data[n].dim[PSL_WEDGE_DR], data[i].dim[PSL_WEDGE_ANGLE_BEGIN],
+								data[i].dim[PSL_WEDGE_ANGLE_END], data[n].dim[PSL_WEDGE_DA], status, fill_active || get_rgb, outline_active);
 						}
 						else
 							PSL_plotsymbol (PSL, xpos[item], data[i].y, data[i].dim, PSL_WEDGE);

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -669,9 +669,13 @@ EXTERN_MSC int GMT_pspolar (void *V_API, int mode, void *args) {
 			if (Ctrl->S2.vector) {
 				double dim[PSL_MAX_DIMS];
 				gmt_M_memset (dim, PSL_MAX_DIMS, double);
-				dim[0] = plot_x + Ctrl->S2.size*si; dim[1] = plot_y + Ctrl->S2.size*co;
-				dim[2] = Ctrl->S2.width; dim[3] = Ctrl->S2.length; dim[4] = Ctrl->S2.head;
-				dim[5] = Ctrl->S2.vector_shape; dim[6] = PSL_VEC_END | PSL_VEC_FILL;
+				dim[PSL_VEC_XTIP]        = plot_x + Ctrl->S2.size*si;
+				dim[PSL_VEC_YTIP]        = plot_y + Ctrl->S2.size*co;
+				dim[PSL_VEC_TAIL_WIDTH]  = Ctrl->S2.width;
+				dim[PSL_VEC_HEAD_LENGTH] = Ctrl->S2.length;
+				dim[PSL_VEC_HEAD_WIDTH]  = Ctrl->S2.head;
+				dim[PSL_VEC_HEAD_SHAPE]  = Ctrl->S2.vector_shape;
+				dim[PSL_VEC_STATUS]      = PSL_VEC_END | PSL_VEC_FILL;
 				if (Ctrl->S2.S.symbol == GMT_SYMBOL_VECTOR_V4)
 					psl_vector_v4 (PSL, plot_x - Ctrl->S2.size*si, plot_y - Ctrl->S2.size*co, dim, Ctrl->S2.fill.rgb, Ctrl->S2.outline);
 				else {	/* Modern vector */


### PR DESCRIPTION
It is hard enough to debug GMT without also having to remember what dim[9] contains, and that it is different for vectors and wedges.  This adds three sets of _enums_ with named indices that are used internally by GMT modules.  All tests still pass.