### PR TITLE
WIP Consistently describe output grid name and modifiers

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7729,6 +7729,24 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 	}
 }
 
+/*! Output grid specification */
+/*!
+	\param GMT ...
+	\param message ...
+*/
+void gmt_outgrid_syntax (struct GMTAPI_CTRL *API, char option, char *message) {
+	if (option == 0)
+		GMT_Usage (API, 1, "\n%s", GMT_OUTGRID);
+	else
+		GMT_Usage (API, 1, "\n-%c%s", option, GMT_OUTGRID);
+	GMT_Usage (API, -2, "%s. Optionally append =<ID> for writing a specific file format and add any modifiers:", message);
+	GMT_Usage (API, 3, "+d Divide data values by the given <divisor> [0]");
+	GMT_Usage (API, 3, "+n Replace data values matching <invalid> with a NaN.");
+	GMT_Usage (API, 3, "+o Offset data values by the given <offset>, or append a for automatic range offset [0].");
+	GMT_Usage (API, 3, "+s Scale data values by the given <scale>, or append a for automatic range scale [1].");
+	GMT_Usage (API, -2, "Note: Any offset is added after any scaling, and +sa also sets +oa (unless overridden). "
+		"To write specific formats via GDAL, use <ID> = gd and supply <driver> [and optionally <dataType>].");
+}
 /*! GSHHG subset specification */
 /*!
 	\param GMT ...

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -109,6 +109,7 @@ EXTERN_MSC bool gmt_get_time_system (struct GMT_CTRL *GMT, char *name, struct GM
 EXTERN_MSC int gmt_hash_lookup (struct GMT_CTRL *GMT, const char *key, struct GMT_HASH *hashnode, unsigned int n, unsigned int n_hash);
 EXTERN_MSC void gmt_syntax (struct GMT_CTRL *GMT, char option);
 EXTERN_MSC void gmt_cont_syntax (struct GMT_CTRL *GMT, unsigned int indent, unsigned int kind);
+EXTERN_MSC void gmt_outgrid_syntax (struct GMTAPI_CTRL *API, char option, char *message);
 EXTERN_MSC void gmt_innercont_syntax (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_refpoint_syntax (struct GMT_CTRL *GMT, char *option, char *string, unsigned int kind, unsigned int part);
 EXTERN_MSC void gmt_mapscale_syntax (struct GMT_CTRL *GMT, char option, char *string);

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -32,6 +32,9 @@
 #ifndef GMT_SYNOPSIS_H
 #define GMT_SYNOPSIS_H
 
+/* Full syntax of output grids */
+#define GMT_OUTGRID  "<outgrid>[=<ID>][+d<divisor>][+n<invalid>][+o<offset>|a][+s<scale>|a][:<driver>[/<dataType>]]"
+
 #define GMT_inc_OPT	"<xinc>[+e|n][/<yinc>[+e|n]]"
 #define GMT_Id_OPT	"-I<xinc>[m|s][/<yinc>[m|s]]"
 #define GMT_Jx_OPT	"-Jx|X<args>"


### PR DESCRIPTION
Similar to #5602 but for output grids.  It differs because on output you can use **+sa** and **+oa** as well as specify GDAL drivers and datatypes.
