### PR TITLE
JPEG quality and recognition of modifiers

### DIFF
--- a/doc/rst/source/begin.rst
+++ b/doc/rst/source/begin.rst
@@ -51,6 +51,8 @@ Optional Arguments
     Give one or more comma-separated graphics extensions from the list of allowable
     :ref:`graphics formats <tbl-formats>`
     (default format is configurable via setting :term:`GMT_GRAPHICS_FORMAT` [pdf]).
+    Optionally, append **+m** for monochrome image (BMP, JPEG, PNG, and TIFF only)
+    and **+q**\ *quality* in 0-100 range to change JPEG quality [90].
 
 .. _begin-options:
 

--- a/doc/rst/source/figure.rst
+++ b/doc/rst/source/figure.rst
@@ -50,6 +50,8 @@ Optional Arguments
 *formats*
     Give one or more comma-separated graphics extensions from the list of allowable graphics
     :ref:`formats <tbl-formats>` (default is configurable via setting GMT_GRAPHICS_FORMAT [pdf]).
+    Optionally, append **+m** for monochrome image (BMP, JPEG, PNG, and TIFF only)
+    and **+q**\ *quality* in 0-100 range to change JPEG quality [90].
 
 .. _figure-options:
 

--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -25,7 +25,7 @@ Synopsis
 [ |-M|\ **b**\|\ **f**\ *pslayer* ]
 [ |-Q|\ [**g**\|\ **p**\|\ **t**][1\|2\|4] ]
 [ |-S| ]
-[ |-T|\ **b**\|\ **e**\|\ **E**\|\ **f**\|\ **F**\|\ **j**\|\ **g**\|\ **G**\|\ **m**\|\ **s**\|\ **t**\ [**+m**] ]
+[ |-T|\ **b**\|\ **e**\|\ **E**\|\ **f**\|\ **F**\|\ **j**\|\ **g**\|\ **G**\|\ **m**\|\ **s**\|\ **t**\ [**+m**][**+q**\ *quality*] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *params* ]
 [ |-Z| ]
@@ -187,13 +187,14 @@ Optional Arguments
 
 .. _-T:
 
-**-Tb**\|\ **e**\|\ **E**\|\ **f**\|\ **F**\|\ **j**\|\ **g**\|\ **G**\|\ **m**\|\ **s**\|\ **t**\ [**+m**]
+**-Tb**\|\ **e**\|\ **E**\|\ **f**\|\ **F**\|\ **j**\|\ **g**\|\ **G**\|\ **m**\|\ **s**\|\ **t**\ [**+m**][**+q**\ *quality*]
     Sets the output format, where **b** means BMP, **e** means EPS,
     **E** means EPS with PageSize command, **f** means PDF, **F** means
     multi-page PDF, **j** means JPEG, **g** means PNG, **G** means
     transparent PNG (untouched regions are transparent), **m** means
     PPM, **s** means SVG, and **t** means TIFF [default is JPEG]. To **bjgt** you can
-    append **+m** in order to get a monochrome (grayscale) image. The EPS format can be
+    append **+m** in order to get a monochrome (grayscale) image. To **j** you can
+    append **+q** to change JPEG quality in 0-100 range [90]. The EPS format can be
     combined with any of the other formats. For example, **-Tef**
     creates both an EPS and a PDF file. The **-TF** creates a multi-page
     PDF file from the list of input PS or PDF files. It requires the **-F** option.

--- a/src/begin.c
+++ b/src/begin.c
@@ -56,6 +56,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "ppm:	Portable Pixel Map.");
 	GMT_Usage (API, 3, "ps:	PostScript.");
 	GMT_Usage (API, 3, "tif:	Tagged Image Format File.");
