### PR TITLE
Rewrite how -i works internally for external sources

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -1320,29 +1320,34 @@ GMT_LOCAL double gmtapi_select_record_value (struct GMT_CTRL *GMT, double *recor
 	return (val);
 }
 
-GMT_LOCAL unsigned int gmtapi_pick_in_col_number (struct GMT_CTRL *GMT, unsigned int col) {
-	/* Return the next column to be selected on input */
-	unsigned int col_pos;
-	if (GMT->common.i.select)	/* -i has selected some columns */
-		col_pos = GMT->current.io.col[GMT_IN][col].col; /* Which data column to pick */
-#if 0
-	else if (GMT->current.setting.io_lonlat_toggle[GMT_IN] && col < GMT_Z)	/* Worry about -: for lon,lat */
-		col_pos = 1 - col;	/* Read lat/lon instead of lon/lat */
-#endif
+unsigned int gmtlib_pick_in_col_number (struct GMT_CTRL *GMT, unsigned int col, unsigned int *col_pos_in) {
+    /* If -i is not active then we simply return col_pos_out = col_pos_in = col.  Done!
+     *
+     * With -i, we must return correct value for both the in and out column positions based on the info in the structure.
+     * Here, col is a loop variable that goes from 0 to number of desired output columns.  However, that col number
+     * is likely neither the input(col) we wish to get nor the output(col) where we want to place it in the output array.
+     * Instead, we set these two different columns via col_pos_in and col_pos_out so that output(col_pos_out) = input(col_pos_in).
+     * col_pos_out will uniquely touch the same values as col loops over, but col_pos_in may be outside that range
+     * and even have repeated column values (e.g., due to -i0,1,2,2+s5). */
+	unsigned int col_pos_out;
+	if (GMT->common.i.select) {	/* -i has selected some columns */
+        *col_pos_in = GMT->current.io.col[GMT_IN][col].col;   /* Which data column to take the value from input */
+        col_pos_out = GMT->current.io.col[GMT_IN][col].order; /* Which data column to place it on output */
+    }
 	else
-		col_pos = col;	/* Just goto that column */
-	return (col_pos);
+		col_pos_out = *col_pos_in = col;	/* They are all the same */
+	return (col_pos_out);
 }
 
 /*! . */
-GMT_LOCAL double gmtapi_get_record_value (struct GMT_CTRL *GMT, double *record, uint64_t col, uint64_t n_colums) {
+GMT_LOCAL double gmtapi_get_record_value (struct GMT_CTRL *GMT, double *record, uint64_t col, uint64_t n_colums, unsigned int *col_pos_out) {
 	/* For binary input of data record via external matrix, we must select correct col entry and possibly make adjustments */
 	double val;
-	unsigned int col_pos;
-	col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
-	val = (col_pos >= n_colums) ? GMT->session.d_NaN : gmt_M_convert_col (GMT->current.io.col[GMT_IN][col_pos], record[col_pos]);	/* If we request a column beyond length of array, return NaN */
+	unsigned int col_pos_in;
+	*col_pos_out = gmtlib_pick_in_col_number (GMT, (unsigned int)col, &col_pos_in);
+	val = (*col_pos_out >= n_colums) ? GMT->session.d_NaN : gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], record[col_pos_in]);	/* If we request a column beyond length of array, return NaN */
 	if (GMT->common.d.active[GMT_IN] && gmt_M_is_dnan (val)) val = GMT->common.d.nan_proxy[GMT_IN];	/* Write this value instead of NaNs */
-	if (gmt_M_is_type (GMT, GMT_IN, col_pos, GMT_IS_LON)) gmt_lon_range_adjust (GMT->current.io.geo.range, &val);	/* Set longitude range */
+	if (gmt_M_is_type (GMT, GMT_IN, *col_pos_out, GMT_IS_LON)) gmt_lon_range_adjust (GMT->current.io.geo.range, &val);	/* Set longitude range */
 	return (val);
 }
 
@@ -3512,7 +3517,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 	 */
 
 	int item, first_item = 0, this_item = GMT_NOTSET, last_item, new_item, new_ID, status;
-	unsigned int geometry = GMT_IS_PLP, n_used = 0, method, smode, type = GMT_READ_DATA;
+	unsigned int geometry = GMT_IS_PLP, n_used = 0, method, smode, type = GMT_READ_DATA, col_pos_out;
 	bool allocate = false, update = false, diff_types, use_GMT_io, greenwich = true;
 	bool via = false, got_data = false, check_col_switch = false;
 	size_t n_alloc, s_alloc = GMT_SMALL_CHUNK;
@@ -3634,7 +3639,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 					GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qi is not implemented for GMT_IS_DUPLICATE GMT_IS_DATASET external memory objects\n");
 				GMT_Report (API, GMT_MSG_INFORMATION, "Duplicating data table from GMT_DATASET memory location\n");
 				check_col_switch = true;
-				D_obj = gmt_duplicate_dataset (GMT, Din_obj, GMT_ALLOC_NORMAL, NULL);
+				D_obj = gmt_duplicate_dataset (GMT, Din_obj, GMT_ALLOC_NORMAL|GMT_ALLOC_VIA_ICOLS, NULL);
 				new_ID = GMT_Register_IO (API, GMT_IS_DATASET, GMT_IS_DUPLICATE, geometry, GMT_IN, NULL, D_obj);	/* Register a new resource to hold D_obj */
 				if ((new_item = gmtlib_validate_id (API, GMT_IS_DATASET, new_ID, GMT_IN, GMT_NOTSET)) == GMT_NOTSET)
 					return_null (API, GMT_OBJECT_NOT_FOUND);	/* Some internal error... */
