### PR TITLE
Let pslegend handle decorated lines too

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18585,6 +18585,18 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 		if (do_line && pen == NULL) pen = &(API->GMT->current.setting.map_default_pen);	/* Must have pen to draw line */
 		if (S->size_x > 0.0 && S->size_y > 0.0 && S->symbol == PSL_RECT)
 			fprintf (fp, "S - %c %gi,%gi %s %s - %s\n", S->symbol, size, S->size_y, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+		else if (S->symbol == 'q') {	/* Quoted line [Experimental] */
+			char scode[GMT_LEN64] = {""};
+			sprintf (scode, "qn1:+ltext");
+			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+		}
+		else if (S->symbol == '~') {	/* Decorated line [Experimental] */
+			char scode[GMT_LEN64] = {""};
+			sprintf (scode, "~n1:+s%s%s", S->D.symbol_code, S->D.size);
+			if (S->D.pen[0])  strcat (scode, "+p"), strcat (scode, S->D.pen);
+			if (S->D.fill[0]) strcat (scode, "+g"), strcat (scode, S->D.fill);
+			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+		}
 		else
 			fprintf (fp, "S - %c %gi %s %s - %s\n", S->symbol, size, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 	}

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -887,11 +887,11 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 		PSL_comment (PSL, "Determine largest possible width\n");
 		PSL_command (PSL, "/PSL_tmp_w PSL_tmp_w PSL_legend_label_width add def\n");
 		PSL_command (PSL, "/PSL_legend_box_width PSL_tmp_w PSL_legend_string_width gt { PSL_tmp_w } { PSL_legend_string_width} ifelse PSL_legend_clear_x add def\n");
-		gmt_M_free (GMT, legend_item);
 	}
 	else {	/* Hardwired width */
 		PSL_defunits (PSL, "PSL_legend_box_width", Ctrl->D.dim[GMT_X]);
 	}
+	if (legend_item) gmt_M_free (GMT, legend_item);
 	PSL_defunits (PSL, "PSL_legend_box_height", Ctrl->D.dim[GMT_Y]);
 
 	gmt_set_refpoint (GMT, Ctrl->D.refpoint);	/* Finalize reference point plot coordinates, if needed */
@@ -1431,7 +1431,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 								off_tt = gmt_M_to_inch (GMT, txt_b);
 							d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT_PRIMARY) * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;	/* To center the text */
 							row_base_y += half_line_spacing;	/* Move to center of box */
-							if (symbol[0] == '-' && !strcmp (size, "-")) sprintf (size, "%gi", def_size);	/* If no size given then we must pick what we learned above */
+							if (strchr ("-~q", symbol[0]) && !strcmp (size, "-")) sprintf (size, "%gi", def_size);	/* If no size given then we must pick what we learned above */
 							if (symbol[0] == 'f') {	/* Front is different, must plot as a line segment */
 								double length, tlen, gap;
 								int n = sscanf (size, "%[^/]/%[^/]/%s", A, B, C);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -428,9 +428,10 @@ GMT_LOCAL bool pslegend_new_fontsyntax (struct GMT_CTRL *GMT, char *word1, char 
 #define SYM 	0
 #define FRONT	1
 #define QLINE	2
-#define TXT	3
-#define PAR	4
-#define N_DAT	5
+#define DLINE	3
+#define TXT	4
+#define PAR	5
+#define N_DAT	6
 
 #define INFO_HIDDEN	0
 #define INFO_GIVEN	1
@@ -442,7 +443,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 	int i, justify = 0, n = 0, n_columns = 1, n_col, col, error = 0, column_number = 0, id, n_scan, status = 0, max_cols = 0;
 	bool flush_paragraph = false, v_line_draw_now = false, gave_label, gave_mapscale_options, did_old = false, use[2] = {false, true};
 	bool drawn = false, b_cpt = false, C_is_active = false, do_width = false, in_PS_ok = true, got_line = false;
-	uint64_t seg, row, n_fronts = 0, n_quoted_lines = 0, n_symbols = 0, n_par_lines = 0, n_par_total = 0, krow[N_DAT], n_records = 0;
+	uint64_t seg, row, n_fronts = 0, n_quoted_lines = 0, n_decorated_lines = 0, n_symbols = 0, n_par_lines = 0, n_par_total = 0, krow[N_DAT], n_records = 0;
 	int64_t n_para = -1;
 	size_t n_char = 0;
 	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, txt_d[GMT_LEN256] = {""};
@@ -1474,7 +1475,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 									return (API->error);
 								}
 							}
