### PR TITLE
Use same -W[+s|w] in several modules

### DIFF
--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-G|\ [*grdfile*] ]
 [ |-S|\ [**m**\|\ **n**\|\ **s**\|\ **w**] ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**i**\|\ **o**][**+s**] ]
+[ |-W|\ [**i**\|\ **o**][**+s**\|\ **w**] ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -122,7 +122,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**i**\|\ **o**][**+s**]
+**-W**\ [**i**\|\ **o**][**+s**\|\ **w**]
     Weighted modifier[s]. Unweighted input and output have 3 columns
     *x*,\ *y*,\ *z*; Weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
     Weights can be used in input to construct weighted mean values for
@@ -130,7 +130,8 @@ Optional Arguments
     several runs, etc. Use **-W** for weighted i/o, **-Wi** for weighted
     input only, and **-Wo** for weighted output only. [Default uses
     unweighted i/o]. If your weights are actually uncertainties (one sigma)
-    then append **+s** and we compute weight = 1/sigma.
+    then append **+s** and we compute weight = 1/sigma.  Otherwise (or via **+w**
+    we use the weights directly).
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-Q| ]
 [ |-T|\ *quantile* ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**i**\|\ **o**][**+s**] ]
+[ |-W|\ [**i**\|\ **o**][**+s**\|\ **w**] ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -145,7 +145,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**i**\|\ **o**][**+s**]
+**-W**\ [**i**\|\ **o**][**+s**\|\ **w**]
     Weighted modifier[s]. Unweighted input and output have 3 columns
     *x*,\ *y*,\ *z*; Weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
     Weights can be used in input to construct weighted median values for each
@@ -153,7 +153,8 @@ Optional Arguments
     several runs, etc. Use **-W** for weighted i/o, **-Wi** for weighted
     input only, and **-Wo** for weighted output only. [Default uses
     unweighted i/o]. If your weights are actually uncertainties (one sigma)
-    then append **+s** and we compute weight = 1/sigma.
+    then append **+s** and we compute weight = 1/sigma.  Otherwise (or via **+w**
+    we use the weights directly).
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-G|\ [*grdfile*] ]
 [ |-Q| ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**i**\|\ **o**][**+s**] ]
+[ |-W|\ [**i**\|\ **o**][**+s**\|\ **w**] ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -146,7 +146,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**i**\|\ **o**][**+s**]
+**-W**\ [**i**\|\ **o**][**+s**\|\ **w**]
     Weighted modifier[s]. Unweighted input and output have 3 columns
     *x*,\ *y*,\ *z*; Weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
     Weights can be used in input to construct weighted modal values for each
@@ -154,7 +154,8 @@ Optional Arguments
     several runs, etc. Use **-W** for weighted i/o, **-Wi** for weighted
     input only, and **-Wo** for weighted output only. [Default uses unweighted i/o].
     If your weights are actually uncertainties (one sigma)
-    then append **+s** and we compute weight = 1/sigma.
+    then append **+s** and we compute weight = 1/sigma.  Otherwise (or via **+w**
+    we use the weights directly).
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -24,7 +24,7 @@ Synopsis
 [ |-S|\ *nu* ]
 [ |-T|\ *maskgrid* ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**w**] ]
+[ |-W|\ [**+s**\|\ **w**] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -153,13 +153,13 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**w**]
+**-W**\ [**+s**\|\ **w**]
    One-sigma data uncertainties for *u* and *v* are provided in the last two columns.
    We then compute least squares weights that are inversely proportional to the square
-   of the uncertainties.  Append **w** if weights are given instead of uncertainties,
-   in which case we just use the weights as provided (no squaring).  This results in
-   a weighted least squares fit.  Note that **-W** only has an effect if **-C** is used.
-   [Default uses no weights or uncertainties].
+   of the uncertainties [Default, or **+s**].  Instead, append **+w** if weights are
+   given instead of uncertainties, in which case we just use the weights as provided
+   (no squaring).  This results in a weighted least squares fit.  Note that **-W**
+   only has an effect if **-C** is used [Default uses no weights or uncertainties].
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: /explain_-V.rst_