@@ -3705,8 +3710,10 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 						}
 					}
 					else {	/* Found a data record */
-						for (col = 0; col < n_columns; col++)	/* Place the record into the dataset segment structure */
-							S->data[col][n_records] = gmtapi_get_record_value (GMT, GMT->current.io.curr_rec, col, M_obj->n_columns);
+						for (col = 0; col < n_columns; col++) {	/* Place the record into the dataset segment structure */
+                            double val = gmtapi_get_record_value (GMT, GMT->current.io.curr_rec, col, M_obj->n_columns, &col_pos_out);
+                            S->data[col_pos_out][n_records] = val;
+                        }
 						got_data = true;	/* No longer before first data record */
 						if (smode) S->text[n_records] = strdup (M_obj->text[row]);
 						n_records++;	/* Update count of records in current segment */
@@ -3773,8 +3780,10 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 						}
 					}
 					else {	/* Data record */
-						for (col = 0; col < n_columns; col++)	/* Place the record into the structure */
-							S->data[col][n_records] = gmtapi_get_record_value (GMT, GMT->current.io.curr_rec, col, V_obj->n_columns);
+						for (col = 0; col < n_columns; col++) {	/* Place the record into the structure */
+                            double val = gmtapi_get_record_value (GMT, GMT->current.io.curr_rec, col, V_obj->n_columns, &col_pos_out);
+                            S->data[col_pos_out][n_records] = val;
+                        }
 						if (smode) S->text[n_records] = strdup (V_obj->text[row]);
 						got_data = true;
 						n_records++;
@@ -4027,7 +4036,7 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 				GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qo is not implemented for GMT_IS_DUPLICATE GMT_IS_DATASET external memory objects\n");
 			GMT_Report (API, GMT_MSG_INFORMATION, "Duplicating data table to GMT_DATASET memory location\n");
 			D_copy = gmt_duplicate_dataset (GMT, D_obj, GMT_ALLOC_NORMAL, NULL);
-			gmtlib_change_dataset (GMT, D_copy);	/* Deal with any -o settings */
+			gmtlib_change_out_dataset (GMT, D_copy);	/* Deal with any -o settings */
 			gmtapi_switch_cols (GMT, D_copy, GMT_OUT);	/* Deals with -:, if it was selected */
 			S_obj->resource = D_copy;	/* Set resource pointer from object to this dataset */
 			break;
@@ -4037,7 +4046,7 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 			if (GMT->common.q.mode == GMT_RANGE_ROW_OUT || GMT->common.q.mode == GMT_RANGE_DATA_OUT)
 				GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qo is not implemented for GMT_IS_REFERENCE GMT_IS_DATASET external memory objects\n");
 			GMT_Report (API, GMT_MSG_INFORMATION, "Referencing data table to GMT_DATASET memory location\n");
-			gmtlib_change_dataset (GMT, D_obj);	/* Deal with any -o settings */
+			gmtlib_change_out_dataset (GMT, D_obj);	/* Deal with any -o settings */
 			gmtapi_switch_cols (GMT, D_obj, GMT_OUT);	/* Deals with -:, if it was selected */
 			S_obj->resource = D_obj;		/* Set resource pointer from object to this dataset */
 			DH->alloc_level = S_obj->alloc_level;	/* Since we are passing it up to the caller */
@@ -8726,10 +8735,14 @@ GMT_LOCAL void gmtapi_maybe_change_method_to_duplicate (struct GMTAPI_CTRL *API,
 		S_obj->method = GMT_IS_DUPLICATE;	/* Must duplicate this resource */
 		GMT_Report (API, GMT_MSG_INFORMATION, "GMT_Open_VirtualFile: Switch method to GMT_IS_DUPLICATE as vectors are not compatible with a GMT grid\n");
 	}
-	else if (S_obj->actual_family == GMT_IS_VECTOR && S_obj->family == GMT_IS_DATASET && !gmtapi_vector_data_conforms_to_dataset (API, S_obj->resource, S_obj->type)) {
-		S_obj->method = GMT_IS_DUPLICATE;	/* Must duplicate this resource */
-		GMT_Report (API, GMT_MSG_INFORMATION, "GMT_Open_VirtualFile: Switch method to GMT_IS_DUPLICATE as input vectors are not compatible with a GMT dataset\n");
-	}
+    else if (S_obj->actual_family == GMT_IS_VECTOR && S_obj->family == GMT_IS_DATASET && !gmtapi_vector_data_conforms_to_dataset (API, S_obj->resource, S_obj->type)) {
+        S_obj->method = GMT_IS_DUPLICATE;   /* Must duplicate this resource */
+        GMT_Report (API, GMT_MSG_INFORMATION, "GMT_Open_VirtualFile: Switch method to GMT_IS_DUPLICATE as input vectors are not compatible with a GMT dataset\n");
+    }
+    else if (S_obj->actual_family == GMT_IS_DATASET && S_obj->family == GMT_IS_DATASET && API->GMT->common.i.select) {
+        S_obj->method = GMT_IS_DUPLICATE;   /* Must duplicate this resource */
+        GMT_Report (API, GMT_MSG_INFORMATION, "GMT_Open_VirtualFile: Switch method to GMT_IS_DUPLICATE as input dataset needs to be operated on to become output GMT dataset\n");
+    }
 }
 
  /*! . */
