### PR TITLE
Fix typo in ISO_3166-1_alpha-2 wikipedia link

### DIFF
--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -34,7 +34,7 @@ and 2 are shown in panels a) and b) respectively of the Figure :ref:`Map region 
 #. **-R**\ *code1,code2,...*\ [**+e**\ \|\ **r**\ \|\ **R**\ *incs*]. This indirectly supplies the region by consulting
    the DCW (Digital Chart of the World) database and derives the bounding regions for one or more countries given by
    the codes. Simply append one or more comma-separated countries using the two-character
-   `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)>`_.
+   `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_.
    To select a state within a country (if available), append .state, e.g, US.TX for Texas. To specify a whole continent,
    prepend **=** to any of the continent codes **AF** (Africa), **AN** (Antarctica), **AS** (Asia), **EU** (Europe),
    **OC** (Oceania), **NA** (North America), or **SA** (South America). The following modifiers can be appended:


### PR DESCRIPTION
There is an extra ")".
