### PR TITLE
Consolidate -A into -F for a more unified option

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -16,10 +16,9 @@ Synopsis
 |-C|\ *canvas*
 |-N|\ *prefix*
 |-T|\ *nframes*\|\ *min*/*max*/*inc*\ [**+n**]\|\ *timefile*\ [**+p**\ *width*]\ [**+s**\ *first*]\ [**+w**\ [*str*]\|\ **W**]
-[ |-A|\ [**+l**\ [*n*]]\ [**+s**\ *stride*] ]
 [ |-D|\ *displayrate* ]
 [ |-E|\ *titlepage*\ [**+d**\ *duration*\ [**s**]][**+f**\ [**i**\|\ **o**]\ *fade*\ [**s**]]\ [**+g**\ *fill*] ]
-[ |-F|\ *format*\ [**+t**]\ [**+o**\ *options*]]
+[ |-F|\ *gif*\|\ *mp4*\|\ *webm*\|\ *png*\ [**+l**\ [*n*]][**+o**\ *options*][**+s**\ *stride*][**+t**] ]
 [ |-G|\ [*fill*]\ [**+p**\ *pen*] ]
 [ |-H|\ *scale*]
 [ |-I|\ *includefile* ]
@@ -114,15 +113,6 @@ Required Arguments
 Optional Arguments
 ------------------
 
-.. _-A:
-
-**-A**\ [**+l**\ [*n*]]\ [**+s**\ *stride*]
-    Build an animated GIF file.  You may specify if the movie should play more than once (i.e., loop)
-    via **+l** and if so append how many times to repeat [infinite].  If a video product is also
-    selected (**-F**) then you can limit the frames being used to make the GIF file.  Append **+s**\ *stride*
-    to only use every *stride* frame, with *stride* being one of a fixed set of strides: 2, 5, 10,
-    20, 50, 100, 200, and 500.
-
 .. _-D:
 
 **-D**\ *displayrate*
@@ -142,16 +132,21 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ *format*\ [**+t**]\ [**+o**\ *options*]
-    Set the format of the final video product.  Repeatable.  Choose either **mp4** (MPEG-4 movie) or
-    **webm** (WebM movie).  You may optionally add additional FFmpeg encoding settings for this format
-    via the **+o** modifier (in quotes if more than one word). If **none** is chosen then no PNGs will
-    be created at all; this requires **-M**.  Choose **+t** to generate transparent PNG images [opaque].
+**-F**\ *gif*\|\ *mp4*\|\ *webm*\|\ *png*\ [**+l**\ [*n*]][**+o**\ *options*][**+s**\ *stride*][**+t**]
+    Select a video product.  Repeatable to make more than one product.  Choose from *gif* (animated GIF),
+    *mp4* (MPEG-4 movie), *webm* (WebM movie) or just *png* (implied by all the others).  You may optionally
+    add additional FFmpeg encoding settings for *mp4* and *webm* via the **+o** modifier (in quotes if more
+    than one word). Choose **+t** to generate transparent PNG images [opaque]. If just *png* is chosen then no
+    animation will be assembled.  For *gif* you may consider using modifier *+l** for turning on looping and
+    optionally append how many times to repeat [infinite].  If either a *mp4* or *webm* product has been
+    selected then you can limit the frames being used to make a GIF animation:  Append **+s**\ *stride*
+    to only use every *stride* frame, with *stride* being one of a fixed set of strides: 2, 5, 10,
+    20, 50, 100, 200, and 500. No **-F** means no video products are created at all; this requires **-M**.
 
 .. _-G:
 
 **-G**\ [*fill*]\ [**+p**\ *pen*] :ref:`(more ...) <-Gfill_attrib>`
-    Set the canvas color or fill before plotting commences [none].
+    Set the canvas color or fill before plotting commences [no fill].
     Optionally, append **+p** to draw the canvas outline with *pen* [no outline].
 
 .. _-H:
@@ -320,7 +315,7 @@ In addition, the *mainscript* also has access to parameters that vary with the f
 Furthermore, if a *timefile* was given then variables **MOVIE_COL0**\ , **MOVIE_COL1**\ , etc. are
 also set, yielding one variable per column in *timefile*.  If *timefile* has trailing text then that text can
 be accessed via the variable **MOVIE_TEXT**, and if word-splitting was explicitly requested by **-T+w** or
-implicitly by selecting word labels in **-F** or **-P**) then
+implicitly by selecting word labels in **-L** or **-P**) then
 the trailing text is also split into individual word parameters **MOVIE_WORD0**\ , **MOVIE_WORD1**\ , etc.
 
 Data Files
@@ -431,9 +426,9 @@ parameter file.  Using the **-Q** option will just produce these scripts which y
 **Note**: The *mainscript* is duplicated per frame and each copy is run simultaneously on all available cores.
 Multi-treaded GMT modules will therefore be limited to a single core as well.
 
-The conversion of PNG frames to an animated GIF (**-F**\ gif) relies on `GraphicsMagick <http://www.graphicsmagick.org/>`_.
+The conversion of PNG frames to an animated GIF (**-F**\ *gif*) relies on `GraphicsMagick <http://www.graphicsmagick.org/>`_.
 Thus, **gm** must be accessible via your standard search path. Likewise, the conversion of
-PNG frames to an MP4 (**-F**\ mp4) or WebM (**-F**\ webm) movie relies on `FFmpeg <https://www.ffmpeg.org/>`_.
+PNG frames to an MP4 (**-F**\ *mp4*) or WebM (**-F**\ *webm*) movie relies on `FFmpeg <https://www.ffmpeg.org/>`_.
 
 Hints for Movie Makers
 ----------------------
@@ -446,7 +441,7 @@ require the frame number you will need to make a file that you can pass to **-T*
 then have all the values you need, per frame (i.e., row), with values across all the columns you need.
 If you need to assign various fixed variables that do not change with time then your *mainscript*
 will look shorter and cleaner if you offload those assignments to a separate *includefile* (**-I**).
-To test your movie, start by using options **-F**\ none **-Q -M** to ensure your master frame page looks correct.
+To test your movie, start by using options **-Q -M** to ensure your master frame page looks correct.
 This page shows you one frame of your movie (you can select which frame via the **-M** arguments).  Fix any
 issues with your use of variables and options until this works.  You can then try to remove **-Q**.
 We recommend you make a very short (i.e., **-T**) and small (i.e., **-C**) movie so you don't have to wait very
@@ -516,7 +511,7 @@ To make an animated GIF movie based on the script globe.sh, which simply spins a
 frame number to serve as the view longitude, using a custom square 600 by 600 pixel canvas and 360 frames,
 place a frame counter in the top left corner, and place a progress indicator in the top right corner, try::
 
-    gmt movie globe.sh -Nglobe -T360 -Agif -C6ix6ix100 -Lf -P
+    gmt movie globe.sh -Nglobe -T360 -Fgif -C6ix6ix100 -Lf -P
 
 Here, the globe.sh bash script simply plots a map with :doc:`coast` but uses the frame number variable
 as the center longitude::
@@ -528,7 +523,7 @@ as the center longitude::
 As the automatic frame loop is executed the different frames will be produced with different
 longitudes.  The equivalent DOS batch script setup would be::
 
-    gmt movie globe.bat -Nglobe -T360 -Agif -C6ix6ix100 -Lf -P
+    gmt movie globe.bat -Nglobe -T360 -Fgif -C6ix6ix100 -Lf -P
 
 Now, the globe.bat DOS script is simply::
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -48,8 +48,8 @@ animation job.  Instead, the user can focus on composing the main frame plot and
 parallel execution of frames and assembly of images into a movie take place in the background.
 Individual frames are converted from *PostScript* plots to lossless, transparent PNG images and optionally
 assembled into an animation (this last step requires external tools that must be present in
-your path; see Technical Details below).  For opaque PNG images, simply specify a background
-color via **-G**.
+your path; see Technical Details below). The user can add title sequences, fading, labels, and
+progress indicators as desired. 
 
 Required Arguments
 ------------------