--- a/doc/rst/source/trend2d.rst
+++ b/doc/rst/source/trend2d.rst
@@ -16,7 +16,7 @@ Synopsis
 [ |-C|\ *condition\_number* ]
 [ |-I|\ [*confidence\_level*] ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**+s**] ]
+[ |-W|\ [**+s**\|\ **w**] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -109,11 +109,12 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**+s**]
+**-W**\ [**+s**\|\ **w**]
     Weights are supplied in input column 4. Do a weighted least squares
     fit [or start with these weights when doing the iterative robust
     fit]. Append **+s** to instead read data uncertainties (one sigma)
-    and create weights as 1/sigma^2 [Default reads only the first 3 columns.]
+    and create weights as 1/sigma^2, or use the weights as read (**+w**)
+    [Default reads only the first 2 columns].
 
 .. |Add_-bi| replace:: [Default is 3 (or 4 if **-W** is set) input columns].
 .. include:: explain_-bi.rst_

--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -74,7 +74,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	const char *extra1[2] = {" [-G<grdfile>]", ""}, *extra2[2] = {" (requires -G)", ""};
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<table>] %s %s [-A<fields>] [-C] [-E[+p|P]]%s [-S[m|n|s|w]] [%s] [-W[i][o][+s]] "
+	GMT_Usage (API, 0, "usage: %s [<table>] %s %s [-A<fields>] [-C] [-E[+p|P]]%s [-S[m|n|s|w]] [%s] [-W[i][o][+s|w]] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_I_OPT, GMT_Rgeo_OPT, extra1[API->external], GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT,
 		GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_q_OPT, GMT_r_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -106,12 +106,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "s: Report data sums.");
 	GMT_Usage (API, 3, "w: Reports weight sums.");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[i|o][+s]");
+	GMT_Usage (API, 1, "\n-W[i|o][+s|w]");
 	GMT_Usage (API, -2, "Perform weighted calculations [no weights]. Optionally set weight directive:");
 	GMT_Usage (API, 3, "i: Read 4 cols (x,y,z,w) but skip w on output.");
 	GMT_Usage (API, 3, "o: Read 3 cols (x,y,z) but include weight sum (i.e., counts) on output.");
 	GMT_Usage (API, -2, "Default selects both weighted input and output. "
-		"Append +s to read standard deviations s instead and compute w = 1/s^2.");
+		"Append +s to read standard deviations s instead and compute w = 1/s^2. Default (or +w) reads weights directly");
 	GMT_Option (API, "a,bi");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 3 columns (or 4 if -W[+s] is set), or 2 for -Sn.");
 	GMT_Option (API, "bo,d,e,f,h,i,o,q,r,w,:,.");

