### PR TITLE
Let -f<col>s explicity set start of input trailing text

### DIFF
--- a/doc/rst/source/explain_-f_full.rst_
+++ b/doc/rst/source/explain_-f_full.rst_
@@ -17,7 +17,8 @@ consecutive columns have the same format you may specify a range of columns rath
 must be given in the format *start*\ [:*inc*]:*stop*, where *inc* defaults to 1 if not specified.  For example, if our
 input file has geographic coordinates (latitude, longitude) with absolute calendar coordinates in the columns 3 and 4,
 we would specify **fi**\ 0\ **y**,1\ **x**,3:4\ **T**. All other columns are assumed to have the default (floating
-point) format and need not be set individually.
+point) format and need not be set individually. **Note**: You can also indicate that all items from the given column
+and to the end of the record should be considered *trailing text* by giving the code **s** (for string).
 
 The shorthand **-f**\ [**i**\|\ **o**]\ **g** means **-f**\ [**i**\|\ **o**]0x,1y (i.e., geographic coordinates). A
 special use of **-f** is to select **-fp**\ [*unit*], which *requires* **-J** and lets you use *projected* map

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -1426,7 +1426,7 @@ GMT_LOCAL int gmtinit_parse_f_option (struct GMT_CTRL *GMT, char *arg) {
 			case 'd':	/* Length dimension (with possible unit) */
 				code = GMT_IS_DIMENSION;
 				break;
-			case 's':	/* This must be start of training text */
+			case 's':	/* This must be start of trailing text */
 				code = GMT_IS_STRING;
 				break;
 			default:	/* No suffix, consider it an error */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -1407,7 +1407,7 @@ GMT_LOCAL int gmtinit_parse_f_option (struct GMT_CTRL *GMT, char *arg) {
 		if ((inc = gmtlib_parse_index_range (GMT, p, &start, &stop)) == 0) return (GMT_PARSE_ERROR);
 		for (c = 0; p[c] && strchr ("0123456789-:", p[c]); c++);	/* Wind to position after the column or column range */
 		d = dir;
-		switch (p[c]) {	/* p[c] is the potential code T, t, x, y, or f. */
+		switch (p[c]) {	/* p[c] is the potential code T, t, x, y, f, d or s. */
 			case 'T':	/* Absolute calendar time */
 				code = GMT_IS_ABSTIME;
 				break;
@@ -1425,6 +1425,9 @@ GMT_LOCAL int gmtinit_parse_f_option (struct GMT_CTRL *GMT, char *arg) {
 				break;
 			case 'd':	/* Length dimension (with possible unit) */
 				code = GMT_IS_DIMENSION;
+				break;
+			case 's':	/* This must be start of training text */
+				code = GMT_IS_STRING;
 				break;
 			default:	/* No suffix, consider it an error */
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Malformed -f argument [%s]\n", arg);
@@ -7496,6 +7499,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 				"Give one or more columns (or column ranges) separated by commas. "
 				"Append T (Calendar format), t (time relative to TIME_EPOCH), "
 				"f (floating point), x (longitude), or y (latitude) to each item. "
+				"You may also use s (string) to indicate the start column of trailing text. "
 				"Note: -f[i|o]g means -f[i|o]0x,1y (geographic, i.e., lon/lat coordinates), "
 				"-f[i|o]c means -f[i|o]0-1f (Cartesian coordinates) while "
 				"-fp[<unit>] means input x,y are in projected coordinates.");

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3261,7 +3261,7 @@ bool gmtlib_maybe_abstime (struct GMT_CTRL *GMT, char *txt, bool *no_T) {
 	return false;
 }
 
-GMT_LOCAL unsigned int gmtio_physical_coltype (struct GMT_CTRL *GMT, unsigned int col) {
+GMT_LOCAL enum gmt_col_enum gmtio_physical_coltype (struct GMT_CTRL *GMT, unsigned int col) {
 	/* The users's -f settings apply to the logical columns and these are the same as
 	 * the physical columns except when -i is used.  This function takes the physical
 	 * column (we are scanning across the physical record) and returns the corresponding
@@ -3318,8 +3318,9 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 	 * (which is what we are handling here) a huge variety of datetime strings are possible via
 	 * the FORMAT_DATE_IN, FORMAT_CLOCK_IN settings.
 	 */
-	unsigned int ret_val = GMT_READ_DATA, pos = 0, col = 0, k, phys_col_type, *type = NULL;
+	unsigned int ret_val = GMT_READ_DATA, pos = 0, col = 0, k, *type = NULL;
 	int got;
+	enum gmt_col_enum phys_col_type;
 	bool found_text = false, no_T = false;
 	char token[GMT_BUFSIZ], message[GMT_BUFSIZ] = {""};
 	double value;
@@ -3328,21 +3329,27 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 	type = gmt_M_memory (GMT, NULL, GMT_MAX_COLUMNS, unsigned int);
 	*tpos = pos;
 	while (!found_text && (gmt_strtok (record, GMT->current.io.scan_separators, &pos, token))) {
-		phys_col_type = gmtio_physical_coltype (GMT, col);
-		if (phys_col_type == GMT_IS_ABSTIME || gmtlib_maybe_abstime (GMT, token, &no_T)) {	/* Might be ISO Absolute time; if not we got junk (and got -> GMT_IS_NAN) */
-			got = gmt_scanf (GMT, token, GMT_IS_ABSTIME, &value);
+		if ((phys_col_type = gmt_get_column_type (GMT, GMT_IN, col)) == GMT_IS_STRING) {	/* Explicit start of trailing text via -f<col>s */
+			found_text = true;	/* We stop right here, return flag as nan and hence n_columns will be col. */
+			got = GMT_IS_NAN;
 		}
-		else	/* Let gmt_scanf_arg figure it out for us by passing UNKNOWN since ABSTIME has been dealt above */
-			got = gmt_scanf_arg (GMT, token, GMT_IS_UNKNOWN, false, &value);
-		if (got == GMT_IS_NAN) {	/* Parsing failed, which means we found our first non-number; but it could also be a valid NaN */
-			gmt_str_tolower (token);
-			if (strncmp (token, "nan", 3U))
-				found_text = true;
-			else
-				type[col++] = got = GMT_IS_FLOAT;
+		else {	/* Auto-guess from examining the token */
+			phys_col_type = gmtio_physical_coltype (GMT, col);
+			if (phys_col_type == GMT_IS_ABSTIME || gmtlib_maybe_abstime (GMT, token, &no_T)) {	/* Might be ISO Absolute time; if not we got junk (and got -> GMT_IS_NAN) */
+				got = gmt_scanf (GMT, token, GMT_IS_ABSTIME, &value);
+			}
+			else	/* Let gmt_scanf_arg figure it out for us by passing UNKNOWN since ABSTIME has been dealt above */
+				got = gmt_scanf_arg (GMT, token, GMT_IS_UNKNOWN, false, &value);
+			if (got == GMT_IS_NAN) {	/* Parsing failed, which means we found our first non-number; but it could also be a valid NaN */
+				gmt_str_tolower (token);
+				if (strncmp (token, "nan", 3U))
+					found_text = true;
+				else
+					type[col++] = got = GMT_IS_FLOAT;
+			}
+			else	/* A successful numerical parsing */
+					type[col++] = got;
 		}
-		else	/* A successful numerical parsing */
-				type[col++] = got;
 		if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION) && col <= 50) {	/* Tell user how we interpreted their first record, but not for excessively long records */
 			k = gmtio_get_type_name_index (got);
 			if (col>1) strcat (message, ",");


### PR DESCRIPTION
At least as long as GMT modules maintain _record-by-record_ reading (i.e., as UNIX filters), we may not always be able to reliable identify the start of trialing text if the first record has numbers in that column.  If that happens, then any trailing text in subsequent columns will be read as NaN and basically lost.  Using **-f*_*col_**t** to explicitly state where trailing text starts makes the determination robust.  Closes #5368.
