### PR TITLE
Docs cleanup

### DIFF
--- a/doc/rst/source/explain_-q.rst_
+++ b/doc/rst/source/explain_-q.rst_
@@ -1,2 +1,2 @@
-**-q**\ [**i**\|\ **o**][~]\ *rows*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-q_full>`
-    Select input or output rows or data range(s) [all].
+**-q**\ [**i**\|\ **o**][~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-q_full>`
+    Select input or output rows or data limit(s) [all].

--- a/doc/rst/source/explain_-q_full.rst_
+++ b/doc/rst/source/explain_-q_full.rst_
@@ -3,7 +3,7 @@ The **-q** option
 
 **Syntax**
 
-**-q**\ [**i**\|\ **o**][~]\ *rows*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**]
+**-q**\ [**i**\|\ **o**][~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**]
     Select specific data rows to be read and/or written.
 
 **Description**

--- a/doc/rst/source/explain_-q_full.rst_
+++ b/doc/rst/source/explain_-q_full.rst_
@@ -23,6 +23,6 @@ Alternatively, use **+c**\ *col* to indicate that the arguments instead are min/
 column *col*. With **+c**\ *col*, only rows whose data for the given column *col* are within the range(s) given by the
 *min*/*max* limits are read (with **-qi**) or written (with **-qo**). **Note**: Because arguments may contain colons or
 be negative, your must specify *start*/*stop* instead of *start*\ [:*inc*]:*stop*. If *min* or *max* is not given we
