### PR TITLE
Fix failure when using +sa for auto grid-range scaling

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13832,7 +13832,7 @@ char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, 
 				allow_a = false;	/* a is not a valid number */
 				switch (modifiers[k]) {	/* The modifier code */
 					case 'o': case 's':	/* +o<offset>|a,  +s<scale>|a */
-						allow_a = true;	/* A for auto is OK for these modifiers */
+						allow_a = true;	/* Argument "a" for auto is OK for these modifiers */
 						/* Fall through on purpose */
 					case 'h': case 'i': case 'n': 	/* +h[<hinge>], +i<inc>, +n<nodata> */
 						k++;	/* Move to start of argument, next modifier, or NULL */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13837,7 +13837,7 @@ char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, 
 					case 'h': case 'i': case 'n': 	/* +h[<hinge>], +i<inc>, +n<nodata> */
 						k++;	/* Move to start of argument, next modifier, or NULL */
 						while (modifiers[k] && modifiers[k] != '+' && strchr ("-+.0123456789eE", modifiers[k])) k++;	/* Skip a numerical argument */
-						if (allow_a && modifiers[k] == 'a') k++;	/* Ok with a for this modifiers */
+						if (allow_a && modifiers[k] == 'a') k++;	/* Ok with a for this modifier */
 						if (!(modifiers[k] == '\0' || modifiers[k] == '+')) error = true;	/* Means we found non-numbers after valid modifier */
 						break;
 					case 'u': case 'U':	/* +u<unit>, +U<unit */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13806,6 +13806,7 @@ char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, 
 	 * found, or NULL.  Any modifier will be of the form +?[<arg>], where ? is a lower or upper-case
 	 * letter, and <arg> is optional. */
 	bool go = true;	/* Keep scanning backwards until we find an unrecognized modifier */
+	bool allow_a;	/* True when "a" is a valid argument to the modifier */
 	char *modifiers = NULL;	/* Pointer to the start of valid modifiers in this filename, or NULL */
 	size_t k = strlen (filename);	/* k will serve as the index of the current character in the filename string */
 	gmt_M_unused (API);
@@ -13828,10 +13829,15 @@ char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, 
 		while (!error && modifiers[k]) {
 			if (modifiers[k] == '+') {
 				k++;
+				allow_a = false;	/* a is not a valid number */
 				switch (modifiers[k]) {	/* The modifier code */
-					case 'h': case 'i': case 'o': case 'n': case 's':	/* +h[<hinge>], +i<inc>, ++o<offset>, +n<nodata>, +s<scale> */
+					case 'o': case 's':	/* +o<offset>|a,  +s<scale>|a */
+						allow_a = true;	/* A for auto is OK for these modifiers */
+						/* Fall through on purpose */
+					case 'h': case 'i': case 'n': 	/* +h[<hinge>], +i<inc>, +n<nodata> */
 						k++;	/* Move to start of argument, next modifier, or NULL */
 						while (modifiers[k] && modifiers[k] != '+' && strchr ("-+.0123456789eE", modifiers[k])) k++;	/* Skip a numerical argument */
+						if (allow_a && modifiers[k] == 'a') k++;	/* Ok with a for this modifiers */
 						if (!(modifiers[k] == '\0' || modifiers[k] == '+')) error = true;	/* Means we found non-numbers after valid modifier */
 						break;
 					case 'u': case 'U':	/* +u<unit>, +U<unit */

--- a/test/xyz2grd/gridrange.sh
+++ b/test/xyz2grd/gridrange.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Check that +sa and +oa parsing work
+cat << EOF > answer.txt
+1.00000000	1.00000000	-0.50196850
+0.00000000	0.00000000	1.25000000
+EOF
+(echo 0 0 1.25; echo 1 1 -0.5) | gmt xyz2grd -R-1/1/-1/1 -I1 -Gout.nc=nb+sa+oa
+gmt grd2xyz -s out.nc --FORMAT_FLOAT_OUT=%.8f > result.txt
+diff -q --strip-trailing-cr result.txt answer.txt > fail


### PR DESCRIPTION
When one wishes to save disk space by using an integer grid format, it is useful to have GMT automaticallly determine scales and offsets so that the precision of the data can be preserved despite being stored as integers.  However, we must have had a regression here since **+sa** or **+oa** lead to errors.  This PR fixes this problem.  For instance, this sequences creates a grid with two nodes that are -0.5 and 1.25 and we wish to store the grid using bytes (0-255).  GMT determines the optimal scale to use the full range of bytes:

```
(echo 0 0 1.25; echo 1 1 -0.5) | gmt xyz2grd -R-1/1/-1/1 -I1 -Gout.nc=nb+sa
gmt grdinfo out.nc
out.nc: Title: z
out.nc: Command: xyz2grd -R-1/1/-1/1 -I1 -Gout.nc=nb+sa
out.nc: Remark: 
out.nc: Gridline node registration used [Cartesian grid]
out.nc: Grid file format: nb = GMT netCDF format (8-bit integer), CF-1.7
out.nc: x_min: -1 x_max: 1 x_inc: 1 name: x n_columns: 3
out.nc: y_min: -1 y_max: 1 y_inc: 1 name: y n_rows: 3
out.nc: v_min: -0.501968503937 v_max: 1.25 name: z
out.nc: scale_factor: 0.00984251968504 add_offset: 0 packed z-range: [-51,127]
out.nc: format: classic
gmt grd2xyz out.nc -s
1	1	-0.501968502998
0	0	1.25
```

So despite using bytes we are still able to approximately store the two floating points via netCDF scale factors.