+	GMT_Usage (API, -2, "Two raster modifiers may be appended:");
+	GMT_Usage (API, 3, "+m For b, g, j, and t, make a monochrome (grayscale) image [color].");
+	GMT_Usage (API, 3, "+q Append quality in 0-100 for JPEG only [%d].", GMT_JPEG_DEF_QUALITY);
 	GMT_Usage (API, 1, "\n<psconvertoptions>");
 	GMT_Usage (API, -2,	"contains one or more comma-separated options that"
 		" will be passed to psconvert when preparing figures [%s].", GMT_SESSION_CONVERT);

--- a/src/begin.c
+++ b/src/begin.c
@@ -37,14 +37,14 @@
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<prefix>] [<format(s)>] [<psconvertoptions] [-C] [%s]\n\n", name, GMT_V_OPT);
+	GMT_Usage (API, 0, "usage: %s [<prefix>] [<formats>] [<psconvertoptions] [-C] [%s]\n\n", name, GMT_V_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	GMT_Message (API, GMT_TIME_NONE, "  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n<prefix>");
 	GMT_Usage (API, -2, "The prefix used for unnamed figures [%s].", GMT_SESSION_NAME);
-	GMT_Usage (API, 1, "\n<format(s)>");
+	GMT_Usage (API, 1, "\n<formats>");
 	GMT_Usage (API, -2, "Sets the default plot format(s) [%s].", gmt_session_format[API->GMT->current.setting.graphics_format]);
 	GMT_Usage (API, -2, "\nChoose one or more of these valid extensions separated by commas:");
 	GMT_Usage (API, 3, "bmp:	MicroSoft BitMap.");
@@ -57,8 +57,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "ps:	PostScript.");
 	GMT_Usage (API, 3, "tif:	Tagged Image Format File.");
 	GMT_Usage (API, -2, "Two raster modifiers may be appended:");
-	GMT_Usage (API, 3, "+m For b, g, j, and t, make a monochrome (grayscale) image [color].");
-	GMT_Usage (API, 3, "+q Append quality in 0-100 for JPEG only [%d].", GMT_JPEG_DEF_QUALITY);
+	GMT_Usage (API, 3, "+m For bmp, png, jpg, and tif, make a monochrome (grayscale) image [color].");
+	GMT_Usage (API, 3, "+q Append quality in 0-100 for jpg only [%d].", GMT_JPEG_DEF_QUALITY);
 	GMT_Usage (API, 1, "\n<psconvertoptions>");
 	GMT_Usage (API, -2,	"contains one or more comma-separated options that"
 		" will be passed to psconvert when preparing figures [%s].", GMT_SESSION_CONVERT);

--- a/src/figure.c
+++ b/src/figure.c
@@ -38,7 +38,7 @@
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <prefix> [<format(s)>] [<psconvertoptions>] [%s]\n\n", name, GMT_V_OPT);
+	GMT_Usage (API, 0, "usage: %s <prefix> [<formats>] [<psconvertoptions>] [%s]\n\n", name, GMT_V_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -46,7 +46,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n<prefix>");
 	GMT_Usage (API, -2, "is the prefix to use for the registered figure\'s name.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n<format(s)>");
+	GMT_Usage (API, 1, "\n<formats>");
 	GMT_Usage (API, -2, "Contains one or more comma-separated formats [%s].", gmt_session_format[API->GMT->current.setting.graphics_format]);
 	GMT_Usage (API, -2, "\nChoose from these valid extensions:");
 	GMT_Usage (API, 3, "bmp:	MicroSoft BitMap.");
@@ -59,8 +59,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "ps:	PostScript.");
 	GMT_Usage (API, 3, "tif:	Tagged Image Format File.");
 	GMT_Usage (API, -2, "Two raster modifiers may be appended:");
-	GMT_Usage (API, 3, "+m For b, g, j, and t, make a monochrome (grayscale) image [color].");
-	GMT_Usage (API, 3, "+q Append quality in 0-100 for JPEG only [%d].", GMT_JPEG_DEF_QUALITY);
+	GMT_Usage (API, 3, "+m For bmp, png, jpg, and tif, make a monochrome (grayscale) image [color].");
+	GMT_Usage (API, 3, "+q Append quality in 0-100 for jpg only [%d].", GMT_JPEG_DEF_QUALITY);
 	GMT_Usage (API, 1, "\n<psconvertoptions>");
 	GMT_Usage (API, -2,	"Contains one or more comma-separated options that"
 		" will be passed to psconvert when preparing this figure [%s].", GMT_SESSION_CONVERT);

