### PR TITLE
Improve velo docs with figure of the four symbols

### DIFF
--- a/doc/rst/source/supplements/geodesy/velo_common.rst_
+++ b/doc/rst/source/supplements/geodesy/velo_common.rst_
@@ -10,6 +10,13 @@ rotational wedges and their uncertainties, anisotropy bars,
 or strain crosses.  Symbol fills or their outlines may be colored
 based on constant parameters or via color lookup tables.
 
+.. figure:: /_images/GMT_velo.*
+   :width: 400 px
+   :align: center
+
+   You can make four different geodetic symbols: Rotational wedges,
+   velocity error ellipses with vector, anisotropy bars, and strain crosses.
+
 Required Arguments
 ------------------
 

--- a/doc/rst/source/supplements/geodesy/velo_common.rst_
+++ b/doc/rst/source/supplements/geodesy/velo_common.rst_
@@ -11,11 +11,13 @@ or strain crosses.  Symbol fills or their outlines may be colored
 based on constant parameters or via color lookup tables.
 
 .. figure:: /_images/GMT_velo.*
-   :width: 400 px
+   :width: 600 px
    :align: center
 
    You can make four different geodetic symbols: Rotational wedges,
    velocity error ellipses with vector, anisotropy bars, and strain crosses.
+   The first two symbols allow you to select separate colors and pens for the main
+   symbol and its error component.
 
 Required Arguments
 ------------------
@@ -67,6 +69,7 @@ Required Arguments
 
         Anisotropy bars. The *barscale* sets the scaling of the bars.
         If *barscale* is not given the we read it from the data file as an extra column.
+        Unless **-A** is used to change it via modifier **+h**\ *shape*, the vector shape defaults to 0.1.
         Parameters are expected to be in the following columns:
 
             **1**,\ **2**:

--- a/doc/scripts/GMT_velo.ps
+++ b/doc/scripts/GMT_velo.ps
@@ -1,0 +1,1081 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.3.0_aef0e2d_2021.06.20 [64-bit] Document from velo
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Jun 20 15:15:47 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt velo -JM12c -R0/4/0/1 -Sw0.915/5.e7 -W0.5p -Glightred -Elightblue -L0.5p -D2
+%@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+clipsave
+0 0 M
+5669 0 D
+0 1408 D
+-5669 0 D
+P
+PSL_clip N
+{1 0.502 0.502 C} FS
+O1
+709 694 M
+0 432 D
+36 -1 D
+49 -7 D
+12 -3 D
+-97 -421 D
+97 421 D
+46 -13 D
+34 -14 D
+11 -5 D
+-188 -389 D
+188 389 D
+33 -17 D
+30 -20 D
+20 -15 D
+-271 -337 D
+271 337 D
+36 -33 D
+25 -27 D
+7 -10 D
+-339 -267 D
+339 267 D
+15 -19 D
+26 -42 D
+11 -21 D
+-391 -185 D
+391 185 D
+22 -57 D
+9 -36 D
+-422 -92 D
+422 92 D
+5 -24 D
+5 -48 D
+0 -25 D
+-432 5 D
+432 -5 D
+-5 -61 D
+-7 -36 D
+-420 102 D
+420 -102 D
+-14 -46 D
+-14 -34 D
+-6 -11 D
+-386 193 D
+386 -193 D
+-17 -32 D
+-28 -40 D
+-8 -10 D
+-333 275 D
+333 -275 D
+-33 -36 D
+-37 -32 D
+-263 343 D
+263 -343 D
+-30 -21 D
+-21 -12 D
+-21 -12 D
+-11 -5 D
+-180 393 D
+180 -393 D
+-11 -5 D
+-12 -4 D
+-11 -5 D
+-12 -4 D
+P
+FO
+{0.678 0.847 0.902 C} FS
+709 694 M
+288 -24 D
+-7 -45 D
+-10 -32 D
+-14 -31 D
+-23 -39 D
+-22 -26 D
+-24 -23 D
+-27 -21 D
+-20 -11 D
+-20 -11 D
+-10 -4 D
+-11 -4 D
+-10 -4 D
+-11 -3 D
+-11 -3 D
+-11 -3 D
+-11 -2 D
+-11 -1 D
+-11 -2 D
+-12 0 D
+-11 -1 D
+-34 2 D
+-44 9 D
+-43 15 D
+-30 16 D
+-28 19 D
+-25 22 D
+-16 17 D
+FO
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt velo -Se0.44/0.39 -A0.5c+p0.25p+e+gblue -Elightred -L0.25p -W2p -R0/4/0/1 -JM12c
+%@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+33 W
+clipsave
+0 0 M
+5669 0 D
+0 1408 D
+-5669 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {4 W 0 A [] 0 B} def
+4 W
+{1 0.502 0.502 C} FS
+O1
+2807 999 M
+-6 19 D
+-11 19 D
+-17 19 D
+-13 11 D
+-22 14 D
+-31 15 D
+-41 13 D
+-40 9 D
+-50 6 D
+-61 2 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-8 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-8 -1 D
+-7 -1 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-8 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -1 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -1 D
+-7 -3 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-7 -2 D
+-6 -2 D
+-7 -3 D
+-6 -2 D
+-13 -6 D
+-6 -2 D
+-12 -6 D
+-6 -2 D
+-12 -6 D
+-12 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-11 -6 D
+-19 -14 D
+-14 -10 D
+-17 -13 D
+-8 -7 D
+-3 -4 D
+-11 -10 D
+-3 -4 D
+-4 -3 D
+-14 -18 D
+-17 -29 D
+-9 -29 D
+-1 -24 D
+5 -23 D
+9 -19 D
+11 -15 D
+20 -19 D
+18 -12 D
+29 -15 D
+35 -13 D
+50 -12 D
+49 -7 D
+60 -2 D
+56 1 D
+79 9 D
+65 13 D
+69 19 D
+47 17 D
+37 16 D
+41 20 D
+46 29 D
+26 20 D
+30 28 D
+15 18 D
+18 29 D
+9 25 D
+3 28 D
+-1 10 D
+FO
+33 W
+{0 0 1 C} FS
+33 W
+V 1772 296 T 45 R
+N 0 0 M 705 0 D S
+U
+V 2395 919 T 45 R
+PSL_vecheadpen
+4 W
+0 0 M
+-236 63 D
+59 -63 D
+-59 -63 D
+P clip fs P S 
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt velo -Sn0.425 -Glightred -Elightred -W4p,orange -R0/4/0/1 -JM12c
+%@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+67 W
+1 0.647 0 C
+clipsave
+0 0 M
+5669 0 D
+0 1408 D
+-5669 0 D
+P
+PSL_clip N
+N 3260 303 M 602 803 D S
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt velo -Sx0.405 -A0.5c+h0.5 -W2p,red -R0/4/0/1 -JM12c
+%@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+33 W
+1 0 0 C
+clipsave
+0 0 M
+5669 0 D
+0 1408 D
+-5669 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 1 0 0 C [] 0 B} def
+{1 0 0 C} FS
+33 W
+V 4961 704 T -30 R
+N 0 0 M 493 0 D S
+U
+V 5541 369 T -30 R
+PSL_vecheadpen
+0 W
+0 0 M
+-236 63 D
+59 -63 D
+-59 -63 D
+P clip fs N 
+U
+33 W
+V 4961 704 T 150 R
+N 0 0 M 493 0 D S
+U
+V 4381 1039 T 150 R
+PSL_vecheadpen
+0 W
+0 0 M
+-236 63 D
+59 -63 D
+-59 -63 D
+P clip fs N 
+U
+33 W
+V 4961 704 T -120 R
+N 177 0 M 301 0 D S
+PSL_vecheadpen
+0 W
+0 0 M
+236 -63 D
+-59 63 D
+59 63 D
+P clip fs N U
+33 W
+V 4961 704 T 60 R
+N 177 0 M 301 0 D S
+PSL_vecheadpen
+0 W
+0 0 M
+236 -63 D
+-59 63 D
+59 63 D
+P clip fs N U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f7p -D0/-1.2c -N -R0/4/0/1 -JM12c
+%@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+822 137 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+117 F0
+(ROTATIONAL WEDGE) mc Z
+2282 137 M (VELOCITY ELLIPSE) mc Z
+3543 137 M (ANISOTROPY BAR) mc Z
+4961 137 M (STRAIN CROSS) mc Z
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/doc/scripts/GMT_velo.ps
+++ b/doc/scripts/GMT_velo.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.3.0_aef0e2d_2021.06.20 [64-bit] Document from velo
+%%Title: GMT v6.3.0_9755b4b_2021.06.20 [64-bit] Document from velo
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Jun 20 15:15:47 2021
+%%CreationDate: Sun Jun 20 16:02:08 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -700,7 +700,7 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt velo -JM12c -R0/4/0/1 -Sw0.915/5.e7 -W0.5p -Glightred -Elightblue -L0.5p -D2
+%@GMT: gmt velo -JM12c -R0/4/0/1 -Sw0.915c/5.e7 -W0.5p -Elightred -Glightblue -L0.5p -D2
 %@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -714,7 +714,7 @@ clipsave
 -5669 0 D
 P
 PSL_clip N
