### PR TITLE
Binary documentation and usage update

### DIFF
--- a/doc/rst/source/explain_-bi.rst_
+++ b/doc/rst/source/explain_-bi.rst_
@@ -1,2 +1,2 @@
-**-bi**\ [*ncols*][**t**] :ref:`(more ...) <-bi_full>`
-    Select native binary format for primary input. |Add_-bi|
+**-bi**\ *record*\ [**+b**\|\ **l**] :ref:`(more ...) <-bi_full>`
+    Select native binary format for primary table input. |Add_-bi|

--- a/doc/rst/source/explain_-bi_full.rst_
+++ b/doc/rst/source/explain_-bi_full.rst_
@@ -27,7 +27,7 @@ format [*ncols*][*type*][**w**], where *ncols* is the number of consecutive data
     - **x** - use to skip *ncols* anywhere in the record
 
 Force byte-swapping of a group by appending **w** at the end of the group.
-For records with mixed types, simply append additional comma-separated combinations of *ncols* *type* (no space).
+For records with mixed types, append additional comma-separated groups (no space between groups).
 The following modifiers are supported:
 
     - **+b**\|\ **l** to indicate that the entire data file should be read as big- or little-endian, respectively.

--- a/doc/rst/source/explain_-bi_full.rst_
+++ b/doc/rst/source/explain_-bi_full.rst_
@@ -3,13 +3,14 @@ The **-bi** option
 
 **Syntax**
 
-**-bi**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
-    Select native binary format for primary input (secondary inputs are always ASCII).
+**-bi**\ *record*\ [**+b**\|\ **l**]
+    Select native binary format for primary table input (secondary inputs are always ASCII).
 
 **Description**
 
-Select native binary format for primary input, where *ncols* is the number of data columns of given *type* and *type*
-must be one of:
+Select native binary record format for primary table input. The *record* is one or more groups with
+format [*ncols*][*type*][**w**], where *ncols* is the number of consecutive data columns of given
+*type* and *type* must be one of:
 
 .. _bi_types:
 
@@ -22,14 +23,14 @@ must be one of:
     - **l** - int64_t (8-byte signed int)
     - **L** - uint64_t (8-byte unsigned int)
     - **f** - 4-byte single-precision float
-    - **d** - 8-byte double-precision float
+    - **d** - 8-byte double-precision float [Default]
     - **x** - use to skip *ncols* anywhere in the record
 
-For records with mixed types, simply append additional comma-separated combinations of *ncols* *type* (no space). The
-following modifiers are supported:
+Force byte-swapping of a group by appending **w** at the end of the group.
+For records with mixed types, simply append additional comma-separated combinations of *ncols* *type* (no space).
+The following modifiers are supported:
 
-    - **w** after any item to force byte-swapping
-    - **+l**\|\ **b** to indicate that the entire data file should be read as little- or big-endian, respectively.
+    - **+b**\|\ **l** to indicate that the entire data file should be read as big- or little-endian, respectively.
 
 The cumulative number of *ncols* may exceed the columns actually needed by the program. If *ncols* is not specified we
 assume that *type* applies to all columns and that *ncols* is implied by the expectation of the program. When using