--- a/src/figure.c
+++ b/src/figure.c
@@ -38,7 +38,7 @@
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <prefix> [<formats>] [<psconvertoptions>] [%s]\n\n", name, GMT_V_OPT);
+	GMT_Usage (API, 0, "usage: %s <prefix> [<format(s)>] [<psconvertoptions>] [%s]\n\n", name, GMT_V_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -46,7 +46,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n<prefix>");
 	GMT_Usage (API, -2, "is the prefix to use for the registered figure\'s name.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n<formats>");
+	GMT_Usage (API, 1, "\n<format(s)>");
 	GMT_Usage (API, -2, "Contains one or more comma-separated formats [%s].", gmt_session_format[API->GMT->current.setting.graphics_format]);
 	GMT_Usage (API, -2, "\nChoose from these valid extensions:");
 	GMT_Usage (API, 3, "bmp:	MicroSoft BitMap.");
@@ -58,6 +58,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "ppm:	Portable Pixel Map.");
 	GMT_Usage (API, 3, "ps:	PostScript.");
 	GMT_Usage (API, 3, "tif:	Tagged Image Format File.");
+	GMT_Usage (API, -2, "Two raster modifiers may be appended:");
+	GMT_Usage (API, 3, "+m For b, g, j, and t, make a monochrome (grayscale) image [color].");
+	GMT_Usage (API, 3, "+q Append quality in 0-100 for JPEG only [%d].", GMT_JPEG_DEF_QUALITY);
 	GMT_Usage (API, 1, "\n<psconvertoptions>");
 	GMT_Usage (API, -2,	"Contains one or more comma-separated options that"
 		" will be passed to psconvert when preparing this figure [%s].", GMT_SESSION_CONVERT);

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -91,6 +91,8 @@
 #define GMT_PAPER_MARGIN_AUTO	5	/* Default paper margin under modern mode, in inches (12.7 centimeter) for auto-size mode */
 #define GMT_PAPER_MARGIN_FIXED	1	/* Default paper margin under modern mode, in inches (12.7 centimeter) for fixed-size mode */
 
