### PR TITLE
Fix a few compilation warnings

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -8680,6 +8680,7 @@ GMT_LOCAL bool gmtapi_matrix_data_conforms_to_dataset (struct GMT_MATRIX *M) {
 }
 
 GMT_LOCAL bool gmtapi_vector_data_conforms_to_dataset (struct GMTAPI_CTRL *API, struct GMT_VECTOR *V, enum GMT_enum_type type) {
+	gmt_M_unused(API);
 	/* Check if the vector data arrays matches the form of a GMT dataset (columns of doubles) */
 	if (type != GMT_DOUBLE) {	/* Only doubles can be passed or memcpy directly */
 		if (V->n_columns == 0) return (false);	/* Having nothing yet means we must duplicate */
@@ -9613,7 +9614,7 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
             col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
             ij = API->current_get_M_index (S->rec, col_pos, M->dim);
             API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
-            col++;           
+            col++;
             while (GMT->common.i.select && col < GMT->common.i.n_cols && GMT->current.io.col[GMT_IN][col].col == GMT->current.io.col[GMT_IN][col-1].col) {
                 /* This input column is requested more than once */
                 col_pos = GMT->current.io.col[GMT_IN][col].order;    /* The data column that will receive this value */
@@ -9678,7 +9679,7 @@ struct GMT_RECORD *api_get_record_vector (struct GMTAPI_CTRL *API, unsigned int 
             col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
             API->current_get_V_val[col_pos] (&(V->data[col_pos]), S->rec, &(GMT->current.io.curr_rec[col]));
             GMT->current.io.curr_rec[col] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col_pos], GMT->current.io.curr_rec[col]);
-           col++;           
+           col++;
             while (GMT->common.i.select && col < GMT->common.i.n_cols && GMT->current.io.col[GMT_IN][col].col == GMT->current.io.col[GMT_IN][col-1].col) {
                 /* This input column is requested more than once */
                 col_pos = GMT->current.io.col[GMT_IN][col].order;    /* The data column that will receive this value */
@@ -14993,7 +14994,7 @@ int GMT_Put_Matrix (void *V_API, struct GMT_MATRIX *M, unsigned int type, int pa
 	MH->alloc_mode = GMT_ALLOC_EXTERNALLY;	/* Since it clearly is a user array */
 	MH->pad = pad;	/* Placing the pad argument here */
 	if ((item = gmtapi_get_item (API, GMT_IS_GRID, M)) != GMT_NOTSET)	/* Found in list, update type here as well */
-		API->object[item]->type = type;	
+		API->object[item]->type = type;
 
 	return GMT_NOERROR;
 }

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2640,7 +2640,7 @@ bool gmtplot_skip_pole_lat_annotation (struct GMT_CTRL *GMT, double lat) {
 
 static char *gmtplot_revise_angles_just (struct GMT_CTRL *GMT, double line_angle, unsigned side, unsigned int def_just[], double *t_angle, unsigned int *just) {
 	/* Given the side (W or E) and angle of the boundary, determine the justification of the text and possibly flip it 180 */
-	static char *flip[2] = {"", "neg "}, *name = "WE";
+	static char *flip[2] = {"", "neg "};
 	unsigned int k = GMT->current.proj.got_azimuths ? 1 : 0, pside;
 	if (side == W_SIDE) side = 0; else side = 1;	/* Turn W_SIDE to 0 and E_SIDE to 1 for use with flip and def_just arrays */
 	pside = GMT->current.proj.got_azimuths ? 1-side : side;	/* Since azimuths go the other way */

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -684,6 +684,7 @@ GMT_LOCAL unsigned int psscale_cpt_transparency (struct GMT_CTRL *GMT, struct GM
 	 * Bit 2 means different slices have different transparencies
 	 * Bit 3 means at least one slice has different transparencies within it
 	 */
+	gmt_M_unused(GMT);
 	unsigned int k, status = 0;
 	for (k = 0; k < P->n_colors; k++) {
 		if (P->data[k].rgb_low[3] > 0.0 || P->data[k].rgb_high[3] > 0.0) status |= 1;	/* Transparency detected */

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -554,7 +554,7 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 	}
 	if (clip_set) PSL_endclipping (PSL, 1);
 
-	for (k = 0; k <= GMT_Z; k++) {	/* /* Plot the 3 axes for -B settings that have been stripped of gridline requests */
+	for (k = 0; k <= GMT_Z; k++) {	/* Plot the 3 axes for -B settings that have been stripped of gridline requests */
 		if (side[k] == 0) continue;	/* Did not want this axis drawn */
 		code = (side[k] & 2) ? cmode[k] : (char)tolower (cmode[k]);
 		sprintf (cmd, "-R%g/%g/0/1 -JX%gi/%gi -O -K -B%c \"-B%s\"", wesn_orig[2*k], wesn_orig[2*k+1], sign[k]*width, height, code, psternary_get_B_setting (boptions[k]));


### PR DESCRIPTION
**Description of proposed changes**

```
../../src/gmt_api.c:8682:76: warning: unused parameter 'API' [-Wunused-parameter]
GMT_LOCAL bool gmtapi_vector_data_conforms_to_dataset (struct GMTAPI_CTRL *API, struct GMT_VECTOR *V, enum GMT_enum_type type) {
                                                                           ^
1 warning generated.
[127/216] Building C object src/CMakeFiles/gmtlib.dir/gmt_plot.c.o
../../src/gmt_plot.c:2643:40: warning: unused variable 'name' [-Wunused-variable]
        static char *flip[2] = {"", "neg "}, *name = "WE";
                                              ^
1 warning generated.
[191/216] Building C object src/CMakeFiles/gmtlib.dir/psternary.c.o
../../src/psternary.c:557:36: warning: '/*' within block comment [-Wcomment]
        for (k = 0; k <= GMT_Z; k++) {  /* /* Plot the 3 axes for -B settings that have been stripped of gridline requests */
                                           ^
1 warning generated.
[192/216] Building C object src/CMakeFiles/gmtlib.dir/psscale.c.o
../../src/psscale.c:681:67: warning: unused parameter 'GMT' [-Wunused-parameter]
GMT_LOCAL unsigned int psscale_cpt_transparency (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
                                                                  ^
1 warning generated.
```



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
