### PR TITLE
Improve events testing via debug feature and test script

### DIFF
--- a/src/psevents.c
+++ b/src/psevents.c
@@ -566,11 +566,10 @@ static int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GMT_O
 				}
 				break;
 
-#ifdef DEBUG
 			case '/':	/* Write time-functions */
 				Ctrl->debug.active = true;
 				break;
-#endif
+
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);
 				break;

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -732,6 +732,7 @@ GMT_LOCAL void psevents_set_outarray (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL
 }
 
 GMT_LOCAL void psevents_test_functions (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl) {
+	/* debug test function to dump the four time-functions */
 	double t[PSEVENTS_NT], now = -2.0, out[4];
 	FILE *fp = fopen ("psevents_function.txt", "w");
 	gmt_M_memset (t, PSEVENTS_NT, double);	/* Initialize the t vector */
@@ -740,14 +741,10 @@ GMT_LOCAL void psevents_test_functions (struct GMT_CTRL *GMT, struct PSEVENTS_CT
 	t[PSEVENTS_T_PLATEAU] = Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_PLATEAU];
 	t[PSEVENTS_T_DECAY]   = t[PSEVENTS_T_PLATEAU] + Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_DECAY];
 	t[PSEVENTS_T_END]     = t[PSEVENTS_T_DECAY] + Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_DECAY];
-	t[PSEVENTS_T_FADE]    = t[PSEVENTS_T_END] + Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_FADE] ;
+	t[PSEVENTS_T_FADE]    = t[PSEVENTS_T_END] + Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_FADE];
 	Ctrl->M.active[PSEVENTS_DZ] = true;
 	fprintf (fp, "# t_rise = -1.0, t_event = 0.0, t_plateau = 1.0, t_decay = 2.0, t_end = 3.0, t_fade = 4.0, now = -2/5\n");
 	fprintf (fp, "# now\tsize\tintens\transp\tdz\n");
