### PR TITLE
Change name of remote file in sph2grd example

### DIFF
--- a/doc/rst/source/sph2grd.rst
+++ b/doc/rst/source/sph2grd.rst
@@ -128,7 +128,7 @@ coefficients in the remote file EGM96_to_360.txt, use
 
    ::
 
-    gmt sph2grd @EGM96_to_360.txt -GEGM96_to_360.nc -Rg -I1 -V
+    gmt sph2grd @EGM96_to_36.txt -GEGM96_to_36.nc -Rg -I1 -V
 
 Reference
 ---------


### PR DESCRIPTION
The sph2grd example references the remote file `@EGM96_to_360.txt`. There doesn't appear to be a file by that name on the GMT server, but there is "EGM96_to_36.txt". I'm assuming this should have been file referenced in the example. This pull requests changes the name of the remote file, and for consistency's sake changes the name of the outgrid as well.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
