### PR TITLE
Update the usage messages of geodesy modules

### DIFF
--- a/src/geodesy/earthtide.c
+++ b/src/geodesy/earthtide.c
@@ -1265,37 +1265,42 @@ GMT_LOCAL void earthtide_solid_ts (struct GMT_CTRL *GMT, struct GMT_GCAL *Cal, d
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [-G<outgrid>] [-C<comp>] [-L<lon>/<lat>]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-T[<min>/<max>/][-|+]<inc>[+i|n]]\n\t[%s] [-S]\n", GMT_I_OPT, GMT_Rgeo_OPT, GMT_Rgeo_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s] [%s] [%s]\n\n", GMT_bo_OPT, GMT_o_OPT, GMT_r_OPT, GMT_x_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s [-G<outgrid>] [-C<comp>] [%s] [-L<lon>/<lat>] [%s] [-S] [-T[<min>/<max>/][-|+]<inc>[+i|n]] "
+		"[%s] [%s] [%s]%s[%s]\n", name, GMT_I_OPT, GMT_Rgeo_OPT, GMT_bo_OPT, GMT_o_OPT,
+		GMT_r_OPT, GMT_x_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
-	GMT_Message (API, GMT_TIME_NONE, "\t-G Specify file name for output grid file (s).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   If more than one component is set via -C then <outgrid> must contain %%s to format component code.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
+	GMT_Message (API, GMT_TIME_NONE, "  OPTIONAL ARGUMENTS:\n");
+	GMT_Usage (API, 1, "\n-C<comp>");
 	if (API->external)
-		GMT_Message (API, GMT_TIME_NONE, "\t-C List of comma-separated components to be written as grids. Choose from\n");
+		GMT_Usage (API, -2, "List of comma-separated components to be written as grids. Choose from");
 	else
-		GMT_Message (API, GMT_TIME_NONE, "\t-C List of comma-separated components to be written as grids (requires -G). Choose from\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   x|e, y|n, z|v. [Default is v (ertical) only].\n");
+		GMT_Usage (API, -2, "List of comma-separated components to be written as grids (requires -G). Choose from");
+	GMT_Usage (API, 3, "x|e: Get x|east component.");
+	GMT_Usage (API, 3, "y|n: Get y|north conmponent.");
+	GMT_Usage (API, 3, "z|v: Get z|vertical component [Default].");
 	GMT_Option (API, "I");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L <lon/lat> Geographical coordinate where to compute the time-series.\n");
+	GMT_Usage (API, 1, "\n-G<outgrid>");
+	GMT_Usage (API, -2, "Specify file name for output grid file (s). "
+		"If more than one component is set via -C then <outgrid> must contain %%s to format component code.");
+	GMT_Usage (API, 1, "\n-L<lon>/<lat>");
+	GMT_Usage (API, -2, "Geographical coordinate where to compute the time-series.");
 	GMT_Option (API, "R");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Output position of Sun and Moon in geographical coordinates plus\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   distance in meters. Output is a Mx7 matrix, where M is the number of\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   times (set by -T) and columns are time, sun_lon, sun_lat, sun_dist\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   moon_lon, moon_lat, moon_dist.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-T Make evenly spaced output time steps from <min> to <max> by <inc>.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append +n to indicate <inc> is the number of t-values to produce over the range instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Alternatively, append +i to indicate <inc> is the reciprocal of desired <inc> (e.g., 3 for 0.3333.....).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append a valid time unit (%s) to the increment and add +t.\n", GMT_TIME_UNITS_DISPLAY);
-	GMT_Message (API, GMT_TIME_NONE, "\t   If no -T is provided get current time in UTC from the computer clock.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   If no -G or -S are provided then -T is interpreted to mean compute a time-series\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   at the location specified by -L, thus then -L becomes mandatory.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   When -G and -T only first time T series is considered.\n");
-	GMT_Option (API, "V");
-	GMT_Option (API, "b,o,r,x,.");
+	GMT_Usage (API, 1, "\n-S Output position of Sun and Moon in geographical coordinates plus "
+		"distance in meters. Output is a Mx7 matrix, where M is the number of "
+		"times (set by -T) and columns are time, sun_lon, sun_lat, sun_dist "
+		"moon_lon, moon_lat, moon_dist.");
+	GMT_Usage (API, 1, "\n-T[<min>/<max>/][-|+]<inc>[+i|n]");
+	GMT_Usage (API, -2, "Make evenly spaced output time steps from <min> to <max> by <inc>. Optional modifiers:");
+	GMT_Usage (API, 3, "+n Indicate <inc> is the number of t-values to produce over the range instead of increment.");
+	GMT_Usage (API, 3, "+i Indicate <inc> is the reciprocal of desired <inc> (e.g., 3 for 0.3333.....).");
+	GMT_Usage (API, -2, "Append a valid time unit (%s) to the increment. "
+		"Notes: If no -T is provided get current time in UTC from the computer clock. "
+		"If no -G or -S are provided then -T is interpreted to mean compute a time-series "
+		"at the location specified by -L, making -L mandatory. "
+		"When -G and -T only first time T series is considered.", GMT_TIME_UNITS_DISPLAY);
+	GMT_Option (API, "V,b,o,r,x,.");
 
 	return (GMT_MODULE_USAGE);
 }