--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -63,7 +63,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	const char *extra1[2] = {" [-G<grdfile>]", ""}, *extra2[2] = {" (requires -G)", ""};
 	GMT_Usage (API, 0, "usage: %s [<table>] %s %s [-A<fields>] [-C] [-E[b|r|s[+l|h]]]%s [-Q] [-T<q>] [%s] "
-		"[-W[i|o][+s]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+		"[-W[i|o][+s|w]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_I_OPT, GMT_Rgeo_OPT, extra1[API->external], GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT,
 		GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_q_OPT, GMT_r_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -94,12 +94,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-T<q>");
 	GMT_Usage (API, -2, "Set quantile (0 < q < 1) to report [Default is 0.5 which is the median of z].");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[i|o][+s]");
+	GMT_Usage (API, 1, "\n-W[i|o][+s|w]");
 	GMT_Usage (API, -2, "Perform weighted calculations [no weights]. Optionally set weight directive:");
 	GMT_Usage (API, 3, "i: Read 4 cols (x,y,z,w) but skip w on output.");
 	GMT_Usage (API, 3, "o: Read 3 cols (x,y,z) but include weight sum (i.e., counts) on output.");
 	GMT_Usage (API, -2, "Default selects both weighted input and output. "
-		"Append +s read/write standard deviations instead, with w = 1/s.");
+		"Append +s read/write standard deviations instead, with w = 1/s. Default (or +w) reads weights directly");
 	GMT_Option (API, "a,bi");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 3 columns (or 4 if -W is set).");
 	GMT_Option (API, "bo,d,e,f,h,i,o,q,r,w,:,.");

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -74,7 +74,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	const char *extra1[2] = {" [-G<grdfile>]", ""}, *extra2[2] = {" (requires -G)", ""};
 	GMT_Usage (API, 0, "usage: %s [<table>] %s %s [-A<fields>] [-C] [-D[<width>][+c][+a|l|h]] [-E[r|s[+l|h]]]%s "
-		"[-Q] [-W[i|o][+s]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+		"[-Q] [-W[i|o][+s|w]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_I_OPT, GMT_Rgeo_OPT, extra1[API->external], GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT,
 		GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_q_OPT, GMT_r_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -109,12 +109,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	}
 	GMT_Usage (API, 1, "\n-Q Quicker; get mode z and mean x,y [Default gets mode x, mode y, mode z].");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[i|o][+s]");
+	GMT_Usage (API, 1, "\n-W[i|o][+s|w]");
 	GMT_Usage (API, -2, "Perform weighted calculations [no weights]. Optionally set weight directive:");
 	GMT_Usage (API, 3, "i: Read 4 cols (x,y,z,w) but skip w on output.");
 	GMT_Usage (API, 3, "o: Read 3 cols (x,y,z) but include weight sum (i.e., counts) on output.");
 	GMT_Usage (API, -2, "Default selects both weighted input and output. "
-		"Append +s read/write standard deviations instead, with w = 1/s.");
+		"Append +s read/write standard deviations instead, with w = 1/s. Default (or +w) reads weights directly.");
 
 	GMT_Option (API, "a,bi");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 3 columns (or 4 if -W is set).");

--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -75,7 +75,7 @@ struct GPSGRIDDER_CTRL {
 		bool active;
 		char *file;
 	} T;
-	struct GPSGRIDDER_W {	/* -W[w] */
+	struct GPSGRIDDER_W {	/* -W[+s|w] */
 		bool active;
 		unsigned int mode;	/* 0 = got sigmas, 1 = got weights */
 	} W;
@@ -137,7 +137,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<table>] -G<outfile> [-C[n]<val>[+f<file>]] [-E<misfitfile>] [-Fd|f<val>] [-I<dx>[/<dy>] "
-		"[-L] [-N<nodefile>] [%s] [-S<nu>] [-T<maskgrid>] [%s] [-W[w]] [%s] [%s] [%s] [%s] "
+		"[-L] [-N<nodefile>] [%s] [-S<nu>] [-T<maskgrid>] [%s] [-W[+s|w]] [%s] [%s] [%s] [%s] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s]%s[%s] [%s]\n", name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT,
 		GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_n_OPT, GMT_o_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_x_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -193,11 +193,11 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Give effective 2-D Poisson's ratio [0.5]. Note: 1.0 is incompressible in a 2-D formulation.");
 	GMT_Usage (API, 1, "\n-T<maskgrid>");
 	GMT_Usage (API, -2, "Mask grid file whose values are NaN or 0; its header implicitly sets -R, -I (and -r).");
-	GMT_Usage (API, 1, "\n-W[w]");
-	GMT_Usage (API, -2, "Expects two extra input columns with data errors sigma_x, sigma_y). "
-		"Append w to indicate these columns carry weights instead "
-		"[Default makes weights via 1/sigma_x^2, 1/sigma_y^2]. "
-		"Note: -W will only have an effect if -C is used.");
+	GMT_Usage (API, 1, "\n-W[+s|w]");
+	GMT_Usage (API, -2, "Expects two extra input columns with either data weights or errors sigma_x, sigma_y):");
+	GMT_Usage (API, 3, "+s Read sigma-errors and make weights via 1/sigma_x^2, 1/sigma_y^2 [Default].");
+	GMT_Usage (API, 3, "+w Read weights directly [Default].");
+	GMT_Usage (API, -2, "Note: -W will only have an effect if -C is used.");
 	GMT_Option (API, "V,bi");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 4-6 input columns (see -W); use -i to select columns from any data table.");
 	GMT_Option (API, "d,e,f,h,i,n,o,qi,r,s,x,:,.");
@@ -310,7 +310,12 @@ static int parse (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *Ctrl, struct GMT
 				break;
 			case 'W':	/* Expect data weights in last two columns */
 				Ctrl->W.active = true;
-				if (opt->arg[0] == 'w') Ctrl->W.mode = GPS_GOT_W;	/* Got weights instead of sigmas */
+				if (opt->arg[0] == 'w')	/* Deprecated syntax -Ww */
+					Ctrl->W.mode = GPS_GOT_W;	/* Got weights instead of sigmas */
+				else if (strstr (opt->arg, "+w"))
+					Ctrl->W.mode = GPS_GOT_W;	/* Got weights instead of sigmas */
+				else if (opt->arg[0] == '\0' || strstr (opt->arg, "+s"))
+					Ctrl->W.mode = GPS_GOT_SIG;	/* Got sigmas instead of weights [Default] */
 				break;
 #ifdef DEBUG
 			case 'Z':	/* Dump matrices */

--- a/src/gmtbinstats.c
+++ b/src/gmtbinstats.c
@@ -124,7 +124,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GMTBINSTATS_CTRL *C) {	/* De
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<table>] -Ca|d|g|i|l|L|m|n|o|p|q[<val>]|r|s|u|U|z -G<outgrid> %s %s -S%s [-E<empty>] [-N] [-T[h|r]] [%s] [-W[+s]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+	GMT_Usage (API, 0, "usage: %s [<table>] -Ca|d|g|i|l|L|m|n|o|p|q[<val>]|r|s|u|U|z -G<outgrid> %s %s -S%s [-E<empty>] [-N] [-T[h|r]] [%s] [-W[+s|w]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 			 name, GMT_I_OPT, GMT_Rgeo_OPT, GMT_RADIUS_OPT, GMT_V_OPT, GMT_a_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -159,8 +159,11 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -3, "h: hexagonal binning, write non-equidistant table to standard output (or file named in -G).");
 	GMT_Usage (API, -3, "r: rectangular binning, writes equidistant grid (named via -G) [Default].");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W Input <table> has observation weights in 4th column. We then compute the weighted version "
-			"of selection in -C. Append +s to read standard deviations s instead and compute weight = 1/s.");
+	GMT_Usage (API, 1, "\n-W[+s|w]");
+	GMT_Usage (API, -2, "Weighted input given, weights in 4th column; compute the weighted version "
+		"of selection in -C [Default is unweighted]. Select modifier:");
+	GMT_Usage (API, 3, "+s Read standard deviations and compute weights as 1/s.");
+	GMT_Usage (API, 3, "+w Read weights directly [Default].");
 	GMT_Option (API, "a,bi");
 	GMT_Message (API, GMT_TIME_NONE, "\t   Default is 3 (or 4 if -W is set) columns.");
 	GMT_Option (API, "di,e,f,h,i");
@@ -253,6 +256,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTBINSTATS_CTRL *Ctrl, struct GM
 				break;
 			case 'W':	/* Use weights */
 				Ctrl->W.active = true;
+				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "sw", GMT_MSG_ERROR)) n_errors++;
 				Ctrl->W.sigma = (strstr (opt->arg, "+s")) ? true : false;
 				break;
 			default:	/* Report bad options */

--- a/src/trend1d.c
+++ b/src/trend1d.c
@@ -525,7 +525,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<table>] -F<xymrw>|p|P|c -N[p|P|f|F|c|C|s|S|x|X]<list-of-terms>[,...][+l<length>][+o<origin>][+r] "
-		"[-C<condition_#>] [-I[<confidence>]] [%s] [-W[+s]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+		"[-C<condition_#>] [-I[<confidence>]] [%s] [-W[+s|w]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_q_OPT, GMT_s_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -565,9 +565,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Iteratively Increase the number of model parameters, to a max of <n_model> so long as the "
 		"reduction in variance is significant at the <confidence> level [0.51].");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[+s]");
