### PR TITLE
Demonstrate events trajectory via resampling the line as points

### DIFF
--- a/test/movie/trajectory2.ps
+++ b/test/movie/trajectory2.ps
@@ -1,0 +1,1611 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 346 195
+%%HiResBoundingBox: 0 0 345.6000 194.4000
+%%Title: GMT v6.3.0_2ac3556-dirty_2021.08.20 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Aug 20 16:31:04 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 5760 def
+/PSL_page_ysize 3240 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot /Users/pwessel/GMTdev/gmt-dev/rbuild/test/movie/trajectory2/trajectory.txt -W0.25p,- -B0 -X0 -Y0 -R0/9.6/-2.7/2.7 -Jx0.5i
+%@PROJ: xy 0.00000000 9.60000000 -2.70000000 2.70000000 0.000 9.600 -2.700 2.700 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+V
+4 W
+[33 17] 0 B
+clipsave
+0 0 M
+5760 0 D
+0 3240 D
+-5760 0 D
+P
+PSL_clip N
+0 1620 M
+1200 -360 D
+600 480 D
+2100 1500 D
+1200 -2220 D
+660 -660 D
+S
+PSL_cliprestore
+U
+[] 0 B
+22 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3240 M 0 -3240 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+5760 0 T
+N 0 3240 M 0 -3240 D S
+-5760 0 T
+N 0 0 M 5760 0 D S
+/PSL_A0_y 0 def
+/PSL_A1_y 0 def
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3240 T
+N 0 0 M 5760 0 D S
+0 -3240 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sc9p -Gblack /Users/pwessel/GMTdev/gmt-dev/rbuild/test/movie/trajectory2/trajectory.txt -R0/9.6/-2.7/2.7 -Jx0.5i
+%@PROJ: xy 0.00000000 9.60000000 -2.70000000 2.70000000 0.000 9.600 -2.700 2.700 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+5760 0 D
+0 3240 D
+-5760 0 D
+P
+PSL_clip N
+V
+4 W
+{0 A} FS
+75 0 1620 Sc
+75 1200 1260 Sc
+75 1800 1740 Sc
+75 3900 3240 Sc
+75 5100 1020 Sc
+75 5760 360 Sc
+U
+PSL_cliprestore
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+/PSL_xorig 0 def /PSL_yorig 0 def
+gsave
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Sc3p -Gred /Users/pwessel/GMTdev/gmt-dev/rbuild/test/movie/trajectory2/trajectory2/points.txt -Es -T6.08695652174 -X0 -Y0
+%@PROJ: xy 0.00000000 9.60000000 -2.70000000 2.70000000 0.000 9.600 -2.700 2.700 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_movie_label_completion {
+V
+67 3173 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+333 F0
+(10) tl Z
+U
+}!
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot /tmp/GMT_psevents_symbols_7991.txt -R0/9.6/-2.7/2.7 -Jx0.5i -O -K -H -I -t -Sc3p --GMT_HISTORY=readonly --PROJ_LENGTH_UNIT=cm -Gred
+%@PROJ: xy 0.00000000 9.60000000 -2.70000000 2.70000000 0.000 9.600 -2.700 2.700 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+5760 0 D
+0 3240 D
+-5760 0 D
+P
+PSL_clip N
+V
+4 W
+{1 0 0 C} FS
+25 0 1620 Sc
+25 5 1619 Sc
+25 9 1617 Sc
+25 14 1616 Sc
+25 18 1615 Sc
+25 23 1613 Sc
+25 27 1612 Sc
+25 32 1610 Sc
+25 36 1609 Sc
+25 41 1608 Sc
+25 45 1606 Sc
+25 50 1605 Sc
+25 54 1604 Sc
+25 59 1602 Sc
+25 63 1601 Sc
+25 68 1600 Sc
+25 72 1598 Sc
+25 77 1597 Sc
+25 81 1596 Sc
+25 86 1594 Sc
+25 90 1593 Sc
+25 95 1591 Sc
+25 100 1590 Sc
+25 104 1589 Sc
+25 109 1587 Sc
+25 113 1586 Sc
+25 118 1585 Sc
+25 122 1583 Sc
+25 127 1582 Sc
+25 131 1581 Sc
+25 136 1579 Sc
+25 140 1578 Sc
+25 145 1577 Sc
+25 149 1575 Sc
+25 154 1574 Sc
+25 158 1572 Sc
+25 163 1571 Sc
+25 167 1570 Sc
+25 172 1568 Sc
+25 176 1567 Sc
+25 181 1566 Sc
+25 186 1564 Sc
+25 190 1563 Sc
+25 195 1562 Sc
+25 199 1560 Sc
+25 204 1559 Sc
+25 208 1558 Sc
+25 213 1556 Sc
+25 217 1555 Sc
+25 222 1553 Sc
+25 226 1552 Sc
+25 231 1551 Sc
+25 235 1549 Sc
+25 240 1548 Sc
+25 244 1547 Sc
+25 249 1545 Sc
+25 253 1544 Sc
+25 258 1543 Sc
+25 262 1541 Sc
+25 267 1540 Sc
+25 271 1539 Sc
+25 276 1537 Sc
+25 281 1536 Sc
+25 285 1534 Sc
+25 290 1533 Sc
+25 294 1532 Sc
+25 299 1530 Sc
+25 303 1529 Sc
+25 308 1528 Sc
+25 312 1526 Sc
+25 317 1525 Sc
+25 321 1524 Sc
+25 326 1522 Sc
+25 330 1521 Sc
+25 335 1520 Sc
+25 339 1518 Sc
+25 344 1517 Sc
+25 348 1515 Sc
+25 353 1514 Sc
+25 357 1513 Sc
+25 362 1511 Sc
+25 366 1510 Sc
+25 371 1509 Sc
+25 376 1507 Sc
+25 380 1506 Sc
+25 385 1505 Sc
+25 389 1503 Sc
+25 394 1502 Sc
+25 398 1501 Sc
+25 403 1499 Sc
+25 407 1498 Sc
+25 412 1496 Sc
+25 416 1495 Sc
+25 421 1494 Sc
+25 425 1492 Sc
+25 430 1491 Sc
+25 434 1490 Sc
+25 439 1488 Sc
+25 443 1487 Sc
+25 448 1486 Sc
+25 452 1484 Sc
+25 457 1483 Sc
+25 462 1482 Sc
+25 466 1480 Sc
+25 471 1479 Sc
+25 475 1477 Sc
+25 480 1476 Sc
+25 484 1475 Sc
+25 489 1473 Sc
+25 493 1472 Sc
+25 498 1471 Sc
+25 502 1469 Sc
+25 507 1468 Sc
+25 511 1467 Sc
+25 516 1465 Sc
+25 520 1464 Sc
+25 525 1463 Sc
+25 529 1461 Sc
+25 534 1460 Sc
+25 538 1458 Sc
+25 543 1457 Sc
+25 547 1456 Sc
+25 552 1454 Sc
+25 557 1453 Sc
+25 561 1452 Sc
+25 566 1450 Sc
+25 570 1449 Sc
+25 575 1448 Sc
+25 579 1446 Sc
+25 584 1445 Sc
+25 588 1444 Sc
+25 593 1442 Sc
+25 597 1441 Sc
+25 602 1439 Sc
+25 606 1438 Sc
+25 611 1437 Sc
+25 615 1435 Sc
+25 620 1434 Sc
+25 624 1433 Sc
+25 629 1431 Sc
+25 633 1430 Sc
+25 638 1429 Sc
+25 642 1427 Sc
+25 647 1426 Sc
+25 652 1425 Sc
+25 656 1423 Sc
+25 661 1422 Sc
+25 665 1420 Sc
+25 670 1419 Sc
+25 674 1418 Sc
+25 679 1416 Sc
+25 683 1415 Sc
+25 688 1414 Sc
+25 692 1412 Sc
+25 697 1411 Sc
+25 701 1410 Sc
+25 706 1408 Sc
+25 710 1407 Sc
+25 715 1406 Sc
+25 719 1404 Sc
+25 724 1403 Sc
+25 728 1401 Sc
+25 733 1400 Sc
+25 738 1399 Sc
+25 742 1397 Sc
+25 747 1396 Sc
+25 751 1395 Sc
+25 756 1393 Sc
+25 760 1392 Sc
+25 765 1391 Sc
+25 769 1389 Sc
+25 774 1388 Sc
+25 778 1387 Sc
+25 783 1385 Sc
+25 787 1384 Sc
+25 792 1382 Sc
+25 796 1381 Sc
+25 801 1380 Sc
+25 805 1378 Sc
+25 810 1377 Sc
+25 814 1376 Sc
+25 819 1374 Sc
+25 823 1373 Sc
+25 828 1372 Sc
+25 833 1370 Sc
+25 837 1369 Sc
+25 842 1368 Sc
+25 846 1366 Sc
+25 851 1365 Sc
+25 855 1363 Sc
+25 860 1362 Sc
+25 864 1361 Sc
+25 869 1359 Sc
+25 873 1358 Sc
+25 878 1357 Sc
+25 882 1355 Sc
+25 887 1354 Sc
+25 891 1353 Sc
+25 896 1351 Sc
+25 900 1350 Sc
+25 905 1349 Sc
+25 909 1347 Sc
+25 914 1346 Sc
+25 918 1344 Sc
+25 923 1343 Sc
+25 928 1342 Sc
+25 932 1340 Sc
+25 937 1339 Sc
+25 941 1338 Sc
+25 946 1336 Sc
+25 950 1335 Sc
+25 955 1334 Sc
+25 959 1332 Sc
+25 964 1331 Sc
+25 968 1330 Sc
+25 973 1328 Sc
+25 977 1327 Sc
+25 982 1325 Sc
+25 986 1324 Sc
+25 991 1323 Sc
+25 995 1321 Sc
+25 1000 1320 Sc
+25 1004 1319 Sc
+25 1009 1317 Sc
+25 1014 1316 Sc
+25 1018 1315 Sc
+25 1023 1313 Sc
+25 1027 1312 Sc
+25 1032 1311 Sc
+25 1036 1309 Sc
+25 1041 1308 Sc
+25 1045 1306 Sc
+25 1050 1305 Sc
+25 1054 1304 Sc
+25 1059 1302 Sc
+25 1063 1301 Sc
+25 1068 1300 Sc
+25 1072 1298 Sc
+25 1077 1297 Sc
+25 1081 1296 Sc
+25 1086 1294 Sc
+25 1090 1293 Sc
+25 1095 1292 Sc
+25 1099 1290 Sc
+25 1104 1289 Sc
+25 1109 1287 Sc
+25 1113 1286 Sc
+25 1118 1285 Sc
+25 1122 1283 Sc
+25 1127 1282 Sc
+25 1131 1281 Sc
+25 1136 1279 Sc
+25 1140 1278 Sc
+25 1145 1277 Sc
+25 1149 1275 Sc
+25 1154 1274 Sc
+25 1158 1273 Sc
+25 1163 1271 Sc
+25 1167 1270 Sc
+25 1172 1268 Sc
+25 1176 1267 Sc
+25 1181 1266 Sc
+25 1185 1264 Sc
+25 1190 1263 Sc
+25 1194 1262 Sc
+25 1199 1260 Sc
+25 1203 1262 Sc
+25 1207 1265 Sc
+25 1210 1268 Sc
+25 1214 1271 Sc
+25 1218 1274 Sc
+25 1221 1277 Sc
+25 1225 1280 Sc
+25 1229 1283 Sc
+25 1232 1286 Sc
+25 1236 1289 Sc
+25 1240 1292 Sc
+25 1243 1295 Sc
+25 1247 1298 Sc
+25 1251 1301 Sc
+25 1255 1304 Sc
+25 1258 1307 Sc
+25 1262 1310 Sc
+25 1266 1312 Sc
+25 1269 1315 Sc
+25 1273 1318 Sc
+25 1277 1321 Sc
+25 1280 1324 Sc
+25 1284 1327 Sc
+25 1288 1330 Sc
+25 1291 1333 Sc
+25 1295 1336 Sc
+25 1299 1339 Sc
+25 1302 1342 Sc
+25 1306 1345 Sc
+25 1310 1348 Sc
+25 1314 1351 Sc
+25 1317 1354 Sc
+25 1321 1357 Sc
+25 1325 1360 Sc
+25 1328 1363 Sc
+25 1332 1366 Sc
+25 1336 1369 Sc
+25 1339 1371 Sc
+25 1343 1374 Sc
+25 1347 1377 Sc
+25 1350 1380 Sc
+25 1354 1383 Sc
+25 1358 1386 Sc
+25 1362 1389 Sc
+25 1365 1392 Sc
+25 1369 1395 Sc
+25 1373 1398 Sc
+25 1376 1401 Sc
+25 1380 1404 Sc
+25 1384 1407 Sc
+25 1387 1410 Sc
+25 1391 1413 Sc
+25 1395 1416 Sc
+25 1398 1419 Sc
+25 1402 1422 Sc
+25 1406 1425 Sc
+25 1409 1428 Sc
+25 1413 1431 Sc
+25 1417 1433 Sc
+25 1421 1436 Sc
+25 1424 1439 Sc
+25 1428 1442 Sc
+25 1432 1445 Sc
+25 1435 1448 Sc
+25 1439 1451 Sc
+25 1443 1454 Sc
+25 1446 1457 Sc
+25 1450 1460 Sc
+25 1454 1463 Sc
+25 1457 1466 Sc
+25 1461 1469 Sc
+25 1465 1472 Sc
+25 1468 1475 Sc
+25 1472 1478 Sc
+25 1476 1481 Sc
+25 1480 1484 Sc
+25 1483 1487 Sc
+25 1487 1490 Sc
+25 1491 1492 Sc
+25 1494 1495 Sc
+25 1498 1498 Sc
+25 1502 1501 Sc
+25 1505 1504 Sc
+25 1509 1507 Sc
+25 1513 1510 Sc
+25 1516 1513 Sc
+25 1520 1516 Sc
+25 1524 1519 Sc
+25 1527 1522 Sc
+25 1531 1525 Sc
+25 1535 1528 Sc
+25 1539 1531 Sc
+25 1542 1534 Sc
+25 1546 1537 Sc
+25 1550 1540 Sc
+25 1553 1543 Sc
+25 1557 1546 Sc
+25 1561 1549 Sc
+25 1564 1552 Sc
+25 1568 1554 Sc
+25 1572 1557 Sc
+25 1575 1560 Sc
+25 1579 1563 Sc
+25 1583 1566 Sc
+25 1587 1569 Sc
+25 1590 1572 Sc
+25 1594 1575 Sc
+25 1598 1578 Sc
+25 1601 1581 Sc
+25 1605 1584 Sc
+25 1609 1587 Sc
+25 1612 1590 Sc
+25 1616 1593 Sc
+25 1620 1596 Sc
+25 1623 1599 Sc
+25 1627 1602 Sc
+25 1631 1605 Sc
+25 1634 1608 Sc
+25 1638 1611 Sc
+25 1642 1613 Sc
+25 1646 1616 Sc
+25 1649 1619 Sc
+25 1653 1622 Sc
+25 1657 1625 Sc
+25 1660 1628 Sc
+25 1664 1631 Sc
+25 1668 1634 Sc
+25 1671 1637 Sc
+25 1675 1640 Sc
+25 1679 1643 Sc
+25 1682 1646 Sc
+25 1686 1649 Sc
+25 1690 1652 Sc
+25 1693 1655 Sc
+25 1697 1658 Sc
+25 1701 1661 Sc
+25 1705 1664 Sc
+25 1708 1667 Sc
+25 1712 1670 Sc
+25 1716 1672 Sc
+25 1719 1675 Sc
+25 1723 1678 Sc
+25 1727 1681 Sc
+25 1730 1684 Sc
+25 1734 1687 Sc
+25 1738 1690 Sc
+25 1741 1693 Sc
+25 1745 1696 Sc
+25 1749 1699 Sc
+25 1753 1702 Sc
+25 1756 1705 Sc
+25 1760 1708 Sc
+25 1764 1711 Sc
+25 1767 1714 Sc
+25 1771 1717 Sc
+25 1775 1720 Sc
+25 1778 1723 Sc
+25 1782 1726 Sc
+25 1786 1729 Sc
+25 1789 1732 Sc
+25 1793 1734 Sc
+25 1797 1737 Sc
+25 1800 1740 Sc
+25 1804 1743 Sc
+25 1808 1746 Sc
+25 1812 1749 Sc
+25 1816 1751 Sc
+25 1820 1754 Sc
+25 1824 1757 Sc
+25 1827 1760 Sc
+25 1831 1762 Sc
+25 1835 1765 Sc
+25 1839 1768 Sc
+25 1843 1771 Sc
+25 1847 1773 Sc
+25 1850 1776 Sc
+25 1854 1779 Sc
+25 1858 1782 Sc
+25 1862 1784 Sc
+25 1866 1787 Sc
+25 1870 1790 Sc
+25 1874 1793 Sc
+25 1877 1795 Sc
+25 1881 1798 Sc
+25 1885 1801 Sc
+25 1889 1803 Sc
+25 1893 1806 Sc
+25 1897 1809 Sc
+25 1900 1812 Sc
+25 1904 1814 Sc
+25 1908 1817 Sc
+25 1912 1820 Sc
+25 1916 1823 Sc
+25 1920 1825 Sc
+25 1923 1828 Sc
+25 1927 1831 Sc
+25 1931 1834 Sc
+25 1935 1836 Sc
+25 1939 1839 Sc
+25 1943 1842 Sc
+25 1947 1845 Sc
+25 1950 1847 Sc
+25 1954 1850 Sc
+25 1958 1853 Sc
+25 1962 1856 Sc
+25 1966 1858 Sc
+25 1970 1861 Sc
+25 1973 1864 Sc
+25 1977 1867 Sc
+25 1981 1869 Sc
+25 1985 1872 Sc
+25 1989 1875 Sc
+25 1993 1878 Sc
+25 1997 1880 Sc
+25 2000 1883 Sc
+25 2004 1886 Sc
+25 2008 1889 Sc
+25 2012 1891 Sc
+25 2016 1894 Sc
+25 2020 1897 Sc
+25 2023 1900 Sc
+25 2027 1902 Sc
+25 2031 1905 Sc
+25 2035 1908 Sc
+25 2039 1911 Sc
+25 2043 1913 Sc
+25 2046 1916 Sc
+25 2050 1919 Sc
+25 2054 1922 Sc
+25 2058 1924 Sc
+25 2062 1927 Sc
+25 2066 1930 Sc
+25 2070 1933 Sc
+25 2073 1935 Sc
+25 2077 1938 Sc
+25 2081 1941 Sc
+25 2085 1944 Sc
+25 2089 1946 Sc
+25 2093 1949 Sc
+25 2096 1952 Sc
+25 2100 1955 Sc
+25 2104 1957 Sc
+25 2108 1960 Sc
+25 2112 1963 Sc
+25 2116 1965 Sc
+25 2120 1968 Sc
+25 2123 1971 Sc
+25 2127 1974 Sc
+25 2131 1976 Sc
+25 2135 1979 Sc
+25 2139 1982 Sc
+25 2143 1985 Sc
+25 2146 1987 Sc
+25 2150 1990 Sc
+25 2154 1993 Sc
+25 2158 1996 Sc
+25 2162 1998 Sc
+25 2166 2001 Sc
+25 2169 2004 Sc
+25 2173 2007 Sc
+25 2177 2009 Sc
+25 2181 2012 Sc
+25 2185 2015 Sc
+25 2189 2018 Sc
+25 2193 2020 Sc
+25 2196 2023 Sc
+25 2200 2026 Sc
+25 2204 2029 Sc
+25 2208 2031 Sc
+25 2212 2034 Sc
+25 2216 2037 Sc
+25 2219 2040 Sc
+25 2223 2042 Sc
+25 2227 2045 Sc
+25 2231 2048 Sc
+25 2235 2051 Sc
+25 2239 2053 Sc
+25 2243 2056 Sc
+25 2246 2059 Sc
+25 2250 2062 Sc
+25 2254 2064 Sc
+25 2258 2067 Sc
+25 2262 2070 Sc
+25 2266 2073 Sc
+25 2269 2075 Sc
+25 2273 2078 Sc
+25 2277 2081 Sc
+25 2281 2084 Sc
+25 2285 2086 Sc
+25 2289 2089 Sc
+25 2293 2092 Sc
+25 2296 2095 Sc
+25 2300 2097 Sc
+25 2304 2100 Sc
+25 2308 2103 Sc
+25 2312 2106 Sc
+25 2316 2108 Sc
+25 2319 2111 Sc
+25 2323 2114 Sc
+25 2327 2116 Sc
+25 2331 2119 Sc
+25 2335 2122 Sc
+25 2339 2125 Sc
+25 2342 2127 Sc
+25 2346 2130 Sc
+25 2350 2133 Sc
+25 2354 2136 Sc
+25 2358 2138 Sc
+25 2362 2141 Sc
+25 2366 2144 Sc
+25 2369 2147 Sc
+25 2373 2149 Sc
+25 2377 2152 Sc
+25 2381 2155 Sc
+25 2385 2158 Sc
+25 2389 2160 Sc
+25 2392 2163 Sc
+25 2396 2166 Sc
+25 2400 2169 Sc
+25 2404 2171 Sc
+25 2408 2174 Sc
+25 2412 2177 Sc
+25 2416 2180 Sc
+25 2419 2182 Sc
+25 2423 2185 Sc
+25 2427 2188 Sc
+25 2431 2191 Sc
+25 2435 2193 Sc
+25 2439 2196 Sc
+25 2442 2199 Sc
+25 2446 2202 Sc
+25 2450 2204 Sc
+25 2454 2207 Sc
+25 2458 2210 Sc
+25 2462 2213 Sc
+25 2465 2215 Sc
+25 2469 2218 Sc
+25 2473 2221 Sc
+25 2477 2224 Sc
+25 2481 2226 Sc
+25 2485 2229 Sc
+25 2489 2232 Sc
+25 2492 2235 Sc
+25 2496 2237 Sc
+25 2500 2240 Sc
+25 2504 2243 Sc
+25 2508 2246 Sc
+25 2512 2248 Sc
+25 2515 2251 Sc
+25 2519 2254 Sc
+25 2523 2257 Sc
+25 2527 2259 Sc
+25 2531 2262 Sc
+25 2535 2265 Sc
+25 2539 2268 Sc
+25 2542 2270 Sc
+25 2546 2273 Sc
+25 2550 2276 Sc
+25 2554 2278 Sc
+25 2558 2281 Sc
+25 2562 2284 Sc
+25 2565 2287 Sc
+25 2569 2289 Sc
+25 2573 2292 Sc
+25 2577 2295 Sc
+25 2581 2298 Sc
+25 2585 2300 Sc
+25 2588 2303 Sc
+25 2592 2306 Sc
+25 2596 2309 Sc
+25 2600 2311 Sc
+25 2604 2314 Sc
+25 2608 2317 Sc
+25 2612 2320 Sc
+25 2615 2322 Sc
+25 2619 2325 Sc
+25 2623 2328 Sc
+25 2627 2331 Sc
+25 2631 2333 Sc
+25 2635 2336 Sc
+25 2638 2339 Sc
+25 2642 2342 Sc
+25 2646 2344 Sc
+25 2650 2347 Sc
+25 2654 2350 Sc
+25 2658 2353 Sc
+25 2662 2355 Sc
+25 2665 2358 Sc
+25 2669 2361 Sc
+25 2673 2364 Sc
+25 2677 2366 Sc
+25 2681 2369 Sc
+25 2685 2372 Sc
+25 2688 2375 Sc
+25 2692 2377 Sc
+25 2696 2380 Sc
+25 2700 2383 Sc
+25 2704 2386 Sc
+25 2708 2388 Sc
+25 2711 2391 Sc
+25 2715 2394 Sc
+25 2719 2397 Sc
+25 2723 2399 Sc
+25 2727 2402 Sc
+25 2731 2405 Sc
+25 2735 2408 Sc
+25 2738 2410 Sc
+25 2742 2413 Sc
+25 2746 2416 Sc
+25 2750 2419 Sc
+25 2754 2421 Sc
+25 2758 2424 Sc
+25 2761 2427 Sc
+25 2765 2430 Sc
+25 2769 2432 Sc
+25 2773 2435 Sc
+25 2777 2438 Sc
+25 2781 2440 Sc
+25 2785 2443 Sc
+25 2788 2446 Sc
+25 2792 2449 Sc
+25 2796 2451 Sc
+25 2800 2454 Sc
+25 2804 2457 Sc
+25 2808 2460 Sc
+25 2811 2462 Sc
+25 2815 2465 Sc
+25 2819 2468 Sc
+25 2823 2471 Sc
+25 2827 2473 Sc
+25 2831 2476 Sc
+25 2834 2479 Sc
+25 2838 2482 Sc
+25 2842 2484 Sc
+25 2846 2487 Sc
+25 2850 2490 Sc
+25 2854 2493 Sc
+25 2858 2495 Sc
+25 2861 2498 Sc
+25 2865 2501 Sc
+25 2869 2504 Sc
+25 2873 2506 Sc
+25 2877 2509 Sc
+25 2881 2512 Sc
+25 2884 2515 Sc
+25 2888 2517 Sc
+25 2892 2520 Sc
+25 2896 2523 Sc
+25 2900 2526 Sc
+25 2904 2528 Sc
+25 2908 2531 Sc
+25 2911 2534 Sc
+25 2915 2537 Sc
+25 2919 2539 Sc
+25 2923 2542 Sc
+25 2927 2545 Sc
+25 2931 2548 Sc
+25 2934 2550 Sc
+25 2938 2553 Sc
+25 2942 2556 Sc
+25 2946 2559 Sc
+25 2950 2561 Sc
+25 2954 2564 Sc
+25 2958 2567 Sc
+25 2961 2570 Sc
+25 2965 2572 Sc
+25 2969 2575 Sc
+25 2973 2578 Sc
+25 2977 2581 Sc
+25 2981 2583 Sc
+25 2984 2586 Sc
+25 2988 2589 Sc
+25 2992 2592 Sc
+25 2996 2594 Sc
+25 3000 2597 Sc
+25 3004 2600 Sc
+25 3007 2602 Sc
+25 3011 2605 Sc
+25 3015 2608 Sc
+25 3019 2611 Sc
+25 3023 2613 Sc
+25 3027 2616 Sc
+25 3031 2619 Sc
+25 3034 2622 Sc
+25 3038 2624 Sc
+25 3042 2627 Sc
+25 3046 2630 Sc
+25 3050 2633 Sc
+25 3054 2635 Sc
+25 3057 2638 Sc
+25 3061 2641 Sc
+25 3065 2644 Sc
+25 3069 2646 Sc
+25 3073 2649 Sc
+25 3077 2652 Sc
+25 3081 2655 Sc
+25 3084 2657 Sc
+25 3088 2660 Sc
+25 3092 2663 Sc
+25 3096 2666 Sc
+25 3100 2668 Sc
+25 3104 2671 Sc
+25 3107 2674 Sc
+25 3111 2677 Sc
+25 3115 2679 Sc
+25 3119 2682 Sc
+25 3123 2685 Sc
+25 3127 2688 Sc
+U
+PSL_cliprestore
+%%EndObject
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/movie/trajectory2.sh
+++ b/test/movie/trajectory2.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Demonstrate plotting of animated trajectories, part 2: Discretized line
+# Create a line with a few points and get Cartesian distances to use as time,
+# then sample densely to plot points to simulate the line
+if [ $# -eq 0 ]; then   # Just make master PostScript frame 10
+        opt="-M10,ps"
+else    # Make MP4 at 2 frames per second
+        opt="-Fmp4 -D2"
+fi
+cat << EOF | gmt mapproject -G+uc > trajectory.txt
+0	0	
+2	-0.6
+3	0.2
+6.5	2.7
+8.5	-1
+9.6	-2.1
+EOF
+cat << 'EOF' > pre.sh
+# Create movie times (end distances is ~13.5 so go 0 to 14 over 24 frames)
+gmt math -T0/14/24+n -o0 T = times.txt
+# Make background static plot with entire dashed line and knots in black
+gmt begin
+	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Ar${MOVIE_DPU} trajectory.txt --GMT_INTERPOLANT=linear > points.txt
+	gmt plot trajectory.txt -W0.25p,- -B0 -X0 -Y0
+	gmt plot -Sc9p -Gblack trajectory.txt
+gmt end
+EOF
+# Make main script that plots trajectory
+cat << 'EOF' > main.sh
+gmt begin
+	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Sc3p -Gred points.txt -Es -T${MOVIE_COL0} -X0 -Y0
+gmt end
+EOF
+# Build the product
+gmt movie -C4.8ix2.7ix100 -Ntrajectory2 -Ttimes.txt -Sbpre.sh main.sh -Lf -M10 ${opt} -Z


### PR DESCRIPTION
This is the second test case showing how to animate a trajectory via **events**. Unlike the case in #5683, this case uses **events -Ar**_dpu_ to create a dense collection of points that can then be plotted via **events** as circles.  The resulting movie looks like this:

https://user-images.githubusercontent.com/26473567/130308304-89ab1654-6223-4fcb-8cdd-6d8f0452f014.mp4

Some differences with the regular trajectory plotting via **-Ar**:

1. No line is plotted, just dense circles.  This means the line will have always the appearance as being plotted with **PS_LINE_CAP**=_round_.
2. Because points are plotted, the full machinery of events **-M** can be used to create a variable thickness line.
3. The resampling from coarse line to dense points reflects the default spline [Akima].  To avoid excursions from straight lines one need to add **--GMT_INTERPOLANT**=_linear_ to the **events -Ar**_dpu_ call (which was done for this example).

Future PR will demonstrate the variable line thickness case. These cases will eventually be used in a new documentation accessible from the events page that discusses how to animate lines.
