### PR TITLE
Complete gmt info -T for absolute time data column

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -1230,8 +1230,8 @@ Calendar/Time Parameters
     **TIME_UNIT**
         Specifies the units of relative time data since epoch (see
         :term:`TIME_EPOCH`). Choose **y** (year - assumes all years are 365.2425
-        days), **o** (month - assumes all months are of equal length y/12), **d**
-        (day), **h** (hour), **m** (minute), or **s** (second) [default is **s**].
+        days), **o** (month - assumes all months are of equal length y/12), *ww*
+        (week) **d** (day), **h** (hour), **m** (minute), or **s** (second) [default is **s**].
 
     **TIME_WEEK_START**
         When weeks are indicated on time axes, this parameter determines the

--- a/doc/rst/source/gmtinfo.rst
+++ b/doc/rst/source/gmtinfo.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-I|\ [**b**\|\ **e**\|\ **f**\|\ **p**\|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...][**+e**\|\ **r**\|\ **R**] ]
 [ |-L| ]
 [ |-S|\ [**x**][**y**] ]
-[ |-T|\ *dz*\ [**+c**\ *col*] ]
+[ |-T|\ *dz*\ [**y**\|\ **o**\|\ **w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**][**+c**\ *col*] ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
@@ -156,9 +156,11 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ *dz*\ [**+c**\ *col*]
+**-T**\ *dz*\ [**y**\|\ **o**\|\ **w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**][**+c**\ *col*]
     Report the min/max of the first (0'th) column to the nearest multiple of *dz* and output this as the
     string **-T**\ *zmin/zmax/dz*. To use another column, append **+c**\ *col*. Cannot be used together with **-I**.
+    **Note**: If your column has absolute time then you may append a valid time unit to *dz*, or rely
+    on the current setting of :term:`GMT_TIME_UNIT` [**s**].
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: explain_-V.rst_

--- a/doc/rst/source/gmtinfo.rst
+++ b/doc/rst/source/gmtinfo.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-I|\ [**b**\|\ **e**\|\ **f**\|\ **p**\|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...][**+e**\|\ **r**\|\ **R**] ]
 [ |-L| ]
 [ |-S|\ [**x**][**y**] ]
-[ |-T|\ *dz*\ [**y**\|\ **o**\|\ **w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**][**+c**\ *col*] ]
+[ |-T|\ *dz*\ [**w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**][**+c**\ *col*] ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
@@ -156,11 +156,11 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ *dz*\ [**y**\|\ **o**\|\ **w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**][**+c**\ *col*]
+**-T**\ *dz*\ [**w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**][**+c**\ *col*]
     Report the min/max of the first (0'th) column to the nearest multiple of *dz* and output this as the
     string **-T**\ *zmin/zmax/dz*. To use another column, append **+c**\ *col*. Cannot be used together with **-I**.
-    **Note**: If your column has absolute time then you may append a valid time unit to *dz*, or rely
-    on the current setting of :term:`GMT_TIME_UNIT` [**s**].
+    **Note**: If your column has absolute time then you may append a valid fixed time unit to *dz*, or rely
+    on the current setting of :term:`TIME_UNIT` [**s**].
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: explain_-V.rst_

--- a/src/gmt_common_string.c
+++ b/src/gmt_common_string.c
@@ -873,3 +873,11 @@ char *basename(char *path) {
 	 assert(strlen(newstr) == newstr_len);
 	 return newstr;
 }
+
+#ifndef HAVE_CHARCAT	/* Do not think this is a standard function but just in case */
+char *charcat (char *dest, const char add) {
+	/* Simple function to add a single character to a string */
+	if (dest) dest[strlen(dest)] = add;
+	return (dest);
+}
+#endif

--- a/src/gmt_common_string.c
+++ b/src/gmt_common_string.c
@@ -875,7 +875,7 @@ char *basename(char *path) {
 }
 
 #ifndef HAVE_CHARCAT	/* Do not think this is a standard function but just in case */
-char *charcat (char *dest, const char add) {
+char *chrcat (char *dest, const char add) {
 	/* Simple function to add a single character to a string. No check if there is room
 	 * only that it is not NULL, and we explicitly terminate the updated string */
 	if (dest) {

--- a/src/gmt_common_string.c
+++ b/src/gmt_common_string.c
@@ -876,8 +876,12 @@ char *basename(char *path) {
 
 #ifndef HAVE_CHARCAT	/* Do not think this is a standard function but just in case */
 char *charcat (char *dest, const char add) {
-	/* Simple function to add a single character to a string */
-	if (dest) dest[strlen(dest)] = add;
+	/* Simple function to add a single character to a string. No check if there is room
+	 * only that it is not NULL, and we explicitly terminate the updated string */
+	if (dest) {
+		dest[strlen(dest)] = add;
+		dest[strlen(dest)] = '\0';
+	}
 	return (dest);
 }
 #endif

--- a/src/gmt_common_string.h
+++ b/src/gmt_common_string.h
@@ -87,6 +87,10 @@ EXTERN_MSC char *stresep (char **stringp, const char *delim, int esc);
 EXTERN_MSC char *basename(char *path);
 #endif
 
+#ifndef HAVE_CHARCAT    /* Do not think this is a standard function but just in case */
+EXTERN_MSC char *charcat (char *dest, const char add);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gmt_common_string.h
+++ b/src/gmt_common_string.h
@@ -88,7 +88,7 @@ EXTERN_MSC char *basename(char *path);
 #endif
 
 #ifndef HAVE_CHARCAT    /* Do not think this is a standard function but just in case */
-EXTERN_MSC char *charcat (char *dest, const char add);
+EXTERN_MSC char *chrcat (char *dest, const char add);
 #endif
 
 #ifdef __cplusplus

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -194,12 +194,14 @@ enum GMT_time_period {
 #define GMT_LEN_UNITS	"dmsefkMnu"	/* Distances in arc-{degree,minute,second} or meter, foot, km, Mile, nautical mile, survey foot */
 #define GMT_ARC_UNITS	"dms"		/* Distances in arc-{degree,minute,second}t */
 #define GMT_TIME_UNITS	"yowdhms"	/* Time increments in year, month, week, day, hour, min, sec */
+#define GMT_TIME_FIX_UNITS	"wdhms"	/* Fixed time increment units */
 #define GMT_TIME_VAR_UNITS	"yo"	/* Variable time increments in year or month*/
 #define GMT_WESN_UNITS	"WESN"		/* Sign-letters for geographic coordinates */
 #define GMT_DIM_UNITS_DISPLAY	"c|i|p"			/* Same, used to display as options */
 #define GMT_LEN_UNITS_DISPLAY	"d|m|s|e|f|k|M|n|u"	/* Same, used to display as options */
 #define GMT_LEN_UNITS2_DISPLAY	"e|f|k|M|n|u"		/* Same, used to display as options */
 #define GMT_TIME_UNITS_DISPLAY	"y|o|w|d|h|m|s"		/* Same, used to display as options */
+#define GMT_TIME_FIX_UNITS_DISPLAY	"w|d|h|m|s"		/* Same, used to display as options */
 #define GMT_DEG2SEC_F	3600.0
 #define GMT_DEG2SEC_I	3600
 #define GMT_SEC2DEG	(1.0 / GMT_DEG2SEC_F)
@@ -214,6 +216,9 @@ enum GMT_time_period {
 #define GMT_HR2DAY	(1.0 / GMT_DAY2HR_F)
 #define GMT_WEEK2DAY_F	7.0
 #define GMT_WEEK2DAY_I	7
+#define GMT_WEEK2SEC_F	604800.0
+#define GMT_WEEK2SEC_I	604800
+#define GMT_SEC2WEEK	(1.0 / GMT_WEEK2SEC_F)
 #define GMT_DAY2WEEK	(1.0 / GMT_WEEK2DAY_F)
 #define GMT_DAY2MIN_F	1440.0
 #define GMT_DAY2MIN_I	1440

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -17410,38 +17410,34 @@ int gmt_init_time_system_structure (struct GMT_CTRL *GMT, struct GMT_TIME_SYSTEM
 
 	/* Check the unit sanity */
 	switch (time_system->unit) {
-		case 'y':
-		case 'Y':
+		case 'y':	case 'Y':
 			/* This is a kludge: we assume all years are the same length, thinking that a user
 			with decimal years doesn't care about precise time.  To do this right would
 			take an entirely different scheme, not a simple unit conversion. */
 			time_system->scale = GMT_YR2SEC_F;
 			break;
-		case 'o':
-		case 'O':
+		case 'o':	case 'O':
 			/* This is also a kludge: we assume all months are the same length, thinking that a user
 			with decimal years doesn't care about precise time.  To do this right would
 			take an entirely different scheme, not a simple unit conversion. */
 			time_system->scale = GMT_MON2SEC_F;
 			break;
-		case 'd':
-		case 'D':
+		case 'w':	case 'W':
+			time_system->scale = GMT_WEEK2SEC_F;
+			break;
+		case 'd':	case 'D':
 			time_system->scale = GMT_DAY2SEC_F;
 			break;
-		case 'h':
-		case 'H':
+		case 'h':	case 'H':
 			time_system->scale = GMT_HR2SEC_F;
 			break;
-		case 'm':
-		case 'M':
+		case 'm':	case 'M':
 			time_system->scale = GMT_MIN2SEC_F;
 			break;
-		case 's':
-		case 'S':
+		case 's':	case 'S':
 			time_system->scale = 1.0;
 			break;
-		case 'c':
-		case 'C':
+		case 'c':	case 'C':
 			if (gmt_M_compat_check (GMT, 4)) {
 				GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Unit c (seconds) is deprecated; use s instead.\n");
 				time_system->scale = 1.0;
@@ -17461,9 +17457,9 @@ int gmt_init_time_system_structure (struct GMT_CTRL *GMT, struct GMT_TIME_SYSTEM
 	if (gmtinit_scanf_epoch (GMT, time_system->epoch, &time_system->rata_die, &time_system->epoch_t0)) error += 2;
 
 	if (error & 1) {
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "TIME_UNIT is invalid.  Default assumed.\n");
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Choose one only from y o d h m s\n");
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Corresponding to year month day hour minute second\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "TIME_UNIT is invalid.  Default second is assumed.\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Choose one only from %s\n", GMT_TIME_UNITS_DISPLAY);
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Corresponding to year month week day hour minute second\n");
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Note year and month are simply defined (365.2425 days and 1/12 of a year)\n");
 	}
 	if (error & 2) {

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -127,9 +127,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<table>] [-Aa|t|s] [-C] [-D[<dx>[/<dy>]]] [-EL|l|H|h[<col>]] "
-		"[-Fi|d|t] [-I[b|e|f|p|s]<dx>[/<dy>[/<dz>..]][+e|r|R<incs>]] [-L] [-S[x][y]] [-T<dz>[+c<col>]] "
+		"[-Fi|d|t] [-I[b|e|f|p|s]<dx>[/<dy>[/<dz>..]][+e|r|R<incs>]] [-L] [-S[x][y]] [-T<dz>[%s][+c<col>]] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]",
-		name, GMT_V_OPT, GMT_a_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT,
+		name, GMT_TIME_UNITS_DISPLAY, GMT_V_OPT, GMT_a_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT,
 		GMT_i_OPT, GMT_o_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -168,8 +168,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "-Sx: Leaves space for horizontal error bar using value in third (2) column.");
 	GMT_Usage (API, 3, "-Sy: Leaves space for vertical error bar using value in third (2) column.");
 	GMT_Usage (API, 3, "-S or -Sxy: Leaves space for both error bars using values in third&fourth (2&3) columns.");
-	GMT_Usage (API, 1, "\n-T<dz>[+c<col>] Return textstring -Tzmin/zmax/dz to nearest multiple of the given dz. "
-		"Calculations are based on the first (0) column; append +c<col> to use another column.");
+	GMT_Usage (API, 1, "\n-T<dz>[%s][+c<col>] Return textstring -Tzmin/zmax/dz to nearest multiple of the given dz. "
+		"Note: Calculations are based on the first (0) column; append +c<col> to use another column. "
+		"If the column has absolute time you may append a valid time unit to dz [Default is set by GMT_TIME_UNIT].",
+		GMT_TIME_UNITS_DISPLAY);
 	GMT_Option (API, "V,a");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Reports the names and data types of the aspatial fields.\n");
 	GMT_Option (API, "bi2,d,e,f,g,h,i,o,qi,r,s,w,:,.");
@@ -336,11 +338,18 @@ static int parse (struct GMT_CTRL *GMT, struct GMTINFO_CTRL *Ctrl, struct GMT_OP
 					n_errors++;
 				}
 				else {	/* Modern syntax and parsing */
+					char unit = 0;
+					size_t L;
 					if ((c = strstr (opt->arg, "+c"))) {
 						Ctrl->T.col = atoi (&c[2]);
 						c[0] = '\0';	/* Temporarily hide the modifier */
 					}
 					Ctrl->T.inc = atof (opt->arg);
+					if ((L = strlen (opt->arg))) unit = opt->arg[L-1];
+					if (L && strchr (GMT_TIME_UNITS, unit)) {	/* Change to another valid time unit */
+						API->GMT->current.setting.time_system.unit = unit;
+						(void) gmt_init_time_system_structure (API->GMT, &API->GMT->current.setting.time_system);
+					}
 					if (c) c[0] = '+';	/* Restore the modifier */
 				}
 				break;
@@ -700,12 +709,20 @@ EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, wesn[YHI], GMT_Y);	strcat (record, &buffer[i]);
 			}
 			else if (Ctrl->T.active) {	/* Return -T string */
+				unsigned int save = gmt_get_column_type (GMT, GMT_OUT, Ctrl->T.col);
 				wesn[XLO]  = floor (xyzmin[Ctrl->T.col] / Ctrl->T.inc) * Ctrl->T.inc;
 				wesn[XHI]  = ceil  (xyzmax[Ctrl->T.col] / Ctrl->T.inc) * Ctrl->T.inc;
 				sprintf (record, "-T");
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, wesn[XLO], Ctrl->T.col);		strcat (record, &buffer[i]);	strcat (record, "/");
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, wesn[XHI], Ctrl->T.col);		strcat (record, &buffer[i]);	strcat (record, "/");
+				gmt_set_column_type (GMT, GMT_OUT, Ctrl->T.col, GMT_IS_FLOAT);
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, Ctrl->T.inc, Ctrl->T.col);	strcat (record, &buffer[i]);
+				gmt_set_column_type (GMT, GMT_OUT, Ctrl->T.col, save);
+				if (save == GMT_IS_ABSTIME) {	/* Append unit used */
+					char the_unit[2] = {""};
+					the_unit[0] = GMT->current.setting.time_system.unit;
+					strcat (record, the_unit);
+				}
 			}
 			else if (Ctrl->E.active) {	/* Return extreme record */
 				gmt_M_memcpy (Out->data, dchosen, ncol, double);

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -729,7 +729,7 @@ EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, Ctrl->T.inc, Ctrl->T.col);	strcat (record, &buffer[i]);
 				if (save == GMT_IS_ABSTIME) {	/* Append unit used */
 					gmt_set_column_type (GMT, GMT_OUT, Ctrl->T.col, save);	/* Reset column type */
-					charcat (record, GMT->current.setting.time_system.unit);
+					chrcat (record, GMT->current.setting.time_system.unit);
 				}
 			}
 			else if (Ctrl->E.active) {	/* Return extreme record */

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -129,7 +129,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 0, "usage: %s [<table>] [-Aa|t|s] [-C] [-D[<dx>[/<dy>]]] [-EL|l|H|h[<col>]] "
 		"[-Fi|d|t] [-I[b|e|f|p|s]<dx>[/<dy>[/<dz>..]][+e|r|R<incs>]] [-L] [-S[x][y]] [-T<dz>[%s][+c<col>]] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]",
-		name, GMT_TIME_UNITS_DISPLAY, GMT_V_OPT, GMT_a_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT,
+		name, GMT_TIME_FIX_UNITS_DISPLAY, GMT_V_OPT, GMT_a_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT,
 		GMT_i_OPT, GMT_o_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -137,18 +137,22 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	GMT_Option (API, "<");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n-A[a|t|s] Select reports for (a)ll [Default], per (t)able, or per (s)egment.");
+	GMT_Usage (API, 1, "\n-A[a|t|s]");
+	GMT_Usage (API, -2, "Select reports for (a)ll [Default], per (t)able, or per (s)egment.");
 	GMT_Usage (API, 1, "\n-C Format the min and max into separate columns; -o may be used to limit output.");
 	GMT_Usage (API, 1, "\n-D Modifies results obtained by -I by shifting the region to better align with "
 		"the data center.  Optionally, append granularity for this shift [exact].");
-	GMT_Usage (API, 1, "\n-EL|l|H|h[<col>] Return the record with extreme value in specified column <col> [last column]. "
+	GMT_Usage (API, 1, "\n-EL|l|H|h[<col>]");
+	GMT_Usage (API, -2, "Return the record with extreme value in specified column <col> [last column]. "
 		"Specify l or h for min or max value, respectively. Upper case L or H "
 		"means we operate instead on the absolute values of the data.");
-	GMT_Usage (API, 1, "\n-Fi|d|t Return various counts of tables, segments, headers, and records, depending on mode:");
+	GMT_Usage (API, 1, "\n-Fi|d|t");
+	GMT_Usage (API, -2, "Return various counts of tables, segments, headers, and records, depending on mode:");
 	GMT_Usage (API, 3, "i: One record with the number of tables, segments, data records, headers, and overall records.");
 	GMT_Usage (API, 3, "d: Dataset: One record per segment with tbl_no, seg_no, nrows, start_rec, stop_rec.");
 	GMT_Usage (API, 3, "t: Tables:  Same as D but the counts resets per table.");
-	GMT_Usage (API, 1, "\n-I[b|e|f|p|s]<dx>[/<dy>[/<dz>..]][+e|r|R<incs>] Return textstring -Rw/e/s/n to nearest multiple of dx/dy (assumes at least two columns). "
+	GMT_Usage (API, 1, "\n-I[b|e|f|p|s]<dx>[/<dy>[/<dz>..]][+e|r|R<incs>]");
+	GMT_Usage (API, -2, "Return textstring -Rw/e/s/n to nearest multiple of <dx>/<dy> (assumes at least two columns). "
 		"Give -Ie to just report the min/max extent in the -Rw/e/s/n string (no multiples). "
 		"If -C is set then no -R string is issued.  Instead, the number of increments "
 		"given determines how many columns are rounded off to the nearest multiple. "
@@ -164,14 +168,15 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"or use +e which is like +r but makes sure the region extends at least by %g x <inc>.\n", GMT_REGION_INCFACTOR);
 	GMT_Usage (API, 1, "\n-L Determine limiting region. With -I it rounds inward so bounds are within data range. "
 		"Use -A to find the limiting common bounds of all segments or tables.");
-	GMT_Usage (API, 1, "\n-S[x][y] Add extra space for error bars. Useful together with -I.");
+	GMT_Usage (API, 1, "\n-S[x][y]");
+	GMT_Usage (API, -2, "Add extra space for error bars. Useful together with -I.");
 	GMT_Usage (API, 3, "-Sx: Leaves space for horizontal error bar using value in third (2) column.");
 	GMT_Usage (API, 3, "-Sy: Leaves space for vertical error bar using value in third (2) column.");
 	GMT_Usage (API, 3, "-S or -Sxy: Leaves space for both error bars using values in third&fourth (2&3) columns.");
-	GMT_Usage (API, 1, "\n-T<dz>[%s][+c<col>] Return textstring -Tzmin/zmax/dz to nearest multiple of the given dz. "
-		"Note: Calculations are based on the first (0) column; append +c<col> to use another column. "
-		"If the column has absolute time you may append a valid time unit to dz [Default is set by GMT_TIME_UNIT].",
-		GMT_TIME_UNITS_DISPLAY);
+	GMT_Usage (API, 1, "\n-T<dz>[%s][+c<col>]", GMT_TIME_FIX_UNITS_DISPLAY);
+	GMT_Usage (API, -2, "Return textstring -Tzmin/zmax/dz to nearest multiple of the given <dz>.");
+	GMT_Usage (API, -2, "Note: Calculations are based on the first (0) column; append +c<col> to use another column. "
+		"If the column is absolute time you may append a valid fixed time unit to <dz> (Default is set by TIME_UNIT [s]).");
 	GMT_Option (API, "V,a");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Reports the names and data types of the aspatial fields.\n");
 	GMT_Option (API, "bi2,d,e,f,g,h,i,o,qi,r,s,w,:,.");
@@ -329,26 +334,31 @@ static int parse (struct GMT_CTRL *GMT, struct GMTINFO_CTRL *Ctrl, struct GMT_OP
 			case 'T':	/* makecpt inc string */
 				Ctrl->T.active = true;
 				if ((c = strchr (opt->arg, '/')) && gmt_M_compat_check (GMT, 5)) {	/* Let it slide for now */
-					GMT_Report (API, GMT_MSG_COMPAT, "Option -T<inc>[/<col>] syntax is deprecated; use -T<inc>[+c<col>] instead.\n");
+					GMT_Report (API, GMT_MSG_COMPAT, "Option -T<inc>[/<col>] syntax is deprecated; use -T<inc>[%s][+c<col>] instead.\n", GMT_TIME_FIX_UNITS_DISPLAY);
 					j = sscanf (opt->arg, "%lf/%d", &Ctrl->T.inc, &Ctrl->T.col);
 					if (j == 1) Ctrl->T.col = 0;
 				}
 				else if (c || opt->arg[0] == '\0') {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -T: Syntax is -T<inc>[+c<col>].\n");
+					GMT_Report (API, GMT_MSG_ERROR, "Option -T: Syntax is -T<inc>[%s][<[+c<col>].\n", GMT_TIME_FIX_UNITS_DISPLAY);
 					n_errors++;
 				}
 				else {	/* Modern syntax and parsing */
-					char unit = 0;
 					size_t L;
-					if ((c = strstr (opt->arg, "+c"))) {
+					if ((c = strstr (opt->arg, "+c"))) {	/* Specified alternate column */
 						Ctrl->T.col = atoi (&c[2]);
 						c[0] = '\0';	/* Temporarily hide the modifier */
 					}
 					Ctrl->T.inc = atof (opt->arg);
-					if ((L = strlen (opt->arg))) unit = opt->arg[L-1];
-					if (L && strchr (GMT_TIME_UNITS, unit)) {	/* Change to another valid time unit */
-						API->GMT->current.setting.time_system.unit = unit;
-						(void) gmt_init_time_system_structure (API->GMT, &API->GMT->current.setting.time_system);
+					if ((L = strlen (opt->arg))) {	/* Switch to another valid time unit */
+						char unit = opt->arg[L-1];
+						if (strchr (GMT_TIME_FIX_UNITS, unit)) {	/* Change to another valid time unit */
+							API->GMT->current.setting.time_system.unit = unit;
+							(void) gmt_init_time_system_structure (API->GMT, &API->GMT->current.setting.time_system);
+						}
+						else if (isalpha (unit)) {	/* Got junk */
+							GMT_Report (API, GMT_MSG_ERROR, "Option -T: Bad time unit %c. Choose from %s.\n", unit, GMT_TIME_FIX_UNITS_DISPLAY);
+							n_errors++;
+						}	/* else it was just part of dz */
 					}
 					if (c) c[0] = '+';	/* Restore the modifier */
 				}

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -709,19 +709,17 @@ EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, wesn[YHI], GMT_Y);	strcat (record, &buffer[i]);
 			}
 			else if (Ctrl->T.active) {	/* Return -T string */
-				unsigned int save = gmt_get_column_type (GMT, GMT_OUT, Ctrl->T.col);
-				wesn[XLO]  = floor (xyzmin[Ctrl->T.col] / Ctrl->T.inc) * Ctrl->T.inc;
+				unsigned int save = gmt_get_column_type (GMT, GMT_OUT, Ctrl->T.col);	/* Remember what column type this is */
+				wesn[XLO]  = floor (xyzmin[Ctrl->T.col] / Ctrl->T.inc) * Ctrl->T.inc;	/* Round min/max given the increment */
 				wesn[XHI]  = ceil  (xyzmax[Ctrl->T.col] / Ctrl->T.inc) * Ctrl->T.inc;
 				sprintf (record, "-T");
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, wesn[XLO], Ctrl->T.col);		strcat (record, &buffer[i]);	strcat (record, "/");
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, wesn[XHI], Ctrl->T.col);		strcat (record, &buffer[i]);	strcat (record, "/");
-				gmt_set_column_type (GMT, GMT_OUT, Ctrl->T.col, GMT_IS_FLOAT);
+				if (save == GMT_IS_ABSTIME) gmt_set_column_type (GMT, GMT_OUT, Ctrl->T.col, GMT_IS_FLOAT);	/* Must temporarily switch to float to typeset increment */
 				i = gmtinfo_strip_blanks_and_output (GMT, buffer, Ctrl->T.inc, Ctrl->T.col);	strcat (record, &buffer[i]);
-				gmt_set_column_type (GMT, GMT_OUT, Ctrl->T.col, save);
 				if (save == GMT_IS_ABSTIME) {	/* Append unit used */
-					char the_unit[2] = {""};
-					the_unit[0] = GMT->current.setting.time_system.unit;
-					strcat (record, the_unit);
+					gmt_set_column_type (GMT, GMT_OUT, Ctrl->T.col, save);	/* Reset column type */
+					charcat (record, GMT->current.setting.time_system.unit);
 				}
 			}
 			else if (Ctrl->E.active) {	/* Return extreme record */


### PR DESCRIPTION
See #5661 for background.  The handling of time data was never implemented for **-T**. This PR fixes the problem that the _dz_ part needs to be typeset separately from the ISO timestamp formatted min/max strings, and there is the issue of what time unit is selected.  Here, we now allow a valid _fixed_ time unit to be appended to _dz_ [Default will consult the **TIME_UNIT** setting], and the output string will have the proper unit added. At present, variable length time units like **y** and **o** are not supported; we may consider upgrades in the future.

A few minor enhancement related to this fix was introduced as well:

1. Function _chrcat_ appends a single character to a string.  This will probably be used in other places to replace more awkward coding.
2. I allow **w**eek to be a valid unit to choose for the time system.  Since it is a fixed interval (7**d**) there is no reason not to support it in **TIME_UNIT** when we already support it elsewhere (e.g., **-w**). This added a few new constants to gmt_constants.h.

