### PR TITLE
Let gmt end better handle -A args

### DIFF
--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -133,14 +133,14 @@ Optional Arguments
     Append **+m** to specify extra margins to extend the bounding box.
     Give either one (uniform), two (x and y) or four (individual sides)
     margins; append unit [Default is set by :term:`PROJ_LENGTH_UNIT`].
-    Use the **-I+s**\ *width* to resize the output image to exactly *width* units.
+    Append **+s**\ *width* to resize the output image to exactly *width* units.
     The default unit is set by :term:`PROJ_LENGTH_UNIT` but you can append a new
     unit and/or impose different width and height (**Note**: This may change the
     image aspect ratio). What happens here is that Ghostscript will do the re-interpolation
-    work and the final image will retain the DPI resolution set by **-E**.  Use **-I+sm**
+    work and the final image will retain the DPI resolution set by **-E**.  Append **+sm**
     to set a maximum size and the new *width* is only imposed if the original figure width
     exceeds it. Append /\ *height* to also impose a maximum height in addition to the width.
-    Alternatively, use **-I+S**\ *scale* to scale the image by a constant factor.
+    Alternatively, append **+S**\ *scale* to scale the image by a constant factor.
 
 .. _-L:
 
@@ -229,7 +229,7 @@ Optional Arguments
     Together with **-V** it prints on screen the gdal_translate
     (gdal_translate is a command line tool from the GDAL package)
     command that reads the raster + world file and creates a true
-    geotiff file. Use **-W+g** to do a system call to gdal_translate
+    geotiff file. Append **+g** to do a system call to gdal_translate
     and create a geoTIFF image right away. The output file will have a
     .tiff extension.
 
@@ -238,7 +238,7 @@ Optional Arguments
     .tfw, for jpeg we have a .jgw and so on. **Note**: This option automatically
     sets **-A** **-P**.  Append **+c** to *not* crop the image.
 
-    Use **-W+k** to create a minimalist KML file that allows loading the
+    Append **+k** to create a minimalist KML file that allows loading the
     image in GoogleEarth. Note that for this option to work it is necessary that the postscript
     image must have been created with **-JX** or **-Jx** Cartesian projection of
     geographical coordinates. If not, a warning is issued but the KML

--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |-F|\ *out_name* ]
 [ |-G|\ *ghost_path* ]
 [ |-H|\ *scale* ]
-[ |-I|\ [**+m**\ *margins*][**+s**\ [**m**]\ *width*/\ *height*][**+S**\ *scale*] ]
+[ |-I|\ [**+m**\ *margins*][**+s**\ [**m**]\ *width*\ [/\ *height*]][**+S**\ *scale*] ]
 [ |-L|\ *list* ]
 [ |-M|\ **b**\|\ **f**\ *pslayer* ]
 [ |-N|\ [**+f**\ *fade*][**+g**\ *paint*][**+i**][**+p**\ [*pen*]] ]
@@ -128,19 +128,18 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ [**+m**\ *margins*][**+s**\ [**m**]\ *width*/\ *height*][**+S**\ *scale*]
+**-I**\ [**+m**\ *margins*][**+s**\ [**m**]\ *width*\ [/\ *height*]][**+S**\ *scale*]
     Adjust the BoundingBox and HiResBoundingBox by scaling and/or adding margins.
     Append **+m** to specify extra margins to extend the bounding box.
     Give either one (uniform), two (x and y) or four (individual sides)
     margins; append unit [Default is set by :term:`PROJ_LENGTH_UNIT`].
-
-    Use the **-I+s**\ *new_width* to resize the output image to exactly *new_width* units.
-    The default is to use what is set by :term:`PROJ_LENGTH_UNIT`
-    but you can append a new unit and/or impose different width and height. What happens
-    here is that Ghostscript will do the re-interpolation work and the final image will
-    retain the DPI resolution set by **-E**.  Use **-I+sm** to set a maximum size and
-    the new width are only imposed if the original figure width exceeds it. Append
-    /\ *new_height* to also impose a maximum height in addition to the width.
+    Use the **-I+s**\ *width* to resize the output image to exactly *width* units.
+    The default unit is set by :term:`PROJ_LENGTH_UNIT` but you can append a new
+    unit and/or impose different width and height (**Note**: This may change the
+    image aspect ratio). What happens here is that Ghostscript will do the re-interpolation
+    work and the final image will retain the DPI resolution set by **-E**.  Use **-I+sm**
+    to set a maximum size and the new *width* are only imposed if the original figure width
+    exceeds it. Append /\ *height* to also impose a maximum height in addition to the width.
     Alternatively, use **-I+S**\ *scale* to scale the image by a constant factor.
 
 .. _-L:

--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -12,22 +12,23 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt psconvert** *psfile(s)*
-[ |-A|\ *params* ]
+**gmt psconvert** *psfiles*
+[ |-A|\ [**+r**][**+u**] ]
 [ |-C|\ *gs_option* ]
 [ |-D|\ *outdir* ]
 [ |-E|\ *resolution* ]
 [ |-F|\ *out_name* ]
 [ |-G|\ *ghost_path* ]
 [ |-H|\ *scale* ]
-[ |-I| ]
+[ |-I|\ [**+m**\ *margins*][**+s**\ [**m**]\ *width*/\ *height*][**+S**\ *scale*] ]
 [ |-L|\ *list* ]
 [ |-M|\ **b**\|\ **f**\ *pslayer* ]
+[ |-N|\ [**+f**\ *fade*][**+g**\ *paint*][**+i**][**+p**\ [*pen*]] ]
 [ |-Q|\ [**g**\|\ **p**\|\ **t**][1\|2\|4] ]
 [ |-S| ]
 [ |-T|\ **b**\|\ **e**\|\ **E**\|\ **f**\|\ **F**\|\ **j**\|\ **g**\|\ **G**\|\ **m**\|\ **s**\|\ **t**\ [**+m**][**+q**\ *quality*] ]
 [ |SYN_OPT-V| ]
-[ |-W|\ *params* ]
+[ |-W|\ [**+a**\ *altmode*\ [*alt*]][**+c**][**+f**\ *minfade/maxfade*][**+g**][**+k**][**+l**\ *minLOD/maxLOD*][**+n**\ *layername*][**+o**\ *foldername*][**+t**\ *docname*][**+u**\ *URL*] ]
 [ |-Z| ]
 [ |SYN_OPT--| ]
 
@@ -64,33 +65,13 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**+f**\ *fade*][**+g**\ *paint*][**+m**\ *margins*][**+n**][**+p**\ [*pen*]][**+r**][**+s**\ [**m**]\|\ **S**\ *width*/\ *height*][**+u**]
+**-A**\ [**+r**][**+u**]
     Adjust the BoundingBox and HiResBoundingBox to the minimum required
-    by the image content. Append **+n** to leave the BoundingBoxes as they are
-    (e.g., to override any automatic setting of **-A** by **-W**).
-    Append **+u** to first remove any GMT-produced time-stamps.
-    Optionally, append **+m** to specify extra margins to extend the bounding box.
-    Give either one (uniform), two (x and y) or four (individual sides)
-    margins; append unit [Default is set by :term:`PROJ_LENGTH_UNIT`].
-
-    Use the **-A+s**\ *new_width* to resize the output image to exactly *new_width* units.
-    The default is to use what is set by :term:`PROJ_LENGTH_UNIT`
-    but you can append a new unit and/or impose different width and height. What happens
-    here is that Ghostscript will do the re-interpolation work and the final image will
-    retain the DPI resolution set by **-E**.  Use **-A+sm** to set a maximum size and
-    the new width are only imposed if the original figure width exceeds it. Append
-    /\ *new_height* to also impose a maximum height in addition to the width.
-    Alternatively use **-A+S**\ *scale* to scale the image by a constant factor.
-
+    by the image content. Append **+u** to first remove any GMT-produced time-stamps.
     Use the **-A+r** to round the HighRes BoundingBox instead of using the ``ceil`` function.
     This is going against Adobe Law but can be useful when creating very small images
-    where the difference of one pixel might matter.
-    If **-V** is used we also report the dimensions of the illustration.
-    Use **-A+f**\ *fade* to fade the entire plot towards black (100%) [no fading, 0].
-    Use **-A+g**\ *paint* to paint the BoundingBox behind the illustration and
-    use **-A+p**\ [*pen*] to draw the BoundingBox outline (append a pen or accept
-    the default pen of 0.25p,black).  **Note**: If both **+g** and **+f** are used
-    then we use *paint* as the fade color instead of black.
+    where the difference of one pixel might matter. If **-V** is used we also report
+    the dimensions of the final illustration.
 
 .. _-C:
 
@@ -147,14 +128,20 @@ Optional Arguments
 
 .. _-I:
 
-**-I**
-    Enforce gray-shades by using ICC profiles.  Ghostscript versions
-    >= 9.00 change gray-shades by using ICC profiles.  Ghostscript 9.05
-    and above provide the '-dUseFastColor=true' option to prevent that
-    and that is what **psconvert** does by default, unless option **-I** is
-    set.  Note that for Ghostscript >= 9.00 and < 9.05 the gray-shade
-    shifting is applied to all but PDF format.  We have no solution to
-    offer other than upgrade Ghostscript.
+**-I**\ [**+m**\ *margins*][**+s**\ [**m**]\ *width*/\ *height*][**+S**\ *scale*]
+    Adjust the BoundingBox and HiResBoundingBox by scaling and/or adding margins.
+    Append **+m** to specify extra margins to extend the bounding box.
+    Give either one (uniform), two (x and y) or four (individual sides)
+    margins; append unit [Default is set by :term:`PROJ_LENGTH_UNIT`].
+
+    Use the **-I+s**\ *new_width* to resize the output image to exactly *new_width* units.
+    The default is to use what is set by :term:`PROJ_LENGTH_UNIT`
+    but you can append a new unit and/or impose different width and height. What happens
+    here is that Ghostscript will do the re-interpolation work and the final image will
+    retain the DPI resolution set by **-E**.  Use **-I+sm** to set a maximum size and
+    the new width are only imposed if the original figure width exceeds it. Append
+    /\ *new_height* to also impose a maximum height in addition to the width.
+    Alternatively, use **-I+S**\ *scale* to scale the image by a constant factor.
 
 .. _-L:
 
