### PR TITLE
Rename local macros to gmt_M_*

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -102,23 +102,20 @@
 #	include <mex.h>
 #endif
 
-#define USER_MEDIA_OFFSET 1000
-
-
-#define GMT_def_scale(case_val) GMT->session.u2u[GMT_INCH][gmtlib_unit_lookup(GMT, GMT->current.setting.given_unit[case_val], GMT->current.setting.proj_length_unit)]
-#define GMT_def_unit(case_val) GMT->current.setting.given_unit[case_val]
-
-#define GMT_more_than_once(GMT,active) (gmt_M_check_condition (GMT, active, "Option -%c given more than once\n", option))
-
+#define GMT_USER_MEDIA_OFFSET 1000
 #define GMT_COMPAT_INFO "Please see " GMT_DOC_URL "/changes.html#new-features-in-gmt-5 for more information.\n"
 #define GMT_COMPAT_WARN GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Parameter %s is deprecated.\n" GMT_COMPAT_INFO, GMT_keyword[case_val])
-#define GMT_COMPAT_CHANGE(new_P) GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Parameter %s is deprecated. Use %s instead.\n" GMT_COMPAT_INFO, GMT_keyword[case_val], new_P)
-#define GMT_COMPAT_TRANSLATE(new_P) error = (gmt_M_compat_check (GMT, 4) ? GMT_COMPAT_CHANGE (new_P) + gmtlib_setparameter (GMT, new_P, value, core) : gmtinit_badvalreport (GMT, keyword))
-#define GMT_COMPAT_OPT(new_P) if (strchr (list, option)) { GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Option -%c is deprecated. Use -%c instead.\n" GMT_COMPAT_INFO, option, new_P); option = new_P; }
+
+#define gmt_M_compat_change(new_P) GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Parameter %s is deprecated. Use %s instead.\n" GMT_COMPAT_INFO, GMT_keyword[case_val], new_P)
+#define gmt_M_compat_translate(new_P) error = (gmt_M_compat_check (GMT, 4) ? gmt_M_compat_change (new_P) + gmtlib_setparameter (GMT, new_P, value, core) : gmtinit_badvalreport (GMT, keyword))
+#define gmt_M_compat_opt(new_P) if (strchr (list, option)) { GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Option -%c is deprecated. Use -%c instead.\n" GMT_COMPAT_INFO, option, new_P); option = new_P; }
+#define gmt_M_def_scale(case_val) GMT->session.u2u[GMT_INCH][gmtlib_unit_lookup(GMT, GMT->current.setting.given_unit[case_val], GMT->current.setting.proj_length_unit)]
+#define gmt_M_def_unit(case_val) GMT->current.setting.given_unit[case_val]
+#define gmt_M_more_than_once(GMT,active) (gmt_M_check_condition (GMT, active, "Option -%c given more than once\n", option))
 
 /* Leave a record that this keyword is no longer a default one
    So far, only gmtset calls this function with core = true, but this is a too fragile solution */
-#define GMT_KEYWORD_UPDATE(val) if (core) GMT_keyword_updated[val] = true
+#define gmt_M_keyword_update(val) if (core) GMT_keyword_updated[val] = true
 
 /*--------------------------------------------------------------------*/
 /* Load private fixed array parameters from include files */
