### PR TITLE
Two small issues in movie and events

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -2171,7 +2171,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		else
 			sprintf (extra, "A+M+r");	/* No cropping, image size is fixed */
 		if (Ctrl->G.active) {	/* Want to set a fixed background canvas color and/or outline - we do this via the psconvert -N option */
-			if (!Ctrl->K.active) strcat (extra, "N");	/* Need to switch to the -N option first */
+			if (!Ctrl->K.active) strcat (extra, ",N");	/* Need to switch to the -N option first */
 			if (Ctrl->G.mode & 1) strcat (extra, "+p"), strcat (extra, Ctrl->G.pen);
 			if (Ctrl->G.mode & 2) strcat (extra, "+g"), strcat (extra, Ctrl->G.fill);
 		}
@@ -2353,7 +2353,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	else
 		sprintf (extra, "A+M+r");	/* No cropping, image size is fixed */
 	if (Ctrl->G.active) {	/* Want to set a fixed background canvas color and/or outline - we do this via the psconvert -N option */
-		if (!Ctrl->K.active) strcat (extra, "N");	/* Need to switch to the -N option first */
+		if (!Ctrl->K.active) strcat (extra, ",N");	/* Need to switch to the -N option first */
 		if (Ctrl->G.mode & 1) strcat (extra, "+p"), strcat (extra, Ctrl->G.pen);
 		if (Ctrl->G.mode & 2) strcat (extra, "+g"), strcat (extra, Ctrl->G.fill);
 	}

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -1026,6 +1026,7 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 				}
 			}
 			gmt_M_memcpy (out, in, n_copy_to_out, double);	/* Pass out the key input parameters unchanged (but not time, duration) */
+			out[x_col] = 1.0;	/* Defaul is full size */
 
 			t_plateau = t_event + Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_PLATEAU];	/* End of the plateau phase */
 			t_decay = t_plateau + Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_DECAY];	/* End of the decay phase */


### PR DESCRIPTION
1. In **events**, after we added the symbol size column, we forgot to set it to 1 by default (then to be modulated by the time curves).  So for plain animation with the default step function curves we ended up with a size of zero.
2. In **movie**, the recent updates to **psconvert** mean we need to insert a comma before adding **N** and color/outline modifiers for the frame since no longer a modifier of **-A**.

All tests pass, hopefully to be approved quickly.