### PR TITLE
Skip NaN-records in seis and geodesy due to unrecognized header records

### DIFF
--- a/src/geodesy/psvelo.c
+++ b/src/geodesy/psvelo.c
@@ -1117,6 +1117,9 @@ EXTERN_MSC int GMT_psvelo (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 
+		if (gmt_M_is_dnan (In->data[GMT_X]) || gmt_M_is_dnan (In->data[GMT_Y]))	/* Probably a non-recognized header since we got NaNs */
+			continue;
+
 		in = In->data;
 		station_name = In->text;
 

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -1092,6 +1092,9 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 
+		if (gmt_M_is_dnan (In->data[GMT_X]) || gmt_M_is_dnan (In->data[GMT_Y]))	/* Probably a non-recognized header since we got NaNs */
+			continue;
+
 		/* Data record to process */
 
 		in = In->data;

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -739,6 +739,9 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 
+		if (gmt_M_is_dnan (In->data[GMT_X]) || gmt_M_is_dnan (In->data[GMT_Y]))	/* Probably a non-recognized header since we got NaNs */
+			continue;
+
 		/* Data record to process */
 		in = In->data;
 

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -579,6 +579,9 @@ EXTERN_MSC int GMT_pspolar (void *V_API, int mode, void *args) {
 				break;
 		}
 
+		if (gmt_M_is_dnan (In->data[GMT_X]) || gmt_M_is_dnan (In->data[GMT_Y]))	/* Probably a non-recognized header since we got NaNs */
+			continue;
+
 		/* Data record to process */
 
 		if (Ctrl->H2.active) {


### PR DESCRIPTION
See this [report](https://github.com/GenericMappingTools/pygmt/issues/1367#issuecomment-873455274) for background.  The old read-loop in the **meca** supplement codes (now **seis** with **psvelo** in **geodesy**) did not have any protection against non-GMT header records which will give x and y as NaN.  This PR adds that check to avoid junk plotted at BL corner.
