### PR TITLE
Fix errors in sample1d for monotonically decreasing time

### DIFF
--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -491,12 +491,12 @@ EXTERN_MSC int GMT_sample1d (void *V_API, int mode, void *args) {
 				if (S->data[Ctrl->N.col][0] > S->data[Ctrl->N.col][S->n_rows-1]) {	/* t-column is monotonically decreasing */
 					min = (Ctrl->T.T.delay[GMT_X]) ? floor (S->data[Ctrl->N.col][0] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.min;
 					max = (Ctrl->T.T.delay[GMT_Y]) ? ceil (S->data[Ctrl->N.col][S->n_rows-1] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.max;
-					Ctrl->T.T.reverse = true;	/* Flag we are monotonically decreasing in value */
+					Ctrl->T.T.reverse = true;	/* Flag we are monotonically decreasing in time for this segment */
 				}
 				else {
 					min = (Ctrl->T.T.delay[GMT_X]) ? ceil (S->data[Ctrl->N.col][0] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.min;
 					max = (Ctrl->T.T.delay[GMT_Y]) ? floor (S->data[Ctrl->N.col][S->n_rows-1] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.max;
-					Ctrl->T.T.reverse = false;	/* Flag we are monotonically increasing in value */
+					Ctrl->T.T.reverse = false;	/* Flag we are monotonically increasing in time for this segment */
 				}
 				if (gmt_create_array(GMT, 'T', &(Ctrl->T.T), &min, &max) != GMT_NOERROR) {
 					GMT_Report(API, GMT_MSG_WARNING, "Segment %" PRIu64 " in table %" PRIu64 " had troubles.\n", seg, tbl);

--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -488,8 +488,16 @@ EXTERN_MSC int GMT_sample1d (void *V_API, int mode, void *args) {
 			}
 			else {	/* Generate evenly spaced output */
 				double min, max;
-				min = (Ctrl->T.T.delay[GMT_X]) ? ceil (S->data[Ctrl->N.col][0] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.min;
-				max = (Ctrl->T.T.delay[GMT_Y]) ? floor (S->data[Ctrl->N.col][S->n_rows-1] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.max;
+				if (S->data[Ctrl->N.col][0] > S->data[Ctrl->N.col][S->n_rows-1]) {	/* t-column is monotonically decreasing */
+					min = (Ctrl->T.T.delay[GMT_X]) ? floor (S->data[Ctrl->N.col][0] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.min;
+					max = (Ctrl->T.T.delay[GMT_Y]) ? ceil (S->data[Ctrl->N.col][S->n_rows-1] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.max;
+					Ctrl->T.T.reverse = true;	/* Flag we are monotonically decreasing in value */
+				}
+				else {
+					min = (Ctrl->T.T.delay[GMT_X]) ? ceil (S->data[Ctrl->N.col][0] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.min;
+					max = (Ctrl->T.T.delay[GMT_Y]) ? floor (S->data[Ctrl->N.col][S->n_rows-1] / Ctrl->T.T.inc) * Ctrl->T.T.inc : Ctrl->T.T.max;
+					Ctrl->T.T.reverse = false;	/* Flag we are monotonically increasing in value */
+				}
 				if (gmt_create_array(GMT, 'T', &(Ctrl->T.T), &min, &max) != GMT_NOERROR) {
 					GMT_Report(API, GMT_MSG_WARNING, "Segment %" PRIu64 " in table %" PRIu64 " had troubles.\n", seg, tbl);
 					continue;


### PR DESCRIPTION
Turns out that while some parts of the new array machinery were aware of reversing time, others did not play ball, leading to errors.  This PR ensures that we check for this condition so that we do not pass max < min to functions that cannot handle that condition.
All tests pass.

Ping to developers, please review and approve asap as this is a bad bug and is holding back someone's workflow.