### PR TITLE
Let Latex text use the specified font color

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -2620,7 +2620,7 @@ GMT_LOCAL void gmtplot_map_label (struct GMT_CTRL *GMT, double x, double y, char
 			if (axis == GMT_Y) PSL_command (PSL, "0 %d M currentpoint T\n", (int)lrint (sgn[below]*GMT->current.setting.map_label_offset[GMT_Y] * PSL->internal.y2iy));
 		}
 		// PSL_command (PSL, "V currentpoint -2000 0 G 4000 0 D S U\n");	/* Debug line for base of label; keep for future debugging */
-		PSL_plotepsimage (PSL, x, y, w, h, PSL_BC, eps, &header);	/* Place the EPS plot */
+		PSL_plotlatexeps (PSL, x, y, w, h, PSL_BC, eps, GMT->current.setting.font_label.fill.rgb, &header);	/* Place the EPS plot */
 		PSL_command (PSL, "U\n");	/* Close up the block */
 		if (set_L_off)	/* Must reset the value of PSL_LH to the EPS image height so the title baseline can be adjusted */
 			PSL_command (PSL, "/PSL_LH %d def\n", (int)lrint (h * PSL->internal.y2iy));
@@ -5342,7 +5342,7 @@ void gmt_map_text (struct GMT_CTRL *GMT, double x, double y, struct GMT_FONT *fo
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "gmt_map_text: Conversion of LaTeX gave dimensions %g x %g\n", w, h);
 		PSL_command (PSL, "V\n");	/* Keep the relative changes inside a save/restore block */
 		PSL_setorigin (PSL, x, y, angle, PSL_FWD);		/* Move to desired point and possibly rotate to angle */
-		PSL_plotepsimage (PSL, 0.0, 0.0, w, h, just, eps, &header);	/* Place the EPS plot */
+		PSL_plotlatexeps (PSL, 0.0, 0.0, w, h, just, eps, font->fill.rgb, &header);	/* Place the EPS plot */
 		PSL_command (PSL, "U\n");	/* Close up the block */
 		PSL_free (eps);
 	}