--- a/src/geodesy/earthtide.c
+++ b/src/geodesy/earthtide.c
@@ -1266,31 +1266,33 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [-G<outgrid>] [-C<comp>] [%s] [-L<lon>/<lat>] [%s] [-S] [-T[<min>/<max>/][-|+]<inc>[+i|n]] "
-		"[%s] [%s] [%s]%s[%s]\n", name, GMT_I_OPT, GMT_Rgeo_OPT, GMT_bo_OPT, GMT_o_OPT,
+		"[%s] [%s] [%s] [%s]%s[%s]\n", name, GMT_I_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_o_OPT,
 		GMT_r_OPT, GMT_x_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
-	GMT_Message (API, GMT_TIME_NONE, "  OPTIONAL ARGUMENTS:\n");
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
+	GMT_Usage (API, 2, "(Note: One of -G, -L, or -S is required.)");
+	GMT_Usage (API, 1, "\n-G<outgrid>");
+	GMT_Usage (API, -2, "Specify file name for output grid file (s). "
+		"If more than one component is set via -C then <outgrid> must contain %%s to format component code.");
+	GMT_Usage (API, 1, "\n-L<lon>/<lat>");
+	GMT_Usage (API, -2, "Geographical coordinate where to compute the time-series.");
+	GMT_Usage (API, 1, "\n-S Output position of Sun and Moon in geographical coordinates plus "
+		"distance in meters. Output is a Mx7 matrix, where M is the number of "
+		"times (set by -T) and columns are time, sun_lon, sun_lat, sun_dist "
+		"moon_lon, moon_lat, moon_dist.");
+	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-C<comp>");
 	if (API->external)
 		GMT_Usage (API, -2, "List of comma-separated components to be written as grids. Choose from");
 	else
 		GMT_Usage (API, -2, "List of comma-separated components to be written as grids (requires -G). Choose from");
 	GMT_Usage (API, 3, "x|e: Get x|east component.");
-	GMT_Usage (API, 3, "y|n: Get y|north conmponent.");
+	GMT_Usage (API, 3, "y|n: Get y|north component.");
 	GMT_Usage (API, 3, "z|v: Get z|vertical component [Default].");
 	GMT_Option (API, "I");
-	GMT_Usage (API, 1, "\n-G<outgrid>");
-	GMT_Usage (API, -2, "Specify file name for output grid file (s). "
-		"If more than one component is set via -C then <outgrid> must contain %%s to format component code.");
-	GMT_Usage (API, 1, "\n-L<lon>/<lat>");
-	GMT_Usage (API, -2, "Geographical coordinate where to compute the time-series.");
 	GMT_Option (API, "R");
-	GMT_Usage (API, 1, "\n-S Output position of Sun and Moon in geographical coordinates plus "
-		"distance in meters. Output is a Mx7 matrix, where M is the number of "
-		"times (set by -T) and columns are time, sun_lon, sun_lat, sun_dist "
-		"moon_lon, moon_lat, moon_dist.");
 	GMT_Usage (API, 1, "\n-T[<min>/<max>/][-|+]<inc>[+i|n]");
 	GMT_Usage (API, -2, "Make evenly spaced output time steps from <min> to <max> by <inc>. Optional modifiers:");
 	GMT_Usage (API, 3, "+n Indicate <inc> is the number of t-values to produce over the range instead of increment.");

