### PR TITLE
Let grdtrend fit model along xx or yy only.

### DIFF
--- a/doc/rst/source/grdtrend.rst
+++ b/doc/rst/source/grdtrend.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdtrend** *grdfile* |-N|\ *n\_model*\ [**+r**]
+**gmt grdtrend** *grdfile* |-N|\ *n\_model*\ [**+r**]\ [**+x** | **+y**]
 [ |-D|\ *diff.nc* ]
 [ |SYN_OPT-R| ]
 [ |-T|\ *trend.nc* ] [ |-W|\ *weight.nc* ]
@@ -38,6 +38,8 @@ reweight the data based on a robust scale estimate, in order to converge
 to a solution insensitive to outliers. This may be handy when separating
 a "regional" field from a "residual" which should have non-zero mean,
 such as a local mountain on a regional surface.
+Optionally append **+x** OR **+y** (just one ofc) to fit a model only along
+the *xx* or *yy* axis.
 
 If data file has values set to NaN, these will be ignored during
 fitting; if output files are written, these will also have NaN in the


### PR DESCRIPTION
Sometimes it may be desirable to fit a model that varies only along one direction. An example will be to remove a N-S gradient only. This PR add **+x** or **+y** as optional modifiers to **-N**. However I had some difficulties because the **gauss* function didn't like to have a set of coords all equal to zero. The solution was to let the last ``xvar`` or ``yvar`` = 1 and write a function to remove the vertical slice shown in attached image. 
Maybe something more clever can be done but meanwhile this now works well.

![Capture_trend](https://user-images.githubusercontent.com/537321/126072478-dc87a6a6-95fe-4dc0-b3f4-034b19267293.JPG)