@@ -168,6 +155,23 @@ Optional Arguments
     Sandwich the current *psfile* between an optional background (**-Mb**) and
     optional foreground (**-Mf**) Postscript plots.  These files are expected
     to be stand-alone plots that will align when stacked.
+
+.. _-N:
+
+**-N**\ [**+f**\ *fade*][**+g**\ *paint*][**+i**][**+p**\ [*pen*]]
+    Set optional canvas fill color, fading, or draw the outline of the canvas.
+    Use **-N+f**\ *fade* to fade the entire plot towards black (100%) [no fading, 0].
+    Use **-N+g**\ *paint* to paint the BoundingBox behind the illustration and
+    use **-N+p**\ [*pen*] to draw the BoundingBox outline (append a pen or accept
+    the default pen of 0.25p,black).  **Note**: If both **+g** and **+f** are used
+    then we use *paint* as the fade color instead of black.
+    Use **-N+i**  to enforce gray-shades by using ICC profiles.  Ghostscript versions
+    >= 9.00 change gray-shades by using ICC profiles.  Ghostscript 9.05
+    and above provide the '-dUseFastColor=true' option to prevent that
+    and that is what **psconvert** does by default, unless modifier **+i** is
+    set.  Note that for Ghostscript >= 9.00 and < 9.05 the gray-shade
+    shifting is applied to all but PDF format.  We have no solution to
+    offer other than suggesting you upgrade Ghostscript.
 
 .. _-Q:
 
@@ -207,7 +211,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**+g**][**+k**][**+t**\ *docname*][**+n**\ *layername*][**+o**\ *foldername*][**+a**\ *altmode*\ [*alt*]][**+l**\ *minLOD/maxLOD*][**+f**\ *minfade/maxfade*][**+u**\ *URL*]
+**-W**\ [**+a**\ *altmode*\ [*alt*]][**+c**][**+f**\ *minfade/maxfade*][**+g**][**+k**][**+l**\ *minLOD/maxLOD*][**+n**\ *layername*][**+o**\ *foldername*][**+t**\ *docname*][**+u**\ *URL*]
     Write a ESRI type world file suitable to make (e.g) .tif files be
     recognized as geotiff by software that know how to do it. Be aware,
     however, that different results are obtained depending on the image
@@ -232,12 +236,12 @@ Optional Arguments
 
     The world file naming follows the convention of jamming a 'w' in the
     file extension. So, if output is tif **-Tt** the world file is a
-    .tfw, for jpeg we have a .jgw and so on. This option automatically
-    sets **-A** **-P**.
+    .tfw, for jpeg we have a .jgw and so on. **Note**: This option automatically
+    sets **-A** **-P**.  Append **+c** to *not* crop the image.
 
     Use **-W+k** to create a minimalist KML file that allows loading the
     image in GoogleEarth. Note that for this option to work it is necessary that the postscript
-    image must have been created with **-JX** or **-Jx** cartesian projection of
+    image must have been created with **-JX** or **-Jx** Cartesian projection of
     geographical coordinates. If not, a warning is issued but the KML
     file is created anyway. Several modifier options are available to
     customize the KML file in the form of **+**\ *opt* strings. Append
@@ -362,14 +366,14 @@ To convert the file psfile.ps to PNG using a tight BoundingBox::
 
     gmt psconvert psfile.ps -A -Tg
 
-To convert the file map.ps to PDF, extend the BoundingBox by 0.2 cm,
+To convert the file map.ps to PDF, crop, then extend the BoundingBox by 0.2 cm,
 fill it with lightblue paint and draw outline with a thick pen::
 
-    gmt psconvert map.ps -A+m0.2c+glightblue+pthick -Tf
+    gmt psconvert map.ps -A -I+m0.2c -N+glightblue+pthick -Tf
 
-To create a 5 cm PNG version at 300 dpi of our example_01.ps file::
+To create a 5 cm PNG version at 300 dpi of our cropped example_01.ps file::
 
-    gmt psconvert example_01.ps -A+s5c -Tg
+    gmt psconvert example_01.ps -A -I+s5c -Tg
 
 To create a 3 pages PDF file from 3 individual PS files::
 

--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -68,7 +68,7 @@ Optional Arguments
 **-A**\ [**+r**][**+u**]
     Adjust the BoundingBox and HiResBoundingBox to the minimum required
     by the image content. Append **+u** to first remove any GMT-produced time-stamps.
-    Use the **-A+r** to round the HighRes BoundingBox instead of using the ``ceil`` function.
+    Append **+r** to *round* the HighResBoundingBox instead of using the ``ceil`` function.
     This is going against Adobe Law but can be useful when creating very small images
     where the difference of one pixel might matter. If **-V** is used we also report
     the dimensions of the final illustration.
@@ -138,7 +138,7 @@ Optional Arguments
     unit and/or impose different width and height (**Note**: This may change the
     image aspect ratio). What happens here is that Ghostscript will do the re-interpolation
     work and the final image will retain the DPI resolution set by **-E**.  Use **-I+sm**
-    to set a maximum size and the new *width* are only imposed if the original figure width
+    to set a maximum size and the new *width* is only imposed if the original figure width
     exceeds it. Append /\ *height* to also impose a maximum height in addition to the width.
     Alternatively, use **-I+S**\ *scale* to scale the image by a constant factor.
 
@@ -158,13 +158,13 @@ Optional Arguments
 .. _-N:
 
 **-N**\ [**+f**\ *fade*][**+g**\ *paint*][**+i**][**+p**\ [*pen*]]
-    Set optional canvas fill color, fading, or draw the outline of the canvas.
-    Use **-N+f**\ *fade* to fade the entire plot towards black (100%) [no fading, 0].
-    Use **-N+g**\ *paint* to paint the BoundingBox behind the illustration and
-    use **-N+p**\ [*pen*] to draw the BoundingBox outline (append a pen or accept
+    Set optional BoundingBox fill color, fading, or draw the outline of the BoundingBox.
+    Append **+f**\ *fade* to fade the entire plot towards black (100%) [no fading, 0].
+    Append **+g**\ *paint* to paint the BoundingBox behind the illustration and
+    append **+p**\ [*pen*] to draw the BoundingBox outline (append a pen or accept
     the default pen of 0.25p,black).  **Note**: If both **+g** and **+f** are used
     then we use *paint* as the fade color instead of black.
-    Use **-N+i**  to enforce gray-shades by using ICC profiles.  Ghostscript versions
+    Append **+i**  to enforce gray-shades by using ICC profiles.  Ghostscript versions
     >= 9.00 change gray-shades by using ICC profiles.  Ghostscript 9.05
     and above provide the '-dUseFastColor=true' option to prevent that
     and that is what **psconvert** does by default, unless modifier **+i** is

--- a/src/figure.c
+++ b/src/figure.c
@@ -115,7 +115,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
 				}
 			}
 			else {	/* Check if valid psconvert options */
-				if (!strchr ("ACDEHMQS", p[0])) {
+				if (!strchr (GMT_PSCONVERT_LIST, p[0])) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unrecognized psconvert option  -%s\n", p);
 					n_errors++;
 				}

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -320,6 +320,9 @@ enum GMT_time_period {
  */
 #define GMT_CPTFILE_MODIFIERS "hiuU"
 
+/* Valid options to psconvert from figure and begin */
+#define GMT_PSCONVERT_LIST "ACDEHIMNQS"
+
 /* Settings for usage message indents and break/continue characters */
 
 #define GMT_LINE_BREAK	"\xe2\x8f\x8e"	/* Glyph for return symbol in UTF-8 */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18194,7 +18194,6 @@ GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 			}
 			else if (not_PS && auto_size) /* No specific settings but must always add -A if not PostScript unless when media size is given */
 				strcat (cmd, " -A");
-			GMT_Report (API, GMT_MSG_NOTICE, "psconvert: %s\n", cmd);
 			GMT_Report (API, GMT_MSG_DEBUG, "psconvert: %s\n", cmd);
 			if ((error = GMT_Call_Module (API, "psconvert", GMT_MODULE_CMD, cmd))) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failed to call psconvert\n");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18000,7 +18000,7 @@ GMT_LOCAL int gmtinit_put_session_name (struct GMTAPI_CTRL *API, char *arg) {
 		unsigned int bad = 0, pos = 0;
 		char p[GMT_LEN256] = {""};
 		while (gmt_strtok (&c[1], ",", &pos, p)) {	/* Check args to determine what kind it is */
-			if (!strchr ("ACDEHMQS", p[0])) {	/* Check if valid psconvert options */
+			if (!strchr (GMT_PSCONVERT_LIST, p[0])) {	/* Check if valid psconvert options */
 				bad++;
 			}
 		}
@@ -18173,8 +18173,9 @@ GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 						if (p[0] == 'D') strncpy (dir, &p[1], GMT_LEN1024-1);	/* Needed in show */
 					}
 				}
-				if (not_PS && auto_size && !gmtinit_A_was_given (fig[k].options))	/* Must always add -A if not PostScript unless when media size is given, unless crop is off via +n */
-					strcat (cmd, " -A");
+				if (not_PS && !gmtinit_A_was_given (fig[k].options)) {	/* -A not given and not PostScript */
+					strcat (cmd, (auto_size) ? " -A" : " -A+M");	/* Must always add -A unless when media size is given */
+				}
 			}
 			else if (API->GMT->current.setting.ps_convert[0]) {	/* Supply chosen session settings for psconvert */
 				pos = 0;	/* Reset position counter */
@@ -18187,8 +18188,9 @@ GMT_LOCAL int gmtinit_process_figures (struct GMTAPI_CTRL *API, char *show) {
 						if (p[0] == 'D') strcpy (dir, &p[1]);	/* Needed in show */
 					}
 				}
