### PR TITLE
Update mgd77 supplement usage messages

### DIFF
--- a/doc/rst/source/supplements/mgd77/mgd77header.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77header.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt mgd77header** *GEODAS-id.a77*
-[ |-H|\ *headervalues.txt* ]
+[ |-H|\ *headertable* ]
 [ |-M|\ **f**\ [*item*]\|\ **r**\|\ **t** ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT--| ]
@@ -40,8 +40,8 @@ Optional Arguments
 
 .. _-H:
 
-**-H**\ *headervalues.txt*
-    Obtain header field values from the input text file. Each row of
+**-H**\ *headertable*
+    Obtain header field values from the appended file. Each row of
     the input file should consist of a header field name and its
     desired value, separated by a space. See below for a sample header
     file and for the full list of header field names.

--- a/doc/rst/source/supplements/mgd77/mgd77info.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77info.rst
@@ -14,7 +14,8 @@ Synopsis
 
 **gmt mgd77info** *GEODAS-ids*
 [ |-C|\ [**m**\|\ **e**] ]
-[ |-E|\ [**m**\|\ **e**] ] [ **-I**\ *ignore* ]
+[ |-E|\ [**m**\|\ **e**] ]
+[ |-I|\ **a\|c\|m\|t** ]
 [ |-M|\ **f**\ [*item*]\|\ **r**\|\ **e**\|\ **h** ]
 [ |-L|\ [**v**] ]
 [ |SYN_OPT-V| ]
@@ -74,7 +75,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ *ignore*
+**-I**\ **a\|c\|m\|t**
     Ignore certain data file formats from consideration. Append
     **a\|c\|m\|t** to ignore MGD77 ASCII, MGD77+ netCDF, MGD77T ASCII or plain
     tab-separated ASCII table files, respectively. The option may be

--- a/doc/rst/source/supplements/mgd77/mgd77list.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77list.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |-E| ]
 [ |-G|\ **a**\ *startrec* ]
 [ |-G|\ **b**\ *stoprec* ]
