### PR TITLE
Enable gridlines when colormap -B implies it

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -102,7 +102,7 @@
 #	include <mex.h>
 #endif
 
-/* These are used in gmtinit_init_custom_annot and gmtinit_decode_tinfo onlly */
+/* These are used in gmtinit_init_custom_annot and gmtinit_decode_tinfo only */
 #define GMT_ITEM_ANNOT		0
 #define GMT_ITEM_INTVAL		1
 #define GMT_ITEM_TICK		2

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5971,8 +5971,11 @@ void gmt_plot_line (struct GMT_CTRL *GMT, double *x, double *y, unsigned int *pe
 }
 
 void gmt_xy_axis2 (struct GMT_CTRL *GMT, double x0, double y0, double length, double val0, double val1, struct GMT_PLOT_AXIS *A, bool below, bool annotate, unsigned side) {
+    /* Only used in psscale.c.  Because gmt_xy_axis does not do gridlines (done in gmt_map_basemap at a higher level),
+     * we must call for gridlines directly here */
 	if (annotate) side |= GMT_AXIS_BARB;
 	gmt_xy_axis (GMT, x0, y0, length, val0, val1, A, below, side);
+    gmtplot_map_gridlines (GMT, GMT->PSL, GMT->common.R.wesn[XLO], GMT->common.R.wesn[XHI], GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI]);
 }
 
 void gmt_linearx_grid (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n, double dval) {
@@ -6096,7 +6099,7 @@ GMT_LOCAL void gmtplot_map_griditems (struct GMT_CTRL *GMT) {
 
 	if (GMT->current.proj.got_azimuths) gmt_M_uint_swap (GMT->current.map.frame.side[E_SIDE], GMT->current.map.frame.side[W_SIDE]);	/* Undo temporary swap */
 
-	GMT->current.map.frame.gridline_plotted = true;	/* Since gmt_map_gridlines is called in gmt_map_basemap we flag if we already have done this step */
+	GMT->current.map.frame.gridline_plotted = true;	/* Since gmtplot_map_gridlines is called in gmt_map_basemap we flag if we already have done this step */
 }
 
 GMT_LOCAL void gmtplot_map_tick_marks (struct GMT_CTRL *GMT) {

--- a/test/pslegend/legcpt.ps
+++ b/test/pslegend/legcpt.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.0.0_1ded948 [64-bit] Document from psbasemap
+%%Title: GMT v6.3.0_9eb0048-dirty_2021.08.16 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Dec  6 10:52:58 2018
+%%CreationDate: Mon Aug 16 11:17:13 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -112,9 +112,11 @@
   PSL_eps_state restore
 }!
 /PSL_transp {
-  /.setopacityalpha where {pop .setblendmode .setopacityalpha}{
-  /pdfmark where {pop [ /BM exch /CA exch dup /ca exch /SetTransparency pdfmark}
-  {pop pop} ifelse} ifelse
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
 }!
 /Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
@@ -253,9 +255,16 @@ PSL_pathtextdict begin
     V cpx cpy itransform T
       dy dx atan R
       0 justy M
-      char show
-      0 justy neg G
-      currentpoint transform
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
       /cpy exch def /cpx exch def
     U /setdist setdist charwidth add def
   } def
@@ -279,6 +288,9 @@ end
   /PSL_strokeline false def
   /PSL_fillbox psl_bits 128 and 128 eq def
   /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
   /PSL_n_paths1 PSL_n_paths 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
   PSL_clippath {clipsave N clippath} if
@@ -326,8 +338,10 @@ end
     node_type 1 eq
     {n 0 eq
       {PSL_CT_drawline}
-      {	PSL_CT_reversepath
-	PSL_CT_textline} ifelse
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
       /j 0 def
       PSL_xp j PSL_xx i get put
       PSL_yp j PSL_yy i get put
@@ -336,9 +350,7 @@ end
   n 0 eq {PSL_CT_drawline} if
 } def
 /PSL_CT_textline
-{ /psl_fnt PSL_fnt k get def
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
-  psl_fnt cvx exec
+{ PSL_fnt k get cvx exec
   /PSL_height PSL_heights k get def
   PSL_placetext	{PSL_CT_placelabel} if
   PSL_clippath {PSL_CT_clippath} if
@@ -556,6 +568,9 @@ end
   /PSL_rounded psl_bits 32 and 32 eq def
   /PSL_fillbox psl_bits 128 and 128 eq def
   /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
   /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
   /PSL_usebox PSL_fillbox PSL_drawbox or def
   0 1 PSL_n_labels_minus_1
@@ -570,7 +585,15 @@ end
       PSL_drawbox {V PSL_setboxpen S U} if
       N
     } if
-    PSL_placetext {PSL_ST_place_label} if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
   } for
 } def
 /PSL_straight_path_clip