@@ -47,5 +48,5 @@ variables to be read (see :doc:`/cookbook/file-formats` and :ref:`Modifiers for 
 
     ::
 
-        echo 1.5 2 2.5 | gmt convert -bo1f,1l,1d > lixo.bin
-        gmt convert lixo.bin -bi1f,1l,1d
+        echo 1.5 2 2.5 | gmt convert -bo1f,1l,1d > test.bin
+        gmt convert test.bin -bi1f,1l,1d

--- a/doc/rst/source/explain_-bo.rst_
+++ b/doc/rst/source/explain_-bo.rst_
@@ -1,2 +1,2 @@
-**-bo**\ [*ncols*][*type*] :ref:`(more ...) <-bo_full>`
-    Select native binary output. |Add_-bo|
+**-bo**\ *record*\ [**+b**\|\ **l**] :ref:`(more ...) <-bo_full>`
+    Select native binary format for table output. |Add_-bo|

--- a/doc/rst/source/explain_-bo_full.rst_
+++ b/doc/rst/source/explain_-bo_full.rst_
@@ -13,8 +13,8 @@ Select native binary format for table output. The *record* must be one or more g
 of given *type* and *type* must be one of **c**, **u**, **h**, **H**, **i**, **I**,
 **l**, **L**, **f**, or **d** [Default] (see :ref:`-bi types <bi_types>` for descriptions).
 Force byte-swapping of a group by appending **w** at the end of the group.
-For a mixed-type output record, append additional comma-separated groups (no space). The
-following modifiers are supported:
+For a mixed-type output record, append additional comma-separated groups (no space between groups)
+The following modifiers are supported:
 
     - **+b**\|\ **l** to indicate that the entire data file should be written as big- or little-endian, respectively.
 

--- a/doc/rst/source/explain_-bo_full.rst_
+++ b/doc/rst/source/explain_-bo_full.rst_
@@ -3,18 +3,20 @@ The **-bo** option
 
 **Syntax**
 
-**-bo**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
-    Select native binary output.
+**-bo**\ *record*\ [**+b**\|\ **l**]
+    Select native binary format for table output.
 
 **Description**
 
-Select native binary output, where *ncols* is the number of data columns of *type*, which must be one of **c**,
-**u**, **h**, **H**, **i**, **I**, **l**, **L**, **f**, or **d** (see :ref:`-bi types <bi_types>` for descriptions).
-For a mixed-type output record, append additional comma-separated combinations of *ncols* *type* (no space). The
+Select native binary format for table output. The *record* must be one or more groups with format
+[*ncols*][*type*][**w**], where *ncols* is the number of consecutive data columns
+of given *type* and *type* must be one of **c**, **u**, **h**, **H**, **i**, **I**,
+**l**, **L**, **f**, or **d** [Default] (see :ref:`-bi types <bi_types>` for descriptions).
+Force byte-swapping of a group by appending **w** at the end of the group.
+For a mixed-type output record, append additional comma-separated groups (no space). The
 following modifiers are supported:
 
-    - **w** after any item to force byte-swapping
-    - **+l**\|\ **b** to indicate that the entire data file should be read as little- or big-endian, respectively.
+    - **+b**\|\ **l** to indicate that the entire data file should be written as big- or little-endian, respectively.
 
 If *ncols* is not specified we assume that *type* applies to all columns and that *ncols* is implied by the default
 output of the program. **Note**: NetCDF file output is not supported.

--- a/doc/rst/source/std-opts-classic.rst
+++ b/doc/rst/source/std-opts-classic.rst
@@ -30,9 +30,9 @@ Common Options (Classic Mode)
      - :ref:`Shift plot origin in y-direction <-XY_full>`
    * - **-a**\ [*col*\ =]\ *name*\ [,\ *...*]
      - :ref:`Associates aspatial data with columns <-aspatial_full>`
-   * - **-bi**\ *record*\ [**+l**\|\ **b**]
+   * - **-bi**\ *record*\ [**+b**\|\ **l**]
      - :ref:`Select binary input <-bi_full>`
-   * - **-bo**\ *record*\ [**+l**\|\ **b**]
+   * - **-bo**\ *record*\ [**+b**\|\ **l**]
      - :ref:`Select binary output <-bo_full>`
    * - **-d**\ [**i**\|\ **o**]\ *nodata*
      - :ref:`Replace columns with nodata with NaN <-d_full>`

--- a/doc/rst/source/std-opts-classic.rst
+++ b/doc/rst/source/std-opts-classic.rst
@@ -30,9 +30,9 @@ Common Options (Classic Mode)
      - :ref:`Shift plot origin in y-direction <-XY_full>`
    * - **-a**\ [*col*\ =]\ *name*\ [,\ *...*]
      - :ref:`Associates aspatial data with columns <-aspatial_full>`
-   * - **-bi**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
+   * - **-bi**\ *record*\ [**+l**\|\ **b**]
      - :ref:`Select binary input <-bi_full>`
-   * - **-bo**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
+   * - **-bo**\ *record*\ [**+l**\|\ **b**]
      - :ref:`Select binary output <-bo_full>`
    * - **-d**\ [**i**\|\ **o**]\ *nodata*
      - :ref:`Replace columns with nodata with NaN <-d_full>`

--- a/doc/rst/source/std-opts.rst
+++ b/doc/rst/source/std-opts.rst
@@ -24,9 +24,9 @@ Common Options
      - :ref:`Shift plot origin in y-direction <-XY_full>`
    * - **-a**\ [*col*\ =]\ *name*\ [,\ *...*]
      - :ref:`Associates aspatial data with columns <-aspatial_full>`
-   * - **-bi**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
+   * - **-bi**\ *record*\ [**+l**\|\ **b**]
      - :ref:`Select binary input <-bi_full>`
-   * - **-bo**\ [*ncols*][*type*][**w**][**+l**\|\ **b**]
+   * - **-bo**\ *record*\ [**+l**\|\ **b**]
      - :ref:`Select binary output <-bo_full>`
    * - **-c**\ [*row*\ ,\ *col*\|\ *index*]
      - :ref:`Advance plot focus to selected (or next) subplot panel <-c_full>`

--- a/doc/rst/source/std-opts.rst
+++ b/doc/rst/source/std-opts.rst
@@ -24,9 +24,9 @@ Common Options
      - :ref:`Shift plot origin in y-direction <-XY_full>`
    * - **-a**\ [*col*\ =]\ *name*\ [,\ *...*]
      - :ref:`Associates aspatial data with columns <-aspatial_full>`
-   * - **-bi**\ *record*\ [**+l**\|\ **b**]
+   * - **-bi**\ *record*\ [**+b**\|\ **l**]
      - :ref:`Select binary input <-bi_full>`
-   * - **-bo**\ *record*\ [**+l**\|\ **b**]
+   * - **-bo**\ *record*\ [**+b**\|\ **l**]
      - :ref:`Select binary output <-bo_full>`
    * - **-c**\ [*row*\ ,\ *col*\|\ *index*]
      - :ref:`Advance plot focus to selected (or next) subplot panel <-c_full>`

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7410,12 +7410,16 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 		case 'C':	/* -b binary option with input only */
 
 			GMT_Usage (API, 1, "\n%s", GMT_bi_OPT);
-			GMT_Usage (API, -2, "Select binary input; data <type> = c|u|h|H|i|I|l|L|f|D.");
+			GMT_Usage (API, -2, "Select native binary table input; <record> is comma-separated  groups of [<ncols>][<type>][w]; "
+				"<ncols> is number of consecutive columns of given <type> from c|u|h|H|i|I|l|L|f|d [d]. "
+				"A group may be byte-swapped by appending w. Available modifiers: ");
+			GMT_Usage (API, 3, "+b Read table assuming big-endian byte-order.");
+			GMT_Usage (API, 3, "+l Read table assuming little-endian byte-order.");
 			break;
 
 		case '0':	/* -bi/-bo addendum when input format is unknown */
 
-			GMT_Usage (API, -2, "Prepend <ncols> for the number of columns for each <type>.");
+			/* Nothing anymore, but leave case since may still be requested by a module */
 			break;
 
 		case '1':	/* -bi/-bo addendum when input format is unknown */
@@ -7426,13 +7430,17 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 		case '6':
 		case '7':
 
-			GMT_Usage (API, -2, "Prepend <ncols> for the number of columns for each <type> in binary file(s) [%c].", options[k]);
+			GMT_Usage (API, -2, "Note: If <ncols> is not given we default to %c.", options[k]);
 			break;
 
 		case 'D':	/* -b binary option with output only */
 
 			GMT_Usage (API, 1, "\n%s", GMT_bo_OPT);
-			GMT_Usage (API, -2, "Select binary output; <type> = c|u|h|H|i|I|l|L|f|D.");
+			GMT_Usage (API, -2, "Select native binary table out; <record> is comma-separated groups of [<ncols>][<type>][w]; "
+				"<ncols> is number of consecutive columns of given <type> from c|u|h|H|i|I|l|L|f|d [d]. "
+				"A group may be byte-swapped by appending w. Available modifiers: ");
+			GMT_Usage (API, 3, "+b Write table in big-endian byte-order.");
+			GMT_Usage (API, 3, "+l Write table in little-endian byte-order.");
 			break;
 
 		case 'c':	/* -c option advances subplot panel focus under modern mode */

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -42,8 +42,8 @@
 
 /* Use b, h, when applies to both i and o, else use only the bi, bo variants */
 
-#define GMT_bi_OPT  "-bi<record>[+l|b]"
-#define GMT_bo_OPT  "-bo<record>[+l|b]"
+#define GMT_bi_OPT  "-bi<record>[+b|l]"
+#define GMT_bo_OPT  "-bo<record>[+b|l]"
 #define GMT_di_OPT	"-di<nodata>"
 #define GMT_do_OPT	"-do<nodata>"
 #define GMT_ho_OPT	"-ho[<nrecs>][+c][+d][+m<segheader>][+r<remark>][+t<title>]"

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -42,8 +42,8 @@
 
 /* Use b, h, when applies to both i and o, else use only the bi, bo variants */
 
-#define GMT_bi_OPT	"-bi[<ncols>][<type>][w][+l|b]"
-#define GMT_bo_OPT	"-bo[<ncols>][<type>][w][+l|b]"
+#define GMT_bi_OPT  "-bi<record>[+l|b]"
+#define GMT_bo_OPT  "-bo<record>[+l|b]"
 #define GMT_di_OPT	"-di<nodata>"
 #define GMT_do_OPT	"-do<nodata>"
 #define GMT_ho_OPT	"-ho[<nrecs>][+c][+d][+m<segheader>][+r<remark>][+t<title>]"

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -681,7 +681,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "%s To use <color> for fill, also select -G+z. ", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s To use <color> for an outline pen, also select -W<pen>+z.", GMT_LINE_BULLET);
 	GMT_Option (API, "a,bi");
-	if (gmt_M_showusage (API)) GMT_Usage (API, 2, "Default is the required number of columns.");
+	if (gmt_M_showusage (API)) GMT_Usage (API, 2, "Default <ncols> is the required number of columns.");
 	GMT_Option (API, "c,di,e,f,g,h,i,l,p,qi,T,w,:,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -351,7 +351,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "%s To use <color> for fill, also select -G+z. ", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s To use <color> for an outline pen, also select -W<pen>+z.", GMT_LINE_BULLET);
 	GMT_Option (API, "a,bi");
-	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is the required number of columns.");
+	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default <ncols> is the required number of columns.");
 	GMT_Option (API, "c,di,e,f,g,h,i,l,p,qi,T,w,:,.");
 
 	return (GMT_MODULE_USAGE);


### PR DESCRIPTION
**Description of proposed changes**

This PR simplifies the explanation and usage for -bi and -bo, fixes a few typos, and positions this option for a simpler transition to long format.  No actual changes to code - this is all about usage statements and RST documentation.  Also clarified that double (**d**) is the default binary table data type.