### PR TITLE
Minor fix for -o syntax in usage message

### DIFF
--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -129,7 +129,7 @@
 #else
 #define GMT_n_OPT	"-n[b|c|l|n][+a][+b<BC>][+c][+t<threshold>]"
 #endif
-#define GMT_o_OPT	"-o<cols>[,...][t[<word>]]"
+#define GMT_o_OPT	"-o<cols>[,...][,t[<word>]]"
 #define GMT_q_OPT	"-q[i|o][~]<rows>[,...][+c<col>][+a|f|s]"
 #define GMT_p_OPT	"-p[x|y|z]<azim>[/<elev>[/<zlevel>]][+w<lon0>/<lat0>[/<z0>][+v<x0>/<y0>]"
 #define GMT_r_OPT	"-r[g|p]"


### PR DESCRIPTION
This aligns it with -**i** and how they both appear in the rst docs.
