### PR TITLE
Enable greenspline in modern mode to pick up session -R -I -r

### DIFF
--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -161,8 +161,8 @@ and those that change with the job number.  The constants are accessible by all 
 total number of jobs (given or inferred from **-T**). Also, if **-I** was used then any static parameters
 listed therein will be available to all the scripts as well. In addition, the *mainscript* also has access
 to parameters that vary with the job counter: **BATCH_JOB**\ : The current job number (an integer, e.g., 136),
-**BATCH_TAG**\ : The formatted job number given the precision (a string, e.g., 000136), and **BATCH_NAME**\ :
-The name prefix unique to the current job (i.e., *prefix*\ _\ **BATCH_TAG**), Furthermore, if a *timefile*
+**BATCH_ITEM**\ : The formatted job number given the precision (a string, e.g., 000136), and **BATCH_NAME**\ :
+The name prefix unique to the current job (i.e., *prefix*\ _\ **BATCH_ITEM**), Furthermore, if a *timefile*
 was given then variables **BATCH_COL0**\ , **BATCH_COL1**\ , etc. are also set, yielding one variable per
 column in *timefile*.  If *timefile* has trailing text then that text can be accessed via the variable
 **BATCH_TEXT**, and if word-splitting was explicitly requested by **+w** modifier to **-T** then the trailing

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -310,8 +310,8 @@ and those that change with the frame number.  The constants are accessible by al
 Also, if **-I** was used then any static parameters listed there will be available to all the scripts as well.
 In addition, the *mainscript* also has access to parameters that vary with the frame counter:
 **MOVIE_FRAME**\ : The current frame number (an integer, e.g., 136),
-**MOVIE_TAG**\ : The formatted frame number (a string, e.g., 000136), and
-**MOVIE_NAME**\ : The name prefix for the current frame (i.e., *prefix*\ _\ **MOVIE_TAG**),
+**MOVIE_ITEM**\ : The formatted frame number (a string, e.g., 000136), and
+**MOVIE_NAME**\ : The name prefix for the current frame (i.e., *prefix*\ _\ **MOVIE_ITEM**),
 Furthermore, if a *timefile* was given then variables **MOVIE_COL0**\ , **MOVIE_COL1**\ , etc. are
 also set, yielding one variable per column in *timefile*.  If *timefile* has trailing text then that text can
 be accessed via the variable **MOVIE_TEXT**, and if word-splitting was explicitly requested by **-T+w** or

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -358,7 +358,7 @@ static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GM
 	 */
 
 	int n_items;
