### PR TITLE
Forgot to update movie regarding psconvert -A -I -N

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -1849,7 +1849,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fclose (Ctrl->E.fp);
 			Return (GMT_ERROR_ON_FOPEN);
 		}
-		sprintf (extra, "A+n+r+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, possibly fading */
+		sprintf (extra, "A+M+r,N+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, possibly fading */
 		if (Ctrl->E.fill) {strcat (extra, "+g"); strcat (extra, Ctrl->E.fill);}	/* Chose another fade color than black */
 		if (Ctrl->E.PS) {	/* Need to place a background title first (which will be in parent dir when loop script is run) */
 			strcat (extra, ",Mb../../");
@@ -2131,12 +2131,13 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			gmt_set_dvalue (fp, Ctrl->In.mode, "MOVIE_FADE", fade_level, 0);
 		}
 		else if (Ctrl->K.active) {
-			sprintf (extra, "A+n+r+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, but fading may be in effect for some frames */
+			sprintf (extra, "A+M+r,N+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, but fading may be in effect for some frames */
 			if (Ctrl->K.fill) {strcat (extra, "+g"); strcat (extra, Ctrl->K.fill);}	/* Chose another fade color than black */
 		}
 		else
-			sprintf (extra, "A+n+r");	/* No cropping, image size is fixed */
+			sprintf (extra, "A+M+r");	/* No cropping, image size is fixed */
 		if (Ctrl->G.active) {	/* Want to set a fixed background canvas color and/or outline - we do this via the psconvert -A option */
+			if (!Ctrl->K.active) strcat (extra, "N");
 			if (Ctrl->G.mode & 1) strcat (extra, "+p"), strcat (extra, Ctrl->G.pen);
 			if (Ctrl->G.mode & 2) strcat (extra, "+g"), strcat (extra, Ctrl->G.fill);
 		}
@@ -2312,12 +2313,13 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		Return (GMT_ERROR_ON_FOPEN);
 	}
 	if (Ctrl->K.active) {
-		sprintf (extra, "A+n+r+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, but fading may be in effect for some frames */
+		sprintf (extra, "A+M+r,N+f%s", gmt_place_var (Ctrl->In.mode, "MOVIE_FADE"));	/* No cropping, image size is fixed, but fading may be in effect for some frames */
 		if (Ctrl->K.fill) {strcat (extra, "+g"); strcat (extra, Ctrl->K.fill);}	/* Chose another fade color than black */
 	}
 	else
-		sprintf (extra, "A+n+r");	/* No cropping, image size is fixed */
-	if (Ctrl->G.active) {	/* Want to set a fixed background canvas color and/or outline - we do this via the psconvert -A option */
+		sprintf (extra, "A+M+r");	/* No cropping, image size is fixed */
+	if (Ctrl->G.active) {	/* Want to set a fixed background canvas color and/or outline - we do this via the psconvert -N option */
+		if (!Ctrl->K.active) strcat (extra, "N");	/* Need to set the -N option */
 		if (Ctrl->G.mode & 1) strcat (extra, "+p"), strcat (extra, Ctrl->G.pen);
 		if (Ctrl->G.mode & 2) strcat (extra, "+g"), strcat (extra, Ctrl->G.fill);
 	}

--- a/src/movie.c
+++ b/src/movie.c
@@ -2136,8 +2136,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		}
 		else
 			sprintf (extra, "A+M+r");	/* No cropping, image size is fixed */
-		if (Ctrl->G.active) {	/* Want to set a fixed background canvas color and/or outline - we do this via the psconvert -A option */
-			if (!Ctrl->K.active) strcat (extra, "N");
+		if (Ctrl->G.active) {	/* Want to set a fixed background canvas color and/or outline - we do this via the psconvert -N option */
+			if (!Ctrl->K.active) strcat (extra, "N");	/* Need to switch to the -N option first */
 			if (Ctrl->G.mode & 1) strcat (extra, "+p"), strcat (extra, Ctrl->G.pen);
 			if (Ctrl->G.mode & 2) strcat (extra, "+g"), strcat (extra, Ctrl->G.fill);
 		}
@@ -2319,7 +2319,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	else
 		sprintf (extra, "A+M+r");	/* No cropping, image size is fixed */
 	if (Ctrl->G.active) {	/* Want to set a fixed background canvas color and/or outline - we do this via the psconvert -N option */
-		if (!Ctrl->K.active) strcat (extra, "N");	/* Need to set the -N option */
+		if (!Ctrl->K.active) strcat (extra, "N");	/* Need to switch to the -N option first */
 		if (Ctrl->G.mode & 1) strcat (extra, "+p"), strcat (extra, Ctrl->G.pen);
 		if (Ctrl->G.mode & 2) strcat (extra, "+g"), strcat (extra, Ctrl->G.fill);
 	}

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -447,11 +447,11 @@ GMT_LOCAL int psconvert_parse_A_settings (struct GMT_CTRL *GMT, char *arg, struc
 		strcat (A_option, "+r");
 	if (gmt_get_modifier (arg, 'u', string))
 		strcat (A_option, "+u");
-	if (gmt_get_modifier (arg, 'M', string))	/* Only issued by gmt end */
+	if (gmt_get_modifier (arg, 'M', string))	/* Only issued by gmt end and movie */
 		strcat (A_option, "+M");
-	/* Note: If -A+n is given then we */
+	/* Note: If -A+n is given then we handle it via backwards compatibility */
 	if (gmt_get_modifier (arg, 'n', string)) {
-		if (gmt_M_compat_check (GMT, 5)) {
+		if (gmt_M_compat_check (GMT, 6)) {
 			GMT_Report (GMT->parent, GMT_MSG_COMPAT, "-A+n (no args) is deprecated, use -W+c instead.\n");
 			Ctrl->W.no_crop = true;
 		}


### PR DESCRIPTION
I forgot that **movie** sets **PSCONVERT** arguments using the old style via **-A**, including the deprecated **+n**.  Also fixed the wrong compatibility level for this in **psconvert**.  Hopefully fixes #5600.
