### PR TITLE
Document -Re and -Ra for modern mode

### DIFF
--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -61,6 +61,6 @@ and 2 are shown in panels a) and b) respectively of the Figure :ref:`Map region 
    the place is plotted with no third dimension.
 
 #. **-Ra**\ [**uto**] or *-Re**\ [**xact**]. Under modern mode, and for *plotting* modules only, you can automatically
-   determine the region from the data used. Depending on argument you can either get the exact area [Default if no **-R**
+   determine the region from the data used. You can either get the exact area using **-Re** [Default if no **-R**
    is given] or a slightly larger area sensibly rounded outwards to the next multiple of increments that depend on
-   the data range.
+   the data range using **-Ra**.

--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -59,3 +59,8 @@ and 2 are shown in panels a) and b) respectively of the Figure :ref:`Map region 
    and the :ref:`-p <option_-p>` option, where the z-range (*zmin*/*zmax*) is appended to the first method to indicate
    the third dimension. This is not used for :ref:`-p <option_-p>` without **-Jz**, in which case a perspective view of
    the place is plotted with no third dimension.
+
+#. **-Ra**\ [**uto**] or *-Re**\ [**xact**]. Under modern mode, and for *plotting* modules only, you can automatically
+   determine the region from the data used. Depending on argument you can either get the exact area [Default if no **-R**
+   is given] or a slightly larger area sensibly rounded outwards to the next multiple of increments that depend on
+   the data range.

--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -44,3 +44,8 @@
     #. **-R**\ *gridfile*. This will copy the domain settings found for the grid in specified file. Note that depending
        on the nature of the calling module, this mechanism will also set grid spacing and possibly the grid registration
        (see :ref:`cookbook/options:Grid registration: The **-r** option`\ ).
+
+    #. **-Ra**\ [**uto**] or *-Re**\ [**xact**]. Under modern mode, and for *plotting* modules only, you can automatically
+       determine the region from the data used. Depending on argument you can either get the exact area [Default if no **-R**
+       is given] or a slightly larger area sensibly rounded outwards to the next multiple of increments that depend on
+       the data range.

--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -46,6 +46,6 @@
        (see :ref:`cookbook/options:Grid registration: The **-r** option`\ ).
 
     #. **-Ra**\ [**uto**] or *-Re**\ [**xact**]. Under modern mode, and for *plotting* modules only, you can automatically
-       determine the region from the data used. Depending on argument you can either get the exact area [Default if no **-R**
+       determine the region from the data used. You can either get the exact area using **-Re** [Default if no **-R**
        is given] or a slightly larger area sensibly rounded outwards to the next multiple of increments that depend on
-       the data range.
+       the data range using **-Ra**.


### PR DESCRIPTION
We forgot to document this feature... The **-Re** is default when there is no **-R** in modern mode, while **-Ra** (-Rauto) will round a little bit outwards.  Decisions are made in gmt_init.c: Function _gmtinit_round_wesn_.
