### PR TITLE
The usage message for -w was wrong

### DIFF
--- a/doc/rst/source/explain_-w_full.rst_
+++ b/doc/rst/source/explain_-w_full.rst_
@@ -20,11 +20,11 @@ simple equation
 
     t' = (t - \tau) \;\mathrm{mod}\; T,
 
-where *t* is the input coordinate, :math:`\tau` is a phase-shift (typically zero), and *T* is the desired period for the
+where *t* is the input coordinate, :math:`\tau` is a phase-shift [Default is zero], and *T* is the desired period for the
 modulus operator, yielding cyclic coordinates :math:`t'`. GMT offers many standard time cycles in prescribed units plus
 a custom cycle for other types of Cartesian coordinates. The table below shows the values for units, phase and period
 that are prescribed and only requires the user to specify the corresponding wrapping code (**y**\|\ **a**\|\ **w**\|\
-**d**\|\ **h**\|\ **m**\|\ **s**\|\ **c**\ *period*\):
+**d**\|\ **h**\|\ **m**\|\ **s**\|\ **c**\ *period*\ [/*phase*]\):
 
 +------------+---------------------------+------------+--------------+-----------+
 | **Code**   | **Purpose** (**unit**)    | **Period** |  **Phase**   | **Range** |
@@ -46,8 +46,8 @@ that are prescribed and only requires the user to specify the corresponding wrap
 | **c**      | Custom cycle (normalized) |  :math:`T` | :math:`\tau` |   0–1     |
 +------------+---------------------------+------------+--------------+-----------+
 
-Optionally, append **+c**\ *col* to select the input column with the coordinates to be wrapped, [default *col* is 0
-(i.e., the first column)]. If the custom cycle **c** is chosen then you must also supply the *period* and optionally
+Optionally, append **+c**\ *col* to select the input column with the coordinates to be wrapped, [default *col* is 0,
+i.e., the first column]. If the custom cycle **c** is chosen then you must also supply the *period* and optionally
 any *phase* [default is 0] in the same units of your data (i.e., no units should be appended to **-w**).
 
 **Note**: Coordinates for **w** in the range 0-1 correspond to the first day of the week [Monday] but can be changed

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7645,10 +7645,10 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 		case 'w':	/* -w option for cyclicity */
 
 			GMT_Usage (API, 1, "\n%s", GMT_w_OPT);
-			GMT_Usage (API, -2, "Wrapped selected column [0] with specified cyclicity: "
+			GMT_Usage (API, -2, "Wrap selected column [0] with specified cyclicity: "
 				"Absolute time: Append y|a|w|d|h|m|s for year, annual (by month), week, day, hour, minute, or second cycles. "
-				"Alternatively, append c<period>[/<phase>] for custom cyclicity.");
-			GMT_Usage (API, 3, "+c<col> Select another column than x for wrapping.");
+				"Alternatively, append c<period>[/<phase>] for custom cyclicity [Default <phase> = 0].");
+			GMT_Usage (API, 3, "+c<col> Select another column than 0 (x) for wrapping.");
 			break;
 
 		case 's':	/* Output control for records where z are NaN */

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -136,7 +136,7 @@
 #define GMT_s_OPT	"-s[<cols>][+a][+r]"
 #define GMT_t_OPT	"-t<transp>[/<transp2>[+f|s]"
 #define GMT_tv_OPT	"-t[<transp>[/<transp2>[+f][+s]]"
-#define GMT_w_OPT	"-wa|y|w|d|p<period][/<phase>][+c<col>]"
+#define GMT_w_OPT	"-wy|a|w|d|h|m|s|c<period>[/<phase>][+c<col>]"
 #define GMT_colon_OPT	"-:[i|o]"
 
 /*! Macro for tools that need to specify FFT information (prepend option flag, e.g., -N and put GMT_FFT_OPT inside [] ) */


### PR DESCRIPTION
Clearly not update as this option matured over a few weeks.  Now the synopsis is correct, no typos, and the RST matches it.