-	GMT_Usage (API, -2, " Weighted input given, weights in 3rd column [Default is unweighted].");
+	GMT_Usage (API, 1, "\n-W[+s|w]");
+	GMT_Usage (API, -2, " Weighted input given, weights in 3rd column [Default is unweighted]. Select modifier:");
 	GMT_Usage (API, 3, "+s Read standard deviations and compute weights as 1/s^2.");
+	GMT_Usage (API, 3, "+w Read weights directly [Default].");
 	GMT_Option (API, "bi");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 2 (or 3 if -W is set) input columns.");
 	GMT_Option (API, "bo,d,e,f,h,i,q,s,w,:,.");
@@ -623,7 +624,7 @@ static int parse (struct GMT_CTRL *GMT, struct TREND1D_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'W':
 				Ctrl->W.active = true;
-				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "s", GMT_MSG_ERROR)) n_errors++;
+				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "sw", GMT_MSG_ERROR)) n_errors++;
 				Ctrl->W.mode = (strstr (opt->arg, "+s")) ? 2 : 1;
 				break;
 

--- a/src/trend2d.c
+++ b/src/trend2d.c
@@ -422,7 +422,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<table>] -F<xyzmrw>|p -N<n_model>[+r] [-C<condition_#>] [-I[<confidence>]] "
-		"[%s] [-W[+s]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+		"[%s] [-W[+s|w]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_q_OPT, GMT_s_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -450,9 +450,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Iteratively Increase # model parameters, to a max of <n_model> so long as the "
 		"reduction in variance is significant at the <confidence> level [0.51].");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[+s]");
-	GMT_Usage (API, -2, "Weighted input given, weights in 3rd column [Default is unweighted].");
+	GMT_Usage (API, 1, "\n-W[+s|w]");
+	GMT_Usage (API, -2, "Weighted input given, weights in 4th column [Default is unweighted]. Select modifier:");
 	GMT_Usage (API, 3, "+s Read standard deviations and compute weights as 1/s^2.");
+	GMT_Usage (API, 3, "+w Read weights directly [Default].");
 	GMT_Option (API, "bi");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 3 (or 4 if -W is set) columns.");
 	GMT_Option (API, "bo,d,e,f,h,i,q,s,w,:,.");
@@ -507,7 +508,7 @@ static int parse (struct GMT_CTRL *GMT, struct TREND2D_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'W':
 				Ctrl->W.active = true;
-				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "s", GMT_MSG_ERROR)) n_errors++;
+				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "sw", GMT_MSG_ERROR)) n_errors++;
 				Ctrl->W.mode = (strstr (opt->arg, "+s")) ? 2 : 1;
 				break;
 


### PR DESCRIPTION
We had **-W**[**+s**] in trend1d/2d and **-Ww** in gpsgridder, while we use **-W**[**i**|**o**][**+s**] in blockm*.  Now we use the common modifier choice [**+s**|**w**] for all of them.  In all cases, either **+s** or **+w** is the default.  No real change otherwise, all tests pass. Backwards compatibility for -Ww in gpsgridder, and fixed wrong column stated for trend2d.