-				if (not_PS && auto_size && !gmtinit_A_was_given (API->GMT->current.setting.ps_convert))	/* Must always add -A if not PostScript unless when media size is given */
-					strcat (cmd, " -A");
+				if (not_PS && !gmtinit_A_was_given (API->GMT->current.setting.ps_convert)) {	/* -A not given and not PostScript */
+					strcat (cmd, (auto_size) ? " -A" : " -A+M");	/* Must always add -A unless when media size is given */
+				}
 			}
 			else if (not_PS && auto_size) /* No specific settings but must always add -A if not PostScript unless when media size is given */
 				strcat (cmd, " -A");

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -623,7 +623,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	const char *Z = (API->GMT->current.setting.run_mode == GMT_CLASSIC) ? " [-Z]" : "";
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <psfile1> <psfile2> ... [-A[+r][+u]] [-C<gs_option>] [-D<dir>] [-E<resolution>] "
+	GMT_Usage (API, 0, "usage: %s <psfiles> [-A[+r][+u]] [-C<gs_option>] [-D<dir>] [-E<resolution>] "
 		"[-F<out_name>] [-G<gs_path>] [-H<scale>] [-I[+m<margins>][+s[m]<width>[/<height>]][+S<scale>]] [-L<list>] [-Mb|f<psfile>] "
 		"[-N[+f<fade>][+g<fill>][+i][+p[<pen>]] [-P] [-Q[g|p|t]1|2|4] [-S] [-Tb|e|E|f|F|g|G|j|m|s|t[+m][+q<quality>]] [%s] "
 		"[-W[+a<mode>[<alt]][+c][+f<minfade>/<maxfade>][+g][+k][+l<lodmin>/<lodmax>][+n<name>][+o<folder>][+t<title>][+u<URL>]]%s "
@@ -635,9 +635,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"image will have the size specified by the BoundingBox. "
 		"As an option, a tight BoundingBox may be computed.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  REQUIRED ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n<psfile1 <psfile2> ... PostScript file(s) to be converted.");
+	GMT_Usage (API, 1, "\n<psfiles> One or more PostScript files to be converted.");
 	if (API->external)
