### PR TITLE
Show date of the link check report

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v2.3.4
 
     - name: Link Checker
-      uses: lycheeverse/lychee-action@v1.0.4
+      uses: lycheeverse/lychee-action@v1.0.8
       with:
         # 429: Too many requests
         args: >
@@ -37,8 +37,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
     - name: Create Issue From File
       uses: peter-evans/create-issue-from-file@v3
       with:
-        title: Link Checker Report
+        title: Link Checker Report on ${{ steps.date.outputs.date }}
         content-filepath: ./lychee/out.md


### PR DESCRIPTION
**Description of proposed changes**

The `check-links.yml` workflow creates a issue report (e.g., https://github.com/GenericMappingTools/gmt/issues/5575)
if broken links are detected. This PR adds the date of the report to the issue title.

The new issue title will be something like "Link Checker Report on 2021-08-01" rather than "Link Checker Report".

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