@@ -9603,24 +9616,17 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
 	}
 	else {	/* Read from the current resource */
 		struct GMT_MATRIX *M = API->current_get_M;
-		uint64_t col, ij, n_use, col_pos;
+        unsigned int col, n_use, col_pos_out, col_pos_in;
+        uint64_t ij;
 		int status;
 		S->status = GMT_IS_USING;				/* Mark as being read */
 		n_use = gmtapi_n_cols_needed_for_gaps (GMT, S->n_columns);
 		gmtapi_update_prev_rec (GMT, n_use);
 
-		col = 0;
-		while (col < API->current_get_n_columns) {
-			col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
-			ij = API->current_get_M_index (S->rec, col_pos, M->dim);
-			API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
-			col++;
-			while (GMT->common.i.select && col < GMT->common.i.n_cols && GMT->current.io.col[GMT_IN][col].col == GMT->current.io.col[GMT_IN][col-1].col) {
-				/* This input column is requested more than once */
-				col_pos = GMT->current.io.col[GMT_IN][col].order;    /* The data column that will receive this value */
-				API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col]));
-				col++;
-			}
+		for (col = 0; col < API->current_get_n_columns; col++) {
+			col_pos_out = gmtlib_pick_in_col_number (GMT, (unsigned int)col, &col_pos_in);
+			ij = API->current_get_M_index (S->rec, col_pos_in, M->dim);
+			API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col_pos_out]));
 		}
 		S->rec++;
 		if ((status = gmtapi_bin_input_memory (GMT, S->n_columns, n_use)) < 0) {	/* Process the data record */
@@ -9668,25 +9674,16 @@ struct GMT_RECORD *api_get_record_vector (struct GMTAPI_CTRL *API, unsigned int 
 	}
 	else {	/* Read from this resource */
 		struct GMT_VECTOR *V = API->current_get_V;
-		uint64_t n_use, col_pos;
+		unsigned int n_use, col_pos_out, col_pos_in;
 		int status;
 		S->status = GMT_IS_USING;				/* Mark as being read */
 		n_use = gmtapi_n_cols_needed_for_gaps (GMT, S->n_columns);
 		gmtapi_update_prev_rec (GMT, n_use);
 
-		col = 0;
-		while (col < API->current_get_n_columns) {
-			col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
-			API->current_get_V_val[col_pos] (&(V->data[col_pos]), S->rec, &(GMT->current.io.curr_rec[col]));
-			GMT->current.io.curr_rec[col] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col_pos], GMT->current.io.curr_rec[col]);
-			col++;
-			while (GMT->common.i.select && col < GMT->common.i.n_cols && GMT->current.io.col[GMT_IN][col].col == GMT->current.io.col[GMT_IN][col-1].col) {
-				/* This input column is requested more than once */
-				col_pos = GMT->current.io.col[GMT_IN][col].order;    /* The data column that will receive this value */
-				API->current_get_V_val[col_pos] (&(V->data[col_pos]), S->rec, &(GMT->current.io.curr_rec[col]));
-				GMT->current.io.curr_rec[col] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col_pos], GMT->current.io.curr_rec[col]);
-				col++;
-			}
+		for (col = 0; col < API->current_get_n_columns; col++) {
+			col_pos_out = gmtlib_pick_in_col_number (GMT, (unsigned int)col, &col_pos_in);
+			API->current_get_V_val[col_pos_in] (&(V->data[col_pos_in]), S->rec, &(GMT->current.io.curr_rec[col_pos_out]));
+			GMT->current.io.curr_rec[col] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], GMT->current.io.curr_rec[col_pos_out]);
 		}
 
 		S->rec++;
@@ -9712,15 +9709,15 @@ GMT_LOCAL struct GMT_RECORD * gmtapi_get_record_dataset (struct GMTAPI_CTRL *API
 	struct GMT_DATASET *D = API->current_get_D_set;	/* Get the current dataset */
 	struct GMT_RECORD *record = NULL;
 	int64_t *count = GMT->current.io.curr_pos[GMT_IN];	/* Shorthand used below */
-	uint64_t col, col_pos;
+	unsigned int col, col_pos_in, col_pos_out;
 	int status = gmtapi_wind_to_next_datarecord (count, D, mode);	/* Get current record status and wind counters if needed */
 
 	switch (status) {
 		case GMT_IO_DATA_RECORD:	/* Got a data record */
 			S->status = GMT_IS_USING;		/* Mark this resource as currently being read */
 			for (col = 0; col < API->current_get_n_columns; col++) {	/* Copy from row to curr_rec */
-				col_pos = gmtapi_pick_in_col_number (GMT, (unsigned int)col);
-				GMT->current.io.curr_rec[col] = D->table[count[GMT_TBL]]->segment[count[GMT_SEG]]->data[col_pos][count[GMT_ROW]];
+				col_pos_out = gmtlib_pick_in_col_number (GMT, (unsigned int)col, &col_pos_in);
+				GMT->current.io.curr_rec[col_pos_out] = D->table[count[GMT_TBL]]->segment[count[GMT_SEG]]->data[col_pos_in][count[GMT_ROW]];
 			}
 			if (D->table[count[GMT_TBL]]->segment[count[GMT_SEG]]->text && D->table[count[GMT_TBL]]->segment[count[GMT_SEG]]->text[count[GMT_ROW]])
 				strncpy (GMT->current.io.curr_trailing_text, D->table[count[GMT_TBL]]->segment[count[GMT_SEG]]->text[count[GMT_ROW]], GMT_BUFSIZ-1);

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3711,9 +3711,9 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 					}
 					else {	/* Found a data record */
 						for (col = 0; col < n_columns; col++) {	/* Place the record into the dataset segment structure */
-                            double val = gmtapi_get_record_value (GMT, GMT->current.io.curr_rec, col, M_obj->n_columns, &col_pos_out);
-                            S->data[col_pos_out][n_records] = val;
-                        }
+							double val = gmtapi_get_record_value (GMT, GMT->current.io.curr_rec, col, M_obj->n_columns, &col_pos_out);
+							S->data[col_pos_out][n_records] = val;
+						}
 						got_data = true;	/* No longer before first data record */
 						if (smode) S->text[n_records] = strdup (M_obj->text[row]);
 						n_records++;	/* Update count of records in current segment */
@@ -3781,9 +3781,9 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 					}
 					else {	/* Data record */
 						for (col = 0; col < n_columns; col++) {	/* Place the record into the structure */
-                            double val = gmtapi_get_record_value (GMT, GMT->current.io.curr_rec, col, V_obj->n_columns, &col_pos_out);
-                            S->data[col_pos_out][n_records] = val;
-                        }
+							double val = gmtapi_get_record_value (GMT, GMT->current.io.curr_rec, col, V_obj->n_columns, &col_pos_out);
+							S->data[col_pos_out][n_records] = val;
+						}
 						if (smode) S->text[n_records] = strdup (V_obj->text[row]);
 						got_data = true;
 						n_records++;