@@ -6169,7 +6169,7 @@ GMT_LOCAL double gmtplot_place_latex_eps (struct GMT_CTRL *GMT, double x, double
 	PSL_command (GMT->PSL, "V\n");	/* Keep the relative changes inside a save/restore block */
 	if (pos_set)
 		PSL_command (GMT->PSL, "currentpoint T\n");	/* Translate to currentpoint since already set by calling function */
-	PSL_plotepsimage (GMT->PSL, x, y, w, h, PSL_BC, eps, &header);
+	PSL_plotlatexeps (GMT->PSL, x, y, w, h, PSL_BC, eps, F->fill.rgb, &header);
 	PSL_command (GMT->PSL, "U\n");
 	PSL_free (eps);
 	return h;

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -447,6 +447,7 @@ EXTERN_MSC int PSL_plotaxis (struct PSL_CTRL *PSL, double annotation_int, char *
 EXTERN_MSC int PSL_plotbitimage (struct PSL_CTRL *PSL, double x, double y, double xsize, double ysize, int justify, unsigned char *buffer, int nx, int ny, double f_rgb[], double b_rgb[]);
 EXTERN_MSC int PSL_plotcolorimage (struct PSL_CTRL *PSL, double x, double y, double xsize, double ysize, int justify, unsigned char *buffer, int nx, int ny, int nbits);
 EXTERN_MSC int PSL_plotepsimage (struct PSL_CTRL *PSL, double x, double y, double xsize, double ysize, int justify, unsigned char *buffer, struct imageinfo *h);
+EXTERN_MSC int PSL_plotlatexeps (struct PSL_CTRL *PSL, double x, double y, double xsize, double ysize, int justify, unsigned char *buffer, double *rgb, struct imageinfo *h);
 EXTERN_MSC int PSL_plotline (struct PSL_CTRL *PSL, double *x, double *y, int n, int type);
 EXTERN_MSC int PSL_plotcurve (struct PSL_CTRL *PSL, double *x, double *y, int n, int type);
 EXTERN_MSC int PSL_plotparagraph (struct PSL_CTRL *PSL, double x, double y, double fontsize, char *paragraph, double angle, int justify);

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -1417,10 +1417,8 @@ EXTERN_MSC int GMT_pstext (void *V_API, int mode, void *args) {
 				c_font[m] = T.font;
 				m++;
 			}
-			else {
+			else
 				gmt_map_text (GMT, plot_x, plot_y, &T.font, curr_txt, T.paragraph_angle, T.block_justify, fmode);
-				//PSL_plottext (PSL, plot_x, plot_y, T.font.size, curr_txt, T.paragraph_angle, T.block_justify, fmode);
-			}
 			if (Ctrl->A.active) T.paragraph_angle = save_angle;	/* Restore original angle */
 			gmt_M_str_free (use_text);
 		}

--- a/test/latex/latexrgb.ps
+++ b/test/latex/latexrgb.ps
@@ -1,0 +1,2120 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 595 842
+%%HiResBoundingBox: 0 0 595.0000 842.0000
+%%Title: GMT v6.3.0_6f6a988-dirty_2021.08.28 [64-bit] Document from text
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sat Aug 28 10:52:00 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 9917 def
+/PSL_page_ysize 14033 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/16/0/8 -Jx1c -Baf -F+f48p,1,red
+%@PROJ: xy 0.00000000 16.00000000 0.00000000 8.00000000 0.000 16.000 0.000 8.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+1 0 0 C
+V
+3780 1890 T
+PSL_eps_begin
+1 0 0 C
+-2440 -480 T 80 80 scale
+-148 -654 T
+N 148 654 M 209 654 L 209 666 L 148 666 L P clip N
+%%BeginDocument: psimage.eps
+%!PS-Adobe-2.0 EPSF-2.0
+%%Creator: dvips(k) 2021.1 Copyright 2021 Radical Eye Software
+%%Title: gmt_eq.dvi
+%%CreationDate: Sat Aug 28 20:52:00 2021
+%%DocumentFonts: CMR10 CMMI10 CMR7
+%%EndComments
+%DVIPSWebPage: (www.radicaleye.com)
+%DVIPSCommandLine: dvips -q -E gmt_eq.dvi -o equation.eps
+%DVIPSParameters: dpi=600
+%DVIPSSource:  TeX output 2021.08.28:1052
+%%BeginProcSet: tex.pro 0 0
+%!
+/TeXDict 300 dict def TeXDict begin/N{def}def/B{bind def}N/S{exch}N/X{S
+N}B/A{dup}B/TR{translate}N/isls false N/vsize 11 72 mul N/hsize 8.5 72
+mul N/landplus90{false}def/@rigin{isls{[0 landplus90{1 -1}{-1 1}ifelse 0
+0 0]concat}if 72 Resolution div 72 VResolution div neg scale isls{
+landplus90{VResolution 72 div vsize mul 0 exch}{Resolution -72 div hsize
+mul 0}ifelse TR}if Resolution VResolution vsize -72 div 1 add mul TR[
+matrix currentmatrix{A A round sub abs 0.00001 lt{round}if}forall round
+exch round exch]setmatrix}N/@landscape{/isls true N}B/@manualfeed{
+statusdict/manualfeed true put}B/@copies{/#copies X}B/FMat[1 0 0 -1 0 0]
+N/FBB[0 0 0 0]N/nn 0 N/IEn 0 N/ctr 0 N/df-tail{/nn 8 dict N nn begin
+/FontType 3 N/FontMatrix fntrx N/FontBBox FBB N string/base X array
+/BitMaps X/BuildChar{CharBuilder}N/Encoding IEn N end A{/foo setfont}2
+array copy cvx N load 0 nn put/ctr 0 N[}B/sf 0 N/df{/sf 1 N/fntrx FMat N
+df-tail}B/dfs{div/sf X/fntrx[sf 0 0 sf neg 0 0]N df-tail}B/E{pop nn A
+definefont setfont}B/Cw{Cd A length 5 sub get}B/Ch{Cd A length 4 sub get
+}B/Cx{128 Cd A length 3 sub get sub}B/Cy{Cd A length 2 sub get 127 sub}
+B/Cdx{Cd A length 1 sub get}B/Ci{Cd A type/stringtype ne{ctr get/ctr ctr
+1 add N}if}B/CharBuilder{save 3 1 roll S A/base get 2 index get S
+/BitMaps get S get/Cd X pop/ctr 0 N Cdx 0 Cx Cy Ch sub Cx Cw add Cy
+setcachedevice Cw Ch true[1 0 0 -1 -.1 Cx sub Cy .1 sub]{Ci}imagemask
+restore}B/D{/cc X A type/stringtype ne{]}if nn/base get cc ctr put nn
+/BitMaps get S ctr S sf 1 ne{A A length 1 sub A 2 index S get sf div put
+}if put/ctr ctr 1 add N}B/I{cc 1 add D}B/bop{userdict/bop-hook known{
+bop-hook}if/SI save N @rigin 0 0 moveto/V matrix currentmatrix A 1 get A
+mul exch 0 get A mul add .99 lt{/QV}{/RV}ifelse load def pop pop}N/eop{
+SI restore userdict/eop-hook known{eop-hook}if showpage}N/@start{
+userdict/start-hook known{start-hook}if pop/VResolution X/Resolution X
+1000 div/DVImag X/IEn 256 array N 2 string 0 1 255{IEn S A 360 add 36 4
+index cvrs cvn put}for pop 65781.76 div/vsize X 65781.76 div/hsize X}N
+/dir 0 def/dyy{/dir 0 def}B/dyt{/dir 1 def}B/dty{/dir 2 def}B/dtt{/dir 3
+def}B/p{dir 2 eq{-90 rotate show 90 rotate}{dir 3 eq{-90 rotate show 90
+rotate}{show}ifelse}ifelse}N/RMat[1 0 0 -1 0 0]N/BDot 260 string N/Rx 0
+N/Ry 0 N/V{}B/RV/v{/Ry X/Rx X V}B statusdict begin/product where{pop
+false[(Display)(NeXT)(LaserWriter 16/600)]{A length product length le{A
+length product exch 0 exch getinterval eq{pop true exit}if}{pop}ifelse}
+forall}{false}ifelse end{{gsave TR -.1 .1 TR 1 1 scale Rx Ry false RMat{
+BDot}imagemask grestore}}{{gsave TR -.1 .1 TR Rx Ry scale 1 1 false RMat
+{BDot}imagemask grestore}}ifelse B/QV{gsave newpath transform round exch
+round exch itransform moveto Rx 0 rlineto 0 Ry neg rlineto Rx neg 0
+rlineto fill grestore}B/a{moveto}B/delta 0 N/tail{A/delta X 0 rmoveto}B
+/M{S p delta add tail}B/b{S p tail}B/c{-4 M}B/d{-3 M}B/e{-2 M}B/f{-1 M}
+B/g{0 M}B/h{1 M}B/i{2 M}B/j{3 M}B/k{4 M}B/w{0 rmoveto}B/l{p -4 w}B/m{p
+-3 w}B/n{p -2 w}B/o{p -1 w}B/q{p 1 w}B/r{p 2 w}B/s{p 3 w}B/t{p 4 w}B/x{
+0 S rmoveto}B/y{3 2 roll p a}B/bos{/SS save N}B/eos{SS restore}B end
+%%EndProcSet
+%%BeginProcSet: l3backend-dvips.pro 0 0
+%%
+%% This is file `l3backend-dvips.pro',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% l3backend-header.dtx  (with options: `header,dvips')
+%% 
+%% Copyright (C) 1990-2021 The LaTeX Project
+%% 
+%% It may be distributed and/or modified under the conditions of
+%% the LaTeX Project Public License (LPPL), either version 1.3c of
+%% this license or (at your option) any later version.  The latest
+%% version of this license is in the file:
+%% 
+%%    https://www.latex-project.org/lppl.txt
+%% 
+%% This file is part of the "l3backend bundle" (The Work in LPPL)
+%% and all files in that bundle must be distributed together.
+%% 
+%% File: l3backend-header.dtx
+/color.sc { } def
+TeXDict begin
+/TeXcolorseparation { setcolor } def
+end
+true setglobal
+/pdf.globaldict 4 dict def
+false setglobal
+/pdf.cvs { 65534 string cvs } def
+/pdf.dvi.pt { 72.27 mul Resolution div } def
+/pdf.pt.dvi { 72.27 div Resolution mul } def
+/pdf.rect.ht { dup 1 get neg exch 3 get add } def
+/pdf.linkmargin { 1 pdf.pt.dvi } def
+/pdf.linkdp.pad { 0 } def
+/pdf.linkht.pad { 0 } def
+/pdf.rect
+  { /Rect [ pdf.llx pdf.lly pdf.urx pdf.ury ] } def
+/pdf.save.ll
+  {
+    currentpoint
+    /pdf.lly exch def
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.ur
+  {
+    currentpoint
+    /pdf.ury exch def
+    /pdf.urx exch def
+  }
+    def
+/pdf.save.linkll
+  {
+    currentpoint
+    pdf.linkmargin add
+    pdf.linkdp.pad add
+    /pdf.lly exch def
+    pdf.linkmargin sub
+    /pdf.llx exch def
+  }
+    def
+/pdf.save.linkur
+  {
+    currentpoint
+    pdf.linkmargin sub
+    pdf.linkht.pad sub
+    /pdf.ury exch def
+    pdf.linkmargin add
+    /pdf.urx exch def
+  }
+    def
+/pdf.dest.anchor
+  {
+    currentpoint exch
+    pdf.dvi.pt 72 add
+    /pdf.dest.x exch def
+    pdf.dvi.pt
+    vsize 72 sub exch sub
+    /pdf.dest.y exch def
+  }
+    def
+/pdf.dest.point
+  { pdf.dest.x pdf.dest.y } def
+/pdf.dest2device
+  {
+    /pdf.dest.y exch def
+    /pdf.dest.x exch def
+    matrix currentmatrix
+    matrix defaultmatrix
+    matrix invertmatrix
+    matrix concatmatrix
+    cvx exec
+    /pdf.dev.y exch def
+    /pdf.dev.x exch def
+    /pdf.tmpd exch def
+    /pdf.tmpc exch def
+    /pdf.tmpb exch def
+    /pdf.tmpa exch def
+    pdf.dest.x pdf.tmpa mul
+      pdf.dest.y pdf.tmpc mul add
+      pdf.dev.x add
+    pdf.dest.x pdf.tmpb mul
+     pdf.dest.y pdf.tmpd mul add
+     pdf.dev.y add
+  }
+    def
+/pdf.bordertracking false def
+/pdf.bordertracking.begin
+  {
+    SDict /pdf.bordertracking true put
+    SDict /pdf.leftboundary undef
+    SDict /pdf.rightboundary undef
+    /a where
+      {
+        /a
+          {
+            currentpoint pop
+            SDict /pdf.rightboundary known dup
+              {
+                SDict /pdf.rightboundary get 2 index lt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.rightboundary exch put }
+            ifelse
+            moveto
+            currentpoint pop
+            SDict /pdf.leftboundary known dup
+              {
+                SDict /pdf.leftboundary get 2 index gt
+                  { not }
+                if
+              }
+            if
+              { pop }
+              { SDict exch /pdf.leftboundary exch put }
+            ifelse
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.bordertracking.end
+  {
+    /a where { /a { moveto } put } if
+    /x where { /x { 0 exch rmoveto } put } if
+    SDict /pdf.leftboundary known
+      { pdf.outerbox 0 pdf.leftboundary put }
+    if
+    SDict /pdf.rightboundary known
+      { pdf.outerbox 2 pdf.rightboundary put }
+    if
+    SDict /pdf.bordertracking false put
+  }
+    def
+  /pdf.bordertracking.endpage
+{
+  pdf.bordertracking
+    {
+      pdf.bordertracking.end
+      true setglobal
+      pdf.globaldict
+        /pdf.brokenlink.rect [ pdf.outerbox aload pop ] put
+      pdf.globaldict
+        /pdf.brokenlink.skip pdf.baselineskip put
+      pdf.globaldict
+        /pdf.brokenlink.dict
+          pdf.link.dict pdf.cvs put
+      false setglobal
+      mark pdf.link.dict cvx exec /Rect
+        [
+          pdf.llx
+          pdf.lly
+          pdf.outerbox 2 get pdf.linkmargin add
+          currentpoint exch pop
+          pdf.outerbox pdf.rect.ht sub pdf.linkmargin sub
+        ]
+      /ANN pdf.pdfmark
+    }
+  if
+}
+  def
+/pdf.bordertracking.continue
+  {
+    /pdf.link.dict pdf.globaldict
+      /pdf.brokenlink.dict get def
+    /pdf.outerbox pdf.globaldict
+      /pdf.brokenlink.rect get def
+    /pdf.baselineskip pdf.globaldict
+      /pdf.brokenlink.skip get def
+    pdf.globaldict dup dup
+    /pdf.brokenlink.dict undef
+    /pdf.brokenlink.skip undef
+    /pdf.brokenlink.rect undef
+    currentpoint
+    /pdf.originy exch def
+    /pdf.originx exch def
+    /a where
+      {
+        /a
+          {
+            moveto
+            SDict
+            begin
+            currentpoint pdf.originy ne exch
+              pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+    /x where
+      {
+        /x
+          {
+            0 exch rmoveto
+            SDict
+            begin
+            currentpoint
+            pdf.originy ne exch pdf.originx ne or
+              {
+                pdf.save.linkll
+                /pdf.lly
+                  pdf.lly pdf.outerbox 1 get sub def
+                pdf.bordertracking.begin
+              }
+            if
+            end
+          }
+        put
+      }
+    if
+  }
+    def
+/pdf.breaklink
+  {
+    pop
+    counttomark 2 mod 0 eq
+      {
+        counttomark /pdf.count exch def
+          {
+           pdf.count 0 eq { exit } if
+           counttomark 2 roll
+           1 index /Rect eq
+             {
+               dup 4 array copy
+               dup dup
+                 1 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add sub
+                 3 exch put
+               dup
+                 pdf.outerbox 2 get
+                 pdf.linkmargin add
+                 2 exch put
+               dup dup
+                 3 get
+                 pdf.outerbox pdf.rect.ht
+                 pdf.linkmargin 2 mul add add
+                 1 exch put
+               /pdf.currentrect exch  def
+               pdf.breaklink.write
+                 {
+                   pdf.currentrect
+                   dup
+                     pdf.outerbox 0 get
+                     pdf.linkmargin sub
+                     0 exch put
+                   dup
+                     pdf.outerbox 2 get
+                     pdf.linkmargin add
+                     2 exch put
+                   dup dup
+                     1 get
+                     pdf.baselineskip add
+                     1 exch put
+                   dup dup
+                     3 get
+                     pdf.baselineskip add
+                     3 exch put
+                   /pdf.currentrect exch def
+                   pdf.breaklink.write
+                  }
+                1 index 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                2 index 1 get sub
+                pdf.baselineskip div round cvi 1 sub
+                exch
+              repeat
+              pdf.currentrect
+              dup
+                pdf.outerbox 0 get
+                pdf.linkmargin sub
+                0 exch put
+              dup dup
+                1 get
+                pdf.baselineskip add
+                1 exch put
+              dup dup
+                3 get
+                pdf.baselineskip add
+                3 exch put
+              dup 2 index 2 get  2 exch put
+              /pdf.currentrect exch def
+              pdf.breaklink.write
+              SDict /pdf.pdfmark.good false put
+              exit
+            }
+            { pdf.count 2 sub /pdf.count exch def }
+          ifelse
+        }
+      loop
+    }
+  if
+  /ANN
+}
+  def
+/pdf.breaklink.write
+  {
+    counttomark 1 sub
+    index /_objdef eq
+      {
+        counttomark -2 roll
+        dup wcheck
+          {
+            readonly
+            counttomark 2 roll
+          }
+          { pop pop }
+        ifelse
+      }
+    if
+    counttomark 1 add copy
+    pop pdf.currentrect
+    /ANN pdfmark
+  }
+    def
+/pdf.pdfmark
+  {
+    SDict /pdf.pdfmark.good true put
+    dup /ANN eq
+      {
+        pdf.pdfmark.store
+        pdf.pdfmark.dict
+          begin
+            Subtype /Link eq
+            currentdict /Rect known and
+            SDict /pdf.outerbox known and
+            SDict /pdf.baselineskip known and
+              {
+                Rect 3 get
+                pdf.linkmargin 2 mul add
+                pdf.outerbox pdf.rect.ht add
+                Rect 1 get sub
+                pdf.baselineskip div round cvi 0 gt
+                  { pdf.breaklink }
+                if
+              }
+            if
+          end
+        SDict /pdf.outerbox undef
+        SDict /pdf.baselineskip undef
+        currentdict /pdf.pdfmark.dict undef
+      }
+    if
+    pdf.pdfmark.good
+      { pdfmark }
+      { cleartomark }
+    ifelse
+  }
+    def
+/pdf.pdfmark.store
+  {
+    /pdf.pdfmark.dict 65534 dict def
+    counttomark 1 add copy
+    pop
+      {
+        dup mark eq
+          {
+            pop
+            exit
+          }
+          {
+            pdf.pdfmark.dict
+            begin def end
+          }
+        ifelse
+      }
+    loop
+}
+  def
+%% 
+%%
+%% End of file `l3backend-dvips.pro'.
+%%EndProcSet
+%%BeginProcSet: texps.pro 0 0
+%!
+TeXDict begin/rf{findfont dup length 1 add dict begin{1 index/FID ne 2
+index/UniqueID ne and{def}{pop pop}ifelse}forall[1 index 0 6 -1 roll
+exec 0 exch 5 -1 roll VResolution Resolution div mul neg 0 0]FontType 0
+ne{/Metrics exch def dict begin Encoding{exch dup type/integertype ne{
+pop pop 1 sub dup 0 le{pop}{[}ifelse}{FontMatrix 0 get div Metrics 0 get
+div def}ifelse}forall Metrics/Metrics currentdict end def}{{1 index type
+/nametype eq{exit}if exch pop}loop}ifelse[2 index currentdict end
+definefont 3 -1 roll makefont/setfont cvx]cvx def}def/ObliqueSlant{dup
+sin S cos div neg}B/SlantFont{4 index mul add}def/ExtendFont{3 -1 roll
+mul exch}def/ReEncodeFont{CharStrings rcheck{/Encoding false def dup[
+exch{dup CharStrings exch known not{pop/.notdef/Encoding true def}if}
+forall Encoding{]exch pop}{cleartomark}ifelse}if/Encoding exch def}def
+end
+%%EndProcSet
+%%BeginProcSet: special.pro 0 0
+%!
+TeXDict begin/SDict 200 dict N SDict begin/@SpecialDefaults{/hs 612 N
+/vs 792 N/ho 0 N/vo 0 N/hsc 1 N/vsc 1 N/ang 0 N/CLIP 0 N/rwiSeen false N
+/rhiSeen false N/letter{}N/note{}N/a4{}N/legal{}N}B/@scaleunit 100 N
+/@hscale{@scaleunit div/hsc X}B/@vscale{@scaleunit div/vsc X}B/@hsize{
+/hs X/CLIP 1 N}B/@vsize{/vs X/CLIP 1 N}B/@clip{/CLIP 2 N}B/@hoffset{/ho
+X}B/@voffset{/vo X}B/@angle{/ang X}B/@rwi{10 div/rwi X/rwiSeen true N}B
+/@rhi{10 div/rhi X/rhiSeen true N}B/@llx{/llx X}B/@lly{/lly X}B/@urx{
+/urx X}B/@ury{/ury X}B/magscale true def end/@MacSetUp{userdict/md known
+{userdict/md get type/dicttype eq{userdict begin md length 10 add md
+maxlength ge{/md md dup length 20 add dict copy def}if end md begin
+/letter{}N/note{}N/legal{}N/od{txpose 1 0 mtx defaultmatrix dtransform S
+atan/pa X newpath clippath mark{transform{itransform moveto}}{transform{
+itransform lineto}}{6 -2 roll transform 6 -2 roll transform 6 -2 roll
+transform{itransform 6 2 roll itransform 6 2 roll itransform 6 2 roll
+curveto}}{{closepath}}pathforall newpath counttomark array astore/gc xdf
+pop ct 39 0 put 10 fz 0 fs 2 F/|______Courier fnt invertflag{PaintBlack}
+if}N/txpose{pxs pys scale ppr aload pop por{noflips{pop S neg S TR pop 1
+-1 scale}if xflip yflip and{pop S neg S TR 180 rotate 1 -1 scale ppr 3
+get ppr 1 get neg sub neg ppr 2 get ppr 0 get neg sub neg TR}if xflip
+yflip not and{pop S neg S TR pop 180 rotate ppr 3 get ppr 1 get neg sub
+neg 0 TR}if yflip xflip not and{ppr 1 get neg ppr 0 get neg TR}if}{
+noflips{TR pop pop 270 rotate 1 -1 scale}if xflip yflip and{TR pop pop
+90 rotate 1 -1 scale ppr 3 get ppr 1 get neg sub neg ppr 2 get ppr 0 get
+neg sub neg TR}if xflip yflip not and{TR pop pop 90 rotate ppr 3 get ppr
+1 get neg sub neg 0 TR}if yflip xflip not and{TR pop pop 270 rotate ppr
+2 get ppr 0 get neg sub neg 0 S TR}if}ifelse scaleby96{ppr aload pop 4
+-1 roll add 2 div 3 1 roll add 2 div 2 copy TR .96 dup scale neg S neg S
+TR}if}N/cp{pop pop showpage pm restore}N end}if}if}N/normalscale{
+Resolution 72 div VResolution 72 div neg scale magscale{DVImag dup scale
+}if 0 setgray}N/@beginspecial{SDict begin/SpecialSave save N gsave
+normalscale currentpoint TR @SpecialDefaults count/ocount X/dcount
+countdictstack N}N/@setspecial{CLIP 1 eq{newpath 0 0 moveto hs 0 rlineto
+0 vs rlineto hs neg 0 rlineto closepath clip}if ho vo TR hsc vsc scale
+ang rotate rwiSeen{rwi urx llx sub div rhiSeen{rhi ury lly sub div}{dup}
+ifelse scale llx neg lly neg TR}{rhiSeen{rhi ury lly sub div dup scale
+llx neg lly neg TR}if}ifelse CLIP 2 eq{newpath llx lly moveto urx lly
+lineto urx ury lineto llx ury lineto closepath clip}if/showpage{}N
+/erasepage{}N/setpagedevice{pop}N/copypage{}N newpath}N/@endspecial{
+count ocount sub{pop}repeat countdictstack dcount sub{end}repeat
+grestore SpecialSave restore end}N/@defspecial{SDict begin}N
+/@fedspecial{end}B/li{lineto}B/rl{rlineto}B/rc{rcurveto}B/np{/SaveX
+currentpoint/SaveY X N 1 setlinecap newpath}N/st{stroke SaveX SaveY
+moveto}N/fil{fill SaveX SaveY moveto}N/ellipse{/endangle X/startangle X
+/yrad X/xrad X/savematrix matrix currentmatrix N TR xrad yrad scale 0 0
+1 startangle endangle arc savematrix setmatrix}N end
+%%EndProcSet
+%%BeginFont: CMR7
+%!PS-AdobeFont-1.0: CMR7 003.002
+%%Title: CMR7
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMR7.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMR7 known{/CMR7 findfont dup/UniqueID known{dup
+/UniqueID get 5000790 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMR7 def
+/FontBBox {-27 -250 1122 750 }readonly def
+/PaintType 0 def
+/FontInfo 9 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMR7.) readonly def
+/FullName (CMR7) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle 0 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 50 /two put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3DD325E55798292D7BD972BD75FA
+0E079529AF9C82DF72F64195C9C210DCE34528F540DA1FFD7BEBB9B40787BA93
+51BBFB7CFC5F9152D1E5BB0AD8D016C6CFA4EB41B3C51D091C2D5440E67CFD71
+7C56816B03B901BF4A25A07175380E50A213F877C44778B3C5AADBCC86D6E551
+E6AF364B0BFCAAD22D8D558C5C81A7D425A1629DD5182206742D1D082A12F078
+0FD4F5F6D3129FCFFF1F4A912B0A7DEC8D33A57B5AE0328EF9D57ADDAC543273
+C01924195A181D03F5054A93B71E5065F8D92FE23794D2DB981ABA2ACC9A23A5
+3E152596AF52983541F86D859FC064A0E3D5FC6647C3CAB83AD4F31DDA35019C
+CDB9E3DD3FEBD4C2B36BA3CF6E6C7DA85E25D8A31A9BAD39BDF31FD0D1790707
+9DE6A078E8A409D8295F642DF492AC4F86AC84383B0F4C6BAA7C22AD5A898A71
+D6CB34D2CD12266C486B75E75A69C14819DD9BB8159088E04D4717E576B8482D
+BDA52110AC8B8A80E4E9D58F470EEBD3CF44A1E1EE8DA318FFF3611B02534FC9
+F4018C7C57E80570D2F634D98BE5D5EC6D95051157F0EA94A3D12BE0B4B79939
+F82F8D73136D3337C44E314B0B16CB030D9A12E01FB667105F334C3EE965E5A3
+D410D2F1531547A4497C355AEEB295CD3C5334BEE5232992960B757594B89F3E
+52095042DBE6B4DA3C3AD50CA95EA9EBADA10630B500CF1FCCA7D60306743681
+7E428D33B7F7C40B425CD58E4CD8AB474BCE6A307BC6C6EBC15A8A96E0E2977E
+A33389154536F5C5D8CF036D07F24094E779E5ACBE5502C92892F10F4C6DB627
+C7EC4C7BF20B39418A8A85D7FD9B0EAAFD871DDD41F93BDE5FE619AFB8711824
+DE890E62C1969A6FE28DD3578AF43D58A728FAFF0B9FAA640962C8F35A26F76C
+67F3548D6DB54A25CEB368B47F97EA2B0C4D7C0E7894A4F0C823C6C1922CF9DC
+10E05600556F1C7C9AFB33A2DB6F8730F70D6BF94B1FB0887451F2FFEEF3584F
+DFADCFA9A2D4846B8F0E51620E1327D994CDF973B837D10C90FF76DE22B47CD5
+EE3183898D156861AB4DFAD34A1E3FA260B8164E6680BF58413A553E88F6100B
+C4F4E8E972C81A5F88A7DBCDC308B4C3581BCDE13877B976B1F84330839FE5CF
+C78551620EB803DF94A5C921F8EE24F7EF8FC4C3E1653514212631F54F90E3DC
+E9EAF96E998F340C4F729ECF7AB430FDB7C0BE3DF2C0D23015820E28B743CAD7
+7F0AE95413C3EEABBC69E852F53EE1DC260D7F1E712BECEF2F18437DB23D8E74
+2902AAFBC733AC5BAA452DD6F3671859AD836C8564E99CDC4183D8495AFD99D6
+1F0D65B6588CE7546717911E25BDCA6C2649E3A7466A3E2DA7C7994A30AB4449
+672EFD00632EFA8629C1AFB7D53D801028F77C864869FE636213A69173003EA6
+BE1ABA95EB07B13D1594BEFCC95ECB0A9CFA9892EE0677D6B6C250855762B7A7
+8E4E022640F93169DFA0303A0D5E73BF3E0F4D4AAD10FD7E4EB20532BA30371F
+E9F480F9513432946F9828AFB5D4AEAFA5829B2CB544E5EB634C4537EF7DF08A
+A1CFD94A52DCF0E7CE4C5EFFB01E6D50558B75DB4C8D5512B06080F27BE62E01
+2EEA6A0357441401458C842D3DD4C35B8F561D816B336216CE0C14BF77648AF5
+E33912CF95872A1E1AB9A18980A0B29A881D13397C15E1CBA5D3E0B27943EBE2
+F3003D15EB446BCFC1C231832475D5B7AA19E4CFDE119D6CD62D053C6D29C333
+5F729791D17B3F7108074EEF4D1BD101CB33E01004532CB0D716D2E54D169C6E
+80163E70C0E9081F31A1ECBAE079D2A518B790B0CB2CD03DFD034A0F4788E800
+B0CD2DC1FAFDD487C2F381EBAB2A2F3F3AF82021B211DC9CD2FBA6A1BB3D4AEA
+4C7F3D9A5C21DFF284CCB827D205A69638E98D5DD8E36AFC1A4481B5CB2A2E8F
+D6C838DA6F81990F5ED928DC7457501B5C979FF4CD20A830896A460C5DB13D56
+A3B2B5D9B292374A9BF392894DD99FCD6A1E655AB395E839F074D1596488700C
+4E2891C8AEEF66568E82A8B826F9A28FF84D4D9BDA21F638EAF96880B4EBE0D8
+081982F34831A03BEE81FC177700C2360D2A48915EC40D5FE85B400E175D5AF1
+067FA0097904FB647757BB44B4042D30D1557BD0F7922D731142FD682139CEB7
+58CA4C8C240A0B86B1888CACC507E24E04020BF1882BD9B4CAECFA97DB24D7F5
+AD64C69454027F198BA35881B94EE9159A2D73E450C3BDAED66B886D6DEBC84B
+653E165176228F88993F12A170775A8D7038BDF2FE8DC1F7B98BDC02D1E6686E
+9B834F6C0AD90780B17DFE25F0A4E470CBA84E73F2D22BEE09A040F14CFA2C14
+0FDA5A5149B5FAFFE49F55EEFC43831BC43A8326FEE9C7F469C0FC3B000884FA
+41DA7318EB57262CB96FC4EC7F16CA07FE1C3BE8C2DBC8A8135953D6DDF20BDF
+75A2B6D26074FCE752BD32FB9F5CA797775E8DB9BB9786B469A3CD65A0D9DDDA
+C2A166E454A94860EEF5B5C12172DDFC576A03F6E6F8A735FF21A3E9CCB4CAA1
+3064893487697986A42CB5888B2B0A79FA3C74E8187BDDF7BEAB884B70B8D4AA
+AC6615745AEB906E08BF831CFDE222F58D02B428D55E9D5A3CDE74E42D8A2CB7
+E1A3A9439B678AD438793ABBEB72B21C58981DAF3EDCE4BB93D95F4A1E943BBC
+B3A012DE92FED4F232A3A7D60CE60B605151F9C7C18A5C653E5D6D15E5B49A63
+73E7A339504D0ACC74B8B116EA88C3EBA2CC631AAB29F761E5F062966AD2FD28
+7FFE52FA8A115DBE23E471094FFB3CBAFBDF11B7E9058313F2D069B2CE98A962
+64645738F02A31E2F2AC11628724034ADBCEE012721EBF0A567893411F950410
+B20754A7510D041FFA6144AC9CC46D846B82581F20BBD001D34D9764010824BE
+61C30D05E5C5D100A24F1917F01799CF5BC4E50FCECFEA732CB50196825F0E08
+8A1EC868C6D4357857EE2957E081A0E4372E31A8ABEF23C3F2EA0FEE57DE4D08
+61C570175C41AA0C7A3A579ADF593F18B4AE3782D2552E4E0759C32E059EE741
+2D8191E381731769F6648B3581CAF11DAE46471896666F18F02918B0860BDA3C
+BD5DE777672447C23C62ACFC2611ED5239D6A266FDA6031EBC5A530C1A2FF7A6
+B4380B9A4C877267854AD1F1677CB5433F28894ADF93D39EAB94541A8D232E08
+22D082D0951A60F62B87DC028714EC74133A4D65F7D0D1296C0E189C4A42AA98
+28E8AE7ECBB9FC8DFABCC6EEB1E9FB06227F90808EF31331CCC5D4C9A6182181
+047902DC9FD0444FB94B60FC74F3B677758088CE6A159D940C5CF682335E756A
+8BACF06AD7225D49B0002392C889B0FE2C71311D2596F4903D12FA20BA2FFE25
+A0804B4BC282929BE31E0F46B34532CB5795A65218CFAE21F390792DA67775C7
+B91A2BF4C16DE4F6551DAE3A5827F616BE9040EE6B1008DA2F99A01EF66D697A
+6CD1A44E0A15D1F39EA8025E886A68A1E9C334327C7703EE721E497CA924AC90
+7723106D913C5ED4BA4FC743CEA8D0F5172526107DA65775C0B1B77179D336C2
+9B09B608D80B1A1E87CA1A84A833A00D980D919BFF56F6390E9D5B45E9935CF5
+E69D003564462F750F7DCE02DC23CC215A0696B74D8BD3156A392A94F557655E
+00BFAA035647568ED66157FACC585E411F7F428569C147DC43F6E4FDE693D0F3
+9917BEFEDF61FB980B85515FF6424824E2D995B05CA1E5D3E8BD8D3281DB7CE4
+E54923E84058FFC0A8A2C491327D0F87CE4C352B724167CEE224DABA3B95757E
+4A419594BE4F92E78BA6D35D4C93D31ECC3134B24A45DC32445725BB044F09A3
+AA8C31EFC0A2944ACE2F2CE054CF24DB350FB3C71115518C24BDC0F7E54250AF
+9D3378D38480E1CB9029F31570C619A28F065CA4FED5665EDB96712ABEB33B9B
+4232C00C1B0215F08D53F7E430887035AC25BEAF06942FD1B6C442253C887AB7
+D694C1A6115C8990B4CAF1E81DD1FDDD6B03C00055BE956BE7FD8A4E1049AE69
+EDA8593CBA8C4A41E046C689FBBF9F1B64E5856A7FB1C61EC815A56DE2A8ED33
+41F370B8203D4E5B19C63AE9E6E0D26F4F3814B5AF48AD30EC9B8402C941FDD9
+722FCAFC638FBB835F83DC77F93D367266FA7DFFFCB567EF82B1695AB4D94D09
+B18AC041811027229DF431F5CB2BBF6ACCE9D500C8F075A74590641C1A607C56
+D2B8624797BCD9C91C3177818691FBB4744EDB6056464A0B95B8D63F7C22309B
+82D6126E2057BCC9FE5566D96B7A9B201A09B0D3252A5494C8CA2C8BA8A13C29
+37EF2A882D61DA708C279F663D88A8E2999A0F3B6F98C49901A7631BF7708B67
+54D0B4C52BF4BE0DA0439E6763A7C9D639AD4092E77B13D3510DAE1475C978AC
+796F9B2AAD3BFF35C5A3E19B5E2BF704B3BBDF68CE48BA4FA2496D60E58888EA
+28AE12D00E9F0816FAC190590A865BB58569A91BF0345D01230ABA361442006D
+BA2C90EC2036BBAB79EBAFC3F217DBD5854C519235F9627A1C3C71D21ED38AEF
+0BB40F3B86BB9F09A3F309473D8757AB7E638DC1C59A7F9BCD49DE4107A2E54F
+422767FB94048987847205584309397F554744690ACFFDF5902FE5DB355930B8
+71863217830DD7A563B0B3A4025ACE75B0E777B4414B62A13B50C54E0E6D47E9
+D43BF769B9411B74E1069BF71BA873B4B8973EC9BA492A5DEA58D267872BB246
+10AA67B143D0E2223FFB4991E583E629413CC894C3FA4869B72D19CE1A0CEC8C
+0FF5E5A3EC1FCB7D3C4289813F0D249A11B55104BD60B2A89BEF44CC77CCDA9A
+065B8B83B4F4253AA1D535290DCFAA4773452D110D2B3370F9E2FE5432B54A9E
+644EB3BA9BFF62347F376839024CD5EF3C5DFD30F412DD5474B7933E6A1AB63B
+4B12F2417C72D0543C26A263AEA53E5BAEBD67E23553A72E949DEC556BEB5D09
+C4D7A89B14FE4EC68D0E3E9D65A64B285E53590F418EDA8175113CA375A29930
+DDCF4C71ABB26CEB800C2C2B253AC1F53651C88A56ABE5A74F3B54CB4FFDDB92
+60AD7272BA25EC2F6FB759AA6E1E7964FB55AD09F4EB25DE45FD01833947BD05
+6266AA8ABB7DD792941C7A070FCF3A4636FBF8921C70298D42FE92F079DBA2AD
+6149D9CF9EF7264DE6DFCD4429949B15EA90B596340713BD61926DDB2BB23BE8
+F9DE38A31620A817420A245946E551463960A8C5C7295E3B3D6A59BCDF5E472A
+40B7A2CDDAA43CD8AAFC411D037142579D11054A903E102DF0D0C7B5BB854DBA
+F3F086AF991F7F5D5C730F8F9AF213F25786F3EC0E54530FF912F4876FDE16B6
+A07D0DC4FC46EC6363BCB68B83ACC448B801EC43FDD2F8BE0E93D809FF81E38E
+176AE17C67C85FEA58EC95435434C49A950AA955D8B20989C550AB1F1C31B7FF
+99422E1F48FB7D6F327C6DBC4695A03903DB275B94CB39386E46579271870A25
+21823E75C377E9D5B46655E8CD8F986372CF8BA846423E26582315A9D19E0BF5
+305C32B2A0EAC3ECB275B1D8BE11A37ADF524944219D94EA2C5DBDA768828B6D
+775DA8CDB09E0570E4ADDF462EFD8D3FA3F86B1DEECDFFB699AF6507257C1879
+16FC615868C2D51F03CD57BA38D42995D9164B257441210084DC409B6EE4C119
+0B2E17B0A8D5326DD0010E4A325D5F77BF935693BC90A00A28C7B5F74817DA39
+F47A41E32F4F92AA04D30D810F7B1484EB53AD8CFC8CE8928B570314E0F713F8
+AF127227190F9C16BB73D2A217FF801C391A29095DA5E4974D137A0CAA7DE702
+E20DD4755B1D78739756A5E7EC3542B96AD6844199FFA2F5F2E9C64E2DA4FB2A
+ED79869F745C59D235438251BC2E6D26112AAED20E06021D1AB896EE1F1DD2EB
+437FBD4A25E42245C5A647493FCC9922E6DD7AF57D5D482921D1CBD6F0F02949
+C27777144751C1E72F4EE2BC343D4AE7A8A8758123B54FB1A026144C643651EF
+0907A376945E19A8FC7F98A034832A5820A481B0823F980F59623E0511593FEA
+BDE6EFBCC0383242CBD4954027B075B21F10472059A480D6E5ED01C3B07461CE
+9810251A5C5643EC7403130C2246E8616CEA25EAC7A0076731FEA8CC43BCE3BE
+933FCE61067F5FD402E67E2B9DAD954AA77C5BC86BC5E4BCE2ED676D8D8EC7D0
+ABC5C86D82180B9D5D7451C71B5149B6B67883578DE9909317928C0A92E3205E
+F23015400A1763A6FBF67FDE3318AD2696685A1832FC31CF38589EBC7CA1C818
+60D2B2211E04EFCCEA88D9A9082E82951EEB123924A267CB03C48889032F2892
+4227E217FA28F87E01CBF27BF1EA60641A4238258CB7AA355908FE36D90F5CAD
+FE992D03A33E47CA9AEBEFDA57793F39DC6A9E85D5B289F6B862B35DBCF82E43
+5CD6A862F6FFAC36478C384C3BDB0148CB1FEDF55969C776E77917635B5A65EB
+F2AD351D21CD3822D43289FE8EB0FED58182997097C7E9F4373553AE1CA92083
+EDE3BBE6C3BC7009D15AB5FEC6A59E9FD1BCC7B2099CA15FEF083B9CBF7B890E
+CDDDE6BA0AFF306C76500C945DC91BD533FF9A585CEEDEF79238C54E6168001E
+26FEB29E523EE501BFA4F60B782B1499B07084C35A2434B4D29D3D8E2C8F945F
+A9922443B68D07DF7EAA1F4CDEFFC438B597D8943E231B5216808A85F30EDC81
+9DF5DD22F54A45335B4C2203887475F39D247F0E7347BACFEAF220ED82F9263A
+6488E73C1910023E505FDEB143006C1A351D441AC57F9D52D2C6D63D78C75605
+999885676BBBAD56074298E0BFDACBA1830BA58E87F436CC670EE8EB1870154D
+72DDBBF3794F8CAAA3F1E11DE29752DD99EAC695838A19BB67A1FA3829B6E0BC
+5301610A0351AAA749F456AE31ADD87D6ABADCDD1FB3CE81C3713F48780DF407
+530CB284B2AC709F52EE7AD647DEF9FA4D2A867CCEF728F3D40CF34C28D21527
+10160B3DAFB5FE16AFC9D36C6EC4021FC189005862082BEA60AC72B63AD27D72
+FAF3C2D89DA2648FC4C65104A069212D87144E8533CD86A6D73DC7CD9DBA25CE
+7DA53B000266F3871B24663C77723703315C5E4A89DFCDBAB384AE7EB2F455AE
+AB191FED406F7F6EC9E5B8276EF5C4CBA041AC7E8BCEC7CAE840154BDCA3232F
+15711ABD1E867A434E9787CA0A6D1F197597DA27ED2402CB2D84ED082E8D3A39
+81E6EB270DCA4E7A90E2BEBD3CBB3A2BE3CAB926192D7292CC16845B6399A543
+BCFD224BB52F21352732DB5154FA3442733066CDC3E186D8AA97CD801DFBE43A
+116C86889BE198DA88CA978B8C40ACB67E8F7BA499DE68A6FF0DC72C3D00BA1A
+B378B39610F15CA026F95ED8155CE3FFFFA2E2FEB352DBE14CEE1669F2387B70
+55B91185FBBED764266215D518716EDA3DFC9E5DB6B148A553E75AE5E38E1CFC
+6EF47B314D54CF24BC13856F4F7C976BB91D143DE32FF49BFFC87E17885A1893
+BA1B8E441B08EFC04F7D103C1FFBB665194B3D0920473740C55FB1C50EBCF717
+A2359B687FCEAD65616EE89A68F8D91AFACAA0B238EE4AF0279AF5BE5294C3DE
+A7E1F5E6248C0210E7D40683F04B12A933C746ECB517CF94BBCC6E4CF49AC715
+D8005AFECBDFB7A6B417DB8A28F8E9EAF39CEC1CA64DF37A5E66A76C26F721F8
+A63B003A040A62F87DCF61B298F960D510BEFA453F118E59E7DE8CA3DD002EF0
+127EAF733D5C61B5132348D280F84D159809CC71A3C6F7373BBFD8D6EF715D34
+0016DEFF14AA5F960BF1BB9AC304A1823722843547BB4CA5EA4C41C6C2701C8F
+7BDC810443F9DF34BA469A3260009B799871BAF8523C8763544DCD0B382D44C5
+F75046AFF85F0B5A3188C2EE786CEEE5496A5AF4BCB0B429CAFC403FB983EFE3
+61FD9F52ADFC38E07A0FD7BACBA530D2E4DAB2592AA9564843E7E2305047F060
+C5FE4243FA8FDF1B5D4F61ACA7850A604FBC6D6970959752695C90F78961B4E2
+C8CFA41082B1A37405AABCEE5BA3DC2B9EA76F486117B84728EC6D8AE6379CCB
+402C2AA89078EC992C00D53151E9D82C65643F549A572A20F05107A41BE5AC57
+8EDE92AE20B05E2D0C98151CC92D5389A675DFE39DF546A33A84A4C534337ADE
+B17C34E09145B37CE1EB1D10D42CC8D6E6B127A3809F7202381FDB88D42084CD
+0AEAEB8A8288CB56870EA2BE9D0B9DC8291021CA561E2BA388DA3494E433E0EE
+5E69DA51D0AC505C9F71562D3E9750F23CF14D2C8ECF0692FBBCB4A92B48B4B0
+AA2163A447D5FBE86D961AE4D4251149F11C4BC269E10B48E8C42DC2484EDE87
+6540CB8A5EA2494148D09CC9D5014EB7272F10897FEB361AAC8C7642DA07EFEE
+356790B9D0755C63CE287BB6533A5A2B6BAB27E291ABCC443BF097D5FD49B9CB
+ACCF7387D6B618E76141EEC43B566C2C8D40E2FB8B9812DDA376AFD07DA6A127
+DC81AC7CC79D5484D5FEB9D68F9D154E0E6D9C10C0D5F74695745B5B14649F37
+CDBAD5DB780F512C2E1790C0F62C82200E5F245CB75E3CF291ADBC2600D221D9
+958484FCDAF56C4F0074103CFA58117204614502D59D2D6AA1475906C91007DC
+D9F035A6D2DE39976DA36879EFE35031F340BA6C211667BF29E32EDB93DAA76B
+BD21192CB456B6BD178CBD6BF5FFD5E0C92DA1807D2DD318
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+%%BeginFont: CMMI10
+%!PS-AdobeFont-1.0: CMMI10 003.002
+%%Title: CMMI10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMMI10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMMI10 known{/CMMI10 findfont dup/UniqueID known{dup
+/UniqueID get 5087385 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMMI10 def
+/FontBBox {-32 -250 1048 750 }readonly def
+/PaintType 0 def
+/FontInfo 10 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMMI10.) readonly def
+/FullName (CMMI10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+/ascent 750 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 27 /sigma put
+dup 120 /x put
+dup 121 /y put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3C05EF98F858322DCEA45E0874C5
+45D25FE192539D9CDA4BAA46D9C431465E6ABF4E4271F89EDED7F37BE4B31FB4
+7934F62D1F46E8671F6290D6FFF601D4937BF71C22D60FB800A15796421E3AA7
+72C500501D8B10C0093F6467C553250F7C27B2C3D893772614A846374A85BC4E
+BEC0B0A89C4C161C3956ECE25274B962C854E535F418279FE26D8F83E38C5C89
+974E9A224B3CBEF90A9277AF10E0C7CAC8DC11C41DC18B814A7682E5F0248674
+11453BC81C443407AF41AF8A831A85A700CFC65E2181BCBFBC7878DFBD546AC2
+1EF6CC527FEEA044B7C8E686367E920F575AD585387358FFF41BCB212922791C
+7B0BD3BED7C6D8F3D9D52D0F181CD4D164E75851D04F64309D810A0DEA1E257B
+0D7633CEFE93FEF9D2FB7901453A46F8ACA007358D904E0189AE7B7221545085
+EDD3D5A3CEACD6023861F13C8A345A68115425E94B8FDCCEC1255454EC3E7A37
+404F6C00A3BCCF851B929D4FE66B6D8FD1C0C80130541609759F18EF07BCD133
+78CBC4A0D8A796A2574260C6A952CA73D9EB5C28356F5C90D1A59DC788762BFF
+A1B6F0614958D09751C0DB2309406F6B4489125B31C5DD365B2F140CB5E42CEE
+88BE11C7176E6BBC90D24E40956279FBDC9D89A6C4A1F4D27EC57F496602FBC4
+C854143903A53EF1188D117C49F8B6F2498B4698C25F2C5E8D8BD833206F88FC
+BD5B495EB993A26B6055BD0BBA2B3DDFD462C39E022D4A1760C845EA448DED88
+98C44BAAB85CD0423E00154C4741240EB3A2290B67144A4C80C88BE3D59AD760
+E553DAC4E8BA00B06398B1D0DFE96FB89449D4AE18CE8B27AFE75D2B84EFDB44
+143FD887F8FB364D000651912E40B0BAEDDA5AD57A3BC0E411E1AD908C77DCE3
+981985F98E258A9BB3A1B845FC4A21BCC54559E51BC0E6C22F0C38540F8C9490
+88A0E23EA504FA79F8960CC9D58611C519D3ACDC63FB2FBCAE6674357D7F2285
+4BCC9F54D3DA421D744D3A341DA3B494BB526C0734E1A8FC71501745399F7683
+FD17EC3044419A88C3979FD2ABA5B0130907B145A8462AAF0A9B511D2C8A7C7F
+347FF6AC057E6512902BFD2918E2CD31DE615F5D643764E900B60287670AE18F
+FDE15545D8BC69591A8CBBB275AFFC9B14BD68DF0AAB32268FB84844D4DBC7BB
+C591C1AC5102C50A9C7BAAA848DA88B0519F0F5F0813BF055CF0E3C86F633A04
+B779D2E8E656DB1E09A66A85FE21CA8BA5523F472A229E83F2C4E91ABA46C733
+F3C7B5775B06C97782BC225C46385BEBDC61572458EFC5CF4190AB7A9C1C92DA
+29F84BAACF552089195966E3AD9E57CC914D20B6962BE80429A16D4DF1ECAA66
+36C4343FADF0B2B48F12E2EB8443C4AA29D00949255F3968617F98B8ABD4CC12
+048B838EE243A21AC808BD295195E4AE9027005F52258BFCA915C8D9AED9A2C0
+80814F79CF943FBE3594C530A22A92E11BE80FCEC1684C4F56712D5846B0749C
+9B54A979B315222F209DEE72583B03093EC38F7C5B9F9BCB21DBE8EDDAE9BE8B
+75ACE6B12A31083AC8348EC84D1D29D2297A266284B7E9734E207DAF59A25F4E
+4AA38509E993C5394FED76E6A2F25462685C4C86C6E8CFC9863338EC1428BDFC
+74616BB1BC8948B0ED4C87C15B4405F3A7796F9DB3798FFFE8BD0A94E834817B
+D5E9812E308D0CC920470A6F2CD088FCB80462BF7CB3F039A7DF3DAF5B2B5355
+E083A385CD2EAF0FC181E40E96DD7E9AB9EF5C7E6866A13B8A54718E950FE097
+EF0951A357114F18CE9933D28B3A77AA71E3CE884661F13284BCED5D5FD1A86D
+543E588FF473DC2CF9A4DC312500135F29C2D0174B32018C8DBD40EF9A232883
+710A1F2AB2CD11312300ACDF789A9B7B93D2035D81D1C84984D92D78A53A00C6
+EDA94B24BBAC1AD17774A4E07E6F74ABD90415965616AD540C8ECD8C3A44EE4F
+7F4F6BB6238C5062D63FA59B7BF08BE93FAEA70A2AB08FBEAAF7DBF56B95FD93
+03CA406543BA6C9527D0DF01F5108D31A51778A5EB1C93F27B72B46146A353A2
+01CACBC829603B9989A87CF64528682CCBA0562A8165B185C58A5C6BB72F5E89
+500ACCAAB8ECEFBB2640E99EAEEC4EA979AA793D013D61D8ACF8784FF8D9398F
+F6A252A709324FB39509F0B3A4E725E82F53543383C6765BE556CC897C758208
+AA3AD37B0406E4A79F8F0A6C1983FC73E71CD858C0DB66ED66D5D992978614EE
+1EA91EBE191E082EBA1FC040AF19A2202575C2EBEB8058833E3520FA03D2F915
+85C1ED337E457B9FEEB0C6EF2735EFDA6E0D05FA641BCF698AC6B97751E8306C
+4DF00A39B8581FF53DB8F8525FDB196D85950906CCB59B8EF171349AA3B567B1
+6A00819947A995FB383C3C1709C9A2C113B2E40BB832B7D4A0FBA0B16A2C455F
+55809CC425C403E9668DC66BE45B71A81C332FD4DB279D22A2959962304A8F18
+085893DAC61317D24A8F198FDAB95F3B86F0AFD35047B868A9A17037A2829A02
+BAB042F75F349E197A7EED41984C2859754CAFD0251439921C248B463B516951
+2E1322C80D73F9CBCAA63A585450275AC2492E4D3FB78E800F788254DB5E610D
+CF788DF5C70FF99892BCDF16133E34B24B77C8F097F546B87C603DDB8998B66E
+BACB68BA27462AF54AA405682EC96D701F0D474DECD5F95CA2102DF639EB169E
+D518162C2BAE45FF698B6DE15FC6E7DE48C336C40A670FD26952A6BAB09115E1
+991F0073419F2CC2A1C08BE91096936AA0C37E4ED3CCCEE235476074B8FF1125
+6BDE3701F85532D8BB64CCC927CC335281C95EA689706F0AC717DC2CF680C754
+E5EFD7FA4BB8880B2B727A964C876D4A223069D4E6001771F0E23EAD2A4BBC80
+E76675297B2EF05F52BF4E71B3EE2BE3048CF088C79540113C66AE98B2FD3CB1
+B0741A215FD070882C52765009D7D711DAA2508F19AE7DDA15229A856AC49BC3
+4DDF40814FF96500E4B9B02D412E94623C5FDCC76C0FB8E42DF56A904FE49D65
+1DA7C53901B2EA71AB658A464D3ABDE27D9DB8D9E0B48F64E61A2495AD5D8DAB
+B5E72424AD017DF37964AF911BD7FA21A5EB4775DC8E95EF0C0EB856B00D89D7
+8172A1DE8530767D317B8256103E53CFB877E10686A04F5A08F8DC58D843DEBA
+FD5F40597588663D103689F6EB3EB14D06E18C8078F2538B43E712DF491FC5C6
+AF639256C8C6134B64D560D8476DEA6329D995E46CC4BC78841C59E73648B47E
+BFA7DE0846422F738454AE77E822A083405289247BD7C478BE4974F742CD6051
+E99FBB1D1B3FBABFEE855174734EE45E87D0AADF32B1283B911162A9955847FD
+38944D70584FAA6B1A7191C5C134B73F98EB632B69E2F0C0F94156787C34C8A3
+7622A029D58F9626B74F8A8A1F3803E0BC20E0EADEB1E99B70F1BD9F980FB751
+2A842843DE42EB142A84D5D3138629AE9EAF6F3479C423E8829C8816FA6EFA27
+DCE5580E65AA9854B1C64163DC318420CD993C15BFD76A8BA1182860A6B03D6D
+22B8CF43CFE6C8AB27C64842E239CAE707D3086BADDE1D7C94E3BC96319470D6
+8D26915C575CFDD03271D6BB9DE86A0EB6EEA6E768B224A626C62A9AB48A6EDB
+44F70BB5AF991CDF9736D65933E81CC57A78F623F33EC9AF535F2F25FA4EEC90
+D50DB7E87F31E971A75A33A301CA6013EEC5A4E179D695B33DADF2C98364434A
+42926776000B610E17524162253F6FA638D6581C18F99EA0BD1D2E24D2424ADF
+C05010D08192485153DD03930C7BF45237593E484F9851E6D464FA10FECA5D9E
+0C8CCC97DE029030900CDBB491C5CF226DBF903CFE7735D939C3FDF3A20B70CE
+66579B28B99313FEE914E295388C7BC8E055A2E54EA3A8206D3C8F4F7C0BA5E6
+E519419FD8CE215F7B8E9BEC604A9E3FE272A0328A24E31997C8A91E0946BCF1
+6943A97CBED2AB9FC636B49828BBB8B89E0BBC2653796431224895ABA5DAC41E
+1854BD9764E86147FD7624F736F40DE3B7582EDDFD15C2BDE3F22B5A54D7DF10
+B87A1301CE85CFC061689A890A321412A13314AE96DCD3EDA75035FDD8F4AB9B
+897A2C68263A68457032C469987970648BA2D88B1C5375DFEAA35A917B8A952E
+EE670427942AEDB3CB599C5746180E392837D371E15D860620ABDB6AA7772C40
+A5E346661673ACA530BE3D8E3FFB895E5DA3DC23B1B43C080C77F7E47847F0F3
+F3AA5CA9E4BF75FC5EBD18D19F21A7DAA3B11CABC6E4070A15F7DBC8B05EB6AA
+A02EF1B078EB66D61D6AFE41DA9B36FE7EC9EF94D1EA26282A9871E2CACB3126
+2AD49C2D9B50A6E47D8F2CCAD50992D1B430979A45FD9E76182A19964BB2A1F6
+51779A2B258DC1DF4C2F3074621286831F3848AC152DDD2BA561E6586ADA88D3
+598A2CE2CD048F027CE0008B828BD915887D7785341E8305DF2346ADB76BE99F
+87B02173BDC334E9221C8DF54114A6B24C1C5340299512FA6C8C51AB4C8778CE
+178CEF531C6D1B5FF0A1BE8EFF767F959BD4C345C52699A29A17B2A230842BF6
+4B011217D6D24EDAC3F6D53482786F1CA33169B90ECD499407D37CE9B70DDF78
+7B7547B32952535BA9ACD1E244447AE3FCED3AF28717083CF9590A09780984D6
+AF0743C82AE4FB3E2BB2856A4153A3967A023FFC35382D6C22D84A924900B6A6
+3DDD400E6D2418DA6C27F2FA34C075C902B89EBAE658B3C9A18EEE449DA5A379
+337DE95CB7AB3F0970CF1A5D8FAD8090E495570FDFB2FBBA79244780D8035547
+C5A55BB21A2270F724BF5D442CDC5BB9F09BE0CAE59B1C2270F0BDACE698F2C5
+DE8F66BFB9634904B161F5BA2B1950048300D69BABD312D58D89C4ED527AF7BA
+7DA2478EDC2CDEE3473DD8A8ED9D891CD1FC21F23013228BB3281B71FCE959BD
+6F8E9059D682A7FCC5265A0620992D4FA8D78377EB34CE3ECA070EE3707239BC
+98907DB0120CE42ABA32CF97127E28382BDDFD685674279F588D4F951216C355
+821361790F64C2CC720DE97E8ECB57326C43EE47367628E05769E106868B54F4
+C33C9951908DF6FC4F5ED2C7787BD8FA591BBB3E9C6C1DA94CC5E38D9B20C886
+7D237572FF46DD896A4D6163408EA6CEFAC398EE041EAE29D577E75326CA17A6
+B072D47A7B13EC441CE6DAA042ECD02134CBFA6809A435050413817193DAEB16
+A5882C8AEA44BCF36E74E9ECCDFE7E19FF5A5DD7A94E5AB4F8702C3DA7F42325
+23C808670A0490F5B373DADE40814FF9650241D3D69C91FBC5ECE728F827D9BF
+C928602E05477903449E079164CA39859C4BCA60C579F490AA455F82B5050BB3
+969AFB478E0D4A257B3356EA3CD62051FCE6C6B1929CFF85BFDF166BEF658E10
+3A55E007F38EBBB248B3F0B8ED1925106B499B762E45113AE1AC9DE09644C84B
+9C08034B297314EE69BC32DB6E7D7FB9913CE5AC17E7335979E9DCCE2BAB3725
+1976155551F9706A576FE0E3ADCCF72C87683291528ECB749CB0ED291966E239
+B5E3630676BD409E08F85BC1AEC9A2D4135376284A96EA24431243BD6FE8B966
+95F11A4BB53F392E0AEFEA623064FF8A7002367B0A515635CB2D2DDFB9B4A8D7
+FE721754E81BBA548848A235B91AD4E4F7DB19CCE2F61D277FC00AB956EB93BE
+44AB4970CA56BF59506C94ED160FB1E25D3DF2988A532BDB787BFB8539D22986
+FDC378AC31444E63C4727FEE121A43751043849E6DCAC5B59D0FC703AAFBBFD4
+E8B7C268F21615AD02CE9DABEFA27B5FE6A6441B619539CAB1F810F1263447AA
+633F5DAF483752EF1A0421740E3A811D2D2898CBF53E7F686C9223FD7235F02D
+6F90D2D48CC20AB87778DE3C6FB335E0F0EC20B5DC5B65223FE117526DE2C72F
+FE839DF93CB2A7D66CD900CB325F891E311BEC932F703FB4FEFA29DB8B9C88DD
+375EC71B3D58C7BC59ADA91971A3BDA1ADEA629CE6CC92BD542CDDFAA7706FB2
+6CDDE2DF07E56D6741916AE8E8744339816F3E6C38062747AA9FDA2A2678A6B7
+EFEA870AA3A4D71B25EE3013EAB1DBA34401B867C7A41AE51E0421D41D3BB83C
+E120C8FEABA6E5DEC53A689C21426D4BBCB68CB37568761C360E6D4E3596FB7D
+F4DEC7918E58C0293D12D6DDA7E9DCDAAD7C939F55CD1BC4A228B31E9A904156
+DA6B40B08E6ACE674618B768DD681C772A3E55FE096CF949CF3B0460ABDCD891
+D17B37B355B29AB5137899C036F31DA026244FA25FB798FBE5105BDA29F46538
+D3D3AC1001A7BCECE64DE94FFE6C354166A0F97256137BDFA07F6E22A3D1D2F4
+9588DBAE95E895BC5E64DDCBBAA8D0A22C229B42CB717FC711E7E9DF793DF80B
+9F14754585A3C7E17F37B32924B9F9870DA8635E3E18BD1DCD81EDF01834D9C6
+B33F23C956C2FCBFA47D84422F583459D827D1E120B97694D12F1F54D02379C0
+D288F7104F3FFCF4F76E3494F4ACBD1BE3A15543CC680924C78A473F8E311ADF
+8FE00A04C6C393DE61AD3EDA5BC031E2353076A2489391B52632387CA28A7B93
+FBB065A6EF3658AE80B1ADA47E9B2539E73A71FA75645F85ED8ECC257FB4CF26
+B6C912DE9D0F9899E70BECCB934AD32CF49A093371A9F73DE6255EBC39DE1E7F
+00D0CBDABD4D0383977E694890E71FBE5C376BE5F3A80C28987417504F515C50
+909F3D31178BB9B1D085BE514F71B910A9085BD6122DDC72A150BFE266920E49
+5661BCB4BAB51D6DEFE32B616963DBD989FCDD1637B294CE4E288655FBEFA1BF
+7F25BBF8CF17C2D5FD161A7C2CC9CC7490D9BF15A1D35B3BFA43ADE256E88BDA
+BD490D92907C57BAC408A575EC84D6AEE070148C7C9A91C03B09FDBD792E8FF0
+C0B886AAD2EDD86541E5E579359D40E3AC312ACD3D8FD49F71BD533DDF8859B1
+BAF17F1884E331DD07CEEF93B71D492AEBAADF7A263450A7A72210CE630A0D37
+BF024BDC09ACC882816B8C22C62AE38A3A8D0F6EBC2B1B2C0B8161A8B076DD5D
+4B779C0788546BB4CF57332230D237856B00D79C28A7C01D11F44B7304F69075
+94B97A745DA43D1BE561372CE611C345A843834E46AD9DDB16CABCD3FA33D6F1
+F6B5C0497F5EE5400B305CDC16A7EC286AA4D45D0EEBB9DA06AC9C5294D68EC9
+E4DC3CA2B92CE8FC0526184A86EDC7AB34D67E60AC12D9CA8FD300235EC968BA
+92C6FBDA47572BC5600F25249F60AD287CBDAE980E747FCBE7EE5CD323E733F0
+63553B494D3DDEB9CC1480B5C3BB79A28E419AA65B18CB297AB383419E890E2A
+CE6F98C9900CCB4675280A10CF060B8D220DDA1BE55DFA65715EABCC1AFAA271
+B1F8732341613E17B231231A0D24D4D7FC198AE04D89A99C4536217769C6FBD9
+5EE24A6302F97438F7C0E311C878F674B4477A5ADA3952CDE4055AC408B8174E
+86F8FB797646DFFFE0ECA25D1BAB9A9F71F3926D3D85AA63E7A8C931D71E79E0
+AF1EAC26FADE468F4FF7F3861D14C10E3BE1F9EAFD6D3A544E8108D5DAB5B180
+3950C74818BC8AF4758A108F462EF1826647A49667F5E482038C54716856D9BC
+35F29922846D2148F92F943E951D7438C73D6A60459A8003174036C64E1629CD
+155D47FD04B03C023AD67CD5A70C98AB556EEAB8C48169706E5B352F6505D580
+AC945171BFE62E81F8F500438AC3B64D857BA5BC54C2C4BBB237F8FA51296255
+E66A92A61FE13FDE781D393557EB72CEBAD86511035F775FAC39A0479CCD400F
+226709118F887F47CC2ECC8F79816D4A945B2845F50AFD62D8C9A9BBF4739496
+9E644BC9F7B04803B7EE75A09EAE94365F6F374B4FCEB0B506C76297564B9B6B
+8B812BC3A33929AA94692572B010E6210AEAA312BDFC88BF302244AB9D587A9B
+919823FD01DE12438D960944D1977800FEB49E638C32E5B188B1CA033E0C37EE
+A142F746367888AA119535F0CCAF7EAA461B790EB089D2D6962E28A398439BB7
+9C9943654D7A2D765B46BC0DD1F915327F369162E1BA1BA83110B93F442905E0
+523BFF5E279508A98568CD5CFD18FABBE9D17265A9081E7BF64155A2CE3C0DF7
+88D00671AD65654709589BAD7EA65BBA811387ABA5CA0BC3F66D3D48597A0D1D
+2C268375DF47CCF62166262AE4840AB03BF49BE67A05EF66328EC729F03CA5FF
+AD3937FC053E223303565DC771ACF32E63DFB96D5030E787961D72D02C195C66
+B48E9AF0309DC169CFE8D16E2818DA94693A18F027DEA0D91051800EE6C54285
+AB0594D87D05EB4CB44FFC094DA0072AE7D4BF2F4F9BB812FED256B937BC2574
+8C529F97ABADF6DFA7FA36E1DC6143DACC84C67787EED07D03C8A9D1FD9B4833
+129C36514145052CBB94273E6C6E08B75FE1789915FC4DA4A244EEEBBD6A82F7
+91A505955F57E74018CAD8385ECB4A1765FC97C59CFC61C1BFF5CB2135D8CDB1
+942BCD7837CC79347BBF68CABF6AF8D69BF07370073363F6293292ABD69CCD7A
+A0766E0DFB4D4EF1B102C6A0079CCBF0642CD37869BC08F1A1060E0AAB8AB746
+A6B456FE0F1D22662FE34FC981ECA211D4C334DA87474A364FFA26300B4E96F1
+C163B586D0BEEC7EA0E1DEC29EE2D54D07A2E031C6BCF0D55D4667D08746DB7A
+0F79101D49B2DF6E86C821176FC77CBE76EA96F615132604EC5F9AE6DCE1534A
+272FFEA3118FA3B049132370A8637A043DB4BD5D188B7C2CBA5CF89FA268428A
+F7677645A1814A80F3E9A12A27AB4609A3A498F2CD16FD5E4FE953907F1DB785
+43D91872492A38250A0B3CA33BC18A009F3F48E6E124AF0BA53A495F98A0465A
+992562EF08D5B53F05FB5ADAE148F90E8CA62B214EA0562234CB744BA59A333A
+2F60DCD2ED410F9EA4B099B02CD0883905424A5EAF5AE47F2E34567FD9B077C8
+E0728DC8EC7CB7F1CA70B5867858EA77B98ADDF26F85F37175010A169E0BB757
+1CBDCC2F63E97F801A2279E9D03A3ED897DE82F4D556AA21A52D8229C83FE07D
+AABEC916CE68253CF74821915DB1F0C4EC670FF97A9B380B2C1FEB7D0B697EFC
+AF8BE55A14EE39037AACB6A7E54CD5E07AC63F7D3D4B8A37C99940458956FDA2
+9FCF6B85EC15D79FDA2216750723BAB22B95917DB36F1BCCB25B0230C46E6B97
+5EEC84F12782514DECB3D371EDD2F91D9C7056A03F18AEF4CC771AB8F4C82AAE
+1C233C82E0608D898001F451F6E5AB212C2C80CA136EE95B7534A051A6DA5A25
+8617F2693A38E0C15A91266174F932219FE142FE808C017487CAD0F350AB52C3
+246BE36A23757B48F510906DD4
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+%%BeginFont: CMR10
+%!PS-AdobeFont-1.0: CMR10 003.002
+%%Title: CMR10
+%Version: 003.002
+%%CreationDate: Mon Jul 13 16:17:00 2009
+%%Creator: David M. Jones
+%Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+%Copyright: (<http://www.ams.org>), with Reserved Font Name CMR10.
+% This Font Software is licensed under the SIL Open Font License, Version 1.1.
+% This license is in the accompanying file OFL.txt, and is also
+% available with a FAQ at: http://scripts.sil.org/OFL.
+%%EndComments
+FontDirectory/CMR10 known{/CMR10 findfont dup/UniqueID known{dup
+/UniqueID get 5000793 eq exch/FontType get 1 eq and}{pop false}ifelse
+{save true}{false}ifelse}{false}ifelse
+11 dict begin
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0 ]readonly def
+/FontName /CMR10 def
+/FontBBox {-40 -250 1009 750 }readonly def
+/PaintType 0 def
+/FontInfo 9 dict dup begin
+/version (003.002) readonly def
+/Notice (Copyright \050c\051 1997, 2009 American Mathematical Society \050<http://www.ams.org>\051, with Reserved Font Name CMR10.) readonly def
+/FullName (CMR10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle 0 def
+/isFixedPitch false def
+/UnderlinePosition -100 def
+/UnderlineThickness 50 def
+end readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 1 /Delta put
+dup 43 /plus put
+dup 61 /equal put
+readonly def
+currentdict end
+currentfile eexec
+D9D66F633B846AB284BCF8B0411B772DE5CE3DD325E55798292D7BD972BD75FA
+0E079529AF9C82DF72F64195C9C210DCE34528F540DA1FFD7BEBB9B40787BA93
+51BBFB7CFC5F9152D1E5BB0AD8D016C6CFA4EB41B3C51D091C2D5440E67CFD71
+7C56816B03B901BF4A25A07175380E50A213F877C44778B3C5AADBCC86D6E551
+E6AF364B0BFCAAD22D8D558C5C81A7D425A1629DD5182206742D1D082A12F078
+0FD4F5F6D3129FCFFF1F4A912B0A7DEC8D33A57B5AE0328EF9D57ADDAC543273
+C01924195A181D03F5054A93B71E5065F8D92FE23794D2DB9B8591E5F01442D8
+569672CF86B91C3F79C5DDC97C190EE0082814A5B5A2A5E77C790F087E729079
+24A5AC880DDED58334DD5E8DC6A0B2BD4F04B17334A74BF8FF5D88B7B678A04A
+2255C050CB39A389106B0C672A1912AFA86A49EFD02E61E6509E50EE35E67944
+8FC63D91C3D2794B49A0C2993832BC4CDC8F7BD7575AD61BCDF42E2E421AA93E
+3FF9E4FAD980256D8B377043A07FC75D6169338028692CCA8CD1FE92FD60AD26
+D57B7519B80A8F8DCE9CEE5CDF720AF268D3C14099498A843D76E3B6C0328F24
+D36EFE7F5C4E5B5C612786200C8DE3A41EE5F1FFAF4097653CFCDC8F4FD32E0B
+03EDB3E413283B9EFB0AC33B055617005BC9B0057FD68C52D1B0E67F0C571685
+767F2AA85ADE4E0104A1C777733D5E318A22A9944336E5B98D965E50D31F357A
+8B6EA5A0EA98E1B027CE68C2EDB149EDDD04ED74A1B3D206D471A0C11C11449B
+DE190BBFEBC08C9E1B7513B43DA3134D6B11A2516E6E86B67F68C970A320D05E
+94FEC57FB347606DF89989C33482BD09D011C55AA920319E7B26A205D3D0F004
+22466F09C0482A164CFB27EF6ED2B040ECCC3DCAF345B5A73676F193D43123B7
+72FD6CFC5E37930E61EBD5A6307E4DE70194E6384EC0D79DB6AD86D3B319A31C
+8B0589D0FE28241D8ACE280D0530EE99C80723E560BB72AE9D53F4713181F491
+344B06D3027BA4E9E94D4305BE1D817197C54C8FF56CD6964165F6448ECC8A8A
+64B48B4F0FD69299A137589E2491A283509B21A3A5772F75B7602A9F60AE559B
+07A58436D04222C73EAEA72DE9A5A441F88D27C11F4F91255EFE280E91A4ACAC
+1E98A4E5E6C57B9AE86FD218C3CD8F24A4104156A80F13821384E529783C52C8
+78B94AB3A0096090867ED32E8A30980E737922037F75F062BD83BF4F5929BC51
+CC22AEE2DBBAAA001CFFBFF41D258424FAD888FFF1BEAB796A44E3126159E120
+7E4025C676CF94888A1971AEF8B6764B3AF4A92D36FAF6FC56FD049710EE3782
+BC2CD84FE2473F133BE03C1346B875463F126DCAB15C7A9BCC9A727D23611462
+4E8D2BFD2466600285D79518712B8681ABCD69608E6AA9578F7BD771EC36E01A
+5A17BC17E375020ECA59B43790ABEB9DF5F4FBBEF807E5699EFEAC563E1ACC5D
+EFA336E75DE6D8248E9381BB110884FDC89C2F9A41EBBC9A8A1F98E6A41F68BE
+EE30E25CA148C1EFF42DFF8C214A6537AB11F260B8C329A4947B5FC8DC9C5622
+4DF7BF4FBFB00380D47BABB03BC30627AA74103E553F55278F538EDD8C1E64CE
+0F1398CA0AB5A86630139B4A7E8FC02804CAFF3830114640AE50D2FDA3B561B5
+C63AD7EE3347804CBB40FB1E77A6C89735DD870351C3A1811591AB493251B904
+314F65791963C0412377C1D02362C5E9655F1C3D4803CD379A8EF24C48218C2E
+DF1165840462BF37DDE1B8D5FF09FA2C3B261E2F1A65ECFBE5D4EAD43B52C029
+EEB3948CB8A252CBAF545C8FA1C31E920E23A12DD7222CEF2D2A513BD758EA13
+DA33BF5FBF1D734653EB83DA2D374A5B9A0CE316F24EE375D6DF6BDA49954C2E
+DB25A88821193636119D469BA66E5DAA9C92520FD4F84426A4E54273FA469084
+7517817A6EE3E21176D333825E88046F50B3CF6938AF9BA79A2F51398239EB91
+1A2D07F7FCD948427FF62F40FF95E39FE1A1AA8451411563FD5388472251C155
+69BDE9283B41900B21EB1190D06E6B13B7794FED020D2C1BDD205AE77B084BCE
+EF628249398B496DE85B406FC2E1939EF00DFC84C07E26CF72EC401BAAE756E5
+7F6673216E7560D1C2A723CB405EE5CA474A07F61B81F8836482F73DC9516D67
+CE0CB770EAD755B6B356198B4B97EBB29C63456953270CCC8D5650C1D006E69D
+38DE2DFEAB27DAD50A817F0D645D30AF5B75A7B53CBD3D2B8D87BD0A7E525AF3
+22F7ADDFCE31716914C2318260C2E2B4664893921B68C5A93334A361D94A759C
+0D7B146D6FD94F0442D672BDA0F6432E18F3C5DFA37ADA378D95B75F413C9ED1
+BB5C606A3EC7DFB3F796F59B0478C13FD1900381EFE0BB5242D5B5D34D03AF1D
+4BDC93EAF8020E26CA23C8B0E7DDEBBC6762A557067A4CE05A524188A8F02E2F
+3625DA38DFCF381727887F5646A3995A8A38A5FB1E5D5EBB395FDD0B7C8E71AD
+B48EEDB62AB2CE99D121435EFBBFCEEA69AE9ED8238B60CC7288DE33C766CDFE
+15B767B4AE2E6CE0965E77272AC9F86023DA620548CFAC85BC751C44218A29C9
+849F1C2DCBDFAD895B54E51A569952ED50F82DC8A19F367E7E44643854EFD6B3
+FCAEB04E55E4661C82D31E2932611748480EF61FB2FBFB0CFB940BEA81AFCD84
+4C6A6332D7A600170E38A8EAFCD4F93DC153C43175434C86BC747348FAC61B76
+1FEC9027C1A193E55C80F1F20B5317AA0A05AAA36AE235F6E49F06E570FEE798
+84857D7552EA92EF3EFAD52DE39C2F8F43C59E3A957B7B926FC95FC4B60186DF
+7F3523EE2AB74E294C8C4BCD8B4975E84849E0FBDA6C0B0F24A636DFA578B122
+CF97BC5089E21E9F5298D1C9F30CB8BAFF6A3A11BB4D9A0A5CF2B18D055C44CA
+4FD4D8FE1AF3630907DE7E585AA811F9CD11FB2C8FC791851D651009FA5DF20B
+3C33FD2FF848A9E3F5652BD294965A332DD3F246C91B0ADA34017FF2451D1394
+F9C3C95AAC6EC8062BE98E8914D51DA6A164AD13938693D446044859D03A949D
+F9AC5DF4A000CDA98BB516D762CB9F6D44B5268FD0C26E88BC4A760C0F75A140
+DEBDECA4F511128B7D2805872160C55236F0A0FA7637FF0D4E94AC079CD3C8A7
+D03A5A56F26B0438B577C46011A10532FEBCAD14FBD6032E224F45691A726886
+56F305231EB2FCDF59C8BBFCB5DBD2D093A0E84D62AC93A2312CA69295E937C4
+8DBA1802B85F54B5E7E6D6216A918F911FF705D3B5CF055F1D873B96283A0B53
+59344D910CD396D883F6F7836BA65FAB4393A773A8F6BC298069E5BA38210EED
+49C9D920F718E3FCE692527DC7CCE6963BF744F2C91BC5952564196D60574E86
+87A0FAB21F2DB2BD5A51D7FBD8FC19946D24E5A228462C4772F978E650ADCE3B
+8D66B9C21279C531CA1C3A8ECE3420BB65837287A7222CC3673A2A5F8BBFDB60
+C719CD073EF9A23675198462C7C87B24CC92D6AEE5C25AC63855CC3281494342
+D28F3D2FDE0C183486769A4FD5B0143193D31FCB2C2A14E487BBD96D0BADBB64
+D1B56021C363A795BF10E2DB448261C363A54A4AC1182B470C457AA82DF3F5D1
+F4B329806141EBD53CAE309319B94133D7EBDC2D0453A905ADD207364371E178
+0A95C2686E3B34C4A978BFC0EE968C39ABA00889BC5149162C2B54483D44FD3B
+5CFF41F611C7E03B94945F414560E874D7CF27FFD0630890D7D7EA66CBD15448
+229059E1C436BB33D69552B5367AB5D53591C4678D0C704DD3EA23F5D9E8A7AC
+17D003C19E333E726FFFA2961F33C70F429085F7BFE3E2510F59B78F58B19CB4
+01B48E184BAD9020FECCE3AF52048A056981DAEA02AE78197E65855DDB170616
+F54278395D9EA50DC83761AE759F9CDEF9E1948E7002414FC05286ED793E6662
+3347F2A9AF8917493D7305B92CF93E8E9185F70015F5594084298A6C2F9FD3C0
+689F262AC9FEDC9B89577ECDE92F08D3142209FBCE7B5C0A840CC767BCA56C20
+4E4E545E2BE4D21C53855CEE4CD0AB35D1A604C0FFFF77DBAE4289752276559F
+A05FEE65F45ECAF44E95E23FAB6052195C7948AF0B1126482D4E02D72BF8AB03
+DE0F1A632F7672AD9DDE70EDC82AA993678A82BEAD0BC2649C4707FD8509810D
+364B5C6FE0E10772E95288C622C2F06C634F4DF8C7FD1432BC9310D5F24FEE3F
+7AB324863D6DABAA1576E70643CA79EF4D7DF4105093D66CEE0F3B87D2164A7F
+26EA05F5C4645B22D3E1BFD2219657712C168FD90DE801FB0F32759E80DEC1E1
+43CEEB19FED12D757205043FC98FEC62D6A8D8B97BC083B4A0E985AF7850D6FD
+8716B9957C1C35A0675BC53DF672C425C79F43FDABAEE7D63F092CF271C9A9D7
+C41F40C4189510987887942E60A412B3EEC84C9A6E1AC7D54D528F5604B72C08
+94B7882621A5BF1F325B92FF96B80878CC550D1AE4D8196E41CB1251856609A5
+C4D3BD05A922D0D45E039D9450DEF8490A3E924E41434194910BF60BA1B08BE1
+B41824345627745541A4F1703E956328F6227D11C74946B38CFB096139979E56
+4E723B889B44C6D78673868C89912F8B4F0B4B485F1587A637B630F92E6072D5
+7F3B44EA6FD96BBD4FC28A6C1D90805E3BE3E42A7BC9C880762966C55BC04E01
+204D083AE976FAE6F37C94F27E68F8C0F28D52B17F6C0FD7C9150701FD78F8CE
+B8E8DC9260E3974005EB5CA728171F482D765016C94D4ADFE4A42EF42212BC56
+7E4EEEE8B0D2A7856CD4E44F55C0BAB762F92CB8D64C17022D4BF3A47C12F5E6
+279FC23101FEE93753653CE8CEDC3B75C9CCB29BF1D4554C6120DE8EE750FCBB
+E38B5D915206974962E320362E59B3F21B3AB1875703191043D03284D4467346
+CFF2F98CEB4845B73ED8E003E0DC94251B73E13A9B51A3F1430BCF6A21EB9B7A
+65E17FA411F53BE6432F1506232B8159E008FA257F884A4A01AC53BE91754D78
+BF14A5B0FBFB9C31BF4908355F8A762052968DF526D118708CCB0B7CB5BEE285
+6DAB6CD2E3934178E60BECB11AAB5478623CF6C50C92F8BB5D1A583609028FA7
+B8A53B791BDC9EF76A124F3F7641857E4BEA0837CB36176EC9A522EA7F41B8D3
+63C37D1145367BD300F17B54522A834BBB74DE12BF9EB26ACE6F24A046D58F89
+4D4B7DF74875F1A0C1C9D97BE0849593D7B398EB4B00BEBC8C8D1497B6EF831A
+A35380FFB7F1AFA4D888AA52C9482E8B1755CC209905F98F40D95B44D4DCBCB6
+67423D1BC2F3560FF0A8B4F0CAC352A4EE2C1D946E45AAEC8A6AD40303F3382C
+DF0756BFA3B1ED64C169E56ED1C760F2FF0E24DC5C9F41306EF8D2628153D30A
+5DCB0791126BEFD4947D7EF08301FE015F2B0008DFFCBF9F2D4D859FD43EC7D9
+C5BE237E9BF6665B7B1BEBB362F0C0C3A8D86010B9C97FA741C97C2E0513386C
+9C26C235B14DD2A58BFDAC7B5F63DB4DA6D5D37D0098175A9071590E1DF66A3D
+B8173A047C29D7D35557F06132CC920B5460B8AFC11D23D09A4E45D089F5EB51
+963FA1A6256E359D485107FD143B2BF21FDE9DA5744BC2615E86C31C89470CF0
+D06C6397D9FCCB316EA9989430240759D2C4945D941F159FC02327F34B042BAB
+B5C3A47C78E8C1A6FBCD396B1A51CC4B020B8AD401841EDABACECDB482D6EC5B
+72D2BFEB4556720FADD49D07307C8B22ACB7E310CA4151A85C71EEF70E8D15DE
+B3B00F26E0E166C14647A65ADA228A3D1C89025BE059306565DB1B1EFC37D358
+8C1EB024254AFD049BA977BD4C2C605050E17940A89D0D4C5D963E792320F5DB
+3706682E03D25D9E02487247819551465092CC22B6B56E93F3AB528038FEC3F0
+668F866707A19B0463BE706EC729D2EE1653AAC7E29BD25BFB3241D4792F5152
+ED415B4E7FA92C2EE5A22E27E8B75542C492E56D811C192E95542A6FE0BFE5A5
+69273C2ABED4300D491B92D2AECDD278404CB84B1BB1BD7AFEC858215837D118
+C0E928BE7E07CFEEB51A6D21375B772B8248C994564014015232A0DA4BEA1754
+3274F407FED0837A236371F1A32056240F2015B1E7F4B2CA72C6B58610A66F13
+407CFFBA5E0A2893C1F572D50F51286E9133B5A84239C9493B0574E77D281D01
+11D00683354A000C9700EAFBC1FD104EA19DFCB87470190E7E2CE26E3A6FD0FF
+2620B87B82AC8686B6206B530F17E9348BC7D04B948348802CE53A312443DB87
+4DBBA5313A6A2A8DAB8A1CC9A594FF8C299281C0A261C8CB2226B732FBEEDE40
+2C6ACC74A1A61379E2E1CD5548CD908268A32FA83D8504C442EA0E183ADBF7FF
+9FD09C037AB03516ECCA93FF048235BD11A25DB07F164512A079C5392AC7F889
+CE96AE5C8D9580BCAFCC087C35E76EED1A671E87C12E3045E15A687134736DF8
+DA984772AFD189D68571A2ED7256F1E204230E41D3D9DD876F938951714A3973
+0CA9310489F8E807C1C7A4E51AEA5BC030610A5D7263FF7E0F9FDE3E5E37A362
+5B919000BD94D978583B942EB79CF2BEAC33FEBC9A67272EB10865BA8FB75FD7
+9D280AB59F91B96C16C982DE848D76D8FA8620DFD7C80B7DEAE7264350D6FB3A
+EF04794DA3305844A7CF718F6D1A4A3AFF6826173A076A1372ABFC54ED3AC6C2
+09C9287FC830556CA694E21CA5342ECA7B10C90AFC4783D841D7B1E34FA3DB7A
+2B706F3E21B0FBAB23E7257962FC3BC309CEA2C7239A9D6B44CC96825115ABD2
+AF9A2566D2F3382C01569FBDB94C8D664A5DA0F7DC3DD140CA77C743D7BC1420
+324ECF9E4780280EB119885E96A6C619CE3C0C8E1E264E2DEB137E5DC8149786
+486D65667ECF47B1A1E20E9E6E4FC8323E0BC8E61BDD3BCDFC6575C69C03E31A
+EFFC290472CBBD049DE3F840AEE37A2486034240F80E75D8A79E0762377DF660
+52B12EAA16D678990B11A9BFBC03C1D4FCDA9FD4FFBB3E88352438102F10B7C5
+9F04C013B6575B5E948FAB58EA691984A0E54E6B9F3F505FFFEF74D06FA1CDF3
+4B8A95904C8A2763AA8AF5B71D00F5DE09DC1CDF87A08B6D181453063E14C12D
+B7BB3775A6E2A901636273D9EEB833EA8CF20FD83AE899E28DADE10EEEC20BD7
+BD93085A4B1AC80AC1AE8280C14767F1A487BD066007A0D050317BD081131A14
+6EA0898ED59E46DA7B6254BDCCBC660686E2EDA0E77A705A653733BB5C5497D0
+B130359F866CF293FB6EF0C2AC5BAA2DB0DED045E2DED3A2612D078333260359
+16CF0CCB272D34767EA069E0F0B0D42327A18529D72E890EDA6195C2688438ED
+E9ACDBEED41E81CA8EB5E43C2B09CE266EFCA03F2D7FF57F12B06F9E54FCC6A6
+546676F6FFC5B8B7D3F0982B6FF0D21D949309F0C0B175CC1D0976F8C55C6AED
+6E821C39041E22D91AB30922F2B2EC2746BC7DAB484991542FBC82D87B487507
+559AB466F73EE23C2D3194DC5CE4C9AE66D3164613AC5CBB3DB501B64DA7C91B
+C7ED2EE9027FC0906820B35D4F2CF66C4F9CE4A884B7C07155BCA884ECA5EB3A
+ABB83F84DB1F5639599DC7D3F51241AB5D95C3BCB7AB1EC90B4BC989F74FB354
+04B2D7366A34D335A47B8C00C05CB423482BF6C7970A95545424A08AFF9A035B
+7F83F52B65A9799CE76E303B85664B624C65E9CA58184C7BE2BB9D9C86A4DE5A
+8165EE3DA2E652B5022EE7893896BABD88931DE1D538F615787645DF5ACBBA0B
+A8E5B899A37321AA7D4B283AC9234978C2DD81813A1EE5DB6EC170DAC1B6EF02
+94892635B498765C07A38D2E9DB0B7581B11056C28278F89B0E60998379C07EB
+C0EAEDC32AA69B8B836F92A61AFD35688315B2C3F860632FC13E4BDFB63214BC
+41CC6859EAB3AC3034449213CAB99FA1D216563419CD6D6CE4E1B56F33E6C654
+7AA9DCB5B05FC068DF02AC32408C8010AD004F6CCA9887830927F8CBCD49CDB5
+18CAC1EAFF815FF2F6F527F936948201565003022C6C7390B4E3C2B219FB4F76
+9F12BD25CA7B3B61D1A2F8DFEE795D04D5428B42FB66E0C254AF7B7A10CEF7FD
+E0B5622DF6FC4BF52147208D9A91EB49B03BB40DE7F8FBFB566F251942C8FFB1
+1DFA50465919400C21CE4724D12E4EB47AA5F392BA927329DBCA28A78FC1DF2E
+6FF27F4E4E3F8971D7BCB5F3FBF8F30C214A26E5E32E0E8CBC71BF20AE573BBB
+163DD66E89F2C4E2B1A1532AE81C060146F755A1ABA3F1365FEA30B403DE7B22
+76F43EDB1A2230934225C290D98237E3E19012E75EB1297250A477781904F794
+39BEC3C61A62874766DC1356C9D659D498EA3DF55CC7F54C4962A697CA30668A
+A94027D0B8EBBFDCF529C1627E12881EC48992F59AE9BE899E0B6EA87DEA3ABC
+016587F24EF9A5740A91FF6D2700B09BD13D0968D366B30CB4FF2BF06FDE1F5E
+B5C5652E6148A64331B03FA6288A12BAC04DFA3F0241AAE667682465F356ABD5
+D2C8BA51EC4CE912963118A25C50C70C56B6CBB9AD7829AC9C7B77E74980A504
+7619A41F16ADC7532A1CA8F6A6CA10F217965867981A9DD526DB6D6341E9200B
+94F00C83DB74EBF830C1D5C1851380B6886B6887E8487284F94CDD35E730F9B6
+7110EFDA91B8739F3A2698E3E7E08AA5E529FF79C55E43EB37ED42C8D302F638
+8B8A7198C98D8292D8C7B84A06A82DF38B2CEE2A1751CC4713EDEB502D2F755A
+C2E9DF0E01466670AFA2C67B1235A1D1F8E54DAAF6525531EA528D77AA1249DC
+67FFC32ADFEB57DECFCC221C70996382B662D354EEEAB0D79C87242739FAB394
+73F9A0B813C57FE6AB3D18522CEF385B973FE9C257DAC12715A1D43B88DAB684
+E95B566E35CB88674F0EF0A3EA1823B84207717ACFF53DDF5574
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+{restore}if
+%%EndFont 
+TeXDict begin 40258437 52099154 1000 600 600 (gmt_eq.dvi)
+@start /Fa 205[33 50[{}1 58.1154 /CMR7 rf /Fb 134[41
+47 92[47 27[{}3 83.022 /CMMI10 rf /Fc 194[65 17[65 41[69
+1[{}3 83.022 /CMR10 rf end
+%%EndProlog
+%%BeginSetup
+%%Feature: *Resolution 600dpi
+TeXDict begin
+ end
+%%EndSetup
+TeXDict begin 1 0 bop 639 523 a Fc(\001)p Fb(\033)27
+b Fc(=)c Fb(x)917 493 y Fa(2)973 523 y Fc(+)18 b Fb(y)1100
+493 y Fa(2)p eop end
+%%Trailer
+userdict /end-hook known{end-hook}if
+%%EOF
+%%EndDocument
+PSL_eps_end
+U
+PSL_cliprestore
+23 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 61 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -61 0 D S
+N 0 945 M -61 0 D S
+N 0 1890 M -61 0 D S
+N 0 2835 M -61 0 D S
+N 0 3780 M -61 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+153 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 46 add def
+0 PSL_A0_y MM
+(0) mr Z
+945 PSL_A0_y MM
+(2) mr Z
+1890 PSL_A0_y MM
+(4) mr Z
+2835 PSL_A0_y MM
+(6) mr Z
+3780 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 472 M -31 0 D S
+N 0 1417 M -31 0 D S
+N 0 2362 M -31 0 D S
+N 0 3307 M -31 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+23 W
+N 0 3780 M 0 -3780 D S
+-7559 0 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 61 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -61 D S
+N 945 0 M 0 -61 D S
+N 1890 0 M 0 -61 D S
+N 2835 0 M 0 -61 D S
+N 3780 0 M 0 -61 D S
+N 4724 0 M 0 -61 D S
+N 5669 0 M 0 -61 D S
+N 6614 0 M 0 -61 D S
+N 7559 0 M 0 -61 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+(12) sh mx
+(14) sh mx
+(16) sh mx
+def
+/PSL_A0_y PSL_A0_y 46 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+945 PSL_A0_y MM
+(2) bc Z
+1890 PSL_A0_y MM
+(4) bc Z
+2835 PSL_A0_y MM
+(6) bc Z
+3780 PSL_A0_y MM
+(8) bc Z
+4724 PSL_A0_y MM
+(10) bc Z
+5669 PSL_A0_y MM
+(12) bc Z
+6614 PSL_A0_y MM
+(14) bc Z
+7559 PSL_A0_y MM
+(16) bc Z
+N 472 0 M 0 -31 D S
+N 1417 0 M 0 -31 D S
+N 2362 0 M 0 -31 D S
+N 3307 0 M 0 -31 D S
+N 4252 0 M 0 -31 D S
+N 5197 0 M 0 -31 D S
+N 6142 0 M 0 -31 D S
+N 7087 0 M 0 -31 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+23 W
+N 0 0 M 7559 0 D S
+0 -3780 T
+0 setlinecap
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/latex/latexrgb.ps
+++ b/test/latex/latexrgb.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.3.0_6f6a988-dirty_2021.08.28 [64-bit] Document from text
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.3.0_b129487_2021.08.28 [64-bit] Document from text
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Sat Aug 28 10:52:00 2021
+%%CreationDate: Sat Aug 28 11:10:07 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -117,39 +117,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -688,8 +688,8 @@ end
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-/PSL_page_xsize 9917 def
-/PSL_page_ysize 14033 def
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
 /PSL_movie_label_completion {} def
 /PSL_movie_prog_indicator_completion {} def
@@ -714,7 +714,7 @@ clipsave
 -7559 0 D
 P
 PSL_clip N
-PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
 1 0 0 C
 V
 3780 1890 T
@@ -727,13 +727,13 @@ N 148 654 M 209 654 L 209 666 L 148 666 L P clip N
 %!PS-Adobe-2.0 EPSF-2.0
 %%Creator: dvips(k) 2021.1 Copyright 2021 Radical Eye Software
 %%Title: gmt_eq.dvi
-%%CreationDate: Sat Aug 28 20:52:00 2021
+%%CreationDate: Sat Aug 28 21:10:07 2021
 %%DocumentFonts: CMR10 CMMI10 CMR7
 %%EndComments
 %DVIPSWebPage: (www.radicaleye.com)
 %DVIPSCommandLine: dvips -q -E gmt_eq.dvi -o equation.eps
 %DVIPSParameters: dpi=600
-%DVIPSSource:  TeX output 2021.08.28:1052
+%DVIPSSource:  TeX output 2021.08.28:1110
 %%BeginProcSet: tex.pro 0 0
 %!
 /TeXDict 300 dict def TeXDict begin/N{def}def/B{bind def}N/S{exch}N/X{S
@@ -2018,7 +2018,7 @@ N 0 945 M -61 0 D S
 N 0 1890 M -61 0 D S
 N 0 2835 M -61 0 D S
 N 0 3780 M -61 0 D S
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /MM {neg exch M} def
 /PSL_AH0 0
 153 F0

--- a/test/latex/latexrgb.sh
+++ b/test/latex/latexrgb.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Testing simple LaTeX expression in pstext with font color
+gmt begin latexrgb ps
+	echo "8 4 <math>\Delta\sigma=x^2+y^2</math>" | gmt text -R0/16/0/8 -Jx1c -Baf -F+f48p,1,red
+gmt end show


### PR DESCRIPTION
While text sets the correct font color, the placement of the EPS image generated by dvips first resets the environment so that color change is lost.  To fix this required cloning _PSL_plotepsimage_ to a new function _PSL_plotlatexeps_ that took an extra _rgb_ argument so we can set the color after the initialization.  I added a new test latexrgb.sh based on the example in the issue which passes.
Closes #5712.