-default to -infinity and + infinity, respectively (e.g., **-qi**\ 50/**+c**\ 2 will only write records whose z-values is ≥ 50).
+default to -infinity and + infinity, respectively (e.g., **-qo**\ 50/**+c**\ 2 will only write records whose z-values is ≥ 50).
 
 **Note**: Header records do not increase the row counters; only data records do.

--- a/doc/rst/source/explain_-q_full.rst_
+++ b/doc/rst/source/explain_-q_full.rst_
@@ -22,6 +22,7 @@ modifiers to control how the rows are counted [Default is **+a**]:
 Alternatively, use **+c**\ *col* to indicate that the arguments instead are min/max *data limits* for the values in
 column *col*. With **+c**\ *col*, only rows whose data for the given column *col* are within the range(s) given by the
 *min*/*max* limits are read (with **-qi**) or written (with **-qo**). **Note**: Because arguments may contain colons or
-be negative, your must specify *start*/*stop* instead of *start*\ [:*inc*]:*stop*.
+be negative, your must specify *start*/*stop* instead of *start*\ [:*inc*]:*stop*. If *min* or *max* is not given we
+default to -infinity and + infinity, respectively (e.g., **-qi**\ 50/**+c**\ 2 will only write records whose z-values is ≥ 50).
 
 **Note**: Header records do not increase the row counters; only data records do.

--- a/doc/rst/source/explain_-qi.rst_
+++ b/doc/rst/source/explain_-qi.rst_
@@ -1,2 +1,2 @@
-**-qi**\ [~]\ *rows*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-qi_full>`
-    Select input rows or data range(s) [default is all rows].
+**-qi**\ [~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-qi_full>`
+    Select input rows or data limit(s) [default is all rows].

--- a/doc/rst/source/explain_-qo.rst_
+++ b/doc/rst/source/explain_-qo.rst_
@@ -1,2 +1,2 @@
-**-qo**\ [~]\ *rows*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-qo_full>`
-    Select output rows or data range(s) [default is all rows].
+**-qo**\ [~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-qo_full>`
+    Select output rows or data limit(s) [default is all rows].

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7451,9 +7451,9 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 			GMT_Usage (API, -2, "Only accept input data records that contain the string \"pattern\". "
 				"Use -e~\"pattern\" to only accept data records that do NOT contain this pattern. "
 				"If your pattern begins with ~, escape it with \\~.  To match against "
-				"extended regular expressions use -e[~]/<regexp>/[i] (i for case-insensitive).");
-			GMT_Usage (API, 3, "+f Read patterns from <file> instead, one per line.");
-			GMT_Usage (API, -2, "To give a single pattern starting with +f, escape it with \\+f.");
+				"extended regular expressions use -e[~]/<regexp>/[i] (i for case-insensitive). "
+				"Use +f<file> to read patterns from a file instead, one pattern per line.");
+			GMT_Usage (API, -2, "Note: To give a single pattern starting with +f, escape it with \\+f.");
 			break;
 
 		case 'k':	/* -di option to tell GMT the relationship between NaN and a nan-proxy for input */
@@ -7636,10 +7636,10 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 		case 'w':	/* -w option for cyclicity */
 
 			GMT_Usage (API, 1, "\n%s", GMT_w_OPT);
-			GMT_Usage (API, -2, "Wrap selected column [0] with specified cyclicity: "
+			GMT_Usage (API, -2, "Wrap selected column [0] with specified cyclicity. "
 				"Absolute time: Append y|a|w|d|h|m|s for year, annual (by month), week, day, hour, minute, or second cycles. "
 				"Alternatively, append c<period>[/<phase>] for custom cyclicity [Default <phase> = 0].");
-			GMT_Usage (API, 3, "+c<col> Select another column than 0 (x) for wrapping.");
+			GMT_Usage (API, 3, "+c<col> Select another column than 0 (first) for wrapping.");
 			break;
 
 		case 's':	/* Output control for records where z are NaN */
@@ -9216,7 +9216,7 @@ GMT_LOCAL int gmtinit_parse_q_option_r (struct GMT_CTRL *GMT, unsigned int direc
 	/* Parsing of <rows> sequences */
 	while ((gmt_strtok (&arg[j], ",", &pos, p))) {	/* While it is not empty, process another range */
 		if (p[0] == '~') {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Only one reverse-the-test sign (~) is required before the first range in -q\n");
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Only one reverse-the-test sign (~) is allowed before the first range in -q\n");
 			return (GMT_PARSE_ERROR);
 		}
 		/* We can process A or A: or A- or A/ or A:B or A-B or A/B or :B or -B or /B */
@@ -9245,7 +9245,7 @@ GMT_LOCAL int gmtinit_parse_q_option_z (struct GMT_CTRL *GMT, unsigned int direc
 	/* Parsing of <range> sequences */
 	while ((gmt_strtok (&arg[j], ",", &pos, p))) {	/* While it is not empty, process another range */
 		if (p[0] == '~') {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Only one reverse-the-test sign (~) is required before the first range in -q\n");
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Only one reverse-the-test sign (~) is allowed before the first range in -q\n");
 			return (GMT_PARSE_ERROR);
 		}
 		/* We can process A or A/ or A/B or /B */

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -47,8 +47,8 @@
 #define GMT_di_OPT	"-di<nodata>"
 #define GMT_do_OPT	"-do<nodata>"
 #define GMT_ho_OPT	"-ho[<nrecs>][+c][+d][+m<segheader>][+r<remark>][+t<title>]"
-#define GMT_qi_OPT	"-qi[~]<rows>[,...][+c<col>][+a|f|s]"
-#define GMT_qo_OPT	"-qo[~]<rows>[,...][+c<col>][+a|f|s]"
+#define GMT_qi_OPT	"-qi[~]<rows>|<limits>[,...][+c<col>][+a|f|s]"
+#define GMT_qo_OPT	"-qo[~]<rows>|<limits>[,...][+c<col>][+a|f|s]"
 #define GMT_PAR_OPT	"--PAR=<value>"
 
 #ifdef GMT_MP_ENABLED


### PR DESCRIPTION
For **-q**, explain that min/max has defaults if one is not given.  Also, since we return an error if more tha one ~ is given then only one is allowed (not required).
For **-e**, the **+f**_file_ is not a modifier but the way to selectpatterns a file.  I do not like that since it is not consistent with the rest of GMT - will get back to that.  
For **-w**: Replace first colon with period and use (first) rather than (x)