### PR TITLE
Documentation improvements for -i and -o

### DIFF
--- a/doc/rst/source/explain_-icols_full.rst_
+++ b/doc/rst/source/explain_-icols_full.rst_
@@ -20,6 +20,8 @@ one of the following modifiers to any column or column range to transform the in
 - **+o** to add the given *offset* to the input values [default is 0].
 
 To read from a given column until the end of the record, leave off *stop* when specifying the column range. Normally,
-any trailing text is read but when **-i** is used you must explicitly add the column **t** to retain the text. To only
-ingest a single word from the trailing text, append the word number (first word is 0).  Finally, **-in** will simply
-read the numerical input and skip any trailing text.
+any trailing text will be read but when **-i** is used to specify specific input columns you must explicitly append the
+"column" **t** to retain the trailing text internally. To only ingest a single word from the trailing text, append
+the word number (first word is 0).  If your trailing text columns start with a valid number and you want to ensure
+the content from a specific column until the end of the record will be considered trailing text, use **-f**\ *col*\ **s**.
+Finally, **-in** will simply read the numerical input and skip any trailing text.

--- a/doc/rst/source/explain_-icols_full.rst_
+++ b/doc/rst/source/explain_-icols_full.rst_
@@ -23,5 +23,5 @@ To read from a given column until the end of the record, leave off *stop* when s
 any trailing text will be read but when **-i** is used to specify specific input columns you must explicitly append the
 "column" **t** to retain the trailing text internally. To only ingest a single word from the trailing text, append
 the word number (first word is 0).  If your trailing text columns start with a valid number and you want to ensure
-the content from a specific column until the end of the record will be considered trailing text, use **-f**\ *col*\ **s**.
+the content from column *col* to the end of the record will be considered trailing text, use **-f**\ *col*\ **s**.
 Finally, **-in** will simply read the numerical input and skip any trailing text.

--- a/doc/rst/source/explain_-ocols_full.rst_
+++ b/doc/rst/source/explain_-ocols_full.rst_
@@ -14,8 +14,9 @@ separated by commas [Default writes all columns in order, starting with the firs
 be repeated. The chosen data columns will be used as given and columns not listed will be skipped. To write from a given
 column until the end of the record, leave off *stop* when specifying the column range.
 
-Normally, any trailing text in the internal records will be written but when **-o** is used you must explicitly add
-the column **t**. To only output a single word from the trailing text, append the word number (first word is 0).
+Normally, any trailing text in the internal records will be included in the output, but when **-o** is used to specify
+specific columns you must explicitly add the extra column **t** to include the trailing text on output. To only select
+a single word from the trailing text, append the word number (first word is 0).
 Finally, **-on** will simply write the numerical output only and skip any trailing text, while **-ot** will only output
 the trailing text (or selected word). **Note**: If **-i** is also used then columns given to **-o** correspond to the
-order *after* the **-i** selection and not the columns in the original record.
+order *after* the **-i** selection have taken place and *not* the columns in the original record.

--- a/doc/rst/source/explain_-ocols_full.rst_
+++ b/doc/rst/source/explain_-ocols_full.rst_
@@ -15,8 +15,8 @@ be repeated. The chosen data columns will be used as given and columns not liste
 column until the end of the record, leave off *stop* when specifying the column range.
 
 Normally, any trailing text in the internal records will be included in the output, but when **-o** is used to specify
-specific columns you must explicitly add the extra column **t** to include the trailing text on output. To only select
+specific columns you must explicitly append the extra "column" **t** to include the trailing text on output. To only select
 a single word from the trailing text, append the word number (first word is 0).
 Finally, **-on** will simply write the numerical output only and skip any trailing text, while **-ot** will only output
 the trailing text (or selected word). **Note**: If **-i** is also used then columns given to **-o** correspond to the
-order *after* the **-i** selection have taken place and *not* the columns in the original record.
+order *after* the **-i** selection has taken place and *not* the columns in the original record.


### PR DESCRIPTION
**Description of proposed changes**

Related to the discussion in #5368 and clarifies the purpose and order of the pseudo-column **t** (for trailing text) in **-i** and **-o**.