@@ -3806,7 +3806,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 				update = via = true;
 				break;
 
-		 	case GMT_IS_REFERENCE|GMT_VIA_VECTOR:
+			case GMT_IS_REFERENCE|GMT_VIA_VECTOR:
 				if ((V_obj = S_obj->resource) == NULL) {
 					gmt_M_free (GMT, D_obj);	return_null (API, GMT_PTR_IS_NULL);
 				}
@@ -9616,8 +9616,8 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
 	}
 	else {	/* Read from the current resource */
 		struct GMT_MATRIX *M = API->current_get_M;
-        unsigned int col, n_use, col_pos_out, col_pos_in;
-        uint64_t ij;
+		unsigned int col, n_use, col_pos_out, col_pos_in;
+		uint64_t ij;
 		int status;
 		S->status = GMT_IS_USING;				/* Mark as being read */
 		n_use = gmtapi_n_cols_needed_for_gaps (GMT, S->n_columns);

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -9683,7 +9683,7 @@ struct GMT_RECORD *api_get_record_vector (struct GMTAPI_CTRL *API, unsigned int 
 		for (col = 0; col < API->current_get_n_columns; col++) {
 			col_pos_out = gmtlib_pick_in_col_number (GMT, (unsigned int)col, &col_pos_in);
 			API->current_get_V_val[col_pos_in] (&(V->data[col_pos_in]), S->rec, &(GMT->current.io.curr_rec[col_pos_out]));
-			GMT->current.io.curr_rec[col] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], GMT->current.io.curr_rec[col_pos_out]);
+			GMT->current.io.curr_rec[col_pos_out] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], GMT->current.io.curr_rec[col_pos_out]);
 		}
 
 		S->rec++;

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 254
+#define GMT_N_API_ENUMS 255
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -42,6 +42,7 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ALLOC_INTERNALLY", 1},
 	{"GMT_ALLOC_NORMAL", 0},
 	{"GMT_ALLOC_VERTICAL", 4},
+	{"GMT_ALLOC_VIA_ICOLS", 16},
 	{"GMT_BGD", 0},
 	{"GMT_CHAR", 0},
 	{"GMT_CMYK", 1},

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -53,6 +53,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC unsigned int gmtlib_pick_in_col_number (struct GMT_CTRL *GMT, unsigned int col, unsigned int *col_pos_in);
 EXTERN_MSC bool gmtlib_set_do_seconds (struct GMT_CTRL *GMT, double inc);
 EXTERN_MSC int gmtlib_getpenstyle (struct GMT_CTRL *GMT, char *line, struct GMT_PEN *P);
 EXTERN_MSC bool gmtlib_data_is_geographic (struct GMTAPI_CTRL *API, const char *file);
@@ -278,7 +279,7 @@ EXTERN_MSC unsigned int gmtlib_expand_headerpad (struct GMT_CTRL *GMT, struct GM
 EXTERN_MSC void gmtlib_contract_headerpad (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, unsigned int *orig_pad, double *orig_wesn);
 EXTERN_MSC void gmtlib_contract_pad (struct GMT_CTRL *GMT, void *object, int family, unsigned int *orig_pad, double *orig_wesn);
 EXTERN_MSC uint64_t gmtlib_glob_list (struct GMT_CTRL *GMT, const char *pattern, char ***list);
-EXTERN_MSC void gmtlib_change_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D);
+EXTERN_MSC void gmtlib_change_out_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D);
 EXTERN_MSC void gmtlib_ellipsoid_name_convert (char *inname, char outname[]);
 
 EXTERN_MSC void gmtlib_module_show_all (void *V_API, struct GMT_MODULEINFO M[], const char *title);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8144,7 +8144,9 @@ struct GMT_DATASET * gmt_alloc_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET
 	 * mode = GMT_ALLOC_VERTICAL means we concatenate all the tables in Din into a single table for Dout
 	 * mode = GMT_ALLOC_HORIZONTAL means we base the Dout size only on the first Din table
 	 *	(# of segments, # of rows/segment) because tables will be pasted horizontally and not vertically.
+	 * mode may also have bitflag GMT_ALLOC_VIA_ICOLS which then complicates the duplication by having to go via -i
 	 */
+	bool slow_duplicate = false;
 	unsigned int hdr, smode;
 	size_t len;
 	uint64_t nr, tbl, seg, n_seg, seg_in_tbl;
@@ -8153,6 +8155,8 @@ struct GMT_DATASET * gmt_alloc_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET
 	struct GMT_DATATABLE *T = NULL;
 	struct GMT_DATATABLE_HIDDEN *TH = NULL;
 
+	if (mode & GMT_ALLOC_VIA_ICOLS)	/* Not used here but in gmt_duplicate_dataset */
+		mode -= GMT_ALLOC_VIA_ICOLS;
 	D->n_columns = (n_columns) ? n_columns : Din->n_columns;
 	D->geometry = Din->geometry;
 	D->type = Din->type;
@@ -8214,12 +8218,41 @@ struct GMT_DATASET * gmt_alloc_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET
 	return (D);
 }
 
