### PR TITLE
Make -x directive clickable

### DIFF
--- a/doc/rst/source/common_SYN_OPTs.rst_
+++ b/doc/rst/source/common_SYN_OPTs.rst_
@@ -70,7 +70,7 @@
 
 .. |SYN_OPT-w| replace:: **-w**\ :ref:`flags <-w_full>`
 
-.. |SYN_OPT-x| replace:: **-x**\ [[-]\ *n*]
+.. |SYN_OPT-x| replace:: **-x**\ [[-]\ :ref:`n <core_full>`]
 
 .. |SYN_OPT-:| replace:: **-:**\ [**i**\|\ **o**]
 


### PR DESCRIPTION
**Description of proposed changes**

Relates to https://github.com/GenericMappingTools/gmt/discussions/4678#discussioncomment-1059959, this PR makes the argument after the -x option in the module synopsis clickable.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