@@ -852,7 +849,7 @@ GMT_LOCAL int gmtinit_parse_h_option (struct GMT_CTRL *GMT, char *item) {
 GMT_LOCAL void gmtinit_setautopagesize (struct GMT_CTRL *GMT) {
 	/* In GMT modern mode we use the largest possible square page (~11x11 meters), portrait mode, and then crop automatically */
 	GMT->current.setting.ps_page_size[0] = GMT->current.setting.ps_page_size[1] = GMT_PAPER_DIM;	/* Max area in points */
-	GMT->current.setting.ps_media = -USER_MEDIA_OFFSET;
+	GMT->current.setting.ps_media = -GMT_USER_MEDIA_OFFSET;
 	GMT->current.setting.ps_orientation = PSL_PORTRAIT;
 }
 
@@ -10072,56 +10069,56 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 	switch (case_val) {
 		/* FORMAT GROUP */
 		case GMTCASE_INPUT_CLOCK_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_CLOCK_IN");
+			gmt_M_compat_translate ("FORMAT_CLOCK_IN");
 			break;
 		case GMTCASE_FORMAT_CLOCK_IN:
 			strncpy (GMT->current.setting.format_clock_in, value, GMT_LEN64-1);
 			error = gmtlib_clock_C_format (GMT, GMT->current.setting.format_clock_in, &GMT->current.io.clock_input, 0);
 			break;
 		case GMTCASE_INPUT_DATE_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_DATE_IN");
+			gmt_M_compat_translate ("FORMAT_DATE_IN");
 			break;
 		case GMTCASE_FORMAT_DATE_IN:
 			strncpy (GMT->current.setting.format_date_in, value, GMT_LEN64-1);
 			error = gmtlib_date_C_format (GMT, GMT->current.setting.format_date_in, &GMT->current.io.date_input, 0);
 			break;
 		case GMTCASE_OUTPUT_CLOCK_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_CLOCK_OUT");
+			gmt_M_compat_translate ("FORMAT_CLOCK_OUT");
 			break;
 		case GMTCASE_FORMAT_CLOCK_OUT:
 			strncpy (GMT->current.setting.format_clock_out, value, GMT_LEN64-1);
 			gmtlib_clock_C_format (GMT, GMT->current.setting.format_clock_out, &GMT->current.io.clock_output, 1);
 			break;
 		case GMTCASE_OUTPUT_DATE_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_DATE_OUT");
+			gmt_M_compat_translate ("FORMAT_DATE_OUT");
 			break;
 		case GMTCASE_FORMAT_DATE_OUT:
 			strncpy (GMT->current.setting.format_date_out, value, GMT_LEN64-1);
 			error = gmtlib_date_C_format (GMT, GMT->current.setting.format_date_out, &GMT->current.io.date_output, 1);
 			break;
 		case GMTCASE_OUTPUT_DEGREE_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_GEO_OUT");
+			gmt_M_compat_translate ("FORMAT_GEO_OUT");
 			break;
 		case GMTCASE_FORMAT_GEO_OUT:
 			strncpy (GMT->current.setting.format_geo_out, value, GMT_LEN64-1);
 			error = gmtlib_geo_C_format (GMT);	/* Can fail if FORMAT_FLOAT_OUT not yet set, but is repeated at the end of gmt_begin */
 			break;
 		case GMTCASE_PLOT_CLOCK_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_CLOCK_MAP");
+			gmt_M_compat_translate ("FORMAT_CLOCK_MAP");
 			break;
 		case GMTCASE_FORMAT_CLOCK_MAP:
 			strncpy (GMT->current.setting.format_clock_map, value, GMT_LEN64-1);
 			gmtlib_clock_C_format (GMT, GMT->current.setting.format_clock_map, &GMT->current.plot.calclock.clock, 2);
 			break;
 		case GMTCASE_PLOT_DATE_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_DATE_MAP");
+			gmt_M_compat_translate ("FORMAT_DATE_MAP");
 			break;
 		case GMTCASE_FORMAT_DATE_MAP:
 			strncpy (GMT->current.setting.format_date_map, value, GMT_LEN64-1);
 			error = gmtlib_date_C_format (GMT, GMT->current.setting.format_date_map, &GMT->current.plot.calclock.date, 2);
 			break;
 		case GMTCASE_PLOT_DEGREE_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_GEO_MAP");
+			gmt_M_compat_translate ("FORMAT_GEO_MAP");
 			break;
 		case GMTCASE_FORMAT_GEO_MAP:
 			strncpy (GMT->current.setting.format_geo_map, value, GMT_LEN64-1);
@@ -10132,19 +10129,19 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			        gmtlib_setparameter (GMT, "FORMAT_TIME_SECONDARY_MAP", value, core);
 			break;
 		case GMTCASE_TIME_FORMAT_PRIMARY:
-			GMT_COMPAT_TRANSLATE ("FORMAT_TIME_PRIMARY_MAP");
+			gmt_M_compat_translate ("FORMAT_TIME_PRIMARY_MAP");
 			break;
 		case GMTCASE_FORMAT_TIME_PRIMARY_MAP:
 			strncpy (GMT->current.setting.format_time[GMT_PRIMARY], value, GMT_LEN64-1);
 			break;
 		case GMTCASE_TIME_FORMAT_SECONDARY:
-			GMT_COMPAT_TRANSLATE ("FORMAT_TIME_SECONDARY_MAP");
+			gmt_M_compat_translate ("FORMAT_TIME_SECONDARY_MAP");
 			break;
 		case GMTCASE_FORMAT_TIME_SECONDARY_MAP:
 			strncpy (GMT->current.setting.format_time[GMT_SECONDARY], value, GMT_LEN64-1);
 			break;
 		case GMTCASE_D_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_FLOAT_OUT");
+			gmt_M_compat_translate ("FORMAT_FLOAT_OUT");
 			break;
 		case GMTCASE_FORMAT_FLOAT_OUT:
 			gmtinit_parse_format_float_out (GMT, value);
@@ -10153,7 +10150,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			strncpy (GMT->current.setting.format_float_map, value, GMT_LEN64-1);
 			break;
 		case GMTCASE_UNIX_TIME_FORMAT:
-			GMT_COMPAT_TRANSLATE ("FORMAT_TIME_STAMP");
+			gmt_M_compat_translate ("FORMAT_TIME_STAMP");
 			break;
 		case GMTCASE_FORMAT_TIME_STAMP:
 			strncpy (GMT->current.setting.format_time_stamp, value, GMT_LEN256-1);
@@ -10176,7 +10173,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			        gmtlib_setparameter (GMT, "FONT_ANNOT_SECONDARY", value, core);
 			break;
 		case GMTCASE_ANNOT_FONT_PRIMARY:
-			GMT_COMPAT_TRANSLATE ("FONT_ANNOT_PRIMARY");
+			gmt_M_compat_translate ("FONT_ANNOT_PRIMARY");
 			break;
 		case GMTCASE_FONT_ANNOT_PRIMARY:
 			if (value[0] == '+') {
@@ -10231,7 +10228,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			}
 			break;
 		case GMTCASE_ANNOT_FONT_SECONDARY:
-			GMT_COMPAT_TRANSLATE ("FONT_ANNOT_SECONDARY");
+			gmt_M_compat_translate ("FONT_ANNOT_SECONDARY");
 			break;
 		case GMTCASE_FONT_ANNOT_SECONDARY:
 			if (gmt_getfont (GMT, value, &GMT->current.setting.font_annot[GMT_SECONDARY])) error = true;
@@ -10249,7 +10246,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			if (gmt_getfont (GMT, value, &GMT->current.setting.font_tag)) error = true;
 			break;
 		case GMTCASE_LABEL_FONT:
-			GMT_COMPAT_TRANSLATE ("FONT_LABEL");
+			gmt_M_compat_translate ("FONT_LABEL");
 			break;
 		case GMTCASE_FONT_LABEL:
 			if (gmt_getfont (GMT, value, &GMT->current.setting.font_label)) error = true;
@@ -10262,11 +10259,11 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 
 		case GMTCASE_ANNOT_FONT_SIZE_PRIMARY:
 			if (gmt_M_compat_check (GMT, 4)) {
-				GMT_COMPAT_CHANGE ("FONT_ANNOT_PRIMARY");
+				gmt_M_compat_change ("FONT_ANNOT_PRIMARY");
 				dval = gmt_convert_units (GMT, value, GMT_PT, GMT_PT);
 				if (dval > 0.0) {
 					GMT->current.setting.font_annot[GMT_PRIMARY].size = dval;
-					GMT_KEYWORD_UPDATE (GMTCASE_FONT_ANNOT_PRIMARY);
+					gmt_M_keyword_update (GMTCASE_FONT_ANNOT_PRIMARY);
 				}
 				else
 					error = true;
@@ -10276,11 +10273,11 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_ANNOT_FONT_SIZE_SECONDARY:
 			if (gmt_M_compat_check (GMT, 4)) {
-				GMT_COMPAT_CHANGE ("FONT_ANNOT_SECONDARY");
+				gmt_M_compat_change ("FONT_ANNOT_SECONDARY");
 				dval = gmt_convert_units (GMT, value, GMT_PT, GMT_PT);
 				if (dval > 0.0) {
 					GMT->current.setting.font_annot[GMT_SECONDARY].size = dval;
-					GMT_KEYWORD_UPDATE (GMTCASE_FONT_ANNOT_SECONDARY);
+					gmt_M_keyword_update (GMTCASE_FONT_ANNOT_SECONDARY);
 				}
 				else
 					error = true;
@@ -10290,11 +10287,11 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_HEADER_FONT_SIZE:
 			if (gmt_M_compat_check (GMT, 4)) {
-				GMT_COMPAT_CHANGE ("FONT_TITLE");
+				gmt_M_compat_change ("FONT_TITLE");
 				dval = gmt_convert_units (GMT, value, GMT_PT, GMT_PT);
 				if (dval > 0.0) {
 					GMT->current.setting.font_title.size = dval;
-					GMT_KEYWORD_UPDATE (GMTCASE_FONT_TITLE);
+					gmt_M_keyword_update (GMTCASE_FONT_TITLE);
 				}
 				else
 					error = true;
@@ -10304,11 +10301,11 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_LABEL_FONT_SIZE:
 			if (gmt_M_compat_check (GMT, 4)) {
-				GMT_COMPAT_CHANGE ("FONT_LABEL");
+				gmt_M_compat_change ("FONT_LABEL");
 				dval = gmt_convert_units (GMT, value, GMT_PT, GMT_PT);
 				if (dval > 0.0) {
 					GMT->current.setting.font_label.size = dval;
-					GMT_KEYWORD_UPDATE (GMTCASE_FONT_LABEL);
+					gmt_M_keyword_update (GMTCASE_FONT_LABEL);
 				}
 				else
 					error = true;
@@ -10320,7 +10317,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		/* MAP GROUP */
 
 		case GMTCASE_ANNOT_OFFSET_PRIMARY:
-			GMT_COMPAT_TRANSLATE ("MAP_ANNOT_OFFSET_PRIMARY");
+			gmt_M_compat_translate ("MAP_ANNOT_OFFSET_PRIMARY");
 			break;
 		case GMTCASE_MAP_ANNOT_OFFSET:
 			error = gmtlib_setparameter (GMT, "MAP_ANNOT_OFFSET_PRIMARY", value, core) +
@@ -10330,13 +10327,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			GMT->current.setting.map_annot_offset[GMT_PRIMARY] = gmt_M_to_inch (GMT, value);
 			break;
 		case GMTCASE_ANNOT_OFFSET_SECONDARY:
-			GMT_COMPAT_TRANSLATE ("MAP_ANNOT_OFFSET_SECONDARY");
+			gmt_M_compat_translate ("MAP_ANNOT_OFFSET_SECONDARY");
 			break;
 		case GMTCASE_MAP_ANNOT_OFFSET_SECONDARY:
 			GMT->current.setting.map_annot_offset[GMT_SECONDARY] = gmt_M_to_inch (GMT, value);
 			break;
 		case GMTCASE_OBLIQUE_ANNOTATION:
-			GMT_COMPAT_TRANSLATE ("MAP_ANNOT_OBLIQUE");
+			gmt_M_compat_translate ("MAP_ANNOT_OBLIQUE");
 			break;
 		case GMTCASE_MAP_ANNOT_OBLIQUE:
 			ival = gmtinit_parse_map_annot_oblique (GMT, value);
@@ -10348,7 +10345,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_ANNOT_MIN_ANGLE:
-			GMT_COMPAT_TRANSLATE ("MAP_ANNOT_MIN_ANGLE");
+			gmt_M_compat_translate ("MAP_ANNOT_MIN_ANGLE");
 			break;
 		case GMTCASE_MAP_ANNOT_MIN_ANGLE:
 			dval = atof (value);
@@ -10358,7 +10355,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.map_annot_min_angle = dval;
 			break;
 		case GMTCASE_ANNOT_MIN_SPACING:
-			GMT_COMPAT_TRANSLATE ("MAP_ANNOT_MIN_SPACING");
+			gmt_M_compat_translate ("MAP_ANNOT_MIN_SPACING");
 			break;
 		case GMTCASE_MAP_ANNOT_MIN_SPACING:
 			if (value[0] == '-')	/* Negative */
@@ -10370,14 +10367,14 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_Y_AXIS_TYPE:
 			if (gmt_M_compat_check (GMT, 4)) {
-				GMT_COMPAT_CHANGE ("MAP_ANNOT_ORTHO");
+				gmt_M_compat_change ("MAP_ANNOT_ORTHO");
 				if (!strcmp (lower_value, "ver_text")) {
 					strncpy (GMT->current.setting.map_annot_ortho, "", 5U);
-					GMT_KEYWORD_UPDATE (GMTCASE_MAP_ANNOT_ORTHO);
+					gmt_M_keyword_update (GMTCASE_MAP_ANNOT_ORTHO);
 				}
 				else if (!strcmp (lower_value, "hor_text")) {
 					strncpy (GMT->current.setting.map_annot_ortho, "we", 5U);
-					GMT_KEYWORD_UPDATE (GMTCASE_MAP_ANNOT_ORTHO);
+					gmt_M_keyword_update (GMTCASE_MAP_ANNOT_ORTHO);
 				}
 				else
 					error = true;
@@ -10389,7 +10386,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			strncpy (GMT->current.setting.map_annot_ortho, lower_value, 5U);
 			break;
 		case GMTCASE_DEGREE_SYMBOL:
-			GMT_COMPAT_TRANSLATE ("MAP_DEGREE_SYMBOL");
+			gmt_M_compat_translate ("MAP_DEGREE_SYMBOL");
 			break;
 		case GMTCASE_MAP_DEGREE_SYMBOL:
 			if (value[0] == '\0' || !strcmp (lower_value, "degree"))	/* Default */
@@ -10405,7 +10402,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			error += gmtlib_plot_C_format (GMT);	/* Update format statement since degree symbol may have changed */
 			break;
 		case GMTCASE_BASEMAP_AXES:
-			GMT_COMPAT_TRANSLATE ("MAP_FRAME_AXES");
+			gmt_M_compat_translate ("MAP_FRAME_AXES");
 			break;
 		case GMTCASE_MAP_FRAME_AXES:
 			strncpy (GMT->current.setting.map_frame_axes, value, 5U);
@@ -10413,7 +10410,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 
 		case GMTCASE_BASEMAP_FRAME_RGB:
-			GMT_COMPAT_TRANSLATE ("MAP_DEFAULT_PEN");
+			gmt_M_compat_translate ("MAP_DEFAULT_PEN");
 			break;
 		case GMTCASE_MAP_DEFAULT_PEN:
 			i = (value[0] == '+') ? 1 : 0;	/* If plus is added, copy color to MAP_*_PEN settings */
@@ -10427,7 +10424,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			}
 			break;
 		case GMTCASE_FRAME_PEN:
-			GMT_COMPAT_TRANSLATE ("MAP_FRAME_PEN");
+			gmt_M_compat_translate ("MAP_FRAME_PEN");
 			break;
 		case GMTCASE_MAP_FRAME_PEN:
 			error = gmt_getpen (GMT, value, &GMT->current.setting.map_frame_pen);
@@ -10440,7 +10437,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.map_frame_percent = dval;
 			break;
 		case GMTCASE_BASEMAP_TYPE:
-			GMT_COMPAT_TRANSLATE ("MAP_FRAME_TYPE");
+			gmt_M_compat_translate ("MAP_FRAME_TYPE");
 			break;
 		case GMTCASE_MAP_FRAME_TYPE:
 			if (!strcmp (lower_value, "plain"))
@@ -10477,13 +10474,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_FRAME_WIDTH:
-			GMT_COMPAT_TRANSLATE ("MAP_FRAME_WIDTH");
+			gmt_M_compat_translate ("MAP_FRAME_WIDTH");
 			break;
 		case GMTCASE_MAP_FRAME_WIDTH:
 			GMT->current.setting.map_frame_width = gmt_M_to_inch (GMT, value);
 			break;
 		case GMTCASE_GRID_CROSS_SIZE_PRIMARY:
-			GMT_COMPAT_TRANSLATE ("MAP_GRID_CROSS_SIZE_PRIMARY");
+			gmt_M_compat_translate ("MAP_GRID_CROSS_SIZE_PRIMARY");
 			break;
 		case GMTCASE_MAP_GRID_CROSS_SIZE:
 			error = gmtlib_setparameter (GMT, "MAP_GRID_CROSS_SIZE_PRIMARY", value, core) +
@@ -10496,7 +10493,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			GMT->current.setting.map_grid_cross_type[GMT_PRIMARY] = ival;
 			break;
 		case GMTCASE_GRID_CROSS_SIZE_SECONDARY:
-			GMT_COMPAT_TRANSLATE ("MAP_GRID_CROSS_SIZE_SECONDARY");
+			gmt_M_compat_translate ("MAP_GRID_CROSS_SIZE_SECONDARY");
 			break;
 		case GMTCASE_MAP_GRID_CROSS_SIZE_SECONDARY:
 			dval = gmt_M_to_inch (GMT, value);
@@ -10509,13 +10506,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			        gmtlib_setparameter (GMT, "MAP_GRID_PEN_SECONDARY", value, core);
 			break;
 		case GMTCASE_GRID_PEN_PRIMARY:
-			GMT_COMPAT_TRANSLATE ("MAP_GRID_PEN_PRIMARY");
+			gmt_M_compat_translate ("MAP_GRID_PEN_PRIMARY");
 			break;
 		case GMTCASE_MAP_GRID_PEN_PRIMARY:
 			error = gmt_getpen (GMT, value, &GMT->current.setting.map_grid_pen[GMT_PRIMARY]);
 			break;
 		case GMTCASE_GRID_PEN_SECONDARY:
-			GMT_COMPAT_TRANSLATE ("MAP_GRID_PEN_SECONDARY");
+			gmt_M_compat_translate ("MAP_GRID_PEN_SECONDARY");
 			break;
 		case GMTCASE_MAP_GRID_PEN_SECONDARY:
 			error = gmt_getpen (GMT, value, &GMT->current.setting.map_grid_pen[GMT_SECONDARY]);
@@ -10540,7 +10537,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			}
 			break;
 		case GMTCASE_LABEL_OFFSET:
-			GMT_COMPAT_TRANSLATE ("MAP_LABEL_OFFSET");
+			gmt_M_compat_translate ("MAP_LABEL_OFFSET");
 			break;
 		case GMTCASE_MAP_LABEL_OFFSET:
 			if ((i = sscanf (value, "%[^/]/%s", txt_a, txt_b)) == 2) {	/* Separate settings for x and y */
@@ -10551,7 +10548,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.map_label_offset[GMT_X] = GMT->current.setting.map_label_offset[GMT_Y] = gmt_M_to_inch (GMT, value);
 			break;
 		case GMTCASE_LINE_STEP:
-			GMT_COMPAT_TRANSLATE ("MAP_LINE_STEP");
+			gmt_M_compat_translate ("MAP_LINE_STEP");
 			break;
 		case GMTCASE_MAP_LINE_STEP:
 			if ((GMT->current.setting.map_line_step = gmt_M_to_inch (GMT, value)) <= 0.0) {
@@ -10560,13 +10557,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			}
 			break;
 		case GMTCASE_UNIX_TIME:
-			GMT_COMPAT_TRANSLATE ("MAP_LOGO");
+			gmt_M_compat_translate ("MAP_LOGO");
 			break;
 		case GMTCASE_MAP_LOGO:
 			error = gmtinit_true_false_or_error (lower_value, &GMT->current.setting.map_logo);
 			break;
 		case GMTCASE_UNIX_TIME_POS:
-			GMT_COMPAT_TRANSLATE ("MAP_LOGO_POS");
+			gmt_M_compat_translate ("MAP_LOGO_POS");
 			break;
 		case GMTCASE_MAP_LOGO_POS:
 			i = sscanf (value, "%[^/]/%[^/]/%s", txt_a, txt_b, txt_c);
@@ -10585,19 +10582,19 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_X_ORIGIN:
-			GMT_COMPAT_TRANSLATE ("MAP_ORIGIN_X");
+			gmt_M_compat_translate ("MAP_ORIGIN_X");
 			break;
 		case GMTCASE_MAP_ORIGIN_X:
 			GMT->current.setting.map_origin[GMT_X] = gmt_M_to_inch (GMT, value);
 			break;
 		case GMTCASE_Y_ORIGIN:
-			GMT_COMPAT_TRANSLATE ("MAP_ORIGIN_Y");
+			gmt_M_compat_translate ("MAP_ORIGIN_Y");
 			break;
 		case GMTCASE_MAP_ORIGIN_Y:
 			GMT->current.setting.map_origin[GMT_Y] = gmt_M_to_inch (GMT, value);
 			break;
 		case GMTCASE_POLAR_CAP:
-			GMT_COMPAT_TRANSLATE ("MAP_POLAR_CAP");
+			gmt_M_compat_translate ("MAP_POLAR_CAP");
 			break;
 		case GMTCASE_MAP_POLAR_CAP:
 			if (!strcmp (lower_value, "none")) {	/* Means reset to no cap -> lat = 90, dlon = 0 */
@@ -10628,13 +10625,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_TICK_LENGTH:
 			if (gmt_M_compat_check (GMT, 4)) {	/* GMT4: */
-				GMT_COMPAT_CHANGE ("MAP_TICK_LENGTH");
+				gmt_M_compat_change ("MAP_TICK_LENGTH");
 				GMT->current.setting.map_tick_length[GMT_ANNOT_UPPER] = gmt_M_to_inch (GMT, value);
 				GMT->current.setting.map_tick_length[GMT_TICK_UPPER]  = 0.50 * GMT->current.setting.map_tick_length[GMT_ANNOT_UPPER];
 				GMT->current.setting.map_tick_length[GMT_ANNOT_LOWER] = 3.00 * GMT->current.setting.map_tick_length[GMT_ANNOT_UPPER];
 				GMT->current.setting.map_tick_length[GMT_TICK_LOWER]  = 0.75 * GMT->current.setting.map_tick_length[GMT_ANNOT_UPPER];
-				GMT_KEYWORD_UPDATE (GMTCASE_MAP_TICK_LENGTH_PRIMARY);
-				GMT_KEYWORD_UPDATE (GMTCASE_MAP_TICK_LENGTH_SECONDARY);
+				gmt_M_keyword_update (GMTCASE_MAP_TICK_LENGTH_PRIMARY);
+				gmt_M_keyword_update (GMTCASE_MAP_TICK_LENGTH_SECONDARY);
 			}
 			else	/* Not recognized so give error message */
 				error = gmtinit_badvalreport (GMT, keyword);
@@ -10654,7 +10651,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			GMT->current.setting.map_tick_length[GMT_TICK_LOWER]  = (i > 1) ? gmt_M_to_inch (GMT, txt_b) : 0.25 * GMT->current.setting.map_tick_length[GMT_ANNOT_LOWER];
 			break;
 		case GMTCASE_TICK_PEN:
-			GMT_COMPAT_TRANSLATE ("MAP_TICK_PEN");
+			gmt_M_compat_translate ("MAP_TICK_PEN");
 			break;
 		case GMTCASE_MAP_TICK_PEN:
 			error = gmtlib_setparameter (GMT, "MAP_TICK_PEN_PRIMARY", value, core) +
@@ -10667,13 +10664,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			error = gmt_getpen (GMT, value, &GMT->current.setting.map_tick_pen[GMT_SECONDARY]);
 			break;
 		case GMTCASE_HEADER_OFFSET:
-			GMT_COMPAT_TRANSLATE ("MAP_TITLE_OFFSET");
+			gmt_M_compat_translate ("MAP_TITLE_OFFSET");
 			break;
 		case GMTCASE_MAP_TITLE_OFFSET:
 			GMT->current.setting.map_title_offset = gmt_M_to_inch (GMT, value);
 			break;
 		case GMTCASE_VECTOR_SHAPE:
-			GMT_COMPAT_TRANSLATE ("MAP_VECTOR_SHAPE");
+			gmt_M_compat_translate ("MAP_VECTOR_SHAPE");
 			break;
 		case GMTCASE_MAP_VECTOR_SHAPE:
 			dval = atof (value);
@@ -10731,7 +10728,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			error = gmt_getrgb (GMT, value, GMT->current.setting.color_patch[GMT_NAN]);
 			break;
 		case GMTCASE_HSV_MIN_SATURATION:
-			GMT_COMPAT_TRANSLATE ("COLOR_HSV_MIN_S");
+			gmt_M_compat_translate ("COLOR_HSV_MIN_S");
 			break;
 		case GMTCASE_COLOR_HSV_MIN_S:
 			dval = atof (value);
@@ -10741,7 +10738,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.color_hsv_min_s = dval;
 			break;
 		case GMTCASE_HSV_MAX_SATURATION:
-			GMT_COMPAT_TRANSLATE ("COLOR_HSV_MAX_S");
+			gmt_M_compat_translate ("COLOR_HSV_MAX_S");
 			break;
 		case GMTCASE_COLOR_HSV_MAX_S:
 			dval = atof (value);
@@ -10751,7 +10748,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.color_hsv_max_s = dval;
 			break;
 		case GMTCASE_HSV_MIN_VALUE:
-			GMT_COMPAT_TRANSLATE ("COLOR_HSV_MIN_V");
+			gmt_M_compat_translate ("COLOR_HSV_MIN_V");
 			break;
 		case GMTCASE_COLOR_HSV_MIN_V:
 			dval = atof (value);
@@ -10761,7 +10758,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.color_hsv_min_v = dval;
 			break;
 		case GMTCASE_HSV_MAX_VALUE:
-			GMT_COMPAT_TRANSLATE ("COLOR_HSV_MAX_V");
+			gmt_M_compat_translate ("COLOR_HSV_MAX_V");
 			break;
 		case GMTCASE_COLOR_HSV_MAX_V:
 			dval = atof (value);
@@ -10808,7 +10805,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		/* PS GROUP */
 
 		case GMTCASE_CHAR_ENCODING:
-			GMT_COMPAT_TRANSLATE ("PS_CHAR_ENCODING");
+			gmt_M_compat_translate ("PS_CHAR_ENCODING");
 			break;
 		case GMTCASE_PS_CHAR_ENCODING:
 			strncpy (GMT->current.setting.ps_encoding.name, value, GMT_LEN64-1);
@@ -10816,7 +10813,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			error = gmtlib_plot_C_format (GMT);	/* Since a chance in char set chances what is degree, ring, etc. */
 			break;
 		case GMTCASE_PS_COLOR:
-			GMT_COMPAT_TRANSLATE ("PS_COLOR_MODEL");
+			gmt_M_compat_translate ("PS_COLOR_MODEL");
 			break;
 		case GMTCASE_PS_COLOR_MODEL:
 			if (!strcmp (lower_value, "rgb"))
@@ -10911,13 +10908,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_PAGE_COLOR:
-			GMT_COMPAT_TRANSLATE ("PS_PAGE_COLOR");
+			gmt_M_compat_translate ("PS_PAGE_COLOR");
 			break;
 		case GMTCASE_PS_PAGE_COLOR:
 			error = gmt_getrgb (GMT, value, GMT->current.setting.ps_page_rgb);
 			break;
 		case GMTCASE_PAGE_ORIENTATION:
-			GMT_COMPAT_TRANSLATE ("PS_PAGE_ORIENTATION");
+			gmt_M_compat_translate ("PS_PAGE_ORIENTATION");
 			break;
 		case GMTCASE_PS_PAGE_ORIENTATION:
 			if (!strcmp (lower_value, "landscape"))
@@ -10928,7 +10925,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_PAPER_MEDIA:
-			GMT_COMPAT_TRANSLATE ("PS_MEDIA");
+			gmt_M_compat_translate ("PS_MEDIA");
 			break;
 		case GMTCASE_PS_MEDIA:
 			if (GMT->current.setting.run_mode == GMT_MODERN && !strcmp (lower_value, "auto")) {
@@ -10956,7 +10953,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			else if (gmtinit_load_user_media (GMT) &&
 				(pos = gmtinit_key_lookup (lower_value, GMT->session.user_media_name, GMT->session.n_user_media)) < GMT->session.n_user_media) {
 				/* Use a user-specified format */
-					GMT->current.setting.ps_media = pos + USER_MEDIA_OFFSET;
+					GMT->current.setting.ps_media = pos + GMT_USER_MEDIA_OFFSET;
 					GMT->current.setting.ps_page_size[0] = GMT->session.user_media[pos].width;
 					GMT->current.setting.ps_page_size[1] = GMT->session.user_media[pos].height;
 				}
@@ -10973,14 +10970,14 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 					GMT->current.setting.ps_page_size[1] = gmt_convert_units (GMT, txt_b, GMT_PT, GMT_PT);
 				if (GMT->current.setting.ps_page_size[0] <= 0.0) error = true;
 				if (GMT->current.setting.ps_page_size[1] <= 0.0) error = true;
-				GMT->current.setting.ps_media = -USER_MEDIA_OFFSET;
+				GMT->current.setting.ps_media = -GMT_USER_MEDIA_OFFSET;
 			}
 			if (!error && manual) GMT->current.setting.ps_page_size[0] = -GMT->current.setting.ps_page_size[0];
 			GMT->current.setting.ps_def_page_size[0] = GMT->current.setting.ps_page_size[0];
 			GMT->current.setting.ps_def_page_size[1] = GMT->current.setting.ps_page_size[1];
 			break;
 		case GMTCASE_GLOBAL_X_SCALE:
-			GMT_COMPAT_TRANSLATE ("PS_SCALE_X");
+			gmt_M_compat_translate ("PS_SCALE_X");
 			break;
 		case GMTCASE_PS_SCALE_X:
 			dval = atof (value);
@@ -10990,7 +10987,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_GLOBAL_Y_SCALE:
-			GMT_COMPAT_TRANSLATE ("PS_SCALE_Y");
+			gmt_M_compat_translate ("PS_SCALE_Y");
 			break;
 		case GMTCASE_PS_SCALE_Y:
 			dval = atof (value);
@@ -11012,7 +11009,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			strncpy (GMT->current.setting.ps_convert, value, GMT_LEN256-1);
 			break;
 		case GMTCASE_PS_VERBOSE:
-			GMT_COMPAT_TRANSLATE ("PS_COMMENTS");
+			gmt_M_compat_translate ("PS_COMMENTS");
 			break;
 		case GMTCASE_PS_COMMENTS:
 			if (!GMT->PSL) return (0);	/* Not using PSL in this session */
@@ -11023,7 +11020,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		/* IO GROUP */
 
 		case GMTCASE_FIELD_DELIMITER:
-			GMT_COMPAT_TRANSLATE ("IO_COL_SEPARATOR");
+			gmt_M_compat_translate ("IO_COL_SEPARATOR");
 			break;
 		case GMTCASE_IO_COL_SEPARATOR:
 			if (value[0] == '\0' || !strcmp (lower_value, "tab"))	/* DEFAULT */
@@ -11054,13 +11051,13 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_GRIDFILE_FORMAT:
-			GMT_COMPAT_TRANSLATE ("IO_GRIDFILE_FORMAT");
+			gmt_M_compat_translate ("IO_GRIDFILE_FORMAT");
 			break;
 		case GMTCASE_IO_GRIDFILE_FORMAT:
 			strncpy (GMT->current.setting.io_gridfile_format, value, GMT_LEN64-1);
 			break;
 		case GMTCASE_GRIDFILE_SHORTHAND:
-			GMT_COMPAT_TRANSLATE ("IO_GRIDFILE_SHORTHAND");
+			gmt_M_compat_translate ("IO_GRIDFILE_SHORTHAND");
 			break;
 		case GMTCASE_IO_GRIDFILE_SHORTHAND:
 			error = gmtinit_true_false_or_error (lower_value, &GMT->current.setting.io_gridfile_shorthand);
@@ -11088,7 +11085,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			if (gmtinit_check_markers (GMT)) error = true;
 			break;
 		case GMTCASE_N_HEADER_RECS:
-			GMT_COMPAT_TRANSLATE ("IO_N_HEADER_RECS");
+			gmt_M_compat_translate ("IO_N_HEADER_RECS");
 			break;
 		case GMTCASE_IO_N_HEADER_RECS:
 			ival = atoi (value);
@@ -11098,7 +11095,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.io_n_header_items = ival;
 			break;
 		case GMTCASE_NAN_RECORDS:
-			GMT_COMPAT_TRANSLATE ("IO_NAN_RECORDS");
+			gmt_M_compat_translate ("IO_NAN_RECORDS");
 			break;
 		case GMTCASE_IO_NAN_RECORDS:
 			if (!strcmp (lower_value, "pass"))
@@ -11136,7 +11133,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_XY_TOGGLE:
-			GMT_COMPAT_TRANSLATE ("IO_LONLAT_TOGGLE");
+			gmt_M_compat_translate ("IO_LONLAT_TOGGLE");
 			break;
 		case GMTCASE_IO_LONLAT_TOGGLE:
 			if (!gmtinit_true_false_or_error (lower_value, &GMT->current.setting.io_lonlat_toggle[GMT_IN]))
@@ -11223,7 +11220,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 
 		case GMTCASE_ELLIPSOID:
-			GMT_COMPAT_TRANSLATE ("PROJ_ELLIPSOID");
+			gmt_M_compat_translate ("PROJ_ELLIPSOID");
 			break;
 		case GMTCASE_PROJ_ELLIPSOID:
 			ival = gmt_get_ellipsoid (GMT, value);
@@ -11248,7 +11245,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 
 		case GMTCASE_MEASURE_UNIT:
-			GMT_COMPAT_TRANSLATE ("PROJ_LENGTH_UNIT");
+			gmt_M_compat_translate ("PROJ_LENGTH_UNIT");
 			break;
 		case GMTCASE_PROJ_LENGTH_UNIT:
 			if (gmt_set_length_unit (GMT, lower_value[0]) == GMT_NOTSET)
@@ -11271,7 +11268,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 
 		case GMTCASE_MAP_SCALE_FACTOR:
-			GMT_COMPAT_TRANSLATE ("PROJ_SCALE_FACTOR");
+			gmt_M_compat_translate ("PROJ_SCALE_FACTOR");
 			break;
 		case GMTCASE_PROJ_SCALE_FACTOR:
 			if (!strncmp (value, "def", 3U)) /* Default scale for chosen projection */
@@ -11473,7 +11470,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.graphics_format = ival;
 			break;
 		case GMTCASE_HISTORY:
-			GMT_COMPAT_TRANSLATE ("GMT_HISTORY");
+			gmt_M_compat_translate ("GMT_HISTORY");
 			break;
 		case GMTCASE_GMT_HISTORY:
 			if (!strcmp (lower_value, "1") || !strcmp (lower_value, "true"))
@@ -11486,7 +11483,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				error = true;
 			break;
 		case GMTCASE_INTERPOLANT:
-			GMT_COMPAT_TRANSLATE ("GMT_INTERPOLANT");
+			gmt_M_compat_translate ("GMT_INTERPOLANT");
 			break;
 		case GMTCASE_GMT_INTERPOLANT:
 			if (!strcmp (lower_value, "linear"))
@@ -11533,11 +11530,11 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			break;
 		case GMTCASE_VERBOSE:
 			if (gmt_M_compat_check (GMT, 4)) {	/* GMT4: */
-				GMT_COMPAT_CHANGE ("GMT_VERBOSE");
+				gmt_M_compat_change ("GMT_VERBOSE");
 				ival = atoi (value) + 2;
 				if (ival >= GMT_MSG_QUIET && ival <= GMT_MSG_DEBUG) {
 					GMT->current.setting.verbose = ival;
-					GMT_KEYWORD_UPDATE (GMTCASE_GMT_VERBOSE);
+					gmt_M_keyword_update (GMTCASE_GMT_VERBOSE);
 				}
 				else
 					error = true;
@@ -11625,10 +11622,10 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			GMT->current.setting.time_interval_fraction = atof (value);
 			break;
 		case GMTCASE_TIME_LANGUAGE:
-			GMT_COMPAT_TRANSLATE ("GMT_LANGUAGE");
+			gmt_M_compat_translate ("GMT_LANGUAGE");
 			break;
 		case GMTCASE_WANT_LEAP_SECONDS:
-			GMT_COMPAT_TRANSLATE ("TIME_LEAP_SECONDS");
+			gmt_M_compat_translate ("TIME_LEAP_SECONDS");
 			break;
 		case GMTCASE_TIME_LEAP_SECONDS:
 			error = gmtinit_true_false_or_error (lower_value, &GMT->current.setting.time_leap_seconds);
@@ -11650,8 +11647,8 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		case GMTCASE_TIME_SYSTEM:
 			error = gmt_get_time_system (GMT, lower_value, &GMT->current.setting.time_system);
 			(void) gmt_init_time_system_structure (GMT, &GMT->current.setting.time_system);
-			GMT_KEYWORD_UPDATE (GMTCASE_TIME_UNIT);
-			GMT_KEYWORD_UPDATE (GMTCASE_TIME_EPOCH);
+			gmt_M_keyword_update (GMTCASE_TIME_UNIT);
+			gmt_M_keyword_update (GMTCASE_TIME_EPOCH);
 			break;
 		case GMTCASE_TIME_WEEK_START:
 			ival = gmtinit_key_lookup (value, GMT_weekdays, 7);
@@ -11663,7 +11660,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				GMT->current.setting.time_week_start = ival;
 			break;
 		case GMTCASE_Y2K_OFFSET_YEAR:
-			GMT_COMPAT_TRANSLATE ("TIME_Y2K_OFFSET_YEAR");
+			gmt_M_compat_translate ("TIME_Y2K_OFFSET_YEAR");
 			break;
 		case GMTCASE_TIME_Y2K_OFFSET_YEAR:
 			if ((ival = atoi (value)) < 0) error = true;
@@ -11706,7 +11703,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		if (error)
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "%s given illegal value (%s)!\n", keyword, value);
 		else
-			GMT_KEYWORD_UPDATE (case_val);
+			gmt_M_keyword_update (case_val);
 	}
 	return ((error) ? 1 : 0);
 }
@@ -11715,7 +11712,7 @@ GMT_LOCAL void gmtinit_place_value (struct GMT_CTRL *GMT, double dim, int kase, 
 	if (gmt_M_is_dnan (dim))
 		snprintf (value, GMT_LEN256, "auto");
 	else
-		snprintf (value, GMT_LEN256, "%g%c", dim * GMT_def_scale(kase), GMT_def_unit(kase));
+		snprintf (value, GMT_LEN256, "%g%c", dim * gmt_M_def_scale(kase), gmt_M_def_unit(kase));
 }
 
 /*! . */
@@ -12054,7 +12051,7 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			else { error = gmtinit_badvalreport (GMT, keyword); break; }	/* Not recognized so give error message */
 			/* Intentionally fall through */
 		case GMTCASE_MAP_GRID_CROSS_SIZE_PRIMARY:
-			snprintf (value, GMT_LEN256, "%s%g%c", PRE[GMT->current.setting.map_grid_cross_type[GMT_PRIMARY]], GMT->current.setting.map_grid_cross_size[GMT_PRIMARY] * GMT_def_scale(GMTCASE_MAP_GRID_CROSS_SIZE_PRIMARY), GMT_def_unit(GMTCASE_MAP_GRID_CROSS_SIZE_PRIMARY));
+			snprintf (value, GMT_LEN256, "%s%g%c", PRE[GMT->current.setting.map_grid_cross_type[GMT_PRIMARY]], GMT->current.setting.map_grid_cross_size[GMT_PRIMARY] * gmt_M_def_scale(GMTCASE_MAP_GRID_CROSS_SIZE_PRIMARY), gmt_M_def_unit(GMTCASE_MAP_GRID_CROSS_SIZE_PRIMARY));
 			break;
 		case GMTCASE_GRID_CROSS_SIZE_SECONDARY:
 			if (gmt_M_compat_check (GMT, 4))	/* GMT4: */
@@ -12062,7 +12059,7 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			else { error = gmtinit_badvalreport (GMT, keyword); break; }	/* Not recognized so give error message */
 			/* Intentionally fall through */
 		case GMTCASE_MAP_GRID_CROSS_SIZE_SECONDARY:
-			snprintf (value, GMT_LEN256, "%s%g%c", PRE[GMT->current.setting.map_grid_cross_type[GMT_PRIMARY]], GMT->current.setting.map_grid_cross_size[GMT_SECONDARY] * GMT_def_scale(GMTCASE_MAP_GRID_CROSS_SIZE_SECONDARY), GMT_def_unit(GMTCASE_MAP_GRID_CROSS_SIZE_SECONDARY));
+			snprintf (value, GMT_LEN256, "%s%g%c", PRE[GMT->current.setting.map_grid_cross_type[GMT_PRIMARY]], GMT->current.setting.map_grid_cross_size[GMT_SECONDARY] * gmt_M_def_scale(GMTCASE_MAP_GRID_CROSS_SIZE_SECONDARY), gmt_M_def_unit(GMTCASE_MAP_GRID_CROSS_SIZE_SECONDARY));
 			break;
 		case GMTCASE_GRID_PEN_PRIMARY:
 			if (gmt_M_compat_check (GMT, 4))	/* GMT4: */
@@ -12102,8 +12099,8 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			if (doubleAlmostEqualZero (GMT->current.setting.map_label_offset[GMT_X], GMT->current.setting.map_label_offset[GMT_Y]))
 				gmtinit_place_value (GMT, GMT->current.setting.map_label_offset[GMT_X], GMTCASE_MAP_LABEL_OFFSET, value);
 			else {
-				snprintf (value, GMT_LEN256, "%g%c/%g%c", GMT->current.setting.map_label_offset[GMT_X] * GMT_def_scale(GMTCASE_MAP_LABEL_OFFSET), GMT_def_unit(GMTCASE_MAP_LABEL_OFFSET),
-					 GMT->current.setting.map_label_offset[GMT_Y] * GMT_def_scale(GMTCASE_MAP_LABEL_OFFSET), GMT_def_unit(GMTCASE_MAP_LABEL_OFFSET));
+				snprintf (value, GMT_LEN256, "%g%c/%g%c", GMT->current.setting.map_label_offset[GMT_X] * gmt_M_def_scale(GMTCASE_MAP_LABEL_OFFSET), gmt_M_def_unit(GMTCASE_MAP_LABEL_OFFSET),
+					 GMT->current.setting.map_label_offset[GMT_Y] * gmt_M_def_scale(GMTCASE_MAP_LABEL_OFFSET), gmt_M_def_unit(GMTCASE_MAP_LABEL_OFFSET));
 			}
 			break;
 		case GMTCASE_LINE_STEP:
@@ -12112,7 +12109,7 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			else { error = gmtinit_badvalreport (GMT, keyword); break; }	/* Not recognized so give error message */
 			/* Intentionally fall through */
 		case GMTCASE_MAP_LINE_STEP:
-			snprintf (value, GMT_LEN256, "%g%c", GMT->current.setting.map_line_step * GMT_def_scale(GMTCASE_MAP_LINE_STEP), GMT_def_unit(GMTCASE_MAP_LINE_STEP));
+			snprintf (value, GMT_LEN256, "%g%c", GMT->current.setting.map_line_step * gmt_M_def_scale(GMTCASE_MAP_LINE_STEP), gmt_M_def_unit(GMTCASE_MAP_LINE_STEP));
 			break;
 		case GMTCASE_UNIX_TIME:
 			if (gmt_M_compat_check (GMT, 4))	/* GMT4: */
@@ -12129,8 +12126,8 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			/* Intentionally fall through */
 		case GMTCASE_MAP_LOGO_POS:
 			snprintf (value, GMT_LEN256, "%s/%g%c/%g%c", GMT_just_string[GMT->current.setting.map_logo_justify],
-			GMT->current.setting.map_logo_pos[GMT_X] * GMT_def_scale(GMTCASE_MAP_LOGO_POS), GMT_def_unit(GMTCASE_MAP_LOGO_POS),
-			GMT->current.setting.map_logo_pos[GMT_Y] * GMT_def_scale(GMTCASE_MAP_LOGO_POS), GMT_def_unit(GMTCASE_MAP_LOGO_POS));
+			GMT->current.setting.map_logo_pos[GMT_X] * gmt_M_def_scale(GMTCASE_MAP_LOGO_POS), gmt_M_def_unit(GMTCASE_MAP_LOGO_POS),
+			GMT->current.setting.map_logo_pos[GMT_Y] * gmt_M_def_scale(GMTCASE_MAP_LOGO_POS), gmt_M_def_unit(GMTCASE_MAP_LOGO_POS));
 			break;
 		case GMTCASE_X_ORIGIN:
 			if (gmt_M_compat_check (GMT, 4))	/* GMT4: */
@@ -12138,7 +12135,7 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			else { error = gmtinit_badvalreport (GMT, keyword); break; }	/* Not recognized so give error message */
 			/* Intentionally fall through */
 		case GMTCASE_MAP_ORIGIN_X:
-			snprintf (value, GMT_LEN256, "%g%c", GMT->current.setting.map_origin[GMT_X] * GMT_def_scale(GMTCASE_MAP_ORIGIN_X), GMT_def_unit(GMTCASE_MAP_ORIGIN_X));
+			snprintf (value, GMT_LEN256, "%g%c", GMT->current.setting.map_origin[GMT_X] * gmt_M_def_scale(GMTCASE_MAP_ORIGIN_X), gmt_M_def_unit(GMTCASE_MAP_ORIGIN_X));
 			break;
 		case GMTCASE_Y_ORIGIN:
 			if (gmt_M_compat_check (GMT, 4))	/* GMT4: */
@@ -12146,7 +12143,7 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			else { error = gmtinit_badvalreport (GMT, keyword); break; }	/* Not recognized so give error message */
 			/* Intentionally fall through */
 		case GMTCASE_MAP_ORIGIN_Y:
-			snprintf (value, GMT_LEN256, "%g%c", GMT->current.setting.map_origin[GMT_Y] * GMT_def_scale(GMTCASE_MAP_ORIGIN_Y), GMT_def_unit(GMTCASE_MAP_ORIGIN_Y));
+			snprintf (value, GMT_LEN256, "%g%c", GMT->current.setting.map_origin[GMT_Y] * gmt_M_def_scale(GMTCASE_MAP_ORIGIN_Y), gmt_M_def_unit(GMTCASE_MAP_ORIGIN_Y));
 			break;
 		case GMTCASE_POLAR_CAP:
 			if (gmt_M_compat_check (GMT, 4))	/* GMT4: */
@@ -12162,7 +12159,7 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 				snprintf (value, GMT_LEN256, "%g/%g", GMT->current.setting.map_polar_cap[0], GMT->current.setting.map_polar_cap[1]);
 			break;
 		case GMTCASE_MAP_SCALE_HEIGHT:
-			snprintf (value, GMT_LEN256, "%g%c", GMT->current.setting.map_scale_height * GMT_def_scale(GMTCASE_MAP_SCALE_HEIGHT), GMT_def_unit(GMTCASE_MAP_SCALE_HEIGHT));
+			snprintf (value, GMT_LEN256, "%g%c", GMT->current.setting.map_scale_height * gmt_M_def_scale(GMTCASE_MAP_SCALE_HEIGHT), gmt_M_def_unit(GMTCASE_MAP_SCALE_HEIGHT));
 			break;
 		case GMTCASE_MAP_TICK_LENGTH:
 		case GMTCASE_TICK_LENGTH:
@@ -12175,8 +12172,8 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 				snprintf (value, GMT_LEN256, "auto");
 			else {
 				snprintf (value, GMT_LEN256, "%g%c/%g%c",
-				GMT->current.setting.map_tick_length[GMT_ANNOT_UPPER] * GMT_def_scale(GMTCASE_MAP_TICK_LENGTH_PRIMARY), GMT_def_unit(GMTCASE_MAP_TICK_LENGTH_PRIMARY),
-				GMT->current.setting.map_tick_length[GMT_TICK_UPPER] * GMT_def_scale(GMTCASE_MAP_TICK_LENGTH_PRIMARY), GMT_def_unit(GMTCASE_MAP_TICK_LENGTH_PRIMARY));
+				GMT->current.setting.map_tick_length[GMT_ANNOT_UPPER] * gmt_M_def_scale(GMTCASE_MAP_TICK_LENGTH_PRIMARY), gmt_M_def_unit(GMTCASE_MAP_TICK_LENGTH_PRIMARY),
+				GMT->current.setting.map_tick_length[GMT_TICK_UPPER] * gmt_M_def_scale(GMTCASE_MAP_TICK_LENGTH_PRIMARY), gmt_M_def_unit(GMTCASE_MAP_TICK_LENGTH_PRIMARY));
 			}
 			break;
 		case GMTCASE_MAP_TICK_LENGTH_SECONDARY:
@@ -12184,8 +12181,8 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 				snprintf (value, GMT_LEN256, "auto");
 			else {
 				snprintf (value, GMT_LEN256, "%g%c/%g%c",
-				GMT->current.setting.map_tick_length[GMT_ANNOT_LOWER] * GMT_def_scale(GMTCASE_MAP_TICK_LENGTH_SECONDARY), GMT_def_unit(GMTCASE_MAP_TICK_LENGTH_SECONDARY),
-				GMT->current.setting.map_tick_length[GMT_TICK_LOWER] * GMT_def_scale(GMTCASE_MAP_TICK_LENGTH_SECONDARY), GMT_def_unit(GMTCASE_MAP_TICK_LENGTH_SECONDARY));
+				GMT->current.setting.map_tick_length[GMT_ANNOT_LOWER] * gmt_M_def_scale(GMTCASE_MAP_TICK_LENGTH_SECONDARY), gmt_M_def_unit(GMTCASE_MAP_TICK_LENGTH_SECONDARY),
+				GMT->current.setting.map_tick_length[GMT_TICK_LOWER] * gmt_M_def_scale(GMTCASE_MAP_TICK_LENGTH_SECONDARY), gmt_M_def_unit(GMTCASE_MAP_TICK_LENGTH_SECONDARY));
 			}
 			break;
 		case GMTCASE_MAP_TICK_PEN:
@@ -12395,10 +12392,10 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 			else { error = gmtinit_badvalreport (GMT, keyword); break; }	/* Not recognized so give error message */
 			/* Intentionally fall through */
 		case GMTCASE_PS_MEDIA:
-			if (GMT->current.setting.ps_media == -USER_MEDIA_OFFSET)
+			if (GMT->current.setting.ps_media == -GMT_USER_MEDIA_OFFSET)
 				snprintf (value, GMT_LEN256, "%gx%g", fabs (GMT->current.setting.ps_page_size[0]), fabs (GMT->current.setting.ps_page_size[1]));
-			else if (GMT->current.setting.ps_media >= USER_MEDIA_OFFSET)
-				snprintf (value, GMT_LEN256, "%s", GMT->session.user_media_name[GMT->current.setting.ps_media-USER_MEDIA_OFFSET]);
+			else if (GMT->current.setting.ps_media >= GMT_USER_MEDIA_OFFSET)
+				snprintf (value, GMT_LEN256, "%s", GMT->session.user_media_name[GMT->current.setting.ps_media-GMT_USER_MEDIA_OFFSET]);
 			else if (GMT->current.setting.ps_media < GMT_N_MEDIA)
 				snprintf (value, GMT_LEN256, "%s", GMT_media_name[GMT->current.setting.ps_media]);
 			if (GMT->current.setting.ps_page_size[0] < 0.0)
@@ -16960,16 +16957,16 @@ GMT_LOCAL int gmtinit_parse_proj4 (struct GMT_CTRL *GMT, char *item, char *dest)
  */
 int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, char *item) {
 
-	int error = 0, i = 0, q = 0;	/* The i and i+= GMT_more_than_once are there to avoid compiler warnings... */
+	int error = 0, i = 0, q = 0;	/* The i and i+= gmt_M_more_than_once are there to avoid compiler warnings... */
 
 	if (!list || !strchr (list, option)) return (0);	/* Not a common option we accept */
 
 	if (gmt_M_compat_check (GMT, 4)) {
 		/* Translate some GMT4 options */
 		switch (option) {
-			case 'E': GMT_COMPAT_OPT ('p'); break;
-			case 'F': GMT_COMPAT_OPT ('r'); break;
-			case 'H': GMT_COMPAT_OPT ('h'); break;
+			case 'E': gmt_M_compat_opt ('p'); break;
+			case 'F': gmt_M_compat_opt ('r'); break;
+			case 'H': gmt_M_compat_opt ('h'); break;
 		}
 	}
 
@@ -17091,18 +17088,18 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case 'K':
-			i += GMT_more_than_once (GMT, GMT->common.K.active);
+			i += gmt_M_more_than_once (GMT, GMT->common.K.active);
 			GMT->common.K.active = true;
 			break;
 
 		case 'O':
-			i += GMT_more_than_once (GMT, GMT->common.O.active);
+			i += gmt_M_more_than_once (GMT, GMT->common.O.active);
 			GMT->common.O.active = true;
 			break;
 
 		case 'P':
 			if (GMT->current.setting.run_mode == GMT_CLASSIC) {
-				i += GMT_more_than_once (GMT, GMT->common.P.active);
+				i += gmt_M_more_than_once (GMT, GMT->common.P.active);
 				GMT->common.P.active = true;
 			}
 			else {
@@ -17124,17 +17121,17 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case 'R':
-			error += (GMT_more_than_once (GMT, GMT->common.R.active[RSET]) || gmt_parse_R_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.R.active[RSET]) || gmt_parse_R_option (GMT, item));
 			GMT->common.R.active[RSET] = true;
 			break;
 
 		case 'U':
-			error += (GMT_more_than_once (GMT, GMT->common.U.active) || gmtinit_parse_U_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.U.active) || gmtinit_parse_U_option (GMT, item));
 			GMT->common.U.active = true;
 			break;
 
 		case 'V':
-			i += GMT_more_than_once (GMT, GMT->common.V.active);
+			i += gmt_M_more_than_once (GMT, GMT->common.V.active);
 			GMT->common.V.active = true;
 			if (item && item[0]) {	/* Specified a verbosity level */
 				if (gmtinit_parse_V_option (GMT, item[0])) {
@@ -17147,12 +17144,12 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case 'X':
-			error += (GMT_more_than_once (GMT, GMT->common.X.active) || gmtinit_parse_X_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.X.active) || gmtinit_parse_X_option (GMT, item));
 			GMT->common.X.active = true;
 			break;
 
 		case 'Y':
-			error += (GMT_more_than_once (GMT, GMT->common.Y.active) || gmtinit_parse_Y_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.Y.active) || gmtinit_parse_Y_option (GMT, item));
 			GMT->common.Y.active = true;
 			break;
 
@@ -17172,7 +17169,7 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case 'a':
-			error += (GMT_more_than_once (GMT, GMT->common.a.active) || gmtinit_parse_a_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.a.active) || gmtinit_parse_a_option (GMT, item));
 			GMT->common.a.active = true;
 			break;
 
