### PR TITLE
Feautures.rst. Typo in HDF4 example file name?

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -2769,7 +2769,7 @@ simple example using :doc:`/grdinfo` would be
 
    ::
 
-    gmt grdinfo A20030012003365.L3m_YR_NSST_9=gd?HDF4_SDS:UNKNOWN:"A20030012003365.L3m_YR_NSST_9:0"
+    gmt grdinfo A20030012003365.L3m_YR_NSST_9=gd?HDF4_SDS:UNKNOWN:"A20030012003365.L3m_YR_NSST_9":0
 
     HDF4_SDS:UNKNOWN:A20030012003365.L3m_YR_NSST_9:0: Title: Grid imported via GDAL
     HDF4_SDS:UNKNOWN:A20030012003365.L3m_YR_NSST_9:0: Command:
@@ -2790,7 +2790,7 @@ via :doc:`/grdmath` first, i.e.,
 
    ::
 
-    gmt grdmath A20030012003365.L3m_YR_NSST_9=gd?HDF4_SDS:UNKNOWN:"A20030012003365.L3m_YR_NSST_9:0" \
+    gmt grdmath A20030012003365.L3m_YR_NSST_9=gd?HDF4_SDS:UNKNOWN:"A20030012003365.L3m_YR_NSST_9":0 \
                 0.000717185 MUL -2 ADD = sst.nc
 
 then plot the ``sst.nc`` directly.


### PR DESCRIPTION
In line 2761 the subset name is: HDF4_SDS:UNKNOWN:"A20030012003365.L3m_YR_NSST_9":0 (notice the position of the last ").
I change the position of " in lines 2772 and 2793.

I am not sure that it is a typo. I understand that the name should be exactly the same.