+GMT_LOCAL void gmtio_duplicate_dataset_cols (struct GMT_CTRL *GMT, struct GMT_DATASET *Din, struct GMT_DATASET *D) {
+	/* D has required dimensions but we need to use -i to populate with data from Din */
+	uint64_t tbl, seg, col, row;
+	unsigned int col_pos_out, col_pos_in;
+	struct GMT_DATASEGMENT *S, *Sin;
+
+	for (tbl = 0; tbl < Din->n_tables; tbl++) {
+		for (seg = 0; seg < Din->table[tbl]->n_segments; seg++) {
+			Sin = Din->table[tbl]->segment[seg];
+			S = D->table[tbl]->segment[seg];
+			for (col = 0; col < S->n_columns; col++) {	/* Dummy loop over the number of output columns but not their order */
+				col_pos_out = gmtlib_pick_in_col_number (GMT, (unsigned int)col, &col_pos_in);
+				if (GMT->current.io.col[GMT_IN][col].convert) {	/* Cannot do a straight copy */
+					for (row = 0; row < Sin->n_rows; row++) {
+						S->data[col_pos_out][row] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], S->data[col_pos_in][row]);
+					}
+				}
+				else	/* Can copy the lot */
+					gmt_M_memcpy (S->data[col_pos_out], S->data[col_pos_in], Sin->n_rows, double);
+			}
+		}
+	}
+}
+
 /*! . */
 struct GMT_DATASET *gmt_duplicate_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *Din, unsigned int mode, unsigned int *geometry) {
 	/* Make an exact replica, return geometry if not NULL */
 	uint64_t tbl, seg;
 	struct GMT_DATASET *D = NULL;
 	D = gmt_alloc_dataset (GMT, Din, 0, Din->n_columns, mode);
+	if (mode & GMT_ALLOC_VIA_ICOLS && GMT->common.i.select) {
+		/* Cannot copy segments but must go via -i */
+		gmtio_duplicate_dataset_cols (GMT, Din, D);
+		return (D);
+	}
 	gmt_M_memcpy (D->min, Din->min, Din->n_columns, double);
 	gmt_M_memcpy (D->max, Din->max, Din->n_columns, double);
 	for (tbl = 0; tbl < Din->n_tables; tbl++) {
@@ -8235,7 +8268,7 @@ struct GMT_DATASET *gmt_duplicate_dataset (struct GMT_CTRL *GMT, struct GMT_DATA
 	return (D);
 }
 
-void gmtlib_change_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D) {
+void gmtlib_change_out_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D) {
 	/* Given the -o option, rearrange the columns of the dataset.
 	 * This is needed by the API when returning a dataset by reference
 	 * as the normal -o path for printing is not taken. */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8232,11 +8232,11 @@ GMT_LOCAL void gmtio_duplicate_dataset_cols (struct GMT_CTRL *GMT, struct GMT_DA
 				col_pos_out = gmtlib_pick_in_col_number (GMT, (unsigned int)col, &col_pos_in);
 				if (GMT->current.io.col[GMT_IN][col].convert) {	/* Cannot do a straight copy */
 					for (row = 0; row < Sin->n_rows; row++) {
-						S->data[col_pos_out][row] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], S->data[col_pos_in][row]);
+						S->data[col_pos_out][row] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], Sin->data[col_pos_in][row]);
 					}
 				}
 				else	/* Can copy the lot */
-					gmt_M_memcpy (S->data[col_pos_out], S->data[col_pos_in], Sin->n_rows, double);
+					gmt_M_memcpy (S->data[col_pos_out], Sin->data[col_pos_in], Sin->n_rows, double);
 			}
 		}
 	}
