### PR TITLE
Let gmt end show only display the first graphics-format listed

### DIFF
--- a/doc/rst/source/end.rst
+++ b/doc/rst/source/end.rst
@@ -31,7 +31,7 @@ Optional Arguments
 **show**
     Open all graphics produced by the session in the default viewer.
     **Note**: In the event you have selected more than one output format
-    we onlly open the first one listed.
+    we only open the first one listed.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: explain_-V.rst_

--- a/doc/rst/source/end.rst
+++ b/doc/rst/source/end.rst
@@ -51,7 +51,7 @@ close the current modern session and finalize any plots requested::
     gmt end
 
 Here is the same example, but this time we want to name the map,
-obtained both PDF and PNG versions of it, and automatically open
+create both PDF and PNG versions of it, and automatically open
 the PDF file in the relevant viewer::
 
     gmt begin map pdf,png

--- a/doc/rst/source/end.rst
+++ b/doc/rst/source/end.rst
@@ -30,6 +30,8 @@ Optional Arguments
 
 **show**
     Open all graphics produced by the session in the default viewer.
+    **Note**: In the event you have selected more than one output format
+    we onlly open the first one listed.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: explain_-V.rst_
@@ -45,13 +47,22 @@ We first create a modern mode session using **begin**, do plotting, and
 close the current modern session and finalize any plots requested::
 
     gmt begin
-    gmt basemap -R0/10/0/10 -JX10c -Baf
+      gmt basemap -R0/10/0/10 -JX10c -Baf
     gmt end
+
+Here is the same example, but this time we want to name the map,
+obtained both PDF and PNG versions of it, and automatically open
+the PDF file in the relevant viewer::
+
+    gmt begin map pdf,png
+      gmt basemap -R0/10/0/10 -JX10c -Baf
+    gmt end show
 
 Disable display
 ---------------
 
-If you wish to run scripts that end with **gmt end show** but sometimes prefer to not display the results,
+If you wish to run scripts that end with **gmt end show** but sometimes
+prefer to not display the results without having to edit all the scripts,
 you can set the environmental parameter **GMT_END_SHOW** to off.
 
 See Also

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18056,7 +18056,7 @@ GMT_LOCAL bool gmtinit_A_was_given (char *text) {
 GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 	/* Loop over all registered figures and their selected formats and
 	 * convert the hidden PostScript figures to selected graphics.
-	 * If show is not NULL then we display them via gmt docs */
+	 * If show is not NULL then we display the first graphics listed (if more than one) via gmt docs */
 
 	char cmd[GMT_BUFSIZ] = {""}, fmt[GMT_LEN16] = {""}, option[GMT_LEN256] = {""}, p[GMT_LEN256] = {""}, dir[PATH_MAX] = {""}, legend_justification[4] = {""}, mark, *c = NULL;
 	char pen[GMT_LEN32] = {""}, fill[GMT_LEN32] = {""}, off[GMT_LEN32] = {""};
@@ -18171,7 +18171,7 @@ GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 				return error;
 			}
 
-			if (show) {	/* Open the plot in the viewer via call to gmt docs */
+			if (show && f == 0) {	/* Open the plot in the viewer via call to gmt docs */
 				size_t start = 0, end = strlen (fig[k].prefix) - 1;
 				char ext[GMT_LEN8] = {""};
 				strcpy (ext, gmt_session_format[gcode[f]]);	/* Set extension */


### PR DESCRIPTION
In the eveny the user wants to produce more than one graphics format of a figure (e.g., by listing pdf,png,jpg), we only want to open the first-listed file in the viewer if **gmt end show** is used.  This PR fixes this inconsistency and updates the documentation.  Also closes #5512.
