### PR TITLE
Replace -N<nodata> with -di

### DIFF
--- a/doc/rst/source/grdblend.rst
+++ b/doc/rst/source/grdblend.rst
@@ -12,14 +12,17 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdblend** [ *blendfile* \| *grid1* *grid2* ... ] |-G|\ *outgrid*
+**gmt grdblend**
+[ *blendfile* \| *grid1* *grid2* ... ]
+|-G|\ *outgrid*
 |SYN_OPT-I|
 |SYN_OPT-R|
 [ |-C|\ **f**\|\ **l**\|\ **o**\|\ **u**\ [**+n**\|\ **p**] ]
-[ |-N|\ *nodata* ]
-[ |-Q| ] [ |-Z|\ *scale* ]
+[ |-Q| ]
+[ |-Z|\ *scale* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [**z**] ]
+[ |SYN_OPT-di| ]
 [ |SYN_OPT-f| ]
 [ |SYN_OPT-n| ]
 [ |SYN_OPT-r| ]
@@ -103,11 +106,6 @@ Optional Arguments
     for subsequent grids we only consider them in the decision if the
     values are >= 0 or <= 0, respectively.
 
-.. _-N:
-
-**-N**\ *nodata*
-    No data. Set nodes with no input grid to this value [Default is NaN].
-
 .. _-Q:
 
 **-Q**
@@ -129,6 +127,10 @@ Optional Arguments
 
 **-Z**\ *scale*
     Scale output values by *scale* before writing to file. [1].
+
+.. |Add_-di| replace:: Also sets nodes with no input constraints to this value
+    [Default is NaN].
+.. include:: explain_-di.rst_
 
 .. |Add_-f| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-f.rst_
@@ -156,24 +158,18 @@ Examples
 .. include:: explain_example.rst_
 
 To create a grid file from the four grid files piece\_?.nc, giving them each the different
-weights, make the blendfile like this
-
-   ::
+weights, make the blendfile like this::
 
     piece_1.nc -R<subregion_1> 1
     piece_2.nc -R<subregion_2> 1.5
     piece_3.nc -R<subregion_3> 0.9
     piece_4.nc -R<subregion_4> 1
 
-Then run
-
-   ::
+Then run::
 
     gmt grdblend blend.job -Gblend.nc -R<full_region> -I<dx/dy> -V
 
-To blend all the grids called MB\_\*.nc given them all equal weight, try
-
-   ::
+To blend all the grids called MB\_\*.nc given them all equal weight, try::
 
     gmt grdblend MB_*.nc -Gblend.nc -R<full_region> -I<dx/dy> -V
 

--- a/doc/rst/source/supplements/segy/segy2grd.rst
+++ b/doc/rst/source/supplements/segy/segy2grd.rst
@@ -12,18 +12,20 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt segy2grd** *segyfile* |-G|\ *grdfile*
+**gmt segy2grd**
+*segyfile*
+|-G|\ *grdfile*
 |SYN_OPT-I|
 |SYN_OPT-R|
 [ |-A|\ [**n**\|\ **z**] ]
 [ |-D|\ |SYN_OPT-D2| ]
 [ |-L|\ [*nsamp*] ]
 [ |-M|\ [*ntraces*] ]
-[ |-N|\ *nodata* ]
 [ |-Q|\ *<mode><value>* ]
 [ |-S|\ [*header*] ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-bi| ]
+[ |SYN_OPT-di| ]
 [ |SYN_OPT-:| ]
 [ |SYN_OPT--| ]
 
@@ -88,12 +90,6 @@ Optional Arguments
     **-M**\ 0 will read number in binary header, **-M**\ *ntraces* will
     attempt to read only *n* traces.
 
-.. _-N:
-
-**-N**\ *nodata*
-    No data. Set nodes with no input sample to this value [Default is
-    NaN].
-
 .. _-Q:
 
 **-Q**\ *<mode><value>*
@@ -115,6 +111,10 @@ Optional Arguments
     :start-after: **Syntax**
     :end-before: **Description**
 
