### PR TITLE
Do not prevent sample1d from sampling a duplicate knots

### DIFF
--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -325,7 +325,8 @@ static int parse (struct GMT_CTRL *GMT, struct SAMPLE1D_CTRL *Ctrl, struct GMT_O
 		Ctrl->T.active = true;
 	}
 	if (Ctrl->T.active) {	/* Do this one here since we need Ctrl->N.col to be set first, if selected */
-		n_errors += gmt_parse_array (GMT, 'T', t_arg, &(Ctrl->T.T), GMT_ARRAY_TIME | GMT_ARRAY_DIST | GMT_ARRAY_NOMINMAX | GMT_ARRAY_UNIQUE, Ctrl->N.col);
+		//n_errors += gmt_parse_array (GMT, 'T', t_arg, &(Ctrl->T.T), GMT_ARRAY_TIME | GMT_ARRAY_DIST | GMT_ARRAY_NOMINMAX | GMT_ARRAY_UNIQUE, Ctrl->N.col);
+		n_errors += gmt_parse_array (GMT, 'T', t_arg, &(Ctrl->T.T), GMT_ARRAY_TIME | GMT_ARRAY_DIST | GMT_ARRAY_NOMINMAX, Ctrl->N.col);
 	}
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->A.loxo && GMT->common.j.mode == GMT_GEODESIC,


### PR DESCRIPTION
This PR fixes the concern raised in [this](https://forum.generic-mapping-tools.org/t/sample1d-dont-eliminate-duplicate-values/1976/2) forum post.  Whatever the initial issue was related to sample1d discussing the referred [post](https://forum.generic-mapping-tools.org/t/sample1d-on-gmt6-1-and-gmt6-2/830/5), there should never be a restriction on whether we can sample a spline more than once in the same spot.  That restriction falls on the data defining the spline only: These must be monotonically increasing and cannot have duplicate points.
I will ask Sabin to remind us what problem he was running into - whatever it was the removal of duplicates from the -Tknots is not the solution.  If it comes to it, we can add a modifier to -T to force removal of duplicates even in the knots file.