-{1 0.502 0.502 C} FS
+{0.678 0.847 0.902 C} FS
 O1
 709 694 M
 0 432 D
@@ -782,7 +782,7 @@ O1
 -12 -4 D
 P
 FO
-{0.678 0.847 0.902 C} FS
+{1 0.502 0.502 C} FS
 709 694 M
 288 -24 D
 -7 -45 D
@@ -820,7 +820,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt velo -Se0.44/0.39 -A0.5c+p0.25p+e+gblue -Elightred -L0.25p -W2p -R0/4/0/1 -JM12c
+%@GMT: gmt velo -Se0.44c/0.39 -A0.5c+p0.25p+e -Glightblue -Elightred -L0.25p -W2p -R0/4/0/1 -JM12c
 %@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -942,7 +942,7 @@ O1
 -1 10 D
 FO
 33 W
-{0 0 1 C} FS
+{0.678 0.847 0.902 C} FS
 33 W
 V 1772 296 T 45 R
 N 0 0 M 705 0 D S
@@ -963,7 +963,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt velo -Sn0.425 -Glightred -Elightred -W4p,orange -R0/4/0/1 -JM12c
+%@GMT: gmt velo -Sn0.425c -Glightred -Elightred -W4p,orange -R0/4/0/1 -JM12c
 %@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -986,7 +986,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt velo -Sx0.405 -A0.5c+h0.5 -W2p,red -R0/4/0/1 -JM12c
+%@GMT: gmt velo -Sx0.405c -A0.5c+h0.5 -W2p,red -R0/4/0/1 -JM12c
 %@PROJ: merc 0.00000000 4.00000000 0.00000000 1.00000000 -222638.982 222638.982 -0.000 110579.965 +proj=merc +lon_0=2 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap

--- a/doc/scripts/GMT_velo.sh
+++ b/doc/scripts/GMT_velo.sh
@@ -1,14 +1,14 @@
 gmt begin GMT_velo
-	gmt velo <<- EOF -JM12c -R0/4/0/1 -Sw0.915/5.e7 -W0.5p -Glightred -Elightblue -L0.5p -D2
+	gmt velo <<- EOF -JM12c -R0/4/0/1 -Sw0.915c/5.e7 -W0.5p -Elightred -Glightblue -L0.5p -D2
 	0.5 0.493  5.65E-08 1.17E-08
 	EOF
-	gmt velo -Se0.44/0.39 -A0.5c+p0.25p+e+gblue -Elightred -L0.25p -W2p <<- EOF
+	gmt velo -Se0.44c/0.39 -A0.5c+p0.25p+e -Glightblue -Elightred -L0.25p -W2p <<- EOF
 	1.25     0.21     3.0    3.0     2.0    1.0  0.300
 	EOF
-	gmt velo -Sn0.425 -Glightred -Elightred  -W4p,orange <<- EOF
+	gmt velo -Sn0.425c -Glightred -Elightred  -W4p,orange <<- EOF
 	2.3     0.215     3.0    4.0 
 	EOF
