### PR TITLE
Update gshhg usage and fix -G bug

### DIFF
--- a/src/gshhg/gshhg.c
+++ b/src/gshhg/gshhg.c
@@ -84,22 +84,29 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GSHHG_CTRL *C) {	/* Dealloca
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s gshhs|wdb_rivers|wdb_borders_[f|h|i|l|c].b [-A<area>] [-G] [-I<id>] [-L] [-N<level>]\n\t[-Qe|i] [%s] [%s] [%s] [%s] [%s]\n\n",
+	GMT_Usage (API, 0, "usage: %s gshhs|wdb_rivers|wdb_borders_[f|h|i|l|c].b [-A<area>] [-G] [-I<id>] [-L] [-N<level>] [-Qe|i] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_V_OPT, GMT_bo_OPT, GMT_do_OPT, GMT_o_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
-	GMT_Message (API, GMT_TIME_NONE, "\tgshhs|wdb_rivers|wdb_borders_[f|h|i|l|c].b is a GSHHG polygon or line file.\n");
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
+	GMT_Usage (API, 1, "\ngshhs|wdb_rivers|wdb_borders_[f|h|i|l|c].b is a binary GSHHG polygon or line file.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-        GMT_Message (API, GMT_TIME_NONE, "\t-A Extract polygons whose area is greater than or equal to <area> (in km^2) [all].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-G Write '%%' at start of each segment header [P or L] (overwrites -M)\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   and write 'NaN NaN' after each segment to enable import by MATLAB or GNU Octave.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L List header records only (no data records will be written).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Output data for polygon number <id> only.  Use -Ic to get all continent polygons\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   [Default is all polygons].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Output features whose level matches <level> [Default outputs all levels].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-Q Control river-lakes: Use -Qe to exclude river-lakes, and -Qi to ONLY get river-lakes\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   [Default outputs all polygons].\n");
+	GMT_Usage (API, 1, "\n-A<area>");
+	GMT_Usage (API, -2, "Extract polygons whose area is greater than or equal to <area> (in km^2) [all].");
+	GMT_Usage (API, 1, "\n-G Prepend '%%' at start of each segment header "
+		"and write a 'NaN NaN' record after each segment to enable import by MATLAB or GNU Octave.");
+	GMT_Usage (API, 1, "\n-L List header records only (no data records will be written).");
+	GMT_Usage (API, 1, "\n-I<id>");
+	GMT_Usage (API, -2, "Output data for polygon number <id> only.  Use -Ic to get all continent polygons "
+		"[Default is all polygons].");
+	GMT_Usage (API, 1, "\n-N<level>");
+	GMT_Usage (API, -2, "Output features whose level matches <level> [Default outputs all levels].");
+	GMT_Usage (API, 1, "\n-Qe|i");
+	GMT_Usage (API, -2, "Control handling of river-lakes; choose a directive:");
+	GMT_Usage (API, 3, "e: Exclude all river-lakes.");
+	GMT_Usage (API, 3, "i: Only output river-lakes.");
+	GMT_Usage (API, -2, "[Default outputs all polygons].");
 	GMT_Option (API, "V,bo2,do,o,:,.");
 
 	return (GMT_MODULE_USAGE);
@@ -377,8 +384,12 @@ EXTERN_MSC int GMT_gshhg (void *V_API, int mode, void *args) {
 				T[seg_no]->data[GMT_Y][row] = p.y * GSHHG_SCL;
 			}
 			T[seg_no]->n_rows = h.n;
-			if (Ctrl->G.active) T[seg_no]->data[GMT_X][row] = T[seg_no]->data[GMT_Y][row] = GMT->session.d_NaN;
 			D->n_records += T[seg_no]->n_rows;
+			if (Ctrl->G.active) {
+				T[seg_no]->data[GMT_X][row] = T[seg_no]->data[GMT_Y][row] = GMT->session.d_NaN;
+				T[seg_no]->n_rows++;
+				D->n_records ++;
+			}
 		}
 		seg_no++;
 		max_east = 180000000;	/* Only Eurasia (the first polygon) needs 270 */

--- a/src/gshhg/gshhg.c
+++ b/src/gshhg/gshhg.c
@@ -384,12 +384,11 @@ EXTERN_MSC int GMT_gshhg (void *V_API, int mode, void *args) {
 				T[seg_no]->data[GMT_Y][row] = p.y * GSHHG_SCL;
 			}
 			T[seg_no]->n_rows = h.n;
-			D->n_records += T[seg_no]->n_rows;
-			if (Ctrl->G.active) {
+			if (Ctrl->G.active) {	/* Must add one more dummy NaN record and increment rows */
 				T[seg_no]->data[GMT_X][row] = T[seg_no]->data[GMT_Y][row] = GMT->session.d_NaN;
 				T[seg_no]->n_rows++;
-				D->n_records ++;
 			}
+			D->n_records += T[seg_no]->n_rows;
 		}
 		seg_no++;
 		max_east = 180000000;	/* Only Eurasia (the first polygon) needs 270 */


### PR DESCRIPTION
As per #5341.  Also, **-G** did not actually work (no NaN-records were added on output since _row_ was not incremented to make space for the extra record) and its usage discussed long-obsolete **P** and **L** header records.