-							else if (symbol[0] == 'q' || symbol[0] == '~') {	/* Quoted and decorated line is different, must plot as a line segment */
+							else if (symbol[0] == 'q') {	/* Quoted line is different, must plot as a line segment */
 								double length = Ctrl->S.scale * gmt_M_to_inch (GMT, size);	/* The length of the line */;
 
 								if ((D[QLINE] = pslegend_get_dataset_pointer (API, D[QLINE], GMT_IS_LINE, 64U, 2U, 2U, false)) == NULL) return (API->error);
@@ -1492,7 +1493,29 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 								D[QLINE]->n_records += 2;
 								n_quoted_lines++;
 								if (n_quoted_lines == GMT_SMALL_CHUNK) {
-									GMT_Report (API, GMT_MSG_ERROR, "Can handle max %d quoted/decorated lines.  Let us know if this is a problem.\n", GMT_SMALL_CHUNK);
+									GMT_Report (API, GMT_MSG_ERROR, "Can handle max %d quoted lines.  Let us know if this is a problem.\n", GMT_SMALL_CHUNK);
+									return (API->error);
+								}
+							}
+							else if (symbol[0] == '~') {	/* Decorated line is different, must plot as a line segment */
+								double length = Ctrl->S.scale * gmt_M_to_inch (GMT, size);	/* The length of the line */;
+
+								if ((D[DLINE] = pslegend_get_dataset_pointer (API, D[DLINE], GMT_IS_LINE, 64U, 2U, 2U, false)) == NULL) return (API->error);
+								x = 0.5 * length;
+								/* Place pen and fill colors in segment header */
+								sprintf (buffer, "-S%s", symbol);
+								if (txt_d[0] != '-') {strcat (buffer, " -W"); strcat (buffer, txt_d);}
+								S[DLINE] = pslegend_get_segment (D, DLINE, n_decorated_lines);	/* Next decorated line segment */
+								S[DLINE]->header = strdup (buffer);
+								GMT_Report (API, GMT_MSG_DEBUG, "DLINE: %s\n", buffer);
+								/* Set begin and end coordinates of the line segment */
+								S[DLINE]->data[GMT_X][0] = x_off + off_ss-x;	S[DLINE]->data[GMT_Y][0] = row_base_y;
+								S[DLINE]->data[GMT_X][1] = x_off + off_ss+x;	S[DLINE]->data[GMT_Y][1] = row_base_y;
+								S[DLINE]->n_rows = 2;
+								D[DLINE]->n_records += 2;
+								n_decorated_lines++;
+								if (n_decorated_lines == GMT_SMALL_CHUNK) {
+									GMT_Report (API, GMT_MSG_ERROR, "Can handle max %d decorated lines.  Let us know if this is a problem.\n", GMT_SMALL_CHUNK);
 									return (API->error);
 								}
 							}
@@ -1812,7 +1835,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 		}
 		sprintf (buffer, "-R0/%g/0/%g -Jx1i -O -K -N -Sqn1 %s --GMT_HISTORY=readonly", GMT->current.proj.rect[XHI], GMT->current.proj.rect[YHI], string);
 		GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: QLINE: gmt %s %s\n", plot_points[ID], buffer);
-		if (GMT_Call_Module (API, plot_points[ID], GMT_MODULE_CMD, buffer) != GMT_NOERROR) {	/* Plot the fronts */
+		if (GMT_Call_Module (API, plot_points[ID], GMT_MODULE_CMD, buffer) != GMT_NOERROR) {	/* Plot the quoted lines */
 			Return (API->error);
 		}
 		if (GMT_Close_VirtualFile (API, string) != GMT_NOERROR) {
@@ -1826,6 +1849,29 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 		}
 #endif
 		D[QLINE]->table[0]->n_segments = GMT_SMALL_CHUNK;	/* Reset to allocation limit */
+	}
+	if (D[DLINE]) {
+		/* Create option list, register D[DLINE] as input source */
+		D[DLINE]->table[0]->n_segments = n_decorated_lines;	/* Set correct number of lines */
+		if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_LINE, GMT_IN|GMT_IS_REFERENCE, D[DLINE], string) != GMT_NOERROR) {
+			Return (API->error);
+		}
+		sprintf (buffer, "-R0/%g/0/%g -Jx1i -O -K -N -S~n1:+sc0.1 %s --GMT_HISTORY=readonly", GMT->current.proj.rect[XHI], GMT->current.proj.rect[YHI], string);
+		GMT_Report (API, GMT_MSG_DEBUG, "RUNNING: DLINE: gmt %s %s\n", plot_points[ID], buffer);
+		if (GMT_Call_Module (API, plot_points[ID], GMT_MODULE_CMD, buffer) != GMT_NOERROR) {	/* Plot the decorated lines */
+			Return (API->error);
+		}
+		if (GMT_Close_VirtualFile (API, string) != GMT_NOERROR) {
+			Return (API->error);
+		}
+#ifdef DEBUG
+		if (Ctrl->DBG.active) {
+			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_LINE, GMT_IO_RESET, NULL, "dump_dline.txt", D[DLINE]) != GMT_NOERROR) {
+				Return (API->error);
+			}
+		}
+#endif
+		D[DLINE]->table[0]->n_segments = GMT_SMALL_CHUNK;	/* Reset to allocation limit */
 	}
 	if (D[SYM]) {
 		D[SYM]->table[0]->n_segments = n_symbols;	/* Set correct number of segments */


### PR DESCRIPTION
See #5416 for background.  Basically, I lumped quoted and decorated lines together but they need to go into separate jobs.  Now it works as expected.

Note: It is important that users use **-S~n** for this which is fine when running **legend** on a legend file created by hand.  But if we use **-l** then it is entirely possible that both **-Sq** and **-S~** use some different choices that may not be suitable for the legend (for instance, the spacing may be too big for the stated line in the legend).  Perhaps a solution would be to take whatever **-Sq -S~** argument is passed and replace anything between -**S~** and the colon with **n**1?  I.e., we only place one decorated symbol at the center of the line, and the same for quoted lines.  Thoughts on this, @joa-quim ?