+#define GMT_JPEG_DEF_QUALITY	90	/* Default JPG quality value for psconvert -Tj */
+
 /*! whether to ignore/read/write history file gmt.history */
 enum GMT_enum_history {
 	/*! 0 */	GMT_HISTORY_OFF = 0,

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18028,13 +18028,11 @@ GMT_LOCAL int gmtinit_get_graphics_formats (struct GMT_CTRL *GMT, char *formats,
 		if ((k = gmt_get_graphics_id (GMT, p)) != GMT_NOTSET) {	/* Valid code */
 			gcode[n] = k;
 			fmt[n++] = gmt_session_code[k];
-			if (gmt_session_code[k] == 'j' ) {	/* Check for modifiers */
-				if ((c = strstr (p, "+q"))) {	/* Gave JPEG quality modifier */
-					*quality = atoi (&c[2]);
-					if (*quality < 0 || *quality > 100) {
-						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad JPEG quality argument (%s} - reset to %d\n", c, GMT_JPEG_DEF_QUALITY);
-						*quality = GMT_JPEG_DEF_QUALITY;
-					}
+			if (gmt_session_code[k] == 'j' && (c = strstr (p, "+q"))) {	/* Check for modifier =q for JPG */
+				*quality = atoi (&c[2]);
+				if (*quality < 0 || *quality > 100) {
+					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad JPEG quality argument (%s} - reset to %d\n", c, GMT_JPEG_DEF_QUALITY);
+					*quality = GMT_JPEG_DEF_QUALITY;
 				}
 			}
 			if (strchr ("bgjt", gmt_session_code[k]) && strstr (p, "+m"))	/* Want monochrome image */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -17872,7 +17872,7 @@ GMT_LOCAL FILE *gmtinit_open_figure_file (struct GMTAPI_CTRL *API, unsigned int 
 int gmt_get_graphics_id (struct GMT_CTRL *GMT, const char *format) {
 	int code = 0;
 	gmt_M_unused(GMT);
-	while (gmt_session_format[code] && strcmp (format, gmt_session_format[code]))
+	while (gmt_session_format[code] && strncmp (format, gmt_session_format[code], strlen (gmt_session_format[code])))
 		code++;
 	return (gmt_session_format[code]) ? code : -1;
 }
@@ -18017,16 +18017,24 @@ GMT_LOCAL int gmtinit_put_session_name (struct GMTAPI_CTRL *API, char *arg) {
 	return GMT_NOERROR;
 }
 
-GMT_LOCAL int gmtinit_get_graphics_formats (struct GMT_CTRL *GMT, char *formats, char fmt[], int gcode[]) {
+GMT_LOCAL int gmtinit_get_graphics_formats (struct GMT_CTRL *GMT, char *formats, char fmt[], int gcode[], int *quality) {
 	/* Count up how many graphics formats were selected and what their codes were.
 	 * We know the arguments are all valid formats since checked by figure or begin */
 	int k, n = 0;
 	unsigned int pos = 0;
-	char p[GMT_LEN32] = {""};
+	char p[GMT_LEN32] = {""}, *c = NULL;
+
 	while ((gmt_strtok (formats, ",", &pos, p))) {
 		if ((k = gmt_get_graphics_id (GMT, p)) != GMT_NOTSET) {	/* Valid code */
 			gcode[n] = k;
 			fmt[n++] = gmt_session_code[k];
+			if (gmt_session_code[k] == 'j' && (c = strstr (p, "+q"))) {	/* Gave JPEG quality modifier */
+				*quality = atoi (&c[2]);
+				if (*quality < 0 || *quality > 100) {
+					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad JPEG quality argument (%s} - reset to %d\n", c, GMT_JPEG_DEF_QUALITY);
+					*quality = GMT_JPEG_DEF_QUALITY;
+				}
+			}
 		}
 	}
 	return (n);
@@ -18067,10 +18075,10 @@ GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 	 * If show is not NULL then we display the first graphics listed (if more than one) via gmt docs */
 
 	char cmd[GMT_BUFSIZ] = {""}, fmt[GMT_LEN16] = {""}, option[GMT_LEN256] = {""}, p[GMT_LEN256] = {""}, dir[PATH_MAX] = {""}, legend_justification[4] = {""}, mark, *c = NULL;
-	char pen[GMT_LEN32] = {""}, fill[GMT_LEN32] = {""}, off[GMT_LEN32] = {""};
+	char pen[GMT_LEN32] = {""}, fill[GMT_LEN32] = {""}, off[GMT_LEN32] = {""}, device_extra[GMT_LEN8] = {""};
 	struct GMT_FIGURE *fig = NULL;
 	bool not_PS, auto_size;
-	int error, k, f, nf, n_figs, n_orig, gcode[GMT_LEN16];
+	int error, k, f, nf, n_figs, n_orig, gcode[GMT_LEN16], jpeg_quality = GMT_JPEG_DEF_QUALITY;
 	unsigned int pos = 0;
 	double legend_width = 0.0, legend_scale = 1.0;
 
@@ -18094,7 +18102,7 @@ GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 		if (!strcmp (fig[k].prefix, "-")) continue;	/* Unnamed outputs are left for manual psconvert calls by external APIs */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Processing GMT figure #%d [%s %s %s]\n", fig[k].ID, fig[k].prefix, fig[k].formats, fig[k].options);
 		/* Go through the format list and build array for -T arguments */
-		nf = gmtinit_get_graphics_formats (API->GMT, fig[k].formats, fmt, gcode);
+		nf = gmtinit_get_graphics_formats (API->GMT, fig[k].formats, fmt, gcode, &jpeg_quality);
 		if (n_orig && k) {	/* Specified one or more figs via gmt figure so must switch to the current figure and update the history */
 			if ((error = GMT_Call_Module (API, "figure", GMT_MODULE_CMD, fig[k].prefix))) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failed to switch to figure%s\n", fig[k].prefix);
@@ -18104,6 +18112,9 @@ GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 			gmtinit_get_history (API->GMT);	/* Make sure we have the latest history for this figure */
 		}
 		for (f = 0; f < nf; f++) {	/* Loop over all desired output formats */
+			device_extra[0] = '\0';	/* Reset device arguments */
+			if (fmt[f] == 'j' && jpeg_quality != GMT_JPEG_DEF_QUALITY)
+				sprintf (device_extra, "+q%d", jpeg_quality);	/* Need to pass quality modifier */
 			mark = '-';	/* This is the last char in extension for a half-baked GMT PostScript file */
 			snprintf (cmd, GMT_BUFSIZ, "%s/gmt_%d.ps%c", API->gwf_dir, fig[k].ID, mark);	/* Check if the file exists */
 			if (access (cmd, F_OK)) {	/* No such file, check if the fully baked file is there instead */
@@ -18132,11 +18143,11 @@ GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 			if ((c = strrchr (fig[k].prefix, '/'))) {	/* Must pass any leading directory in the file name via -D and file prefix via -F */
 				char *file_only = &c[1];	/* The file name */
 				c[0] = '\0';		/* Temporarily chop off the file to yield directory only */
-				snprintf (cmd, GMT_BUFSIZ, "'%s/gmt_%d.ps-' -T%c -D%s -F%s", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix, file_only);
+				snprintf (cmd, GMT_BUFSIZ, "'%s/gmt_%d.ps-' -T%c%s -D%s -F%s", API->gwf_dir, fig[k].ID, fmt[f], device_extra, fig[k].prefix, file_only);
 				c[0] = '/';		/* Restore last slash */
 			}
 			else	/* Place products in current directory */
-				snprintf (cmd, GMT_BUFSIZ, "'%s/gmt_%d.ps-' -T%c -F%s", API->gwf_dir, fig[k].ID, fmt[f], fig[k].prefix);
+				snprintf (cmd, GMT_BUFSIZ, "'%s/gmt_%d.ps-' -T%c%s -F%s", API->gwf_dir, fig[k].ID, fmt[f], device_extra, fig[k].prefix);
 			gmt_filename_get (fig[k].prefix);
 			not_PS = (fmt[f] != 'p');	/* Do not add convert options if plain PS */
 			/* Append psconvert optional settings */

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -487,7 +487,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	C->G.file = strdup (GMT_GS_EXECUTABLE);
 #endif
 	C->D.dir = strdup (".");
-	C->T.quality = 90;	/* Default JPG quality */
+	C->T.quality = GMT_JPEG_DEF_QUALITY;	/* Default JPG quality */
 
 	C->W.doctitle = strdup ("GMT KML Document");
 	C->W.overlayname = strdup ("GMT Image Overlay");
@@ -902,7 +902,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.on[PSC_GEO] && Ctrl->T.device != GS_DEV_PDF,
 	                                   "Creating GeoPDF format requires -Tf\n");
 	n_errors += gmt_M_check_condition (GMT, (Ctrl->T.device == GS_DEV_JPG || Ctrl->T.device == GS_DEV_JPGG) && (Ctrl->T.quality < 0 || Ctrl->T.quality > 100),
-	                                   "JPG Quality value must be in 0-100 range [90]\n");
+	                                   "JPG Quality value must be in 0-100 range [%d]\n", GMT_JPEG_DEF_QUALITY);
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.on[PSC_LINES] && (Ctrl->Q.bits[PSC_LINES] < 1 || Ctrl->Q.bits[PSC_LINES] > 4),
 	                                   "Anti-aliasing for graphics requires sub-sampling box of 1,2, or 4\n");

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -174,6 +174,7 @@ struct PSCONVERT_CTRL {
 		int eps;	/* 1 if we want to make EPS, -1 with setpagedevice (possibly in addition to another format) */
 		int ps;		/* 1 if we want to save the final PS under "modern" setting */
 		int device;	/* May be negative */
+		int quality;	/* For JPG [90] */
 	} T;
 	struct PSCONVERT_W {	/* -W -- for world file production */
 		bool active;
@@ -486,6 +487,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	C->G.file = strdup (GMT_GS_EXECUTABLE);
 #endif
 	C->D.dir = strdup (".");
+	C->T.quality = 90;	/* Default JPG quality */
 
 	C->W.doctitle = strdup ("GMT KML Document");
 	C->W.overlayname = strdup ("GMT Image Overlay");
@@ -524,7 +526,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <psfile1> <psfile2> <...> [-A[+f<fade>][+g<fill>][+m<margins>][+n][+p[<pen>]][+r][+s[m]|S<width>[/<height>]][+u]] "
 		"[-C<gs_option>] [-D<dir>] [-E<resolution>] [-F<out_name>] [-G<gs_path>] [-H<scale>] [-I] [-L<list>] [-Mb|f<psfile>] "
-		"[-P] [-Q[g|p|t]1|2|4] [-S] [-Tb|e|E|f|F|g|G|j|m|s|t[+m]] [%s] "
+		"[-P] [-Q[g|p|t]1|2|4] [-S] [-Tb|e|E|f|F|g|G|j|m|s|t[+m][+q<quality>]] [%s] "
 		"[-W[+a<mode>[<alt]][+f<minfade>/<maxfade>][+g][+k][+l<lodmin>/<lodmax>][+n<name>][+o<folder>][+t<title>][+u<URL>]]%s "
 		"[%s]\n", name, GMT_V_OPT, Z, GMT_PAR_OPT);
 
@@ -608,8 +610,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Optionally, use -Qp to create a GeoPDF (requires -Tf).");
 	GMT_Usage (API, 1, "\n-S Apart from executing it, also writes the Ghostscript command to "
 		"standard error and keeps all intermediate files.");
-	GMT_Usage (API, 1, "\n-Tb|e|E|f|F|g|G|j|m|s|t[+m]");
-	GMT_Usage (API, -2, "Set output format [default is jpeg]:");
+	GMT_Usage (API, 1, "\n-Tb|e|E|f|F|g|G|j|m|s|t[+m][+q<quality>]");
+	GMT_Usage (API, -2, "Set output format [default is JPEG]:");
 	GMT_Usage (API, 3, "b: Select BMP.");
 	GMT_Usage (API, 3, "e: Select EPS.");
 	GMT_Usage (API, 3, "E: Select EPS with setpagedevice command.");
@@ -621,8 +623,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "m: Select PPM.");
 	GMT_Usage (API, 3, "s: Select SVG [if supported by your Ghostscript version].");
 	GMT_Usage (API, 3, "t: Select TIF.");
-	GMT_Usage (API, -2, "Note: For b, g, j, and t, append +m to get a monochrome (grayscale) image [color]. "
-		"The EPS format can be combined with any of the other formats. "
+	GMT_Usage (API, -2, "Two raster modifiers may be appended:");
+	GMT_Usage (API, 3, "+m For b, g, j, and t, make a monochrome (grayscale) image [color].");
+	GMT_Usage (API, 3, "+q Append quality in 0-100 for JPEG only [%d].", GMT_JPEG_DEF_QUALITY);
+	GMT_Usage (API, -2, "Note: The EPS format can be combined with any of the other formats. "
 		"For example, -Tef creates both an EPS and PDF file.");
 	GMT_Option (API, "V");
 	GMT_Usage (API, -2, "Note: Shows the gdal_translate command, in case you want to use this program "
@@ -686,6 +690,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 	unsigned int n_errors = 0, mode;
 	int j = 0;
 	bool grayscale = false, halfbaked = false;
+	char *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 
 	for (opt = options; opt; opt = opt->next) {
@@ -789,6 +794,10 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 					grayscale = true;
 				else if (strstr (opt->arg, "+m"))	/* Modern monochrome option (like -M in grdimage) */
 					grayscale = true;
+				if ((c = strstr (opt->arg, "+q"))) {	/* Got a quality setting for JPG */
+					Ctrl->T.quality = atoi (&c[2]);
+					c[0] = '\0';	/* Chop this modifier off for now */
+				}
 				for (j = 0; opt->arg[j]; j++) {
 					switch (opt->arg[j]) {
 						case 'e':	/* EPS */
@@ -838,6 +847,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 							break;
 					}
 				}
+				if (c) c[0] = '+';	/* Restore modifier */
 				break;
 			case 'W':	/* Save world file */
 				n_errors += psconvert_parse_GE_settings (GMT, opt->arg, Ctrl);
@@ -891,6 +901,8 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.on[PSC_GEO] && Ctrl->T.device != GS_DEV_PDF,
 	                                   "Creating GeoPDF format requires -Tf\n");
+	n_errors += gmt_M_check_condition (GMT, (Ctrl->T.device == GS_DEV_JPG || Ctrl->T.device == GS_DEV_JPGG) && (Ctrl->T.quality < 0 || Ctrl->T.quality > 100),
+	                                   "JPG Quality value must be in 0-100 range [90]\n");
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.on[PSC_LINES] && (Ctrl->Q.bits[PSC_LINES] < 1 || Ctrl->Q.bits[PSC_LINES] > 4),
 	                                   "Anti-aliasing for graphics requires sub-sampling box of 1,2, or 4\n");
@@ -1469,7 +1481,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 
 	char **ps_names = NULL;
 	char ps_file[PATH_MAX] = "", no_U_file[PATH_MAX] = "", clean_PS_file[PATH_MAX] = "", tmp_file[PATH_MAX] = "",
-	     out_file[PATH_MAX] = "", BB_file[PATH_MAX] = "", resolution[GMT_LEN128] = "";
+	     out_file[PATH_MAX] = "", BB_file[PATH_MAX] = "", resolution[GMT_LEN128] = "", jpeg_device[GMT_LEN16] = {""};
 	char *line = NULL, c1[20] = {""}, c2[20] = {""}, c3[20] = {""}, c4[20] = {""}, GSstring[GMT_LEN64] = {""},
 	     cmd[GMT_BUFSIZ] = {""}, proj4_name[20] = {""}, *quiet = NULL;
 	char *gs_BB = NULL, *proj4_cmd = NULL;
@@ -1593,6 +1605,11 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 	}
 
 	/* Parameters for all the formats available */
+
+	if (Ctrl->T.quality != GMT_JPEG_DEF_QUALITY) {	/* User wanted a specific JPG quality */
+		sprintf (jpeg_device, "-dJPEGQ=%d", Ctrl->T.quality);
+		device_options[Ctrl->T.device] = jpeg_device;	/* Use this one instead */
+	}
 
 	/* Artifex says that the -dSCANCONVERTERTYPE=2 new scan converter is faster (confirmed) and
    	   will be the default in a future release. Since it was introduced in 9.21 we start using it


### PR DESCRIPTION
**Description of proposed changes**

See #5573 for background.  This PR does a few things:

1. Adds **+q**_quality_ as a modifier to **psconvert -Tj** so one can change the JPEG quality [Default remains at 90].
2. Documents that the default is 90.
3. Allows both the existing modifier **+m** as well as **+q** to be recognized when used in **begin** and **figure** (previously one could not pass **+m** in these modules).

All tests still pass, and this simple example shows both **+m** and **+q** being processed:

```
gmt begin map jpg+q95+m,pdf A,S
	gmt coast -RFR -JM6i -Gred -B
gmt end show
```
