### PR TITLE
Improve the grdgdal order in the core modules

### DIFF
--- a/doc/rst/source/modules.rst
+++ b/doc/rst/source/modules.rst
@@ -212,7 +212,6 @@ Core Modules
     - :doc:`gmtconnect`
     - :doc:`gmtconvert`
     - :doc:`gmtdefaults`
-    - :doc:`grdgdal`
     - :doc:`gmtget`
     - :doc:`gmtinfo`
     - :doc:`gmtlogo`
@@ -234,6 +233,7 @@ Core Modules
     - :doc:`grdconvert`
     - :doc:`grdcut`
     - :doc:`grdedit`
+    - :doc:`grdgdal`
     - :doc:`grdfft`
     - :doc:`grdfill`
     - :doc:`grdfilter`

--- a/doc/rst/source/modules.rst
+++ b/doc/rst/source/modules.rst
@@ -233,10 +233,10 @@ Core Modules
     - :doc:`grdconvert`
     - :doc:`grdcut`
     - :doc:`grdedit`
-    - :doc:`grdgdal`
     - :doc:`grdfft`
     - :doc:`grdfill`
     - :doc:`grdfilter`
+    - :doc:`grdgdal`
     - :doc:`grdgradient`
     - :doc:`grdhisteq`
     - :doc:`grdimage`


### PR DESCRIPTION
**Description of proposed changes**

Module `grdgdal` is classified as [**Miscellaneous**](https://docs.generic-mapping-tools.org/latest/modules.html#miscellaneous). Would it be better to near those `grd*` modules in the list of [**Core Modules**](https://docs.generic-mapping-tools.org/latest/modules.html#core-modules)?

BTW, I don't know if it could be better to add `img2google`, which is classified as [**Utility Scripts**](https://docs.generic-mapping-tools.org/latest/modules.html#utility-scripts), to [**IMG**](https://docs.generic-mapping-tools.org/latest/modules.html#img), which only contains `img2grd` now.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