@@ -594,9 +617,7 @@ end
   /psl_xp PSL_txt_x psl_k get def
   /psl_yp PSL_txt_y psl_k get def
   /psl_label PSL_label_str psl_k get def
-  /psl_fnt PSL_label_font psl_k get def
-  psl_fnt cvx exec
-  psl_fnt (FS) search {pop pop pop /PSL_fmode 2 def} {pop /PSL_fmode 1 def} ifelse
+  PSL_label_font psl_k get cvx exec
   /PSL_height PSL_heights psl_k get def
   /psl_boxH PSL_height PSL_gap_y 2 mul add def
   /PSL_just PSL_label_justify psl_k get def
@@ -639,8 +660,21 @@ end
 {
     V psl_xp psl_yp T psl_angle R
     psl_SW PSL_justx mul psl_y0 M
-    psl_label dup sd neg 0 exch G
-    PSL_fmode 1 eq {show} {false charpath V S U fs N} ifelse
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
     U
 } def
 /PSL_nclip 0 def
@@ -651,6 +685,7 @@ end
 
 %%BeginSetup
 /PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
 PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
 %%EndSetup
 
@@ -662,8 +697,9 @@ V 0.06 0.06 scale
 
 /PSL_page_xsize 10200 def
 /PSL_page_ysize 13200 def
-/PSL_completion {} def
-/PSL_movie_completion {} def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
 %PSL_End_Header
 gsave
 0 A
@@ -674,15 +710,15 @@ O0
 % PostScript produced by:
 %@GMT: gmt psbasemap -JX15c/9c -R0/25/0/3 -P -Bafg '-B+glightgray+tpsbasemap sets -B, pslegend sets -B (bar)' -K -Xc
 %@PROJ: xy 0.00000000 25.00000000 0.00000000 3.00000000 0.000 25.000 0.000 3.000 +xy
-%GMTBoundingBox: -212.598 72 425.197 255.118
+%GMTBoundingBox: -212.598425197 72 425.196850394 255.118110236
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.827 A} FS
 -7087 0 0 4252 7087 0 3 0 0 SP
-25 W
 4 W
+0 A
 0 0 M
 0 4252 D
 S
@@ -713,8 +749,9 @@ S
 0 4252 M
 7087 0 D
 S
-2 setlinecap
 25 W
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
 N 0 4252 M 0 -4252 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -723,8 +760,8 @@ N 0 0 M -83 0 D S
 N 0 1417 M -83 0 D S
 N 0 2835 M -83 0 D S
 N 0 4252 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
@@ -765,8 +802,8 @@ N 0 0 M 83 0 D S
 N 0 1417 M 83 0 D S
 N 0 2835 M 83 0 D S
 N 0 4252 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (0) sw mx
 (1) sw mx
 (2) sw mx
@@ -806,8 +843,8 @@ N 2835 0 M 0 -83 D S
 N 4252 0 M 0 -83 D S
 N 5669 0 M 0 -83 D S
 N 7087 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (5) sh mx
 (10) sh mx
@@ -861,8 +898,8 @@ N 2835 0 M 0 83 D S
 N 4252 0 M 0 83 D S
 N 5669 0 M 0 83 D S
 N 7087 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (0) sh mx
 (5) sh mx
 (10) sh mx
@@ -908,9 +945,10 @@ N 6803 0 M 0 42 D S
 0 -4252 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-3543 4252 PSL_H_y add M
+3543 4252 PSL_H_y add PSL_slant_y add M
 400 F0
 (psbasemap sets -B, pslegend sets -B \(bar\)) bc Z
+0 A
 %%EndObject
 0 A
 FQ
@@ -923,7 +961,9 @@ O0
 %%BeginObject PSL_Layer_2
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
+/PSL_legend_box_width 5669 def
+/PSL_legend_box_height 2126 def
 709 1063 T
 {1 1 0.878 C} FS
 2126 5669 2835 1063 Sr