-	//Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_RISE] = Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_DECAY] = Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_FADE] = 1.0;
-	//Ctrl->M.value[PSEVENTS_SIZE][PSEVENTS_VAL1] = Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL1] = Ctrl->M.value[PSEVENTS_INT][PSEVENTS_VAL1] = Ctrl->M.value[PSEVENTS_DZ][PSEVENTS_VAL1] = 1.0;
-	//Ctrl->M.value[PSEVENTS_SIZE][PSEVENTS_VAL2] = Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL2] = 0.2;
-	//Ctrl->M.value[PSEVENTS_INT][PSEVENTS_VAL2] = Ctrl->M.value[PSEVENTS_INT][PSEVENTS_VAL2] = Ctrl->M.value[PSEVENTS_DZ][PSEVENTS_VAL2] = -0.2;
 	while (now <= 5.005) {
 		gmt_M_memset (out, 4, double);	/* Initialize the out vector */
 		psevents_set_outarray (GMT, Ctrl, now, t, true, true, 0, 1, 2, 3, out);

--- a/test/movie/trajectory5.ps
+++ b/test/movie/trajectory5.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 346 195
 %%HiResBoundingBox: 0 0 345.6000 194.4000
-%%Title: GMT v6.3.0_0b510af-dirty_2021.08.21 [64-bit] Document from plot
+%%Title: GMT v6.3.0_b273d54_2021.08.22 [64-bit] Document from plot
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sun Aug 22 13:20:28 2021
+%%CreationDate: Sun Aug 22 23:23:01 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -700,7 +700,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot /Users/pwessel/trajectory.txt -W0.25p,- -B0 -X0 -Y0 -R0/9.6/-2.7/2.7 -Jx0.5i
+%@GMT: gmt plot /Users/pwessel/GMTdev/gmt-dev/rbuild/test/movie/trajectory5/trajectory.txt -W0.25p,- -B0 -X0 -Y0 -R0/9.6/-2.7/2.7 -Jx0.5i
 %@PROJ: xy 0.00000000 9.60000000 -2.70000000 2.70000000 0.000 9.600 -2.700 2.700 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -752,7 +752,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot -Sc9p -Gblack /Users/pwessel/trajectory.txt -R0/9.6/-2.7/2.7 -Jx0.5i
+%@GMT: gmt plot -Sc9p -Gblack /Users/pwessel/GMTdev/gmt-dev/rbuild/test/movie/trajectory5/trajectory.txt -R0/9.6/-2.7/2.7 -Jx0.5i
 %@PROJ: xy 0.00000000 9.60000000 -2.70000000 2.70000000 0.000 9.600 -2.700 2.700 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -787,7 +787,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Sc3p -Cheat.cpt /Users/pwessel/points.txt -Es+r1.5+d0.25 -Mz -T6.08695652174 -X0 -Y0
+%@GMT: gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Sc3p -Cheat.cpt /Users/pwessel/GMTdev/gmt-dev/rbuild/test/movie/trajectory5/trajectory5/points.txt -Es+d0.25 -Mz -T6.08695652174 -X0 -Y0
 %@PROJ: xy 0.00000000 9.60000000 -2.70000000 2.70000000 0.000 9.600 -2.700 2.700 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -805,7 +805,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot /tmp/GMT_psevents_symbols_2912.txt -R0/9.6/-2.7/2.7 -Jx0.5i -O -K -H -I -t -Sc3p --GMT_HISTORY=readonly --PROJ_LENGTH_UNIT=cm -Cheat.cpt
+%@GMT: gmt plot /tmp/GMT_psevents_symbols_15862.txt -R0/9.6/-2.7/2.7 -Jx0.5i -O -K -H -I -t -Sc3p --GMT_HISTORY=readonly --PROJ_LENGTH_UNIT=cm -Cheat.cpt
 %@PROJ: xy 0.00000000 9.60000000 -2.70000000 2.70000000 0.000 9.600 -2.700 2.700 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -1564,673 +1564,69 @@ V
 25 3000 2597 Sc
 25 3004 2600 Sc
 {0.001 0 0 C} FS
-4 W
 25 3007 2602 Sc
 {0.00691 0 0 C} FS
-4 W
 25 3011 2605 Sc
 {0.0181 0 0 C} FS
-4 W
 25 3015 2608 Sc
 {0.0346 0 0 C} FS
-4 W
 25 3019 2611 Sc
 {0.0564 0 0 C} FS
-4 W
-24 3023 2613 Sc
+25 3023 2613 Sc
 {0.0834 0 0 C} FS
-4 W
-24 3027 2616 Sc
+25 3027 2616 Sc
 {0.116 0 0 C} FS
-4 W
-24 3031 2619 Sc
+25 3031 2619 Sc
 {0.153 0 0 C} FS
-4 W
-24 3034 2622 Sc
+25 3034 2622 Sc
 {0.196 0 0 C} FS
-4 W
-23 3038 2624 Sc
+25 3038 2624 Sc
 {0.245 0 0 C} FS
-4 W
-23 3042 2627 Sc
+25 3042 2627 Sc
 {0.298 0 0 C} FS
-4 W
-22 3046 2630 Sc
+25 3046 2630 Sc
 {0.357 0 0 C} FS
-4 W
-22 3050 2633 Sc
+25 3050 2633 Sc
 {0.421 0 0 C} FS
-4 W
-21 3054 2635 Sc
+25 3054 2635 Sc
 {0.49 0 0 C} FS
-3 W
-20 3057 2638 Sc
+25 3057 2638 Sc
 {0.565 0 0 C} FS
-3 W
-20 3061 2641 Sc
+25 3061 2641 Sc
 {0.645 0 0 C} FS
-3 W
-19 3065 2644 Sc
+25 3065 2644 Sc
 {0.73 0 0 C} FS
-3 W
-18 3069 2646 Sc
+25 3069 2646 Sc
 {0.821 0 0 C} FS
-3 W
-17 3073 2649 Sc
+25 3073 2649 Sc
 {0.917 0 0 C} FS
-3 W
-16 3077 2652 Sc
+25 3077 2652 Sc
 {1 0.0177 0 C} FS
-3 W
-15 3081 2655 Sc
+25 3081 2655 Sc
 {1 0.124 0 C} FS
-2 W
-14 3084 2657 Sc
+25 3084 2657 Sc
 {1 0.236 0 C} FS
-2 W
-13 3088 2660 Sc
+25 3088 2660 Sc
 {1 0.353 0 C} FS
-2 W
-12 3092 2663 Sc
+25 3092 2663 Sc
 {1 0.475 0 C} FS
-2 W
-11 3096 2666 Sc
+25 3096 2666 Sc
 {1 0.603 0 C} FS
-2 W
-10 3100 2668 Sc
+25 3100 2668 Sc
 {1 0.735 0 C} FS
-1 W
-9 3104 2671 Sc
+25 3104 2671 Sc
 {1 0.874 0 C} FS
-1 W
-7 3107 2674 Sc
+25 3107 2674 Sc
 {1 1 0.0255 C} FS
-1 W
-6 3111 2677 Sc
+25 3111 2677 Sc
 {1 1 0.249 C} FS
-1 W
-5 3115 2679 Sc
+25 3115 2679 Sc
 {1 1 0.48 C} FS
-1 W
-3 3119 2682 Sc
+25 3119 2682 Sc
 {1 1 0.718 C} FS
-0 W
-2 3123 2685 Sc
+25 3123 2685 Sc
 {1 1 0.965 C} FS
-0 W
-0 3127 2688 Sc
-0.99096972 0.99096972 /Normal PSL_transp
-{1 1 0.964 C} FS
-0 W
-0 3130 2690 Sc
-0.9805474 0.9805474 /Normal PSL_transp
-{1 1 0.922 C} FS
-0 3134 2693 Sc
-0.9701801 0.9701801 /Normal PSL_transp
-{1 1 0.881 C} FS
-0 3138 2696 Sc
-0.959868 0.959868 /Normal PSL_transp
-{1 1 0.839 C} FS
-0 3142 2699 Sc
-0.9496109 0.9496109 /Normal PSL_transp
-{1 1 0.798 C} FS
-0 3146 2701 Sc
-0.9394089 0.9394089 /Normal PSL_transp
-{1 1 0.758 C} FS
-0 3150 2704 Sc
-0.9292621 0.9292621 /Normal PSL_transp
-{1 1 0.717 C} FS
-0 3154 2707 Sc
-0.9191703 0.9191703 /Normal PSL_transp
-{1 1 0.677 C} FS
-0 3157 2710 Sc
-0.9091336 0.9091336 /Normal PSL_transp
-{1 1 0.637 C} FS
-0 3161 2712 Sc
-0.899152 0.899152 /Normal PSL_transp
-{1 1 0.597 C} FS
-0 3165 2715 Sc
-0.889226 0.889226 /Normal PSL_transp
-{1 1 0.557 C} FS
-0 3169 2718 Sc
-0.879354 0.879354 /Normal PSL_transp
-{1 1 0.517 C} FS
-0 3173 2721 Sc
-0.869538 0.869538 /Normal PSL_transp
-{1 1 0.478 C} FS
-0 3177 2723 Sc
-0.859777 0.859777 /Normal PSL_transp
-{1 1 0.439 C} FS
-0 3180 2726 Sc
-0.850071 0.850071 /Normal PSL_transp
-{1 1 0.4 C} FS
-0 3184 2729 Sc
-0.84042 0.84042 /Normal PSL_transp
-{1 1 0.362 C} FS
-0 3188 2732 Sc
-0.830824 0.830824 /Normal PSL_transp
-{1 1 0.323 C} FS
-0 3192 2734 Sc
-0.821283 0.821283 /Normal PSL_transp
-{1 1 0.285 C} FS
-0 3196 2737 Sc
-0.811797 0.811797 /Normal PSL_transp
-{1 1 0.247 C} FS
-0 3200 2740 Sc
-0.802367 0.802367 /Normal PSL_transp
-{1 1 0.209 C} FS
-0 3204 2743 Sc
-0.792991 0.792991 /Normal PSL_transp
-{1 1 0.172 C} FS
-0 3207 2745 Sc
-0.783671 0.783671 /Normal PSL_transp
-{1 1 0.135 C} FS
-0 3211 2748 Sc
-0.774406 0.774406 /Normal PSL_transp
-{1 1 0.0976 C} FS
-0 3215 2751 Sc
-0.765195 0.765195 /Normal PSL_transp
-{1 1 0.0608 C} FS
-0 3219 2753 Sc
-0.75604 0.75604 /Normal PSL_transp
-{1 1 0.0242 C} FS
-0 3223 2756 Sc
-0.74694 0.74694 /Normal PSL_transp
-{1 0.992 0 C} FS
-0 3227 2759 Sc
-0.737895 0.737895 /Normal PSL_transp
-{1 0.968 0 C} FS
-0 3230 2762 Sc
-0.728906 0.728906 /Normal PSL_transp
-{1 0.944 0 C} FS
-0 3234 2764 Sc
-0.719971 0.719971 /Normal PSL_transp
-{1 0.92 0 C} FS
-0 3238 2767 Sc
-0.711091 0.711091 /Normal PSL_transp
-{1 0.896 0 C} FS
-0 3242 2770 Sc
-0.702267 0.702267 /Normal PSL_transp
-{1 0.873 0 C} FS
-0 3246 2773 Sc
-0.693497 0.693497 /Normal PSL_transp
-{1 0.849 0 C} FS
-0 3250 2775 Sc
-0.684783 0.684783 /Normal PSL_transp
-{1 0.826 0 C} FS
-0 3253 2778 Sc
-0.676124 0.676124 /Normal PSL_transp
-{1 0.803 0 C} FS
-0 3257 2781 Sc
-0.66752 0.66752 /Normal PSL_transp
-{1 0.78 0 C} FS
-0 3261 2784 Sc
-0.658971 0.658971 /Normal PSL_transp
-{1 0.757 0 C} FS
-0 3265 2786 Sc
-0.650477 0.650477 /Normal PSL_transp
-{1 0.735 0 C} FS
-0 3269 2789 Sc
-0.642038 0.642038 /Normal PSL_transp
-{1 0.712 0 C} FS
-0 3273 2792 Sc
-0.633654 0.633654 /Normal PSL_transp
-{1 0.69 0 C} FS
-0 3277 2795 Sc
-0.625325 0.625325 /Normal PSL_transp
-{1 0.668 0 C} FS
-0 3280 2797 Sc
-0.617052 0.617052 /Normal PSL_transp
-{1 0.645 0 C} FS
-0 3284 2800 Sc
-0.608833 0.608833 /Normal PSL_transp
-{1 0.624 0 C} FS
-0 3288 2803 Sc
-0.60067 0.60067 /Normal PSL_transp
-{1 0.602 0 C} FS
-0 3292 2806 Sc
-0.592562 0.592562 /Normal PSL_transp
-{1 0.58 0 C} FS
-0 3296 2808 Sc
-0.584509 0.584509 /Normal PSL_transp
-{1 0.559 0 C} FS
-0 3300 2811 Sc
-0.576511 0.576511 /Normal PSL_transp
-{1 0.537 0 C} FS
-0 3303 2814 Sc
-0.568568 0.568568 /Normal PSL_transp
-{1 0.516 0 C} FS
-0 3307 2817 Sc
-0.56068 0.56068 /Normal PSL_transp
-{1 0.495 0 C} FS
-0 3311 2819 Sc
-0.552847 0.552847 /Normal PSL_transp
-{1 0.474 0 C} FS
-0 3315 2822 Sc
-0.545069 0.545069 /Normal PSL_transp
-{1 0.454 0 C} FS
-0 3319 2825 Sc
-0.537347 0.537347 /Normal PSL_transp
-{1 0.433 0 C} FS
-0 3323 2828 Sc
-0.529679 0.529679 /Normal PSL_transp
-{1 0.412 0 C} FS
-0 3327 2830 Sc
-0.522067 0.522067 /Normal PSL_transp
-{1 0.392 0 C} FS
-0 3330 2833 Sc
-0.51451 0.51451 /Normal PSL_transp
-{1 0.372 0 C} FS
-0 3334 2836 Sc
-0.507008 0.507008 /Normal PSL_transp
-{1 0.352 0 C} FS
-0 3338 2839 Sc
-0.49956 0.49956 /Normal PSL_transp
-{1 0.332 0 C} FS
-0 3342 2841 Sc
-0.492169 0.492169 /Normal PSL_transp
-{1 0.312 0 C} FS
-0 3346 2844 Sc
-0.484832 0.484832 /Normal PSL_transp
-{1 0.293 0 C} FS
-0 3350 2847 Sc
-0.47755 0.47755 /Normal PSL_transp
-{1 0.273 0 C} FS
-0 3353 2850 Sc
-0.470323 0.470323 /Normal PSL_transp
-{1 0.254 0 C} FS
-0 3357 2852 Sc
-0.463152 0.463152 /Normal PSL_transp
-{1 0.235 0 C} FS
-0 3361 2855 Sc
-0.456035 0.456035 /Normal PSL_transp
-{1 0.216 0 C} FS
-0 3365 2858 Sc
-0.448974 0.448974 /Normal PSL_transp
-{1 0.197 0 C} FS
-0 3369 2861 Sc
-0.441967 0.441967 /Normal PSL_transp
-{1 0.179 0 C} FS
-0 3373 2863 Sc
-0.435016 0.435016 /Normal PSL_transp
-{1 0.16 0 C} FS
-0 3376 2866 Sc
-0.42812 0.42812 /Normal PSL_transp
-{1 0.142 0 C} FS
-0 3380 2869 Sc
-0.421279 0.421279 /Normal PSL_transp
-{1 0.123 0 C} FS
-0 3384 2872 Sc
-0.414493 0.414493 /Normal PSL_transp
-{1 0.105 0 C} FS
-0 3388 2874 Sc
-0.407762 0.407762 /Normal PSL_transp
-{1 0.0874 0 C} FS
-0 3392 2877 Sc
-0.401087 0.401087 /Normal PSL_transp
-{1 0.0696 0 C} FS
-0 3396 2880 Sc
-0.394466 0.394466 /Normal PSL_transp
-{1 0.0519 0 C} FS
-0 3400 2883 Sc
-0.387901 0.387901 /Normal PSL_transp
-{1 0.0344 0 C} FS
-0 3403 2885 Sc
-0.38139 0.38139 /Normal PSL_transp
-{1 0.017 0 C} FS
-0 3407 2888 Sc
-0.374935 0.374935 /Normal PSL_transp
-{1 0 0 C} FS
-0 3411 2891 Sc
-0.368535 0.368535 /Normal PSL_transp
-{0.983 0 0 C} FS
-0 3415 2894 Sc
-0.36219 0.36219 /Normal PSL_transp
-{0.966 0 0 C} FS
-0 3419 2896 Sc
-0.3559 0.3559 /Normal PSL_transp
-{0.949 0 0 C} FS
-0 3423 2899 Sc
-0.349665 0.349665 /Normal PSL_transp
-{0.932 0 0 C} FS
-0 3426 2902 Sc
-0.343485 0.343485 /Normal PSL_transp
-{0.916 0 0 C} FS
-0 3430 2905 Sc
-0.33736 0.33736 /Normal PSL_transp
-{0.9 0 0 C} FS
-0 3434 2907 Sc
-0.33129 0.33129 /Normal PSL_transp
-{0.883 0 0 C} FS
-0 3438 2910 Sc
-0.325276 0.325276 /Normal PSL_transp
-{0.867 0 0 C} FS
-0 3442 2913 Sc
-0.319316 0.319316 /Normal PSL_transp
-{0.852 0 0 C} FS
-0 3446 2915 Sc
-0.313412 0.313412 /Normal PSL_transp
-{0.836 0 0 C} FS
-0 3450 2918 Sc
-0.307563 0.307563 /Normal PSL_transp
-{0.82 0 0 C} FS
-0 3453 2921 Sc
-0.301769 0.301769 /Normal PSL_transp
-{0.805 0 0 C} FS
-0 3457 2924 Sc
-0.29603 0.29603 /Normal PSL_transp
-{0.789 0 0 C} FS
-0 3461 2926 Sc
-0.290346 0.290346 /Normal PSL_transp
-{0.774 0 0 C} FS
-0 3465 2929 Sc
-0.284717 0.284717 /Normal PSL_transp
-{0.759 0 0 C} FS
-0 3469 2932 Sc
-0.279143 0.279143 /Normal PSL_transp
-{0.744 0 0 C} FS
-0 3473 2935 Sc
-0.273625 0.273625 /Normal PSL_transp
-{0.73 0 0 C} FS
-0 3476 2937 Sc
-0.268161 0.268161 /Normal PSL_transp
-{0.715 0 0 C} FS
-0 3480 2940 Sc
-0.262753 0.262753 /Normal PSL_transp
-{0.701 0 0 C} FS
-0 3484 2943 Sc
-0.257399 0.257399 /Normal PSL_transp
-{0.686 0 0 C} FS
-0 3488 2946 Sc
-0.252101 0.252101 /Normal PSL_transp
-{0.672 0 0 C} FS
-0 3492 2948 Sc
-0.246858 0.246858 /Normal PSL_transp
-{0.658 0 0 C} FS
-0 3496 2951 Sc
-0.24167 0.24167 /Normal PSL_transp
-{0.644 0 0 C} FS
-0 3500 2954 Sc
-0.236537 0.236537 /Normal PSL_transp
-{0.631 0 0 C} FS
-0 3503 2957 Sc
-0.231459 0.231459 /Normal PSL_transp
-{0.617 0 0 C} FS
-0 3507 2959 Sc
-0.226436 0.226436 /Normal PSL_transp
-{0.604 0 0 C} FS
-0 3511 2962 Sc
-0.221468 0.221468 /Normal PSL_transp
-{0.591 0 0 C} FS
-0 3515 2965 Sc
-0.216556 0.216556 /Normal PSL_transp
-{0.577 0 0 C} FS
-0 3519 2968 Sc
-0.211698 0.211698 /Normal PSL_transp
-{0.565 0 0 C} FS
-0 3523 2970 Sc
-0.206896 0.206896 /Normal PSL_transp
-{0.552 0 0 C} FS
-0 3526 2973 Sc
-0.202149 0.202149 /Normal PSL_transp
-{0.539 0 0 C} FS
-0 3530 2976 Sc
-0.197456 0.197456 /Normal PSL_transp
-{0.527 0 0 C} FS
-0 3534 2979 Sc
-0.192819 0.192819 /Normal PSL_transp
-{0.514 0 0 C} FS
-0 3538 2981 Sc
-0.188237 0.188237 /Normal PSL_transp
-{0.502 0 0 C} FS
-0 3542 2984 Sc
-0.183711 0.183711 /Normal PSL_transp
-{0.49 0 0 C} FS
-0 3546 2987 Sc
-0.179239 0.179239 /Normal PSL_transp
-{0.478 0 0 C} FS
-0 3549 2990 Sc
-0.174822 0.174822 /Normal PSL_transp
-{0.466 0 0 C} FS
-0 3553 2992 Sc
-0.17046 0.17046 /Normal PSL_transp
-{0.455 0 0 C} FS
-0 3557 2995 Sc
-0.166154 0.166154 /Normal PSL_transp
-{0.443 0 0 C} FS
-0 3561 2998 Sc
-0.161903 0.161903 /Normal PSL_transp
-{0.432 0 0 C} FS
-0 3565 3001 Sc
-0.157706 0.157706 /Normal PSL_transp
-{0.421 0 0 C} FS
-0 3569 3003 Sc
-0.153565 0.153565 /Normal PSL_transp
-{0.41 0 0 C} FS
-0 3573 3006 Sc
-0.149479 0.149479 /Normal PSL_transp
-{0.399 0 0 C} FS
-0 3576 3009 Sc
-0.145448 0.145448 /Normal PSL_transp
-{0.388 0 0 C} FS
-0 3580 3012 Sc
-0.141472 0.141472 /Normal PSL_transp
-{0.377 0 0 C} FS
-0 3584 3014 Sc
-0.137551 0.137551 /Normal PSL_transp
-{0.367 0 0 C} FS
-0 3588 3017 Sc
-0.133685 0.133685 /Normal PSL_transp
-{0.356 0 0 C} FS
-0 3592 3020 Sc
-0.129875 0.129875 /Normal PSL_transp
-{0.346 0 0 C} FS
-0 3596 3023 Sc
-0.126119 0.126119 /Normal PSL_transp
-{0.336 0 0 C} FS
-0 3599 3025 Sc
-0.122419 0.122419 /Normal PSL_transp
-{0.326 0 0 C} FS
-0 3603 3028 Sc
-0.118774 0.118774 /Normal PSL_transp
-{0.317 0 0 C} FS
-0 3607 3031 Sc
-0.115183 0.115183 /Normal PSL_transp
-{0.307 0 0 C} FS
-0 3611 3034 Sc
-0.111648 0.111648 /Normal PSL_transp
-{0.298 0 0 C} FS
-0 3615 3036 Sc
-0.108168 0.108168 /Normal PSL_transp
-{0.288 0 0 C} FS
-0 3619 3039 Sc
-0.104743 0.104743 /Normal PSL_transp
-{0.279 0 0 C} FS
-0 3623 3042 Sc
-0.101373 0.101373 /Normal PSL_transp
-{0.27 0 0 C} FS
-0 3626 3045 Sc
-0.098059 0.098059 /Normal PSL_transp
-{0.261 0 0 C} FS
-0 3630 3047 Sc
-0.094799 0.094799 /Normal PSL_transp
-{0.253 0 0 C} FS
-0 3634 3050 Sc
-0.091594 0.091594 /Normal PSL_transp
-{0.244 0 0 C} FS
-0 3638 3053 Sc
-0.088445 0.088445 /Normal PSL_transp
-{0.236 0 0 C} FS
-0 3642 3056 Sc
-0.085351 0.085351 /Normal PSL_transp
-{0.228 0 0 C} FS
-0 3646 3058 Sc
-0.082311 0.082311 /Normal PSL_transp
-{0.219 0 0 C} FS
-0 3649 3061 Sc
-0.079327 0.079327 /Normal PSL_transp
-{0.212 0 0 C} FS
-0 3653 3064 Sc
-0.076398 0.076398 /Normal PSL_transp
-{0.204 0 0 C} FS
-0 3657 3067 Sc
-0.073524 0.073524 /Normal PSL_transp
-{0.196 0 0 C} FS
-0 3661 3069 Sc
-0.070705 0.070705 /Normal PSL_transp
-{0.189 0 0 C} FS
-0 3665 3072 Sc
-0.067942 0.067942 /Normal PSL_transp
-{0.181 0 0 C} FS
-0 3669 3075 Sc
-0.065233 0.065233 /Normal PSL_transp
-{0.174 0 0 C} FS
-0 3672 3077 Sc
-0.062579 0.062579 /Normal PSL_transp
-{0.167 0 0 C} FS
-0 3676 3080 Sc
-0.059981 0.059981 /Normal PSL_transp
-{0.16 0 0 C} FS
-0 3680 3083 Sc
-0.057438 0.057438 /Normal PSL_transp
-{0.153 0 0 C} FS
-0 3684 3086 Sc
-0.054949 0.054949 /Normal PSL_transp
-{0.147 0 0 C} FS
-0 3688 3088 Sc
-0.052516 0.052516 /Normal PSL_transp
-{0.14 0 0 C} FS
-0 3692 3091 Sc
-0.050138 0.050138 /Normal PSL_transp
-{0.134 0 0 C} FS
-0 3696 3094 Sc
-0.047815 0.047815 /Normal PSL_transp
-{0.128 0 0 C} FS
-0 3699 3097 Sc
-0.045547 0.045547 /Normal PSL_transp
-{0.121 0 0 C} FS
-0 3703 3099 Sc
-0.043334 0.043334 /Normal PSL_transp
-{0.116 0 0 C} FS
-0 3707 3102 Sc
-0.041177 0.041177 /Normal PSL_transp
-{0.11 0 0 C} FS
-0 3711 3105 Sc
-0.039074 0.039074 /Normal PSL_transp
-{0.104 0 0 C} FS
-0 3715 3108 Sc
-0.037027 0.037027 /Normal PSL_transp
-{0.0987 0 0 C} FS
-0 3719 3110 Sc
-0.035034 0.035034 /Normal PSL_transp
-{0.0934 0 0 C} FS
-0 3722 3113 Sc
-0.033097 0.033097 /Normal PSL_transp
-{0.0883 0 0 C} FS
-0 3726 3116 Sc
-0.031215 0.031215 /Normal PSL_transp
-{0.0832 0 0 C} FS
-0 3730 3119 Sc
-0.029388 0.029388 /Normal PSL_transp
-{0.0784 0 0 C} FS
-0 3734 3121 Sc
-0.027616 0.027616 /Normal PSL_transp
-{0.0736 0 0 C} FS
-0 3738 3124 Sc
-0.025899 0.025899 /Normal PSL_transp
-{0.0691 0 0 C} FS
-0 3742 3127 Sc
-0.024237 0.024237 /Normal PSL_transp
-{0.0646 0 0 C} FS
-0 3746 3130 Sc
-0.02263 0.02263 /Normal PSL_transp
-{0.0603 0 0 C} FS
-0 3749 3132 Sc
-0.021079 0.021079 /Normal PSL_transp
-{0.0562 0 0 C} FS
-0 3753 3135 Sc
-0.019582 0.019582 /Normal PSL_transp
-{0.0522 0 0 C} FS
-0 3757 3138 Sc
-0.018141 0.018141 /Normal PSL_transp
-{0.0484 0 0 C} FS
-0 3761 3141 Sc
-0.016754 0.016754 /Normal PSL_transp
-{0.0447 0 0 C} FS
-0 3765 3143 Sc
-0.015423 0.015423 /Normal PSL_transp
-{0.0411 0 0 C} FS
-0 3769 3146 Sc
-0.014147 0.014147 /Normal PSL_transp
-{0.0377 0 0 C} FS
-0 3772 3149 Sc
-0.012926 0.012926 /Normal PSL_transp
-{0.0345 0 0 C} FS
-0 3776 3152 Sc
-0.01176 0.01176 /Normal PSL_transp
-{0.0314 0 0 C} FS
-0 3780 3154 Sc
-0.010649 0.010649 /Normal PSL_transp
-{0.0284 0 0 C} FS
-0 3784 3157 Sc
-0.009593 0.009593 /Normal PSL_transp
-{0.0256 0 0 C} FS
-0 3788 3160 Sc
-0.008593 0.008593 /Normal PSL_transp
-{0.0229 0 0 C} FS
-0 3792 3163 Sc
-0.007647 0.007647 /Normal PSL_transp
-{0.0204 0 0 C} FS
-0 3795 3165 Sc
-0.006757 0.006757 /Normal PSL_transp
-{0.018 0 0 C} FS
-0 3799 3168 Sc
-0.005922 0.005922 /Normal PSL_transp
-{0.0158 0 0 C} FS
-0 3803 3171 Sc
-0.005141 0.005141 /Normal PSL_transp
-{0.0137 0 0 C} FS
-0 3807 3174 Sc
-0.004416 0.004416 /Normal PSL_transp
-{0.0118 0 0 C} FS
-0 3811 3176 Sc
-0.003746 0.003746 /Normal PSL_transp
-{0.00999 0 0 C} FS
-0 3815 3179 Sc
-0.003131 0.003131 /Normal PSL_transp
-{0.00835 0 0 C} FS
-0 3819 3182 Sc
-0.002571 0.002571 /Normal PSL_transp
-{0.00686 0 0 C} FS
-0 3822 3185 Sc
-0.002067 0.002067 /Normal PSL_transp
-{0.00551 0 0 C} FS
-0 3826 3187 Sc
-0.001617 0.001617 /Normal PSL_transp
-{0.00431 0 0 C} FS
-0 3830 3190 Sc
-0.001222 0.001222 /Normal PSL_transp
-{0.00326 0 0 C} FS
-0 3834 3193 Sc
-0.000883 0.000883 /Normal PSL_transp
-{0.00235 0 0 C} FS
-0 3838 3196 Sc
-0.000599 0.000599 /Normal PSL_transp
-{0.0016 0 0 C} FS
-0 3842 3198 Sc
-0.000369 0.000369 /Normal PSL_transp
-{0.000985 0 0 C} FS
-0 3845 3201 Sc
-0.000195 0.000195 /Normal PSL_transp
-{0.00052 0 0 C} FS
-0 3849 3204 Sc
-7.6e-05 7.6e-05 /Normal PSL_transp
-{0.000203 0 0 C} FS
-0 3853 3207 Sc
-1.19999999999e-05 1.19999999999e-05 /Normal PSL_transp
-{3.21e-05 0 0 C} FS
-0 3857 3209 Sc
-1 1 /Normal PSL_transp
+25 3127 2688 Sc
 U
 PSL_cliprestore
 %%EndObject

--- a/test/movie/trajectory5.sh
+++ b/test/movie/trajectory5.sh
@@ -32,7 +32,7 @@ EOF
 # Make main script that plots trajectory colored based on the y-coordinate
 cat << 'EOF' > main.sh
 gmt begin
-	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Sc3p -Cheat.cpt points.txt -Es+r0.5+d0.25 -Mz -T${MOVIE_COL0} -X0 -Y0
+	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Sc3p -Cheat.cpt points.txt -Es+d0.25 -Mz -T${MOVIE_COL0} -X0 -Y0
 gmt end
 EOF
 # Build the product

--- a/test/movie/trajectory5.sh
+++ b/test/movie/trajectory5.sh
@@ -32,7 +32,7 @@ EOF
 # Make main script that plots trajectory colored based on the y-coordinate
 cat << 'EOF' > main.sh
 gmt begin
-	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Sc3p -Cheat.cpt points.txt -Es+r1.5+d0.25 -Mz -T${MOVIE_COL0} -X0 -Y0
+	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Sc3p -Cheat.cpt points.txt -Es+r0.5+d0.25 -Mz -T${MOVIE_COL0} -X0 -Y0
 gmt end
 EOF
 # Build the product

--- a/test/psevents/psevents_functions.ps
+++ b/test/psevents/psevents_functions.ps
@@ -1,0 +1,1624 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.3.0_f478a67-dirty_2021.08.22 [64-bit] Document from text
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Aug 22 22:13:51 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/6.29921/0/10.4922 -Jx1i -N -F+jBC+f16p,Helvetica-Bold,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.29921000 0.00000000 10.49220000 0.000 6.299 0.000 10.492 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+3780 12950 M 267 F1
+(-Es+r1+p1+d1+f1 -Ms1.5+c0.5 -Mi1+c-0.2 -Mt1+c0 -Mz0.8+c-0.4) bc Z
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 9756 TM
+% PostScript produced by:
+%@GMT: gmt plot psevents_function.txt -i0,1 -W3p,red -BWrtS -Bxafg10 -Byafg1 -Xa0i -Ya8.13i -R-2/5/-0.5/1.5 -JX15c/15c
+%@PROJ: xy -2.00000000 5.00000000 -0.50000000 1.50000000 -2.000 5.000 -0.500 1.500 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 9756 T
+0 A 55 2780 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(size) tl Z
+U
+}!
+4 W
+0 A
+2160 0 M
+0 2835 D
+S
+0 709 M
+7559 0 D
+S
+0 2126 M
+7559 0 D
+S
+V
+50 W
+1 0 0 C
+clipsave
+0 0 M
+7559 0 D
+0 2835 D
+-7559 0 D
+P
+PSL_clip N
+0 709 M
+1101 1 D
+33 4 D
+32 8 D
+33 12 D
+43 22 D
+43 29 D
+22 17 D
+54 50 D
+43 48 D
+54 69 D
+65 97 D
+54 93 D
+54 103 D
+54 113 D
+54 125 D
+64 163 D
+44 117 D
+75 222 D
+65 207 D
+76 260 D
+75 281 D
+22 85 D
+1080 0 D
+75 -96 D
+65 -77 D
+65 -71 D
+43 -45 D
+22 -21 D
+10 -11 D
+54 -51 D
+76 -65 D
+65 -50 D
+75 -52 D
+65 -39 D
+65 -34 D
+65 -29 D
+86 -31 D
+65 -17 D
+75 -13 D
+33 -4 D
+75 -3 D
+1080 0 D
+76 -96 D
+54 -64 D
+43 -49 D
+43 -46 D
+65 -66 D
+86 -79 D
+76 -62 D
+76 -55 D
+32 -22 D
+43 -26 D
+43 -25 D
+87 -42 D
+75 -29 D
+87 -25 D
+54 -11 D
+54 -7 D
+54 -4 D
+1112 -1 D
+S
+PSL_cliprestore
+U
+26 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2835 M 0 -2835 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M -69 0 D S
+N 0 709 M -69 0 D S
+N 0 1417 M -69 0 D S
+N 0 2126 M -69 0 D S
+N 0 2835 M -69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+171 F0
+(”0.5) sw mx
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+def
+/PSL_A0_y PSL_A0_y 51 add def
+0 PSL_A0_y MM
+(”0.5) mr Z
+709 PSL_A0_y MM
+(0.0) mr Z
+1417 PSL_A0_y MM
+(0.5) mr Z
+2126 PSL_A0_y MM
+(1.0) mr Z
+2835 PSL_A0_y MM
+(1.5) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 142 M -34 0 D S
+N 0 283 M -34 0 D S
+N 0 425 M -34 0 D S
+N 0 567 M -34 0 D S
+N 0 850 M -34 0 D S
+N 0 992 M -34 0 D S
+N 0 1134 M -34 0 D S
+N 0 1276 M -34 0 D S
+N 0 1559 M -34 0 D S
+N 0 1701 M -34 0 D S
+N 0 1843 M -34 0 D S
+N 0 1984 M -34 0 D S
+N 0 2268 M -34 0 D S
+N 0 2409 M -34 0 D S
+N 0 2551 M -34 0 D S
+N 0 2693 M -34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+26 W
+N 0 2835 M 0 -2835 D S
+-7559 0 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 -69 D S
+N 1080 0 M 0 -69 D S
+N 2160 0 M 0 -69 D S
+N 3240 0 M 0 -69 D S
+N 4319 0 M 0 -69 D S
+N 5399 0 M 0 -69 D S
+N 6479 0 M 0 -69 D S
+N 7559 0 M 0 -69 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”2) sh mx
+(”1) sh mx
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+(4) sh mx
+(5) sh mx
+def
+/PSL_A0_y PSL_A0_y 51 add PSL_AH0 add def
+0 PSL_A0_y MM
+(”2) bc Z
+1080 PSL_A0_y MM
+(”1) bc Z
+2160 PSL_A0_y MM
+(0) bc Z
+3240 PSL_A0_y MM
+(1) bc Z
+4319 PSL_A0_y MM
+(2) bc Z
+5399 PSL_A0_y MM
+(3) bc Z
+6479 PSL_A0_y MM
+(4) bc Z
+7559 PSL_A0_y MM
+(5) bc Z
+N 216 0 M 0 -34 D S
+N 432 0 M 0 -34 D S
+N 648 0 M 0 -34 D S
+N 864 0 M 0 -34 D S
+N 1296 0 M 0 -34 D S
+N 1512 0 M 0 -34 D S
+N 1728 0 M 0 -34 D S
+N 1944 0 M 0 -34 D S
+N 2376 0 M 0 -34 D S
+N 2592 0 M 0 -34 D S
+N 2808 0 M 0 -34 D S
+N 3024 0 M 0 -34 D S
+N 3456 0 M 0 -34 D S
+N 3672 0 M 0 -34 D S
+N 3888 0 M 0 -34 D S
+N 4103 0 M 0 -34 D S
+N 4535 0 M 0 -34 D S
+N 4751 0 M 0 -34 D S
+N 4967 0 M 0 -34 D S
+N 5183 0 M 0 -34 D S
+N 5615 0 M 0 -34 D S
+N 5831 0 M 0 -34 D S
+N 6047 0 M 0 -34 D S
+N 6263 0 M 0 -34 D S
+N 6695 0 M 0 -34 D S
+N 6911 0 M 0 -34 D S
+N 7127 0 M 0 -34 D S
+N 7343 0 M 0 -34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2835 T
+26 W
+N 0 0 M 7559 0 D S
+0 -2835 T
+0 setlinecap
+%%EndObject
+0 -9756 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 6504 TM
+% PostScript produced by:
+%@GMT: gmt plot psevents_function.txt -i0,2 -W3p,red -BWrtS -Bxafg10 -Byafg1 -Xa0i -Ya5.42i -R-2/5/-0.5/1.5 -JX15c/15c
+%@PROJ: xy -2.00000000 5.00000000 -0.50000000 1.50000000 -2.000 5.000 -0.500 1.500 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 6504 T
+0 A 55 2780 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(intensity) tl Z
+U
+}!
+4 W
+0 A
+2160 0 M
+0 2835 D
+S
+0 709 M
+7559 0 D
+S
+0 2126 M
+7559 0 D
+S
+V
+50 W
+1 0 0 C
+clipsave
+0 0 M
+7559 0 D
+0 2835 D
+-7559 0 D
+P
+PSL_clip N
+0 709 M
+1112 1 D
+33 4 D
+43 9 D
+43 13 D
+65 29 D
+65 39 D
+54 41 D
+54 47 D
+10 11 D
+33 32 D
+65 74 D
+54 68 D
+54 76 D
+64 100 D
+44 73 D
+64 117 D
+44 84 D
+75 158 D
+65 146 D
+76 184 D
+43 111 D
+1080 0 D
+75 -191 D
+65 -154 D
+65 -142 D
+43 -90 D
+54 -106 D
+43 -79 D
+65 -111 D
+54 -84 D
+54 -77 D
+43 -57 D
+54 -64 D
+54 -58 D
+32 -31 D
+54 -46 D
+65 -46 D
+43 -25 D
+65 -29 D
+54 -16 D
+54 -9 D
+43 -2 D
+1080 0 D
+87 -44 D
+118 -54 D
+119 -47 D
+108 -37 D
+119 -34 D
+119 -27 D
+108 -19 D
+129 -15 D
+87 -5 D
+97 -2 D
+1069 0 D
+S
+PSL_cliprestore
+U
+26 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2835 M 0 -2835 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M -69 0 D S
+N 0 709 M -69 0 D S
+N 0 1417 M -69 0 D S
+N 0 2126 M -69 0 D S
+N 0 2835 M -69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+171 F0
+(”0.5) sw mx
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+def
+/PSL_A0_y PSL_A0_y 51 add def
+0 PSL_A0_y MM
+(”0.5) mr Z
+709 PSL_A0_y MM
+(0.0) mr Z
+1417 PSL_A0_y MM
+(0.5) mr Z
+2126 PSL_A0_y MM
+(1.0) mr Z
+2835 PSL_A0_y MM
+(1.5) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 142 M -34 0 D S
+N 0 283 M -34 0 D S
+N 0 425 M -34 0 D S
+N 0 567 M -34 0 D S
+N 0 850 M -34 0 D S
+N 0 992 M -34 0 D S
+N 0 1134 M -34 0 D S
+N 0 1276 M -34 0 D S
+N 0 1559 M -34 0 D S
+N 0 1701 M -34 0 D S
+N 0 1843 M -34 0 D S
+N 0 1984 M -34 0 D S
+N 0 2268 M -34 0 D S
+N 0 2409 M -34 0 D S
+N 0 2551 M -34 0 D S
+N 0 2693 M -34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+26 W
+N 0 2835 M 0 -2835 D S
+-7559 0 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 -69 D S
+N 1080 0 M 0 -69 D S
+N 2160 0 M 0 -69 D S
+N 3240 0 M 0 -69 D S
+N 4319 0 M 0 -69 D S
+N 5399 0 M 0 -69 D S
+N 6479 0 M 0 -69 D S
+N 7559 0 M 0 -69 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”2) sh mx
+(”1) sh mx
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+(4) sh mx
+(5) sh mx
+def
+/PSL_A0_y PSL_A0_y 51 add PSL_AH0 add def
+0 PSL_A0_y MM
+(”2) bc Z
+1080 PSL_A0_y MM
+(”1) bc Z
+2160 PSL_A0_y MM
+(0) bc Z
+3240 PSL_A0_y MM
+(1) bc Z
+4319 PSL_A0_y MM
+(2) bc Z
+5399 PSL_A0_y MM
+(3) bc Z
+6479 PSL_A0_y MM
+(4) bc Z
+7559 PSL_A0_y MM
+(5) bc Z
+N 216 0 M 0 -34 D S
+N 432 0 M 0 -34 D S
+N 648 0 M 0 -34 D S
+N 864 0 M 0 -34 D S
+N 1296 0 M 0 -34 D S
+N 1512 0 M 0 -34 D S
+N 1728 0 M 0 -34 D S
+N 1944 0 M 0 -34 D S
+N 2376 0 M 0 -34 D S
+N 2592 0 M 0 -34 D S
+N 2808 0 M 0 -34 D S
+N 3024 0 M 0 -34 D S
+N 3456 0 M 0 -34 D S
+N 3672 0 M 0 -34 D S
+N 3888 0 M 0 -34 D S
+N 4103 0 M 0 -34 D S
+N 4535 0 M 0 -34 D S
+N 4751 0 M 0 -34 D S
+N 4967 0 M 0 -34 D S
+N 5183 0 M 0 -34 D S
+N 5615 0 M 0 -34 D S
+N 5831 0 M 0 -34 D S
+N 6047 0 M 0 -34 D S
+N 6263 0 M 0 -34 D S
+N 6695 0 M 0 -34 D S
+N 6911 0 M 0 -34 D S
+N 7127 0 M 0 -34 D S
+N 7343 0 M 0 -34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2835 T
+26 W
+N 0 0 M 7559 0 D S
+0 -2835 T
+0 setlinecap
+%%EndObject
+0 -6504 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 3252 TM
+% PostScript produced by:
+%@GMT: gmt plot psevents_function.txt -i0,3 -W3p,red -BWrtS -Bxafg10 -Byafg1 -Xa0i -Ya2.71i -R-2/5/-0.5/1.5 -JX15c/15c
+%@PROJ: xy -2.00000000 5.00000000 -0.50000000 1.50000000 -2.000 5.000 -0.500 1.500 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 3252 T
+0 A 55 2780 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(transparency) tl Z
+U
+}!
+4 W
+0 A
+2160 0 M
+0 2835 D
+S
+0 709 M
+7559 0 D
+S
+0 2126 M
+7559 0 D
+S
+V
+50 W
+1 0 0 C
+clipsave
+0 0 M
+7559 0 D
+0 2835 D
+-7559 0 D
+P
+PSL_clip N
+0 2126 M
+1112 -1 D
+54 -8 D
+43 -11 D
+44 -16 D
+43 -21 D
+54 -32 D
+43 -30 D
+43 -35 D
+43 -40 D
+44 -44 D
+54 -62 D
+54 -69 D
+54 -75 D
+21 -33 D
+33 -50 D
+54 -90 D
+54 -97 D
+75 -148 D
+65 -138 D
+65 -148 D
+65 -158 D
+43 -111 D
+5399 0 D
+S
+PSL_cliprestore
+U
+26 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2835 M 0 -2835 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M -69 0 D S
+N 0 709 M -69 0 D S
+N 0 1417 M -69 0 D S
+N 0 2126 M -69 0 D S
+N 0 2835 M -69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+171 F0
+(”0.5) sw mx
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+def
+/PSL_A0_y PSL_A0_y 51 add def
+0 PSL_A0_y MM
+(”0.5) mr Z
+709 PSL_A0_y MM
+(0.0) mr Z
+1417 PSL_A0_y MM
+(0.5) mr Z
+2126 PSL_A0_y MM
+(1.0) mr Z
+2835 PSL_A0_y MM
+(1.5) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 142 M -34 0 D S
+N 0 283 M -34 0 D S
+N 0 425 M -34 0 D S
+N 0 567 M -34 0 D S
+N 0 850 M -34 0 D S
+N 0 992 M -34 0 D S
+N 0 1134 M -34 0 D S
+N 0 1276 M -34 0 D S
+N 0 1559 M -34 0 D S
+N 0 1701 M -34 0 D S
+N 0 1843 M -34 0 D S
+N 0 1984 M -34 0 D S
+N 0 2268 M -34 0 D S
+N 0 2409 M -34 0 D S
+N 0 2551 M -34 0 D S
+N 0 2693 M -34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+26 W
+N 0 2835 M 0 -2835 D S
+-7559 0 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 -69 D S
+N 1080 0 M 0 -69 D S
+N 2160 0 M 0 -69 D S
+N 3240 0 M 0 -69 D S
+N 4319 0 M 0 -69 D S
+N 5399 0 M 0 -69 D S
+N 6479 0 M 0 -69 D S
+N 7559 0 M 0 -69 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”2) sh mx
+(”1) sh mx
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+(4) sh mx
+(5) sh mx
+def
+/PSL_A0_y PSL_A0_y 51 add PSL_AH0 add def
+0 PSL_A0_y MM
+(”2) bc Z
+1080 PSL_A0_y MM
+(”1) bc Z
+2160 PSL_A0_y MM
+(0) bc Z
+3240 PSL_A0_y MM
+(1) bc Z
+4319 PSL_A0_y MM
+(2) bc Z
+5399 PSL_A0_y MM
+(3) bc Z
+6479 PSL_A0_y MM
+(4) bc Z
+7559 PSL_A0_y MM
+(5) bc Z
+N 216 0 M 0 -34 D S
+N 432 0 M 0 -34 D S
+N 648 0 M 0 -34 D S
+N 864 0 M 0 -34 D S
+N 1296 0 M 0 -34 D S
+N 1512 0 M 0 -34 D S
+N 1728 0 M 0 -34 D S
+N 1944 0 M 0 -34 D S
+N 2376 0 M 0 -34 D S
+N 2592 0 M 0 -34 D S
+N 2808 0 M 0 -34 D S
+N 3024 0 M 0 -34 D S
+N 3456 0 M 0 -34 D S
+N 3672 0 M 0 -34 D S
+N 3888 0 M 0 -34 D S
+N 4103 0 M 0 -34 D S
+N 4535 0 M 0 -34 D S
+N 4751 0 M 0 -34 D S
+N 4967 0 M 0 -34 D S
+N 5183 0 M 0 -34 D S
+N 5615 0 M 0 -34 D S
+N 5831 0 M 0 -34 D S
+N 6047 0 M 0 -34 D S
+N 6263 0 M 0 -34 D S
+N 6695 0 M 0 -34 D S
+N 6911 0 M 0 -34 D S
+N 7127 0 M 0 -34 D S
+N 7343 0 M 0 -34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2835 T
+26 W
+N 0 0 M 7559 0 D S
+0 -2835 T
+0 setlinecap
+%%EndObject
+0 -3252 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot psevents_function.txt -i0,4 -W3p,red -BWrtS -Bxafg10 -Byafg1 -Xa0i -Ya0i -R-2/5/-0.5/1.5 -JX15c/15c
+%@PROJ: xy -2.00000000 5.00000000 -0.50000000 1.50000000 -2.000 5.000 -0.500 1.500 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A 55 2780 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(delta z) tl Z
+U
+}!
+4 W
+0 A
+2160 0 M
+0 2835 D
+S
+0 709 M
+7559 0 D
+S
+0 2126 M
+7559 0 D
+S
+V
+50 W
+1 0 0 C
+clipsave
+0 0 M
+7559 0 D
+0 2835 D
+-7559 0 D
+P
+PSL_clip N
+0 709 M
+1123 1 D
+65 10 D
+54 14 D
+54 20 D
+65 31 D
+54 33 D
+54 38 D
+54 43 D
+54 50 D
+54 55 D
+54 60 D
+54 67 D
+54 72 D
+54 77 D
+54 84 D
+54 89 D
+54 94 D
+75 142 D
+76 154 D
+1080 0 D
+32 -67 D
+54 -108 D
+65 -121 D
+86 -149 D
+76 -118 D
+32 -47 D
+54 -74 D
+54 -69 D
+54 -63 D
+65 -68 D
+43 -41 D
+54 -46 D
+65 -47 D
+54 -34 D
+43 -22 D
+54 -24 D
+54 -17 D
+43 -10 D
+54 -8 D
+1123 -1 D
+54 -56 D
+76 -72 D
+54 -49 D
+75 -63 D
+98 -73 D
+43 -29 D
+65 -41 D
+75 -43 D
+65 -32 D
+54 -23 D
+65 -25 D
+75 -23 D
+76 -18 D
+65 -11 D
+54 -6 D
+75 -3 D
+1091 0 D
+S
+PSL_cliprestore
+U
+26 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2835 M 0 -2835 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M -69 0 D S
+N 0 709 M -69 0 D S
+N 0 1417 M -69 0 D S
+N 0 2126 M -69 0 D S
+N 0 2835 M -69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+171 F0
+(”0.5) sw mx
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+def
+/PSL_A0_y PSL_A0_y 51 add def
+0 PSL_A0_y MM
+(”0.5) mr Z
+709 PSL_A0_y MM
+(0.0) mr Z
+1417 PSL_A0_y MM
+(0.5) mr Z
+2126 PSL_A0_y MM
+(1.0) mr Z
+2835 PSL_A0_y MM
+(1.5) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 142 M -34 0 D S
+N 0 283 M -34 0 D S
+N 0 425 M -34 0 D S
+N 0 567 M -34 0 D S
+N 0 850 M -34 0 D S
+N 0 992 M -34 0 D S
+N 0 1134 M -34 0 D S
+N 0 1276 M -34 0 D S
+N 0 1559 M -34 0 D S
+N 0 1701 M -34 0 D S
+N 0 1843 M -34 0 D S
+N 0 1984 M -34 0 D S
+N 0 2268 M -34 0 D S
+N 0 2409 M -34 0 D S
+N 0 2551 M -34 0 D S
+N 0 2693 M -34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+26 W
+N 0 2835 M 0 -2835 D S
+-7559 0 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 -69 D S
+N 1080 0 M 0 -69 D S
+N 2160 0 M 0 -69 D S
+N 3240 0 M 0 -69 D S
+N 4319 0 M 0 -69 D S
+N 5399 0 M 0 -69 D S
+N 6479 0 M 0 -69 D S
+N 7559 0 M 0 -69 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”2) sh mx
+(”1) sh mx
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+(4) sh mx
+(5) sh mx
+def
+/PSL_A0_y PSL_A0_y 51 add PSL_AH0 add def
+0 PSL_A0_y MM
+(”2) bc Z
+1080 PSL_A0_y MM
+(”1) bc Z
+2160 PSL_A0_y MM
+(0) bc Z
+3240 PSL_A0_y MM
+(1) bc Z
+4319 PSL_A0_y MM
+(2) bc Z
+5399 PSL_A0_y MM
+(3) bc Z
+6479 PSL_A0_y MM
+(4) bc Z
+7559 PSL_A0_y MM
+(5) bc Z
+N 216 0 M 0 -34 D S
+N 432 0 M 0 -34 D S
+N 648 0 M 0 -34 D S
+N 864 0 M 0 -34 D S
+N 1296 0 M 0 -34 D S
+N 1512 0 M 0 -34 D S
+N 1728 0 M 0 -34 D S
+N 1944 0 M 0 -34 D S
+N 2376 0 M 0 -34 D S
+N 2592 0 M 0 -34 D S
+N 2808 0 M 0 -34 D S
+N 3024 0 M 0 -34 D S
+N 3456 0 M 0 -34 D S
+N 3672 0 M 0 -34 D S
+N 3888 0 M 0 -34 D S
+N 4103 0 M 0 -34 D S
+N 4535 0 M 0 -34 D S
+N 4751 0 M 0 -34 D S
+N 4967 0 M 0 -34 D S
+N 5183 0 M 0 -34 D S
+N 5615 0 M 0 -34 D S
+N 5831 0 M 0 -34 D S
+N 6047 0 M 0 -34 D S
+N 6263 0 M 0 -34 D S
+N 6695 0 M 0 -34 D S
+N 6911 0 M 0 -34 D S
+N 7127 0 M 0 -34 D S
+N 7343 0 M 0 -34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2835 T
+26 W
+N 0 0 M 7559 0 D S
+0 -2835 T
+0 setlinecap
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psevents/psevents_functions.sh
+++ b/test/psevents/psevents_functions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Test the 4 time-functions in psevents for some settings
+# Note event duration becomes sum of rise, plateau, decay times = 3
+# We run undocumented psevents -/ to get the functions for an event at t = 0.
+gmt begin psevents_functions ps
+	gmt events -/ -Es+r1+p1+d1+f1 -Ms1.5+c0.5 -Mi1+c-0.2 -Mt1+c0 -Mz0.8+c-0.4
+	# Plot the four curves
+	gmt subplot begin 4x1 -R-2/5/-0.5/1.5 -Fs16c/6c -Bxafg10 -Byafg1 -A -T"-Es+r1+p1+d1+f1 -Ms1.5+c0.5 -Mi1+c-0.2 -Mt1+c0 -Mz0.8+c-0.4" --FONT_HEADING=16p
+		gmt subplot set 0 -A"size"
+		gmt plot psevents_function.txt -i0,1 -W3p,red
+		gmt subplot set 1 -A"intensity"
+		gmt plot psevents_function.txt -i0,2 -W3p,red
+		gmt subplot set 2 -A"transparency"
+		gmt plot psevents_function.txt -i0,3 -W3p,red
+		gmt subplot set 3 -A"delta z"
+		gmt plot psevents_function.txt -i0,4 -W3p,red
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
Like we did for **greenspline**, I have implemented an undocumented way to output just plain time-functions so we can test them, here in test script _psevents_functions.sh_, which have been added.  The main change was to create a sub-function for the evaluation of the four time-functions so that it could easily be called for the debug case.