+.. |Add_-di| replace:: Also sets nodes with no input SEGY coverage to this value
+    [Default is NaN].
+.. include:: ../../explain_-di.rst_
+
 .. |Add_nodereg| unicode:: 0x20 .. just an invisible code
 .. include:: ../../explain_nodereg.rst_
 
@@ -123,9 +123,7 @@ Optional Arguments
 Examples
 --------
 
-To create a grid file from an even spaced SEGY file test.segy, try
-
-   ::
+To create a grid file from an even spaced SEGY file test.segy, try::
 
     gmt segy2grd test.segy -I0.1/0.1 -Gtest.nc -R198/208/18/25 -V
 
@@ -134,9 +132,7 @@ first trace will be assumed to be at X=198
 
 To create a grid file from the SEGY file test.segy, locating traces
 according to the CDP number, where there are 10 CDPs per km and the
-sample interval is 0.1, try
-
-   ::
+sample interval is 0.1, try::
 
     gmt segy2grd test.segy -Gtest.nc -R0/100/0/10 -I0.5/0.2 -V -Qx0.1 -Qy0.1
 

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -45,7 +45,7 @@
 #define THIS_MODULE_PURPOSE	"Blend several partially overlapping grids into one larger grid"
 #define THIS_MODULE_KEYS	"<G{+,GG}"
 #define THIS_MODULE_NEEDS	"R"
-#define THIS_MODULE_OPTIONS "-:RVfnr"
+#define THIS_MODULE_OPTIONS "-:RVdfnr"
 
 #define BLEND_UPPER	0
 #define BLEND_LOWER	1
@@ -67,10 +67,6 @@ struct GRDBLEND_CTRL {
 		unsigned int mode;
 		int sign;
 	} C;
-	struct GRDBLEND_N {	/* -N<nodata> */
-		bool active;
-		double nodata;
-	} N;
 	struct GRDBLEND_Q {	/* -Q */
 		bool active;
 	} Q;
@@ -642,7 +638,6 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 
-	C->N.nodata = GMT->session.d_NaN;
 	C->Z.scale = 1.0;
 
 	return (C);
@@ -661,8 +656,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<blendfile> | <grid1> <grid2> ...] -G<outgrid> "
-		"%s %s [-Cf|l|o|u[+n|p]] [-N<nodata>] [-Q] [%s] [-W[z]] [-Z<scale>] [%s] [%s] [%s] [%s]\n",
-		name, GMT_I_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_f_OPT, GMT_n_OPT, GMT_r_OPT, GMT_PAR_OPT);
+		"%s %s [-Cf|l|o|u[+n|p]] [-Q] [%s] [-W[z]] [-Z<scale>] [%s] [%s] [%s] [%s] [%s]\n",
+		name, GMT_I_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_di_OPT, GMT_f_OPT, GMT_n_OPT, GMT_r_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -694,8 +689,6 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Clobbering affects any value. Optionally, append one of two modifiers to change this:");
 	GMT_Usage (API, 3, "+n Only consider clobbering if grid value is <= 0).");
 	GMT_Usage (API, 3, "+p Only consider clobbering if grid value is >= 0.0).");
-	GMT_Usage (API, 1, "\n-N<nodata>");
-	GMT_Usage (API, -2, "Set value for nodes without constraints [Default is NaN].");
 	GMT_Usage (API, 1, "\n-Q Raster output without a leading grid header [Default writes GMT grid file]. "
 		"Output grid must be in one of the native binary formats.");
 	GMT_Option (API, "V");
@@ -704,6 +697,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Append z to write weight-sum w times z instead.");
 	GMT_Usage (API, 1, "\n-Z<scale>");
 	GMT_Usage (API, -2, "Multiply z-values by this scale before writing to file [1].");
+	GMT_Option (API, "di");
+	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Also sets value for nodes without constraints [Default is NaN].");
 	GMT_Option (API, "f,n");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "(-n is passed to grdsample if grids are not co-registered).");
 	GMT_Option (API, "r,.");
