### PR TITLE
Correct a parsing mistake in mapproject -G

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -572,7 +572,7 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 					if (q) q[2] = '+';
 					if (p) p[0] = '\0';	/* Chop off all modifiers */
 					/* Here, opt->arg is -G[<lon0/lat0>] */
-					if (opt->arg[0] == '\0') /* Just gave -G, should mean -G+ue+a */
+					if (opt->arg[0] == '\0' && Ctrl->G.mode == 0) /* Just gave -G, should mean -G+ue+a */
 						Ctrl->G.mode |= GMT_MP_CUMUL_DIST;
 					else if (n_slash == 1) {	/* Got -G<lon0/lat0> so we were given a fixed point */
 						Ctrl->G.mode |= GMT_MP_FIXED_POINT;


### PR DESCRIPTION
As explained in #5662, **mapproject -G**_modifiers_ adds cumulative distances regardless of the modifiers.  This PR fixes this mistake.
