### PR TITLE
Remove AUR upload task from release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -84,7 +84,6 @@ assignees: ''
 - [ ] update [macports ports](https://github.com/macports/macports-ports/blob/master/science/gmt5/Portfile) (@remkos, @seisman)
 - [ ] update [the RPM repository](https://copr.fedorainfracloud.org/coprs/genericmappingtools/gmt/) (@seisman)
 - [ ] update the [try-gmt](https://github.com/GenericMappingTools/try-gmt) Jupyter lab (@seisman)
-- [ ] update [the AUR repository](https://aur.archlinux.org/packages/gmt6/) (@holishing)
 - [ ] update [winget manifest file](https://github.com/microsoft/winget-pkgs/tree/master/manifests/GenericMappingTools/gmt) (@seisman)
 
 ---


### PR DESCRIPTION
**Description of proposed changes**

since GMT has been uploaded to Arch Linux Official Repository (community section):
https://archlinux.org/packages/community/x86_64/gmt/

We just have to trust maintainers in Arch Linux will update this package ASAP.

Besides, origin AUR package (`gmt6`) that I maintained has been directly removed by AUR "Trusted User". :rofl: 