@@ -134,10 +134,10 @@ Optional Arguments
 
 **-F**\ *gif*\|\ *mp4*\|\ *webm*\|\ *png*\ [**+l**\ [*n*]][**+o**\ *options*][**+s**\ *stride*][**+t**]
     Select a video product.  Repeatable to make more than one product.  Choose from *gif* (animated GIF),
-    *mp4* (MPEG-4 movie), *webm* (WebM movie) or just *png* (implied by all the others).  You may optionally
+    *mp4* (MPEG-4 movie), *webm* (WebM movie) or just *png* images (implied by all the others).  You may optionally
     add additional FFmpeg encoding settings for *mp4* and *webm* via the **+o** modifier (in quotes if more
     than one word). Choose **+t** to generate transparent PNG images [opaque]. If just *png* is chosen then no
-    animation will be assembled.  For *gif* you may consider using modifier *+l** for turning on looping and
+    animation will be assembled.  For *gif* you may consider using modifier **+l** for turning on looping and
     optionally append how many times to repeat [infinite].  If either a *mp4* or *webm* product has been
     selected then you can limit the frames being used to make a GIF animation:  Append **+s**\ *stride*
     to only use every *stride* frame, with *stride* being one of a fixed set of strides: 2, 5, 10,

--- a/src/movie.c
+++ b/src/movie.c
@@ -113,7 +113,10 @@
 #define MOVIE_RASTER_EXTENSION	"png"	/* Fixed raster format extension */
 #define MOVIE_DEBUG_FORMAT	",ps"	/* Comma is intentional since we append to a list of formats */
 