-	gmt velo -Sx0.405 -A0.5c+h0.5 -W2p,red <<- EOF
+	gmt velo -Sx0.405c -A0.5c+h0.5 -W2p,red <<- EOF
 	3.5     0.5     3.5    -2.5 30
 	EOF
 	gmt text -F+f7p -D0/-1.2c -N <<- EOF

--- a/doc/scripts/GMT_velo.sh
+++ b/doc/scripts/GMT_velo.sh
@@ -1,0 +1,20 @@
+gmt begin GMT_velo
+	gmt velo <<- EOF -JM12c -R0/4/0/1 -Sw0.915/5.e7 -W0.5p -Glightred -Elightblue -L0.5p -D2
+	0.5 0.493  5.65E-08 1.17E-08
+	EOF
+	gmt velo -Se0.44/0.39 -A0.5c+p0.25p+e+gblue -Elightred -L0.25p -W2p <<- EOF
+	1.25     0.21     3.0    3.0     2.0    1.0  0.300
+	EOF
+	gmt velo -Sn0.425 -Glightred -Elightred  -W4p,orange <<- EOF
+	2.3     0.215     3.0    4.0 
+	EOF
+	gmt velo -Sx0.405 -A0.5c+h0.5 -W2p,red <<- EOF
+	3.5     0.5     3.5    -2.5 30
+	EOF
+	gmt text -F+f7p -D0/-1.2c -N <<- EOF
+	0.58 0.5 ROTATIONAL WEDGE
+	1.61 0.5 VELOCITY ELLIPSE
+	2.5 0.5 ANISOTROPY BAR
+	3.5 0.5 STRAIN CROSS
+	EOF
+gmt end show

--- a/src/geodesy/psvelo.c
+++ b/src/geodesy/psvelo.c
@@ -739,7 +739,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSVELO_CTRL *Ctrl, struct GMT_OPT
 
 	unsigned int n_errors = 0, n_set;
 	int n;
-	bool got_A = false;
+	bool got_A = false, got_shape = false;
 	char txt[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, symbol, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 
@@ -777,6 +777,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSVELO_CTRL *Ctrl, struct GMT_OPT
 						n_errors += gmt_parse_vector (GMT, symbol, txt_b, &Ctrl->A.S);
 					}
 					Ctrl->A.S.symbol = PSL_VECTOR;
+					if (strstr (opt->arg, "+h")) got_shape = true;	/* User specified vector head shape */
 				}
 				break;
 			case 'C':	/* Select CPT for coloring */
@@ -923,6 +924,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSVELO_CTRL *Ctrl, struct GMT_OPT
 		}
 	}
 
+	if (Ctrl->S.symbol == CROSS && !got_shape) Ctrl->A.S.v.v_shape = 0.1;	/* Traditional default cross vector shape if none given */
 	gmt_consider_current_cpt (GMT->parent, &Ctrl->C.active, &(Ctrl->C.file));
 
         /* Only one allowed */
@@ -1320,7 +1322,7 @@ EXTERN_MSC int GMT_psvelo (void *V_API, int mode, void *args) {
 					gmt_scale_pen (GMT, &current_pen, scl);
 				}
 				psvelo_trace_cross (GMT, in[GMT_X],in[GMT_Y],eps1,eps2,theta,size,Ctrl->A.S.v.v_width,Ctrl->A.S.v.h_length,
-					Ctrl->A.S.v.h_width,0.1,Ctrl->L.active,&(current_pen));
+					Ctrl->A.S.v.h_width,Ctrl->A.S.v.v_shape,Ctrl->L.active,&(current_pen));
 				break;
 			case WEDGE:
 				PSL_comment (PSL, "begin wedge number %li", n_rec);


### PR DESCRIPTION
**Description of proposed changes**

First, while **-Sx** will default to using a vector head shape of 0.1, the user may now override that via **-A**'s **+h**_shape_ modifier.  Second, I am adding a small documentation script (_GMT_velo.sh_) that reproduces the four symbol types that **velo** can make and use it in the documentation.  The man page now looks like this:

![velo](https://user-images.githubusercontent.com/26473567/122697640-71154c00-d1e1-11eb-865f-082fc6608837.png)