--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -136,22 +136,24 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *C) {	/* Dea
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<table>] -G<outfile> [-C[n]<val>[+f<file>]] [-Fd|f<val>] [-I<dx>[/<dy>] "
+	GMT_Usage (API, 0, "usage: %s [<table>] -G<outfile> [-C[n]<val>[+f<file>]] [-E<misfitfile>] [-Fd|f<val>] [-I<dx>[/<dy>] "
 		"[-L] [-N<nodefile>] [%s] [-S<nu>] [-T<maskgrid>] [%s] [-W[w]] [%s] [%s] [%s] [%s] "
-		"[%s] [%s] [%s] [%s] [%s] [%s] [%s]%s[%s] [%s]\n", name, GMT_Rgeo_OPT GMT_V_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT,
+		"[%s] [%s] [%s] [%s] [%s] [%s] [%s]%s[%s] [%s]\n", name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT,
 		GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_n_OPT, GMT_o_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_x_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	GMT_Usage (API, 1, "Choose one of three ways to specify where to evaluate the spline:");
-	GMT_Usage (API, 2, "1. Specify a rectangular grid domain with options -R, -I [and optionally -r].");
-	GMT_Usage (API, 2, "2. Supply a mask file via -T whose values are NaN or 0.  The spline will then "
-		"only be evaluated at the nodes originally set to zero.");
-	GMT_Usage (API, 2, "3. Specify a set of output locations via the -N option.");
+	GMT_Usage (API, 2, "%s Specify a rectangular grid domain with options -R, -I [and optionally -r].", GMT_LINE_BULLET);
+	GMT_Usage (API, 2, "%s Supply a mask file via -T whose values are NaN or 0.  The spline will then "
+		"only be evaluated at the nodes originally set to zero.", GMT_LINE_BULLET);
+	GMT_Usage (API, 2, "%s Specify a set of output locations via the -N option.", GMT_LINE_BULLET);
 
 	GMT_Message (API, GMT_TIME_NONE, "\n  REQUIRED ARGUMENTS:\n");
-	GMT_Option (API, "<");
-	GMT_Usage (API, -2, "<table> [or stdin] must contain x y u v [weight_u weight_v] records. "
+	GMT_Usage (API, 1, "\n<table>");
+	GMT_Usage (API, -2, "<table> is one or more data files (in ASCII, binary, netCDF). "
+		"If no files are given, standard input is read. "
+		"The data must contain x y u v [weight_u weight_v] records. "
 		"Specify -fg to convert longitude, latitude to Flat Earth coordinates.");
 	GMT_Usage (API, 1, "\n-G<outfile>");
 	GMT_Usage (API, -2, "Give name of output file (if -N) or a gridfile name template that must "
@@ -165,7 +167,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Use -C<val> to select only the largest <val> eigenvalues [all]. "
 		"If <val> is in 0-1 range we assume it is the fraction of eigenvalues to use. "
 		"Note: ~1/4 of the total number of data constraints is a good starting point "
-		"[Default uses Gauss-Jordan elimination to solve the linear system]");
+		"[Default uses Gauss-Jordan elimination to solve the linear system].");
+	GMT_Usage (API, 1, "\n-E[<misfitfile>]");
+	GMT_Usage (API, -2, "Evaluate spline at input locations and report statistics on the misfit. "
+		"If <misfitfile> is given then we write individual location misfits to that file.");
 	GMT_Usage (API, 1, "\n-Fd|f<val>");
 	GMT_Usage (API, -2, "Fudging factor to avoid Green-function singularities. Choose among two directives:");
 	GMT_Usage (API, 3, "d: Append <del_radius> to add to all distances between nodes and points "

--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -136,59 +136,65 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *C) {	/* Dea
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] -G<outfile> [-C[n]<val>[+f<file>]] [-Fd|f<val>] [-I<dx>[/<dy>]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-L] [-N<nodefile>] [%s] [-S<nu>] [-T<maskgrid>]\n", GMT_Rgeo_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-W[w]] [%s] [%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s]%s[%s] [%s]\n\n", GMT_V_OPT,
-		GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_n_OPT, GMT_o_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_x_OPT, GMT_colon_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s [<table>] -G<outfile> [-C[n]<val>[+f<file>]] [-Fd|f<val>] [-I<dx>[/<dy>] "
+		"[-L] [-N<nodefile>] [%s] [-S<nu>] [-T<maskgrid>] [%s] [-W[w]] [%s] [%s] [%s] [%s] "
+		"[%s] [%s] [%s] [%s] [%s] [%s] [%s]%s[%s] [%s]\n", name, GMT_Rgeo_OPT GMT_V_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT,
+		GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_n_OPT, GMT_o_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_x_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
-	GMT_Message (API, GMT_TIME_NONE, "\tChoose one of three ways to specify where to evaluate the spline:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t1. Specify a rectangular grid domain with options -R, -I [and optionally -r].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t2. Supply a mask file via -T whose values are NaN or 0.  The spline will then\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   only be evaluated at the nodes originally set to zero.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t3. Specify a set of output locations via the -N option.\n\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t<table> [or stdin] must contain x y u v [weight_u weight_v] records.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Specify -fg to convert longitude, latitude to Flat Earth coordinates.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-G Give name of output file (if -N) or a gridfile name template that must.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   contain the format specifier \"%%s\" which will be replaced with u or v.\n");
+	GMT_Usage (API, 1, "Choose one of three ways to specify where to evaluate the spline:");
+	GMT_Usage (API, 2, "1. Specify a rectangular grid domain with options -R, -I [and optionally -r].");
+	GMT_Usage (API, 2, "2. Supply a mask file via -T whose values are NaN or 0.  The spline will then "
+		"only be evaluated at the nodes originally set to zero.");
+	GMT_Usage (API, 2, "3. Specify a set of output locations via the -N option.");
 
+	GMT_Message (API, GMT_TIME_NONE, "\n  REQUIRED ARGUMENTS:\n");
+	GMT_Option (API, "<");
+	GMT_Usage (API, -2, "<table> [or stdin] must contain x y u v [weight_u weight_v] records. "
+		"Specify -fg to convert longitude, latitude to Flat Earth coordinates.");
+	GMT_Usage (API, 1, "\n-G<outfile>");
+	GMT_Usage (API, -2, "Give name of output file (if -N) or a gridfile name template that must "
+		"contain the format specifier \"%%s\" which will be replaced with u or v.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 
-	GMT_Option (API, "<");
-	GMT_Message (API, GMT_TIME_NONE, "\t-C Solve by SVD and eliminate eigenvalues whose ratio to largest eigenvalue is less than <val> [0].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally append +f<filename> to save the eigenvalues to this file.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   A negative cutoff will stop execution after saving the eigenvalues.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use -C<val> to select only the largest <val> eigenvalues [all].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     If <val> is in 0-1 range we assume it is the fraction of eigenvalues to use.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     (Note 1/4 of the total number of data constraints is a good starting point.) \n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   [Default uses Gauss-Jordan elimination to solve the linear system]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-F Fudging factor to avoid Green-function singularities.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Fd<del_radius> will add <del_radius> to all distances between nodes and points.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     (For geographical specify <del_radius> in km. A value of 8 km is optimal for California.)\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Ff<factor> will add <r_min>*<factor> to all distances between nodes and points.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       where <r_min> is the shortest inter-point distance found.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       [Default is -Ff0.01].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Specify a regular set of output locations.  Give equidistant increment for each dimension.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Requires -R for specifying the output domain.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Leave trend alone.  Do not remove least squares plane from data before spline fit.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t    [Default removes least squares plane, fits normalized residuals, and restores plane].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N ASCII file with desired output locations.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   The resulting ASCII coordinates and interpolation are written to file given in -G\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   or stdout if no file specified (see -bo for binary output).\n");
+	GMT_Usage (API, 1, "\n-C[n]<val>[+f<file>]");
+	GMT_Usage (API, -2, "Solve by SVD and eliminate eigenvalues whose ratio to largest eigenvalue is less than <val> [0]. "
+		"Optionally append +f<filename> to save the eigenvalues to this file. "
+		"A negative cutoff will stop execution after saving the eigenvalues. "
+		"Use -C<val> to select only the largest <val> eigenvalues [all]. "
+		"If <val> is in 0-1 range we assume it is the fraction of eigenvalues to use. "
+		"Note: ~1/4 of the total number of data constraints is a good starting point "
+		"[Default uses Gauss-Jordan elimination to solve the linear system]");
+	GMT_Usage (API, 1, "\n-Fd|f<val>");
+	GMT_Usage (API, -2, "Fudging factor to avoid Green-function singularities. Choose among two directives:");
+	GMT_Usage (API, 3, "d: Append <del_radius> to add to all distances between nodes and points "
+		"(For geographical specify <del_radius> in km. A value of 8 km is optimal for California.).");
+	GMT_Usage (API, 3, "f: Append <factor> and add <r_min>*<factor> to all distances between nodes and points, "
+		"where <r_min> is the shortest inter-point distance found [Default is -Ff0.01].");
+	GMT_Option (API, "I");
+	GMT_Usage (API, 1, "\n-L Leave trend alone.  Do not remove least squares plane from data before spline fit "
+		"[Default removes least squares plane, fits normalized residuals, and restores plane].");
+	GMT_Usage (API, 1, "\n-N<nodefile>");
+	GMT_Usage (API, -2, "ASCII file with desired output locations. "
+		"The resulting ASCII coordinates and interpolation are written to file given in -G "
+		"or stdout if no file specified (see -bo for binary output).");
 	GMT_Option (API, "R");
 	if (gmt_M_showusage (API)) {
-		GMT_Message (API, GMT_TIME_NONE, "\t   Requires -I for specifying equidistant increments.  A gridfile may be given;\n");
-		GMT_Message (API, GMT_TIME_NONE, "\t   this then also sets -I (and perhaps -r); use those options to override the grid settings.\n");
+		GMT_Usage (API, -2, "Requires -I for specifying equidistant increments.  A gridfile may be given; "
+			"this then also sets -I (and perhaps -r); use those options to override the grid settings.");
 	}
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Give effective 2-D Poisson's ratio [0.5]. (Note: 1.0 is incompressible in a 2-D formulation)\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-T Mask grid file whose values are NaN or 0; its header implicitly sets -R, -I (and -r).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-W Expects two extra input columns with data errors sigma_x, sigma_y).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append w to indicate these columns carry weights instead.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   [Default makes weights via 1/sigma_x^2, 1/sigma_y^2].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Note this option will only have an effect if -C is used.\n");
+	GMT_Usage (API, 1, "\n-S<nu>");
+	GMT_Usage (API, -2, "Give effective 2-D Poisson's ratio [0.5]. Note: 1.0 is incompressible in a 2-D formulation.");
+	GMT_Usage (API, 1, "\n-T<maskgrid>");
+	GMT_Usage (API, -2, "Mask grid file whose values are NaN or 0; its header implicitly sets -R, -I (and -r).");
+	GMT_Usage (API, 1, "\n-W[w]");
+	GMT_Usage (API, -2, "Expects two extra input columns with data errors sigma_x, sigma_y). "
+		"Append w to indicate these columns carry weights instead "
+		"[Default makes weights via 1/sigma_x^2, 1/sigma_y^2]. "
+		"Note: -W will only have an effect if -C is used.");
 	GMT_Option (API, "V,bi");
-	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t   Default is 4-6 input columns (see -W); use -i to select columns from any data table.\n");
+	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 4-6 input columns (see -W); use -i to select columns from any data table.");
 	GMT_Option (API, "d,e,f,h,i,n,o,qi,r,s,x,:,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/geodesy/psvelo.c
+++ b/src/geodesy/psvelo.c
@@ -676,54 +676,67 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] %s %s [-A<vecpar>] [%s]\n", name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-C<cpt>] [-D<scale>] [-G<fill>] [-H[<scale>]] [-I[<intens>]] %s[-L[<pen>][+c[f|l]]] [-N] %s%s[-S<symbol>[<scale>][</args>][+f<font>]]\n", API->K_OPT, API->O_OPT, API->P_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-V] [-W[<pen>][+c[f|l]]] [%s] [%s]\n", GMT_U_OPT, GMT_X_OPT, GMT_Y_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-Z[m|e|n|u][+e] %s[%s] [%s] [%s]\n\t[%s] [%s]\n\t[%s] [%s] [%s] [%s]\n\n", API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_tv_OPT, GMT_colon_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s [<table>] %s %s -S<symbol>[<scale>][</args>][+f<font>] [-A<vecpar>] [%s] [-C<cpt>] [-D<scale>] [-E<fill>] "
+		"[-G<fill>] [-H[<scale>]] [-I[<intens>]] %s[-L[<pen>][+c[f|l]]] [-N] %s%s[%s] [%s] "
+		"[-W[<pen>][+c[f|l]]] [%s] [%s] [-Z[m|e|n|u][+e]] %s[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+		name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_B_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_U_OPT, GMT_V_OPT, GMT_X_OPT,
+		GMT_Y_OPT, API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_tv_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
+	GMT_Option (API, "<");
 	GMT_Option (API, "J-,R");
+	GMT_Usage (API, 1, "\n-S<symbol>[<scale>][</args>][+f<font>]");
+	GMT_Usage (API, -2, "Select symbol type and <scale> (plus optional font; see documentation). "
+		"If <scale> is not given then it is read from the first column after the required columns. "
+		"Choose from the following geodetic symbols:");
+	GMT_Usage (API, 3, "e: Velocity ellipses: in X,Y,Vx,Vy,SigX,SigY,CorXY,name format. "
+		"Append <confidence> value (0-1) for error ellipse or give 0 to not draw the ellipse.");
+	GMT_Usage (API, 3, "r: Velocity ellipses: in X,Y,Vx,Vy,a,b,theta,name format. "
+		"Append <confidence> value (0-1) for error ellipse or give 0 to not draw the ellipse.");
+	GMT_Usage (API, 3, "n: Anisotropy: in X,Y,Vx,Vy.");
+	GMT_Usage (API, 3, "w: Rotational wedges: in X,Y,Spin,Spinsig. "
+		"Append <wedgemag> value to scale the the Spin values [1].");
+	GMT_Usage (API, 3, "x: Strain crosses: in X,Y,Eps1,Eps2,Theta.n");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Option (API, "<,B-");
-	GMT_Message (API, GMT_TIME_NONE, "\t-A Specify arrow head attributes:\n");
-	gmt_vector_syntax (API->GMT, 15, 2);
-	GMT_Message (API, GMT_TIME_NONE, "\t   Default is %gp+gblack+p1p\n", VECTOR_HEAD_LENGTH);
-	GMT_Message (API, GMT_TIME_NONE, "\t-C Use CPT to assign colors based on vector magnitude.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   For other coloring options, see -W and -Z.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Multiply uncertainties by <scale> (for -Se and -Sw options only).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-E Set color used for uncertainty ellipses and wedges [no fill].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   For other coloring options, see -L and -Z.\n");
+	GMT_Option (API, "B-");
+	GMT_Usage (API, 1, "\n-A<vecpar>");
+	GMT_Usage (API, -2, "Specify arrow head attributes:");
+	gmt_vector_syntax (API->GMT, 15, 3);
+	GMT_Usage (API, -2, "Default is %gp+gblack+p1p", VECTOR_HEAD_LENGTH);
+	GMT_Usage (API, 1, "\n-C<cpt>");
+	GMT_Usage (API, -2, "Use CPT to assign colors based on vector magnitude. "
+		"For other coloring options, see -W and -Z.");
+	GMT_Usage (API, 1, "\n-D<scale>");
+	GMT_Usage (API, -2, "Multiply uncertainties by <scale> (for -Se and -Sw options only).");
+	GMT_Usage (API, 1, "\n-E<fill>");
+	GMT_Usage (API, -2, "Set color used for uncertainty ellipses and wedges [no fill]; see -G for syntax. "
+		"For other coloring options, see -L and -Z.");
 	gmt_fill_syntax (API->GMT, 'G', NULL, "Specify color or pattern for symbol fill [no fill].");
-	GMT_Message (API, GMT_TIME_NONE, "\t-H Scale symbol sizes (set via -S or input column) and pen attributes by factors read from scale column.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   The scale column follows the symbol size column.  Alternatively, append a fixed <scale>.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Use the intensity to modulate the symbol fill color (requires -C or -G).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   If no intensity is given we expect it to follow the required columns in the data record.\n");
+	GMT_Usage (API, 1, "\n-H[<scale>]");
+	GMT_Usage (API, -2, "Scale symbol sizes (set via -S or input column) and pen attributes by factors read from scale column. "
+		"he scale column follows the symbol size column.  Alternatively, append a fixed <scale>.");
+	GMT_Usage (API, 1, "\n-I[<intens>]");
+	GMT_Usage (API, -2, "Use the intensity to modulate the symbol fill color (requires -C or -G). "
+		"If no intensity is given we expect it to follow the required columns in the data record.");
 	GMT_Option (API, "K");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Draw line or symbol outline using the current pen (see -W).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append separate pen for error outlines [Same as -W].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Do Not skip/clip symbols that fall outside map border [Default will ignore those outside].\n");
+	GMT_Usage (API, 1, "\n-L[<pen>][+c[f|l]]");
+	GMT_Usage (API, -2, "Draw line or symbol outline using the current pen (see -W). "
+		"Optionally, append separate pen for error outlines [Same as -W].");
+	GMT_Usage (API, 1, "\n-N Do Not skip/clip symbols that fall outside map border [Default will ignore those outside].");
 	GMT_Option (API, "O,P");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Select symbol type and <scale> (plus optional font; see documentation).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   If <scale> is not given then it is read from the first column after the required columns.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Choose from the following geodetic symbols:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     e  Velocity ellipses: in X,Y,Vx,Vy,SigX,SigY,CorXY,name format.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        Append <confidence> value (0-1) for error ellipse or give 0 to not draw the ellipse.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     r  Velocity ellipses: in X,Y,Vx,Vy,a,b,theta,name format.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        Append <confidence> value (0-1) for error ellipse or give 0 to not draw the ellipse.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     n  Anisotropy : in X,Y,Vx,Vy.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     w  Rotational wedges: in X,Y,Spin,Spinsig.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        Append <wedgemag> value to scale the the Spin values [1].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     x  Strain crosses : in X,Y,Eps1,Eps2,Theta.\n");
 	GMT_Option (API, "U,V");
-	GMT_Message (API, GMT_TIME_NONE, "\t-W Set pen attributes [%s].\n", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
+	GMT_Usage (API, 1, "\n-W[<pen>][+c[f|l]]");
+	GMT_Usage (API, -2, "Set pen attributes [%s].", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Option (API, "X");
-	GMT_Message (API, GMT_TIME_NONE, "\t-Z Select quantity to use with -C to look-up colors.  Choose among:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   m: Magnitude of vector or rotation [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   e: East velocity component.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   n: North velocity component.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   u: User column (given after required columns).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Color selected will replace -G<fill>.  Append +e to instead act as -E<fill>.\n");
+	GMT_Usage (API, 1, "\n-Z[m|e|n|u][+e]");
+	GMT_Usage (API, -2, "Select quantity to use with -C to look-up colors.  Choose among:");
+	GMT_Usage (API, 3, "m: Magnitude of vector or rotation [Default].");
+	GMT_Usage (API, 3, "e: East velocity component.");
+	GMT_Usage (API, 3, "n: North velocity component.");
+	GMT_Usage (API, 3, "u: User column (given after required columns).");
+	GMT_Usage (API, -2, "Note: Color selected will replace -G<fill>.  Append +e to instead act as -E<fill>.");
 	GMT_Option (API, "c,di,e,h,i,p,qi,T,:,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6940,7 +6940,9 @@ GMT_LOCAL void gmtinit_explain_R_geo (struct GMT_CTRL *GMT) {
 void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 	char u, *GMT_choice[2] = {"OFF", "ON"}, *V_code = GMT_VERBOSE_CODES;
+#ifdef GMT_MP_ENABLED
 	int cores = 0;
+#endif
 	double s;
 	unsigned int k;
 	size_t s_length;
@@ -7437,9 +7439,10 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 
 		case 'c':	/* -c option advances subplot panel focus under modern mode */
 
-			if (GMT->current.setting.run_mode == GMT_MODERN || GMT->current.setting.use_modern_name)	/* -c has no use in classic */
+			if (GMT->current.setting.run_mode == GMT_MODERN || GMT->current.setting.use_modern_name) {	/* -c has no use in classic */
 				GMT_Usage (API, 1, "\n%s", GMT_c0_OPT);
 				GMT_Usage (API, -2, "Move to next subplot panel [Default] or append <row>,<col> or <index> of desired panel.");
+			}
 			break;
 
 		case 'd':	/* -d option to tell GMT the relationship between NaN and a nan-proxy for input/output */


### PR DESCRIPTION
As per issue #5341.  Fixing a few inconsistencies as well.  This PR covers **earthtide**, **gpsgridder**, and **psvelo**.