@@ -935,12 +975,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psscale -Ccol.cpt -O -K -Dx2.3622i/1.37999i+w3.93701i/1c+h+jTC -Ba1000f100g500+lm --GMT_HISTORY=false
+%@GMT: gmt psscale -Ccol.cpt -O -K -Dx2.3622i/1.37999i+w3.93701i/1c+h+jTC -Ba1000f100g500+lm --GMT_HISTORY=readonly
 %@PROJ: xy -8000.00000000 0.00000000 0.00000000 0.39370079 -8000.000 0.000 0.000 0.394 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 472 1184 T
 25 W
 V N 0 0 T 4724 472 scale /DeviceRGB setcolorspace
@@ -985,8 +1025,8 @@ N 2953 0 M 0 -83 D S
 N 3543 0 M 0 -83 D S
 N 4134 0 M 0 -83 D S
 N 4724 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (”8000) sh mx
@@ -1143,6 +1183,60 @@ S
 4724 0 M
 0 472 D
 S
+0 0 M
+4724 0 D
+S
+0 0 M
+0 472 D
+S
+295 0 M
+0 472 D
+S
+591 0 M
+0 472 D
+S
+886 0 M
+0 472 D
+S
+1181 0 M
+0 472 D
+S
+1476 0 M
+0 472 D
+S
+1772 0 M
+0 472 D
+S
+2067 0 M
+0 472 D
+S
+2362 0 M
+0 472 D
+S
+2657 0 M
+0 472 D
+S
+2953 0 M
+0 472 D
+S
+3248 0 M
+0 472 D
+S
+3543 0 M
+0 472 D
+S
+3839 0 M
+0 472 D
+S
+4134 0 M
+0 472 D
+S
+4429 0 M
+0 472 D
+S
+4724 0 M
+0 472 D
+S
 2362 -446 M 267 F0
 (m) tc Z
 0 setlinecap
@@ -1159,12 +1253,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/5.90551/0/3.54331 -Jx1i -O -K -N -F+f+j @GMTAPI@-000001 --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/5.90551/0/3.54331 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000001 --GMT_HISTORY=readonly
 %@PROJ: xy 0.00000000 5.90551000 0.00000000 3.54331000 0.000 5.906 0.000 3.543 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 2835 1818 M 267 F1
 (10 events during Monday to Friday) bc Z
@@ -1182,11 +1276,11 @@ O0
 %%BeginObject PSL_Layer_5
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 {0.827 A} FS
 -7087 0 0 4252 7087 0 3 0 0 SP
-25 W
 4 W
+0 A
 0 0 M
 0 4252 D
 S
@@ -1217,8 +1311,9 @@ S
 0 4252 M
 7087 0 D
 S
-2 setlinecap
 25 W
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
 N 0 4252 M 0 -4252 D S
 /PSL_A0_y 83 def
 /PSL_A1_y 0 def
@@ -1227,8 +1322,8 @@ N 0 0 M -83 0 D S
 N 0 1417 M -83 0 D S
 N 0 2835 M -83 0 D S
 N 0 4252 M -83 0 D S
-/PSL_AH0 0
 /MM {neg exch M} def
+/PSL_AH0 0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 200 F0
 (0) sw mx
@@ -1269,8 +1364,8 @@ N 0 0 M 83 0 D S
 N 0 1417 M 83 0 D S
 N 0 2835 M 83 0 D S
 N 0 4252 M 83 0 D S
-/PSL_AH0 0
 /MM {exch M} def
+/PSL_AH0 0
 (0) sw mx
 (1) sw mx
 (2) sw mx
@@ -1310,8 +1405,8 @@ N 2835 0 M 0 -83 D S
 N 4252 0 M 0 -83 D S
 N 5669 0 M 0 -83 D S
 N 7087 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 (0) sh mx
 (5) sh mx
 (10) sh mx
@@ -1365,8 +1460,8 @@ N 2835 0 M 0 83 D S
 N 4252 0 M 0 83 D S
 N 5669 0 M 0 83 D S
 N 7087 0 M 0 83 D S
-/PSL_AH0 0
 /MM {M} def
+/PSL_AH0 0
 (0) sh mx
 (5) sh mx
 (10) sh mx
