### PR TITLE
docs-cleanup: begin module

### DIFF
--- a/src/begin.c
+++ b/src/begin.c
@@ -37,29 +37,33 @@
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<prefix>] [<format(s)>] [<psconvertoptions] [-C] [%s]\n\n", name, GMT_V_OPT);
+	GMT_Usage (API, 0, "usage: %s [<prefix>] [<format(s)>] [<psconvertoptions] [-C] [%s]\n\n", name, GMT_V_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	GMT_Message (API, GMT_TIME_NONE, "  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t<prefix> is the prefix to use for unnamed figures [%s].\n", GMT_SESSION_NAME);
-	GMT_Message (API, GMT_TIME_NONE, "\t<format(s)> sets the default plot format(s) [%s].\n", gmt_session_format[API->GMT->current.setting.graphics_format]);
-	GMT_Message (API, GMT_TIME_NONE, "\t   Choose one or more of these valid extensions separated by commas:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     bmp:	MicroSoft BitMap.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     eps:	Encapsulated PostScript.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     jpg:	Joint Photographic Experts Group format.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     pdf:	Portable Document Format [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     png:	Portable Network Graphics.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     PNG:	Portable Network Graphics (with transparency layer).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     ppm:	Portable Pixel Map.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     ps:	PostScript.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     tif:	Tagged Image Format File.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t<psconvertoptions> contains one or more comma-separated options that\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   will be passed to psconvert when preparing figures [%s].\n", GMT_SESSION_CONVERT);
-	GMT_Message (API, GMT_TIME_NONE, "\t   The valid subset of psconvert options are\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     A[<args>],C<args>,D<dir>,E<dpi>,H<factor>,Mb|f<file>,Q<args>,S\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   See the psconvert documentation for details.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-C Clean start: Ignore any %s files in the normal search path.\n", GMT_SETTINGS_FILE);
+	GMT_Usage (API, 1, "\n<prefix>");
+	GMT_Usage (API, -2, "The prefix used for unnamed figures [%s].", GMT_SESSION_NAME);
+	GMT_Usage (API, 1, "\n<format(s)>");
+	GMT_Usage (API, -2, "Sets the default plot format(s) [%s].", gmt_session_format[API->GMT->current.setting.graphics_format]);
+	GMT_Usage (API, -2, "\nChoose one or more of these valid extensions separated by commas:");
+	GMT_Usage (API, 3, "bmp:	MicroSoft BitMap.");
+	GMT_Usage (API, 3, "eps:	Encapsulated PostScript.");
+	GMT_Usage (API, 3, "jpg:	Joint Photographic Experts Group format.");
+	GMT_Usage (API, 3, "pdf:	Portable Document Format [Default].");
+	GMT_Usage (API, 3, "png:	Portable Network Graphics.");
+	GMT_Usage (API, 3, "PNG:	Portable Network Graphics (with transparency layer).");
+	GMT_Usage (API, 3, "ppm:	Portable Pixel Map.");
+	GMT_Usage (API, 3, "ps:	PostScript.");
+	GMT_Usage (API, 3, "tif:	Tagged Image Format File.");
+	GMT_Usage (API, 1, "\n<psconvertoptions>");
+	GMT_Usage (API, -2,	"contains one or more comma-separated options that"
+		" will be passed to psconvert when preparing figures [%s].", GMT_SESSION_CONVERT);
+	GMT_Usage (API, -2,	"\nThe valid subset of psconvert options are");
+	GMT_Usage (API, -3,	"A[<args>], C<args>, D<dir>, E<dpi>, H<factor>, Mb|f<file>, Q<args>, S");
+	GMT_Usage (API, -2,	"See the psconvert documentation for details.");
+	GMT_Usage (API, 1, "\n-C");
+	GMT_Usage (API, -2, "Clean start: Ignore any %s files in the normal search path.", GMT_SETTINGS_FILE);
 	GMT_Option (API, "V,;");
 
 	return (GMT_MODULE_USAGE);

--- a/src/begin.c
+++ b/src/begin.c
@@ -59,9 +59,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n<psconvertoptions>");
 	GMT_Usage (API, -2,	"contains one or more comma-separated options that"
 		" will be passed to psconvert when preparing figures [%s].", GMT_SESSION_CONVERT);
-	GMT_Usage (API, -2,	"\nThe valid subset of psconvert options are");
-	GMT_Usage (API, -3,	"A[<args>], C<args>, D<dir>, E<dpi>, H<factor>, Mb|f<file>, Q<args>, S");
-	GMT_Usage (API, -2,	"See the psconvert documentation for details.");
+	GMT_Usage (API, -2, "\nThe valid subset of psconvert options are");
+	GMT_Usage (API, -3, "A[<args>], C<args>, D<dir>, E<dpi>, H<factor>, Mb|f<file>, Q<args>, S");
+	GMT_Usage (API, -2, "See the psconvert documentation for details.");
 	GMT_Usage (API, 1, "\n-C");
 	GMT_Usage (API, -2, "Clean start: Ignore any %s files in the normal search path.", GMT_SETTINGS_FILE);
 	GMT_Option (API, "V,;");


### PR DESCRIPTION
**Description of proposed changes**

As per #5341 reformatted the usage message for the `begin` module.
 
One minor issue – something is messing with the line breaks. See line breaks in plot formats list for entries `jpg` and `PNG`:

![broken line breaks](https://user-images.githubusercontent.com/45796239/123551178-fadc9080-d770-11eb-88e9-5c5d44975a00.png)
You can replicate it with a 45 char wide terminal window. (Easy check with `tput cols`).