-enum enum_video {MOVIE_MP4,	/* Create a H.264 MP4 video */
+enum enum_video {
+	MOVIE_PNG,	/* Create PNGs */
+	MOVIE_GIF,	/* Create an animated GIF*/
+	MOVIE_MP4,	/* Create a H.264 MP4 video */
 	MOVIE_WEBM,		/* Create a WebM video */
 	MOVIE_N_FORMATS};	/* Number of video formats above */
 
@@ -157,13 +160,6 @@ struct MOVIE_CTRL {
 		char *file;	/* Name of main script */
 		FILE *fp;	/* Open file pointer to main script */
 	} In;
-	struct MOVIE_A {	/* -A[+l[<nloops>]][+s<stride>]  */
-		bool active;
-		bool loop;
-		bool skip;
-		unsigned int loops;
-		unsigned int stride;
-	} A;
 	struct MOVIE_C {	/* -C<namedcanvas>|<canvas_and_dpu> */
 		bool active;
 		double dim[3];
@@ -186,6 +182,10 @@ struct MOVIE_CTRL {
 	struct MOVIE_F {	/* -F<videoformat>[+o<options>][+t] */
 		bool active[MOVIE_N_FORMATS];
 		bool transparent;
+		bool loop;
+		bool skip;
+		unsigned int loops;
+		unsigned int stride;
 		char *format[MOVIE_N_FORMATS];
 		char *options[MOVIE_N_FORMATS];
 	} F;
@@ -272,9 +272,9 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	struct MOVIE_CTRL *C;
 
 	C = gmt_M_memory (GMT, NULL, 1, struct MOVIE_CTRL);
-	C->A.loops = 1;		/* No loop, just play once */
 	C->C.unit = 'c';	/* c for SI units */
 	C->D.framerate = 24.0;	/* 24 frames/sec */
+	C->F.loops = 1;		/* No loop, just play once */
 	C->F.options[MOVIE_WEBM] = strdup ("-crf 10 -b:v 1.2M");	/* Default WebM options for now */
 	strcpy (C->T.sep, "\t ");	/* Any white space */
 	C->x.n_threads = GMT->parent->n_cores;	/* Use all cores available unless -x is set */
@@ -320,7 +320,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <mainscript> -C<canvas>|<width>x<height>x<dpu> -N<prefix> -T<nframes>|<min>/<max>/<inc>[+n]|<timefile>[+p<width>][+s<first>][+w[<str>]|W] "
-		"[-A[+l[<n>]][+s<stride>]] [-D<rate>] [-E<titlepage>[+d<duration>[s]][+f[i|o]<fade>[s]][+g<fill>]] [-F<format>[+o<opts>][+t]] [-G[<fill>][+p<pen>]] [-H<scale>] "
+		"[-D<rate>] [-E<titlepage>[+d<duration>[s]][+f[i|o]<fade>[s]][+g<fill>]] [-Fgif|mp4|webm|png[+l[<n>]][+o<opts>][+s<stride>][+t]] [-G[<fill>][+p<pen>]] [-H<scale>] "
 		"[-I<includefile>] [-K[+f[i|o]<fade>[s]][+g<fill>][+p[i|o]]] [-L<labelinfo>] [-M[<frame>|f|m|l,][<format>][+r<dpu>]] [-P<progressinfo>] [-Q[s]] [-Sb<background>] "
 		"[-Sf<foreground>] [%s] [-W[<dir>]] [-Z[s]] [%s] [-x[[-]<n>]] [%s]\n", name, GMT_V_OPT, GMT_f_OPT, GMT_PAR_OPT);
 
@@ -369,11 +369,6 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"We use space or TAB as separators; append <str> to set custom characters as separators instead.");
 	GMT_Usage (API, 3, "+W Same as +w but only use TAB as separator.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n-A[+l[<n>]][+s<stride>]");
-	GMT_Usage (API, -2, "Animated GIF, with modifiers:");
-	GMT_Usage (API, 3, "+l Enable looping [no loop]; optionally append number of loops [infinite loop].");
-	GMT_Usage (API, 3, "+s Set stride: If -F is used you may restrict the GIF animation to use every <stride> frame only [all]. "
-		"<stride> must be taken from the list 2, 5, 10, 20, 50, 100, 200, or 500.");
 	GMT_Usage (API, 1, "\n-D<rate>");
 	GMT_Usage (API, -2, "Set movie display frame rate in frames/second [24].");
 	GMT_Usage (API, 1, "\n-E<titlepage>[+d<duration>[s]][+f[i|o]<fade>[s]][+g<fill>]");
@@ -383,15 +378,20 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+f Fade in and out over the title via black [1s]. "
 		"Use +fi and/or +fo to set unequal fade lengths or to just select one of them.");
 	GMT_Usage (API, 3, "+g Select another terminal fade fill than black.");