-[ |-I|\ *ignore* ]
+[ |-I|\ **a\|c\|m\|t** ]
 [ |-L|\ [*corrtable*] ]
 [ |-N|\ **d**\|\ **s**\ *unit* ]
 [ |-Q|\ **a**\|\ **c**\|\ **v**\ *min*/*max* ]
@@ -345,6 +345,9 @@ Optional Arguments
     for feet, **k** for km, **M** for miles, **n** for nautical miles,
     or **u** for survey feet [Default is **e** (meters)].
 
+**-At**
+    Compute fake times for cruises with known duration but lacking individual record times.
+
 .. _-D:
 
 **-Da**\ *startdate*
@@ -375,7 +378,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ *ignore*
+**-I**\ **a\|c\|m\|t**
     Ignore certain data file formats from consideration. Append
     **a\|c\|m\|t** to ignore MGD77 ASCII, MGD77+ netCDF, MGD77T ASCII, or plain
     tab-separated ASCII table files, respectively. The option may be

--- a/doc/rst/source/supplements/mgd77/mgd77path.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77path.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt mgd77path** *GEODAS-ids* [ |-A|\ [**c**] ] [ |-D| ]
-[ |-I|\ *ignore* ]
+[ |-I|\ **a\|c\|m\|t** ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT--| ]
 
@@ -48,7 +48,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ *ignore*
+**-I**\ **a\|c\|m\|t**
     Ignore certain data file formats from consideration. Append
     **a\|c\|m\|t** to ignore MGD77 ASCII, MGD77+ netCDF, MGD77T ASCII, or plain
     tab-separated ASCII table files, respectively. The option may be

--- a/doc/rst/source/supplements/mgd77/mgd77sniffer.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77sniffer.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt mgd77sniffer** *GEODAS-ids* [ |-A|\ *fieldabbrev*,\ *scale*,\ *offset* ]
 [ |-C|\ *maxspd* ]
-[ |-D|\ **d**\|\ **e**\|\ **E**\|\ **f**\|\ **l**\|\ **m**\|\ **s**\|\ **v**\ [*r*] ]
+[ |-D|\ **d**\|\ **e**\|\ **E**\|\ **f**\|\ **l**\|\ **m**\|\ **s**\|\ **v**\ [**r**] ]
 [ |-E| ]
 [ |-G|\ *fieldabbrev*,\ *imggrid*,\ *scale*,\ *mode* or |-G|\ *fieldabbrev*,\ *grid* ]
 [ |-H| ]
@@ -74,11 +74,11 @@ Optional Arguments
 
 .. _-D:
 
-**-D**\ **d**\|\ **e**\|\ **E**\|\ **f**\|\ **l**\|\ **m**\|\ **s**\|\ **v**\ [*r*]
+**-D**\ **d**\|\ **e**\|\ **E**\|\ **f**\|\ **l**\|\ **m**\|\ **s**\|\ **v**\ [**r**]
     Suppress default warning output and only dump cruise data row-by-row
     such as values, gradients, grid-cruise differences, E77 error
     summaries for each record, re-created MGD77 records or sniffer
-    limits. Append *r* to include all records (default omits records where
+    limits. Append **r** to include all records (default omits records where
     navigation errors were detected).
 
     **-Dd** output differences between cruise and grid data. Requires

--- a/doc/rst/source/supplements/mgd77/mgd77track-classic.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77track-classic.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-D|\ **b**\ *stopdate* ]
 [ |-F| ]
 [ |-G|\ **d**\|\ **t**\|\ **n**\ *gap* ]
-[ |-I|\ *ignore* ]
+[ |-I|\ **a\|c\|m\|t** ]
 [ |-K| ]
 [ |-L|\ *trackticks* ]
 [ |SYN_OPT-O| ]

--- a/doc/rst/source/supplements/mgd77/mgd77track.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77track.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-D|\ **b**\ *stopdate* ]
 [ |-F| ]
 [ |-G|\ **d**\|\ **t**\|\ **n**\ *gap* ]
-[ |-I|\ *ignore* ]
+[ |-I|\ **a\|c\|m\|t** ]
 [ |-L|\ *trackticks* ]
 [ |-S|\ **a**\ *startdist* ]
 [ |-S|\ **b**\ *stopdist* ]

--- a/doc/rst/source/supplements/mgd77/mgd77track_common.rst_
+++ b/doc/rst/source/supplements/mgd77/mgd77track_common.rst_
@@ -67,7 +67,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ *ignore*
+**-I**\ **a\|c\|m\|t** 
     Ignore certain data file formats from consideration. Append
     **a\|c\|m\|t** to ignore MGD77 ASCII, MGD77+ netCDF, MGD77T ASCII, or plain table
     files, respectively. The option may be repeated to ignore more than

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13496,7 +13496,7 @@ GMT_LOCAL unsigned int gmtapi_hyphen (const char *line, unsigned int stop) {
 GMT_LOCAL struct GMT_WORD * gmtapi_split_words (const char *line) {
 	/* Split line into an array of words where words are separated by either
 	 * a space (like between options), the occurrence of "][" sequences, or
-	 * items separated by slashes "/" or bars "|" or hyphens "-".
+	 * items separated by slashes "/", commas ",", bars "|" or hyphens "-".
 	 * These are the places where we are allowed to break the line. */
 	struct GMT_WORD *array = NULL;
 	unsigned int n = 0, c, start = 0, next, end, j, stop, space = 0, n_alloc = GMT_LEN256, hyphen = 0;
@@ -13505,14 +13505,14 @@ GMT_LOCAL struct GMT_WORD * gmtapi_split_words (const char *line) {
         hyphen = 0; /* Initialize */
 		/* Find the next break location */
 		stop = start;
-		while (line[stop] && !(strchr (" /|", line[stop]) || (line[stop] == ']' && line[stop+1] == '[') || (hyphen = gmtapi_hyphen (line, stop)))) stop++;
+		while (line[stop] && !(strchr (" ,/|", line[stop]) || (line[stop] == ']' && line[stop+1] == '[') || (hyphen = gmtapi_hyphen (line, stop)))) stop++;
 		end = next = stop;	/* Mark likely end */
 		array[n].space = space;	/* Do we need a leading space (set via previous word)? */
 		if (line[stop] == ' ') {	/* Skip the space to start over at next word */
 			while (line[stop] == ' ') stop++;	/* In case there are more than one space */
 			next = stop; space = 1;
 		}
-        else if (line[stop] && strchr ("/|]", line[stop])) {   /* Include this char then break */
+        else if (line[stop] && strchr (",/|]", line[stop])) {   /* Include this char then break */
             next = ++end, space = 0;
         }
         else if (line[stop] == '-') {   /* Include this char then break with no break symbol */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8261,15 +8261,15 @@ void gmt_segmentize_syntax (struct GMT_CTRL *GMT, char option, unsigned int mode
 }
 
 /*! For programs that can read *.img grids */
-void gmt_img_syntax (struct GMT_CTRL *GMT) {
+void gmt_img_syntax (struct GMT_CTRL *GMT, int indent) {
 	struct GMTAPI_CTRL *API = GMT->parent;
-	GMT_Usage (API, 2, "Give filename and append comma-separated scale, mode, and optionally max latitude. "
+	GMT_Usage (API, indent, "Give filename and append comma-separated scale, mode, and optionally max latitude. "
 		"The scale (typically 0.1 or 1) is used to multiply after read; give mode as follows:");
-	GMT_Usage (API, 3, "0: img file with no constraints coded, interpolate to get data at track.");
-	GMT_Usage (API, 3, "1: img file with constraints coded, interpolate to get data at track.");
-	GMT_Usage (API, 3, "2: img file with constraints coded, gets data only at constrained points, NaN elsewhere.");
-	GMT_Usage (API, 3, "3: img file with constraints coded, gets 1 at constraints, 0 elsewhere.");
-	GMT_Usage (API, -2, "For mode 2|3 you may want to consider the -n+t<threshold> setting.");
+	GMT_Usage (API, indent+1, "0: img file with no constraints coded, interpolate to get data at track.");
+	GMT_Usage (API, indent+1, "1: img file with constraints coded, interpolate to get data at track.");
+	GMT_Usage (API, indent+1, "2: img file with constraints coded, gets data only at constrained points, NaN elsewhere.");
+	GMT_Usage (API, indent+1, "3: img file with constraints coded, gets 1 at constraints, 0 elsewhere.");
+	GMT_Usage (API, -indent, "For mode 2|3 you may want to consider the -n+t<threshold> setting.");
 }
 
 /*! . */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -122,7 +122,7 @@ EXTERN_MSC void gmt_label_syntax (struct GMT_CTRL *GMT, unsigned int indent, uns
 EXTERN_MSC void gmt_dist_syntax (struct GMT_CTRL *GMT, char *option, char *string);
 EXTERN_MSC void gmt_vector_syntax (struct GMT_CTRL *GMT, unsigned int mode, int level);
 EXTERN_MSC void gmt_segmentize_syntax (struct GMT_CTRL *GMT, char option, unsigned int mode);
-EXTERN_MSC void gmt_img_syntax (struct GMT_CTRL *GMT);
+EXTERN_MSC void gmt_img_syntax (struct GMT_CTRL *GMT, int indent);
 EXTERN_MSC void gmt_GSHHG_syntax (struct GMT_CTRL *GMT, char option);
 EXTERN_MSC void gmt_GSHHG_resolution_syntax (struct GMT_CTRL *GMT, char option, char *string);
 EXTERN_MSC int gmt_getdefaults (struct GMT_CTRL *GMT, char *this_file);

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -179,7 +179,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Repeat -G for as many grids as you wish to sample, or "
 		"use -G+l<list> to pass a list of grid file names. "
 		"Note: If the file is a Sandwell/Smith Mercator grid (IMG format) then more information is required:");
-	gmt_img_syntax (API->GMT);
+	gmt_img_syntax (API->GMT, 2);
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 
 	GMT_Option (API, "<");

--- a/src/mgd77/mgd77.c
+++ b/src/mgd77/mgd77.c
@@ -4293,13 +4293,14 @@ void MGD77_end (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F) {
 }
 
 void MGD77_Cruise_Explain (struct GMT_CTRL *GMT) {
-	GMT_Usage (GMT->parent, 1, "<cruises> can be one of five kinds of specifiers: "
-		"1) 8-character NGDC IDs, e.g., 01010083, JA010010, etc., etc., "
-		"2) 2-character <agency> codes which will return all cruises from each agency, "
-		"3) 4-character <agency><vessel> codes, which will return all cruises from those vessels, "
-		"4) A single =<list>, where <list> is a table with NGDC IDs, one per line, "
-		"5) If nothing is specified we return all cruises in the data base. "
-		"[See the documentation for agency and vessel codes].");
+	GMT_Usage (GMT->parent, 1, "\n<cruise(s)>");
+	GMT_Usage (GMT->parent, -2, "This can be one of five types of specifiers:");
+	GMT_Usage (GMT->parent, 3, "%s 8-character NGDC IDs, e.g., 01010083, JA010010, etc., etc.", GMT_LINE_BULLET);
+	GMT_Usage (GMT->parent, 3, "%s 2-character <agency> codes which will return all cruises from each agency.", GMT_LINE_BULLET);
+	GMT_Usage (GMT->parent, 3, "%s 4-character <agency><vessel> codes, which will return all cruises from those vessels.", GMT_LINE_BULLET);
+	GMT_Usage (GMT->parent, 3, "%s A single =<list>, where <list> is a table with NGDC IDs, one per line.", GMT_LINE_BULLET);
+	GMT_Usage (GMT->parent, -2, "If nothing is specified we return all cruises in the data base. "
+		"(See the documentation for agency and vessel codes).");
 }
 
 GMT_LOCAL int mgd77_compare_L (const void *p1, const void *p2) {
@@ -5633,24 +5634,23 @@ int MGD77_igrf10syn (struct GMT_CTRL *GMT, int isv, double date, int itype, doub
 	return (MGD77_NO_ERROR);
 }
 
-void MGD77_IGF_text (struct GMT_CTRL *GMT, FILE *fp, int version) {
-	gmt_M_unused(GMT);
+void MGD77_IGF_text (struct GMTAPI_CTRL *API, int indent, int version) {
 	switch (version) {
 		case 1:	/* Heiskanen 1924 model */
-			fprintf (fp, "g = %.12g * [1 + %.6f * sin^2(lat) - %.7f * sin^2(2*lat) + %.6f * cos^2(lat) * cos^2(lon-18)]\n",
+			GMT_Usage (API, indent, "g = %.12g * [1 + %.6f * sin^2(lat) - %.7f * sin^2(2*lat) + %.6f * cos^2(lat) * cos^2(lon-18)]",
 				MGD77_IGF24_G0, MGD77_IGF24_G1, MGD77_IGF24_G2, MGD77_IGF24_G3);
 			break;
 		case 2:	/* International 1930 model */
-			fprintf (fp, "g = %.12g * [1 + %.7f * sin^2(lat) - %.7f * sin^2(2*lat)]\n", MGD77_IGF30_G0, MGD77_IGF30_G1, MGD77_IGF30_G2 );
+			GMT_Usage (API, indent, "g = %.12g * [1 + %.7f * sin^2(lat) - %.7f * sin^2(2*lat)]", MGD77_IGF30_G0, MGD77_IGF30_G1, MGD77_IGF30_G2 );
 			break;
 		case 3:	/* IAG 1967 model */
-			fprintf (fp, "g = %.12g * [1 + %.7f * sin^2(lat) - %.7f * sin^2(2*lat)]\n", MGD77_IGF67_G0, MGD77_IGF67_G1, MGD77_IGF67_G2);
+			GMT_Usage (API, indent, "g = %.12g * [1 + %.7f * sin^2(lat) - %.7f * sin^2(2*lat)]", MGD77_IGF67_G0, MGD77_IGF67_G1, MGD77_IGF67_G2);
 			break;
 		case 4:	/* IAG 1980 model */
-			fprintf (fp, "g = %.12g * [(1 + %.14g * sin^2(lat)) / sqrt (1 - %.14g * sin^2(lat))]\n", MGD77_IGF80_G0, MGD77_IGF80_G1, MGD77_IGF80_G2);
+			GMT_Usage (API, indent, "g = %.12g * [(1 + %.14g * sin^2(lat)) / sqrt (1 - %.14g * sin^2(lat))]", MGD77_IGF80_G0, MGD77_IGF80_G1, MGD77_IGF80_G2);
 			break;
 		default:	/* Unrecognized */
-			fprintf (fp, "Unrecognized theoretical gravity formula code (%d)\n", version);
+			GMT_Usage (API, indent, "Unrecognized theoretical gravity formula code (%d)", version);
 			break;
 	}
 }

--- a/src/mgd77/mgd77.h
+++ b/src/mgd77/mgd77.h
@@ -555,7 +555,7 @@ EXTERN_MSC double MGD77_carter_correction (struct GMT_CTRL *GMT, double lon, dou
 
 EXTERN_MSC int MGD77_igrf10syn (struct GMT_CTRL *GMT, int isv, double date, int itype, double alt, double lon, double lat, double *out);
 EXTERN_MSC double MGD77_Theoretical_Gravity (struct GMT_CTRL *GMT, double lon, double lat, int version);
-EXTERN_MSC void MGD77_IGF_text (struct GMT_CTRL *GMT, FILE *fp, int version);
+EXTERN_MSC void MGD77_IGF_text (struct GMTAPI_CTRL *API, int indent, int version);
 EXTERN_MSC double MGD77_Recalc_Mag_Anomaly_IGRF (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, double time, double lon, double lat, double obs, bool calc_date);
 EXTERN_MSC double MGD77_time_to_fyear (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, double time);
 EXTERN_MSC double MGD77_cal_to_fyear (struct GMT_CTRL *GMT, struct GMT_GCAL *cal);

--- a/src/mgd77/mgd77convert.c
+++ b/src/mgd77/mgd77convert.c
@@ -78,23 +78,37 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77CONVERT_CTRL *C) {	/* D
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> -Fa|c|m|t -Ta|c|m|t[+f] [-C] [-D] [-L[e][w][+l]] [%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)> -Fa|c|m|t -Ta|c|m|t[+f] [-C] [-D] [-L[e][w][+l]] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
-	GMT_Message (API, GMT_TIME_NONE, "\t   [Files are read from data repositories and written to current directory]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-F Convert from a file that is either (a) MGD77 ASCII, (c) MGD77+ netCDF, (m) MGD77T ASCII, or (t) plain table.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use -FC to recover the original MGD77 setting from the MGD77+ file [Default applies E77 corrections].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-T Convert to a file that is either (a) MGD77 ASCII, (c) MGD77+ netCDF, (m) MGD77T ASCII, or (t) plain table.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   By default we will refuse to overwrite existing files.  Append +f to force an override this policy.\n");
+	GMT_Usage (API, -2, "[Files are read from data repositories and written to current directory].");
+	GMT_Usage (API, 1, "\n-Fa|c|m|t");
+	GMT_Usage (API, -2, "Convert from a file that is either:");
+	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
+	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
+	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
+	GMT_Usage (API, 3, "t: Plain table.");
+	GMT_Usage (API, -2, "Note: Use -FC to recover the original MGD77 setting from the MGD77+ file [Default applies E77 corrections].");
+	GMT_Usage (API, 1, "\n-Ta|c|m|t[+f]");
+	GMT_Usage (API, -2, "Convert to a file that is either:");
+	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
+	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
+	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
+	GMT_Usage (API, 3, "t: Plain table.");
+	GMT_Usage (API, -2, "By default we will refuse to overwrite existing files.  Append +f to force an override this policy.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-C Convert from NGDC (*.h77, *.a77) to *.mgd77 format; no other options allowed.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Give one or more names of h77-files, a77-files, or just cruise prefixes.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Select high-resolution, 4-byte storage for mag, diur, faa, eot, and msd with precision\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   of 10 fTesla, 1 nGal, 0.01 mm [Default is 2-byte with 0.1 nTesla, 0.1 mGal, m precision].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Set log level and destination setting for verification reporting.  Append a combination\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   of w for warnings and e for errors, and append +l to send log to stdout [Default is stderr].\n");
+	GMT_Usage (API, 1, "\n-C Convert from NGDC (*.h77, *.a77) to *.mgd77 format; no other options allowed. "
+		"Give one or more names of h77-files, a77-files, or just cruise prefixes.");
+	GMT_Usage (API, 1, "\n-D Select high-resolution, 4-byte storage for mag, diur, faa, eot, and msd with precision "
+		"of 10 fTesla, 1 nGal, 0.01 mm [Default is 2-byte with 0.1 nTesla, 0.1 mGal, m precision].");
+	GMT_Usage (API, 1, "\n-L[e][w][+l]");
+	GMT_Usage (API, -2, "Set log level and destination setting for verification reporting.  Append a combination of:");
+	GMT_Usage (API, 3, "w: Warning messages.");
+	GMT_Usage (API, 3, "e: Error messages.");
+	GMT_Usage (API, -2, "Append +l to send the log to stdout [Default is stderr].");
 	GMT_Option (API, "V,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/mgd77/mgd77convert.c
+++ b/src/mgd77/mgd77convert.c
@@ -84,16 +84,16 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
-	GMT_Usage (API, -2, "[Files are read from data repositories and written to current directory].");
+	GMT_Usage (API, -2, "Note: Files are read from data repositories and written to current directory.");
 	GMT_Usage (API, 1, "\n-Fa|c|m|t");
-	GMT_Usage (API, -2, "Convert from a file that is either:");
+	GMT_Usage (API, -2, "Convert from a file that has this format:");
 	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
 	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
 	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
 	GMT_Usage (API, 3, "t: Plain table.");
 	GMT_Usage (API, -2, "Note: Use -FC to recover the original MGD77 setting from the MGD77+ file [Default applies E77 corrections].");
 	GMT_Usage (API, 1, "\n-Ta|c|m|t[+f]");
-	GMT_Usage (API, -2, "Convert to a file that is either:");
+	GMT_Usage (API, -2, "Convert to a file that has this format:");
 	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
 	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
 	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
@@ -103,9 +103,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-C Convert from NGDC (*.h77, *.a77) to *.mgd77 format; no other options allowed. "
 		"Give one or more names of h77-files, a77-files, or just cruise prefixes.");
 	GMT_Usage (API, 1, "\n-D Select high-resolution, 4-byte storage for mag, diur, faa, eot, and msd with precision "
-		"of 10 fTesla, 1 nGal, 0.01 mm [Default is 2-byte with 0.1 nTesla, 0.1 mGal, m precision].");
+		"of 10 fTesla, 1 nGal, 0.01 mm [Default is 2-byte with 0.1 nTesla, 0.1 mGal, 1 m precision].");
 	GMT_Usage (API, 1, "\n-L[e][w][+l]");
-	GMT_Usage (API, -2, "Set log level and destination setting for verification reporting.  Append a combination of:");
+	GMT_Usage (API, -2, "Set log level and destination setting for verification reporting.  Append one or both of:");
 	GMT_Usage (API, 3, "w: Warning messages.");
 	GMT_Usage (API, 3, "e: Error messages.");
 	GMT_Usage (API, -2, "Append +l to send the log to stdout [Default is stderr].");

--- a/src/mgd77/mgd77header.c
+++ b/src/mgd77/mgd77header.c
@@ -73,7 +73,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <cruise(s)>  [-H<headinfo>] [-Mf[<item>]|f|r|t] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)>  [-H<headinfo>] [-Mf[<item>]|r|t] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -84,11 +84,11 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-H<headinfo>");
 	GMT_Usage (API, -2, "Read and assign header values from a file. Each input file row gives an exact "
 		"header_field_name, space or tab, and header value. Values are read according to "
-		"NGDC's MGD77 header format specification, e.g.:");
+		"NGDC's MGD77 header format specification. Two examples are given:");
 	GMT_Usage (API, 3, "Source_Institution Univ. of Hawaii.");
 	GMT_Usage (API, 3, "Port_of_Arrival Honolulu, HAWAII");
 	GMT_Usage (API, -2, "Note: See mgd77info -Mf output for recognized header field names.");
-	GMT_Usage (API, 1, "\n-Mf[<item>]|f|r|t");
+	GMT_Usage (API, 1, "\n-Mf[<item>]|r|t");
 	GMT_Usage (API, -2, "Print header items.  Append type of presentation:");
 	GMT_Usage (API, 3, "f: Print header items individually, one per line.  Append name of a particular "
 		"item (e.g., Port_of_Departure), all [Default], or - to see a list of items."

--- a/src/mgd77/mgd77header.c
+++ b/src/mgd77/mgd77header.c
@@ -73,23 +73,28 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)>  [-H<headinfo>] [-Mf[<item>]|r|e|h] [%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)>  [-H<headinfo>] [-Mf[<item>]|f|r|t] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	MGD77_Init (API->GMT, &M);		/* Initialize MGD77 Machinery */
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-H Read and assign header values from a file. Each input file row gives an exact\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   header_field_name, space or tab, and header value. Values are read according to\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   NGDC's MGD77 header format specification.\n\t\te.g.,\n\t\tSource_Institution Univ. of Hawaii\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t\tPort_of_Arrival Honolulu, HAWAII\n\t\t...\n	   See mgd77info -Mf output for recognized header field names.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-M Print header items.  Append type of presentation:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     f: Print header items individually, one per line.  Append name of a particular\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        item (e.g., Port_of_Departure), all [Default], or - to see a list of items.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        You can also use the number of the item.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     r: Display raw original MGD77 header records [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     t: Display raw original M77T header records.\n");
+	GMT_Usage (API, 1, "\n-H<headinfo>");
+	GMT_Usage (API, -2, "Read and assign header values from a file. Each input file row gives an exact "
+		"header_field_name, space or tab, and header value. Values are read according to "
+		"NGDC's MGD77 header format specification, e.g.:");
+	GMT_Usage (API, 3, "Source_Institution Univ. of Hawaii.");
+	GMT_Usage (API, 3, "Port_of_Arrival Honolulu, HAWAII");
+	GMT_Usage (API, -2, "Note: See mgd77info -Mf output for recognized header field names.");
+	GMT_Usage (API, 1, "\n-Mf[<item>]|f|r|t");
+	GMT_Usage (API, -2, "Print header items.  Append type of presentation:");
+	GMT_Usage (API, 3, "f: Print header items individually, one per line.  Append name of a particular "
+		"item (e.g., Port_of_Departure), all [Default], or - to see a list of items."
+		"You can also use the number of the item.");
+	GMT_Usage (API, 3, "r: Display raw original MGD77 header records [Default].");
+	GMT_Usage (API, 3, "t: Display raw original M77T header records.");
 	GMT_Option (API, "V,.");
 
 	MGD77_end (API->GMT, &M);	/* Close machinery */

--- a/src/mgd77/mgd77header.c
+++ b/src/mgd77/mgd77header.c
@@ -73,7 +73,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <cruise(s)>  [-H<headinfo>] [-Mf[<item>]|r|t] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)>  [-H<headertable>] [-Mf[<item>]|r|t] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -81,8 +81,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n-H<headinfo>");
-	GMT_Usage (API, -2, "Read and assign header values from a file. Each input file row gives an exact "
+	GMT_Usage (API, 1, "\n-H<headertable>");
+	GMT_Usage (API, -2, "Read and assign header values from the given file. Each input file row gives an exact "
 		"header_field_name, space or tab, and header value. Values are read according to "
 		"NGDC's MGD77 header format specification. Two examples are given:");
 	GMT_Usage (API, 3, "Source_Institution Univ. of Hawaii.");

--- a/src/mgd77/mgd77info.c
+++ b/src/mgd77/mgd77info.c
@@ -85,7 +85,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <cruise(s)> [-C[m|e]] [-E[m|e]] [-I<code>] [-Mf[<item>]|r|e|h] [-L[v]] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)> [-C[m|e]] [-E[m|e]] [-Ia|c|m|t] [-Mf[<item>]|r|e|h] [-L[v]] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -93,23 +93,31 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-C List abbreviations of all columns present for each cruise.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append m for listing just the MGD77 columns present.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append e for listing just any extra columns present.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-E Give the information summary of each cruise's geographical/temporal extent.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append m for counting just the number of non-NaN values for each MGD77 field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append e for counting just the of non-NaN values for each extra field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-M Print header items (and MGD77+ history).  Append type of presentation:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     f: Print header items individually, one per line.  Append name of a particular\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        item (e.g., Port_of_Departure), all [Default], or - to see a list of items.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        You can also use the number of the item.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     r: Display raw original MGD77 header records.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     e: Display the MGD77+ file's E77 status.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     h: Display the MGD77+ file's history.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Ignore certain data file formats from consideration. Append combination of act to ignore\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   (a) MGD77 ASCII, (c) MGD77+ netCDF, (m) MGD77T ASCII, or (t) plain table files [Default ignores none].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L List all the institutions and their 2-character GEODAS codes only.  Append v to also\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   display the vessels and their 4-character codes for each institution.\n");
+	GMT_Usage (API, 1, "\n-C[m|e]");
+	GMT_Usage (API, -2, "List abbreviations of all columns present for each cruise.:");
+	GMT_Usage (API, 3, "m: List just the MGD77 columns present");
+	GMT_Usage (API, 3, "e: List just any extra columns present");
+	GMT_Usage (API, 1, "\n-E[m|e]");
+	GMT_Usage (API, -2, "Give the information summary of each cruise's geographical/temporal extent.:");
+	GMT_Usage (API, 3, "m: Count just the number of non-NaN values for each MGD77 field.");
+	GMT_Usage (API, 3, "e: Count just the of non-NaN values for each extra field.");
+	GMT_Usage (API, 1, "\n-Mf[<item>]|r|e|h");
+	GMT_Usage (API, -2, "Print header items (and MGD77+ history).  Append type of presentation:");
+	GMT_Usage (API, 3, "f: Print header items individually, one per line.  Append name of a particular "
+		"item (e.g., Port_of_Departure), all [Default], or - to see a list of items. "
+		"You can also use the number of the item.");
+	GMT_Usage (API, 3, "r: Display raw original MGD77 header records.");
+	GMT_Usage (API, 3, "e: Display the MGD77+ file's E77 status.");
+	GMT_Usage (API, 3, "h: Display the MGD77+ file's history.");
+	GMT_Usage (API, 1, "\n-Ia|c|m|t");
+	GMT_Usage (API, -2, "Ignore certain data file formats from consideration. Append combination of acmt to ignore [Default ignores none]:");
+	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
+	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
+	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
+	GMT_Usage (API, 3, "t: Plain table.");
+	GMT_Usage (API, 1, "\n-L[v]");
+	GMT_Usage (API, -2, "List all the institutions and their 2-character GEODAS codes only.  Append v to also "
+		"display the vessels and their 4-character codes for each institution.");
 	GMT_Option (API, "V,.");
 
 	MGD77_end (API->GMT, &M);	/* Close machinery */

--- a/src/mgd77/mgd77info.c
+++ b/src/mgd77/mgd77info.c
@@ -94,11 +94,11 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-C[m|e]");
-	GMT_Usage (API, -2, "List abbreviations of all columns present for each cruise.:");
+	GMT_Usage (API, -2, "List abbreviations of all columns present for each cruise:");
 	GMT_Usage (API, 3, "m: List just the MGD77 columns present");
 	GMT_Usage (API, 3, "e: List just any extra columns present");
 	GMT_Usage (API, 1, "\n-E[m|e]");
-	GMT_Usage (API, -2, "Give the information summary of each cruise's geographical/temporal extent.:");
+	GMT_Usage (API, -2, "Give the information summary of each cruise's geographical/temporal extent:");
 	GMT_Usage (API, 3, "m: Count just the number of non-NaN values for each MGD77 field.");
 	GMT_Usage (API, 3, "e: Count just the of non-NaN values for each extra field.");
 	GMT_Usage (API, 1, "\n-Mf[<item>]|r|e|h");

--- a/src/mgd77/mgd77info.c
+++ b/src/mgd77/mgd77info.c
@@ -85,11 +85,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> [-C[m|e]] [-E[m|e]] [-I<code>] [-Mf[<item>]|r|e|h] [-L[v]]\n\t[%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)> [-C[m|e]] [-E[m|e]] [-I<code>] [-Mf[<item>]|r|e|h] [-L[v]] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	MGD77_Init (API->GMT, &M);		/* Initialize MGD77 Machinery */
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-C List abbreviations of all columns present for each cruise.\n");

--- a/src/mgd77/mgd77list.c
+++ b/src/mgd77/mgd77list.c
@@ -184,165 +184,191 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77LIST_CTRL *C) {	/* Deal
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> -F<dataflags>[,<tests>] [-Ac|d|f|m|t[<code>][+f]]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-Da<startdate>] [-Db<stopdate>] [-E] [-Ga<startrec>] [-Gb<stoprec>] [-I<code>]\n\t[-L[<corrtable.txt>]] [-N[s|p]]] [-Qa|v<min>/<max>]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-Sa<startdist>] [-Sb<stopdist>]\n\t[-T[m|e]] [%s] [-W<Weight>] [-Z[n|p] [%s] [%s] [-h] [%s] [%s] [%s]\n\n", GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_do_OPT, GMT_j_OPT, GMT_colon_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)> -F<dataflags>[,<tests>] [-Ac|d|f|m|t[<code>][+f]] "
+		"[-Da|b<date>] [-E] [-Ga|b<rec>] [-Ia|c|m|t] [-L[<corrtable.txt>]] [-Nd|s<unit>] [-Qa|c|v<min>/<max>] "
+		"[%s] [-Sa|b<dist>] [-T[m|e]] [%s] [-W<Weight>] [-Z[n|p] [%s] [%s] [-h] [%s] [%s] [%s]\n",
+		name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_do_OPT, GMT_j_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
-	GMT_Message (API, GMT_TIME_NONE, "\t-F <dataflags> is a comma-separated string made up of one or more of these abbreviations\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   (for standard MGD77 files - use mgd77list to probe for other columns in MGD77+ files).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   >Track information.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     time:    Choose between Absolute time [default], Relative time, or fractional year.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       atime: Absolute time (formatted according to FORMAT_DATE_OUT, FORMAT_CLOCK_OUT).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       rtime: Relative time (formatted according to FORMAT_FLOAT_OUT and TIME_SYSTEM (or TIME_EPOCH, TIME_UNIT)).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       ytime: Absolute time as decimal year (formatted according to FORMAT_FLOAT_OUT).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       year:  Record year.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       month: Record month (1-12).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       day :  Record day of month (1-31).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       hour:  Record hour(0-23).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       min:   Record minute (0-59).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       sec:   Record second (0-60).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       dmin:  Decimal minute (0-59.xxxx).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       hhmm:  Clock hhmm.xxxx (0-2359.xxxx).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       date:  yyyymmdd string.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       tz :   Time zone adjustment in hours (-13 to +12).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     lon:     Longitude (formatted according to FORMAT_GEO_OUT).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     lat:     Latitude (formatted according to FORMAT_GEO_OUT).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     id:      Survey leg ID [string_output].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     ngdcid:  NGDC ID [TEXTSTRING].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     recno:   Record number.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   >Derived navigational information.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     dist:    Along-track distances (see -j for method and -N for units).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     azim:    Track azimuth (Degrees east from north).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     cc:      Course change, i.e., change in azimuth (Degrees east from north).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     vel:     Ship velocity (m/s).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   >Geophysical Observations.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     twt:     Two-way travel-time (s).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     depth:   Corrected bathymetry (m) [Also see -Z].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     mtf1:    Magnetic Total Field Sensor 1 (gamma, nTesla).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     mtf2:    Magnetic Total Field Sensor 2 (gamma, nTesla).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     mag:     Magnetic residual anomaly (gamma, nTesla).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     gobs:    Observed gravity (mGal).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     faa:     Free-air gravity anomaly (mGal).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   >Codes, Corrections, and Information.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     drt:     Data record type [5].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     ptc:     Position type code.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     bcc:     Bathymetric correction code.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     btc:     Bathymetric type code.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     msens:   Magnetic sensor for residual field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     msd:     Magnetic sensor depth/altitude (m).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     diur:    Magnetic diurnal correction (gamma, nTesla).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     eot:     Stored Eotvos correction (mGal).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     sln:     Seismic line number string [TEXTSTRING].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     sspn:    Seismic shot point number string [TEXTSTRING].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     nqc:     Navigation quality code.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   >Computed Information.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     carter:  Carter correction from twt (m).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     igrf:    International Geomagnetic Reference Field (gamma, nTesla).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     ceot:    Calculated Eotvos correction (mGal).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     ngrav:   IGF, or Theoretical (Normal) Gravity Field (mGal).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     weight:  Report weight as specified in -W [1].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  The data are written in the order specified in <dataflags>.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  Shortcut flags are.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     mgd77:   The full set of all 27 fields in the MGD77 specification.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     mgd77t:  The full set of all 26 columns in the MGD77T specification.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     geo:     time,lon,lat + the 7 geophysical observations.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     all:     As mgd77 but with time items written as a date-time string.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     allt:    As mgd77t but with time items written as a date-time string.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     dat:     As mgd77t but in plain table file order.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t    Append + to include the 5 derived quantities dist, azim, cc, vel, and weight [see -W]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t    [Default is all].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  Abbreviations in UPPER CASE will suppress records where any such column is NaN.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  (Note that -E is a shorthand to set all abbreviations to upper case).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  Optionally, append comma-separated logical tests that data columns must pass to be output.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  (Note: These checks do not applied to derived or computed data columns).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  Format is <flag><OP><value>, where flag is any of the dataflags above, and <OP> is\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  one of the operators <, <=, =, >=, >, |, and !=.  <value> is the limit you are testing,\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  including NaN (with = and != only).  If <flag> is UPPERCASE the test MUST be passed;\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  else at least ONE of the tests must pass for output to take place.  When using operators\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  involving characters <, >, and |, put entire argument to -F in single quotes.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  Finally, for MGD77+ files you may optionally append : followed by one or more comma-\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  separated -+|-<col> terms.  This compares specific E77 bitflags for each listed column\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  + means bit must be 1, - means it must be 0.  All bit tests given must be passed.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  By default, MGD77+ files with error bit flags will use the flags to suppress bad data.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  Turn this behavior off by append : with no arguments.  For controlling systematic\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  corrections encoded in MGD77+ files, see -T.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\n\tOPTIONS.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-A Adjust some data values before output. Append c|d|f|m|t to select field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   c<code>[,<v>] Adjust field carter. <v>, the sound velocity in water, is taken from\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     the MGD77 header (or 1500 if invalid); optionally append your <v> (in m/s)\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     Here, C(twt) is Carter correction, U(twt,v) is uncorrected depth (given <v>).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     TC(z) is twt from inverse Carter correction, TU(z,v) is twt from uncorrected depth.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       c1 return difference between U(twt,v) and depth [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       c2 return difference between U(twt,v) and Carter(twt).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       c4 return difference between (uncorrected) depth and Carter (TU(depth,v)).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       c8 return difference between U(TC(depth),v) and depth.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   d<code>[,<v>] Adjust field depth. <v> is optional sound speed in water (m/s)\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       d1 return depth as stored in file [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       d2 return calculated uncorrected depth U(twt,v).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       d4 return calculated corrected depth Carter (twt,v).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   f<code>[,<field>] Adjust field faa. <field>, the IGF reference field, is taken\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     from the MGD77 header (or 4 if invalid); optionally append your <field> from.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     1 = Heiskanen 1924 formula.\n\t       ");
+	GMT_Usage (API, 1, "\n-F<dataflags>[,<tests>]");
+	GMT_Usage (API, -2, "Give comma-separated string made up of one or more of these abbreviations "
+		"(for standard MGD77 files - use mgd77list to probe for other columns in MGD77+ files).");
+	GMT_Usage (API, -2, "%s Track information.:", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "time: Choose between Absolute time [default], Relative time, or fractional year:");
+	GMT_Usage (API, 4, "atime: Absolute time (formatted according to FORMAT_DATE_OUT, FORMAT_CLOCK_OUT).");
+	GMT_Usage (API, 4, "rtime: Relative time (formatted according to FORMAT_FLOAT_OUT and TIME_SYSTEM (or TIME_EPOCH, TIME_UNIT)).");
+	GMT_Usage (API, 4, "ytime: Absolute time as decimal year (formatted according to FORMAT_FLOAT_OUT).");
+	GMT_Usage (API, 4, "year:  Record year.");
+	GMT_Usage (API, 4, "month: Record month (1-12).");
+	GMT_Usage (API, 4, "day :  Record day of month (1-31).");
+	GMT_Usage (API, 4, "hour:  Record hour(0-23).");
+	GMT_Usage (API, 4, "min:   Record minute (0-59).");
+	GMT_Usage (API, 4, "sec:   Record second (0-60).");
+	GMT_Usage (API, 4, "dmin:  Decimal minute (0-59.xxxx).");
+	GMT_Usage (API, 4, "hhmm:  Clock hhmm.xxxx (0-2359.xxxx).");
+	GMT_Usage (API, 4, "date:  yyyymmdd string.");
+	GMT_Usage (API, 4, "tz :   Time zone adjustment in hours (-13 to +12).");
+	GMT_Usage (API, 3, "lon:     Longitude (formatted according to FORMAT_GEO_OUT).");
+	GMT_Usage (API, 3, "lat:     Latitude (formatted according to FORMAT_GEO_OUT).");
+	GMT_Usage (API, 3, "id:      Survey leg ID [string_output].");
+	GMT_Usage (API, 3, "ngdcid:  NGDC ID [TEXTSTRING].");
+	GMT_Usage (API, 3, "recno:   Record number.");
+	GMT_Usage (API, -2, "%s Derived navigational information.\n", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "dist:    Along-track distances (see -j for method and -N for units).");
+	GMT_Usage (API, 3, "azim:    Track azimuth (Degrees east from north).");
+	GMT_Usage (API, 3, "cc:      Course change, i.e., change in azimuth (Degrees east from north).");
+	GMT_Usage (API, 3, "vel:     Ship velocity (m/s).");
+	GMT_Usage (API, -2, "%s Geophysical Observations.\n", GMT_LINE_BULLET)
+	GMT_Usage (API, 3, "twt:     Two-way travel-time (s).");
+	GMT_Usage (API, 3, "depth:   Corrected bathymetry (m) [Also see -Z].");
+	GMT_Usage (API, 3, "mtf1:    Magnetic Total Field Sensor 1 (gamma, nTesla).");
+	GMT_Usage (API, 3, "mtf2:    Magnetic Total Field Sensor 2 (gamma, nTesla).");
+	GMT_Usage (API, 3, "mag:     Magnetic residual anomaly (gamma, nTesla).");
+	GMT_Usage (API, 3, "gobs:    Observed gravity (mGal).");
+	GMT_Usage (API, 3, "faa:     Free-air gravity anomaly (mGal).");
+	GMT_Usage (API, -2, "%s Codes, Corrections, and Information.\n", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "drt:     Data record type [5].");
+	GMT_Usage (API, 3, "ptc:     Position type code.");
+	GMT_Usage (API, 3, "bcc:     Bathymetric correction code.");
+	GMT_Usage (API, 3, "btc:     Bathymetric type code.");
+	GMT_Usage (API, 3, "msens:   Magnetic sensor for residual field.");
+	GMT_Usage (API, 3, "msd:     Magnetic sensor depth/altitude (m).");
+	GMT_Usage (API, 3, "diur:    Magnetic diurnal correction (gamma, nTesla).");
+	GMT_Usage (API, 3, "eot:     Stored Eotvos correction (mGal).");
+	GMT_Usage (API, 3, "sln:     Seismic line number string [TEXTSTRING].");
+	GMT_Usage (API, 3, "sspn:    Seismic shot point number string [TEXTSTRING].");
+	GMT_Usage (API, 3, "nqc:     Navigation quality code.");
+	GMT_Usage (API, -2, "%s Computed Information.\n", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "carter:  Carter correction from twt (m).");
+	GMT_Usage (API, 3, "igrf:    International Geomagnetic Reference Field (gamma, nTesla).");
+	GMT_Usage (API, 3, "ceot:    Calculated Eotvos correction (mGal).");
+	GMT_Usage (API, 3, "ngrav:   IGF, or Theoretical (Normal) Gravity Field (mGal).");
+	GMT_Usage (API, 3, "weight:  Report weight as specified in -W [1].");
+	GMT_Usage (API, -2, "Note: The data are written in the order specified in <dataflags>.");
+	GMT_Usage (API, -2, "Shortcut flags are:");
+	GMT_Usage (API, 3, "mgd77:   The full set of all 27 fields in the MGD77 specification.");
+	GMT_Usage (API, 3, "mgd77t:  The full set of all 26 columns in the MGD77T specification.");
+	GMT_Usage (API, 3, "geo:     time,lon,lat + the 7 geophysical observations.");
+	GMT_Usage (API, 3, "all:     As mgd77 but with time items written as a date-time string.");
+	GMT_Usage (API, 3, "allt:    As mgd77t but with time items written as a date-time string.");
+	GMT_Usage (API, 3, "dat:     As mgd77t but in plain table file order.");
+	GMT_Usage (API, -2, "Append + to include the 5 derived quantities dist, azim, cc, vel, and weight [see -W] "
+		"[Default is all].");
+	GMT_Usage (API, -2, "Note: Abbreviations in UPPER CASE will suppress records where any such column is NaN "
+		"(Note that -E is a shorthand to set all abbreviations to upper case).");
+	GMT_Usage (API, -2, "Optionally, append comma-separated logical tests that data columns must pass to be output. "
+		"(Note: These checks do not applied to derived or computed data columns). "
+		"Format is <flag><OP><value>, where flag is any of the dataflags above, and <OP> is "
+		"one of the operators <, <=, =, >=, >, |, and !=.  <value> is the limit you are testing, "
+		"including NaN (with = and != only).  If <flag> is UPPERCASE the test MUST be passed; "
+		"else at least ONE of the tests must pass for output to take place.  When using operators "
+		"involving characters <, >, and |, put entire argument to -F in single quotes. "
+		"Finally, for MGD77+ files you may optionally append : followed by one or more comma- "
+		"separated -+|-<col> terms.  This compares specific E77 bitflags for each listed column "
+		"+ means bit must be 1, - means it must be 0.  All bit tests given must be passed. "
+		"By default, MGD77+ files with error bit flags will use the flags to suppress bad data. "
+		"Turn this behavior off by append : with no arguments.  For controlling systematic "
+		"corrections encoded in MGD77+ files, see -T.");
+	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
+	GMT_Usage (API, 1, "\n-Ac|d|f|m|t[<code>][+f]");
+	GMT_Usage (API, -2, "Adjust some data values before output. Append c|d|f|m|t to select field:");
+	GMT_Usage (API, 3, "c: Append <code>[,<v>] to adjust field carter. <v>, the sound velocity in water, is taken from "
+		"the MGD77 header (or 1500 if invalid); optionally append your <v> (in m/s). "
+		"Here, C(twt) is Carter correction, U(twt,v) is uncorrected depth (given <v>), "
+		"TC(z) is twt from inverse Carter correction, TU(z,v) is twt from uncorrected depth. Available <code>:");
+	GMT_Usage (API, 4, "1: Return difference between U(twt,v) and depth [Default].");
+	GMT_Usage (API, 4, "2: Return difference between U(twt,v) and Carter(twt).");
+	GMT_Usage (API, 4, "4: Return difference between (uncorrected) depth and Carter (TU(depth,v)).");
+	GMT_Usage (API, 4, "8: Return difference between U(TC(depth),v) and depth.");
+	GMT_Usage (API, 3, "d: Append <code>[,<v>] to adjust field depth. <v> is optional sound speed in water (m/s). Available <code>:");
+	GMT_Usage (API, 4, "1: Return depth as stored in file [Default].");
+	GMT_Usage (API, 4, "2: Return calculated uncorrected depth U(twt,v).");
+	GMT_Usage (API, 4, "4: Return calculated corrected depth Carter (twt,v).");
+	GMT_Usage (API, 3, "f: Append <code>[,<field>] to adjust field faa. <field>, the IGF reference field, is taken "
+		"from the MGD77 header (or 4 if invalid). Available <code>:");
+	GMT_Usage (API, 4, "1: Return faa as stored in file [Default].");
+	GMT_Usage (API, 4, "2: Return difference gobs - ngrav.");
+	GMT_Usage (API, 4, "4: Return difference gobs + eot - ngrav.");
+	GMT_Usage (API, 4, "8: Return difference gobs + ceot - ngrav.");
+	GMT_Usage (API, -3, "Pptionally append your <field>:");
+	GMT_Usage (API, 4, "1: Heiskanen 1924 formula. ");
 	MGD77_IGF_text (API->GMT, API->GMT->session.std[GMT_ERR], 1);
-	GMT_Message (API, GMT_TIME_NONE, "\t     2 = International 1930 formula.\n\t       ");
+	GMT_Usage (API, 4, "2: International 1930 formula. ");
 	MGD77_IGF_text (API->GMT, API->GMT->session.std[GMT_ERR], 2);
-	GMT_Message (API, GMT_TIME_NONE, "\t     3 = International 1967 formula.\n\t       ");
+	GMT_Usage (API, 4, "3: International 1967 formula. ");
 	MGD77_IGF_text (API->GMT, API->GMT->session.std[GMT_ERR], 3);
-	GMT_Message (API, GMT_TIME_NONE, "\t     4 = International 1980 formula.\n\t       ");
+	GMT_Usage (API, 4, "4: International 1980 formula. ");
 	MGD77_IGF_text (API->GMT, API->GMT->session.std[GMT_ERR], 4);
-	GMT_Message (API, GMT_TIME_NONE, "\t       f1 return faa as stored in file [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       f2 return difference gobs - ngrav.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       f4 return difference gobs + eot - ngrav.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       f8 return difference gobs + ceot - ngrav.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   m<code> Adjust field mag.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       m1  return mag as stored in file [Default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       m2  return difference mtfx - igrf, where x = msens (or 1 if undefined).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       m4  return difference mtfx - igrf, where x != msens (or 2 if undefined).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       m8  return difference mtfx + diur - igrf, where x = msens (or 1 if undefined).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       m16 return difference mtfx + diur - igrf, where x != msens (or 2 if undefined).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t       mc<offset> Apply cable tow distance correction to mtf1.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   t will compute fake times for cruises with known duration but lacking record times.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append +f to force selected anomalies to be recalculated even when the original\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   anomaly is NaN [Default honors NaNs in existing anomalies].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D List from a<date> (given as yyyy-mm-ddT[hh:mm:ss]) [Start of cruise]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   up to b<date> (given as yyyy-mm-ddT[hh:mm:ss]) [End of cruise].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   If A|B is used instead or a|b then records with no time are excluded from output.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-E Output records that exactly matches the requested geophysical information in -F\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   [Default will output all record that matches at least one column].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-G List from given a<record> [Start of cruise] up to given b<record> [End of cruise].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Ignore certain data file formats from consideration. Append combination of act to ignore\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   (a) MGD77 ASCII, (c) MGD77+ netCDF, (m) MGD77T ASCII, or (t) plain table files. [Default ignores none].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Subtract systematic corrections from the data. If no correction file is given,\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   the default file mgd77_corrections.txt in $MGD77_HOME is assumed.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Append (d)istances or (s)peed, and your choice for unit. Choose among.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   e Metric units I (meters, m/s).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   f British/US units I (feet, feet/s).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   k Metric units II (km, km/hr).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   M British/US units II (miles, miles/hr).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   n Nautical units (nautical miles, knots).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   u Old US units (survey feet, sfeets).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   [Default is -Ndk -Nse].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-Q Return data whose azimuth (-Qa) or velocity (-Qv) fall inside specified range.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -Qa<min_az>/<max_az>, where <min_az> < <max_az> [all azimuths, i.e., 0/360].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -Qc<min_cc>/<max_cc>, where <min_cc> < <max_cc> [all course changes, i.e., -360/360].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      Use -QC to use abs value |cc| in the test [0/360].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -Qv<min_vel>[/<max_vel>], where <max_vel> is optional [all velocities, i.e., 0/infinity].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      Velocities are given in m/s unless changed by -Ns.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-R Return data inside the specified region only [0/360/-90/90].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Begin list from a<startdist>; append unit from %s [meter] [Start of cruise]\n", GMT_LEN_UNITS2_DISPLAY);
-	GMT_Message (API, GMT_TIME_NONE, "\t   End list at b<stopdist> [End of cruise].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-T Turn OFF the otherwise automatic adjustment of values based on correction terms\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   stored in the mgd77+ file (option has no effect on plain MGD77 ASCII files).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append m or e to indicate the MGD77 data set or the extended columns set [Default is both].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   For controlling application of point bit flags, see -F and the : modifier discussion.\n");
+	GMT_Usage (API, 3, "m: Append <code> to adjust field mag:");
+	GMT_Usage (API, 4, "1: Return mag as stored in file [Default].");
+	GMT_Usage (API, 4, "2: Return difference mtfx - igrf, where x = msens (or 1 if undefined).");
+	GMT_Usage (API, 4, "4: Return difference mtfx - igrf, where x != msens (or 2 if undefined).");
+	GMT_Usage (API, 4, "8: Return difference mtfx + diur - igrf, where x = msens (or 1 if undefined).");
+	GMT_Usage (API, 4, "16: Return difference mtfx + diur - igrf, where x != msens (or 2 if undefined).");
+	GMT_Usage (API, 4, "c: Append <offset> to apply cable tow distance correction to mtf1.");
+	GMT_Usage (API, 3, "t: Compute fake times for cruises with known duration but lacking record times.");
+	GMT_Usage (API, -2, "Append +f to force selected anomalies to be recalculated even when the original "
+		"anomaly is NaN [Default honors NaNs in existing anomalies].");
+	GMT_Usage (API, 1, "\n-Da|b<date>");
+	GMT_Usage (API, -2, "Limit output based on time. Append a directive and date (given as yyyy-mm-ddT[hh:mm:ss]); repeatable:");
+	GMT_Usage (API, 3, "a: Start output at this time [Start of cruise].");
+	GMT_Usage (API, 3, "b: End output at this time [End of cruise].");
+	GMT_Usage (API, -2, "Note: If A|B is used instead or a|b then records with no time are excluded from output.");
+	GMT_Usage (API, 1, "\n-E Output records that exactly matches the requested geophysical information in -F "
+		"[Default will output all record that matches at least one column].");
+	GMT_Usage (API, 1, "\n-Ga|b<rec>");
+	GMT_Usage (API, -2, "Limit output based on record numbers. Append a directive and record number; repeatable:");
+	GMT_Usage (API, 3, "a: Start output at this record number [Start of cruise].");
+	GMT_Usage (API, 3, "b: End output at this record number [End of cruise].");
+	GMT_Usage (API, 1, "\n-Ia|c|m|t");
+	GMT_Usage (API, -2, "Ignore certain data file formats from consideration. Append combination of acmt to ignore [Default ignores none]:");
+	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
+	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
+	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
+	GMT_Usage (API, 3, "t: Plain table.");
+	GMT_Usage (API, 1, "\n-L[<corrtable.txt>]");
+	GMT_Usage (API, -2, "Subtract systematic corrections from the data. If no correction file is given, "
+		"the default file mgd77_corrections.txt in $MGD77_HOME is assumed.");
+	GMT_Usage (API, 1, "\n-Nd|s<unit>");
+	GMT_Usage (API, -2, "Control units for (d)istances or (s)peed, and append you choice for unit. Choose among:");
+	GMT_Usage (API, 3, "e: Metric units I (meters, m/s).");
+	GMT_Usage (API, 3, "f: British/US units I (feet, feet/s).");
+	GMT_Usage (API, 3, "k: Metric units II (km, km/hr).");
+	GMT_Usage (API, 3, "M: British/US units II (miles, miles/hr).");
+	GMT_Usage (API, 3, "n: Nautical units (nautical miles, knots).");
+	GMT_Usage (API, 3, "u: Old US units (survey feet, sfeet/s).");
+	GMT_Usage (API, -2, "[Default is -Ndk -Nse].");
+	GMT_Usage (API, 1, "\n-Qa|c|v<min>/<max>");
+	GMT_Usage (API, -2, "Return data whose azimuth (-Qa), course changes (-Qc) or velocity (-Qv) fall inside specified range:");
+	GMT_Usage (API, 3, "a: Append <min_az>/<max_az>, where <min_az> < <max_az> [all azimuths, i.e., 0/360].");
+	GMT_Usage (API, 3, "c: Append <min_cc>/<max_cc>, where <min_cc> < <max_cc> [all course changes, i.e., -360/360]. "
+		"Use -QC to use abs value |cc| in the test [0/360].");
+	GMT_Usage (API, 3, "v: Append <min_vel>[/<max_vel>], where <max_vel> is optional [all velocities, i.e., 0/infinity]. "
+		"Velocities are given in m/s unless changed by -Ns.");
+	GMT_Usage (API, 1, "\n%s", GMT_Rgeo_OPT);
+	GMT_Usage (API, -2, "Return data inside the specified region only [0/360/-90/90].");
+	GMT_Usage (API, 1, "\n-Ga|b<rec>");
+	GMT_Usage (API, -2, "Limit output based on distance along cruise. Append a directive and distance (with optional unit from %s [meter]); repeatable:", GMT_LEN_UNITS2_DISPLAY);
+	GMT_Usage (API, 3, "a: Start output at this distance[Start of cruise].");
+	GMT_Usage (API, 3, "b: End output at this distance [End of cruise].");
+	GMT_Usage (API, 1, "\n-T[m|e]");
+	GMT_Usage (API, -2, "Turn OFF the otherwise automatic adjustment of values based on correction terms "
+		"stored in the mgd77+ file (option has no effect on plain MGD77 ASCII files). Optionally append directives to adjust one set only [Default adjusts both]:");
+	GMT_Usage (API, 3, "m: Select the MGD77 data set.");
+	GMT_Usage (API, 3, "e: Select the extended columns set.");
+	GMT_Usage (API, -2, "Note: For controlling application of point bit flags, see -F and the : modifier discussion.");
 	GMT_Option (API, "V");
-	GMT_Message (API, GMT_TIME_NONE, "\t-W Set weight for these data [1].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-Z Append n to report bathymetry and msd as negative depths [Default is positive -Zp].\n");
+	GMT_Usage (API, 1, "\n-W<Weight>");
+	GMT_Usage (API, -2, "Set weight for these data [1].");
+	GMT_Usage (API, 1, "\n-Z[n|p]");
+	GMT_Usage (API, -2, "Control the direction of positive depth.  Choose one of:");
+	GMT_Usage (API, 3, "n: Report bathymetry and msd as negative depths.");
+	GMT_Usage (API, 3, "p: Report bathymetry and msd as positive depths [Default].");
 	GMT_Option (API, "bo,do");
-	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t-h Write header record with column information [Default is no header].\n");
+	GMT_Usage (API, 1, "\n-h Write header record with column information [Default is no header].");
 	GMT_Option (API, "j,:,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/mgd77/mgd77list.c
+++ b/src/mgd77/mgd77list.c
@@ -221,7 +221,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "azim:    Track azimuth (Degrees east from north).");
 	GMT_Usage (API, 3, "cc:      Course change, i.e., change in azimuth (Degrees east from north).");
 	GMT_Usage (API, 3, "vel:     Ship velocity (m/s).");
-	GMT_Usage (API, -2, "%s Geophysical Observations.\n", GMT_LINE_BULLET)
+	GMT_Usage (API, -2, "%s Geophysical Observations.\n", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "twt:     Two-way travel-time (s).");
 	GMT_Usage (API, 3, "depth:   Corrected bathymetry (m) [Also see -Z].");
 	GMT_Usage (API, 3, "mtf1:    Magnetic Total Field Sensor 1 (gamma, nTesla).");
@@ -350,7 +350,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Velocities are given in m/s unless changed by -Ns.");
 	GMT_Usage (API, 1, "\n%s", GMT_Rgeo_OPT);
 	GMT_Usage (API, -2, "Return data inside the specified region only [0/360/-90/90].");
-	GMT_Usage (API, 1, "\n-Ga|b<rec>");
+	GMT_Usage (API, 1, "\n-Sa|b<dist>");
 	GMT_Usage (API, -2, "Limit output based on distance along cruise. Append a directive and distance (with optional unit from %s [meter]); repeatable:", GMT_LEN_UNITS2_DISPLAY);
 	GMT_Usage (API, 3, "a: Start output at this distance[Start of cruise].");
 	GMT_Usage (API, 3, "b: End output at this distance [End of cruise].");

--- a/src/mgd77/mgd77list.c
+++ b/src/mgd77/mgd77list.c
@@ -185,8 +185,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <cruise(s)> -F<dataflags>[,<tests>] [-Ac|d|f|m|t[<code>][+f]] "
-		"[-Da|b<date>] [-E] [-Ga|b<rec>] [-Ia|c|m|t] [-L[<corrtable.txt>]] [-Nd|s<unit>] [-Qa|c|v<min>/<max>] "
-		"[%s] [-Sa|b<dist>] [-T[m|e]] [%s] [-W<Weight>] [-Z[n|p] [%s] [%s] [-h] [%s] [%s] [%s]\n",
+		"[-Da|b<date>] [-E] [-Ga|b<rec>] [-Ia|c|m|t] [-L[<corrtable>]] [-Nd|s<unit>] [-Qa|c|v<min>/<max>] "
+		"[%s] [-Sa|b<dist>] [-T[m|e]] [%s] [-W<weight>] [-Z[n|p] [%s] [%s] [-h] [%s] [%s] [%s]\n",
 		name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_do_OPT, GMT_j_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -196,7 +196,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-F<dataflags>[,<tests>]");
 	GMT_Usage (API, -2, "Give comma-separated string made up of one or more of these abbreviations "
 		"(for standard MGD77 files - use mgd77list to probe for other columns in MGD77+ files).");
-	GMT_Usage (API, -2, "%s Track information.:", GMT_LINE_BULLET);
+	GMT_Usage (API, -2, "%s Track information:", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "time: Choose between Absolute time [default], Relative time, or fractional year:");
 	GMT_Usage (API, 4, "atime: Absolute time (formatted according to FORMAT_DATE_OUT, FORMAT_CLOCK_OUT).");
 	GMT_Usage (API, 4, "rtime: Relative time (formatted according to FORMAT_FLOAT_OUT and TIME_SYSTEM (or TIME_EPOCH, TIME_UNIT)).");
@@ -216,12 +216,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "id:      Survey leg ID [string_output].");
 	GMT_Usage (API, 3, "ngdcid:  NGDC ID [TEXTSTRING].");
 	GMT_Usage (API, 3, "recno:   Record number.");
-	GMT_Usage (API, -2, "%s Derived navigational information.\n", GMT_LINE_BULLET);
+	GMT_Usage (API, -2, "%s Derived navigational information:", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "dist:    Along-track distances (see -j for method and -N for units).");
 	GMT_Usage (API, 3, "azim:    Track azimuth (Degrees east from north).");
 	GMT_Usage (API, 3, "cc:      Course change, i.e., change in azimuth (Degrees east from north).");
 	GMT_Usage (API, 3, "vel:     Ship velocity (m/s).");
-	GMT_Usage (API, -2, "%s Geophysical Observations.\n", GMT_LINE_BULLET);
+	GMT_Usage (API, -2, "%s Geophysical Observations:", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "twt:     Two-way travel-time (s).");
 	GMT_Usage (API, 3, "depth:   Corrected bathymetry (m) [Also see -Z].");
 	GMT_Usage (API, 3, "mtf1:    Magnetic Total Field Sensor 1 (gamma, nTesla).");
@@ -229,7 +229,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "mag:     Magnetic residual anomaly (gamma, nTesla).");
 	GMT_Usage (API, 3, "gobs:    Observed gravity (mGal).");
 	GMT_Usage (API, 3, "faa:     Free-air gravity anomaly (mGal).");
-	GMT_Usage (API, -2, "%s Codes, Corrections, and Information.\n", GMT_LINE_BULLET);
+	GMT_Usage (API, -2, "%s Codes, Corrections, and Information:", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "drt:     Data record type [5].");
 	GMT_Usage (API, 3, "ptc:     Position type code.");
 	GMT_Usage (API, 3, "bcc:     Bathymetric correction code.");
@@ -241,21 +241,21 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "sln:     Seismic line number string [TEXTSTRING].");
 	GMT_Usage (API, 3, "sspn:    Seismic shot point number string [TEXTSTRING].");
 	GMT_Usage (API, 3, "nqc:     Navigation quality code.");
-	GMT_Usage (API, -2, "%s Computed Information.\n", GMT_LINE_BULLET);
+	GMT_Usage (API, -2, "%s Computed Information:", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "carter:  Carter correction from twt (m).");
 	GMT_Usage (API, 3, "igrf:    International Geomagnetic Reference Field (gamma, nTesla).");
 	GMT_Usage (API, 3, "ceot:    Calculated Eotvos correction (mGal).");
 	GMT_Usage (API, 3, "ngrav:   IGF, or Theoretical (Normal) Gravity Field (mGal).");
 	GMT_Usage (API, 3, "weight:  Report weight as specified in -W [1].");
 	GMT_Usage (API, -2, "Note: The data are written in the order specified in <dataflags>.");
-	GMT_Usage (API, -2, "Shortcut flags are:");
+	GMT_Usage (API, -2, "Special group shortcut flags are available:");
 	GMT_Usage (API, 3, "mgd77:   The full set of all 27 fields in the MGD77 specification.");
 	GMT_Usage (API, 3, "mgd77t:  The full set of all 26 columns in the MGD77T specification.");
 	GMT_Usage (API, 3, "geo:     time,lon,lat + the 7 geophysical observations.");
 	GMT_Usage (API, 3, "all:     As mgd77 but with time items written as a date-time string.");
 	GMT_Usage (API, 3, "allt:    As mgd77t but with time items written as a date-time string.");
 	GMT_Usage (API, 3, "dat:     As mgd77t but in plain table file order.");
-	GMT_Usage (API, -2, "Append + to include the 5 derived quantities dist, azim, cc, vel, and weight [see -W] "
+	GMT_Usage (API, -2, "Append + to any shortcut include the five derived quantities dist, azim, cc, vel, and weight [see -W] "
 		"[Default is all].");
 	GMT_Usage (API, -2, "Note: Abbreviations in UPPER CASE will suppress records where any such column is NaN "
 		"(Note that -E is a shorthand to set all abbreviations to upper case).");
@@ -277,31 +277,31 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Adjust some data values before output. Append c|d|f|m|t to select field:");
 	GMT_Usage (API, 3, "c: Append <code>[,<v>] to adjust field carter. <v>, the sound velocity in water, is taken from "
 		"the MGD77 header (or 1500 if invalid); optionally append your <v> (in m/s). "
-		"Here, C(twt) is Carter correction, U(twt,v) is uncorrected depth (given <v>), "
-		"TC(z) is twt from inverse Carter correction, TU(z,v) is twt from uncorrected depth. Available <code>:");
+		"Below, C(twt) is Carter correction, U(twt,v) is uncorrected depth (given <v>), "
+		"TC(z) is twt from inverse Carter correction, TU(z,v) is twt from uncorrected depth. Select a <code>:");
 	GMT_Usage (API, 4, "1: Return difference between U(twt,v) and depth [Default].");
 	GMT_Usage (API, 4, "2: Return difference between U(twt,v) and Carter(twt).");
 	GMT_Usage (API, 4, "4: Return difference between (uncorrected) depth and Carter (TU(depth,v)).");
 	GMT_Usage (API, 4, "8: Return difference between U(TC(depth),v) and depth.");
-	GMT_Usage (API, 3, "d: Append <code>[,<v>] to adjust field depth. <v> is optional sound speed in water (m/s). Available <code>:");
+	GMT_Usage (API, 3, "d: Append <code>[,<v>] to adjust field depth. <v> is optional sound speed in water (m/s). Select a <code>:");
 	GMT_Usage (API, 4, "1: Return depth as stored in file [Default].");
 	GMT_Usage (API, 4, "2: Return calculated uncorrected depth U(twt,v).");
 	GMT_Usage (API, 4, "4: Return calculated corrected depth Carter (twt,v).");
 	GMT_Usage (API, 3, "f: Append <code>[,<field>] to adjust field faa. <field>, the IGF reference field, is taken "
-		"from the MGD77 header (or 4 if invalid). Available <code>:");
+		"from the MGD77 header (or 4 if invalid). Select a <code>:");
 	GMT_Usage (API, 4, "1: Return faa as stored in file [Default].");
 	GMT_Usage (API, 4, "2: Return difference gobs - ngrav.");
 	GMT_Usage (API, 4, "4: Return difference gobs + eot - ngrav.");
 	GMT_Usage (API, 4, "8: Return difference gobs + ceot - ngrav.");
-	GMT_Usage (API, -3, "Pptionally append your <field>:");
-	GMT_Usage (API, 4, "1: Heiskanen 1924 formula. ");
-	MGD77_IGF_text (API->GMT, API->GMT->session.std[GMT_ERR], 1);
-	GMT_Usage (API, 4, "2: International 1930 formula. ");
-	MGD77_IGF_text (API->GMT, API->GMT->session.std[GMT_ERR], 2);
-	GMT_Usage (API, 4, "3: International 1967 formula. ");
-	MGD77_IGF_text (API->GMT, API->GMT->session.std[GMT_ERR], 3);
-	GMT_Usage (API, 4, "4: International 1980 formula. ");
-	MGD77_IGF_text (API->GMT, API->GMT->session.std[GMT_ERR], 4);
+	GMT_Usage (API, -4, "Optionally append your <field>:");
+	GMT_Usage (API, 5, "1: Heiskanen 1924 formula. ");
+	MGD77_IGF_text (API, 5, 1);
+	GMT_Usage (API, 5, "2: International 1930 formula. ");
+	MGD77_IGF_text (API, 5, 2);
+	GMT_Usage (API, 5, "3: International 1967 formula. ");
+	MGD77_IGF_text (API, 5, 3);
+	GMT_Usage (API, 5, "4: International 1980 formula. ");
+	MGD77_IGF_text (API, 5, 4);
 	GMT_Usage (API, 3, "m: Append <code> to adjust field mag:");
 	GMT_Usage (API, 4, "1: Return mag as stored in file [Default].");
 	GMT_Usage (API, 4, "2: Return difference mtfx - igrf, where x = msens (or 1 if undefined).");
@@ -317,8 +317,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "a: Start output at this time [Start of cruise].");
 	GMT_Usage (API, 3, "b: End output at this time [End of cruise].");
 	GMT_Usage (API, -2, "Note: If A|B is used instead or a|b then records with no time are excluded from output.");
-	GMT_Usage (API, 1, "\n-E Output records that exactly matches the requested geophysical information in -F "
-		"[Default will output all record that matches at least one column].");
+	GMT_Usage (API, 1, "\n-E Output records that exactly match the requested geophysical information in -F "
+		"[Default will output all records that match at least one column].");
 	GMT_Usage (API, 1, "\n-Ga|b<rec>");
 	GMT_Usage (API, -2, "Limit output based on record numbers. Append a directive and record number; repeatable:");
 	GMT_Usage (API, 3, "a: Start output at this record number [Start of cruise].");
@@ -329,11 +329,11 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
 	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
 	GMT_Usage (API, 3, "t: Plain table.");
-	GMT_Usage (API, 1, "\n-L[<corrtable.txt>]");
+	GMT_Usage (API, 1, "\n-L[<corrtable>]");
 	GMT_Usage (API, -2, "Subtract systematic corrections from the data. If no correction file is given, "
 		"the default file mgd77_corrections.txt in $MGD77_HOME is assumed.");
 	GMT_Usage (API, 1, "\n-Nd|s<unit>");
-	GMT_Usage (API, -2, "Control units for (d)istances or (s)peed, and append you choice for unit. Choose among:");
+	GMT_Usage (API, -2, "Control units for (d)istances or (s)peed, and append you choice for unit; repeatable. Choose among:");
 	GMT_Usage (API, 3, "e: Metric units I (meters, m/s).");
 	GMT_Usage (API, 3, "f: British/US units I (feet, feet/s).");
 	GMT_Usage (API, 3, "k: Metric units II (km, km/hr).");
@@ -342,7 +342,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "u: Old US units (survey feet, sfeet/s).");
 	GMT_Usage (API, -2, "[Default is -Ndk -Nse].");
 	GMT_Usage (API, 1, "\n-Qa|c|v<min>/<max>");
-	GMT_Usage (API, -2, "Return data whose azimuth (-Qa), course changes (-Qc) or velocity (-Qv) fall inside specified range:");
+	GMT_Usage (API, -2, "Return data whose (a)zimuth, (c)ourse changes or (v)elocity fall inside specified range:");
 	GMT_Usage (API, 3, "a: Append <min_az>/<max_az>, where <min_az> < <max_az> [all azimuths, i.e., 0/360].");
 	GMT_Usage (API, 3, "c: Append <min_cc>/<max_cc>, where <min_cc> < <max_cc> [all course changes, i.e., -360/360]. "
 		"Use -QC to use abs value |cc| in the test [0/360].");
@@ -352,7 +352,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Return data inside the specified region only [0/360/-90/90].");
 	GMT_Usage (API, 1, "\n-Sa|b<dist>");
 	GMT_Usage (API, -2, "Limit output based on distance along cruise. Append a directive and distance (with optional unit from %s [meter]); repeatable:", GMT_LEN_UNITS2_DISPLAY);
-	GMT_Usage (API, 3, "a: Start output at this distance[Start of cruise].");
+	GMT_Usage (API, 3, "a: Start output at this distance [Start of cruise].");
 	GMT_Usage (API, 3, "b: End output at this distance [End of cruise].");
 	GMT_Usage (API, 1, "\n-T[m|e]");
 	GMT_Usage (API, -2, "Turn OFF the otherwise automatic adjustment of values based on correction terms "
@@ -361,10 +361,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "e: Select the extended columns set.");
 	GMT_Usage (API, -2, "Note: For controlling application of point bit flags, see -F and the : modifier discussion.");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W<Weight>");
+	GMT_Usage (API, 1, "\n-W<weight>");
 	GMT_Usage (API, -2, "Set weight for these data [1].");
 	GMT_Usage (API, 1, "\n-Z[n|p]");
-	GMT_Usage (API, -2, "Control the direction of positive depth.  Choose one of:");
+	GMT_Usage (API, -2, "Control the direction of positive depth.  Choose between:");
 	GMT_Usage (API, 3, "n: Report bathymetry and msd as negative depths.");
 	GMT_Usage (API, 3, "p: Report bathymetry and msd as positive depths [Default].");
 	GMT_Option (API, "bo,do");

--- a/src/mgd77/mgd77magref.c
+++ b/src/mgd77/mgd77magref.c
@@ -84,75 +84,85 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77MAGREF_CTRL *C) {	/* De
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s [<table>] [-A+y+a<alt>+t<date>] [-C<cm4file>] [-D<dstfile>] [-E<f107file>]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-F<rthxyzdi[/[0|9]1234567]>] [-G] [-L<rtxyz[/1234]>] [-Sc|l<low>/<high>] [%s]\n", GMT_V_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [%s] [%s]\n\t[%s] [%s] [%s]\n\n", GMT_b_OPT, GMT_d_OPT, GMT_h_OPT, GMT_o_OPT, GMT_colon_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s [<table>] [-A+y+a<alt>+t<date>] [-C<cm4file>] [-D<dstfile>] [-E<f107file>] "
+		"[-Frthxyzdi[/[0|9]1234567]] [-G] [-Lrtxyz[/1234]] [-Sc|l<low>/<high>] [%s "
+		"[%s] [%s] [%s] [%s] [%s] [%s]\n",
+		name, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_h_OPT, GMT_o_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
+	GMT_Usage (API, 1, "\n<table>");
+	GMT_Usage (API, -2, "File with records that must contain lon, lat, alt, time[, other cols]. "
+		"longitude and latitude is the geocentric position on the ellipsoid [but see -G]. "
+		"alt is the altitude in km positive above the ellipsoid. "
+		"time is the time of data acquisition, in <date>T<clock> format (but see -A+y). "
+		"We read <stdin> if no input file is given.");
 	GMT_Message (API, GMT_TIME_NONE, "  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t<table> contains records that must contain lon, lat, alt, time[, other cols].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   longitude and latitude is the geocentric position on the ellipsoid [but see -G].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   alt is the altitude in km positive above the ellipsoid.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   time is the time of data acquisition, in <date>T<clock> format (but see -A+y).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   We read <stdin> if no input file is given.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-A Adjust how the input records are interpreted. Append\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   +a<alt> to indicate a constant altitude [Default is 3rd column].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   +t<time> to indicate a constant time [Default is 4th column].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   +y to indicate times are given in decimal years [Default is ISO <date>T<clock> format].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-C Select an alternate file with coefficients for the CM4 model [%s/umdl.CM4].\n",
+	GMT_Usage (API, 1, "\n-A+y+a<alt>+t<date>");
+	GMT_Usage (API, -2, "Adjust how the input records are interpreted. Append modifiers:");
+	GMT_Usage (API, 3, "+a Append <alt> to indicate a constant altitude [Default is 3rd column].");
+	GMT_Usage (API, 3, "+t Append <time> to indicate a constant time [Default is 4th column].");
+	GMT_Usage (API, 3, "+y Indicate times are given in decimal years [Default is ISO <date>T<clock> format].");
+	GMT_Usage (API, 1, "\n-C<cm4file>");
+	GMT_Usage (API, -2, "Select an alternate file with coefficients for the CM4 model [%s/umdl.CM4].",
 		API->GMT->session.SHAREDIR);
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Select an alternate file with hourly means of the Dst index for CM4 [%s/Dst_all.wdc],\n",
+	GMT_Usage (API, 1, "\n-D<dstfile>");
+	GMT_Usage (API, -2, "Select an alternate file with hourly means of the Dst index for CM4 [%s/Dst_all.wdc], "
+		"OR a single Dst index to apply for all records.",
 		API->GMT->session.SHAREDIR);
-	GMT_Message (API, GMT_TIME_NONE, "\t   OR a single Dst index to apply for all records.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-E Select an alternate file with monthly means of absolute F10.7 solar radio flux for CM4 [%s/F107_mon.plt],\n",
+	GMT_Usage (API, 1, "\n-E<f107file>");
+	GMT_Usage (API, -2, "Select an alternate file with monthly means of absolute F10.7 solar radio flux for CM4 [%s/F107_mon.plt], "
+		"OR a single solar radio flux to apply for all records.",
 		API->GMT->session.SHAREDIR);
-	GMT_Message (API, GMT_TIME_NONE, "\t   OR a single solar radio flux to apply for all records.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-F Dataflags is a string made up of 1 or more of these characters:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 r means output all input columns before adding the items below (all in nTesla).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 t means list total field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 h means list horizontal field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 x means list X component.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 y means list Y component.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 z means list Z component.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 d means list declination.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 i means list inclination.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append a number to indicate the requested field contribution(s):\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 0 means Core field from IGRF only (no CM4 evaluation).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 1 means Core field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 2 means Lithospheric field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 3 Primary Magnetospheric field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 4 Induced Magnetospheric field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 5 Primary ionospheric field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 6 Induced ionospheric field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 7 Toroidal field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 9 means Core field from IGRF and other contributions from CM4. DO NOT USE BOTH 1 AND 9.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append several numbers to add up the different contributions. For example,\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Ft/12 computes the total field due to CM4 Core and Lithospheric sources.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     Two special cases are allowed which mix which Core field from IGRF and other sources from CM4.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Ft/934 computes Core field due to IGRF plus terms 3 and 4 from CM4.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Fxyz/934 the same as above but output the field components.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 The data is written out in the order specified in <dataflags>\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 [Default is -Frthxyzdi/1]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-G Specify that coordinates are geocentric [geodetic].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Compute J field vectors from certain external sources.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Dataflags is a string made up of 1 or more of these characters:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 r means output all input columns before adding the items below (all in Ampers/m).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 t means list magnitude field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 x means list X component.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 y means list Y component.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 z means list Z or current function Psi.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append a number to indicate the requested J contribution(s)\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 1 means Induced Magnetospheric field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 2 means Primary ionospheric field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 3 means Induced ionospheric field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t	 4 means Poloidal field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Limit the CM4 contributions from core and lithosphere to certain harmonic degree bands.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append c(ore) or l(ithosphere) and the low and high degrees to use [-Sc1/13 -Sl14/65].\n");
+	GMT_Usage (API, 1, "\n-Frthxyzdi[/[0|9]1234567]");
+	GMT_Usage (API, -2, "Dataflags is a string made up of one or more of these characters:");
+	GMT_Usage (API, 3, "r: Output all input columns before adding the items below (all in nTesla).");
+	GMT_Usage (API, 3, "t: List total field.");
+	GMT_Usage (API, 3, "h: List horizontal field.");
+	GMT_Usage (API, 3, "x: List X component.");
+	GMT_Usage (API, 3, "y: List Y component.");
+	GMT_Usage (API, 3, "z: List Z component.");
+	GMT_Usage (API, 3, "d: List declination.");
+	GMT_Usage (API, 3, "i: List inclination.");
+	GMT_Usage (API, -2, "Optionally, append a number to indicate the requested field contribution(s):");
+	GMT_Usage (API, 3, "0: Core field from IGRF only (no CM4 evaluation).");
+	GMT_Usage (API, 3, "1: Core field.\n");
+	GMT_Usage (API, 3, "2: Lithosphericield.");
+	GMT_Usage (API, 3, "3: Primary Magnetospheric field.");
+	GMT_Usage (API, 3, "4: Induced Magnetospheric field.");
+	GMT_Usage (API, 3, "5: Primary ionospheric field.");
+	GMT_Usage (API, 3, "6: Induced ionospheric field.");
+	GMT_Usage (API, 3, "7: Toroidal field.");
+	GMT_Usage (API, 3, "9: Core field from IGRF and other contributions from CM4. DO NOT USE BOTH 1 AND 9.");
+	GMT_Usage (API, -2, "Note: Append several numbers to add up the different contributions. For example, "
+		"-Ft/12 computes the total field due to CM4 Core and Lithospheric sources. "
+		"Two special cases are allowed which mix Core field from IGRF and other sources from CM4: "
+		"-Ft/934 computes Core field due to IGRF plus terms 3 and 4 from CM4. "
+		"-Fxyz/934 the same as above but output the field components. "
+		"The data are written out in the order specified "
+		"[Default is -Frthxyzdi/1].");
+	GMT_Usage (API, 1, "\n-G Specify that coordinates are geocentric [geodetic].");
+	GMT_Usage (API, 1, "\n-Lrtxyz[/1234]");
+	GMT_Usage (API, -2, "Compute J field vectors from certain external sources. "
+		"Append a string made up of 1 or more of these characters:");
+		GMT_Usage (API, 3, "r: Output all input columns before adding the items below (all in Ampers/m).");
+		GMT_Usage (API, 3, "t: List magnitude field.");
+		GMT_Usage (API, 3, "x: List X component.");
+		GMT_Usage (API, 3, "y: List Y component.");
+		GMT_Usage (API, 3, "z: List Z or current function Psi.");
+	GMT_Usage (API, -2, "Optionally, append a number to indicate the requested J contribution(s):");
+	GMT_Usage (API, -2, "1: Induced Magnetospheric field.");
+	GMT_Usage (API, -2, "2: Primary ionospheric field.");
+	GMT_Usage (API, -2, "3: Induced ionospheric field.");
+	GMT_Usage (API, -2, "4: Poloidal field.");
+	GMT_Usage (API, 1, "\n-Sc|l<low>/<high>");
+	GMT_Usage (API, -2, "Limit the CM4 contributions from core and lithosphere to certain harmonic degree bands. "
+		"Append c(ore) or l(ithosphere) and the low and high degrees to use [-Sc1/13 -Sl14/65].");
 	GMT_Option (API, "V,bi0");
 	if (gmt_M_showusage (API)) {
-		GMT_Message (API, GMT_TIME_NONE, "\t   Default is 4 input columns (unless -A is used).  Note for binary input, absolute time must\n");
-		GMT_Message (API, GMT_TIME_NONE, "\t   be in the unix time-system (unless -A+y is used).\n");
+		GMT_Usage (API, -2, "Default is 4 input columns (unless -A is used).  Note for binary input, absolute time must "
+			"be in the UNIX time-system (unless -A+y is used).");
 	}
 	GMT_Option (API, "bo,d,h,o,:,.");
 

--- a/src/mgd77/mgd77magref.c
+++ b/src/mgd77/mgd77magref.c
@@ -84,7 +84,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77MAGREF_CTRL *C) {	/* De
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<table>] [-A+y+a<alt>+t<date>] [-C<cm4file>] [-D<dstfile>] [-E<f107file>] "
+	GMT_Usage (API, 0, "usage: %s [<table>] [-A+a<alt>+t<date>+y] [-C<cm4file>] [-D<dstfile>] [-E<f107file>] "
 		"[-Frthxyzdi[/[0|9]1234567]] [-G] [-Lrtxyz[/1234]] [-Sc|l<low>/<high>] [%s "
 		"[%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_h_OPT, GMT_o_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -93,13 +93,13 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n<table>");
-	GMT_Usage (API, -2, "File with records that must contain lon, lat, alt, time[, other cols]. "
-		"longitude and latitude is the geocentric position on the ellipsoid [but see -G]. "
-		"alt is the altitude in km positive above the ellipsoid. "
-		"time is the time of data acquisition, in <date>T<clock> format (but see -A+y). "
+	GMT_Usage (API, -2, "File with records that must contain <lon>, <lat>, <alt>, <time>[, other cols]. "
+		"Here, (<lon>, <lat>) is the geocentric position on the ellipsoid [but see -G], "
+		"<alt> is the altitude in km positive above the ellipsoid, and "
+		"<time> is the time of data acquisition, in <date>T<clock> format (but see -A+y). "
 		"We read <stdin> if no input file is given.");
-	GMT_Message (API, GMT_TIME_NONE, "  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n-A+y+a<alt>+t<date>");
+	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
+	GMT_Usage (API, 1, "\n-A+a<alt>+t<date>+y");
 	GMT_Usage (API, -2, "Adjust how the input records are interpreted. Append modifiers:");
 	GMT_Usage (API, 3, "+a Append <alt> to indicate a constant altitude [Default is 3rd column].");
 	GMT_Usage (API, 3, "+t Append <time> to indicate a constant time [Default is 4th column].");
@@ -116,7 +116,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"OR a single solar radio flux to apply for all records.",
 		API->GMT->session.SHAREDIR);
 	GMT_Usage (API, 1, "\n-Frthxyzdi[/[0|9]1234567]");
-	GMT_Usage (API, -2, "Dataflags is a string made up of one or more of these characters:");
+	GMT_Usage (API, -2, "Dataflags is a string made up of one or more of these codes:");
 	GMT_Usage (API, 3, "r: Output all input columns before adding the items below (all in nTesla).");
 	GMT_Usage (API, 3, "t: List total field.");
 	GMT_Usage (API, 3, "h: List horizontal field.");
@@ -125,10 +125,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "z: List Z component.");
 	GMT_Usage (API, 3, "d: List declination.");
 	GMT_Usage (API, 3, "i: List inclination.");
-	GMT_Usage (API, -2, "Optionally, append a number to indicate the requested field contribution(s):");
+	GMT_Usage (API, -2, "Optionally, append one or more numbers to indicate the requested field contribution(s):");
 	GMT_Usage (API, 3, "0: Core field from IGRF only (no CM4 evaluation).");
-	GMT_Usage (API, 3, "1: Core field.\n");
-	GMT_Usage (API, 3, "2: Lithosphericield.");
+	GMT_Usage (API, 3, "1: Core field.");
+	GMT_Usage (API, 3, "2: Lithospheric field.");
 	GMT_Usage (API, 3, "3: Primary Magnetospheric field.");
 	GMT_Usage (API, 3, "4: Induced Magnetospheric field.");
 	GMT_Usage (API, 3, "5: Primary ionospheric field.");
@@ -145,8 +145,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-G Specify that coordinates are geocentric [geodetic].");
 	GMT_Usage (API, 1, "\n-Lrtxyz[/1234]");
 	GMT_Usage (API, -2, "Compute J field vectors from certain external sources. "
-		"Append a string made up of 1 or more of these characters:");
-		GMT_Usage (API, 3, "r: Output all input columns before adding the items below (all in Ampers/m).");
+		"Append a string made up of one or more of these codes:");
+		GMT_Usage (API, 3, "r: Output all input columns before adding the items below (all in Ampere/m).");
 		GMT_Usage (API, 3, "t: List magnitude field.");
 		GMT_Usage (API, 3, "x: List X component.");
 		GMT_Usage (API, 3, "y: List Y component.");
@@ -158,7 +158,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "4: Poloidal field.");
 	GMT_Usage (API, 1, "\n-Sc|l<low>/<high>");
 	GMT_Usage (API, -2, "Limit the CM4 contributions from core and lithosphere to certain harmonic degree bands. "
-		"Append c(ore) or l(ithosphere) and the low and high degrees to use [-Sc1/13 -Sl14/65].");
+		"Append c(ore) or l(ithosphere) and the <low> and <high> degrees to use [-Sc1/13 -Sl14/65].");
 	GMT_Option (API, "V,bi0");
 	if (gmt_M_showusage (API)) {
 		GMT_Usage (API, -2, "Default is 4 input columns (unless -A is used).  Note for binary input, absolute time must "

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -122,37 +122,43 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77MANAGE_CTRL *C) {	/* De
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> [-Aa|c|d|D|e|E|g|i|n|t|T<info>[+f]] [-D<name1>,<name2>,...]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-E<no_char>] [-F] [-I<abbrev>/<name>/<units>/<size>/<scale>/<offset>/\"comment\"]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t[-N%s] [%s] [%s] [%s]\n\t[%s] [%s] [%s]\n\n",
-	             GMT_LEN_UNITS2_DISPLAY, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_j_OPT, GMT_n_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)> [-Aa|c|d|D|e|E|g|i|n|t|T<info>[+f]] [-D<name1>,<name2>,...] "
+		"[-E<no_char>] [-F] [-I<abbrev>/<name>/<units>/<size>/<scale>/<offset>/\"comment\"] "
+		"[-N%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+	    name, GMT_LEN_UNITS2_DISPLAY, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_j_OPT, GMT_n_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-A Append a new data column to the given files.  Append +f to overwrite an\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   existing column with same name with new data [Default will refuse if an\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   existing column has the same abbreviation as the new data].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   The code letters are:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   a: Give filename with a new column to add.  We expect a single-column file\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      with the same number of records as the MGD77 file.  Only one cruise can be set.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      If filename is - we read from stdin.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   c: Create a new column to be calculated from existing columns.  Add code:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        m = IGRF total field, c = Carter correction, g = IGF (\"normal gravity\").\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        r = recomputed magnetic anomaly rmag = mtfx - IGRF total field.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        Append x for which mtfx field to use (1 or 2) [1].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        For g, optionally append 1-4 to select the gravity formula to use:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        1 = Heiskanen 1924, 2 = International 1930, 3 = IGF1967, 4 = IGF1980.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        [Default uses formula specified in the MGD77 header, or 4 if not valid].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   d: Give filename with (dist [see -N], data) for a new column.  We expect a two-column file\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      with distances (in km) in first column and data values in 2nd.  Only one cruise can be set.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      If filename is - we read from stdin.  Only records with matching distance will have data assigned.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   D: Same as d but we interpolate between the dist,data pairs to fill in all data records.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   e: Ingest MGD77 error/correction information (e77) produced by mgd77sniffer.  We will look\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      for the <cruise>.e77 file in the current directory or in $MGD77_HOME/E77.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      By default we will apply recommended header (h) and systematic fixes (f) and set all data bit flags.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      Append a combination of these flags to change the default accordingly:\n");
+	GMT_Usage (API, 1, "\n-Aa|c|d|D|e|E|g|i|n|t|T<info>[+f]");
+	MT_Usage (API, -2, "Append a new data column to the given files.  Append +f to overwrite an "
+		"existing column with same name with new data [Default will refuse if an "
+		"existing column has the same abbreviation as the new data]. "
+		"The code letters are:");
+	GMT_Usage (API, 3, "a: Give filename with a new column to add.  We expect a single-column file "
+		"with the same number of records as the MGD77 file. Only one cruise can be set. "
+		"If filename is - we read from stdin.");
+	GMT_Usage (API, 3, "c: Create a new column to be calculated from existing columns.  Add code:");
+	GMT_Usage (API, 4, "m: IGRF total field.");
+	GMT_Usage (API, 4, "c: Carter correction.");
+	GMT_Usage (API, 4, "g: IGF (\"normal gravity\"). Optionally append 1-4 to select the gravity formula to use:");
+	GMT_Usage (API, 5, "1: Heiskanen 1924.");
+	GMT_Usage (API, 5, "2: International 1930.");
+	GMT_Usage (API, 5, "3: IGF1967.");
+	GMT_Usage (API, 5, "4: IGF1980.\n");
+	GMT_Usage (API, -4, "[Default uses formula specified in the MGD77 header, or 4 if not valid].");
+	GMT_Usage (API, 4, "r: Recomputed magnetic anomaly rmag = mtfx - IGRF total field. "
+		"Append x for which mtfx field to use (1 or 2) [1].");
+	GMT_Usage (API, 3, "d: Give filename with (dist [see -N], data) for a new column.  We expect a two-column file "
+		"with distances (in km) in first column and data values in 2nd.  Only one cruise can be set. "
+		"If filename is - we read from stdin.  Only records with matching distance will have data assigned.");
+	GMT_Usage (API, 3, "D: Same as d but we interpolate between the dist,data pairs to fill in all data records.");
+	GMT_Usage (API, 3, "e: Ingest MGD77 error/correction information (e77) produced by mgd77sniffer.  We will look "
+		"for the <cruise>.e77 file in the current directory or in $MGD77_HOME/E77. "
+		"By default we will apply recommended header (h) and systematic fixes (f) and set all data bit flags. "
+		"Append a combination of these flags to change the default accordingly:");
 	GMT_Message (API, GMT_TIME_NONE, "\t        h = Ignore all header recommendations\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        f = Ignore all systematic fixes recommendations\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t        n = Ignore data record bitflags pertaining to navigation (time, lon, lat).\n");
@@ -160,17 +166,17 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\t        s = Ignore data record bitflags pertaining to data slopes (gradients).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      Use -DE to ignore the verification status of the e77 file [Default requires verification to be Y].\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      Note: Previous E77 information will be removed prior to processing this E77 information.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   g: Sample a GMT grid along track. (also see -n; use -R to select a sub-region).\n");
+	GMT_Usage (API, 3, "g: Sample a GMT grid along track. (also see -n; use -R to select a sub-region).\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      Append filename of the GMT grid.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   i: Sample a Sandwell/Smith *.img Mercator grid along track (also see -n; use -R to select a sub-region).\n");
+	GMT_Usage (API, 3, "i: Sample a Sandwell/Smith *.img Mercator grid along track (also see -n; use -R to select a sub-region).\n");
 	gmt_img_syntax (API->GMT);
-	GMT_Message (API, GMT_TIME_NONE, "\t   n: Give filename with (rec_no, data) for a new column.  We expect a two-column file\n");
+	GMT_Usage (API, 3, "n: Give filename with (rec_no, data) for a new column.  We expect a two-column file\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      with record numbers (0 means 1st row) in first column and data values in 2nd.  Only one cruise can be set.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      If filename is - we read from stdin.  Only records with matching record numbers will have data assigned.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   t: Give filename with (abstime, data) for a new column.  We expect a two-column file\n");
+	GMT_Usage (API, 3, "t: Give filename with (abstime, data) for a new column.  We expect a two-column file\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      with dateTclock strings in first column and data values in 2nd.  Only one cruise can be set.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t      If filename is - we read from stdin.  Only records with matching times will have data assigned.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   T: Same as t but we interpolate between the time, data pairs to fill in all data records.\n");
+	GMT_Usage (API, 3, "T: Same as t but we interpolate between the time, data pairs to fill in all data records.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t-D Delete the columns listed from all the cruise data files.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   The columns are removed before any data are added.  It is not a substitute for -A...+f.\n");
 	GMT_Message (API, GMT_TIME_NONE, "\t   However, sometimes the shape of new data demands the old to be deleted first (you will be told).\n");

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -140,14 +140,14 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "a: Give filename with a new column to add.  We expect a single-column file "
 		"with the same number of records as the MGD77 file. Only one cruise can be set. "
 		"If filename is - we read from stdin.");
-	GMT_Usage (API, 3, "c: Create a new column to be calculated from existing columns.  Add code:");
+	GMT_Usage (API, 3, "c: Create a new column to be calculated from existing columns.  Add a code:");
 	GMT_Usage (API, 4, "m: IGRF total field.");
 	GMT_Usage (API, 4, "c: Carter correction.");
 	GMT_Usage (API, 4, "g: IGF (\"normal gravity\"). Optionally append 1-4 to select the gravity formula to use:");
 	GMT_Usage (API, 5, "1: Heiskanen 1924.");
 	GMT_Usage (API, 5, "2: International 1930.");
 	GMT_Usage (API, 5, "3: IGF1967.");
-	GMT_Usage (API, 5, "4: IGF1980.\n");
+	GMT_Usage (API, 5, "4: IGF1980.");
 	GMT_Usage (API, -4, "[Default uses formula specified in the MGD77 header, or 4 if not valid].");
 	GMT_Usage (API, 4, "r: Recomputed magnetic anomaly rmag = mtfx - IGRF total field. "
 		"Append x for which mtfx field to use (1 or 2) [1].");
@@ -164,12 +164,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 4, "n: Ignore data record bitflags pertaining to navigation (time, lon, lat).");
 	GMT_Usage (API, 4, "v: Ignore data record bitflags pertaining to data values.");
 	GMT_Usage (API, 4, "s: Ignore data record bitflags pertaining to data slopes (gradients).");
-	GMT_Usage (API, 3, "Use -DE to ignore the verification status of the e77 file [Default requires verification to be Y]. "
+	GMT_Usage (API, 4, "Use -DE to ignore the verification status of the e77 file [Default requires verification to be Y]. "
 		"Note: Previous E77 information will be removed prior to processing this E77 information.");
-	GMT_Usage (API, 3, "g: Sample a GMT grid along track. (also see -n; use -R to select a sub-region). "
+	GMT_Usage (API, 3, "g: Sample a GMT grid along track (also see -n; use -R to select a sub-region). "
 		"Append filename of the GMT grid.");
 	GMT_Usage (API, 3, "i: Sample a Sandwell/Smith *.img Mercator grid along track (also see -n; use -R to select a sub-region). ");
-	gmt_img_syntax (API->GMT);
+	gmt_img_syntax (API->GMT, 4);
 	GMT_Usage (API, 3, "n: Give filename with (rec_no, data) for a new column.  We expect a two-column file "
 		"with record numbers (0 means 1st row) in first column and data values in 2nd.  Only one cruise can be set. "
 		"If filename is - we read from stdin.  Only records with matching record numbers will have data assigned.");
@@ -193,8 +193,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "scale:   Multiply data by this scale before writing to mgd77+ file.");
 	GMT_Usage (API, 3, "offset:  Add after scaling before writing to mgd77+ file.");
 	GMT_Usage (API, 3, "comment: Any text (in double quotes) for information about column (%d char max).", MGD77_COL_COMMENT_LEN);
-	GMT_Usage (API, -2, "Note: Option -I is ignored by -Ae.");
-	GMT_Usage (API, -2, "Note for text: Interpolation is not allowed, and \"not-a-string\" is created from -E.");
+	GMT_Usage (API, -2, "Note: Option -I is ignored by -Ae. "
+		"Note for text: Interpolation is not allowed, and \"not-a-string\" is created from -E.");
 	GMT_Usage (API, 1, "\n-N%s", GMT_LEN_UNITS2_DISPLAY);
 	GMT_Usage (API, -2, "Append your choice for distance unit (if -Ad|D are set). Choose among "
 		"m(e)ter, (f)oot, (k)m, (M)ile, (n)autical mile, or s(u)rvey foot [Default is -Nk].");

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -133,7 +133,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-Aa|c|d|D|e|E|g|i|n|t|T<info>[+f]");
-	MT_Usage (API, -2, "Append a new data column to the given files.  Append +f to overwrite an "
+	GMT_Usage (API, -2, "Append a new data column to the given files.  Append +f to overwrite an "
 		"existing column with same name with new data [Default will refuse if an "
 		"existing column has the same abbreviation as the new data]. "
 		"The code letters are:");
@@ -159,42 +159,46 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"for the <cruise>.e77 file in the current directory or in $MGD77_HOME/E77. "
 		"By default we will apply recommended header (h) and systematic fixes (f) and set all data bit flags. "
 		"Append a combination of these flags to change the default accordingly:");
-	GMT_Message (API, GMT_TIME_NONE, "\t        h = Ignore all header recommendations\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        f = Ignore all systematic fixes recommendations\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        n = Ignore data record bitflags pertaining to navigation (time, lon, lat).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        v = Ignore data record bitflags pertaining to data values.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t        s = Ignore data record bitflags pertaining to data slopes (gradients).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      Use -DE to ignore the verification status of the e77 file [Default requires verification to be Y].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      Note: Previous E77 information will be removed prior to processing this E77 information.\n");
-	GMT_Usage (API, 3, "g: Sample a GMT grid along track. (also see -n; use -R to select a sub-region).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      Append filename of the GMT grid.\n");
-	GMT_Usage (API, 3, "i: Sample a Sandwell/Smith *.img Mercator grid along track (also see -n; use -R to select a sub-region).\n");
+	GMT_Usage (API, 4, "h: Ignore all header recommendations.");
+	GMT_Usage (API, 4, "f: Ignore all systematic fixes recommendations.");
+	GMT_Usage (API, 4, "n: Ignore data record bitflags pertaining to navigation (time, lon, lat).");
+	GMT_Usage (API, 4, "v: Ignore data record bitflags pertaining to data values.");
+	GMT_Usage (API, 4, "s: Ignore data record bitflags pertaining to data slopes (gradients).");
+	GMT_Usage (API, 3, "Use -DE to ignore the verification status of the e77 file [Default requires verification to be Y]. "
+		"Note: Previous E77 information will be removed prior to processing this E77 information.");
+	GMT_Usage (API, 3, "g: Sample a GMT grid along track. (also see -n; use -R to select a sub-region). "
+		"Append filename of the GMT grid.");
+	GMT_Usage (API, 3, "i: Sample a Sandwell/Smith *.img Mercator grid along track (also see -n; use -R to select a sub-region). ");
 	gmt_img_syntax (API->GMT);
-	GMT_Usage (API, 3, "n: Give filename with (rec_no, data) for a new column.  We expect a two-column file\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      with record numbers (0 means 1st row) in first column and data values in 2nd.  Only one cruise can be set.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      If filename is - we read from stdin.  Only records with matching record numbers will have data assigned.\n");
-	GMT_Usage (API, 3, "t: Give filename with (abstime, data) for a new column.  We expect a two-column file\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      with dateTclock strings in first column and data values in 2nd.  Only one cruise can be set.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      If filename is - we read from stdin.  Only records with matching times will have data assigned.\n");
-	GMT_Usage (API, 3, "T: Same as t but we interpolate between the time, data pairs to fill in all data records.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Delete the columns listed from all the cruise data files.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   The columns are removed before any data are added.  It is not a substitute for -A...+f.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   However, sometimes the shape of new data demands the old to be deleted first (you will be told).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-E Give character used to fill empty/missing string columns [9]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-F Force mode.  This allows you to even replace the standard MGD77 columns [only extended columns can be changed].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I In addition to the file information above, you must also specify column information:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      abbrev:  Short, abbreviated word (lower case only), like satfaa (%d char max).\n", MGD77_COL_ABBREV_LEN);
-	GMT_Message (API, GMT_TIME_NONE, "\t      name:    Descriptive name, like \"Geosat/ERS-1 Free-air gravity\" (%d char max).\n", MGD77_COL_NAME_LEN);
-	GMT_Message (API, GMT_TIME_NONE, "\t      units:   Units for the column (e.g., mGal, gamma, km) (%d char max).\n", MGD77_COL_NAME_LEN);
-	GMT_Message (API, GMT_TIME_NONE, "\t      size:    Either t(ext), b(yte), s(hort), f(loat), i(nt), or d(ouble).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      scale:   Multiply data by this scale before writing to mgd77+ file.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      offset:  Add after scaling before writing to mgd77+ file.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t      comment: Any text (in double quotes) for information about column (%d char max).\n", MGD77_COL_COMMENT_LEN);
-	GMT_Message (API, GMT_TIME_NONE, "\t      -I is ignored by -Ae.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Note for text: Interpolation is not allowed, and \"not-a-string\" is created from -E.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Append your choice for distance unit (if -Ad|D are set). Choose among:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   m(e)ter, (f)oot, (k)m, (M)ile, (n)autical mile, or s(u)rvey foot [Default is -Nk].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t    See -j for selecting distance calculation procedure.\n");
+	GMT_Usage (API, 3, "n: Give filename with (rec_no, data) for a new column.  We expect a two-column file "
+		"with record numbers (0 means 1st row) in first column and data values in 2nd.  Only one cruise can be set. "
+		"If filename is - we read from stdin.  Only records with matching record numbers will have data assigned.");
+	GMT_Usage (API, 3, "t: Give filename with (abstime, data) for a new column.  We expect a two-column file "
+		"with dateTclock strings in first column and data values in 2nd.  Only one cruise can be set. "
+		"If filename is - we read from stdin.  Only records with matching times will have data assigned.");
+	GMT_Usage (API, 3, "T: Same as t but we interpolate between the time, data pairs to fill in all data records.");
+	GMT_Usage (API, 1, "\n-D<name1>,<name2>,...");
+	GMT_Usage (API, -2, "Delete the columns listed from all the cruise data files. "
+		"The columns are removed before any data are added.  It is not a substitute for -A...+f. "
+		"However, sometimes the shape of new data demands the old to be deleted first (you will be told).");
+	GMT_Usage (API, 1, "\n-E<no_char>");
+	GMT_Usage (API, -2, "Give character used to fill empty/missing string columns [9].");
+	GMT_Usage (API, 1, "\n-F Force mode.  This allows you to even replace the standard MGD77 columns [only extended columns can be changed].");
+	GMT_Usage (API, 1, "\n-I<abbrev>/<name>/<units>/<size>/<scale>/<offset>/\"comment\"");
+	GMT_Usage (API, -2, "In addition to the file information above, you must also specify column information:");
+	GMT_Usage (API, 3, "abbrev:  Short, abbreviated word (lower case only), like satfaa (%d char max).", MGD77_COL_ABBREV_LEN);
+	GMT_Usage (API, 3, "name:    Descriptive name, like \"Geosat/ERS-1 Free-air gravity\" (%d char max).", MGD77_COL_NAME_LEN);
+	GMT_Usage (API, 3, "units:   Units for the column (e.g., mGal, gamma, km) (%d char max).", MGD77_COL_NAME_LEN);
+	GMT_Usage (API, 3, "size:    Either t(ext), b(yte), s(hort), f(loat), i(nt), or d(ouble).");
+	GMT_Usage (API, 3, "scale:   Multiply data by this scale before writing to mgd77+ file.");
+	GMT_Usage (API, 3, "offset:  Add after scaling before writing to mgd77+ file.");
+	GMT_Usage (API, 3, "comment: Any text (in double quotes) for information about column (%d char max).", MGD77_COL_COMMENT_LEN);
+	GMT_Usage (API, -2, "Note: Option -I is ignored by -Ae.");
+	GMT_Usage (API, -2, "Note for text: Interpolation is not allowed, and \"not-a-string\" is created from -E.");
+	GMT_Usage (API, 1, "\n-N%s", GMT_LEN_UNITS2_DISPLAY);
+	GMT_Usage (API, -2, "Append your choice for distance unit (if -Ad|D are set). Choose among "
+		"m(e)ter, (f)oot, (k)m, (M)ile, (n)autical mile, or s(u)rvey foot [Default is -Nk].");
+	GMT_Usage (API, -2, "Note: See -j for selecting distance calculation procedure.");
 	GMT_Option (API, "Rg,V,bi,di,j,n,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/mgd77/mgd77path.c
+++ b/src/mgd77/mgd77path.c
@@ -59,16 +59,16 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77PATH_CTRL *C) {	/* Deal
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <cruise(s)> -A[c] -D [-Ia|c|m|t] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)> [-A[c]] [-D] [-Ia|c|m|t] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
+	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-A[c]");
 	GMT_Usage (API, -2, "List full cruise pAths [Default].  Append c to only get cruise names.");
 	GMT_Usage (API, 1, "\n-D List all directories with MGD77 files instead.");
-	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-Ia|c|m|t");
 	GMT_Usage (API, -2, "Ignore certain data file formats from consideration. Append combination of acmt to ignore [Default ignores none]:");
 	GMT_Usage (API, 3, "a: MGD77 ASCII table.");

--- a/src/mgd77/mgd77path.c
+++ b/src/mgd77/mgd77path.c
@@ -59,16 +59,22 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct MGD77PATH_CTRL *C) {	/* Deal
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruise(s)> A[c] -D [-I<code>] [%s] [%s]\n\n", name, GMT_V_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruise(s)> -A[c] -D [-Ia|c|m|t] [%s] [%s]\n", name, GMT_V_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
-	GMT_Message (API, GMT_TIME_NONE, "\t-A List full cruise pAths [Default].  Append c to only get cruise names.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D List all directories with MGD77 files instead.\n");
+	GMT_Usage (API, 1, "\n-A[c]");
+	GMT_Usage (API, -2, "List full cruise pAths [Default].  Append c to only get cruise names.");
+	GMT_Usage (API, 1, "\n-D List all directories with MGD77 files instead.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Ignore certain data file formats from consideration. Append combination of act to ignore\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   (a) MGD77 ASCII, (c) MGD77+ netCDF, (m) MGD77T ASCII, or (t) plain table files. [Default ignores none].\n");
+	GMT_Usage (API, 1, "\n-Ia|c|m|t");
+	GMT_Usage (API, -2, "Ignore certain data file formats from consideration. Append combination of acmt to ignore [Default ignores none]:");
+	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
+	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
+	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
+	GMT_Usage (API, 3, "t: Plain table.");
 	GMT_Option (API, "V,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/mgd77/mgd77sniffer.c
+++ b/src/mgd77/mgd77sniffer.c
@@ -371,98 +371,117 @@ GMT_LOCAL int decimate (struct GMT_CTRL *GMT, double *new_val, double *orig, uns
 GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s <cruises> [-A<fieldabbrev>,<scale>,<offset>] [-Cmaxspd] [-Dd|e|E|f|l|m|s|v][r]\n", name);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-E] [-F] [-G<fieldabbrev>,<imggrid>,<scale>,<mode>[,<latmax>] or -G<fieldabbrev>,<grid>] [-H]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t[-I<fieldabbrev>,<rec1>,<recN>] [-L<custom_limits_file>] [-M] [-N]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t[%s] [-Sd|s|t] [-T<gap>] [-Wc|g|o|s|t|v|x] [-Wc|g|o|s|t|v|x]\n\t[%s] [-Z<level>] [%s] [%s] [%s] [%s]\n\n",
-	 	GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_do_OPT, GMT_n_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s <cruises> [-A<fieldabbrev>,<scale>,<offset>] [-C<maxspd>] [-Dd|e|E|f|l|m|s|v[r]] "
+		"[-E] [-F] [-G<fieldabbrev>,<imggrid>,<scale>,<mode>[,<latmax>]] | -G<fieldabbrev>,<grid>] [-H] "
+		"[-I<fieldabbrev>,<rec1>,<recN>] [-L<custom_limits_file>] [-M] [-N] "
+		"[%s] [-Sd|s|t] [-T<gap>] [-Wc|g|o|s|t|v|x] [%s] [-Z<level>] [%s] [%s] [%s] [%s]\n",
+	 	name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_do_OPT, GMT_n_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
-	GMT_Message (API, GMT_TIME_NONE, "\tScan MGD77 files for errors using point-by-point sanity checking,\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t\talong-track detection of excessive slopes and comparison of cruise\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t\tdata with global bathymetry and gravity grids.");
-	GMT_Message (API, GMT_TIME_NONE, "\twhere <cruises> is one or more MGD77 legnames, e.g., 08010001 etc.\n");
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
+	GMT_Usage (API, 1, "\n<cruises>");
+	GMT_Usage (API, -2, "Scan MGD77 files for errors using point-by-point sanity checking, "
+		"along-track detection of excessive slopes and comparison of cruise "
+		"data with global bathymetry and gravity grids. "
+		"where <cruises> is one or more MGD77 legnames, e.g., 08010001 etc.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-A Apply scale factor and DC adjustment to specified data field. Allows adjustment of\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   cruise data prior to along-track analysis. CAUTION: data must be thoroughly examined\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   before applying these global data adjustments. May not be used for multiple cruises.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-C Set maximum ship speed (10 m/s by default, use -N to indicate knots).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Dump cruise data such as sniffer limits, values, gradients and mgd77 records.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Dd print out cruise-grid differences (requires -G option).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -De output formatted error summary for each record. See E77 ERROR FORMAT below.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -DE same as -De but no regression checks will be done.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Df for each field, output value change and distance (or time with -St) since last observation.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Dl print out mgd77sniffer default limits (requires no additional arguments).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Dm print out MGD77 format\n\t  -Ds print out gradients\n\t  -Dv print out values.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Dn print out distance to coast for each record (requires -Gnav).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Append r to include all records (default omits records where navigation errors were detected).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-E Reverse navigation quality flags (good to bad and vice versa). May be necessary when a\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   majority of navigation fixes are erroneously flagged bad, which can happen when a cruise's\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   first navigation fix is extremely erroneous. Caution! This will affect sniffer output and\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   should only be attempted after careful manual navigation review.\n");
+	GMT_Usage (API, 1, "\n-A<fieldabbrev>,<scale>,<offset>");
+	GMT_Usage (API, -2, "Apply scale factor and DC adjustment to specified data field. Allows adjustment of "
+		"cruise data prior to along-track analysis. CAUTION: data must be thoroughly examined "
+		"before applying these global data adjustments. May not be used for multiple cruises.");
+	GMT_Usage (API, 1, "\n-C<maxspd>");
+	GMT_Usage (API, -2, "Set maximum ship speed (10 m/s by default, use -N to indicate knots).");
+	GMT_Usage (API, 1, "\n-Dd|e|E|f|l|m|s|v[r]");
+	GMT_Usage (API, -2, "Dump cruise data such as sniffer limits, values, gradients and mgd77 records. Select item:");
+	GMT_Usage (API, 3, "d: Print out cruise-grid differences (requires -G option).");
+	GMT_Usage (API, 3, "e: Output formatted error summary for each record. See E77 ERROR FORMAT below.");
+	GMT_Usage (API, 3, "E: Same as -De but no regression checks will be done.");
+	GMT_Usage (API, 3, "f: For each field, output value change and distance (or time with -St) since last observation.");
+	GMT_Usage (API, 3, "l: Print out mgd77sniffer default limits (requires no additional arguments).");
+	GMT_Usage (API, 3, "m: Print out MGD77 format.");
+	GMT_Usage (API, 3, "s: Print out gradients.");
+	GMT_Usage (API, 3, "v: Print out values.");
+	GMT_Usage (API, 3, "n: Print out distance to coast for each record (requires -Gnav).");
+	GMT_Usage (API, -2, "Append r to include all records (default omits records where navigation errors were detected).");
+	GMT_Usage (API, 1, "\n-E Reverse navigation quality flags (good to bad and vice versa). May be necessary when a "
+		"majority of navigation fixes are erroneously flagged bad, which can happen when a cruise's "
+		"first navigation fix is extremely erroneous. Caution! This will affect sniffer output and "
+		"should only be attempted after careful manual navigation review.");
 #ifdef DEBUG
-	GMT_Message (API, GMT_TIME_NONE, "\t-F Test regression analysis. A simulated grid is created from the ship data using slope\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   and intercept passed through the -G option (i.e., -Gfield,m/b no grid name is passed).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   These factors are then reflected in regression output. Multiple -G calls allowed.\n");
+	GMT_Usage (API, 1, "\n-F Test regression analysis. A simulated grid is created from the ship data using slope "
+		"and intercept passed through the -G option (i.e., -Gfield,m/b no grid name is passed). "
+		"These factors are then reflected in regression output. Multiple -G calls allowed.");
 #endif
-	GMT_Message (API, GMT_TIME_NONE, "\t-G Compare cruise data to the specified GMT geographic grid or Sandwell/Smith Mercator img grid\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   a) Compare cruise data to the specified Sandwell/Smith Mercator grid. Requires valid MGD77\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   field abbreviation followed by a comma, the path (if not in current directory)\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   and grid filename, scale (0.1 or 1), and mode (see mgd77manage for details).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append max latitude in the IMG file [72.0059773539]. Nav on land\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   test can be activated using the -G option and requires a distance to nearest\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   coast grid (i.e., -Gnav,/data/GRIDS/dist_to_land.grd) with distance reported in cm.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   b) Compare cruise data to the specified GMT geographic grid. Requires valid MGD77 field abbreviation\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   followed by a comma, then the path (if not in current directory) and grid filename.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Excessive offsets are flagged according to maxArea threshold (use -L option to\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   adjust maxArea). Useful for comparing faa or depth to global grids though any MGD77\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   field can be compared to any GMT or IMG compatible grid. Multiple grid comparison is\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   supported by  using separate -G calls for each grid.  See GRID FILE INFO below.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Nav on land test can be activated using the -G option and requires a distance to\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   nearest coast grid (i.e., -Gnav,/data/GRIDS/dist_to_land.grd) with distance reported\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   in cm.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-H (with -G only) disable (or force) decimation during RLS analysis of ship and gridded data.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   By default mgd77sniffer analyses both the full and decimated data sets then reports\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   RLS statistics for the higher correlation regression.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Hb analyze both (default), report better of two.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Hd to disable data decimation (equivalent to -H with no argument).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Hf to force data decimation.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Give one or more record numbers to specify ranges of data record that should be flagged as bad\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   prior to along-track analysis.  The flag information will be echoed out to E77 files.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   May not be used for multiple cruises.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Override mgd77sniffer default error detection limits. Supply path and filename of\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   the custom limits file. Rows not beginning with a valid MGD77 field abbreviation are\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   ignored. Field abbreviations are listed below in exact form under MGD77 FIELD INFO.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Multiple field limits may be modified using one default file, one field per line.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Field min, max, maxGradient and maxArea may be changed for each field. maxGradient\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   pertains to the gradient type selected using the -S option. maxArea is used by the\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   -G option as the threshold for flagging excessive offsets. Dump defaults (-Dd) to\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   view syntax or to quickly create an editable custom limits file.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Example custom default file contents (see below for field units):\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t\tdepth	0	11000	1000	4500\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t\tmag	-800	800	-	-\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t\tfaa	-250	250	100	2500\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use a dash '-' to retain a default limit.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Hint: to test your custom limits, try: mgd77sniffer -Dl -L<yourlimitsfile>.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-M Adjust navigation on land threshold (meters inland) [100].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Use nautical units.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Specify gradient type for along-track excessive slope checking.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Sd Calculate change in z values along track (dz).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -Ss Calculate spatial gradients (dz/ds) [default].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t  -St Calculate time gradients (dz/dt).\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-T Set maximum acceptable distance gap between records (km) [5].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Set to zero to deactivate gap checking.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-W Print out only certain warning types. Comma delimit any combination of c|g|o|s|t|v|x:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   where (c) type code warnings, (g)radient out of range, (o)ffsets from grid (requires -G),\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   (s)peed out of range, (t)ime warnings, (v)alue out of range, (x) warning summaries.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   By default ALL warning messages are printed. Not allowed with -D option.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-V Run in verbose mode.\n\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-Z Flag regression statistics that are outside the specified confidence level.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   (i.e., -Z5 flags coefficients m, b, rms, and r that fall outside 95%%.)\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-b Output binary data for -D option.  Append d for double and s for single precision [double].\n\n");
+	GMT_Usage (API, 1, "\n-G<fieldabbrev>,<imggrid>,<scale>,<mode>[,<latmax>]] | -G<fieldabbrev>,<grid>");
+	GMT_Usage (API, -2, "Compare cruise data to the specified GMT geographic grid or Sandwell/Smith Mercator img grid:");
+	GMT_Usage (API, 3, "%s Compare cruise data to the specified Sandwell/Smith Mercator grid. Requires valid MGD77 "
+		"field abbreviation followed by a comma, the path (if not in current directory) "
+		"and grid filename, scale (0.1 or 1), and mode (see mgd77manage for details). "
+		"Optionally, append max latitude in the IMG file [72.0059773539]. Nav on land "
+		"test can be activated using the -G option and requires a distance to nearest "
+		"coast grid (i.e., -Gnav,/data/GRIDS/dist_to_land.grd) with distance reported in cm.", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s Compare cruise data to the specified GMT geographic grid. Requires valid MGD77 field abbreviation "
+		"followed by a comma, then the path (if not in current directory) and grid filename. "
+		"Excessive offsets are flagged according to maxArea threshold (use -L option to "
+		"adjust maxArea). Useful for comparing faa or depth to global grids though any MGD77 "
+		"field can be compared to any GMT or IMG compatible grid. Multiple grid comparison is "
+		"supported by  using separate -G calls for each grid.  See GRID FILE INFO below. "
+		"Nav on land test can be activated using the -G option and requires a distance to "
+		"nearest coast grid (i.e., -Gnav,/data/GRIDS/dist_to_land.grd) with distance reported "
+		"in cm.", GMT_LINE_BULLET);
+	GMT_Usage (API, 1, "\n-H (with -G only) disable (or force) decimation during RLS analysis of ship and gridded data. "
+		"By default mgd77sniffer analyses both the full and decimated data sets then reports "
+		"RLS statistics for the higher correlation regression. Optional directives:");
+	GMT_Usage (API, 3, "b: Analyze both (default), report the better of two.");
+	GMT_Usage (API, 3, "d: Disable data decimation (equivalent to -H with no argument).");
+	GMT_Usage (API, 3, "f: Force data decimation.");
+	GMT_Usage (API, 1, "\n-I<fieldabbrev>,<rec1>,<recN>");
+	GMT_Usage (API, -2, "Give one or more record numbers to specify ranges of data record that should be flagged as bad "
+		"prior to along-track analysis.  The flag information will be echoed out to E77 files. "
+		"May not be used for multiple cruises.");
+	GMT_Usage (API, 1, "\n-L<custom_limits_file>");
+	GMT_Usage (API, -2, "Override mgd77sniffer default error detection limits. Supply path and filename of "
+		"the custom limits file. Rows not beginning with a valid MGD77 field abbreviation are "
+		"ignored. Field abbreviations are listed below in exact form under MGD77 FIELD INFO. "
+		"Multiple field limits may be modified using one default file, one field per line. "
+		"Field min, max, maxGradient and maxArea may be changed for each field. maxGradient "
+		"pertains to the gradient type selected using the -S option. maxArea is used by the "
+		"-G option as the threshold for flagging excessive offsets. Dump defaults (-Dd) to "
+		"view syntax or to quickly create an editable custom limits file. "
+		"Example custom default file contents (see below for field units):");
+	GMT_Usage (API, 3, "depth	0	11000	1000	4500");
+	GMT_Usage (API, 3, "mag	-800	800	-	-");
+	GMT_Usage (API, 3, "faa	-250	250	100	2500");
+	GMT_Usage (API, -2, "Use a dash '-' to retain a default limit. "
+		"Hint: to test your custom limits, try: mgd77sniffer -Dl -L<yourlimitsfile>.");
+	GMT_Usage (API, 1, "\n-M Adjust navigation on land threshold (meters inland) [100].");
+	GMT_Usage (API, 1, "\n-N Use nautical units.");
+	GMT_Usage (API, 1, "\n-Sd|s|t");
+	GMT_Usage (API, -2, "Specify gradient type for along-track excessive slope checking:");
+	GMT_Usage (API, 3, "d: Calculate change in z values along track (dz).");
+	GMT_Usage (API, 3, "s: Calculate spatial gradients (dz/ds) [default].");
+	GMT_Usage (API, 3, "t: Calculate time gradients (dz/dt).");
+	GMT_Usage (API, 1, "\n-T<gap>");
+	GMT_Usage (API, -2, "Set maximum acceptable distance gap between records (km) [5]. "
+		"Set to zero to deactivate gap checking.");
+	GMT_Usage (API, 1, "\n-Wc|g|o|s|t|v|x");
+	GMT_Usage (API, -2, "Print out only certain warning types. Comma delimit any combination of c|g|o|s|t|v|x, where:");
+	GMT_Usage (API, 3, "c: Type code warnings.");
+	GMT_Usage (API, 3, "g: Gradient out of range.");
+	GMT_Usage (API, 3, "o: Offsets from grid (requires -G).");
+	GMT_Usage (API, 3, "s: Speed out of range,.");
+	GMT_Usage (API, 3, "t: Time warnings.");
+	GMT_Usage (API, 3, "v: Value out of range.");
+	GMT_Usage (API, 3, "x: Warning summaries.");
+	GMT_Usage (API, -2, "By default ALL warning messages are printed. Not allowed with -D option.");
+	GMT_Option (API, "V");
+	GMT_Usage (API, 1, "\n-Z<level>");
+	GMT_Usage (API, -2, "Flag regression statistics that are outside the specified confidence level. "
+		"(i.e., -Z5 flags coefficients m, b, rms, and r that fall outside 95%%.)");
+	GMT_Usage (API, 1, "\n-bo Output binary data for -D option.  Append d for double and s for single precision [double].");
 	GMT_Option (API, "do,n,.");
-	GMT_Message (API, GMT_TIME_NONE, "\tMGD77 FIELD INFO:\n");
+	GMT_Usage (API, -2, "MGD77 FIELD INFO:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\tField\t\t\tAbbreviation\t\tUnits\n");
 	GMT_Message (API, GMT_TIME_NONE, "\tTwo-way Travel Time\ttwt\t\t\tsec\n");
 	GMT_Message (API, GMT_TIME_NONE, "\tCorrected Depth \tdepth\t\t\tm\n");

--- a/src/mgd77/mgd77sniffer.c
+++ b/src/mgd77/mgd77sniffer.c
@@ -414,7 +414,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		"These factors are then reflected in regression output. Multiple -G calls allowed.");
 #endif
 	GMT_Usage (API, 1, "\n-G<fieldabbrev>,<imggrid>,<scale>,<mode>[,<latmax>]] | -G<fieldabbrev>,<grid>");
-	GMT_Usage (API, -2, "Compare cruise data to the specified GMT geographic grid or Sandwell/Smith Mercator img grid:");
+	GMT_Usage (API, -2, "Compare cruise data to the specified  Sandwell/Smith Mercator img grid or GMT geographic grid:");
 	GMT_Usage (API, 3, "%s Compare cruise data to the specified Sandwell/Smith Mercator grid. Requires valid MGD77 "
 		"field abbreviation followed by a comma, the path (if not in current directory) "
 		"and grid filename, scale (0.1 or 1), and mode (see mgd77manage for details). "
@@ -460,17 +460,17 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-Sd|s|t");
 	GMT_Usage (API, -2, "Specify gradient type for along-track excessive slope checking:");
 	GMT_Usage (API, 3, "d: Calculate change in z values along track (dz).");
-	GMT_Usage (API, 3, "s: Calculate spatial gradients (dz/ds) [default].");
+	GMT_Usage (API, 3, "s: Calculate spatial gradients (dz/ds) [Default].");
 	GMT_Usage (API, 3, "t: Calculate time gradients (dz/dt).");
 	GMT_Usage (API, 1, "\n-T<gap>");
 	GMT_Usage (API, -2, "Set maximum acceptable distance gap between records (km) [5]. "
 		"Set to zero to deactivate gap checking.");
 	GMT_Usage (API, 1, "\n-Wc|g|o|s|t|v|x");
-	GMT_Usage (API, -2, "Print out only certain warning types. Comma delimit any combination of c|g|o|s|t|v|x, where:");
+	GMT_Usage (API, -2, "Print out only certain warning types. Comma-delimit any combination of c|g|o|s|t|v|x, where:");
 	GMT_Usage (API, 3, "c: Type code warnings.");
 	GMT_Usage (API, 3, "g: Gradient out of range.");
 	GMT_Usage (API, 3, "o: Offsets from grid (requires -G).");
-	GMT_Usage (API, 3, "s: Speed out of range,.");
+	GMT_Usage (API, 3, "s: Speed out of range.");
 	GMT_Usage (API, 3, "t: Time warnings.");
 	GMT_Usage (API, 3, "v: Value out of range.");
 	GMT_Usage (API, 3, "x: Warning summaries.");
@@ -481,7 +481,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		"(i.e., -Z5 flags coefficients m, b, rms, and r that fall outside 95%%.)");
 	GMT_Usage (API, 1, "\n-bo Output binary data for -D option.  Append d for double and s for single precision [double].");
 	GMT_Option (API, "do,n,.");
-	GMT_Usage (API, -2, "MGD77 FIELD INFO:\n");
+	GMT_Usage (API, -2, "\nMGD77 FIELD INFO:\n");
 	GMT_Message (API, GMT_TIME_NONE, "\tField\t\t\tAbbreviation\t\tUnits\n");
 	GMT_Message (API, GMT_TIME_NONE, "\tTwo-way Travel Time\ttwt\t\t\tsec\n");
 	GMT_Message (API, GMT_TIME_NONE, "\tCorrected Depth \tdepth\t\t\tm\n");

--- a/src/mgd77/mgd77sniffer.c
+++ b/src/mgd77/mgd77sniffer.c
@@ -457,6 +457,7 @@ GMT_LOCAL int usage (struct GMTAPI_CTRL *API, int level) {
 		"Hint: to test your custom limits, try: mgd77sniffer -Dl -L<yourlimitsfile>.");
 	GMT_Usage (API, 1, "\n-M Adjust navigation on land threshold (meters inland) [100].");
 	GMT_Usage (API, 1, "\n-N Use nautical units.");
+	GMT_Option (API, "Rg");
 	GMT_Usage (API, 1, "\n-Sd|s|t");
 	GMT_Usage (API, -2, "Specify gradient type for along-track excessive slope checking:");
 	GMT_Usage (API, 3, "d: Calculate change in z values along track (dz).");

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -182,7 +182,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Plot track based on time. Append a directive and date (given as yyyy-mm-ddT[hh:mm:ss]); repeatable:");
 	GMT_Usage (API, 3, "a: Start plotting at this time [Start of cruise].");
 	GMT_Usage (API, 3, "b: End plotting at this time [End of cruise].");
-	GMT_Usage (API, 1, "\nDo NOT apply bitflags to MGD77+ cruises [Default applies error flags stored in the file].");
+	GMT_Usage (API, 1, "\n-F Do NOT apply bitflags to MGD77+ cruises [Default applies error flags stored in the file].");
 	GMT_Usage (API, 1, "\n-Gt|d|n<number>");
 	GMT_Usage (API, -2, "Consider point separations exceeding d<gap> (km) or t<gap> (minutes) to indicate a gap (do not draw) [0]. "
 		"Use n<number> to plot only one every other <number> points. Useful to reduce plot file size.");

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -172,7 +172,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Option (API, "J-,R");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n-A[c][<size>]][+i<inc>");
+	GMT_Usage (API, 1, "\n-A[c][<size>]][+i<inc>]");
 	GMT_Usage (API, -2, "Annotate legs when they enter the grid. Append c for cruise ID [Default is file prefix]; "
 		"<size> is optional text size in points [9].  The font used is controlled by FONT_LABEL. "
 		"Optionally, append +i<inc> to place label every <inc> units apart, where unit may be "
@@ -186,6 +186,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-Gt|d|n<number>");
 	GMT_Usage (API, -2, "Consider point separations exceeding d<gap> (km) or t<gap> (minutes) to indicate a gap (do not draw) [0]. "
 		"Use n<number> to plot only one every other <number> points. Useful to reduce plot file size.");
+	GMT_Usage (API, 1, "\n-Ia|c|m|t");
 	GMT_Usage (API, -2, "Ignore certain data file formats from consideration. Append combination of acmt to ignore [Default ignores none]:");
 	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
 	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
@@ -200,25 +201,25 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "O,P");
 	GMT_Usage (API, 1, "\n-Sa|b<dist>");
 	GMT_Usage (API, -2, "Limit plotting based on distance along cruise. Append a directive and distance (with optional unit from %s [meter]); repeatable:", GMT_LEN_UNITS2_DISPLAY);
-	GMT_Usage (API, 3, "a: Start plotting at this distance[Start of cruise].");
+	GMT_Usage (API, 3, "a: Start plotting at this distance [Start of cruise].");
 	GMT_Usage (API, 3, "b: End plotting at this distance [End of cruise].");
 	GMT_Usage (API, 1, "\n-TT|t|d<ms,mc,mfs,mf,mfc>");
 	GMT_Usage (API, -2, "Set attributes of marker items. First select a marker directive:");
 	GMT_Usage (API, 3, "T: New day marker.");
 	GMT_Usage (API, 3, "t: Same day marker.");
 	GMT_Usage (API, 3, "d: Distance marker.");
-	GMT_Usage (API, -2, "Next append 5 comma-separated items: "
+	GMT_Usage (API, -2, "Next append five comma-separated items: "
 		"<markersize>,<markercolor>,<markerfontsize,<markerfont>,<markerfontcolor>.");
 	GMT_Usage (API, -2, "Default settings for the three marker types are:");
-	GMT_Usage (API, 3, "%s T%s,black,%g,%d,black.",
+	GMT_Usage (API, 3, "%s T%s,black,%g,%d,black.", GMT_LINE_BULLET,
 		day_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
-		API->GMT->current.setting.font_annot[GMT_PRIMARY].id, GMT_LINE_BULLET);
-	GMT_Usage (API, 3, "%s t%s,white,%g,%d,black.",
+		API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
+	GMT_Usage (API, 3, "%s t%s,white,%g,%d,black.", GMT_LINE_BULLET,
 		day_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
-		API->GMT->current.setting.font_annot[GMT_PRIMARY].id, GMT_LINE_BULLET);
-	GMT_Usage (API, 3, "d%s,black,%g,%d,black.",
+		API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
+	GMT_Usage (API, 3, "%s d%s,black,%g,%d,black.", GMT_LINE_BULLET,
 		dist_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
-		API->GMT->current.setting.font_annot[GMT_PRIMARY].id, GMT_LINE_BULLET);
+		API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
 	GMT_Option (API, "U,V");
 	GMT_Usage (API, 1, "\n-W<pen>");
 	GMT_Usage (API, -2, "Set track pen attributes [%s].", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -160,52 +160,68 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		strcpy (dist_marker_size, "0.06i");
 	}
 
-	GMT_Message (API, GMT_TIME_NONE, "usage: %s cruise(s) %s %s\n\t[-A[c][<size>]][+i<inc>] [%s] ", name, GMT_Rgeo_OPT, GMT_J_OPT, GMT_B_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-Da<startdate>] [-Db<stopdate>] [-F]\n\t[-Gt|d|n<gap>] [-I<code>] %s[-L<trackticks>] [-N] %s%s[-Sa<startdist>]\n", API->K_OPT, API->O_OPT, API->P_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t[-Sb<stopdist>] [-TT|t|d<ms,mc,mfs,mf,mfc>] [%s]\n\t[%s] [-W<pen>] [%s] [%s]\n",
-	             GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT);
-	GMT_Message (API, GMT_TIME_NONE, "\t%s[%s] [%s] [%s]\n\n", API->c_OPT, GMT_p_OPT, GMT_t_OPT, GMT_PAR_OPT);
+	GMT_Usage (API, 0, "usage: %s cruise(s) %s %s [-A[c][<size>]][+i<inc>] [%s] [-Da|b<date>] [-F] "
+		"[-Gt|d|n<number>] [-Ia|c|m|t] %s[-L<trackticks>] [-N] %s%s[-Sa|b<dist>] [-TT|t|d<ms,mc,mfs,mf,mfc>] "
+		"[%s] [%s] [-W<pen>] [%s] [%s] %s[%s] [%s] [%s]\n",
+		name, GMT_Rgeo_OPT, GMT_J_OPT, GMT_B_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_U_OPT, GMT_V_OPT,
+		GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_p_OPT, GMT_t_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
+	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	MGD77_Cruise_Explain (API->GMT);
 	GMT_Option (API, "J-,R");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-A Annotate legs when they enter the grid. Append c for cruise ID [Default is file prefix];\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   <size> is optional text size in points [9].  The font used is controlled by FONT_LABEL.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Optionally, append +i<inc> to place label every <inc> units apart, where unit may be\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   k (km) or n (nautical miles), or d (days), h (hours).\n");
+	GMT_Usage (API, 1, "\n-A[c][<size>]][+i<inc>");
+	GMT_Usage (API, -2, "Annotate legs when they enter the grid. Append c for cruise ID [Default is file prefix]; "
+		"<size> is optional text size in points [9].  The font used is controlled by FONT_LABEL. "
+		"Optionally, append +i<inc> to place label every <inc> units apart, where unit may be "
+		"k (km) or n (nautical miles), or d (days), h (hours).");
 	GMT_Option (API, "B-");
-	GMT_Message (API, GMT_TIME_NONE, "\t-D Plot from a<startdate> (given as yyyy-mm-ddT[hh:mm:ss]) [Start of cruise]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   up to b<stopdate> (given as yyyy-mm-ddT[hh:mm:ss]) [End of cruise]\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-F Do NOT apply bitflags to MGD77+ cruises [Default applies error flags stored in the file].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-G Consider point separations exceeding d<gap> (km) or t<gap> (minutes) to indicate a gap (do not draw) [0].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Use n<number> to plot only one every other <number> points. Useful to reduce plot file size.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-I Ignore certain data file formats from consideration. Append combination of act to ignore\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   (a) MGD77 ASCII, (c) MGD77+ netCDF, (m) MGD77T ASCII, or (t) plain table files. [Default ignores none].\n");
+	GMT_Usage (API, 1, "\n-Da|b<date>");
+	GMT_Usage (API, -2, "Plot track based on time. Append a directive and date (given as yyyy-mm-ddT[hh:mm:ss]); repeatable:");
+	GMT_Usage (API, 3, "a: Start plotting at this time [Start of cruise].");
+	GMT_Usage (API, 3, "b: End plotting at this time [End of cruise].");
+	GMT_Usage (API, 1, "\nDo NOT apply bitflags to MGD77+ cruises [Default applies error flags stored in the file].");
+	GMT_Usage (API, 1, "\n-Gt|d|n<number>");
+	GMT_Usage (API, -2, "Consider point separations exceeding d<gap> (km) or t<gap> (minutes) to indicate a gap (do not draw) [0]. "
+		"Use n<number> to plot only one every other <number> points. Useful to reduce plot file size.");
+	GMT_Usage (API, -2, "Ignore certain data file formats from consideration. Append combination of acmt to ignore [Default ignores none]:");
+	GMT_Usage (API, 3, "a: MGD77 ASCII table.");
+	GMT_Usage (API, 3, "c: MGD77+ netCDF table.");
+	GMT_Usage (API, 3, "m: MGD77T ASCII table.");
+	GMT_Usage (API, 3, "t: Plain table.");
 	GMT_Option (API, "K");
-	GMT_Message (API, GMT_TIME_NONE, "\t-L Put time/distance log marks on the track. E.g. a500ka24ht6h means (a)nnotate\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   every 500 km (k) and 24 h(ours), with (t)ickmarks every 500 km and 6 (h)ours.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Units of n(autical miles) and d(ays) are also recognized.\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-N Do Not clip leg name annotation that fall outside map border [Default will clip].\n");
+	GMT_Usage (API, 1, "\n-L<trackticks>");
+	GMT_Usage (API, -2, "Put time/distance log marks on the track. E.g. a500ka24ht6h means (a)nnotate "
+		"every 500 km (k) and 24 h(ours), with (t)ickmarks every 500 km and 6 (h)ours. "
+		"Units of n(autical miles) and d(ays) are also recognized.");
+	GMT_Usage (API, 1, "\n-N Do Not clip leg name annotation that fall outside map border [Default will clip].");
 	GMT_Option (API, "O,P");
-	GMT_Message (API, GMT_TIME_NONE, "\t-S Plot from a<startdist>, append unit from %s [meter] [Start of cruise]\n", GMT_LEN_UNITS2_DISPLAY);
-	GMT_Message (API, GMT_TIME_NONE, "\t   up to b<stopdist> [End of cruise].\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t-T Set attributes of marker items. Append T for new day marker, t for same\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   day marker, and d for distance marker.  Then, append 5 comma-separated items:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   <markersize>,<markercolor>,<markerfontsize,<markerfont>,<markerfontcolor>\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t   Default settings for the three marker types are:\n");
-	GMT_Message (API, GMT_TIME_NONE, "\t     -TT%s,black,%g,%d,black\n",
-	             day_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
-	             API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Tt%s,white,%g,%d,black\n",
-	             day_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
-	             API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
-	GMT_Message (API, GMT_TIME_NONE, "\t     -Td%s,black,%g,%d,black\n",
-	             dist_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
-	             API->GMT->current.setting.font_annot[GMT_PRIMARY].id);
+	GMT_Usage (API, 1, "\n-Sa|b<dist>");
+	GMT_Usage (API, -2, "Limit plotting based on distance along cruise. Append a directive and distance (with optional unit from %s [meter]); repeatable:", GMT_LEN_UNITS2_DISPLAY);
+	GMT_Usage (API, 3, "a: Start plotting at this distance[Start of cruise].");
+	GMT_Usage (API, 3, "b: End plotting at this distance [End of cruise].");
+	GMT_Usage (API, 1, "\n-TT|t|d<ms,mc,mfs,mf,mfc>");
+	GMT_Usage (API, -2, "Set attributes of marker items. First select a marker directive:");
+	GMT_Usage (API, 3, "T: New day marker.");
+	GMT_Usage (API, 3, "t: Same day marker.");
+	GMT_Usage (API, 3, "d: Distance marker.");
+	GMT_Usage (API, -2, "Next append 5 comma-separated items: "
+		"<markersize>,<markercolor>,<markerfontsize,<markerfont>,<markerfontcolor>.");
+	GMT_Usage (API, -2, "Default settings for the three marker types are:");
+	GMT_Usage (API, 3, "%s T%s,black,%g,%d,black.",
+		day_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
+		API->GMT->current.setting.font_annot[GMT_PRIMARY].id, GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s t%s,white,%g,%d,black.",
+		day_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
+		API->GMT->current.setting.font_annot[GMT_PRIMARY].id, GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "d%s,black,%g,%d,black.",
+		dist_marker_size, API->GMT->current.setting.font_annot[GMT_PRIMARY].size,
+		API->GMT->current.setting.font_annot[GMT_PRIMARY].id, GMT_LINE_BULLET);
 	GMT_Option (API, "U,V");
-	GMT_Message (API, GMT_TIME_NONE, "\t-W Set track pen attributes [%s].\n", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
+	GMT_Usage (API, 1, "\n-W<pen>");
+	GMT_Usage (API, -2, "Set track pen attributes [%s].", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Option (API, "X,c,p,t,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -160,7 +160,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		strcpy (dist_marker_size, "0.06i");
 	}
 
-	GMT_Usage (API, 0, "usage: %s cruise(s) %s %s [-A[c][<size>]][+i<inc>] [%s] [-Da|b<date>] [-F] "
+	GMT_Usage (API, 0, "usage: %s <cruise(s)> %s %s [-A[c][<size>]][+i<inc>] [%s] [-Da|b<date>] [-F] "
 		"[-Gt|d|n<number>] [-Ia|c|m|t] %s[-L<trackticks>] [-N] %s%s[-Sa|b<dist>] [-TT|t|d<ms,mc,mfs,mf,mfc>] "
 		"[%s] [%s] [-W<pen>] [%s] [%s] %s[%s] [%s] [%s]\n",
 		name, GMT_Rgeo_OPT, GMT_J_OPT, GMT_B_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_U_OPT, GMT_V_OPT,


### PR DESCRIPTION
As per #5341.  Apart from the usual upgrades and fixes to minor issues here and there, this required an update to the _gmt_img_syntax_ function that explains IMG file format so that it could take an indent level [we needed a different indent level in **mgd77manage** than in **grdtrack**, for instance].  Also there were updates to _MGD77_IGF_text_ so it would use GMT_Usage in the formatting.  Some usage messages got simplified in the processes.