@@ -8245,8 +8245,16 @@ GMT_LOCAL void gmtio_duplicate_dataset_cols (struct GMT_CTRL *GMT, struct GMT_DA
 /*! . */
 struct GMT_DATASET *gmt_duplicate_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *Din, unsigned int mode, unsigned int *geometry) {
 	/* Make an exact replica, return geometry if not NULL */
-	uint64_t tbl, seg;
+	uint64_t tbl, seg, n_columns;
 	struct GMT_DATASET *D = NULL;
+
+	if (mode & GMT_ALLOC_VIA_ICOLS && GMT->common.i.select) {
+		/* Cannot copy segments but must go via -i */
+		D = gmt_alloc_dataset (GMT, Din, 0, GMT->common.i.n_cols, mode);
+		gmtio_duplicate_dataset_cols (GMT, Din, D);
+		return (D);
+	}
+
 	D = gmt_alloc_dataset (GMT, Din, 0, Din->n_columns, mode);
 	if (mode & GMT_ALLOC_VIA_ICOLS && GMT->common.i.select) {
 		/* Cannot copy segments but must go via -i */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8146,7 +8146,6 @@ struct GMT_DATASET * gmt_alloc_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET
 	 *	(# of segments, # of rows/segment) because tables will be pasted horizontally and not vertically.
 	 * mode may also have bitflag GMT_ALLOC_VIA_ICOLS which then complicates the duplication by having to go via -i
 	 */
-	bool slow_duplicate = false;
 	unsigned int hdr, smode;
 	size_t len;
 	uint64_t nr, tbl, seg, n_seg, seg_in_tbl;
@@ -8252,15 +8251,12 @@ struct GMT_DATASET *gmt_duplicate_dataset (struct GMT_CTRL *GMT, struct GMT_DATA
 		/* Cannot copy segments but must go via -i */
 		D = gmt_alloc_dataset (GMT, Din, 0, GMT->common.i.n_cols, mode);
 		gmtio_duplicate_dataset_cols (GMT, Din, D);
+		if (geometry)
+			*geometry = D->geometry;
 		return (D);
 	}
-
+	/* Regular duplication */
 	D = gmt_alloc_dataset (GMT, Din, 0, Din->n_columns, mode);
-	if (mode & GMT_ALLOC_VIA_ICOLS && GMT->common.i.select) {
-		/* Cannot copy segments but must go via -i */
-		gmtio_duplicate_dataset_cols (GMT, Din, D);
-		return (D);
-	}
 	gmt_M_memcpy (D->min, Din->min, Din->n_columns, double);
 	gmt_M_memcpy (D->max, Din->max, Din->n_columns, double);
 	for (tbl = 0; tbl < Din->n_tables; tbl++) {

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -281,7 +281,8 @@ enum GMT_enum_alloc {
 	GMT_ALLOC_INTERNALLY = 1,	/* Allocated by GMT: We may reallocate as needed and free when no longer needed */
 	GMT_ALLOC_NORMAL = 0,		/* Normal allocation of new dataset based on shape of input dataset */
 	GMT_ALLOC_VERTICAL = 4,		/* Allocate a single table for data set to hold all input tables by vertical concatenation */
-	GMT_ALLOC_HORIZONTAL = 8	/* Allocate a single table for data set to hold all input tables by horizontal (paste) concatenations */
+	GMT_ALLOC_HORIZONTAL = 8,	/* Allocate a single table for data set to hold all input tables by horizontal (paste) concatenations */
+	GMT_ALLOC_VIA_ICOLS = 16	/* Follow -i settings when doing the duplication */
 };
 
 enum GMT_enum_duplicate {

--- a/src/testapi_columns.c
+++ b/src/testapi_columns.c
@@ -11,7 +11,7 @@
  * We will use -qo5:10 to just write 6 of those records.
  *
  * The equivalent command line that gives the comparing data is here:
- * gmt convert @wus_gps_final_crowell.txt -qi0:19 -i1,0,3,3,2,5+s10,6+o10 -qo5:10 --FORMAT_FLOAT_OUT=%8.3f
+ * gmt convert @wus_gps_final_crowell.txt -qi0:19 -i1,0,3,3+d2,2,5+s10,6+o10 -qo5:10 --FORMAT_FLOAT_OUT=%8.3f
  * which gave clean formatted output like this:
  * 33.332	-117.159	  26.923	  26.923	 -24.876	   6.410	   9.962
  * 34.420	-119.606	  26.503	  26.503	 -27.888	   4.000	  10.045
@@ -19,33 +19,40 @@
  * 35.003	-119.838	  27.247	  27.247	 -25.570	   3.540	  10.007
  * 35.084	-120.584	  33.325	  33.325	 -28.717	   4.000	  10.043
  * 35.855	-120.799	  33.060	  33.060	 -25.520	   4.470	  10.041
+ *
+ * Notes: 1) As -qo is not yet implemented on externals we skip it for now.
+ *        2) Same for -qi for dataset for now, so k starts at 1
  */
 int main () {
 	void *API = NULL;                 /* The API control structure */
 	void *data[2] = {NULL, NULL};
-	const char *convert = "-qi0:19 -i1,0,3,3,2,5+s10,6+o10 -qo5:10 --FORMAT_FLOAT_OUT=%8.3f";
+	//const char *convert = "-qi0:19 -i1,0,3,3,2,5+s10,6+o10 -qo5:10 --FORMAT_FLOAT_OUT=%8.3f";
+	const char *convert = "-i1,0,3,3+d2,2,5+s10,6+o10 --FORMAT_FLOAT_OUT=%8.3f";
 	const char *file[3] = {"dataset.txt", "matrix.txt", "vector.txt"};
-	char cmd[GMT_LEN128], input[GMT_VF_LEN] = {""}, out[GMT_VF_LEN] = {""};
+	char cmd[128], filename[128] = {""}, input[GMT_VF_LEN] = {""}, output[GMT_VF_LEN] = {""};
 	unsigned int family[3] = {GMT_IS_DATASET, GMT_IS_MATRIX, GMT_IS_VECTOR};
+	unsigned int reference[3] = {GMT_IS_DUPLICATE, GMT_IS_REFERENCE, GMT_IS_REFERENCE};
 	unsigned int k, via[3] = {0, GMT_VIA_MATRIX, GMT_VIA_VECTOR};
 
 	/* Initialize the GMT session */
 	API = GMT_Create_Session ("test", 2U, GMT_SESSION_EXTERNAL, NULL);
 	for (k = 0; k < 3; k++) {
 		/* Read in our data table to memory */
-		data[GMT_IN] = GMT_Read_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@wus_gps_final_crowell.txt", NULL);
+		//data[GMT_IN] = GMT_Read_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@wus_gps_final_crowell.txt", NULL);
+		data[GMT_IN] = GMT_Read_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "t.txt", NULL);
 		/* Create a virtual file for this input data set */
-		GMT_Open_VirtualFile (API, family[k]|via[k], GMT_IS_POINT, GMT_IN|GMT_IS_REFERENCE, data[GMT_IN], input);
+		GMT_Open_VirtualFile (API, GMT_IS_DATASET|via[k], GMT_IS_POINT, GMT_IN|reference[k], data[GMT_IN], input);
 		/* Create a virtual file to hold the output */
-		GMT_Open_VirtualFile (API, family[k]|via[k], GMT_IS_POINT, GMT_OUT, data[GMT_OUT], output);
-		/* Create command for module gmtconvert*/
+		GMT_Open_VirtualFile (API, GMT_IS_DATASET|via[k], GMT_IS_POINT, GMT_OUT, data[GMT_OUT], output);
+		/* Create command for module gmtconvert */
 		sprintf (cmd, "%s %s ->%s", convert, input, output);
 		/* Call the gmtconvert module */
-		GMT_Call_Module (API, "gmtconvert", GMT_MODULE_CMD, args);
+		GMT_Call_Module (API, "gmtconvert", GMT_MODULE_CMD, cmd);
 		/* Obtain the output container from the output virtual file */
 		data[GMT_OUT] = GMT_Read_VirtualFile (API, output);
 		/* Write the result out to a table */
-		GMT_Write_Data (API, family[k]|via[k], GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, file[k], data[GMT_OUT]);
+		sprintf (filename, "%s", file[k]);
+		GMT_Write_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, filename, data[GMT_OUT]);
 		/* Destroy the two memory resources */
 		GMT_Destroy_Data (API, &data[GMT_IN]);
 		GMT_Destroy_Data (API, &data[GMT_OUT]);

--- a/src/testapi_columns.c
+++ b/src/testapi_columns.c
@@ -1,32 +1,25 @@
 #include "gmt.h"
 /*
- * Testing the implementation of -i, -o, etc in the API.
- * The test script api/apicolumns_io.sh will run this and compare.
+ * Testing the implementation of -i in the API.
+ * The test script api/apicolumns_icol.sh will run this and compare.
  *
  * We read in the file @wus_gps_final_crowell.txt which has 3277 records of 7 columns.
- * We will test various things here:
- * We will pass -qi0:19 and thus only read 20 rows
- * We will use -i to select some of the columns, including a repeat column, and
+ * * We will use -i to select some of the columns, including a repeat column, and
  *   apply the scale/offset modifiers
- * We will use -qo5:10 to just write 6 of those records.
  *
  * The equivalent command line that gives the comparing data is here:
- * gmt convert @wus_gps_final_crowell.txt -qi0:19 -i1,0,3,3+d2,2,5+s10,6+o10 -qo5:10 --FORMAT_FLOAT_OUT=%8.3f
+ * gmt convert @wus_gps_final_crowell.txt -i1,0,3,3+d2,2,5+s10,6+o10 --FORMAT_FLOAT_OUT=%8.3f
  * which gave clean formatted output like this:
- * 33.332	-117.159	  26.923	  26.923	 -24.876	   6.410	   9.962
- * 34.420	-119.606	  26.503	  26.503	 -27.888	   4.000	  10.045
- * 34.531	-120.346	  32.742	  32.742	 -29.632	   4.870	  10.065
- * 35.003	-119.838	  27.247	  27.247	 -25.570	   3.540	  10.007
- * 35.084	-120.584	  33.325	  33.325	 -28.717	   4.000	  10.043
- * 35.855	-120.799	  33.060	  33.060	 -25.520	   4.470	  10.041
+ * 34.754	-118.146	  15.280	   7.640	 -13.544	   6.900	  10.170
+ * 34.503	-118.255	  21.994	  10.997	 -23.513	   7.460	  10.032
+ * 34.566	-119.264	  23.275	  11.637	 -28.284	   7.300	  10.082
+ * 33.375	-117.565	  28.953	  14.476	 -26.153	   5.470	   9.957
  *
- * Notes: 1) As -qo is not yet implemented on externals we skip it for now.
- *        2) Same for -qi for dataset for now, so k starts at 1
+ * Notes: 1) Another issue to fix for datasets, so k starts at 1
  */
 int main () {
 	void *API = NULL;                 /* The API control structure */
 	void *data[2] = {NULL, NULL};
-	//const char *convert = "-qi0:19 -i1,0,3,3,2,5+s10,6+o10 -qo5:10 --FORMAT_FLOAT_OUT=%8.3f";
 	const char *convert = "-i1,0,3,3+d2,2,5+s10,6+o10 --FORMAT_FLOAT_OUT=%8.3f";
 	const char *file[3] = {"dataset.txt", "matrix.txt", "vector.txt"};
 	char cmd[128], filename[128] = {""}, input[GMT_VF_LEN] = {""}, output[GMT_VF_LEN] = {""};
@@ -36,10 +29,9 @@ int main () {
 
 	/* Initialize the GMT session */
 	API = GMT_Create_Session ("test", 2U, GMT_SESSION_EXTERNAL, NULL);
-	for (k = 0; k < 3; k++) {
+	for (k = 1; k < 3; k++) {
 		/* Read in our data table to memory */
-		//data[GMT_IN] = GMT_Read_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@wus_gps_final_crowell.txt", NULL);
-		data[GMT_IN] = GMT_Read_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "t.txt", NULL);
+		data[GMT_IN] = GMT_Read_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@wus_gps_final_crowell.txt", NULL);
 		/* Create a virtual file for this input data set */
 		GMT_Open_VirtualFile (API, GMT_IS_DATASET|via[k], GMT_IS_POINT, GMT_IN|reference[k], data[GMT_IN], input);
 		/* Create a virtual file to hold the output */
@@ -52,7 +44,7 @@ int main () {
 		data[GMT_OUT] = GMT_Read_VirtualFile (API, output);
 		/* Write the result out to a table */
 		sprintf (filename, "%s", file[k]);
-		GMT_Write_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, filename, data[GMT_OUT]);
+		GMT_Write_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL|GMT_IO_RESET, NULL, filename, data[GMT_OUT]);
 		/* Destroy the two memory resources */
 		GMT_Destroy_Data (API, &data[GMT_IN]);
 		GMT_Destroy_Data (API, &data[GMT_OUT]);

--- a/src/testapi_columns.c
+++ b/src/testapi_columns.c
@@ -1,0 +1,55 @@
+#include "gmt.h"
+/*
+ * Testing the implementation of -i, -o, etc in the API.
+ * The test script api/apicolumns_io.sh will run this and compare.
+ *
+ * We read in the file @wus_gps_final_crowell.txt which has 3277 records of 7 columns.
+ * We will test various things here:
+ * We will pass -qi0:19 and thus only read 20 rows
+ * We will use -i to select some of the columns, including a repeat column, and
+ *   apply the scale/offset modifiers
+ * We will use -qo5:10 to just write 6 of those records.
+ *
+ * The equivalent command line that gives the comparing data is here:
+ * gmt convert @wus_gps_final_crowell.txt -qi0:19 -i1,0,3,3,2,5+s10,6+o10 -qo5:10 --FORMAT_FLOAT_OUT=%8.3f
+ * which gave clean formatted output like this:
+ * 33.332	-117.159	  26.923	  26.923	 -24.876	   6.410	   9.962
+ * 34.420	-119.606	  26.503	  26.503	 -27.888	   4.000	  10.045
+ * 34.531	-120.346	  32.742	  32.742	 -29.632	   4.870	  10.065
+ * 35.003	-119.838	  27.247	  27.247	 -25.570	   3.540	  10.007
+ * 35.084	-120.584	  33.325	  33.325	 -28.717	   4.000	  10.043
+ * 35.855	-120.799	  33.060	  33.060	 -25.520	   4.470	  10.041
+ */
+int main () {
+	void *API = NULL;                 /* The API control structure */
+	void *data[2] = {NULL, NULL};
+	const char *convert = "-qi0:19 -i1,0,3,3,2,5+s10,6+o10 -qo5:10 --FORMAT_FLOAT_OUT=%8.3f";
+	const char *file[3] = {"dataset.txt", "matrix.txt", "vector.txt"};
+	char cmd[GMT_LEN128], input[GMT_VF_LEN] = {""}, out[GMT_VF_LEN] = {""};
+	unsigned int family[3] = {GMT_IS_DATASET, GMT_IS_MATRIX, GMT_IS_VECTOR};
+	unsigned int k, via[3] = {0, GMT_VIA_MATRIX, GMT_VIA_VECTOR};
+
+	/* Initialize the GMT session */
+	API = GMT_Create_Session ("test", 2U, GMT_SESSION_EXTERNAL, NULL);
+	for (k = 0; k < 3; k++) {
+		/* Read in our data table to memory */
+		data[GMT_IN] = GMT_Read_Data (API, family[k], GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, "@wus_gps_final_crowell.txt", NULL);
+		/* Create a virtual file for this input data set */
+		GMT_Open_VirtualFile (API, family[k]|via[k], GMT_IS_POINT, GMT_IN|GMT_IS_REFERENCE, data[GMT_IN], input);
+		/* Create a virtual file to hold the output */
+		GMT_Open_VirtualFile (API, family[k]|via[k], GMT_IS_POINT, GMT_OUT, data[GMT_OUT], output);
+		/* Create command for module gmtconvert*/
+		sprintf (cmd, "%s %s ->%s", convert, input, output);
+		/* Call the gmtconvert module */
+		GMT_Call_Module (API, "gmtconvert", GMT_MODULE_CMD, args);
+		/* Obtain the output container from the output virtual file */
+		data[GMT_OUT] = GMT_Read_VirtualFile (API, output);
+		/* Write the result out to a table */
+		GMT_Write_Data (API, family[k]|via[k], GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, file[k], data[GMT_OUT]);
+		/* Destroy the two memory resources */
+		GMT_Destroy_Data (API, &data[GMT_IN]);
+		GMT_Destroy_Data (API, &data[GMT_OUT]);
+	}
+	/* Destroy the GMT session */
+	if (GMT_Destroy_Session (API)) return EXIT_FAILURE;
+};

--- a/test/api/apicolumns_icol.sh
+++ b/test/api/apicolumns_icol.sh
@@ -5,5 +5,6 @@
 # This file holds what is expected to be produced on output
 gmt set FORMAT_FLOAT_OUT %8.3f
 gmt convert @wus_gps_final_crowell.txt -i1,0,3,3+d2,2,5+s10,6+o10  > answer.txt
-testapi_columns > results.txt
-diff -q --strip-trailing-cr results.txt answer.txt > fail
+testapi_columns
+diff -q --strip-trailing-cr matrix.txt answer.txt > fail
+diff -q --strip-trailing-cr vector.txt answer.txt >> fail

--- a/test/api/apicolumns_icol.sh
+++ b/test/api/apicolumns_icol.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Test the -i option for external vectors or matrices passed as datasets
+
+# This file holds what is expected to be produced on output
+gmt set FORMAT_FLOAT_OUT %8.3f
+gmt convert @wus_gps_final_crowell.txt -i1,0,3,3+d2,2,5+s10,6+o10  > answer.txt
+testapi_columns > results.txt
+diff -q --strip-trailing-cr results.txt answer.txt > fail


### PR DESCRIPTION
**Description of proposed changes**

There were several conceptual issues with how we had implemented **-i** when reading from matrices and vectors (and datasets) from memory.  This has now been fixed (I hope) and we are now using a procedure more like this:

```
for (col = 0; col < n_columns; col++) {
   col_pos_out = gmtlib_pick_in_col_number (GMT, col, &col_pos_in);
   output[col_pos_out] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], input[col_pos_in]);
}
```

Thus, the `col` is just a dummy loop variable and the in/out-cols can be independent from that. `col_pos_out` covers the same values that col does, but not necessarily in any particular order, and `col_pos_in` may go outside that range and even have repeats.  I added a new test program (_testapi_columns.c_) driven by test script _apicolumns_icol.sh_, which passes. Note: Only testing matrices and vectors here as testing datasets revealed some unrelated issues that will be dealt with later.

Keeping this at WIP to see if it fixes recent trouble related to external tables in PyGMT (@seisman) and GMT.jl (@joa-quim).