@@ -773,14 +768,21 @@ static int parse (struct GMT_CTRL *GMT, struct GRDBLEND_CTRL *Ctrl, struct GMT_O
 			case 'I':	/* Grid spacings */
 				n_errors += gmt_parse_inc_option (GMT, 'I', opt->arg);
 				break;
-			case 'N':	/* NaN-value */
-				Ctrl->N.active = true;
-				if (opt->arg[0])
-					Ctrl->N.nodata = (opt->arg[0] == 'N' || opt->arg[0] == 'n') ? GMT->session.d_NaN : atof (opt->arg);
-				else {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -N option: Must specify value or NaN\n");
-					n_errors++;
+			case 'N':	/* NaN-value (deprecated 7.29.2021 PW, use -di) */
+				if (gmt_M_compat_check (GMT, 4)) {	/* Honor old -N<value> option */
+					GMT_Report (API, GMT_MSG_COMPAT, "Option -N is deprecated; use GMT common option -di<nodata> instead.\n");
+					if (opt->arg[0]) {
+						char arg[GMT_LEN64] = {""};
+						sprintf (arg, "i%s", opt->arg);
+						n_errors += gmt_parse_d_option (GMT, arg);
+					}
+					else {
+						GMT_Report (API, GMT_MSG_ERROR, "Option -N: Must specify value or NaN\n");
+						n_errors++;
+					}
 				}
+				else
+					n_errors += gmt_default_error (GMT, opt->option);
 				break;
 			case 'Q':	/* No header on output */
 				Ctrl->Q.active = true;
@@ -944,7 +946,7 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 
 	/* Process blend parameters and populate blend structure and open input files and seek to first row inside the output grid */
 
-	no_data_f = (gmt_grdfloat)Ctrl->N.nodata;
+	no_data_f = (GMT->common.d.active[GMT_IN]) ? (gmt_grdfloat)GMT->common.d.nan_proxy[GMT_IN] : GMT->session.f_NaN;
 
 	/* Initialize header structure for output blend grid */
 

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -769,7 +769,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDBLEND_CTRL *Ctrl, struct GMT_O
 				n_errors += gmt_parse_inc_option (GMT, 'I', opt->arg);
 				break;
 			case 'N':	/* NaN-value (deprecated 7.29.2021 PW, use -di) */
-				if (gmt_M_compat_check (GMT, 4)) {	/* Honor old -N<value> option */
+				if (gmt_M_compat_check (GMT, 6)) {	/* Honor old -N<value> option */
 					GMT_Report (API, GMT_MSG_COMPAT, "Option -N is deprecated; use GMT common option -di<nodata> instead.\n");
 					if (opt->arg[0]) {
 						char arg[GMT_LEN64] = {""};

--- a/src/segy/segy2grd.c
+++ b/src/segy/segy2grd.c
@@ -33,7 +33,7 @@
 #define THIS_MODULE_PURPOSE	"Converting SEGY data to a grid"
 #define THIS_MODULE_KEYS	"GG}"
 #define THIS_MODULE_NEEDS	"R"
-#define THIS_MODULE_OPTIONS "-VRr" GMT_OPT("F")
+#define THIS_MODULE_OPTIONS "-VRdr" GMT_OPT("F")
 
 #define COUNT	1
 #define AVERAGE	2
@@ -77,11 +77,6 @@ struct SEGY2GRD_CTRL {
 		bool active;
 		unsigned int value;
 	} M;
-	struct SEGY2GRD_N {	/* -N */
-		bool active;
-		double d_value;
-		float f_value;
-	} N;
 	struct SEGY2GRD_Q {	/* -Qx|y */
 		bool active[2];
 		double value[2];
@@ -102,8 +97,6 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 	C->A.mode = AVERAGE;
 	C->M.value = 10000;
-	C->N.f_value = GMT->session.f_NaN;
-	C->N.d_value = GMT->session.d_NaN;
 	C->Q.value[X_ID] = 1.0;
 	return (C);
 }
@@ -120,8 +113,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <segyfile> -G<outgrid> %s %s [-A[n|z]] [%s] [-L<nsamp>] "
-		"[-M<ntraces>] [-N<nodata>] [-Q<mode><value>] [-S<header>] [%s] [%s] [%s]\n",
-		name, GMT_Id_OPT, GMT_Rgeo_OPT, GMT_GRDEDIT2D, GMT_V_OPT, GMT_r_OPT, GMT_PAR_OPT);
+		"[-M<ntraces>] [-Q<mode><value>] [-S<header>] [%s] [%s] [%s] [%s]\n",
+		name, GMT_Id_OPT, GMT_Rgeo_OPT, GMT_GRDEDIT2D, GMT_V_OPT, GMT_di_OPT, GMT_r_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -144,8 +137,6 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-M<ntraces>");
 	GMT_Usage (API, -2, "Fix the number of traces. -M0 will read number in binary header, while "
 		"-M<ntraces> will attempt to read only <ntraces> traces [Default reads all traces].");
-	GMT_Usage (API, 1, "\n-N<nodata>");
-	GMT_Usage (API, -2, "Set value for nodes without corresponding input sample [Default is NaN].");
 	GMT_Usage (API, 1, "\n-Q<mode><value>");
 	GMT_Usage (API, -2, "Append <mode><value> to change either of two different settings:");
 	GMT_Usage (API, 3, "x: Append <scl> applied to coordinates in trace header to match the coordinates specified in -R.");
@@ -154,7 +145,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Append <header> to set variable spacing. "
 		"<header> is c for cdp, o for offset, b<number> for 4-byte float starting at byte number. "
 		"Note: If -S not set, assumes even spacing of samples at dx, dy supplied with -I.");
-	GMT_Option (API, "V,r,.");
+	GMT_Option (API, "V,di");
+	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Also sets value for nodes without input SEGY coverage [Default is NaN].");
+	GMT_Option (API, "r,.");
 
 	return (GMT_MODULE_USAGE);
 }
@@ -207,16 +200,21 @@ static int parse (struct GMT_CTRL *GMT, struct SEGY2GRD_CTRL *Ctrl, struct GMT_O
 			case 'I':
 				n_errors += gmt_parse_inc_option (GMT, 'I', opt->arg);
 				break;
-			case 'N':
-				if (!opt->arg[0]) {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -N: Must specify value or NaN\n");
-					n_errors++;
+			case 'N':	/* Deprecated 7.29.2021 PW, use -di */
+				if (gmt_M_compat_check (GMT, 4)) {	/* Honor old -N<value> option */
+					GMT_Report (API, GMT_MSG_COMPAT, "Option -N is deprecated; use GMT common option -di<nodata> instead.\n");
+					if (opt->arg[0]) {
+						char arg[GMT_LEN64] = {""};
+						sprintf (arg, "i%s", opt->arg);
+						n_errors += gmt_parse_d_option (GMT, arg);
+					}
+					else {
+						GMT_Report (API, GMT_MSG_ERROR, "Option -N: Must specify value or NaN\n");
+						n_errors++;
+					}
 				}
-				else {
-					Ctrl->N.d_value = (opt->arg[0] == 'N' || opt->arg[0] == 'n') ? GMT->session.d_NaN : atof (opt->arg);
-					Ctrl->N.f_value = (float)Ctrl->N.d_value;
-					Ctrl->N.active = true;
-				}
+				else
+					n_errors += gmt_default_error (GMT, opt->option);
 				break;
 			case 'Q':
 				switch (opt->arg[0]) {
@@ -282,7 +280,7 @@ EXTERN_MSC int GMT_segy2grd (void *V_API, int mode, void *args) {
 
 	uint64_t ij, ij0, n_samp = 0, isamp;
 
-	double idy, x0, yval;
+	double idy, x0, yval, no_data_d;
 
 	char line[GMT_BUFSIZ] = {""};
 
@@ -292,7 +290,7 @@ EXTERN_MSC int GMT_segy2grd (void *V_API, int mode, void *args) {
 
 /* SEGY parameters */
 	char reelhead[3200] = {""};
-	float *data = NULL;
+	float *data = NULL, no_data_f;
 	SEGYHEAD *header = NULL;
 	SEGYREEL binhead;
 
@@ -418,9 +416,12 @@ EXTERN_MSC int GMT_segy2grd (void *V_API, int mode, void *args) {
 
 	/* starts reading actual data here....... */
 
+	no_data_d = (GMT->common.d.active[GMT_IN]) ? GMT->common.d.nan_proxy[GMT_IN] : GMT->session.d_NaN;
+	no_data_f = (GMT->common.d.active[GMT_IN]) ? (gmt_grdfloat)GMT->common.d.nan_proxy[GMT_IN] : GMT->session.f_NaN;
+
 	if (read_cont) {	/* old-style segy2grd */
 		ix = 0;
-		for (ij = 0; ij < Grid->header->size; ij++) Grid->data[ij] = Ctrl->N.f_value;
+		for (ij = 0; ij < Grid->header->size; ij++) Grid->data[ij] = no_data_f;
 		if (Grid->header->n_columns < Ctrl->M.value) {
 			GMT_Report (API, GMT_MSG_WARNING, "Number of traces in header > size of grid. Reading may be truncated\n");
 			Ctrl->M.value = Grid->header->n_columns;
@@ -545,7 +546,7 @@ EXTERN_MSC int GMT_segy2grd (void *V_API, int mode, void *args) {
 			}
 			else if (flag[ij] == 0) {
 				n_empty++;
-				Grid->data[ij] = Ctrl->N.f_value;
+				Grid->data[ij] = no_data_f;
 			}
 			else {	/* More than 1 value went to this node */
 				if (Ctrl->A.mode == COUNT)
@@ -558,10 +559,10 @@ EXTERN_MSC int GMT_segy2grd (void *V_API, int mode, void *args) {
 		}
 
 		if (gmt_M_is_verbose (GMT, GMT_MSG_INFORMATION)) {
-			if (gmt_M_is_dnan (Ctrl->N.d_value))
+			if (gmt_M_is_dnan (no_data_d))
 				strcpy (line, "NaN\n");
 			else
-				sprintf (line, GMT->current.setting.format_float_out, Ctrl->N.d_value);
+				sprintf (line, GMT->current.setting.format_float_out, no_data_d);
 			GMT_Report (API, GMT_MSG_INFORMATION, " n_read: %d  n_used: %d  n_filled: %d  n_empty: %d set to %s\n", n_read, n_used, n_filled, n_empty, line);
 		}
 		if (n_stuffed) GMT_Report (API, GMT_MSG_WARNING, "%d nodes had multiple entries that were averaged\n", n_stuffed);

--- a/src/segy/segy2grd.c
+++ b/src/segy/segy2grd.c
@@ -201,7 +201,7 @@ static int parse (struct GMT_CTRL *GMT, struct SEGY2GRD_CTRL *Ctrl, struct GMT_O
 				n_errors += gmt_parse_inc_option (GMT, 'I', opt->arg);
 				break;
 			case 'N':	/* Deprecated 7.29.2021 PW, use -di */
-				if (gmt_M_compat_check (GMT, 4)) {	/* Honor old -N<value> option */
+				if (gmt_M_compat_check (GMT, 6)) {	/* Honor old -N<value> option */
 					GMT_Report (API, GMT_MSG_COMPAT, "Option -N is deprecated; use GMT common option -di<nodata> instead.\n");
 					if (opt->arg[0]) {
 						char arg[GMT_LEN64] = {""};

--- a/src/xyz2grd.c
+++ b/src/xyz2grd.c
@@ -145,7 +145,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "[Default format is scanline orientation in ASCII representation: -ZTLa]. This option assumes "
 		"all nodes have data values.");
 	GMT_Option (API, "bi3,di");
-	if (gmt_M_showusage (API)) GMT_Message (API, GMT_TIME_NONE, "\t   Also sets value for nodes without input xyz triplet [Default is NaN].");
+	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Also sets value for nodes without input xyz triplet [Default is NaN].");
 	GMT_Option (API, "e,f,h,i,qi,r,s,w,:,.");
 
 	return (GMT_MODULE_USAGE);


### PR DESCRIPTION
As was done a while ago with **xyz2grd**, this PR extends it and replaces the module-specific **-N**_nodata_ option in **grdblend** and **segy2grd** with the GMT common option **-di**, in a backwards compatible way, of course.  This reduces the need to module-specific options.