@@ -17212,7 +17209,7 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case 'e':
-			error += (GMT_more_than_once (GMT, GMT->common.e.active) || gmtinit_parse_e_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.e.active) || gmtinit_parse_e_option (GMT, item));
 			GMT->common.e.active = true;
 			break;
 
@@ -17246,22 +17243,22 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case 'h':
-			error += (GMT_more_than_once (GMT, GMT->common.h.active) || gmtinit_parse_h_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.h.active) || gmtinit_parse_h_option (GMT, item));
 			GMT->common.h.active = true;
 			break;
 
 		case 'i':
-			error += (GMT_more_than_once (GMT, GMT->common.i.active) || gmt_parse_i_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.i.active) || gmt_parse_i_option (GMT, item));
 			GMT->common.i.active = true;
 			break;
 
 		case 'j':
-			error += (GMT_more_than_once (GMT, GMT->common.j.active) || gmt_parse_j_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.j.active) || gmt_parse_j_option (GMT, item));
 			GMT->common.j.active = true;
 			break;
 
 		case 'l':
-			error += (GMT_more_than_once (GMT, GMT->common.l.active) || gmtinit_parse_l_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.l.active) || gmtinit_parse_l_option (GMT, item));
 			GMT->common.l.active = true;
 			break;
 
@@ -17277,35 +17274,35 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case 'n':
-			error += (GMT_more_than_once (GMT, GMT->common.n.active) || gmtinit_parse_n_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.n.active) || gmtinit_parse_n_option (GMT, item));
 			GMT->common.n.active = true;
 			break;
 
 		case 'o':
