### PR TITLE
Improve check for zero or negative font size to turn of labelling in seis

### DIFF
--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -792,8 +792,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 
 							if (gmt_get_modifier (opt->arg, 'j', word) && strchr ("LCRBMT", word[0]) && strchr ("LCRBMT", word[1]))
 								Ctrl->S.justify = gmt_just_decode (GMT, word, Ctrl->S.justify);
-							if (gmt_get_modifier (opt->arg, 'f', word))
-								n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));
+							if (gmt_get_modifier (opt->arg, 'f', word)) {
+								if (word[0] == '-' || (word[0] == '0' && (word[1] == '\0' || word[1] == 'p')))
+									Ctrl->S.font.size = 0.0;
+								else
+									n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));
+							}
 							if (gmt_get_modifier (opt->arg, 'o', word)) {
 								if (gmt_get_pair (GMT, word, GMT_PAIR_DIM_DUP, Ctrl->S.offset) < 0) n_errors++;
 							} else {	/* Set default offset */

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -931,7 +931,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 					if (gmt_get_modifier (opt->arg, 'j', word) && strchr ("LCRBMT", word[0]) && strchr ("LCRBMT", word[1]))
 						Ctrl->S.justify = gmt_just_decode (GMT, word, Ctrl->S.justify);
 					if (gmt_get_modifier (opt->arg, 'f', word)) {
-						if (word[0] == '0' && (word[1] == '\0' || word[1] == 'p'))
+						if (word[0] == '-' || (word[0] == '0' && (word[1] == '\0' || word[1] == 'p')))
 							Ctrl->S.font.size = 0.0;
 						else
 							n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -546,10 +546,10 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 					if (gmt_get_modifier (opt->arg, 'j', word) && strchr ("LCRBMT", word[0]) && strchr ("LCRBMT", word[1]))
 						Ctrl->S.justify = gmt_just_decode (GMT, word, Ctrl->S.justify);
 					if (gmt_get_modifier (opt->arg, 'f', word)) {
-						if (strcmp (word, "0"))
-							n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));
-						else
+						if (word[0] == '-' || (word[0] == '0' && (word[1] == '\0' || word[1] == 'p')))
 							Ctrl->S.font.size = 0.0;
+						else
+							n_errors += gmt_getfont (GMT, word, &(Ctrl->S.font));
 					}
 					if (gmt_get_modifier (opt->arg, 'o', word)) {
 						if (gmt_get_pair (GMT, word, GMT_PAIR_DIM_DUP, Ctrl->S.offset) < 0) n_errors++;

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -455,8 +455,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSPOLAR_CTRL *Ctrl, struct GMT_OP
 							Ctrl->T.angle = atof(word);
 						if (gmt_get_modifier (opt->arg, 'j', word) && strchr ("LCRBMT", word[0]) && strchr ("LCRBMT", word[1]))
 							Ctrl->T.justify = gmt_just_decode (GMT, word, Ctrl->T.justify);
-						if (gmt_get_modifier (opt->arg, 'f', word))
-							n_errors += gmt_getfont (GMT, word, &(Ctrl->T.font));
+						if (gmt_get_modifier (opt->arg, 'f', word)) {
+							if (word[0] == '-' || (word[0] == '0' && (word[1] == '\0' || word[1] == 'p')))
+								Ctrl->T.font.size = 0.0;
+							else
+								n_errors += gmt_getfont (GMT, word, &(Ctrl->T.font));
+						}
 						if (gmt_get_modifier (opt->arg, 'o', word)) {
 							if (gmt_get_pair (GMT, word, GMT_PAIR_DIM_DUP, Ctrl->T.offset) < 0) n_errors++;
 						} else {	/* Set default offset */


### PR DESCRIPTION
**Description of proposed changes**

Make sure both zero and negative font sizes in **-S+f**_font_ turn off labeling in seis modules. Since the old version asked for negative (not just 0) we need to check for that.