@@ -1412,11 +1507,14 @@ N 6803 0 M 0 42 D S
 0 -4252 T
 0 setlinecap
 /PSL_H_y PSL_L_y PSL_LH add 233 add def
-3543 4252 PSL_H_y add M
+3543 4252 PSL_H_y add PSL_slant_y add M
 400 F0
 (pslegend sets both frame/bar -B) bc Z
+/PSL_legend_box_width 5669 def
+/PSL_legend_box_height 2126 def
 709 1063 T
 {1 1 0.878 C} FS
+O0
 2126 5669 2835 1063 Sr
 17 W
 N 0 1711 M 5669 0 D S
@@ -1426,12 +1524,12 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt psscale -Ccol.cpt -O -K -Dx2.3622i/1.37999i+w3.93701i/1c+h+jTC -Ba1000f100g500+lm --GMT_HISTORY=false
+%@GMT: gmt psscale -Ccol.cpt -O -K -Dx2.3622i/1.37999i+w3.93701i/1c+h+jTC -Ba1000f100g500+lm --GMT_HISTORY=readonly
 %@PROJ: xy -8000.00000000 0.00000000 0.00000000 0.39370079 -8000.000 0.000 0.000 0.394 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 472 1184 T
 25 W
 V N 0 0 T 4724 472 scale /DeviceRGB setcolorspace
@@ -1476,8 +1574,8 @@ N 2953 0 M 0 -83 D S
 N 3543 0 M 0 -83 D S
 N 4134 0 M 0 -83 D S
 N 4724 0 M 0 -83 D S
-/PSL_AH0 0
 /MM {neg M} def
+/PSL_AH0 0
 200 F0
 (”8000) sh mx
 (”7000) sh mx
@@ -1633,6 +1731,60 @@ S
 4724 0 M
 0 472 D
 S
+0 0 M
+4724 0 D
+S
+0 0 M
+0 472 D
+S
+295 0 M
+0 472 D
+S
+591 0 M
+0 472 D
+S
+886 0 M
+0 472 D
+S
+1181 0 M
+0 472 D
+S
+1476 0 M
+0 472 D
+S
+1772 0 M
+0 472 D
+S
+2067 0 M
+0 472 D
+S
+2362 0 M
+0 472 D
+S
+2657 0 M
+0 472 D
+S
+2953 0 M
+0 472 D
+S
+3248 0 M
+0 472 D
+S
+3543 0 M
+0 472 D
+S
+3839 0 M
+0 472 D
+S
+4134 0 M
+0 472 D
+S
+4429 0 M
+0 472 D
+S
+4724 0 M
+0 472 D
+S
 2362 -446 M 267 F0
 (m) tc Z
 0 setlinecap
@@ -1649,21 +1801,25 @@ O0
 0 0 TM
 
 % PostScript produced by:
-%@GMT: gmt pstext -R0/5.90551/0/3.54331 -Jx1i -O -K -N -F+f+j @GMTAPI@-000001 --GMT_HISTORY=false
+%@GMT: gmt pstext -R0/5.90551/0/3.54331 -Jx1i -O -K -N -F+f+j @GMTAPI@-S-I-D-D-N-N-000001 --GMT_HISTORY=readonly
 %@PROJ: xy 0.00000000 5.90551000 0.00000000 3.54331000 0.000 5.906 0.000 3.543 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
 0 setlinejoin
-3.32551 setmiterlimit
+3.32550952342 setmiterlimit
 PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 2835 1818 M 267 F1
 (10 events during Monday to Friday) bc Z
 %%EndObject
 -709 -1063 T
+25 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
 %%EndObject
 
 grestore
-PSL_movie_completion /PSL_movie_completion {} def
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
 %PSL_Begin_Trailer
 %%PageTrailer
 U


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/more-colorbar-user-errors-or-bugs/1983) for background.  Turns out that when **colormap** used **-B** we did not draw gridlines since the Cartesian axis function used by design skipped gridlines as those were expected to be done later in the _gmt_map_basemap_ function.  Except for **colormap** which does not use _gmt_map_basemap_ and hence there was no call to plot gridlines.  This PR fixes that issue, updates a test original PS (_legcpt.sh_) that now failed (since it should have had gridlines but did not), and did some minor coding improvements to make it easier to understand the algorithms related to custom annotations.
