### PR TITLE
Fix minor typo in explain_-I.rst

### DIFF
--- a/doc/rst/source/explain_-I.rst_
+++ b/doc/rst/source/explain_-I.rst_
@@ -1,6 +1,6 @@
 **-I**\ *xinc*\ [**+e**\|\ **n**][/\ *yinc*\ [**+e**\|\ **n**]]
     *x_inc* [and optionally *y_inc*] is the grid spacing. **Geographical
-    (degrees) coordinates**: Optionally, append a increment unit. Choose among
+    (degrees) coordinates**: Optionally, append an increment unit. Choose among
     **m** to indicate arc minutes or **s** to indicate arc seconds. If one
     of the units **e**, **f**, **k**, **M**, **n** or **u** is appended
     instead, the increment is assumed to be given in meter, foot, km, Mile,


### PR DESCRIPTION
This pull request changes "append a increment unit" to "append an increment unit" in `explain_-I.rst`.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
