### PR TITLE
Fix the minimum required macOS version for the bundle

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ version requires a computer with the M1 Apple Silicon chip.
 
 | **GMT Version** | **Minimum MacOS** |
 |-------------|-------------|
-| 6.2         | macOS 11    |
+| 6.2         | macOS 10.15 |
 | 6.1         | macOS 10.12 |
 | 6.0         | macOS 10.12 |
 | 5.4         | macOS 10.12 |


### PR DESCRIPTION
**Description of proposed changes**

I can't test macOS 10.13 or 10.14, but at least the macOS bundle works
for macOS 10.15 and macOS 11.

See https://github.com/GenericMappingTools/gmt-release-testbot/runs/3167176008
for the CI tests on macOS 10.15.
