### PR TITLE
Add check if CPT file is empty

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7760,8 +7760,14 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 	/* Determine input source */
 
 	if (source_type == GMT_IS_FILE) {	/* source is a file name */
+		struct stat S;
 		strncpy (cpt_file, source, PATH_MAX-1);
 		Z = gmtsupport_cpt_parse (GMT, cpt_file, GMT_IN, &hinge_mode, &z_hinge);
+		if (stat (cpt_file, &S) == 0 && S.st_size == 0) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Color palette table %s is empty\n", cpt_file);
+			gmt_M_free (GMT, Z);
+			return (NULL);
+		}
 		if ((fp = fopen (cpt_file, "r")) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot open color palette table %s\n", cpt_file);
 			gmt_M_free (GMT, Z);


### PR DESCRIPTION
Instead of saying the the file has no z-slices (which is confusing; see this [post](https://forum.generic-mapping-tools.org/t/problems-with-generating-cpt-palette-files-and-odd-problem-after-editing-color-palette-files/1875/2)) we now check if the file is empty and say that instead.