-		GMT_Usage (API, -2, "Note: To access the current internal GMT plot, specify <psfile> as \"=\".");
+		GMT_Usage (API, -2, "Note: To access the current internal GMT plot, specify <psfiles> as \"=\".");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-A[+r][+u]");
 	GMT_Usage (API, -2, "Adjust the BoundingBox to the minimum required by the image contents. Optional modifiers:");

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -103,25 +103,12 @@ struct PSCONVERT_CTRL {
 	struct PSCONVERT_In {	/* Input file info */
 		unsigned int n_files;
 	} In;
-	struct PSCONVERT_A {             /* -A[+f<fade>][+g<fill>][+m<margins>][+n][+p<pen>][+r][+s|S[m]<width>[/<height>]][+u] */
+	struct PSCONVERT_A {             /* -A[+r][+u] */
 		bool active;
-		bool max;          /* Only scale if dim exceeds the given size */
-		bool round;        /* Round HiRes BB instead of ceil (+r) */
-		bool strip;        /* Remove the -U time-stamp (+u)*/
-		bool resize;       /* Resize to a user selected size */
-		bool rescale;      /* Resize to a user selected scale factor */
-		bool outline;      /* Draw frame around plot with selected pen (+p) [0.25p] */
-		bool paint;        /* Paint box behind plot with selected fill (+g) */
-		bool crop;         /* If true we must find the BB; turn off via -A+n */
-		bool fade;         /* If true we must fade out the plot to black */
-		bool media;        /* If true we must crop to current media size in PS_MEDIA. Only issued indirectly by gmt end */
-		double scale;      /* Scale factor to go along with the 'rescale' option */
-		double fade_level;      /* Fade to black at this level of transparency */
-		double new_size[2];
-		double margin[4];
-		double new_dpi_x, new_dpi_y;
-		struct GMT_PEN pen;
-		struct GMT_FILL fill;
+		bool crop;	/* Round HiRes BB instead of ceil (+r) */
+		bool round;	/* Round HiRes BB instead of ceil (+r) */
+		bool strip;	/* Remove the -U time-stamp (+u)*/
+		bool media;	/* If true we must crop to current media size in PS_MEDIA. Only issued indirectly by gmt end */
 	} A;
 	struct PSCONVERT_C {	/* -C<option> */
 		bool active;
@@ -147,8 +134,15 @@ struct PSCONVERT_CTRL {
 		bool active;
 		int factor;
 	} H;
-	struct PSCONVERT_I {	/* -I */
+	struct PSCONVERT_I {	/* -I[+m<margins>][+s|S[m]<width>[/<height>]] */
 		bool active;
+		bool max;          /* Only scale if dim exceeds the given size */
+		bool resize;       /* Resize to a user selected size */
+		bool rescale;      /* Resize to a user selected scale factor */
+		double scale;      /* Scale factor to go along with the 'rescale' option */
+		double new_size[2];
+		double margin[4];
+		double new_dpi_x, new_dpi_y;
 	} I;
 	struct PSCONVERT_L {	/* -L<list> */
 		bool active;
@@ -158,6 +152,16 @@ struct PSCONVERT_CTRL {
 		bool active;
 		char *file;
 	} M[2];
+	struct PSCONVERT_N {             /* -N[+f<fade>][+g<fill>][+i][+p<pen>] */
+		bool active;
+		bool outline;      /* Draw frame around plot with selected pen (+p) [0.25p] */
+		bool paint;        /* Paint box behind plot with selected fill (+g) */
+		bool fade;         /* If true we must fade out the plot to black */
+		bool use_ICC_profiles;
+		double fade_level;      /* Fade to black at this level of transparency */
+		struct GMT_PEN pen;
+		struct GMT_FILL fill;
+	} N;
 	struct PSCONVERT_P {	/* -P */
 		bool active;
 	} P;
@@ -181,6 +185,7 @@ struct PSCONVERT_CTRL {
 		bool folder;
 		bool warp;
 		bool kml;
+		bool no_crop;
 		unsigned int mode;	/* 0 = clamp at ground, 1 is relative to ground, 2 is absolute 3 is relative to seafloor, 4 is clamp at seafloor */
 		int min_lod, max_lod;	/* minLodPixels and maxLodPixels settings */
 		int min_fade, max_fade;	/* minFadeExtent and maxFadeExtent settings */
@@ -251,164 +256,255 @@ GMT_LOCAL void psconvert_pclose2 (struct popen2 **Faddr, int dir) {
 }
 #endif
 
-GMT_LOCAL int psconvert_parse_A_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *Ctrl) {
-	/* Syntax:
-	 * New : -A[+f<fade>][+g<fill>][+m<margins>][+n][+p<pen>][+r][+s|S[m]<width>[/<height>]][+u]
-	 * Old : -A[-][u][<margins>][+g<fill>][+p<pen>][+r][+s|S[m]<width>[/<height>]]
+GMT_LOCAL int psconvert_parse_new_A_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *Ctrl) {
+	/* Syntax: -A[+r][+u] */
+
+	Ctrl->A.active = Ctrl->A.crop = true;
+
+	if (strstr (arg, "r"))
+		Ctrl->A.round = true;
+	if (strstr (arg, "u"))
+		Ctrl->A.strip = true;
+	if (strstr (arg, "M"))	/* +M is hidden and only issued by gmt end */
+		Ctrl->A.media = true;
+	return (GMT_NOERROR);
+}
+
+GMT_LOCAL int psconvert_parse_new_I_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *Ctrl) {
+	/* Syntax: I[+m<margins>][+s[m]<width>[/<height>]][+S<scale>]
+	 * Repeatable, so can use -I to deal with grayshades as before
 	 */
 
 	unsigned int pos = 0, error = 0;
-	int j, k = 0, trim_j = -1;
-	char txt[GMT_LEN128] = {""}, p[GMT_LEN128] = {""};
-	char txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, txt_c[GMT_LEN64] = {""}, txt_d[GMT_LEN64] = {""};
+	int k, j;
+	char p[GMT_LEN128] = {""}, txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, txt_c[GMT_LEN64] = {""}, txt_d[GMT_LEN64] = {""};
 
-	Ctrl->A.active = Ctrl->A.crop = true;	/* The default is to crop unless we get -A+n */
-
-	/* For historical reasons we may encounter -A-<stuff> or -Au- so check for both */
-
-	/* The next lines down to NEW is simply backwards compatible parsing */
-	if (arg[k] == 'u') {Ctrl->A.strip = true; k++;}		/* Eliminate GMT time stamp */
-	else if (arg[k] == '-') {Ctrl->A.crop = false; k++;}	/* No cropping requested */
-	/* If there are +modifiers later we need to temporarily disable them: */
-	for (j = k; arg[j] && arg[j] != '+'; j++);	/* Find position of first + */
-	if (arg[j] == '+') arg[j] = 0, trim_j = j;	/* Remember that position and chop off modifiers */
-	if (arg[k] && arg[k] != '+') {	/* Also specified desired margin(s) using the old syntax */
-		j = sscanf (&arg[k], "%[^/]/%[^/]/%[^/]/%s", txt_a, txt_b, txt_c, txt_d);
-		switch (j) {
-			case 1:	/* Got uniform margin */
-				Ctrl->A.margin[XLO] = Ctrl->A.margin[XHI] = Ctrl->A.margin[YLO] = Ctrl->A.margin[YHI] = gmt_M_to_points (GMT, txt_a);
-				break;
-			case 2:	/* Got separate x/y margins */
-				Ctrl->A.margin[XLO] = Ctrl->A.margin[XHI] = gmt_M_to_points (GMT, txt_a);
-				Ctrl->A.margin[YLO] = Ctrl->A.margin[YHI] = gmt_M_to_points (GMT, txt_b);
-				break;
-			case 4:	/* Got different margins for all sides */
-				Ctrl->A.margin[XLO] = gmt_M_to_points (GMT, txt_a);
-				Ctrl->A.margin[XHI] = gmt_M_to_points (GMT, txt_b);
-				Ctrl->A.margin[YLO] = gmt_M_to_points (GMT, txt_c);
-				Ctrl->A.margin[YHI] = gmt_M_to_points (GMT, txt_d);
-				break;
-			default:
-				error++;
-				GMT_Report (Ctrl, GMT_MSG_ERROR, "-A: Must specify 1, 2, or 4 margins\n");
-				break;
+	if (arg[0] == '\0') {	/* This is the old -I option */
+		if (gmt_M_compat_check (GMT, 4)) {
+			GMT_Report (GMT->parent, GMT_MSG_COMPAT, "-I (no args) is deprecated; use -N+i instead.\n");
+			Ctrl->N.use_ICC_profiles = true;
 		}
+		else {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -I: No arguments given\n");
+			error = 1;
+		}
+		return (error);
 	}
-	if (trim_j >= 0) arg[trim_j] = '+';	/* Restore the chopped off section */
-	/* Here we are doing the NEW syntax parsing */
-	strncpy (txt, arg, GMT_LEN128-1);
-	while (!error && (gmt_strtok (txt, "+", &pos, p))) {
+
+	Ctrl->I.active = true;
+	while (gmt_getmodopt (GMT, 'N', arg, "msS", &pos, p, &error) && error == 0) {
 		switch (p[0]) {
-			case 'f':	/* Fade out */
-				Ctrl->A.fade = true;
-				if (!p[1]) {
-					GMT_Report (Ctrl, GMT_MSG_ERROR, "-A+f: Append the fade setting in 0-100 range.\n");
-					error++;
-				}
-				else if ((Ctrl->A.fade_level = atof (&p[1])) < 0.0 || Ctrl->A.fade_level > 100.0) {
-					GMT_Report (Ctrl, GMT_MSG_ERROR, "-A+f: Must specify fading in 0 (no fade) - 100 (fully faded) range.\n");
-					error++;
-				}
-				Ctrl->A.fade_level *= 0.01;	/* Normalized */
-				break;
-			case 'g':	/* Fill background */
-				Ctrl->A.paint = true;
-				if (!p[1]) {
-					GMT_Report (Ctrl, GMT_MSG_ERROR, "-A+g: Append the background fill\n");
-					error++;
-				}
-				else if (gmt_getfill (GMT, &p[1], &Ctrl->A.fill)) {
-					gmt_pen_syntax (GMT, 'A', NULL, "sets background fill attributes", NULL, 0);
-					error++;
-				}
-				break;
 			case 'm':	/* Margins */
 				j = sscanf (&p[1], "%[^/]/%[^/]/%[^/]/%s", txt_a, txt_b, txt_c, txt_d);
 				switch (j) {
 					case 1:	/* Got uniform margin */
-						Ctrl->A.margin[XLO] = Ctrl->A.margin[XHI] = Ctrl->A.margin[YLO] = Ctrl->A.margin[YHI] = gmt_M_to_points (GMT, txt_a);
+						Ctrl->I.margin[XLO] = Ctrl->I.margin[XHI] = Ctrl->I.margin[YLO] = Ctrl->I.margin[YHI] = gmt_M_to_points (GMT, txt_a);
 						break;
 					case 2:	/* Got separate x/y margins */
-						Ctrl->A.margin[XLO] = Ctrl->A.margin[XHI] = gmt_M_to_points (GMT, txt_a);
-						Ctrl->A.margin[YLO] = Ctrl->A.margin[YHI] = gmt_M_to_points (GMT, txt_b);
+						Ctrl->I.margin[XLO] = Ctrl->I.margin[XHI] = gmt_M_to_points (GMT, txt_a);
+						Ctrl->I.margin[YLO] = Ctrl->I.margin[YHI] = gmt_M_to_points (GMT, txt_b);
 						break;
 					case 4:	/* Got different margins for all sides */
-						Ctrl->A.margin[XLO] = gmt_M_to_points (GMT, txt_a);
-						Ctrl->A.margin[XHI] = gmt_M_to_points (GMT, txt_b);
-						Ctrl->A.margin[YLO] = gmt_M_to_points (GMT, txt_c);
-						Ctrl->A.margin[YHI] = gmt_M_to_points (GMT, txt_d);
+						Ctrl->I.margin[XLO] = gmt_M_to_points (GMT, txt_a);
+						Ctrl->I.margin[XHI] = gmt_M_to_points (GMT, txt_b);
+						Ctrl->I.margin[YLO] = gmt_M_to_points (GMT, txt_c);
+						Ctrl->I.margin[YHI] = gmt_M_to_points (GMT, txt_d);
 						break;
 					default:
 						error++;
-						GMT_Report (Ctrl, GMT_MSG_ERROR, "-A+m: Must specify 1, 2, or 4 margins\n");
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "-I+m: Must specify 1, 2, or 4 margins\n");
 						break;
 				}
 				break;
-			case 'n':	/* No crop */
-				Ctrl->A.crop = false;
-				break;
-			case 'M':	/* Crop to media */
-				Ctrl->A.media = true;
-				break;
-			case 'p':	/* Draw outline */
-				Ctrl->A.outline = true;
-				if (!p[1])
-					Ctrl->A.pen = GMT->current.setting.map_default_pen;
-				else if (gmt_getpen (GMT, &p[1], &Ctrl->A.pen)) {
-					gmt_pen_syntax (GMT, 'A', NULL, "sets background outline pen attributes", NULL, 0);
-					error++;
-				}
-				break;
-			case 'r':	/* Round */
-				Ctrl->A.round = true;
-				break;
 			case 'S':	/* New size via a scale factor */
-				Ctrl->A.rescale = true;
-				Ctrl->A.scale = atof(&p[1]);
+				Ctrl->I.rescale = true;
+				Ctrl->I.scale = atof (&p[1]);
 				break;
 			case 's':	/* New size +s[m]<width>[/<height>] */
-				Ctrl->A.resize = true;
-				if (p[1] == 'm') { Ctrl->A.max = true, k = 2;} else k = 1;
+				Ctrl->I.resize = true;
+				if (p[1] == 'm') { Ctrl->I.max = true, k = 2;} else k = 1;
 				j = sscanf (&p[k], "%[^/]/%s", txt_a, txt_b);
 				switch (j) {
 					case 1:	/* Got width only. Height will be computed later */
-						Ctrl->A.new_size[0] = gmt_M_to_points (GMT, txt_a);
+						Ctrl->I.new_size[0] = gmt_M_to_points (GMT, txt_a);
 						break;
 					case 2:	/* Got separate width/height */
-						Ctrl->A.new_size[0] = gmt_M_to_points (GMT, txt_a);
-						Ctrl->A.new_size[1] = gmt_M_to_points (GMT, txt_b);
+						Ctrl->I.new_size[0] = gmt_M_to_points (GMT, txt_a);
+						Ctrl->I.new_size[1] = gmt_M_to_points (GMT, txt_b);
 						break;
 					default:
-						GMT_Report (Ctrl, GMT_MSG_ERROR, "Option -A+s[m]<width[/height]>: Wrong size parameters\n");
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -I+s[m]<width[/height]>: Wrong size parameters\n");
 						error++;
 						break;
 					}
 				break;
-			case 'u':	/* Strip timestamp */
-				Ctrl->A.strip = true;
+			default:	/* These are caught in gmt_getmodopt so break is just for Coverity */
 				break;
 		}
 	}
-	if (Ctrl->A.fade) Ctrl->A.paint = false;	/* With fading, the paint color is the terminal color */
-	if (Ctrl->A.rescale && Ctrl->A.resize) {
-		GMT_Report (Ctrl, GMT_MSG_ERROR, "Option -A+s|S: Cannot set both -A+s and -A+S\n");
+	if (Ctrl->I.rescale && Ctrl->I.resize) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -I+s|S: Cannot set both -I+s and -I+S\n");
 		error++;
 	}
-	else if (Ctrl->A.rescale)    /* But we can. This makes the coding simpler later on */
-		Ctrl->A.resize = true;
+	else if (Ctrl->I.rescale)    /* But we can. This makes the coding simpler later on */
+		Ctrl->I.resize = true;
 
 	return (error);
 }
 
+GMT_LOCAL int psconvert_parse_new_N_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *Ctrl) {
+	/* Syntax: -N[+f<fade>][+g<fill>][+i][+p<pen>] */
+
+	unsigned int pos = 0, error = 0;
+	int j, k = 0;
+	char p[GMT_LEN128] = {""}, txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, txt_c[GMT_LEN64] = {""}, txt_d[GMT_LEN64] = {""};
+
+	if (gmt_validate_modifiers (GMT, arg, 'N', "fgip", GMT_MSG_ERROR)) return (1);	/* Bail right away */
+
+	Ctrl->N.active = true;
+
+	while (gmt_getmodopt (GMT, 'N', arg, "fgip", &pos, p, &error) && error == 0) {
+		switch (p[0]) {
+			case 'f':	/* Fade out */
+				if (!p[1]) {
+					GMT_Report (GMT->parent, GMT_MSG_ERROR, "-N+f: Append the fade setting in 0-100 range.\n");
+					error++;
+				}
+				else if ((Ctrl->N.fade_level = atof (&p[1])) < 0.0 || Ctrl->N.fade_level > 100.0) {
+					GMT_Report (GMT->parent, GMT_MSG_ERROR, "-N+f: Must specify fading in 0 (no fade) - 100 (fully faded) range.\n");
+					error++;
+				}
+				Ctrl->N.fade_level *= 0.01;	/* Normalized */
+				break;
+			case 'g':	/* Fill background */
+				Ctrl->N.paint = true;
+				if (!p[1]) {
+					GMT_Report (GMT->parent, GMT_MSG_ERROR, "-N+g: Append the background fill\n");
+					error++;
+				}
+				else if (gmt_getfill (GMT, &p[1], &Ctrl->N.fill)) {
+					gmt_pen_syntax (GMT, 'N', NULL, "sets background fill attributes", NULL, 0);
+					error++;
+				}
+				break;
+			case 'i':	/* Formerly -I */
+				/* Ghostscript versions >= 9.00 change gray-shades by using ICC profiles.
+				   GS 9.05 and above provide the '-dUseFastColor=true' option to prevent that
+				   and that is what psconvert does by default, unless option -I is set.
+				   Note that for GS >= 9.00 and < 9.05 the gray-shade shifting is applied
+				   to all but PDF format. We have no solution to offer other than ... upgrade GS. */
+				Ctrl->N.use_ICC_profiles = true;
+				break;
+			case 'p':	/* Draw outline */
+				Ctrl->N.outline = true;
+				if (!p[1])
+					Ctrl->N.pen = GMT->current.setting.map_default_pen;
+				else if (gmt_getpen (GMT, &p[1], &Ctrl->N.pen)) {
+					gmt_pen_syntax (GMT, 'N', NULL, "sets background outline pen attributes", NULL, 0);
+					error++;
+				}
+				break;
+			default:	/* These are caught in gmt_getmodopt so break is just for Coverity */
+				break;
+		}
+	}
+	if (Ctrl->N.fade) Ctrl->N.paint = false;	/* With fading, the paint color is the terminal color */
+
+	return (error);
+}
+
+GMT_LOCAL int psconvert_parse_A_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *Ctrl) {
+	/* Given there have been many syntax changes and most recently splitting of -A into -A, -I, -N we do
+	 * an initial assessment here and build -I -N -A option strings from old-style -A arguments and
+	 * call the -I -N parsers, if required, as well as the -A parser */
+	int k = 0, n_errors = 0, j;
+	char A_option[GMT_LEN128] = {""}, I_option[GMT_LEN128] = {""}, N_option[GMT_LEN128] = {""};
+	char string[GMT_LEN128] = {""};
+
+	/* Harvest -A arguments, if any */
+	if (arg[0] && strchr ("u-", arg[0])) {	/* Ancient -A syntax */
+		if (gmt_M_compat_check (GMT, 4)) {
+			GMT_Report (GMT->parent, GMT_MSG_COMPAT, "-A[-][u][<margin>][...] is deprecated, see -A -I -N syntax.\n");
+			if (arg[0] == '-') k++;	/* The old -A- no crop signal is now just skipped */
+			else if (arg[0] == 'u') {	/* The old way of +u */
+				strcat (A_option, "+u");
+				k++;
+			}
+		}
+		else {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A: Bad arguments %s.\n" ,arg);
+			n_errors++;
+		}
+	}
+	if (arg[k] && arg[k] != '+') {	/* Old-style margin directives no goes to -I instead */
+		for (j = k + 1; arg[j] && arg[j] != '+'; j++);	/* Wind to the end of margins */
+		strcat (I_option, "+m");
+		strncat (I_option, &arg[k], j-k);	/* Append margin argument */
+	}
+	/* These are newer -A modifiers */
+	if (gmt_get_modifier (arg, 'r', string))
+		strcat (A_option, "+r");
+	if (gmt_get_modifier (arg, 'u', string))
+		strcat (A_option, "+u");
+	if (gmt_get_modifier (arg, 'M', string))	/* Only issued by gmt end */
+		strcat (A_option, "+M");
+	/* Note: If -A+n is given then we */
+	if (gmt_get_modifier (arg, 'n', string)) {
+		if (gmt_M_compat_check (GMT, 5)) {
+			GMT_Report (GMT->parent, GMT_MSG_COMPAT, "-A+n (no args) is deprecated, use -W+c instead.\n");
+			Ctrl->W.no_crop = true;
+		}
+		else {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A: Unrecognized modifier +n.\n");
+			n_errors++;
+		}
+	}
+
+	/* Harvest -N arguments, if any */
+	if (gmt_get_modifier (arg, 'f', string)) {
+		strcat (N_option, "+f");
+		strcat (N_option, string);
+	}
+	if (gmt_get_modifier (arg, 'g', string)) {
+		strcat (N_option, "+g");
+		strcat (N_option, string);
+	}
+	if (gmt_get_modifier (arg, 'p', string)) {
+		strcat (N_option, "+p");
+		strcat (N_option, string);
+	}
+
+	/* Harvest -I arguments, if any */
+	if (gmt_get_modifier (arg, 'm', string)) {
+		strcat (I_option, "+m");
+		strcat (I_option, string);
+	}
+	if (gmt_get_modifier (arg, 's', string)) {
+		strcat (I_option, "+s");
+		strcat (I_option, string);
+	}
+	if (gmt_get_modifier (arg, 'S', string)) {
+		strcat (I_option, "+S");
+		strcat (I_option, string);
+	}
+	/* Now parse -A and possibly -I -N via backwards compatibility conversions */
+	n_errors += psconvert_parse_new_A_settings (GMT, A_option, Ctrl);
+	if (I_option[0])
+		n_errors += psconvert_parse_new_I_settings (GMT, I_option, Ctrl);
+	if (N_option[0])
+		n_errors += psconvert_parse_new_N_settings (GMT, N_option, Ctrl);
+	return (n_errors);
+}
+
 GMT_LOCAL int psconvert_parse_GE_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *C) {
-	/* Syntax: -W[+g][+k][+t<doctitle>][+n<layername>][+a<altmode>][+l<lodmin>/<lodmax>] */
+	/* Syntax: -W[+a<altmode>][+c][+f<minfade>/<maxfade>][+g][+k][+l<lodmin>/<lodmax>][+n<layername>][+o<folder>][+t<doctitle>][+u<URL>] */
 
 	unsigned int pos = 0, error = 0;
 	char p[GMT_LEN256] = {""};
 	gmt_M_unused(GMT);
 
 	C->W.active = true;
-	while (gmt_getmodopt (GMT, 'W', arg, "afgklnotu", &pos, p, &error) && error == 0) {	/* Looking for +a, etc */
+	while (gmt_getmodopt (GMT, 'W', arg, "acfgklnotu", &pos, p, &error) && error == 0) {	/* Looking for +a, etc */
 		switch (p[0]) {
 			case 'a':	/* Altitude setting */
 				switch (p[1]) {	/* Check which altitude mode we selected */
@@ -431,10 +527,13 @@ GMT_LOCAL int psconvert_parse_GE_settings (struct GMT_CTRL *GMT, char *arg, stru
 						C->W.mode = KML_SEAFLOOR_ABS;
 						break;
 					default:
-						GMT_Report (C, GMT_MSG_ERROR, "Option -W+a<mode>[par]: Unrecognized altitude mode %c\n", p[1]);
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -W+a<mode>[par]: Unrecognized altitude mode %c\n", p[1]);
 						error++;
 						break;
 				}
+				break;
+			case 'c':	/* Used to be done by -A+n */
+				C->W.no_crop = true;
 				break;
 			case 'f':	/* Set fading options in KML */
 				sscanf (&p[1], "%d/%d", &C->W.min_fade, &C->W.max_fade);
@@ -466,7 +565,7 @@ GMT_LOCAL int psconvert_parse_GE_settings (struct GMT_CTRL *GMT, char *arg, stru
 				C->W.URL = gmt_assign_text (GMT, p);
 				break;
 			default:
-				GMT_Report (C, GMT_MSG_ERROR, "Option -W+<opt>: Unrecognized option selection %c\n", p[1]);
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -W+<opt>: Unrecognized option selection %c\n", p[1]);
 				error++;
 				break;
 		}
@@ -524,10 +623,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	const char *Z = (API->GMT->current.setting.run_mode == GMT_CLASSIC) ? " [-Z]" : "";
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <psfile1> <psfile2> <...> [-A[+f<fade>][+g<fill>][+m<margins>][+n][+p[<pen>]][+r][+s[m]|S<width>[/<height>]][+u]] "
-		"[-C<gs_option>] [-D<dir>] [-E<resolution>] [-F<out_name>] [-G<gs_path>] [-H<scale>] [-I] [-L<list>] [-Mb|f<psfile>] "
-		"[-P] [-Q[g|p|t]1|2|4] [-S] [-Tb|e|E|f|F|g|G|j|m|s|t[+m][+q<quality>]] [%s] "
-		"[-W[+a<mode>[<alt]][+f<minfade>/<maxfade>][+g][+k][+l<lodmin>/<lodmax>][+n<name>][+o<folder>][+t<title>][+u<URL>]]%s "
+	GMT_Usage (API, 0, "usage: %s <psfile1> <psfile2> ... [-A[+r][+u]] [-C<gs_option>] [-D<dir>] [-E<resolution>] "
+		"[-F<out_name>] [-G<gs_path>] [-H<scale>] [-I[+m<margins>][+s[m]<width>[/<height>]][+S<scale>]] [-L<list>] [-Mb|f<psfile>] "
+		"[-N[+f<fade>][+g<fill>][+i][+p[<pen>]] [-P] [-Q[g|p|t]1|2|4] [-S] [-Tb|e|E|f|F|g|G|j|m|s|t[+m][+q<quality>]] [%s] "
+		"[-W[+a<mode>[<alt]][+c][+f<minfade>/<maxfade>][+g][+k][+l<lodmin>/<lodmax>][+n<name>][+o<folder>][+t<title>][+u<URL>]]%s "
 		"[%s]\n", name, GMT_V_OPT, Z, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -536,29 +635,13 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"image will have the size specified by the BoundingBox. "
 		"As an option, a tight BoundingBox may be computed.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  REQUIRED ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n<psfile(s)> PostScript file(s) to be converted.");
+	GMT_Usage (API, 1, "\n<psfile1 <psfile2> ... PostScript file(s) to be converted.");
 	if (API->external)
 		GMT_Usage (API, -2, "Note: To access the current internal GMT plot, specify <psfile> as \"=\".");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n-A[+f<fade>][+g<fill>][+m<margins>][+n][+p[<pen>]][+r][+s[m]|S<width>[/<height>]][+u]");
+	GMT_Usage (API, 1, "\n-A[+r][+u]");
 	GMT_Usage (API, -2, "Adjust the BoundingBox to the minimum required by the image contents. Optional modifiers:");
-	GMT_Usage (API, 3, "+f Append <fade> (0-100) to fade entire plot to black (100%% fade)[no fading]. "
-		"Use +g to change the fade color [black].");
-	GMT_Usage (API, 3, "+g Append <fill> to paint the BoundingBox [no fill].");
-	GMT_Usage (API, 3, "+m Append <margin(s)> to enlarge the BoundingBox, with <margin(s)> being "
-		"<off> for uniform margin for all 4 sides, "
-		"<xoff>/<yoff> for separate x- and y-margins, or "
-		"<woff>/<eoff>/<soff>/<noff> for separate w-,e-,s-,n-margins.");
-	GMT_Usage (API, 3, "+n Leave the BoundingBox as is.");
-	GMT_Usage (API, 3, "+p Outline the BoundingBox, optionally append <pen> [%s].",
-		gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Usage (API, 3, "+r Force rounding of HighRes BoundingBox instead of ceil.");
-	GMT_Usage (API, 3, "+s Append [m]<width>[/<height>] the select a new image size "
-		"but maintaining the DPI set by -E (Ghostscript does the re-interpolation work). "
-		"Use +sm to only change size if figure size exceeds the new maximum size(s). "
-		"Append measurement unit u (%s) [%c].",
-		GMT_DIM_UNITS_DISPLAY, API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit][0]);
-	GMT_Usage (API, 3, "+S Scale the image by the appended <scale> factor.");
 	GMT_Usage (API, 3, "+u Strip out time-stamps (produced by GMT -U options).");
 	GMT_Usage (API, 1, "\n-C<gs_option>");
 	GMT_Usage (API, -2, "Specify a single, custom option that will be passed on to Ghostscript "
@@ -588,17 +671,32 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-H<scale>");
 	GMT_Usage (API, -2, "Temporarily increase dpi by integer <scale>, rasterize, then downsample [no downsampling]. "
 		"Used to improve raster image quality, especially for lower raster resolutions.");
-	GMT_Usage (API, 1, "\n-I Ghostscript versions >= 9.00 change gray-shades by using ICC profiles. "
-		"GS 9.05 and above provide the '-dUseFastColor=true' option to prevent that "
-		"and that is what psconvert does by default, unless option -I is set. "
-		"Note that for GS >= 9.00 and < 9.05 the gray-shade shifting is applied "
-		"to all but PDF format. We have no solution to offer other than ... upgrade GS.");
+	GMT_Usage (API, 1, "\n-I[+m<margins>][+s[m]<width>[/<height>]][+S<scale>]");
+	GMT_Usage (API, -2, "Scale image and add margins. Optional modifiers:");
+	GMT_Usage (API, 3, "+m Append <margin(s)> to enlarge the BoundingBox, with <margin(s)> being "
+		"<off> for uniform margin for all 4 sides, "
+		"<xoff>/<yoff> for separate x- and y-margins, or "
+		"<woff>/<eoff>/<soff>/<noff> for separate w-,e-,s-,n-margins.");
+	GMT_Usage (API, 3, "+s Append [m]<width>[/<height>] the select a new image size "
+		"but maintaining the DPI set by -E (Ghostscript does the re-interpolation work). "
+		"Use +sm to only change size if figure size exceeds the new maximum size(s). "
+		"Append measurement unit u (%s) [%c].",
+		GMT_DIM_UNITS_DISPLAY, API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit][0]);
+	GMT_Usage (API, 3, "+S Scale the image by the appended <scale> factor.");
 	GMT_Usage (API, 1, "\n-L<list>");
 	GMT_Usage (API, -2, "The <list> is an ASCII file with names of files to be converted. ");
 	GMT_Usage (API, 1, "\n-Mb|f<psfile>");
 	GMT_Usage (API, -2, "Sandwich current psfile between background and foreground plots:");
 	GMT_Usage (API, 3, "b: Append the name of a background PostScript plot [none].");
 	GMT_Usage (API, 3, "f: Append name of foreground PostScript plot [none].");
+	GMT_Usage (API, 1, "\n-N[+f<fade>][+g<fill>][+i][+p[<pen>]]");
+	GMT_Usage (API, -2, "Specify painting, fading, or outline of the BoundingBox via optional modifiers:");
+	GMT_Usage (API, 3, "+f Append <fade> (0-100) to fade entire plot to black (100%% fade)[no fading]. "
+		"Use +g to change the fade color [black].");
+	GMT_Usage (API, 3, "+g Append <fill> to paint the BoundingBox [no fill].");
+	GMT_Usage (API, 3, "+i Change gray-shades by using ICC profiles [Default sets -dUseFastColor=true].");
+	GMT_Usage (API, 3, "+p Outline the BoundingBox, optionally append <pen> [%s].",
+		gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Usage (API, 1, "\n-P Force Portrait mode. All Landscape mode plots will be rotated back "
 		"so that they show unrotated in Portrait mode. "
 		"This is practical when converting to image formats or preparing "
@@ -631,7 +729,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "V");
 	GMT_Usage (API, -2, "Note: Shows the gdal_translate command, in case you want to use this program "
 		"to create a geoTIFF file.");
-	GMT_Usage (API, 1, "\n-W[+a<mode>[<alt]][+f<minfade>/<maxfade>][+g][+k][+l<lodmin>/<lodmax>][+n<name>][+o<folder>][+t<title>][+u<URL>]");
+	GMT_Usage (API, 1, "\n-W[+a<mode>[<alt]][+c][+f<minfade>/<maxfade>][+g][+k][+l<lodmin>/<lodmax>][+n<name>][+o<folder>][+t<title>][+u<URL>]");
 	GMT_Usage (API, -2, "Write a ESRI type world file suitable to make (e.g.,) .tif files "
 		"recognized as geotiff by software that know how to do it. Be aware, "
 		"however, that different results are obtained depending on the image "
@@ -659,6 +757,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 4, "A: Append absolute altitude (in m).");
 	GMT_Usage (API, 4, "s: Append altitude (in m) relative to seafloor.");
 	GMT_Usage (API, 4, "S: Clamped to the seafloor.");
+	GMT_Usage (API, 3, "+c Do not crop [Default crops the image].");
 	GMT_Usage (API, 3, "+f Append <minfade>/<maxfade>] to set distances over which we fade from opaque "
 		"to transparent [no fading].");
 	GMT_Usage (API, 3, "+l Append <minLOD>/<maxLOD>] to set Level Of Detail when layer should be "
@@ -706,7 +805,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 
 			/* Processes program-specific parameters */
 
-			case 'A':	/* Adjust BoundingBox: -A[u][<margins>][+n][+r][+s<width>[/<height>]] */
+			case 'A':	/* Crop settings (plus backwards comptible parsing of older -A option syntax) */
 				n_errors += psconvert_parse_A_settings (GMT, opt->arg, Ctrl);
 				break;
 			case 'C':	/* Append extra custom GS options */
@@ -737,8 +836,8 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 				Ctrl->H.active = true;
 				Ctrl->H.factor = atoi (opt->arg);
 				break;
-			case 'I':	/* Do not use the ICC profile when converting gray shades */
-				Ctrl->I.active = true;
+			case 'I':	/* Set margins/scale modifiers [Deprecated -I: Do not use the ICC profile when converting gray shades] */
+				n_errors += psconvert_parse_new_I_settings (GMT, opt->arg, Ctrl);
 				break;
 			case 'L':	/* Give list of files to convert */
 				Ctrl->L.active = true;
@@ -764,6 +863,9 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 						n_errors++;
 					}
 				}
+				break;
+			case 'N':	/* Set media paint, fade, outline */
+				n_errors += psconvert_parse_new_N_settings (GMT, opt->arg, Ctrl);
 				break;
 			case 'P':	/* Force Portrait mode */
 				Ctrl->P.active = true;
@@ -996,21 +1098,21 @@ GMT_LOCAL inline char *psconvert_alpha_bits (struct PSCONVERT_CTRL *Ctrl) {
 	return alpha;
 }
 
-GMT_LOCAL void psconvert_possibly_fill_or_outline_BB (struct GMT_CTRL *GMT, struct PSCONVERT_A *A, FILE *fp) {
+GMT_LOCAL void psconvert_possibly_fill_or_outline_BB (struct GMT_CTRL *GMT, struct PSCONVERT_N *N, FILE *fp) {
 	/* Check if user wanted to paint or outline the BoundingBox - otherwise do nothing */
 	char *ptr = NULL;
 	GMT->PSL->internal.dpp = PSL_DOTS_PER_INCH / 72.0;	/* Dots pr. point resolution of output device, set here since no PSL initialization */
-	if (A->paint) {	/* Paint the background of the page */
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Paint background BoundingBox using paint %s\n", gmt_putrgb (GMT, A->fill.rgb));
-		if (GMT->PSL->internal.comments) fprintf (fp, "%% Paint background BoundingBox using paint %s\n", gmt_putrgb (GMT, A->fill.rgb));
-		ptr = PSL_makecolor (GMT->PSL, A->fill.rgb);
+	if (N->paint) {	/* Paint the background of the page */
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Paint background BoundingBox using paint %s\n", gmt_putrgb (GMT, N->fill.rgb));
+		if (GMT->PSL->internal.comments) fprintf (fp, "%% Paint background BoundingBox using paint %s\n", gmt_putrgb (GMT, N->fill.rgb));
+		ptr = PSL_makecolor (GMT->PSL, N->fill.rgb);
 		fprintf (fp, "gsave clippath %s F N U\n", ptr);
 	}
-	if (A->outline) {	/* Draw the outline of the page */
-		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Outline background BoundingBox using pen %s\n", gmt_putpen (GMT, &A->pen));
-		if (GMT->PSL->internal.comments) fprintf (fp, "%% Outline background BoundingBox using pen %s\n", gmt_putpen (GMT, &A->pen));
+	if (N->outline) {	/* Draw the outline of the page */
+		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Outline background BoundingBox using pen %s\n", gmt_putpen (GMT, &N->pen));
+		if (GMT->PSL->internal.comments) fprintf (fp, "%% Outline background BoundingBox using pen %s\n", gmt_putpen (GMT, &N->pen));
 		/* Double pen thickness since half will be clipped by BoundingBox */
-		ptr = PSL_makepen (GMT->PSL, 2.0*A->pen.width, A->pen.rgb, A->pen.style, A->pen.offset);
+		ptr = PSL_makepen (GMT->PSL, 2.0*N->pen.width, N->pen.rgb, N->pen.style, N->pen.offset);
 		fprintf (fp, "gsave %s clippath S U\n", ptr);
 	}
 }
@@ -1105,7 +1207,7 @@ GMT_LOCAL int psconvert_pipe_HR_BB(struct GMTAPI_CTRL *API, struct PSCONVERT_CTR
 		else
 			xt = -x0, yt = -y0, *w = x1-x0, *h = y1-y0, r = 0;
 
-		if (margin == 0) margin = Ctrl->A.margin[0];		/* We may have margins set via -A*/
+		if (margin == 0) margin = Ctrl->I.margin[0];		/* We may have margins set via -A*/
 	}
 	else {		/* Get the page size from original PS headers */
 		if ((pch = strstr(PS->data, "%%HiResB")) == NULL) {
@@ -1633,7 +1735,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 	}
 
 	if (Ctrl->W.active) {	/* Implies -P and -A (unless -A+n is set ) */
-		if (!Ctrl->A.active) Ctrl->A.active = Ctrl->A.crop = true;
+		if (!Ctrl->W.no_crop) Ctrl->A.active = Ctrl->A.crop = true;
 		Ctrl->P.active = true;
 	}
 
@@ -1667,35 +1769,35 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Need to complete the half-baked PS file */
 		if (Ctrl->In.n_files == 0) {	/* Add the default hidden PS file */
 			if ((k = gmt_set_psfilename (GMT)) == 0) {	/* Get hidden file name for current PS */
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "No hidden PS file %s found\n", GMT->current.ps.filename);
+				GMT_Report (API, GMT_MSG_ERROR, "No hidden PS file %s found\n", GMT->current.ps.filename);
 				Return (GMT_RUNTIME_ERROR);
 			}
-			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Hidden PS file %s found\n", GMT->current.ps.filename);
+			GMT_Report (API, GMT_MSG_DEBUG, "Hidden PS file %s found\n", GMT->current.ps.filename);
 			ps_names = gmt_M_memory (GMT, NULL, 1, char *);
 			ps_names[0] = gmt_strdup_noquote (GMT->current.ps.filename);
 			Ctrl->In.n_files = 1;
 		}
 		if (access (ps_names[0], F_OK) == 0) {	/* File exist, so complete it */
 			struct stat buf;
-			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Complete partial PS file %s\n", ps_names[0]);
+			GMT_Report (API, GMT_MSG_DEBUG, "Complete partial PS file %s\n", ps_names[0]);
 			if (stat (ps_names[0], &buf))
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not determine size of file %s\n", ps_names[0]);
+				GMT_Report (API, GMT_MSG_ERROR, "Could not determine size of file %s\n", ps_names[0]);
 			else
-				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Size of half-baked PS file = %" PRIuS ".\n", buf.st_size);
+				GMT_Report (API, GMT_MSG_DEBUG, "Size of half-baked PS file = %" PRIuS ".\n", buf.st_size);
 			half_baked_size = buf.st_size;	/* Remember the original size */
 			if ((fp = PSL_fopen (GMT->PSL, ps_names[0], "a")) == NULL) {	/* Must open inside PSL DLL */
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot append to file %s\n", ps_names[0]);
+				GMT_Report (API, GMT_MSG_ERROR, "Cannot append to file %s\n", ps_names[0]);
 				gmt_M_str_free (ps_names[0]);
 				Return (GMT_RUNTIME_ERROR);
 			}
 			GMT->PSL->internal.call_level++;	/* Must increment here since PSL_beginplot not called, and PSL_endplot will decrement */
 			PSL_endplot (GMT->PSL, 1);	/* Finalize the PS plot */
 			if (PSL_fclose (GMT->PSL)) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to close hidden PS file %s!\n", ps_names[0]);
+				GMT_Report (API, GMT_MSG_ERROR, "Unable to close hidden PS file %s!\n", ps_names[0]);
 				gmt_M_str_free (ps_names[0]);
 				Return (GMT_RUNTIME_ERROR);
 			}
-			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Fattened up PS file %s\n", ps_names[0]);
+			GMT_Report (API, GMT_MSG_DEBUG, "Fattened up PS file %s\n", ps_names[0]);
 		}
 	}
 
@@ -1716,7 +1818,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 	/* --------------------------------------------------------------------------------------------- */
 
 	/* Let gray 50 be rasterized as 50/50/50. See http://gmtrac.soest.hawaii.edu/issues/50 */
-	if (!Ctrl->I.active && ((gsVersion.major == 9 && gsVersion.minor >= 5) || gsVersion.major > 9))
+	if (!Ctrl->N.use_ICC_profiles && ((gsVersion.major == 9 && gsVersion.minor >= 5) || gsVersion.major > 9))
 		add_to_list (Ctrl->C.arg, "-dUseFastColor=true");
 
 	/* --------------------------------------------------------------------------------------------- */
@@ -1776,7 +1878,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 
 		if (Ctrl->M[0].active || Ctrl->M[1].active) {	/* Must sandwich file in-between one or two layers */
 			if (psconvert_wrap_the_PS_sandwich (GMT, ps_file, Ctrl->M[0].file, Ctrl->M[1].file)) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to wrap %s inside optional back- and fore-ground layers!\n", ps_file);
+				GMT_Report (API, GMT_MSG_ERROR, "Unable to wrap %s inside optional back- and fore-ground layers!\n", ps_file);
 				if (fp) fclose (fp);
 				Return (GMT_RUNTIME_ERROR);
 			}
@@ -1852,6 +1954,8 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 			y1 = GMT->current.setting.ps_def_page_size[1];
 			got_BB = got_HRBB = got_end = true;
 			GMT_Report (API, GMT_MSG_INFORMATION, "Crop to media BoundingBox [%g %g %g %g].\n", x0, y0, x1, y1);
+			x0 -= Ctrl->I.margin[XLO];	x1 += Ctrl->I.margin[XHI];	/* If not given, margin = 0/0/0/0 */
+			y0 -= Ctrl->I.margin[YLO];	y1 += Ctrl->I.margin[YHI];
 		}
 		else if (Ctrl->A.crop) {
 			char *psfile_to_use = NULL;
@@ -1896,8 +2000,8 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 					sscanf (&line[19], "%s %s %s %s", c1, c2, c3, c4);
 					x0 = atof (c1);		y0 = atof (c2);
 					x1 = atof (c3);		y1 = atof (c4);
-					x0 -= Ctrl->A.margin[XLO];	x1 += Ctrl->A.margin[XHI];	/* If not given, margin = 0/0/0/0 */
-					y0 -= Ctrl->A.margin[YLO];	y1 += Ctrl->A.margin[YHI];
+					x0 -= Ctrl->I.margin[XLO];	x1 += Ctrl->I.margin[XHI];	/* If not given, margin = 0/0/0/0 */
+					y0 -= Ctrl->I.margin[YLO];	y1 += Ctrl->I.margin[YHI];
 					if (x1 <= x0 || y1 <= y0) {
 						GMT_Report (API, GMT_MSG_ERROR, "Unable to decode BoundingBox file %s (maybe no non-white features were plotted?)\n", BB_file);
 						fclose (fpb);	fpb = NULL;            /* so we don't accidentally close twice */
@@ -2050,10 +2154,10 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 		else
 			xt = -x0, yt = -y0, w = x1-x0, h = y1-y0, r = 0;
 
-		xt_bak = xt;	yt_bak = yt;		/* Needed when Ctrl->A.resize */
+		xt_bak = xt;	yt_bak = yt;		/* Needed when Ctrl->I.resize */
 
 		/* Set new height when width was set and no height given */
-		if (Ctrl->A.new_size[0] > 0.0 && Ctrl->A.new_size[1] == 0.0) Ctrl->A.new_size[1] = Ctrl->A.new_size[0] * h / w;
+		if (Ctrl->I.new_size[0] > 0.0 && Ctrl->I.new_size[1] == 0.0) Ctrl->I.new_size[1] = Ctrl->I.new_size[0] * h / w;
 
 		/* ****************************************************************** */
 		/*         Rewind the input file and start copying and replacing      */
@@ -2064,7 +2168,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 		/* To produce non-PDF output from PS with transparency we must determine if transparency is requested in the PS */
 		look_for_transparency = Ctrl->T.device != GS_DEV_PDF && Ctrl->T.device != -GS_DEV_PDF;
 		has_transparency = transparency = add_grestore = false;
-		set_background = (Ctrl->A.paint || Ctrl->A.outline);
+		set_background = (Ctrl->N.paint || Ctrl->N.outline);
 		trans_line = 0;
 
 		while (psconvert_file_line_reader (GMT, &line, &line_size, fp, PS->data, &pos) != EOF) {
@@ -2145,8 +2249,8 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 			if (!strncmp (line, "%%BoundingBox:", 14)) {
 				double w_t, h_t;
 				w_t = w;	h_t = h;
-				if (Ctrl->A.resize) {		/* Here the BB is the new size itself */
-					w_t = Ctrl->A.new_size[0];		h_t = Ctrl->A.new_size[1];
+				if (Ctrl->I.resize) {		/* Here the BB is the new size itself */
+					w_t = Ctrl->I.new_size[0];		h_t = Ctrl->I.new_size[1];
 				}
 				if (got_BB && !Ctrl->A.round)
 					fprintf (fpo, "%%%%BoundingBox: 0 0 %ld %ld\n", lrint (psconvert_smart_ceil(w_t)), lrint (psconvert_smart_ceil(h_t)));
@@ -2164,8 +2268,8 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 			else if (!strncmp (line, "%%HiResBoundingBox:", 19)) {
 				double w_t, h_t;
 				w_t = w;	h_t = h;
-				if (Ctrl->A.resize) {		/* Here the BB is the new size itself */
-					w_t = Ctrl->A.new_size[0];		h_t = Ctrl->A.new_size[1];
+				if (Ctrl->I.resize) {		/* Here the BB is the new size itself */
+					w_t = Ctrl->I.new_size[0];		h_t = Ctrl->I.new_size[1];
 				}
 				if (got_HRBB)
 					fprintf (fpo, "%%%%HiResBoundingBox: 0 0 %.4f %.4f\n", w_t, h_t);
@@ -2190,7 +2294,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 				xt = yt = 0.0;
 				r = 0;
 			}
-			else if (Ctrl->A.resize) {
+			else if (Ctrl->I.resize) {
 				/* We are going to trick Ghostscript to do what -dEPSFitPage was supposed to do but doesn't
 				   because it's bugged. For that we recompute a new scale, offsets and DPIs such that at the
 				   end we will end up with an image with the imposed size and the current -E dpi setting.
@@ -2235,26 +2339,26 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 				}
 				else if (BeginPageSetup_here) {
 					BeginPageSetup_here = false;
-					Ctrl->A.resize = false;       /* Need to reset so it doesn't keep checking inside this branch */
+					Ctrl->I.resize = false;       /* Need to reset so it doesn't keep checking inside this branch */
 					/* Now we must calculate the new scale */
-					if (Ctrl->A.rescale)          /* except if it was set as an option */
-						r_x = Ctrl->A.scale;
-					else if (Ctrl->A.max) {	/* Check if plot size exceeds specified limits */
-						r_x = (w > Ctrl->A.new_size[0]) ? Ctrl->A.new_size[0] / w : 1.0;
-						if (Ctrl->A.new_size[1] / h < r_x) r_x = Ctrl->A.new_size[1] / h;	/* Pick the smallest scale */
+					if (Ctrl->I.rescale)          /* except if it was set as an option */
+						r_x = Ctrl->I.scale;
+					else if (Ctrl->I.max) {	/* Check if plot size exceeds specified limits */
+						r_x = (w > Ctrl->I.new_size[0]) ? Ctrl->I.new_size[0] / w : 1.0;
+						if (Ctrl->I.new_size[1] / h < r_x) r_x = Ctrl->I.new_size[1] / h;	/* Pick the smallest scale */
 					}
 					else
-						r_x = Ctrl->A.new_size[0] / w;
+						r_x = Ctrl->I.new_size[0] / w;
 
 					new_scale_x = new_scale_y = old_scale_x * r_x;
 					new_off_x = -xt_bak + xt_bak * r_x;     /* Need to recompute the new offsets as well */
 					new_off_y = -yt_bak + yt_bak * r_x;
-					Ctrl->A.new_dpi_x = Ctrl->A.new_dpi_y = Ctrl->E.dpi * r_x;
-					if (!Ctrl->A.max && Ctrl->A.new_size[1]) {
-						r_y = Ctrl->A.new_size[1] / h;
+					Ctrl->I.new_dpi_x = Ctrl->I.new_dpi_y = Ctrl->E.dpi * r_x;
+					if (!Ctrl->I.max && Ctrl->I.new_size[1]) {
+						r_y = Ctrl->I.new_size[1] / h;
 						new_scale_y = old_scale_y * r_y;
 						new_off_y = -yt_bak + yt_bak * r_y;
-						Ctrl->A.new_dpi_y = Ctrl->E.dpi * r_y;
+						Ctrl->I.new_dpi_y = Ctrl->E.dpi * r_y;
 					}
 					else
 						r_y = r_x;	/* Not sure of this. Added later to shut up a compiler warning of r_y potentially used uninitialized */
@@ -2268,14 +2372,14 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 						fprintf (fpo, "gsave %g %g scale\n", new_scale_x, new_scale_y);
 					set_background = false;
 					add_grestore = true;
-					psconvert_possibly_fill_or_outline_BB (GMT, &(Ctrl->A), fpo);
+					psconvert_possibly_fill_or_outline_BB (GMT, &(Ctrl->N), fpo);
 				}
 			}
 			else if (set_background) {
 				/* Paint or outline the background rectangle. */
 				if (!strncmp (line, "%%EndPageSetup", 14)) {
 					set_background = false;
-					psconvert_possibly_fill_or_outline_BB (GMT, &(Ctrl->A), fpo);
+					psconvert_possibly_fill_or_outline_BB (GMT, &(Ctrl->N), fpo);
 				}
 			}
 			else if (!strncmp (line, "%%Page:", 7)) {
@@ -2286,11 +2390,11 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 				xt = yt = 0.0;
 				r = 0;
 			}
-			else if (Ctrl->A.fade && !strncmp (line, "%%PageTrailer", 13) && Ctrl->A.fade_level > 0.0) {
+			else if (Ctrl->N.fade && !strncmp (line, "%%PageTrailer", 13) && Ctrl->N.fade_level > 0.0) {
 				/* Place a transparent black rectangle over everything, at level of transparency */
-				char *ptr = PSL_makecolor (GMT->PSL, Ctrl->A.fill.rgb);
-				GMT_Report (API, GMT_MSG_INFORMATION, "Append fading to %s at %d%%.\n", gmt_putrgb (GMT, Ctrl->A.fill.rgb), irint (100.0*Ctrl->A.fade_level));
-				fprintf (fpo, "V clippath %s %g %g /Normal PSL_transp F N U\n", ptr, Ctrl->A.fade_level, Ctrl->A.fade_level);
+				char *ptr = PSL_makecolor (GMT->PSL, Ctrl->N.fill.rgb);
+				GMT_Report (API, GMT_MSG_INFORMATION, "Append fading to %s at %d%%.\n", gmt_putrgb (GMT, Ctrl->N.fill.rgb), irint (100.0*Ctrl->N.fade_level));
+				fprintf (fpo, "V clippath %s %g %g /Normal PSL_transp F N U\n", ptr, Ctrl->N.fade_level, Ctrl->N.fade_level);
 				transparency = true;
 			}
 #ifdef HAVE_GDAL
@@ -2404,9 +2508,9 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 			}
 			strcat (out_file, ext[Ctrl->T.device]);
 
-			if (Ctrl->A.new_dpi_x) {	/* We have a resize request (was Ctrl->A.resize = true;) */
-				pix_w = urint (psconvert_smart_ceil (w * Ctrl->A.new_dpi_x / 72.0));
-				pix_h = urint (psconvert_smart_ceil (h * Ctrl->A.new_dpi_y / 72.0));
+			if (Ctrl->I.new_dpi_x) {	/* We have a resize request (was Ctrl->I.resize = true;) */
+				pix_w = urint (psconvert_smart_ceil (w * Ctrl->I.new_dpi_x / 72.0));
+				pix_h = urint (psconvert_smart_ceil (h * Ctrl->I.new_dpi_y / 72.0));
 			}
 			else {
 				pix_w = urint (psconvert_smart_ceil (w * Ctrl->E.dpi / 72.0));
@@ -2584,8 +2688,8 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 
 			if (gmtBB_width != 0) {			/* Got the BB via GMT internal message system. */
 				double dpi_x, dpi_y;
-				if (Ctrl->A.new_dpi_x) {
-					dpi_x = Ctrl->A.new_dpi_x;		dpi_y = Ctrl->A.new_dpi_y;
+				if (Ctrl->I.new_dpi_x) {
+					dpi_x = Ctrl->I.new_dpi_x;		dpi_y = Ctrl->I.new_dpi_y;
 				}
 				else {
 					dpi_x = Ctrl->E.dpi;		dpi_y = Ctrl->E.dpi;

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1632,7 +1632,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_ERROR, "As far as we know selected raster type is unsupported by GE.\n");
 	}
 
-	if (Ctrl->W.active) {	/* Implies -P and -A (unless -A- is set ) */
+	if (Ctrl->W.active) {	/* Implies -P and -A (unless -A+n is set ) */
 		if (!Ctrl->A.active) Ctrl->A.active = Ctrl->A.crop = true;
 		Ctrl->P.active = true;
 	}


### PR DESCRIPTION
See #5582 for background.  This minor change allows the margins and other **-A** modifiers such as **+g**, **+f**, etc.