### PR TITLE
Let grdcut -S properly handle arc distances

### DIFF
--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -536,7 +536,10 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 		while (wesn_new[XLO] > G->header->wesn[XHI]) wesn_new[XLO] -= 360.0, wesn_new[XHI] -= 360.0;
 		wesn_new[YLO] = wesn_new[YHI] = Ctrl->S.lat;
 		/* First adjust the S and N boundaries */
-		radius = R2D * (Ctrl->S.radius / GMT->current.map.dist[GMT_MAP_DIST].scale) / GMT->current.proj.mean_radius;	/* Approximate radius in degrees */
+		if (GMT->current.map.dist[GMT_MAP_DIST].arc)	/* Got arc distance */
+			radius = (Ctrl->S.radius / GMT->current.map.dist[GMT_MAP_DIST].scale);	/* Radius in degrees */
+		else
+			radius = R2D * (Ctrl->S.radius / GMT->current.map.dist[GMT_MAP_DIST].scale) / GMT->current.proj.mean_radius;	/* Approximate radius in degrees */
 		wesn_new[YLO] -= radius;	/* Approximate south limit in degrees */
 		if (wesn_new[YLO] <= G->header->wesn[YLO]) {	/* Way south, reset to grid S limit */
 			wesn_new[YLO] = G->header->wesn[YLO];


### PR DESCRIPTION
Unfortunately, if you gave a distance in arc units (e.g. degrees, such as in -S30/40/45d) it assumed it still was in units like km and converted from length to radians to degree and got it all wrong.