-			error += (GMT_more_than_once (GMT, GMT->common.o.active) || gmt_parse_o_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.o.active) || gmt_parse_o_option (GMT, item));
 			GMT->common.o.active = true;
 			break;
 
 		case 'p':
-			error += (GMT_more_than_once (GMT, GMT->common.p.active) || gmtinit_parse_p_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.p.active) || gmtinit_parse_p_option (GMT, item));
 			GMT->common.p.active = true;
 			break;
 
 		case 'q':
 			switch (item[0]) {
 				case 'o':
-					error += (GMT_more_than_once (GMT, GMT->common.q.active[GMT_OUT]) || gmtinit_parse_q_option (GMT, item));
+					error += (gmt_M_more_than_once (GMT, GMT->common.q.active[GMT_OUT]) || gmtinit_parse_q_option (GMT, item));
 					GMT->common.q.active[GMT_OUT] = true;
 					break;
 				default:
-					error += (GMT_more_than_once (GMT, GMT->common.q.active[GMT_IN]) || gmtinit_parse_q_option (GMT, item));
+					error += (gmt_M_more_than_once (GMT, GMT->common.q.active[GMT_IN]) || gmtinit_parse_q_option (GMT, item));
 					GMT->common.q.active[GMT_IN] = true;
 					break;
 			}
 			break;
 
 		case 'r':