-	unsigned int n_errors = 0, k, pos = 0, dimension = 0;
+	unsigned int n_errors = 0, dimension, k, pos = 0;
 	char txt[6][GMT_LEN64], p[GMT_BUFSIZ] = {""}, *c = NULL, *i = NULL, *r = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -60,6 +60,7 @@ EXTERN_MSC int gmtlib_cspline (struct GMT_CTRL *GMT, double *x, double *y, uint6
 /* Control structure for greenspline */
 
 struct GREENSPLINE_CTRL {
+	unsigned int dimension;
 	struct GREENSPLINE_A {	/* -A<gradientfile> */
 		bool active;
 		unsigned int mode;	/* 0 = azimuths, 1 = directions, 2 = dx,dy components, 3 = dx, dy, dz components */
@@ -328,6 +329,27 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
+GMT_LOCAL unsigned int greenspline_pre_parser (struct GMT_CTRL *GMT, struct GMT_OPTION *options) {
+	/* Help GMT_Parse know if -R is geographic based on -Z mode and return dimension */
+	unsigned int dim = 0;
+	struct GMT_OPTION *opt = NULL;
+	for (opt = options; opt; opt = opt->next) {	/* Look for -Z only */
+		if (opt->option != 'Z' || opt->arg[0] == '\0') continue;
+		switch (opt->arg[0]) {
+			case '0':	dim = 1;	break;
+			case '1':	dim = 2;	break;
+			case '2':	case '3':	case '4':
+				dim = 2;
+				gmt_set_geographic (GMT, GMT_IN);
+				gmt_set_geographic (GMT, GMT_OUT);
+				break;
+			case '5':	dim = 3;	break;
+			default:	dim = 0;	break;
+		}
+	}
+	return (dim);
+}
+
 static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to greenspline and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.
@@ -336,8 +358,8 @@ static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GM
 	 */
 
 	int n_items;
-	unsigned int n_errors = 0, dimension, k, pos = 0;
-	char txt[6][GMT_LEN64], p[GMT_BUFSIZ] = {""}, *c = NULL;
+	unsigned int n_errors = 0, k, pos = 0, dimension = 0;
+	char txt[6][GMT_LEN64], p[GMT_BUFSIZ] = {""}, *c = NULL, *i = NULL, *r = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -351,7 +373,23 @@ static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GM
 			case 'R':	/* Normally processed internally but must be handled separately since it can take 1,2,3 dimensions */
 				GMT->common.R.active[RSET] = true;
 				Ctrl->R3.dimension = 1;	/* At least */
-
+				if (GMT->current.setting.run_mode == GMT_MODERN && Ctrl->dimension == 2) {	/* Watch for multi-item -R string created by gmt_init_module that would not have been parsed */
+					/* This is needed because we are not using gmt_parse_R_option in greenspline */
+					if ((r = strstr (opt->arg, "+G"))) {	/* Got grid registration implicitly via history */
+						switch (r[2]) {
+							case 'G':	GMT->common.R.registration = GMT_GRID_NODE_REG;		break;
+							default:	GMT->common.R.registration = GMT_GRID_PIXEL_REG;	break;
+						}
+						r[0] = '\0';	/* Chop off this modifier */
+						GMT->common.R.active[GSET] = true;
+					}
+					if ((i = strstr (opt->arg, "+I"))) {	/* Got grid increments implicitly via history */
+						Ctrl->I.active = true;
+						k = gmt_getincn (GMT, &i[2], Ctrl->I.inc, 2);
+						i[0] = '\0';	/* Chop off this modifier */
+						GMT->common.R.active[ISET] = true;
+					}
+				}
 				if (opt->arg[0] == 'g' && opt->arg[1] == '\0') {	/* Got -Rg */
 					Ctrl->R3.range[0] = 0.0;	Ctrl->R3.range[1] = 360.0;	Ctrl->R3.range[2] = -90.0;	Ctrl->R3.range[3] = 90.0;
 					Ctrl->R3.dimension = 2;
@@ -417,6 +455,8 @@ static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GM
 					n_errors += gmt_verify_expectations (GMT, gmt_M_type (GMT, GMT_IN, GMT_Z), gmt_scanf_arg (GMT, txt[5], gmt_M_type (GMT, GMT_IN, GMT_Z), false, &Ctrl->R3.range[5]), txt[5]);
 				}
 				if (Ctrl->R3.dimension > 1) gmt_M_memcpy (GMT->common.R.wesn, Ctrl->R3.range, 4, double);
+				if (r) r[0] = '+';	/* Restore modifier */
+				if (i) i[0] = '+';	/* Restore modifier */
 				break;
 
 			/* Processes program-specific parameters */
@@ -1512,8 +1552,10 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 	/* Parse the command-line arguments */
 
 	if ((GMT = gmt_init_module (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_KEYS, THIS_MODULE_NEEDS, NULL, &options, &GMT_cpy)) == NULL) bailout (API->error); /* Save current state */
+	dimension = greenspline_pre_parser (GMT, options);	/* Check -Z and possibly change default to geographic data mode before -R is parsed */
 	if (GMT_Parse_Common (API, THIS_MODULE_OPTIONS, options)) Return (API->error);
 	Ctrl = New_Ctrl (GMT);	/* Allocate and initialize a new control structure */
+	Ctrl->dimension = dimension;
 	if ((error = parse (GMT, Ctrl, options)) != 0) Return (error);
 
 	/*---------------------------- This is the greenspline main code ----------------------------*/


### PR DESCRIPTION
In modern mode, modules that take **-R -I -r** can fish these from the history.  However, **greenspline** is a bit of an odd duck in that its **-R** option is _not_ parsed as a common option since it may take limits for 1-D, 2-D, or 3-D domains.  So, when no **-R** is given then the things that normally happens for other modules do not happen for **greenspline**.  This PR implements the required steps so that **-R -I -r** can be found if present in the history.

Unfortunately, I also fixed a few documentation errors for batch and movie in this PR: We talked about **MOVIE_TAG**, **BATCH_TAG** but the actual parameters are **MOVIE_ITEM** and **BATCH_ITEM**.

Tests pass with these changes, as does a new movie script that starts this way:

```
gmt begin
	gmt convert -Em10 @geologists.txt -i0,1,2+s-1 -s | gmt blockmedian -R158:00W/156:58W/18:00N/19:40N -I1m > geo.txt
	gmt greenspline geo.txt -Sc -C+feigenvalues.txt+c+i -Ggeo.grd -Z2
	...
```

