### PR TITLE
Draw clip path before initiating clipping

### DIFF
--- a/doc/rst/source/clip_common.rst_
+++ b/doc/rst/source/clip_common.rst_
@@ -96,7 +96,7 @@ Optional Arguments
 .. _-W:
 
 **-W**\ *pen*
-    Draw outline of clip path using given pen attributes [Default is no outline].
+    Draw outline of clip path using given pen attributes before clipping is initiated [Default is no outline].
 
 .. |Add_-XY| replace:: |Add_-XY_links|
 .. include:: explain_-XY.rst_

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2862,7 +2862,7 @@ GMT_LOCAL void gmtinit_freeshorthand (struct GMT_CTRL *GMT) {/* Free memory used
 	gmt_M_free (GMT, GMT->session.shorthand);
 }
 
-GMT_LOCAL unsigned int gmtinit_subplot_status (struct GMTAPI_CTRL *API, int fig) {
+unsigned int gmt_subplot_status (struct GMTAPI_CTRL *API, int fig) {
 	/* Return GMT_SUBPLOT_ACTIVE if we are in a subplot situation, and add GMT_PANEL_NOTSET if no panel set yet */
 	char file[PATH_MAX] = {""};
 	bool answer;
@@ -14890,7 +14890,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 
 		if (GMT->current.ps.active) {	/* Only explore -c settings, etc for plot modules */
 			/* Check if a subplot operation is in effect and if there is a current panel already */
-			subplot_status = gmtinit_subplot_status (API, fig);
+			subplot_status = gmt_subplot_status (API, fig);
 			if ((inset_status = gmtinit_get_inset_dimensions (API, fig, &GMT->current.plot.inset))) {
 				return (NULL);
 			}
@@ -18350,7 +18350,7 @@ int gmt_get_current_figure (struct GMTAPI_CTRL *API) {
 void gmtlib_get_graphics_item (struct GMTAPI_CTRL *API, int *fig, int *subplot, char *panel, int *inset) {
 	/* Determine figure number, subplot panel, inset for current graphics item */
 	*fig = gmt_get_current_figure (API);	/* Return figure number 1-? or 0 if a session plot */
-	*subplot = gmtinit_subplot_status (API, *fig);	/* Get information about subplot, if active */
+	*subplot = gmt_subplot_status (API, *fig);	/* Get information about subplot, if active */
 	panel[0] = '\0';
 	if ((*subplot) & GMT_SUBPLOT_ACTIVE) {	/* subplot is active */
 		if (((*subplot) & GMT_PANEL_NOTSET) == 0) {

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -49,6 +49,7 @@ EXTERN_MSC int gmt_nc_create (struct GMT_CTRL *GMT, char *path, int mode, int *i
 
 /* gmt_init.c: */
 
+EXTERN_MSC unsigned int gmt_subplot_status (struct GMTAPI_CTRL *API, int fig);
 EXTERN_MSC void gmt_round_wesn (double wesn[], bool geo);
 EXTERN_MSC int gmt_get_dim_unit (struct GMT_CTRL *GMT, char c);
 EXTERN_MSC void gmt_set_undefined_axes (struct GMT_CTRL *GMT, bool conf_update);

--- a/src/psclip.c
+++ b/src/psclip.c
@@ -220,7 +220,7 @@ GMT_LOCAL void psclip_terminate_clipping (struct GMT_CTRL *C, struct PSL_CTRL *P
 
 EXTERN_MSC int GMT_psclip (void *V_API, int mode, void *args) {
 	int error = 0;
-	unsigned int tbl, first, eo_flag = 0;
+	unsigned int tbl, first, eo_flag = 0, was;
 	bool duplicate;
 	uint64_t row, seg, n_new;
 	double x0, y0;
@@ -246,9 +246,12 @@ EXTERN_MSC int GMT_psclip (void *V_API, int mode, void *args) {
 	/* Parse the command-line arguments; return if errors are encountered */
 
 	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, NULL, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
+	was = GMT->current.map.frame.init;
 	if (GMT_Parse_Common (API, THIS_MODULE_OPTIONS, options)) Return (API->error);
+	GMT->current.map.frame.init = 0;	/* May be set if called within a subplot so we want to bypass the usual check. */
 	Ctrl = New_Ctrl (GMT);	/* Allocate and initialize a new control structure */
 	if ((error = parse (GMT, Ctrl, options)) != 0) Return (error);
+	if (was) GMT->current.map.frame.init = was;
 
 	/*---------------------------- This is the psclip main code ----------------------------*/
 

--- a/src/psclip.c
+++ b/src/psclip.c
@@ -192,9 +192,13 @@ static int parse (struct GMT_CTRL *GMT, struct PSCLIP_CTRL *Ctrl, struct GMT_OPT
 	if (Ctrl->T.active) Ctrl->N.active = true;	/* -T implies -N */
 	if (Ctrl->T.active && n_files) GMT_Report (API, GMT_MSG_WARNING, "Option -T ignores all input files\n");
 
-	if (Ctrl->N.active && GMT->current.map.frame.init) {
-		GMT_Report (API, GMT_MSG_WARNING, "Option -B cannot be used in combination with Options -N or -T. -B is ignored.\n");
-		GMT->current.map.frame.draw = false;
+	if (Ctrl->N.active) {
+		unsigned int fig = gmt_get_current_figure (API);	/* Get current figure number */
+		unsigned int subplot_status = gmt_subplot_status (API, fig);
+		if (GMT->current.map.frame.init && !(subplot_status & GMT_SUBPLOT_ACTIVE)) {
+			GMT_Report (API, GMT_MSG_WARNING, "Option -B cannot be used in combination with Options -N or -T. -B is ignored.\n");
+			GMT->current.map.frame.draw = false;
+		}
 	}
 
 	n_errors += gmt_check_binary_io (GMT, 2);
@@ -220,7 +224,7 @@ GMT_LOCAL void psclip_terminate_clipping (struct GMT_CTRL *C, struct PSL_CTRL *P
 
 EXTERN_MSC int GMT_psclip (void *V_API, int mode, void *args) {
 	int error = 0;
-	unsigned int tbl, first, eo_flag = 0, was;
+	unsigned int tbl, first, eo_flag = 0;
 	bool duplicate;
 	uint64_t row, seg, n_new;
 	double x0, y0;
@@ -246,12 +250,9 @@ EXTERN_MSC int GMT_psclip (void *V_API, int mode, void *args) {
 	/* Parse the command-line arguments; return if errors are encountered */
 
 	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, NULL, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
-	was = GMT->current.map.frame.init;
 	if (GMT_Parse_Common (API, THIS_MODULE_OPTIONS, options)) Return (API->error);
-	GMT->current.map.frame.init = 0;	/* May be set if called within a subplot so we want to bypass the usual check. */
 	Ctrl = New_Ctrl (GMT);	/* Allocate and initialize a new control structure */
 	if ((error = parse (GMT, Ctrl, options)) != 0) Return (error);
-	if (was) GMT->current.map.frame.init = was;
 
 	/*---------------------------- This is the psclip main code ----------------------------*/
 

--- a/src/psclip.c
+++ b/src/psclip.c
@@ -107,7 +107,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "O,P");
 	GMT_Usage (API, 1, "\n-T Set clip path for the entire map frame.  No input file is required.");
 	GMT_Option (API, "U,V");
-	gmt_pen_syntax (API->GMT, 'W', NULL, "Draw clip path with given pen attributes [Default is no line].", NULL, 0);
+	gmt_pen_syntax (API->GMT, 'W', NULL, "Draw clip path first with given pen attributes [Default is no line].", NULL, 0);
 	GMT_Option (API, "X,bi2,c,di,e,f,g,h,i,p,qi,t,:,.");
 
 	return (GMT_MODULE_USAGE);
@@ -281,9 +281,6 @@ EXTERN_MSC int GMT_psclip (void *V_API, int mode, void *args) {
 	gmt_plotcanvas (GMT);	/* Fill canvas if requested */
 	gmt_map_basemap (GMT);
 
-	/* Start new clip_path */
-	first = (Ctrl->N.active) ? 0 : 1;
-
 	gmt_set_line_resampling (GMT, Ctrl->A.active, Ctrl->A.mode);	/* Possibly change line resampling mode */
 	gmt_init_fill (GMT, &no_fill, -1.0, -1.0, -1.0);
 #ifdef DEBUG
@@ -292,11 +289,8 @@ EXTERN_MSC int GMT_psclip (void *V_API, int mode, void *args) {
 #endif
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input table data\n");
-	if (Ctrl->N.active) {	/* Must clip map */
-		eo_flag = PSL_EO_CLIP;	/* Do odd/even clipping when we first lay down the map perimeter */
-		gmt_map_clip_on (GMT, GMT->session.no_rgb, 1 + eo_flag);
-	}
-	if (!Ctrl->T.active) {
+
+	if (!Ctrl->T.active) {	/* Read the data */
 		struct GMT_DATASET_HIDDEN *DH = NULL;
 		if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_POLY, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {
 			Return (API->error);	/* Register data input */
@@ -314,11 +308,11 @@ EXTERN_MSC int GMT_psclip (void *V_API, int mode, void *args) {
 		}
 		DH = gmt_get_DD_hidden (D);
 		duplicate = (DH->alloc_mode == GMT_ALLOC_EXTERNALLY && GMT->current.map.path_mode == GMT_RESAMPLE_PATH);
-		if (Ctrl->W.active) {
-			gmt_setpen (GMT, &Ctrl->W.pen);
-			gmt_setfill (GMT, &no_fill, 1);
-		}
+	}
 
+	if (Ctrl->W.active) {	/* First draw the clip path */
+		gmt_setpen (GMT, &Ctrl->W.pen);
+		gmt_setfill (GMT, &no_fill, 1);
 		for (tbl = 0; tbl < D->n_tables; tbl++) {
 			for (seg = 0; seg < D->table[tbl]->n_segments; seg++) {	/* For each segment in the table */
 				S = D->table[tbl]->segment[seg];	/* Shortcut to current segment */
@@ -334,8 +328,36 @@ EXTERN_MSC int GMT_psclip (void *V_API, int mode, void *args) {
 					gmt_set_seg_minmax (GMT, D->geometry, 2, S);	/* Update min/max of x/y only */
 					GMT_Report (API, GMT_MSG_DEBUG, "Resample polygon, now has %d points\n", S->n_rows);
 				}
-				if (Ctrl->W.active)
-					gmt_geo_polygons (GMT, S);
+				gmt_geo_polygons (GMT, S);
+				if (duplicate)	/* Free duplicate segment */
+					gmt_free_segment (GMT, &S);
+			}
+		}
+	}
+
+	/* Start new clip_path */
+	first = (Ctrl->N.active) ? 0 : 1;
+
+	if (Ctrl->N.active) {	/* Must clip map first to invert sense of clipping */
+		eo_flag = PSL_EO_CLIP;	/* Do odd/even clipping when we first lay down the map perimeter */
+		gmt_map_clip_on (GMT, GMT->session.no_rgb, 1 + eo_flag);
+	}
+	if (!Ctrl->T.active) {	/* Got a clipping path to lay down */
+		for (tbl = 0; tbl < D->n_tables; tbl++) {
+			for (seg = 0; seg < D->table[tbl]->n_segments; seg++) {	/* For each segment in the table */
+				S = D->table[tbl]->segment[seg];	/* Shortcut to current segment */
+				if (duplicate) {	/* Must duplicate externally allocated segment since it needs to be resampled below */
+					GMT_Report (API, GMT_MSG_DEBUG, "Must duplicate external memory polygon\n");
+					S = gmt_duplicate_segment (GMT, D->table[tbl]->segment[seg]);
+				}
+				if (GMT->current.map.path_mode == GMT_RESAMPLE_PATH) {	/* Resample if spacing is too coarse or stair-case is requested */
+					if ((n_new = gmt_fix_up_path (GMT, &S->data[GMT_X], &S->data[GMT_Y], S->n_rows, Ctrl->A.step, Ctrl->A.mode)) == 0) {
+						Return (GMT_RUNTIME_ERROR);
+					}
+					S->n_rows = n_new;
+					gmt_set_seg_minmax (GMT, D->geometry, 2, S);	/* Update min/max of x/y only */
+					GMT_Report (API, GMT_MSG_DEBUG, "Resample polygon, now has %d points\n", S->n_rows);
+				}
 
 				for (row = 0; row < S->n_rows; row++) {	/* Apply map projection */
 					gmt_geo_to_xy (GMT, S->data[GMT_X][row], S->data[GMT_Y][row], &x0, &y0);

--- a/test/psclip/clip_draw.ps
+++ b/test/psclip/clip_draw.ps
@@ -1,0 +1,1478 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.3.0_c00d296-dirty_2021.08.27 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Aug 27 13:22:49 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/6.54421/0/6.54421 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.54421000 0.00000000 6.54421000 0.000 6.544 0.000 6.544 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4074 TM
+% PostScript produced by:
+%@GMT: gmt basemap -BWens -Bxaf -Byaf -Xa0i -Ya3.3946i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 4074 T
+0 A 52 3727 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+261 F0
+(-N) tl Z
+U
+}!
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -65 0 D S
+N 0 756 M -65 0 D S
+N 0 1512 M -65 0 D S
+N 0 2268 M -65 0 D S
+N 0 3024 M -65 0 D S
+N 0 3780 M -65 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+163 F0
+(0.0) sw mx
+(0.2) sw mx
+(0.4) sw mx
+(0.6) sw mx
+(0.8) sw mx
+(1.0) sw mx
+def
+/PSL_A0_y PSL_A0_y 49 add def
+0 PSL_A0_y MM
+(0.0) mr Z
+756 PSL_A0_y MM
+(0.2) mr Z
+1512 PSL_A0_y MM
+(0.4) mr Z
+2268 PSL_A0_y MM
+(0.6) mr Z
+3024 PSL_A0_y MM
+(0.8) mr Z
+3780 PSL_A0_y MM
+(1.0) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 378 M -33 0 D S
+N 0 1134 M -33 0 D S
+N 0 1890 M -33 0 D S
+N 0 2646 M -33 0 D S
+N 0 3402 M -33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+24 W
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 65 0 D S
+N 0 756 M 65 0 D S
+N 0 1512 M 65 0 D S
+N 0 2268 M 65 0 D S
+N 0 3024 M 65 0 D S
+N 0 3780 M 65 0 D S
+N 0 378 M 33 0 D S
+N 0 1134 M 33 0 D S
+N 0 1890 M 33 0 D S
+N 0 2646 M 33 0 D S
+N 0 3402 M 33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+24 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -65 D S
+N 756 0 M 0 -65 D S
+N 1512 0 M 0 -65 D S
+N 2268 0 M 0 -65 D S
+N 3024 0 M 0 -65 D S
+N 3780 0 M 0 -65 D S
+N 378 0 M 0 -33 D S
+N 1134 0 M 0 -33 D S
+N 1890 0 M 0 -33 D S
+N 2646 0 M 0 -33 D S
+N 3402 0 M 0 -33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+24 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 65 D S
+N 756 0 M 0 65 D S
+N 1512 0 M 0 65 D S
+N 2268 0 M 0 65 D S
+N 3024 0 M 0 65 D S
+N 3780 0 M 0 65 D S
+N 378 0 M 0 33 D S
+N 1134 0 M 0 33 D S
+N 1890 0 M 0 33 D S
+N 2646 0 M 0 33 D S
+N 3402 0 M 0 33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+0 A
+%%EndObject
+0 -4074 TM
+0 A
+FQ
+O0
+0 4074 TM
+% PostScript produced by:
+%@GMT: gmt clip clip.txt -N -Xa0i -Ya3.3946i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+0 -3780 D
+0 0 M
+3780 3780 D
+-3780 0 D
+0 -3780 D
+PSL_eoclip N
+%%EndObject
+0 -4074 TM
+0 A
+FQ
+O0
+0 4074 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sc.5c -G128 -W.5p,0 data.txt -Xa0i -Ya3.3946i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+V
+8 W
+{0.502 A} FS
+O1
+118 1890 945 Sc
+118 1890 1890 Sc
+118 1890 2835 Sc
+118 945 1890 Sc
+118 2835 1890 Sc
+U
+PSL_cliprestore
+%%EndObject
+0 -4074 TM
+0 A
+FQ
+O0
+0 4074 TM
+% PostScript produced by:
+%@GMT: gmt clip -C -Xa0i -Ya3.3946i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 0.000 0.000 0.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_nclip {PSL_cliprestore} repeat
+%%EndObject
+0 -4074 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4074 4074 TM
+% PostScript produced by:
+%@GMT: gmt clip clip.txt -N -W.25p,blue -Bwens -Bxaf -Byaf -Xa3.3946i -Ya3.3946i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4074 4074 T
+0 A 52 3727 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+261 F0
+(-N -W) tl Z
+U
+}!
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -65 0 D S
+N 0 756 M -65 0 D S
+N 0 1512 M -65 0 D S
+N 0 2268 M -65 0 D S
+N 0 3024 M -65 0 D S
+N 0 3780 M -65 0 D S
+N 0 378 M -33 0 D S
+N 0 1134 M -33 0 D S
+N 0 1890 M -33 0 D S
+N 0 2646 M -33 0 D S
+N 0 3402 M -33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+24 W
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 65 0 D S
+N 0 756 M 65 0 D S
+N 0 1512 M 65 0 D S
+N 0 2268 M 65 0 D S
+N 0 3024 M 65 0 D S
+N 0 3780 M 65 0 D S
+N 0 378 M 33 0 D S
+N 0 1134 M 33 0 D S
+N 0 1890 M 33 0 D S
+N 0 2646 M 33 0 D S
+N 0 3402 M 33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+24 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -65 D S
+N 756 0 M 0 -65 D S
+N 1512 0 M 0 -65 D S
+N 2268 0 M 0 -65 D S
+N 3024 0 M 0 -65 D S
+N 3780 0 M 0 -65 D S
+N 378 0 M 0 -33 D S
+N 1134 0 M 0 -33 D S
+N 1890 0 M 0 -33 D S
+N 2646 0 M 0 -33 D S
+N 3402 0 M 0 -33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+24 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 65 D S
+N 756 0 M 0 65 D S
+N 1512 0 M 0 65 D S
+N 2268 0 M 0 65 D S
+N 3024 0 M 0 65 D S
+N 3780 0 M 0 65 D S
+N 378 0 M 0 33 D S
+N 1134 0 M 0 33 D S
+N 1890 0 M 0 33 D S
+N 2646 0 M 0 33 D S
+N 3402 0 M 0 33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+4 W
+0 0 1 C
+O1
+0 0 M
+3780 3780 D
+-3780 0 D
+P S
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+0 -3780 D
+0 0 M
+3780 3780 D
+-3780 0 D
+0 -3780 D
+PSL_eoclip N
+0 A
+%%EndObject
+-4074 -4074 TM
+0 A
+FQ
+O0
+4074 4074 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sc.5c -G128 -W.5p,0 data.txt -Xa3.3946i -Ya3.3946i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+V
+8 W
+{0.502 A} FS
+O1
+118 1890 945 Sc
+118 1890 1890 Sc
+118 1890 2835 Sc
+118 945 1890 Sc
+118 2835 1890 Sc
+U
+PSL_cliprestore
+%%EndObject
+-4074 -4074 TM
+0 A
+FQ
+O0
+4074 4074 TM
+% PostScript produced by:
+%@GMT: gmt clip -C -Xa3.3946i -Ya3.3946i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 0.000 0.000 0.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_nclip {PSL_cliprestore} repeat
+%%EndObject
+-4074 -4074 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt basemap -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A 52 3727 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+261 F0
+(none) tl Z
+U
+}!
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -65 0 D S
+N 0 756 M -65 0 D S
+N 0 1512 M -65 0 D S
+N 0 2268 M -65 0 D S
+N 0 3024 M -65 0 D S
+N 0 3780 M -65 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+163 F0
+(0.0) sw mx
+(0.2) sw mx
+(0.4) sw mx
+(0.6) sw mx
+(0.8) sw mx
+(1.0) sw mx
+def
+/PSL_A0_y PSL_A0_y 49 add def
+0 PSL_A0_y MM
+(0.0) mr Z
+756 PSL_A0_y MM
+(0.2) mr Z
+1512 PSL_A0_y MM
+(0.4) mr Z
+2268 PSL_A0_y MM
+(0.6) mr Z
+3024 PSL_A0_y MM
+(0.8) mr Z
+3780 PSL_A0_y MM
+(1.0) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 378 M -33 0 D S
+N 0 1134 M -33 0 D S
+N 0 1890 M -33 0 D S
+N 0 2646 M -33 0 D S
+N 0 3402 M -33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+24 W
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 65 0 D S
+N 0 756 M 65 0 D S
+N 0 1512 M 65 0 D S
+N 0 2268 M 65 0 D S
+N 0 3024 M 65 0 D S
+N 0 3780 M 65 0 D S
+N 0 378 M 33 0 D S
+N 0 1134 M 33 0 D S
+N 0 1890 M 33 0 D S
+N 0 2646 M 33 0 D S
+N 0 3402 M 33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+24 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -65 D S
+N 756 0 M 0 -65 D S
+N 1512 0 M 0 -65 D S
+N 2268 0 M 0 -65 D S
+N 3024 0 M 0 -65 D S
+N 3780 0 M 0 -65 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0.0) sh mx
+(0.2) sh mx
+(0.4) sh mx
+(0.6) sh mx
+(0.8) sh mx
+(1.0) sh mx
+def
+/PSL_A0_y PSL_A0_y 49 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0.0) bc Z
+756 PSL_A0_y MM
+(0.2) bc Z
+1512 PSL_A0_y MM
+(0.4) bc Z
+2268 PSL_A0_y MM
+(0.6) bc Z
+3024 PSL_A0_y MM
+(0.8) bc Z
+3780 PSL_A0_y MM
+(1.0) bc Z
+N 378 0 M 0 -33 D S
+N 1134 0 M 0 -33 D S
+N 1890 0 M 0 -33 D S
+N 2646 0 M 0 -33 D S
+N 3402 0 M 0 -33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+24 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 65 D S
+N 756 0 M 0 65 D S
+N 1512 0 M 0 65 D S
+N 2268 0 M 0 65 D S
+N 3024 0 M 0 65 D S
+N 3780 0 M 0 65 D S
+N 378 0 M 0 33 D S
+N 1134 0 M 0 33 D S
+N 1890 0 M 0 33 D S
+N 2646 0 M 0 33 D S
+N 3402 0 M 0 33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+0 A
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt clip clip.txt -Xa0i -Ya0i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3780 3780 D
+-3780 0 D
+0 -3780 D
+PSL_clip N
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sc.5c -G128 -W.5p,0 data.txt -Xa0i -Ya0i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+V
+8 W
+{0.502 A} FS
+O1
+118 1890 945 Sc
+118 1890 1890 Sc
+118 1890 2835 Sc
+118 945 1890 Sc
+118 2835 1890 Sc
+U
+PSL_cliprestore
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt clip -C -Xa0i -Ya0i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 0.000 0.000 0.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_nclip {PSL_cliprestore} repeat
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+4074 0 TM
+% PostScript produced by:
+%@GMT: gmt basemap -BwenS -Bxaf -Byaf -Xa3.3946i -Ya0i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+4074 0 T
+0 A 52 3727 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+261 F0
+(-W) tl Z
+U
+}!
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -65 0 D S
+N 0 756 M -65 0 D S
+N 0 1512 M -65 0 D S
+N 0 2268 M -65 0 D S
+N 0 3024 M -65 0 D S
+N 0 3780 M -65 0 D S
+N 0 378 M -33 0 D S
+N 0 1134 M -33 0 D S
+N 0 1890 M -33 0 D S
+N 0 2646 M -33 0 D S
+N 0 3402 M -33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3780 0 T
+24 W
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 65 0 D S
+N 0 756 M 65 0 D S
+N 0 1512 M 65 0 D S
+N 0 2268 M 65 0 D S
+N 0 3024 M 65 0 D S
+N 0 3780 M 65 0 D S
+N 0 378 M 33 0 D S
+N 0 1134 M 33 0 D S
+N 0 1890 M 33 0 D S
+N 0 2646 M 33 0 D S
+N 0 3402 M 33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-3780 0 T
+24 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -65 D S
+N 756 0 M 0 -65 D S
+N 1512 0 M 0 -65 D S
+N 2268 0 M 0 -65 D S
+N 3024 0 M 0 -65 D S
+N 3780 0 M 0 -65 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg M} def
+/PSL_AH0 0
+163 F0
+(0.0) sh mx
+(0.2) sh mx
+(0.4) sh mx
+(0.6) sh mx
+(0.8) sh mx
+(1.0) sh mx
+def
+/PSL_A0_y PSL_A0_y 49 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0.0) bc Z
+756 PSL_A0_y MM
+(0.2) bc Z
+1512 PSL_A0_y MM
+(0.4) bc Z
+2268 PSL_A0_y MM
+(0.6) bc Z
+3024 PSL_A0_y MM
+(0.8) bc Z
+3780 PSL_A0_y MM
+(1.0) bc Z
+N 378 0 M 0 -33 D S
+N 1134 0 M 0 -33 D S
+N 1890 0 M 0 -33 D S
+N 2646 0 M 0 -33 D S
+N 3402 0 M 0 -33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+24 W
+N 0 0 M 3780 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 65 D S
+N 756 0 M 0 65 D S
+N 1512 0 M 0 65 D S
+N 2268 0 M 0 65 D S
+N 3024 0 M 0 65 D S
+N 3780 0 M 0 65 D S
+N 378 0 M 0 33 D S
+N 1134 0 M 0 33 D S
+N 1890 0 M 0 33 D S
+N 2646 0 M 0 33 D S
+N 3402 0 M 0 33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+0 A
+%%EndObject
+-4074 0 TM
+0 A
+FQ
+O0
+4074 0 TM
+% PostScript produced by:
+%@GMT: gmt clip clip.txt -W.25p,blue -Xa3.3946i -Ya0i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 0 1 C
+O1
+0 0 M
+3780 3780 D
+-3780 0 D
+P S
+clipsave
+0 0 M
+3780 3780 D
+-3780 0 D
+0 -3780 D
+PSL_clip N
+%%EndObject
+-4074 0 TM
+0 A
+FQ
+O0
+4074 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sc.5c -G128 -W.5p,0 data.txt -Xa3.3946i -Ya0i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 1.000 0.000 1.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3780 0 D
+0 3780 D
+-3780 0 D
+P
+PSL_clip N
+V
+8 W
+{0.502 A} FS
+O1
+118 1890 945 Sc
+118 1890 1890 Sc
+118 1890 2835 Sc
+118 945 1890 Sc
+118 2835 1890 Sc
+U
+PSL_cliprestore
+%%EndObject
+-4074 0 TM
+0 A
+FQ
+O0
+4074 0 TM
+% PostScript produced by:
+%@GMT: gmt clip -C -Xa3.3946i -Ya0i -R0/1/0/1 -JX15c/15c
+%@PROJ: xy 0.00000000 1.00000000 0.00000000 1.00000000 0.000 0.000 0.000 0.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_nclip {PSL_cliprestore} repeat
+%%EndObject
+-4074 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psclip/clip_draw.sh
+++ b/test/psclip/clip_draw.sh
@@ -10,7 +10,7 @@ echo ".5 .25
 .25 .5
 .75 .5" > data.txt
 
-gmt begin clip_draw ps
+gmt begin clip_draw
 	# -N
 	gmt subplot begin 2x2 -Fs8c -Scb -Srl -R0/1/0/1 -A
 	gmt subplot set -A"-N"

--- a/test/psclip/clip_draw4.sh
+++ b/test/psclip/clip_draw4.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Ensure -W -N play nice, see https://github.com/GenericMappingTools/gmt/issues/5704
+
+echo "0 0
+1 1
+0 1" > clip.txt
+echo ".5 .25
+.5 .5
+.5 .75
+.25 .5
+.75 .5" > data.txt
+
+gmt begin clip_draw ps
+	# -N
+	gmt subplot begin 2x2 -Fs8c -Scb -Srl -R0/1/0/1 -A
+	gmt subplot set -A"-N"
+	gmt basemap
+	gmt clip clip.txt -N
+	gmt plot -Sc.5c -G128 -W.5p,0 data.txt
+	gmt clip -C
+	# -N -W
+	gmt subplot set -A"-N -W"
+	gmt clip clip.txt -N -W.25p,blue
+	gmt plot -Sc.5c -G128 -W.5p,0 data.txt
+	gmt clip -C
+	# neither
+	gmt subplot set -A"none"
+	gmt basemap
+	gmt clip clip.txt
+	gmt plot -Sc.5c -G128 -W.5p,0 data.txt
+	gmt clip -C
+	#-W
+	gmt subplot set -A"-W"
+	gmt psbasemap
+	gmt clip clip.txt -W.25p,blue
+	gmt plot -Sc.5c -G128 -W.5p,0 data.txt
+	gmt clip -C
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
See #5704 for background.  The problem was that the drawing of the path happened in the same loop as we are laying down the clip path and that fails somehow with **-N**.  Now we draw the clip path first (if **-W** is given), and then lay down the clip path.  I have added a test to show the four version of the OP's case.  In fixing this I noticed **clip** would complain if used in subplots since the **-N** restriction on **-B** collides with what **-B** is set via **subplot**.  Thus I needed to let **clip** know when it is being used in a panel.

 Closes #5704.

![clip_draw](https://user-images.githubusercontent.com/26473567/131199211-83533fd8-c319-48a1-98ea-17df54e27717.png)

All tests including the new one now passes.