-			error += GMT_more_than_once (GMT, GMT->common.R.active[GSET]);
+			error += gmt_M_more_than_once (GMT, GMT->common.R.active[GSET]);
 			GMT->common.R.active[GSET] = true;
 			if (item[0]) {	/* Gave argument for specific registration */
 				switch (item[0]) {
@@ -17322,27 +17319,27 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 			break;
 
 		case 's':
-			error += (GMT_more_than_once (GMT, GMT->common.s.active) || gmt_parse_s_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.s.active) || gmt_parse_s_option (GMT, item));
 			GMT->common.s.active = true;
 			break;
 
 		case 't':
-			error += GMT_more_than_once (GMT, GMT->common.t.active) || gmtinit_parse_t_option (GMT, item);
+			error += gmt_M_more_than_once (GMT, GMT->common.t.active) || gmtinit_parse_t_option (GMT, item);
 			break;
 
 		case 'w':
-			error += GMT_more_than_once (GMT, GMT->common.w.active) || gmtinit_parse_w_option (GMT, item);
+			error += gmt_M_more_than_once (GMT, GMT->common.w.active) || gmtinit_parse_w_option (GMT, item);
 			break;
 
 #ifdef GMT_MP_ENABLED
 		case 'x':
-			error += (GMT_more_than_once (GMT, GMT->common.x.active) || gmtinit_parse_x_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.x.active) || gmtinit_parse_x_option (GMT, item));
 			GMT->common.x.active = true;
 			break;
 #endif
 
 		case ':':