-	GMT_Usage (API, 1, "\n-F<format>[+o<opts>][+t]");
-	GMT_Usage (API, -2, "Select the final video format(s) from among these choices. Repeatable:");
-	GMT_Usage (API, 3, "%s mp4 : Convert PNG frames into an MP4 movie", GMT_LINE_BULLET);
-	GMT_Usage (API, 3, "%s webm: Convert PNG frames into an WebM movie", GMT_LINE_BULLET);
-	GMT_Usage (API, 3, "%s none: Make no PNG frames; requires -M", GMT_LINE_BULLET);
-	GMT_Usage (API, -2, "Two modifiers are available as well:");
+	GMT_Usage (API, 1, "\n-Fgif|mp4|webm|png[+l[<n>]][+o<opts>][+s<stride>][+t]");
+	GMT_Usage (API, -2, "Select the desired video format(s) from available choices. Repeatable:");
+	GMT_Usage (API, 3, "%s gif: Make and convert PNG frames into an animated GIF.", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s mp4: Make and convert PNG frames into an MP4 movie.", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s webm: Make and convert PNG frames into an WebM movie.", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s png: Just make the PNG frames.", GMT_LINE_BULLET);
+	GMT_Usage (API, -2, "Note: gif|mp4|webm all imply png. Two modifiers are available for mp4 or webm:");
+	GMT_Usage (API, 3, "+o Append custom FFmpeg encoding options (in quotes) [none].");
 	GMT_Usage (API, 3, "+t Build transparent images [opaque].");
-	GMT_Usage (API, 3, "+o Append custom encoding options (in quotes) for mp4 or webm [none].");
-	GMT_Usage (API, -2, "[Default is no video products; just create the PNG frames].");
+	GMT_Usage (API, -2, "Two modifiers are available for gif:");
+	GMT_Usage (API, 3, "+l Enable looping [no loop]; optionally append number of loops [infinite loop].");
+	GMT_Usage (API, 3, "+s Set stride: If -Fmp4|webm is also used you may restrict the GIF animation to use every <stride> frame only [all]. "
+		"<stride> must be taken from the list 2, 5, 10, 20, 50, 100, 200, or 500.");
+	GMT_Usage (API, -2, "Default is no video products; this requires -M.");
 	GMT_Usage (API, 1, "\n-G[<fill>][+p<pen>]");
 	GMT_Usage (API, -2, "Set the canvas background color [none].  Append +p<pen> to draw canvas outline [none].");
 	GMT_Usage (API, 1, "\n-H<scale>");
@@ -706,32 +706,37 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				if (GMT_Get_FilePath (GMT->parent, GMT_IS_DATASET, GMT_IN, GMT_FILE_REMOTE, &(Ctrl->In.file))) n_errors++;;
 				break;
 
-			case 'A':	/* Animated GIF */
-				Ctrl->A.active = Ctrl->animate = true;
-				if ((c = gmt_first_modifier (GMT, opt->arg, "ls"))) {	/* Process any modifiers */
-					pos = 0;	/* Reset to start of new word */
-					while (gmt_getmodopt (GMT, 'A', c, "ls", &pos, p, &n_errors) && n_errors == 0) {
-						switch (p[0]) {
-							case 'l':	/* Specify loops */
-								Ctrl->A.loop = true;
-								Ctrl->A.loops = (p[1]) ? atoi (&p[1]) : 0;
-								break;
-							case 's':	/* Specify GIF stride, 2,5,10,20,50,100,200,500 etc. */
-								Ctrl->A.skip = true;
-								Ctrl->A.stride = atoi (&p[1]);
-								mag = urint (pow (10.0, floor (log10 ((double)Ctrl->A.stride))));
-								k = Ctrl->A.stride / mag;
-								if (!(k == 1 || k == 2 || k == 5)) {
-									GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A+s: Allowable strides are 2,5,10,20,50,100,200,500,...\n");
-									n_errors++;
-								}
-								break;
-							default:
-								break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
+			case 'A':	/* Animated GIF [Deprecated] */
+				if (gmt_M_compat_check (GMT, 6)) {	/* GMT6 compatibility allows -A */
+					GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Option -A is deprecated - use -F instead\n");
+					Ctrl->F.active[MOVIE_GIF] = Ctrl->F.active[MOVIE_PNG] = Ctrl->animate = true;	/* old -A implies -Fpng */
+					if ((c = gmt_first_modifier (GMT, opt->arg, "ls"))) {	/* Process any modifiers */
+						pos = 0;	/* Reset to start of new word */
+						while (gmt_getmodopt (GMT, 'A', c, "ls", &pos, p, &n_errors) && n_errors == 0) {
+							switch (p[0]) {
+								case 'l':	/* Specify loops */
+									Ctrl->F.loop = true;
+									Ctrl->F.loops = (p[1]) ? atoi (&p[1]) : 0;
+									break;
+								case 's':	/* Specify GIF stride, 2,5,10,20,50,100,200,500 etc. */
+									Ctrl->F.skip = true;
+									Ctrl->F.stride = atoi (&p[1]);
+									mag = urint (pow (10.0, floor (log10 ((double)Ctrl->F.stride))));
+									k = Ctrl->F.stride / mag;
+									if (!(k == 1 || k == 2 || k == 5)) {
+										GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A+s: Allowable strides are 2,5,10,20,50,100,200,500,...\n");
+										n_errors++;
+									}
+									break;
+								default:
+									break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
+							}
 						}
+						c[0] = '\0';
 					}
-					c[0] = '\0';
 				}
+				else
+					n_errors += gmt_default_error (GMT, opt->option);
 				break;
 
 			case 'C':	/* Known frame dimension or set a custom canvas size */
@@ -841,12 +846,26 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				break;
 
 			case 'F':	/* Set movie format and optional FFmpeg options */
-				if ((c = gmt_first_modifier (GMT, opt->arg, "ot"))) {	/* Process any modifiers */
+				if ((c = gmt_first_modifier (GMT, opt->arg, "lost"))) {	/* Process any modifiers */
 					pos = 0;	/* Reset to start of new word */
-					while (gmt_getmodopt (GMT, 'F', c, "ot", &pos, p, &n_errors) && n_errors == 0) {
+					while (gmt_getmodopt (GMT, 'F', c, "lost", &pos, p, &n_errors) && n_errors == 0) {
 						switch (p[0]) {
-							case 'o':	/* Duration of entire title/fade sequence */
+							case 'l':	/* Specify loops for GIF */
+								Ctrl->F.loop = true;
+								Ctrl->F.loops = (p[1]) ? atoi (&p[1]) : 0;
+								break;
+							case 'o':	/* FFmpeg option to pass along */
 								s = strdup (&p[1]);	/* Retain start of encoding options for later */
+								break;
+							case 's':	/* Specify GIF stride, 2,5,10,20,50,100,200,500 etc. */
+								Ctrl->F.skip = true;
+								Ctrl->F.stride = atoi (&p[1]);
+								mag = urint (pow (10.0, floor (log10 ((double)Ctrl->F.stride))));
+								k = Ctrl->F.stride / mag;
+								if (!(k == 1 || k == 2 || k == 5)) {
+									GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -F+s: Allowable strides are 2,5,10,20,50,100,200,500,...\n");
+									n_errors++;
+								}
 								break;
 							case 't':	/* Transparent images */
 								Ctrl->F.transparent = true;
@@ -858,11 +877,22 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 					c[0] = '\0';	/* Chop off modifiers */
 				}
 				strncpy (arg, opt->arg, GMT_LEN64-1);	/* Get a copy of the args (minus encoding options)... */
-				gmt_str_tolower (arg);	/* ..so we can convert it to lower case for comparisons */
+				gmt_str_tolower (arg);	/* ...so we can convert it to lower case for comparisons */
 				if (!strcmp (opt->arg, "none")) {	/* Do not make those PNGs at all, just a master plot */
-					Ctrl->M.exit = true;
+					if (gmt_M_compat_check (GMT, 6)) {	/* GMT6 compatibility allows -Fnone */
+						GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Option -Fnone is deprecated, it is the default action\n");
+						Ctrl->M.exit = true;
+					}
+					else {
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -F: Unrecognized format %s\n", opt->arg);
+						n_errors++;
+					}
 					break;
 				}
+				if (!strcmp (opt->arg, "png"))	/* Just make those PNGs */
+					k = MOVIE_PNG;
+				else if (!strcmp (opt->arg, "gif"))	/* Make animated GIF */
+					k = MOVIE_GIF;
 				else if (!strcmp (opt->arg, "mp4"))	/* Make a MP4 movie */
 					k = MOVIE_MP4;
 				else if (!strcmp (opt->arg, "webm"))	/* Make a WebM movie */
@@ -879,7 +909,8 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 						break;
 					}
 					/* Here we have a new video format selected */
-					Ctrl->F.active[k] = Ctrl->animate = true;
+					Ctrl->F.active[k] = true;
+					if (k != MOVIE_PNG) Ctrl->animate = true;
 					if (s) {	/* Gave specific encoding options */
 						if (Ctrl->F.options[k]) gmt_M_str_free (Ctrl->F.options[k]);	/* Free old setting first */
 						Ctrl->F.options[k] = s;
@@ -1128,10 +1159,13 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 		}
 	}
 
+	if (Ctrl->F.active[MOVIE_GIF] || Ctrl->F.active[MOVIE_MP4] || Ctrl->F.active[MOVIE_WEBM]) Ctrl->F.active[MOVIE_PNG] = true;	/* All animations require PNGs */
+	if (Ctrl->M.active && !Ctrl->F.active[MOVIE_PNG]) Ctrl->M.exit = true;	/* Only make the master frame */
+
 	n_errors += gmt_M_check_condition (GMT, n_files != 1 || Ctrl->In.file == NULL, "Must specify a main script file\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->C.active, "Option -C: Must specify a canvas dimension\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->M.exit && Ctrl->animate, "Option -F: Cannot use none with other selections\n");
-	n_errors += gmt_M_check_condition (GMT, !Ctrl->Q.active && !Ctrl->M.active && !Ctrl->animate, "Must select at least one output product (-A, -F, -M)\n");
+	n_errors += gmt_M_check_condition (GMT, !Ctrl->Q.active && !Ctrl->M.active && !Ctrl->F.active[MOVIE_PNG], "Must select at least one output product (-F, -M)\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active && Ctrl->Z.active, "Cannot use -Z if -Q is also set\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->H.active && Ctrl->H.factor < 2, "Option -H: factor must be and integer > 1\n");
 	if (!Ctrl->T.split) {	/* Make sure we split text if we request word columns in the labeling */
@@ -1153,10 +1187,10 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 					"Option -T: Must specify number of frames or a time file\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->T.split && Ctrl->T.sep[0] == '\0',
 					"Option -T: Must specify a string of characters if using +w<str>\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && !(Ctrl->Q.active || Ctrl->animate || Ctrl->M.active),
-					"Option -Z: Cannot be used without specifying a GIF (-A), master (-M) or movie (-F) product\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->A.skip && !(Ctrl->F.active[MOVIE_MP4] || Ctrl->F.active[MOVIE_WEBM]),
-					"Option -A: Cannot specify a GIF stride > 1 without selecting a movie product (-F)\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && !(Ctrl->Q.active || Ctrl->F.active[MOVIE_PNG] || Ctrl->M.active),
+					"Option -Z: Cannot be used without specifying a master (-M) or animation (-F) product\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->F.skip && !(Ctrl->F.active[MOVIE_MP4] || Ctrl->F.active[MOVIE_WEBM]),
+					"Option -Fgif: Cannot specify a GIF stride > 1 without selecting a movie product (-Fmp4|webm)\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->M.active && !Ctrl->M.update && Ctrl->M.frame < Ctrl->T.start_frame,
 					"Option -M: Cannot specify a frame before the first frame number set via -T\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && Ctrl->W.active && Ctrl->W.dir && !strcmp (Ctrl->W.dir, "/tmp"),
@@ -1357,7 +1391,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	else {	/* Will run scripts and may even need to make a movie */
 		run_script = system;	/* The standard system function will be used */
 
-		if (Ctrl->A.active) {	/* Ensure we have the GraphicsMagick executable "gm" installed in the path */
+		if (Ctrl->F.active[MOVIE_GIF]) {	/* Ensure we have the GraphicsMagick executable "gm" installed in the path */
 			if (gmt_check_executable (GMT, "gm", "version", "www.GraphicsMagick.org", line)) {
 				sscanf (line, "%*s %s %*s", version);
 				GMT_Report (API, GMT_MSG_INFORMATION, "GraphicsMagick %s found.\n", version);
@@ -1972,7 +2006,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", ",Mb../movie_background.ps");		/* Current frame tag (formatted frame number) */
 		else
 			gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", "");		/* Nothing */
-		if (Ctrl->F.transparent && Ctrl->A.active) place_background = false;	/* Only place background once if transparent images */
+		if (Ctrl->F.transparent && Ctrl->F.active[MOVIE_GIF]) place_background = false;	/* Only place background once if transparent images */
 		gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
 		for (col = 0; col < n_values; col++) {	/* Derive frame variables from <timefile> in each parameter file */
 			sprintf (string, "MOVIE_COL%u", col);
@@ -2461,26 +2495,26 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		Return (GMT_RUNTIME_ERROR);
 	}
 
-	if (Ctrl->A.active) {	/* Want an animated GIF */
+	if (Ctrl->F.active[MOVIE_GIF]) {	/* Want an animated GIF */
 		/* Set up system call to gm (which we know exists) */
 		unsigned int delay = urint (100.0 / Ctrl->D.framerate);	/* Delay to nearest ~1/100 s */
 		char files[GMT_LEN32] = {""};
 		files[0] = '*';
-		if (Ctrl->A.skip) {	/* Only use every stride file */
-			if (Ctrl->A.stride == 2 || Ctrl->A.stride == 20 || Ctrl->A.stride == 200 || Ctrl->A.stride == 2000)
+		if (Ctrl->F.skip) {	/* Only use every stride file */
+			if (Ctrl->F.stride == 2 || Ctrl->F.stride == 20 || Ctrl->F.stride == 200 || Ctrl->F.stride == 2000)
 				strcat (files, "[02468]");
-			else if (Ctrl->A.stride == 5 || Ctrl->A.stride == 50 || Ctrl->A.stride == 500 || Ctrl->A.stride == 5000)
+			else if (Ctrl->F.stride == 5 || Ctrl->F.stride == 50 || Ctrl->F.stride == 500 || Ctrl->F.stride == 5000)
 				strcat (files, "[05]");
 			else	/* 10, 100, 1000, etc */
 				strcat (files, "[0]");
-			if (Ctrl->A.stride > 1000)
+			if (Ctrl->F.stride > 1000)
 				strcat (files, "000");
-			else if (Ctrl->A.stride > 100)
+			else if (Ctrl->F.stride > 100)
 				strcat (files, "00");
-			else if (Ctrl->A.stride > 10)
+			else if (Ctrl->F.stride > 10)
 				strcat (files, "0");
 		}
-		sprintf (cmd, "gm convert -delay %u -loop %u +dither %s%c%s_%s.%s %s.gif", delay, Ctrl->A.loops, tmpwpath, dir_sep, Ctrl->N.prefix, files, MOVIE_RASTER_EXTENSION, Ctrl->N.prefix);
+		sprintf (cmd, "gm convert -delay %u -loop %u +dither %s%c%s_%s.%s %s.gif", delay, Ctrl->F.loops, tmpwpath, dir_sep, Ctrl->N.prefix, files, MOVIE_RASTER_EXTENSION, Ctrl->N.prefix);
 		gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure all files are synced before building the movie */
 		GMT_Report (API, GMT_MSG_NOTICE, "Running: %s\n", cmd);
 		if ((error = system (cmd))) {
@@ -2488,7 +2522,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 		GMT_Report (API, GMT_MSG_INFORMATION, "GIF animation built: %s.gif\n", Ctrl->N.prefix);
-		if (Ctrl->A.skip) GMT_Report (API, GMT_MSG_INFORMATION, "GIF animation reflects every %d frame only\n", Ctrl->A.stride);
+		if (Ctrl->F.skip) GMT_Report (API, GMT_MSG_INFORMATION, "GIF animation reflects every %d frame only\n", Ctrl->F.stride);
 	}
 	if (Ctrl->F.active[MOVIE_MP4]) {
 		/* Set up system call to FFmpeg (which we know exists) */


### PR DESCRIPTION
While **-F** let you choose among video options and add some suitable modifiers, animated GIF was not one of them and it had its own option **-A** with modifier.  Yet, **-A+s** required **-F** to have been set, etc.  Same with **-M**, requiring **-F**_none_ if no animation desired. This PR lets **-F** specify which products to build from the list of gif,png,mp4,webm and offers modifiers.  The option is repeatable.  We thus deprecate **-A** (now **-F**_gif_) and **-F**_none_ (now default) which will be handled via standard backwards compatibility rules.  Closes #5522.