-			error += (GMT_more_than_once (GMT, GMT->common.colon.active) || gmtinit_parse_colon_option (GMT, item));
+			error += (gmt_M_more_than_once (GMT, GMT->common.colon.active) || gmtinit_parse_colon_option (GMT, item));
 			GMT->common.colon.active = true;
 			break;
 

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -77,7 +77,7 @@
 
 #define GMT_PROJ_MAX_ITERATIONS	200
 #define GMT_PROJ_CONV_LIMIT	1e-9
-#define GMT_PROJ_IS_ZERO(x) (fabs (x) < GMT_PROJ_CONV_LIMIT)
+#define gmt_M_proj_is_zero(x) (fabs (x) < GMT_PROJ_CONV_LIMIT)
 
 GMT_LOCAL double gmtproj_robinson_spline (struct GMT_CTRL *GMT, double xp, double *x, double *y, double *c) {
 	/* Returns the interpolated value y(xp) from the Robinson coefficients */
@@ -154,7 +154,7 @@ GMT_LOCAL void gmtproj_ipolyconic_sub (struct GMT_CTRL *GMT, double y, double lo
 	gmt_M_wind_lon (GMT, *x);
 	y *= GMT->current.proj.i_EQ_RAD;
 	y += GMT->current.proj.pole * D2R;
-	if (GMT_PROJ_IS_ZERO (y))
+	if (gmt_M_proj_is_zero (y))
 		*x *= GMT->current.proj.EQ_RAD * D2R;
 	else {
 		phi = y;
@@ -1535,7 +1535,7 @@ GMT_LOCAL void gmtproj_vgenper (struct GMT_CTRL *GMT, double lon0, double lat0, 
 	lat0 = gmtproj_genper_getgeocentric (GMT, lat0, 0.0);
 	sincosd (lat0, &(GMT->current.proj.sinp), &(GMT->current.proj.cosp));
 
-	if (!GMT_PROJ_IS_ZERO (GMT->current.proj.ECC2)) {
+	if (!gmt_M_proj_is_zero (GMT->current.proj.ECC2)) {
 		gmtproj_genper_setup (GMT, 0.0, altitude, lat0_save, lon0);
 		GMT->current.proj.central_meridian = lon0;
 		GMT->current.proj.pole = GMT->current.proj.g_phig;
@@ -1997,7 +1997,7 @@ GMT_LOCAL void gmtproj_azeqdist (struct GMT_CTRL *GMT, double lon, double lat, d
 
 	gmt_M_wind_lon (GMT, lon)	/* Remove central meridian and place lon in -180/+180 range */
 
-	if (GMT_PROJ_IS_ZERO (lat-GMT->current.proj.pole) && GMT_PROJ_IS_ZERO (lon)) {	/* Center of projection */
+	if (gmt_M_proj_is_zero (lat-GMT->current.proj.pole) && gmt_M_proj_is_zero (lon)) {	/* Center of projection */
 		*x = *y = 0.0;
 		return;
 	}
@@ -2012,7 +2012,7 @@ GMT_LOCAL void gmtproj_azeqdist (struct GMT_CTRL *GMT, double lon, double lat, d
 	}
 	else {
 		c = d_acos (cc);
-		k = (GMT_PROJ_IS_ZERO (c)) ? GMT->current.proj.EQ_RAD : GMT->current.proj.EQ_RAD * c / sin (c);
+		k = (gmt_M_proj_is_zero (c)) ? GMT->current.proj.EQ_RAD : GMT->current.proj.EQ_RAD * c / sin (c);
 		*x = k * clat * slon;
 		*y = k * (GMT->current.proj.cosp * slat - GMT->current.proj.sinp * t);
 	}
@@ -2176,7 +2176,7 @@ GMT_LOCAL void gmtproj_grinten (struct GMT_CTRL *GMT, double lon, double lat, do
 
 	gmt_M_wind_lon (GMT, lon)	/* Remove central meridian and place lon in -180/+180 range */
 
-	if (GMT_PROJ_IS_ZERO (flat)) {	/* Save time */
+	if (gmt_M_proj_is_zero (flat)) {	/* Save time */
 		*x = GMT->current.proj.EQ_RAD * D2R * lon;
 		*y = 0.0;
 		return;
@@ -2248,7 +2248,7 @@ GMT_LOCAL void gmtproj_winkel (struct GMT_CTRL *GMT, double lon, double lat, dou
 
 	sincos (lat, &s, &c);
 	D = d_acos (c * cos (lon));
-	if (GMT_PROJ_IS_ZERO (D))
+	if (gmt_M_proj_is_zero (D))
 		x1 = y1 = 0.0;
 	else {
 		X = s / sin (D);
@@ -2702,7 +2702,7 @@ GMT_LOCAL void gmtproj_cassini (struct GMT_CTRL *P, double lon, double lat, doub
 	gmt_M_wind_lon (P, lon)	/* Remove central meridian and place lon in -180/+180 range */
 	lon *= D2R;
 
-	if (GMT_PROJ_IS_ZERO (lat)) {	/* Quick when lat is zero */
+	if (gmt_M_proj_is_zero (lat)) {	/* Quick when lat is zero */
 		*x = P->current.proj.EQ_RAD * lon;
 		*y = -P->current.proj.c_M0;
 		return;
@@ -2761,7 +2761,7 @@ GMT_LOCAL void gmtproj_cassini_sph (struct GMT_CTRL *GMT, double lon, double lat
 
 	gmt_M_wind_lon (GMT, lon)	/* Remove central meridian and place lon in -180/+180 range */
 
-	if (GMT_PROJ_IS_ZERO (lat)) {	/* Quick when lat is zero */
+	if (gmt_M_proj_is_zero (lat)) {	/* Quick when lat is zero */
 		*x = GMT->current.proj.EQ_RAD * lon * D2R;
 		*y = -GMT->current.proj.EQ_RAD * GMT->current.proj.c_p;
 		return;
@@ -2807,9 +2807,9 @@ GMT_LOCAL void gmtproj_valbers (struct GMT_CTRL *GMT, double lon0, double lat0, 
 
 	m1 = c1 * c1 / (1.0 - GMT->current.proj.ECC2 * s1 * s1);	/* Actually m1 and m2 squared */
 	m2 = c2 * c2 / (1.0 - GMT->current.proj.ECC2 * s2 * s2);
-	q0 = (GMT_PROJ_IS_ZERO (GMT->current.proj.ECC)) ? 2.0 * s0 : GMT->current.proj.one_m_ECC2 * (s0 / (1.0 - GMT->current.proj.ECC2 * s0 * s0) - GMT->current.proj.i_half_ECC * log ((1.0 - GMT->current.proj.ECC * s0) / (1.0 + GMT->current.proj.ECC * s0)));
-	q1 = (GMT_PROJ_IS_ZERO (GMT->current.proj.ECC)) ? 2.0 * s1 : GMT->current.proj.one_m_ECC2 * (s1 / (1.0 - GMT->current.proj.ECC2 * s1 * s1) - GMT->current.proj.i_half_ECC * log ((1.0 - GMT->current.proj.ECC * s1) / (1.0 + GMT->current.proj.ECC * s1)));
-	q2 = (GMT_PROJ_IS_ZERO (GMT->current.proj.ECC)) ? 2.0 * s2 : GMT->current.proj.one_m_ECC2 * (s2 / (1.0 - GMT->current.proj.ECC2 * s2 * s2) - GMT->current.proj.i_half_ECC * log ((1.0 - GMT->current.proj.ECC * s2) / (1.0 + GMT->current.proj.ECC * s2)));
+	q0 = (gmt_M_proj_is_zero (GMT->current.proj.ECC)) ? 2.0 * s0 : GMT->current.proj.one_m_ECC2 * (s0 / (1.0 - GMT->current.proj.ECC2 * s0 * s0) - GMT->current.proj.i_half_ECC * log ((1.0 - GMT->current.proj.ECC * s0) / (1.0 + GMT->current.proj.ECC * s0)));
+	q1 = (gmt_M_proj_is_zero (GMT->current.proj.ECC)) ? 2.0 * s1 : GMT->current.proj.one_m_ECC2 * (s1 / (1.0 - GMT->current.proj.ECC2 * s1 * s1) - GMT->current.proj.i_half_ECC * log ((1.0 - GMT->current.proj.ECC * s1) / (1.0 + GMT->current.proj.ECC * s1)));
+	q2 = (gmt_M_proj_is_zero (GMT->current.proj.ECC)) ? 2.0 * s2 : GMT->current.proj.one_m_ECC2 * (s2 / (1.0 - GMT->current.proj.ECC2 * s2 * s2) - GMT->current.proj.i_half_ECC * log ((1.0 - GMT->current.proj.ECC * s2) / (1.0 + GMT->current.proj.ECC * s2)));
 
 	GMT->current.proj.a_n = (doubleAlmostEqualZero (ph1, ph2)) ? s1 : (m1 - m2) / (q2 - q1);
 	GMT->current.proj.a_i_n = 1.0 / GMT->current.proj.a_n;
@@ -2848,7 +2848,7 @@ GMT_LOCAL void gmtproj_albers (struct GMT_CTRL *GMT, double lon, double lat, dou
 	gmt_M_wind_lon (GMT, lon)	/* Remove central meridian and place lon in -180/+180 range */
 
 	s = sind (lat);
-	if (GMT_PROJ_IS_ZERO (GMT->current.proj.ECC))
+	if (gmt_M_proj_is_zero (GMT->current.proj.ECC))
 		q = 2.0 * s;
 	else {
 		r = GMT->current.proj.ECC * s;
@@ -2985,7 +2985,7 @@ GMT_LOCAL void gmtproj_polyconic (struct GMT_CTRL *GMT, double lon, double lat, 
 
 	gmt_M_wind_lon (GMT, lon)	/* Remove central meridian and place lon in -180/+180 range */
 
-	if (GMT_PROJ_IS_ZERO(lat)) {
+	if (gmt_M_proj_is_zero(lat)) {
 		*x = GMT->current.proj.EQ_RAD * lon * D2R;
 		*y = GMT->current.proj.EQ_RAD * (lat - GMT->current.proj.pole) * D2R;
 	}
@@ -3007,7 +3007,7 @@ GMT_LOCAL void gmtproj_ipolyconic (struct GMT_CTRL *GMT, double *lon, double *la
 	x *= GMT->current.proj.i_EQ_RAD;
 	y *= GMT->current.proj.i_EQ_RAD;
 	y += GMT->current.proj.pole * D2R;
-	if (GMT_PROJ_IS_ZERO (y)) {
+	if (gmt_M_proj_is_zero (y)) {
 		*lat = y * R2D + GMT->current.proj.pole;
 		*lon = x * R2D + GMT->current.proj.central_meridian;
 	}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -3199,7 +3199,7 @@ static inline bool gmtsupport_same_longitude (double a, double b) {
 	return doubleAlmostEqualZero (a, b);
 }
 
-#define GMT_SAME_LATITUDE(A,B)  (doubleAlmostEqualZero (A,B))			/* A and B are the same latitude */
+#define gmt_M_same_latitude(A,B)  (doubleAlmostEqualZero (A,B))			/* A and B are the same latitude */
 
 /*! . */
 GMT_LOCAL int gmtsupport_inonout_sphpol_count (double plon, double plat, const struct GMT_DATASEGMENT *P, unsigned int count[]) {
@@ -3221,7 +3221,7 @@ GMT_LOCAL int gmtsupport_inonout_sphpol_count (double plon, double plat, const s
 		 * Since we want to obtain either ONE or ZERO intersections per segment we will skip to next
 		 * point if case (2) occurs: this avoids counting a crossing twice for consecutive segments.
 		 */
-		if (gmtsupport_same_longitude (plon, P->data[GMT_X][i]) && GMT_SAME_LATITUDE (plat, P->data[GMT_Y][i])) return (GMT_ONEDGE);	/* Point is on the perimeter */
+		if (gmtsupport_same_longitude (plon, P->data[GMT_X][i]) && gmt_M_same_latitude (plat, P->data[GMT_Y][i])) return (GMT_ONEDGE);	/* Point is on the perimeter */
 		in = i + 1;			/* Next point index */
 		/* Next deal with case when the longitude of P goes ~right through the second of the line nodes */
 		if (gmtsupport_same_longitude (plon, P->data[GMT_X][in])) continue;	/* Line goes through the 2nd node - ignore */
@@ -3273,8 +3273,8 @@ GMT_LOCAL int gmtsupport_inonout_sphpol_count (double plon, double plat, const s
 			return (1);	/* P is on segment boundary; we are done*/
 		}
 		/* Calculate latitude at intersection */
-		if (GMT_SAME_LATITUDE (P->data[GMT_Y][i], P->data[GMT_Y][in])) {	/* Special cases */
-			if (GMT_SAME_LATITUDE (plat, P->data[GMT_Y][in])) return (GMT_ONEDGE);	/* P is on S boundary */
+		if (gmt_M_same_latitude (P->data[GMT_Y][i], P->data[GMT_Y][in])) {	/* Special cases */
+			if (gmt_M_same_latitude (plat, P->data[GMT_Y][in])) return (GMT_ONEDGE);	/* P is on S boundary */
 			x_lat = P->data[GMT_Y][i];
 		}
 		else


### PR DESCRIPTION
Just following the rules laid down earlier.  All caps are reserved for constants (e.g. **GMT_INCH**) while macros taking arguments are called gmt_M_*.

