### PR TITLE
Allow for angled cross-tracks in grdtrack -C

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt grdtrack** [ *table* ] |-G|\ *grd1* |-G|\ *grd2* ...
 [ |-A|\ **f**\|\ **p**\|\ **m**\|\ **r**\|\ **R**\ [**+l**] ]
-[ |-C|\ *length*/\ *ds*\ [*/spacing*][**+a**\|\ **+v**][**l**\|\ **r**] ]
+[ |-C|\ *length*/\ *ds*\ [*/spacing*][**+a**\|\ **v**][**d**\ *deviation*][**l**\|\ **r**] ]
 [ |-D|\ *dfile* ]
 [ |-E|\ *line* ]
 [ |-F|\ [**+b**][**+n**][**+r**][**+z**\ *z0*] ]
@@ -104,7 +104,7 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ *length*/\ *ds*\ [*/spacing*][**+a**\|\ **+v**][**l**\|\ **r**]
+**-C**\ *length*/\ *ds*\ [*/spacing*][**+a**\|\ **v**][**d**\ *deviation*][**l**\|\ **r**]
     Use input line segments to create an equidistant and (optionally)
     equally-spaced set of crossing profiles along which we sample the
     grid(s) [Default simply samples the grid(s) at the input locations].
@@ -124,7 +124,11 @@ Optional Arguments
     `Units`_ below). The default unit for geographic grids is meter while
     Cartesian grids implies the user unit.  The output columns will be
     *lon*, *lat*, *dist*, *azimuth*, *z1*, *z2*, ..., *zn* (The *zi* are
-    the sampled values for each of the *n* grids)
+    the sampled values for each of the *n* grids). Finally, use **+d** to
+    change the profiles from being orthogonal to the line by the given
+    *deviation* [0]. Looking in the direction of the line, a positive *deviation*
+    will rotate the crosslines clockwise and a negative one will rotate them
+    counter-clockwise.
 
 .. _-D:
 

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -694,7 +694,7 @@ EXTERN_MSC int gmt_colorname2index (struct GMT_CTRL *GMT, char *name);
 EXTERN_MSC void gmt_list_custom_symbols (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmt_smart_justify (struct GMT_CTRL *GMT, int just, double angle, double dx, double dy, double *x_shift, double *y_shift, unsigned int mode);
 EXTERN_MSC struct GMT_DATASET * gmt_resample_data (struct GMT_CTRL *GMT, struct GMT_DATASET *Din, double along_ds, unsigned int mode, unsigned int ex_cols, enum GMT_enum_track smode);
-EXTERN_MSC struct GMT_DATASET * gmt_crosstracks (struct GMT_CTRL *GMT, struct GMT_DATASET *Din, double cross_length, double across_ds, uint64_t n_cols, unsigned int mode, char unit);
+EXTERN_MSC struct GMT_DATASET * gmt_crosstracks (struct GMT_CTRL *GMT, struct GMT_DATASET *Din, double cross_length, double across_ds, double deviation, uint64_t n_cols, unsigned int mode, char unit);
 EXTERN_MSC uint64_t gmt_resample_path (struct GMT_CTRL *GMT, double **x, double **y, uint64_t n_in, double step_out, enum GMT_enum_track mode);
 EXTERN_MSC bool gmt_crossing_dateline (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S);
 EXTERN_MSC struct GMT_DATASET * gmt_segmentize_data (struct GMT_CTRL *GMT, struct GMT_DATASET *Din, struct GMT_SEGMENTIZE *S);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -5639,9 +5639,10 @@ GMT_LOCAL struct GMT_DATASET * gmtsupport_crosstracks_spherical (struct GMT_CTRL
 				gmt_cross3v (GMT, T, P, E);			/* Get pole E to plane trough P normal to L,R (hence going trough P) */
 				gmt_normalize3v (GMT, E);			/* Make sure E has unit length */
 				if (!gmt_M_is_zero (deviation)) {	/* Must now rotate E about P by the deviation first */
-					gmtlib_load_rot_matrix (D2R * deviation, Rot0, P);
-					gmt_matrix_vect_mult (GMT, 3U, Rot, E, X);				/* Rotate E about P by deviation */
+					gmtlib_load_rot_matrix (-D2R * deviation, Rot0, P);	/* Negative so that rotation goes clockwise */
+					gmt_matrix_vect_mult (GMT, 3U, Rot0, E, X);				/* Rotate E about P by deviation */
 					gmt_M_memcpy (E, X, 3u, double);	/* Copy the result to E */
+					gmt_normalize3v (GMT, E);			/* Make sure E has unit length */
 				}
 				gmtlib_init_rot_matrix (Rot0, E);			/* Get partial rotation matrix since no actual angle is applied yet */
 				az_cross = fmod (Tin->segment[seg]->data[SEG_AZIM][row] + 270.0, 360.0);	/* Azimuth of cross-profile in 0-360 range */
@@ -5753,9 +5754,9 @@ GMT_LOCAL struct GMT_DATASET * gmtsupport_crosstracks_cartesian (struct GMT_CTRL
 	n_tot_cols = 4 + n_cols;				/* Total number of columns in the resulting data set */
 	k_start = -n_half_cross;
 	k_stop = n_half_cross;
-	if (mode & GMT_LEFT_ONLY)	/* Only want left side of profiles */
+	if (mode & GMT_RIGHT_ONLY)	/* Only want left side of profiles */
 		k_stop = 0;
-	else if (mode & GMT_RIGHT_ONLY)	/* Only want right side of profiles */
+	else if (mode & GMT_LEFT_ONLY)	/* Only want right side of profiles */
 		k_start = 0;
 	np_cross = k_stop - k_start + 1;			/* Total cross-profile length */
 	dim[GMT_TBL] = Din->n_tables;	dim[GMT_COL] = n_tot_cols;	dim[GMT_ROW] = np_cross;

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -79,12 +79,12 @@ struct GRDTRACK_CTRL {
 		bool active, loxo;
 		enum GMT_enum_track mode;
 	} A;
-	struct GRDTRACK_C {	/* -C<length>/<ds>[/<spacing>][+a][+v] */
+	struct GRDTRACK_C {	/* -C<length>/<ds>[/<spacing>][+a|v][+d<deviation>][+l|r] */
 		bool active;
 		unsigned int mode;
 		int dist_mode;	/* May be negative */
 		char unit;
-		double ds, spacing, length;
+		double ds, spacing, length, deviation;
 	} C;
 	struct GRDTRACK_D {	/* -Dresampfile */
 		bool active;
@@ -164,7 +164,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDTRACK_CTRL *C) {	/* Deall
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s -G%s -G<grid2> ... [<table>] [-A[f|m|p|r|R][+l]] [-C<length>/<ds>[/<spacing>][+a|v][+l|r]] "
+	GMT_Usage (API, 0, "usage: %s -G%s -G<grid2> ... [<table>] [-A[f|m|p|r|R][+l]] [-C<length>/<ds>[/<spacing>][+a|v][+d<deviation>][+l|r]] "
 		"[-D<dfile>] [-E<line1>[,<line2>,...][+a<az>][+c][+d][+g][+i<step>][+l<length>][+n<np][+o<az>][+r<radius>]] "
 		"[-F[+b][+n][+r][+z<z0>]] [-N] [%s] [-S[a|l|L|m|p|u|U][+a][+c][+d][+r][+s[<file>]]] [-T<radius>>[+e|p]] [%s] [-Z] [%s] [%s] [%s] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s] %s] [%s] [%s] [%s]\n",
@@ -190,7 +190,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "r: Resample at equidistant locations; input points not necessarily included.");
 	GMT_Usage (API, 3, "R: Same, but adjust given spacing to fit the track length exactly.");
 	GMT_Usage (API, -2, "Append +l to compute distances along rhumblines (loxodromes) [no].");
-	GMT_Usage (API, 1, "\n-C<length>/<ds>[/<spacing>][+a|v][+l|r]");
+	GMT_Usage (API, 1, "\n-C<length>/<ds>[/<spacing>][+a|v][+d<deviation>][+l|r]");
 	GMT_Usage (API, -2, "Create equidistant cross-profiles from input line segments. Append 2-3 parameters:");
 	GMT_Usage (API, 3, "1. <length>: The full-length of each cross profile. "
 		"Append distance unit u (%s); this unit also applies to <ds> and <spacing>. "
@@ -199,6 +199,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "3. Optionally, append /<spacing> to set the spacing between cross-profiles, in units of u [Default erects cross-profiles at input locations].");
 	GMT_Usage (API, -2, "Several modifiers controls the creation of the profiles:");
 	GMT_Usage (API, 3, "+a Alternate the direction of cross-profiles [Default orients all the same way].");
+	GMT_Usage (API, 3, "+d Set deviation from orthogonal cross-profiles [no deviation].");
 	GMT_Usage (API, 3, "+l Only use the left half of the profiles [entire profile].");
 	GMT_Usage (API, 3, "+r Only use the right half of the profiles [entire profile].");
 	GMT_Usage (API, 3, "+v Adjust direction of cross-profiles for E-W or S-N viewing [Default orients all the same way].");
@@ -335,11 +336,12 @@ static int parse (struct GMT_CTRL *GMT, struct GRDTRACK_CTRL *Ctrl, struct GMT_O
 				break;
 			case 'C':	/* Create cross profiles */
 				Ctrl->C.active = true;
-				if ((c = gmt_first_modifier (GMT, opt->arg, "alrv"))) {	/* Process any modifiers */
+				if ((c = gmt_first_modifier (GMT, opt->arg, "adlrv"))) {	/* Process any modifiers */
 					pos = 0;	/* Reset to start of new word */
-					while (gmt_getmodopt (GMT, 'C', c, "alrv", &pos, p, &n_errors) && n_errors == 0) {
+					while (gmt_getmodopt (GMT, 'C', c, "adlrv", &pos, p, &n_errors) && n_errors == 0) {
 						switch (p[0]) {
 							case 'a': Ctrl->C.mode |= GMT_ALTERNATE; break;		/* Select alternating direction of cross-profiles */
+							case 'd': Ctrl->C.deviation = atof (&p[1]); break;		/* Less than orthogonal vy given deviation */
 							case 'l': Ctrl->C.mode |= GMT_LEFT_ONLY; break;		/* cross-profile starts at line and go to left side only */
 							case 'r': Ctrl->C.mode |= GMT_RIGHT_ONLY; break;	/* cross-profile starts at line and go to right side only */
 							case 'v': Ctrl->C.mode |= GMT_EW_SN; break;		/* Select preferred E-W, S-N direction of cross-profiles */
@@ -897,7 +899,7 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 			if (Ctrl->S.selected[STACK_ADD_DEV]) n_cols += Ctrl->G.n_grids;	/* Make space for the stacked deviations(s) in each profile */
 			if (Ctrl->S.selected[STACK_ADD_RES]) n_cols += Ctrl->G.n_grids;	/* Make space for the stacked residuals(s) in each profile */
 		}
-		if ((Dout = gmt_crosstracks (GMT, Dtmp, Ctrl->C.length, Ctrl->C.ds, n_cols, Ctrl->C.mode, Ctrl->C.unit)) == NULL) Return (API->error);
+		if ((Dout = gmt_crosstracks (GMT, Dtmp, Ctrl->C.length, Ctrl->C.ds, Ctrl->C.deviation, n_cols, Ctrl->C.mode, Ctrl->C.unit)) == NULL) Return (API->error);
 
 		if (Ctrl->F.active) {	/* Keep a record of the along-track distances produced in -C */
 			dist = gmt_M_memory (GMT, NULL, Dtmp->n_records, double);

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -199,7 +199,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "3. Optionally, append /<spacing> to set the spacing between cross-profiles, in units of u [Default erects cross-profiles at input locations].");
 	GMT_Usage (API, -2, "Several modifiers controls the creation of the profiles:");
 	GMT_Usage (API, 3, "+a Alternate the direction of cross-profiles [Default orients all the same way].");
-	GMT_Usage (API, 3, "+d Set deviation from orthogonal cross-profiles [no deviation].");
+	GMT_Usage (API, 3, "+d Set deviation (-90/+90 range) from orthogonal cross-profiles [0 (no deviation)].");
 	GMT_Usage (API, 3, "+l Only use the left half of the profiles [entire profile].");
 	GMT_Usage (API, 3, "+r Only use the right half of the profiles [entire profile].");
 	GMT_Usage (API, 3, "+v Adjust direction of cross-profiles for E-W or S-N viewing [Default orients all the same way].");

--- a/test/grdtrack/crosstrack_cart.ps
+++ b/test/grdtrack/crosstrack_cart.ps
@@ -1,0 +1,1740 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.3.0_841bc60_2021.08.30 [64-bit] Document from text
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Mon Aug 30 16:25:16 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/6.29921/0/9.96279 -Jx1i -N -F+jBC+f28.7825p,Helvetica-Bold,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.29921000 0.00000000 9.96279000 0.000 6.299 0.000 9.963 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+3780 12384 M 480 F1
+(Cartesian cross-tracks) bc Z
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 8176 TM
+% PostScript produced by:
+%@GMT: gmt plot -Jx6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWeNs -Bxaf -Byaf -Xa0i -Ya6.8132i -R-10/10/-5/5
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 8176 T
+0 A 55 3725 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(No deviation) tl Z
+U
+}!
+0 A
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {8 W 0 A [] 0 B} def
+V
+8 W
+[67 33] 0 B
+{1 0 0 C} FS
+O1
+8 W
+V 378 1890 T N 0 0 M 6653 0 D S
+U
+V 7181 1890 T PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+50 -54 D
+-50 -54 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+[] 0 B
+26 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 378 M -69 0 D S
+N 0 1134 M -69 0 D S
+N 0 1890 M -69 0 D S
+N 0 2646 M -69 0 D S
+N 0 3402 M -69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+171 F0
+(”4) sw mx
+(”2) sw mx
+(0) sw mx
+(2) sw mx
+(4) sw mx
+def
+/PSL_A0_y PSL_A0_y 51 add def
+378 PSL_A0_y MM
+(”4) mr Z
+1134 PSL_A0_y MM
+(”2) mr Z
+1890 PSL_A0_y MM
+(0) mr Z
+2646 PSL_A0_y MM
+(2) mr Z
+3402 PSL_A0_y MM
+(4) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -34 0 D S
+N 0 756 M -34 0 D S
+N 0 1512 M -34 0 D S
+N 0 2268 M -34 0 D S
+N 0 3024 M -34 0 D S
+N 0 3780 M -34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+26 W
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 378 M 69 0 D S
+N 0 1134 M 69 0 D S
+N 0 1890 M 69 0 D S
+N 0 2646 M 69 0 D S
+N 0 3402 M 69 0 D S
+N 0 0 M 34 0 D S
+N 0 756 M 34 0 D S
+N 0 1512 M 34 0 D S
+N 0 2268 M 34 0 D S
+N 0 3024 M 34 0 D S
+N 0 3780 M 34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+26 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 -69 D S
+N 1890 0 M 0 -69 D S
+N 3780 0 M 0 -69 D S
+N 5669 0 M 0 -69 D S
+N 7559 0 M 0 -69 D S
+N 378 0 M 0 -34 D S
+N 756 0 M 0 -34 D S
+N 1134 0 M 0 -34 D S
+N 1512 0 M 0 -34 D S
+N 2268 0 M 0 -34 D S
+N 2646 0 M 0 -34 D S
+N 3024 0 M 0 -34 D S
+N 3402 0 M 0 -34 D S
+N 4157 0 M 0 -34 D S
+N 4535 0 M 0 -34 D S
+N 4913 0 M 0 -34 D S
+N 5291 0 M 0 -34 D S
+N 6047 0 M 0 -34 D S
+N 6425 0 M 0 -34 D S
+N 6803 0 M 0 -34 D S
+N 7181 0 M 0 -34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+26 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 69 D S
+N 1890 0 M 0 69 D S
+N 3780 0 M 0 69 D S
+N 5669 0 M 0 69 D S
+N 7559 0 M 0 69 D S
+/MM {M} def
+/PSL_AH0 0
+(”10) sh mx
+(”5) sh mx
+(0) sh mx
+(5) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 51 add def
+0 PSL_A0_y MM
+(”10) bc Z
+1890 PSL_A0_y MM
+(”5) bc Z
+3780 PSL_A0_y MM
+(0) bc Z
+5669 PSL_A0_y MM
+(5) bc Z
+7559 PSL_A0_y MM
+(10) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 378 0 M 0 34 D S
+N 756 0 M 0 34 D S
+N 1134 0 M 0 34 D S
+N 1512 0 M 0 34 D S
+N 2268 0 M 0 34 D S
+N 2646 0 M 0 34 D S
+N 3024 0 M 0 34 D S
+N 3402 0 M 0 34 D S
+N 4157 0 M 0 34 D S
+N 4535 0 M 0 34 D S
+N 4913 0 M 0 34 D S
+N 5291 0 M 0 34 D S
+N 6047 0 M 0 34 D S
+N 6425 0 M 0 34 D S
+N 6803 0 M 0 34 D S
+N 7181 0 M 0 34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+%%EndObject
+0 -8176 TM
+0 A
+FQ
+O0
+0 8176 TM
+% PostScript produced by:
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya6.8132i -R-10/10/-5/5 -Jx6.2992i
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+50 W
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+1134 1890 M
+5291 0 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -8176 TM
+0 A
+FQ
+O0
+0 8176 TM
+% PostScript produced by:
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya6.8132i -R-10/10/-5/5 -Jx6.2992i
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+17 W
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+1134 378 M
+0 3024 D
+S
+1512 378 M
+0 3024 D
+S
+1890 378 M
+0 3024 D
+S
+2268 378 M
+0 3024 D
+S
+2646 378 M
+0 3024 D
+S
+3024 378 M
+0 3024 D
+S
+3402 378 M
+0 3024 D
+S
+3780 378 M
+0 3024 D
+S
+4157 378 M
+0 3024 D
+S
+4535 378 M
+0 3024 D
+S
+4913 378 M
+0 3024 D
+S
+5291 378 M
+0 3024 D
+S
+5669 378 M
+0 3024 D
+S
+6047 378 M
+0 3024 D
+S
+6425 378 M
+0 3024 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -8176 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4088 TM
+% PostScript produced by:
+%@GMT: gmt plot -Jx6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWens -Bxaf -Byaf -Xa0i -Ya3.4066i -R-10/10/-5/5
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 4088 T
+0 A 55 3725 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(+30 deviation) tl Z
+U
+}!
+0 A
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {8 W 0 A [] 0 B} def
+V
+8 W
+[67 33] 0 B
+{1 0 0 C} FS
+O1
+8 W
+V 378 1890 T N 0 0 M 6653 0 D S
+U
+V 7181 1890 T PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+50 -54 D
+-50 -54 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+[] 0 B
+26 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 378 M -69 0 D S
+N 0 1134 M -69 0 D S
+N 0 1890 M -69 0 D S
+N 0 2646 M -69 0 D S
+N 0 3402 M -69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+171 F0
+(”4) sw mx
+(”2) sw mx
+(0) sw mx
+(2) sw mx
+(4) sw mx
+def
+/PSL_A0_y PSL_A0_y 51 add def
+378 PSL_A0_y MM
+(”4) mr Z
+1134 PSL_A0_y MM
+(”2) mr Z
+1890 PSL_A0_y MM
+(0) mr Z
+2646 PSL_A0_y MM
+(2) mr Z
+3402 PSL_A0_y MM
+(4) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -34 0 D S
+N 0 756 M -34 0 D S
+N 0 1512 M -34 0 D S
+N 0 2268 M -34 0 D S
+N 0 3024 M -34 0 D S
+N 0 3780 M -34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+26 W
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 378 M 69 0 D S
+N 0 1134 M 69 0 D S
+N 0 1890 M 69 0 D S
+N 0 2646 M 69 0 D S
+N 0 3402 M 69 0 D S
+N 0 0 M 34 0 D S
+N 0 756 M 34 0 D S
+N 0 1512 M 34 0 D S
+N 0 2268 M 34 0 D S
+N 0 3024 M 34 0 D S
+N 0 3780 M 34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+26 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 -69 D S
+N 1890 0 M 0 -69 D S
+N 3780 0 M 0 -69 D S
+N 5669 0 M 0 -69 D S
+N 7559 0 M 0 -69 D S
+N 378 0 M 0 -34 D S
+N 756 0 M 0 -34 D S
+N 1134 0 M 0 -34 D S
+N 1512 0 M 0 -34 D S
+N 2268 0 M 0 -34 D S
+N 2646 0 M 0 -34 D S
+N 3024 0 M 0 -34 D S
+N 3402 0 M 0 -34 D S
+N 4157 0 M 0 -34 D S
+N 4535 0 M 0 -34 D S
+N 4913 0 M 0 -34 D S
+N 5291 0 M 0 -34 D S
+N 6047 0 M 0 -34 D S
+N 6425 0 M 0 -34 D S
+N 6803 0 M 0 -34 D S
+N 7181 0 M 0 -34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+26 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 69 D S
+N 1890 0 M 0 69 D S
+N 3780 0 M 0 69 D S
+N 5669 0 M 0 69 D S
+N 7559 0 M 0 69 D S
+N 378 0 M 0 34 D S
+N 756 0 M 0 34 D S
+N 1134 0 M 0 34 D S
+N 1512 0 M 0 34 D S
+N 2268 0 M 0 34 D S
+N 2646 0 M 0 34 D S
+N 3024 0 M 0 34 D S
+N 3402 0 M 0 34 D S
+N 4157 0 M 0 34 D S
+N 4535 0 M 0 34 D S
+N 4913 0 M 0 34 D S
+N 5291 0 M 0 34 D S
+N 6047 0 M 0 34 D S
+N 6425 0 M 0 34 D S
+N 6803 0 M 0 34 D S
+N 7181 0 M 0 34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+%%EndObject
+0 -4088 TM
+0 A
+FQ
+O0
+0 4088 TM
+% PostScript produced by:
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya3.4066i -R-10/10/-5/5 -Jx6.2992i
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+50 W
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+1134 1890 M
+5291 0 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -4088 TM
+0 A
+FQ
+O0
+0 4088 TM
+% PostScript produced by:
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya3.4066i -R-10/10/-5/5 -Jx6.2992i
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+17 W
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+378 580 M
+435 753 D
+113 197 D
+265 458 D
+94 164 D
+95 163 D
+113 197 D
+246 425 D
+113 197 D
+38 65 D
+S
+756 580 M
+416 721 D
+397 687 D
+94 164 D
+265 458 D
+94 164 D
+95 163 D
+113 197 D
+38 65 D
+S
+1134 580 M
+416 721 D
+340 589 D
+416 720 D
+94 164 D
+76 130 D
+132 230 D
+38 65 D
+S
+1512 580 M
+548 950 D
+246 425 D
+113 197 D
+246 425 D
+113 197 D
+76 130 D
+132 230 D
+38 65 D
+S
+1890 580 M
+132 230 D
+95 163 D
+113 197 D
+246 425 D
+113 197 D
+76 130 D
+132 230 D
+246 425 D
+113 197 D
+246 425 D
+S
+2268 580 M
+132 230 D
+265 458 D
+94 164 D
+95 163 D
+113 197 D
+76 130 D
+132 230 D
+227 392 D
+132 230 D
+246 425 D
+S
+2646 580 M
+132 230 D
+265 458 D
+94 164 D
+76 130 D
+132 230 D
+246 425 D
+94 164 D
+95 163 D
+132 230 D
+227 392 D
+18 33 D
+S
+3024 580 M
+132 230 D
+246 425 D
+113 197 D
+76 130 D
+132 230 D
+227 392 D
+113 197 D
+265 458 D
+94 164 D
+95 163 D
+18 33 D
+S
+3402 580 M
+132 230 D
+246 425 D
+113 197 D
+246 425 D
+94 164 D
+95 163 D
+113 197 D
+265 458 D
+94 164 D
+113 196 D
+S
+3780 580 M
+132 230 D
+227 392 D
+132 230 D
+246 425 D
+94 164 D
+95 163 D
+113 197 D
+246 425 D
+113 197 D
+113 196 D
+S
+4157 580 M
+171 295 D
+94 164 D
+95 163 D
+132 230 D
+227 392 D
+113 197 D
+265 458 D
+94 164 D
+95 163 D
+113 197 D
+113 196 D
+S
+4535 580 M
+171 295 D
+94 164 D
+265 458 D
+94 164 D
+95 163 D
+113 197 D
+246 425 D
+113 197 D
+265 458 D
+56 98 D
+S
+4913 580 M
+152 262 D
+113 197 D
+265 458 D
+94 164 D
+265 458 D
+94 164 D
+95 163 D
+113 197 D
+246 425 D
+75 131 D
+S
+5291 580 M
+152 262 D
+113 197 D
+246 425 D
+113 197 D
+265 458 D
+94 164 D
+76 130 D
+132 230 D
+246 425 D
+75 131 D
+S
+5669 580 M
+322 557 D
+94 164 D
+95 163 D
+113 197 D
+246 425 D
+113 197 D
+76 130 D
+132 230 D
+227 392 D
+94 164 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -4088 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Jx6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R-10/10/-5/5
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A 55 3725 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(-30 deviation, right side only) tl Z
+U
+}!
+0 A
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {8 W 0 A [] 0 B} def
+V
+8 W
+[67 33] 0 B
+{1 0 0 C} FS
+O1
+8 W
+V 378 1890 T N 0 0 M 6653 0 D S
+U
+V 7181 1890 T PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+50 -54 D
+-50 -54 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+[] 0 B
+26 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 378 M -69 0 D S
+N 0 1134 M -69 0 D S
+N 0 1890 M -69 0 D S
+N 0 2646 M -69 0 D S
+N 0 3402 M -69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+171 F0
+(”4) sw mx
+(”2) sw mx
+(0) sw mx
+(2) sw mx
+(4) sw mx
+def
+/PSL_A0_y PSL_A0_y 51 add def
+378 PSL_A0_y MM
+(”4) mr Z
+1134 PSL_A0_y MM
+(”2) mr Z
+1890 PSL_A0_y MM
+(0) mr Z
+2646 PSL_A0_y MM
+(2) mr Z
+3402 PSL_A0_y MM
+(4) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -34 0 D S
+N 0 756 M -34 0 D S
+N 0 1512 M -34 0 D S
+N 0 2268 M -34 0 D S
+N 0 3024 M -34 0 D S
+N 0 3780 M -34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+26 W
+N 0 3780 M 0 -3780 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 378 M 69 0 D S
+N 0 1134 M 69 0 D S
+N 0 1890 M 69 0 D S
+N 0 2646 M 69 0 D S
+N 0 3402 M 69 0 D S
+N 0 0 M 34 0 D S
+N 0 756 M 34 0 D S
+N 0 1512 M 34 0 D S
+N 0 2268 M 34 0 D S
+N 0 3024 M 34 0 D S
+N 0 3780 M 34 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+-7559 0 T
+26 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 -69 D S
+N 1890 0 M 0 -69 D S
+N 3780 0 M 0 -69 D S
+N 5669 0 M 0 -69 D S
+N 7559 0 M 0 -69 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”10) sh mx
+(”5) sh mx
+(0) sh mx
+(5) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 51 add PSL_AH0 add def
+0 PSL_A0_y MM
+(”10) bc Z
+1890 PSL_A0_y MM
+(”5) bc Z
+3780 PSL_A0_y MM
+(0) bc Z
+5669 PSL_A0_y MM
+(5) bc Z
+7559 PSL_A0_y MM
+(10) bc Z
+N 378 0 M 0 -34 D S
+N 756 0 M 0 -34 D S
+N 1134 0 M 0 -34 D S
+N 1512 0 M 0 -34 D S
+N 2268 0 M 0 -34 D S
+N 2646 0 M 0 -34 D S
+N 3024 0 M 0 -34 D S
+N 3402 0 M 0 -34 D S
+N 4157 0 M 0 -34 D S
+N 4535 0 M 0 -34 D S
+N 4913 0 M 0 -34 D S
+N 5291 0 M 0 -34 D S
+N 6047 0 M 0 -34 D S
+N 6425 0 M 0 -34 D S
+N 6803 0 M 0 -34 D S
+N 7181 0 M 0 -34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3780 T
+26 W
+N 0 0 M 7559 0 D S
+/PSL_A0_y 69 def
+/PSL_A1_y 0 def
+9 W
+N 0 0 M 0 69 D S
+N 1890 0 M 0 69 D S
+N 3780 0 M 0 69 D S
+N 5669 0 M 0 69 D S
+N 7559 0 M 0 69 D S
+N 378 0 M 0 34 D S
+N 756 0 M 0 34 D S
+N 1134 0 M 0 34 D S
+N 1512 0 M 0 34 D S
+N 2268 0 M 0 34 D S
+N 2646 0 M 0 34 D S
+N 3024 0 M 0 34 D S
+N 3402 0 M 0 34 D S
+N 4157 0 M 0 34 D S
+N 4535 0 M 0 34 D S
+N 4913 0 M 0 34 D S
+N 5291 0 M 0 34 D S
+N 6047 0 M 0 34 D S
+N 6425 0 M 0 34 D S
+N 6803 0 M 0 34 D S
+N 7181 0 M 0 34 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -3780 T
+0 setlinecap
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya0i -R-10/10/-5/5 -Jx6.2992i
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+50 W
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+1134 1890 M
+5291 0 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya0i -R-10/10/-5/5 -Jx6.2992i
+%@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+17 W
+clipsave
+0 0 M
+7559 0 D
+0 3780 D
+-7559 0 D
+P
+PSL_clip N
+1890 580 M
+-303 524 D
+-113 197 D
+-265 458 D
+-75 131 D
+S
+2268 580 M
+-322 557 D
+-94 164 D
+-95 163 D
+-113 197 D
+-132 229 D
+S
+2646 580 M
+-152 262 D
+-113 197 D
+-246 425 D
+-113 197 D
+-132 229 D
+S
+3024 580 M
+-152 262 D
+-113 197 D
+-265 458 D
+-94 164 D
+-132 229 D
+S
+3402 580 M
+-171 295 D
+-94 164 D
+-265 458 D
+-94 164 D
+-95 163 D
+-37 66 D
+S
+3780 580 M
+-171 295 D
+-94 164 D
+-95 163 D
+-132 230 D
+-227 392 D
+-37 66 D
+S
+4157 580 M
+-132 230 D
+-227 392 D
+-132 230 D
+-246 425 D
+-18 33 D
+S
+4535 580 M
+-132 230 D
+-246 425 D
+-113 197 D
+-76 130 D
+-132 230 D
+-56 98 D
+S
+4913 580 M
+-132 230 D
+-246 425 D
+-113 197 D
+-76 130 D
+-132 230 D
+-57 98 D
+S
+5291 580 M
+-132 230 D
+-265 458 D
+-94 164 D
+-76 130 D
+-132 230 D
+-57 98 D
+S
+5669 580 M
+-132 230 D
+-265 458 D
+-94 164 D
+-95 163 D
+-113 197 D
+-57 98 D
+S
+6047 580 M
+-132 230 D
+-95 163 D
+-113 197 D
+-246 425 D
+-113 197 D
+-57 98 D
+S
+6425 580 M
+-548 950 D
+-208 360 D
+S
+6803 580 M
+-416 721 D
+-340 589 D
+S
+7181 580 M
+-416 721 D
+-340 589 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/grdtrack/crosstrack_cart.ps
+++ b/test/grdtrack/crosstrack_cart.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.3.0_841bc60_2021.08.30 [64-bit] Document from text
+%%Title: GMT v6.3.0_d7a32bb_2021.08.30 [64-bit] Document from text
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Aug 30 16:25:16 2021
+%%CreationDate: Tue Aug 31 09:42:12 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -117,39 +117,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/Standard+_Encoding [
+/ISOLatin1+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
-/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
-/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
-/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
-/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
-/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
-/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
-/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
-/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
-/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
-/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
-/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
-/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
-/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
-/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
-/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -700,23 +700,23 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt text -R0/6.29921/0/9.96279 -Jx1i -N -F+jBC+f28.7825p,Helvetica-Bold,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=readonly
-%@PROJ: xy 0.00000000 6.29921000 0.00000000 9.96279000 0.000 6.299 0.000 9.963 +xy
+%@GMT: gmt text -R0/5.51181/0/8.76536 -Jx1i -N -F+jBC+f27.868p,Helvetica-Bold,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 5.51181000 0.00000000 8.76536000 0.000 5.512 0.000 8.765 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
-3780 12384 M 480 F1
-(Cartesian cross-tracks) bc Z
+PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+3307 10933 M 464 F1
+(Cartesian cross­tracks) bc Z
 %%EndObject
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
 FQ
 O0
-0 8176 TM
+0 7211 TM
 % PostScript produced by:
-%@GMT: gmt plot -Jx6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWeNs -Bxaf -Byaf -Xa0i -Ya6.8132i -R-10/10/-5/5
+%@GMT: gmt plot -Jx5.5118i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWeNs -Bxaf -Byaf -Xa0i -Ya6.0095i -R-10/10/-5/5
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -724,18 +724,18 @@ O0
 3.32550952342 setmiterlimit
 /PSL_plot_completion {
 V
-0 8176 T
-0 A 55 3725 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-274 F0
+0 7211 T
+0 A 53 3254 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+265 F0
 (No deviation) tl Z
 U
 }!
 0 A
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
 /PSL_vecheadpen {8 W 0 A [] 0 B} def
@@ -745,9 +745,9 @@ V
 {1 0 0 C} FS
 O1
 8 W
-V 378 1890 T N 0 0 M 6653 0 D S
+V 331 1654 T N 0 0 M 5803 0 D S
 U
-V 7181 1890 T PSL_vecheadpen
+V 6283 1654 T PSL_vecheadpen
 17 W
 0 0 M
 -200 54 D
@@ -758,152 +758,152 @@ U
 U
 PSL_cliprestore
 [] 0 B
-26 W
+25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 69 def
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 378 M -69 0 D S
-N 0 1134 M -69 0 D S
-N 0 1890 M -69 0 D S
-N 0 2646 M -69 0 D S
-N 0 3402 M -69 0 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+8 W
+N 0 331 M -66 0 D S
+N 0 992 M -66 0 D S
+N 0 1654 M -66 0 D S
+N 0 2315 M -66 0 D S
+N 0 2976 M -66 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /MM {neg exch M} def
 /PSL_AH0 0
-171 F0
-(”4) sw mx
-(”2) sw mx
+166 F0
+(-4) sw mx
+(-2) sw mx
 (0) sw mx
 (2) sw mx
 (4) sw mx
 def
-/PSL_A0_y PSL_A0_y 51 add def
-378 PSL_A0_y MM
-(”4) mr Z
-1134 PSL_A0_y MM
-(”2) mr Z
-1890 PSL_A0_y MM
+/PSL_A0_y PSL_A0_y 50 add def
+331 PSL_A0_y MM
+(-4) mr Z
+992 PSL_A0_y MM
+(-2) mr Z
+1654 PSL_A0_y MM
 (0) mr Z
-2646 PSL_A0_y MM
+2315 PSL_A0_y MM
 (2) mr Z
-3402 PSL_A0_y MM
+2976 PSL_A0_y MM
 (4) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 0 M -34 0 D S
-N 0 756 M -34 0 D S
-N 0 1512 M -34 0 D S
-N 0 2268 M -34 0 D S
-N 0 3024 M -34 0 D S
-N 0 3780 M -34 0 D S
+N 0 0 M -33 0 D S
+N 0 661 M -33 0 D S
+N 0 1323 M -33 0 D S
+N 0 1984 M -33 0 D S
+N 0 2646 M -33 0 D S
+N 0 3307 M -33 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-7559 0 T
-26 W
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 69 def
+6614 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 378 M 69 0 D S
-N 0 1134 M 69 0 D S
-N 0 1890 M 69 0 D S
-N 0 2646 M 69 0 D S
-N 0 3402 M 69 0 D S
-N 0 0 M 34 0 D S
-N 0 756 M 34 0 D S
-N 0 1512 M 34 0 D S
-N 0 2268 M 34 0 D S
-N 0 3024 M 34 0 D S
-N 0 3780 M 34 0 D S
+8 W
+N 0 331 M 66 0 D S
+N 0 992 M 66 0 D S
+N 0 1654 M 66 0 D S
+N 0 2315 M 66 0 D S
+N 0 2976 M 66 0 D S
+N 0 0 M 33 0 D S
+N 0 661 M 33 0 D S
+N 0 1323 M 33 0 D S
+N 0 1984 M 33 0 D S
+N 0 2646 M 33 0 D S
+N 0 3307 M 33 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--7559 0 T
-26 W
-N 0 0 M 7559 0 D S
-/PSL_A0_y 69 def
+-6614 0 T
+25 W
+N 0 0 M 6614 0 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 0 M 0 -69 D S
-N 1890 0 M 0 -69 D S
-N 3780 0 M 0 -69 D S
-N 5669 0 M 0 -69 D S
-N 7559 0 M 0 -69 D S
-N 378 0 M 0 -34 D S
-N 756 0 M 0 -34 D S
-N 1134 0 M 0 -34 D S
-N 1512 0 M 0 -34 D S
-N 2268 0 M 0 -34 D S
-N 2646 0 M 0 -34 D S
-N 3024 0 M 0 -34 D S
-N 3402 0 M 0 -34 D S
-N 4157 0 M 0 -34 D S
-N 4535 0 M 0 -34 D S
-N 4913 0 M 0 -34 D S
-N 5291 0 M 0 -34 D S
-N 6047 0 M 0 -34 D S
-N 6425 0 M 0 -34 D S
-N 6803 0 M 0 -34 D S
-N 7181 0 M 0 -34 D S
+8 W
+N 0 0 M 0 -66 D S
+N 1654 0 M 0 -66 D S
+N 3307 0 M 0 -66 D S
+N 4961 0 M 0 -66 D S
+N 6614 0 M 0 -66 D S
+N 331 0 M 0 -33 D S
+N 661 0 M 0 -33 D S
+N 992 0 M 0 -33 D S
+N 1323 0 M 0 -33 D S
+N 1984 0 M 0 -33 D S
+N 2315 0 M 0 -33 D S
+N 2646 0 M 0 -33 D S
+N 2976 0 M 0 -33 D S
+N 3638 0 M 0 -33 D S
+N 3968 0 M 0 -33 D S
+N 4299 0 M 0 -33 D S
+N 4630 0 M 0 -33 D S
+N 5291 0 M 0 -33 D S
+N 5622 0 M 0 -33 D S
+N 5953 0 M 0 -33 D S
+N 6283 0 M 0 -33 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3780 T
-26 W
-N 0 0 M 7559 0 D S
-/PSL_A0_y 69 def
+0 3307 T
+25 W
+N 0 0 M 6614 0 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 0 M 0 69 D S
-N 1890 0 M 0 69 D S
-N 3780 0 M 0 69 D S
-N 5669 0 M 0 69 D S
-N 7559 0 M 0 69 D S
+8 W
+N 0 0 M 0 66 D S
+N 1654 0 M 0 66 D S
+N 3307 0 M 0 66 D S
+N 4961 0 M 0 66 D S
+N 6614 0 M 0 66 D S
 /MM {M} def
 /PSL_AH0 0
-(”10) sh mx
-(”5) sh mx
+(-10) sh mx
+(-5) sh mx
 (0) sh mx
 (5) sh mx
 (10) sh mx
 def
-/PSL_A0_y PSL_A0_y 51 add def
+/PSL_A0_y PSL_A0_y 50 add def
 0 PSL_A0_y MM
-(”10) bc Z
-1890 PSL_A0_y MM
-(”5) bc Z
-3780 PSL_A0_y MM
+(-10) bc Z
+1654 PSL_A0_y MM
+(-5) bc Z
+3307 PSL_A0_y MM
 (0) bc Z
-5669 PSL_A0_y MM
+4961 PSL_A0_y MM
 (5) bc Z
-7559 PSL_A0_y MM
+6614 PSL_A0_y MM
 (10) bc Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 378 0 M 0 34 D S
-N 756 0 M 0 34 D S
-N 1134 0 M 0 34 D S
-N 1512 0 M 0 34 D S
-N 2268 0 M 0 34 D S
-N 2646 0 M 0 34 D S
-N 3024 0 M 0 34 D S
-N 3402 0 M 0 34 D S
-N 4157 0 M 0 34 D S
-N 4535 0 M 0 34 D S
-N 4913 0 M 0 34 D S
-N 5291 0 M 0 34 D S
-N 6047 0 M 0 34 D S
-N 6425 0 M 0 34 D S
-N 6803 0 M 0 34 D S
-N 7181 0 M 0 34 D S
+N 331 0 M 0 33 D S
+N 661 0 M 0 33 D S
+N 992 0 M 0 33 D S
+N 1323 0 M 0 33 D S
+N 1984 0 M 0 33 D S
+N 2315 0 M 0 33 D S
+N 2646 0 M 0 33 D S
+N 2976 0 M 0 33 D S
+N 3638 0 M 0 33 D S
+N 3968 0 M 0 33 D S
+N 4299 0 M 0 33 D S
+N 4630 0 M 0 33 D S
+N 5291 0 M 0 33 D S
+N 5622 0 M 0 33 D S
+N 5953 0 M 0 33 D S
+N 6283 0 M 0 33 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -3780 T
+0 -3307 T
 0 setlinecap
 %%EndObject
-0 -8176 TM
+0 -7211 TM
 0 A
 FQ
 O0
-0 8176 TM
+0 7211 TM
 % PostScript produced by:
-%@GMT: gmt plot line.txt -W3p -Xa0i -Ya6.8132i -R-10/10/-5/5 -Jx6.2992i
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya6.0095i -R-10/10/-5/5 -Jx5.5118i
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -913,24 +913,24 @@ V
 50 W
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
-1134 1890 M
-5291 0 D
+992 1654 M
+4630 0 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -8176 TM
+0 -7211 TM
 0 A
 FQ
 O0
-0 8176 TM
+0 7211 TM
 % PostScript produced by:
-%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya6.8132i -R-10/10/-5/5 -Jx6.2992i
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya6.0095i -R-10/10/-5/5 -Jx5.5118i
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -940,67 +940,67 @@ V
 17 W
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
-1134 378 M
-0 3024 D
+992 331 M
+0 2645 D
 S
-1512 378 M
-0 3024 D
+1323 331 M
+0 2645 D
 S
-1890 378 M
-0 3024 D
+1654 331 M
+0 2645 D
 S
-2268 378 M
-0 3024 D
+1984 331 M
+0 2645 D
 S
-2646 378 M
-0 3024 D
+2315 331 M
+0 2645 D
 S
-3024 378 M
-0 3024 D
+2646 331 M
+0 2645 D
 S
-3402 378 M
-0 3024 D
+2976 331 M
+0 2645 D
 S
-3780 378 M
-0 3024 D
+3307 331 M
+0 2645 D
 S
-4157 378 M
-0 3024 D
+3638 331 M
+0 2645 D
 S
-4535 378 M
-0 3024 D
+3968 331 M
+0 2645 D
 S
-4913 378 M
-0 3024 D
+4299 331 M
+0 2645 D
 S
-5291 378 M
-0 3024 D
+4630 331 M
+0 2645 D
 S
-5669 378 M
-0 3024 D
+4961 331 M
+0 2645 D
 S
-6047 378 M
-0 3024 D
+5291 331 M
+0 2645 D
 S
-6425 378 M
-0 3024 D
+5622 331 M
+0 2645 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -8176 TM
+0 -7211 TM
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
 FQ
 O0
-0 4088 TM
+0 3606 TM
 % PostScript produced by:
-%@GMT: gmt plot -Jx6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWens -Bxaf -Byaf -Xa0i -Ya3.4066i -R-10/10/-5/5
+%@GMT: gmt plot -Jx5.5118i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWens -Bxaf -Byaf -Xa0i -Ya3.0047i -R-10/10/-5/5
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -1008,18 +1008,18 @@ O0
 3.32550952342 setmiterlimit
 /PSL_plot_completion {
 V
-0 4088 T
-0 A 55 3725 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-274 F0
+0 3606 T
+0 A 53 3254 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+265 F0
 (+30 deviation) tl Z
 U
 }!
 0 A
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
 /PSL_vecheadpen {8 W 0 A [] 0 B} def
@@ -1029,9 +1029,9 @@ V
 {1 0 0 C} FS
 O1
 8 W
-V 378 1890 T N 0 0 M 6653 0 D S
+V 331 1654 T N 0 0 M 5803 0 D S
 U
-V 7181 1890 T PSL_vecheadpen
+V 6283 1654 T PSL_vecheadpen
 17 W
 0 0 M
 -200 54 D
@@ -1042,132 +1042,132 @@ U
 U
 PSL_cliprestore
 [] 0 B
-26 W
+25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 69 def
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 378 M -69 0 D S
-N 0 1134 M -69 0 D S
-N 0 1890 M -69 0 D S
-N 0 2646 M -69 0 D S
-N 0 3402 M -69 0 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+8 W
+N 0 331 M -66 0 D S
+N 0 992 M -66 0 D S
+N 0 1654 M -66 0 D S
+N 0 2315 M -66 0 D S
+N 0 2976 M -66 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /MM {neg exch M} def
 /PSL_AH0 0
-171 F0
-(”4) sw mx
-(”2) sw mx
+166 F0
+(-4) sw mx
+(-2) sw mx
 (0) sw mx
 (2) sw mx
 (4) sw mx
 def
-/PSL_A0_y PSL_A0_y 51 add def
-378 PSL_A0_y MM
-(”4) mr Z
-1134 PSL_A0_y MM
-(”2) mr Z
-1890 PSL_A0_y MM
+/PSL_A0_y PSL_A0_y 50 add def
+331 PSL_A0_y MM
+(-4) mr Z
+992 PSL_A0_y MM
+(-2) mr Z
+1654 PSL_A0_y MM
 (0) mr Z
-2646 PSL_A0_y MM
+2315 PSL_A0_y MM
 (2) mr Z
-3402 PSL_A0_y MM
+2976 PSL_A0_y MM
 (4) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 0 M -34 0 D S
-N 0 756 M -34 0 D S
-N 0 1512 M -34 0 D S
-N 0 2268 M -34 0 D S
-N 0 3024 M -34 0 D S
-N 0 3780 M -34 0 D S
+N 0 0 M -33 0 D S
+N 0 661 M -33 0 D S
+N 0 1323 M -33 0 D S
+N 0 1984 M -33 0 D S
+N 0 2646 M -33 0 D S
+N 0 3307 M -33 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-7559 0 T
-26 W
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 69 def
+6614 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 378 M 69 0 D S
-N 0 1134 M 69 0 D S
-N 0 1890 M 69 0 D S
-N 0 2646 M 69 0 D S
-N 0 3402 M 69 0 D S
-N 0 0 M 34 0 D S
-N 0 756 M 34 0 D S
-N 0 1512 M 34 0 D S
-N 0 2268 M 34 0 D S
-N 0 3024 M 34 0 D S
-N 0 3780 M 34 0 D S
+8 W
+N 0 331 M 66 0 D S
+N 0 992 M 66 0 D S
+N 0 1654 M 66 0 D S
+N 0 2315 M 66 0 D S
+N 0 2976 M 66 0 D S
+N 0 0 M 33 0 D S
+N 0 661 M 33 0 D S
+N 0 1323 M 33 0 D S
+N 0 1984 M 33 0 D S
+N 0 2646 M 33 0 D S
+N 0 3307 M 33 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--7559 0 T
-26 W
-N 0 0 M 7559 0 D S
-/PSL_A0_y 69 def
+-6614 0 T
+25 W
+N 0 0 M 6614 0 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 0 M 0 -69 D S
-N 1890 0 M 0 -69 D S
-N 3780 0 M 0 -69 D S
-N 5669 0 M 0 -69 D S
-N 7559 0 M 0 -69 D S
-N 378 0 M 0 -34 D S
-N 756 0 M 0 -34 D S
-N 1134 0 M 0 -34 D S
-N 1512 0 M 0 -34 D S
-N 2268 0 M 0 -34 D S
-N 2646 0 M 0 -34 D S
-N 3024 0 M 0 -34 D S
-N 3402 0 M 0 -34 D S
-N 4157 0 M 0 -34 D S
-N 4535 0 M 0 -34 D S
-N 4913 0 M 0 -34 D S
-N 5291 0 M 0 -34 D S
-N 6047 0 M 0 -34 D S
-N 6425 0 M 0 -34 D S
-N 6803 0 M 0 -34 D S
-N 7181 0 M 0 -34 D S
+8 W
+N 0 0 M 0 -66 D S
+N 1654 0 M 0 -66 D S
+N 3307 0 M 0 -66 D S
+N 4961 0 M 0 -66 D S
+N 6614 0 M 0 -66 D S
+N 331 0 M 0 -33 D S
+N 661 0 M 0 -33 D S
+N 992 0 M 0 -33 D S
+N 1323 0 M 0 -33 D S
+N 1984 0 M 0 -33 D S
+N 2315 0 M 0 -33 D S
+N 2646 0 M 0 -33 D S
+N 2976 0 M 0 -33 D S
+N 3638 0 M 0 -33 D S
+N 3968 0 M 0 -33 D S
+N 4299 0 M 0 -33 D S
+N 4630 0 M 0 -33 D S
+N 5291 0 M 0 -33 D S
+N 5622 0 M 0 -33 D S
+N 5953 0 M 0 -33 D S
+N 6283 0 M 0 -33 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3780 T
-26 W
-N 0 0 M 7559 0 D S
-/PSL_A0_y 69 def
+0 3307 T
+25 W
+N 0 0 M 6614 0 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 0 M 0 69 D S
-N 1890 0 M 0 69 D S
-N 3780 0 M 0 69 D S
-N 5669 0 M 0 69 D S
-N 7559 0 M 0 69 D S
-N 378 0 M 0 34 D S
-N 756 0 M 0 34 D S
-N 1134 0 M 0 34 D S
-N 1512 0 M 0 34 D S
-N 2268 0 M 0 34 D S
-N 2646 0 M 0 34 D S
-N 3024 0 M 0 34 D S
-N 3402 0 M 0 34 D S
-N 4157 0 M 0 34 D S
-N 4535 0 M 0 34 D S
-N 4913 0 M 0 34 D S
-N 5291 0 M 0 34 D S
-N 6047 0 M 0 34 D S
-N 6425 0 M 0 34 D S
-N 6803 0 M 0 34 D S
-N 7181 0 M 0 34 D S
+8 W
+N 0 0 M 0 66 D S
+N 1654 0 M 0 66 D S
+N 3307 0 M 0 66 D S
+N 4961 0 M 0 66 D S
+N 6614 0 M 0 66 D S
+N 331 0 M 0 33 D S
+N 661 0 M 0 33 D S
+N 992 0 M 0 33 D S
+N 1323 0 M 0 33 D S
+N 1984 0 M 0 33 D S
+N 2315 0 M 0 33 D S
+N 2646 0 M 0 33 D S
+N 2976 0 M 0 33 D S
+N 3638 0 M 0 33 D S
+N 3968 0 M 0 33 D S
+N 4299 0 M 0 33 D S
+N 4630 0 M 0 33 D S
+N 5291 0 M 0 33 D S
+N 5622 0 M 0 33 D S
+N 5953 0 M 0 33 D S
+N 6283 0 M 0 33 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -3780 T
+0 -3307 T
 0 setlinecap
 %%EndObject
-0 -4088 TM
+0 -3606 TM
 0 A
 FQ
 O0
-0 4088 TM
+0 3606 TM
 % PostScript produced by:
-%@GMT: gmt plot line.txt -W3p -Xa0i -Ya3.4066i -R-10/10/-5/5 -Jx6.2992i
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya3.0047i -R-10/10/-5/5 -Jx5.5118i
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -1177,24 +1177,24 @@ V
 50 W
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
-1134 1890 M
-5291 0 D
+992 1654 M
+4630 0 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -4088 TM
+0 -3606 TM
 0 A
 FQ
 O0
-0 4088 TM
+0 3606 TM
 % PostScript produced by:
-%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya3.4066i -R-10/10/-5/5 -Jx6.2992i
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya3.0047i -R-10/10/-5/5 -Jx5.5118i
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -1204,197 +1204,124 @@ V
 17 W
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
-378 580 M
-435 753 D
-113 197 D
-265 458 D
-94 164 D
-95 163 D
-113 197 D
-246 425 D
-113 197 D
-38 65 D
-S
-756 580 M
-416 721 D
+331 508 M
+380 659 D
 397 687 D
-94 164 D
-265 458 D
-94 164 D
-95 163 D
-113 197 D
-38 65 D
+463 802 D
+83 143 D
 S
-1134 580 M
-416 721 D
-340 589 D
-416 720 D
-94 164 D
-76 130 D
-132 230 D
-38 65 D
+661 508 M
+133 229 D
+132 229 D
+248 430 D
+364 630 D
+446 773 D
 S
-1512 580 M
-548 950 D
-246 425 D
-113 197 D
-246 425 D
-113 197 D
-76 130 D
-132 230 D
-38 65 D
+992 508 M
+364 630 D
+463 802 D
+281 487 D
+215 372 D
 S
-1890 580 M
-132 230 D
-95 163 D
-113 197 D
-246 425 D
-113 197 D
-76 130 D
-132 230 D
-246 425 D
-113 197 D
-246 425 D
+1323 508 M
+529 916 D
+496 860 D
+298 515 D
 S
-2268 580 M
-132 230 D
-265 458 D
-94 164 D
-95 163 D
-113 197 D
-76 130 D
-132 230 D
-227 392 D
-132 230 D
-246 425 D
+1654 508 M
+198 344 D
+248 429 D
+248 430 D
+215 372 D
+248 430 D
+165 286 D
 S
-2646 580 M
-132 230 D
-265 458 D
-94 164 D
-76 130 D
-132 230 D
-246 425 D
-94 164 D
-95 163 D
-132 230 D
-227 392 D
-18 33 D
+1984 508 M
+232 401 D
+347 601 D
+463 802 D
+281 487 D
 S
-3024 580 M
-132 230 D
-246 425 D
-113 197 D
-76 130 D
-132 230 D
-227 392 D
-113 197 D
-265 458 D
-94 164 D
-95 163 D
-18 33 D
+2315 508 M
+248 430 D
+116 200 D
+347 601 D
+463 802 D
+149 258 D
 S
-3402 580 M
-132 230 D
-246 425 D
-113 197 D
-246 425 D
-94 164 D
-95 163 D
-113 197 D
-265 458 D
-94 164 D
-113 196 D
+2646 508 M
+165 286 D
+215 373 D
+248 429 D
+215 373 D
+248 429 D
+231 401 D
 S
-3780 580 M
-132 230 D
-227 392 D
-132 230 D
-246 425 D
-94 164 D
-95 163 D
-113 197 D
-246 425 D
-113 197 D
-113 196 D
+2976 508 M
+133 229 D
+165 286 D
+215 373 D
+248 429 D
+463 802 D
+99 172 D
 S
-4157 580 M
-171 295 D
-94 164 D
-95 163 D
-132 230 D
-227 392 D
-113 197 D
-265 458 D
-94 164 D
-95 163 D
-113 197 D
-113 196 D
+3307 508 M
+364 630 D
+314 544 D
+215 373 D
+116 200 D
+314 544 D
 S
-4535 580 M
-171 295 D
-94 164 D
-265 458 D
-94 164 D
-95 163 D
-113 197 D
-246 425 D
-113 197 D
-265 458 D
-56 98 D
+3638 508 M
+347 601 D
+215 373 D
+248 429 D
+215 373 D
+248 429 D
+50 86 D
 S
-4913 580 M
-152 262 D
-113 197 D
-265 458 D
-94 164 D
-265 458 D
-94 164 D
-95 163 D
-113 197 D
-246 425 D
-75 131 D
+3968 508 M
+133 229 D
+347 601 D
+215 373 D
+248 429 D
+215 373 D
+165 286 D
 S
-5291 580 M
-152 262 D
-113 197 D
-246 425 D
-113 197 D
-265 458 D
-94 164 D
-76 130 D
-132 230 D
-246 425 D
-75 131 D
+4299 508 M
+232 401 D
+380 659 D
+397 687 D
+314 544 D
 S
-5669 580 M
-322 557 D
-94 164 D
-95 163 D
-113 197 D
-246 425 D
-113 197 D
-76 130 D
-132 230 D
-227 392 D
-94 164 D
+4630 508 M
+281 487 D
+364 630 D
+562 974 D
+116 200 D
+S
+4961 508 M
+165 286 D
+463 802 D
+496 859 D
+198 344 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -4088 TM
+0 -3606 TM
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot -Jx6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R-10/10/-5/5
+%@GMT: gmt plot -Jx5.5118i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R-10/10/-5/5
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_7
 0 setlinecap
@@ -1402,17 +1329,17 @@ O0
 3.32550952342 setmiterlimit
 /PSL_plot_completion {
 V
-0 A 55 3725 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-274 F0
-(-30 deviation, right side only) tl Z
+0 A 53 3254 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+265 F0
+(­30 deviation, right side only) tl Z
 U
 }!
 0 A
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
 /PSL_vecheadpen {8 W 0 A [] 0 B} def
@@ -1422,9 +1349,9 @@ V
 {1 0 0 C} FS
 O1
 8 W
-V 378 1890 T N 0 0 M 6653 0 D S
+V 331 1654 T N 0 0 M 5803 0 D S
 U
-V 7181 1890 T PSL_vecheadpen
+V 6283 1654 T PSL_vecheadpen
 17 W
 0 0 M
 -200 54 D
@@ -1435,142 +1362,142 @@ U
 U
 PSL_cliprestore
 [] 0 B
-26 W
+25 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 69 def
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 378 M -69 0 D S
-N 0 1134 M -69 0 D S
-N 0 1890 M -69 0 D S
-N 0 2646 M -69 0 D S
-N 0 3402 M -69 0 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+8 W
+N 0 331 M -66 0 D S
+N 0 992 M -66 0 D S
+N 0 1654 M -66 0 D S
+N 0 2315 M -66 0 D S
+N 0 2976 M -66 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /MM {neg exch M} def
 /PSL_AH0 0
-171 F0
-(”4) sw mx
-(”2) sw mx
+166 F0
+(-4) sw mx
+(-2) sw mx
 (0) sw mx
 (2) sw mx
 (4) sw mx
 def
-/PSL_A0_y PSL_A0_y 51 add def
-378 PSL_A0_y MM
-(”4) mr Z
-1134 PSL_A0_y MM
-(”2) mr Z
-1890 PSL_A0_y MM
+/PSL_A0_y PSL_A0_y 50 add def
+331 PSL_A0_y MM
+(-4) mr Z
+992 PSL_A0_y MM
+(-2) mr Z
+1654 PSL_A0_y MM
 (0) mr Z
-2646 PSL_A0_y MM
+2315 PSL_A0_y MM
 (2) mr Z
-3402 PSL_A0_y MM
+2976 PSL_A0_y MM
 (4) mr Z
 /PSL_A0_y PSL_A0_y PSL_AH0 add def
-N 0 0 M -34 0 D S
-N 0 756 M -34 0 D S
-N 0 1512 M -34 0 D S
-N 0 2268 M -34 0 D S
-N 0 3024 M -34 0 D S
-N 0 3780 M -34 0 D S
+N 0 0 M -33 0 D S
+N 0 661 M -33 0 D S
+N 0 1323 M -33 0 D S
+N 0 1984 M -33 0 D S
+N 0 2646 M -33 0 D S
+N 0 3307 M -33 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-7559 0 T
-26 W
-N 0 3780 M 0 -3780 D S
-/PSL_A0_y 69 def
+6614 0 T
+25 W
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 378 M 69 0 D S
-N 0 1134 M 69 0 D S
-N 0 1890 M 69 0 D S
-N 0 2646 M 69 0 D S
-N 0 3402 M 69 0 D S
-N 0 0 M 34 0 D S
-N 0 756 M 34 0 D S
-N 0 1512 M 34 0 D S
-N 0 2268 M 34 0 D S
-N 0 3024 M 34 0 D S
-N 0 3780 M 34 0 D S
+8 W
+N 0 331 M 66 0 D S
+N 0 992 M 66 0 D S
+N 0 1654 M 66 0 D S
+N 0 2315 M 66 0 D S
+N 0 2976 M 66 0 D S
+N 0 0 M 33 0 D S
+N 0 661 M 33 0 D S
+N 0 1323 M 33 0 D S
+N 0 1984 M 33 0 D S
+N 0 2646 M 33 0 D S
+N 0 3307 M 33 0 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
--7559 0 T
-26 W
-N 0 0 M 7559 0 D S
-/PSL_A0_y 69 def
+-6614 0 T
+25 W
+N 0 0 M 6614 0 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 0 M 0 -69 D S
-N 1890 0 M 0 -69 D S
-N 3780 0 M 0 -69 D S
-N 5669 0 M 0 -69 D S
-N 7559 0 M 0 -69 D S
+8 W
+N 0 0 M 0 -66 D S
+N 1654 0 M 0 -66 D S
+N 3307 0 M 0 -66 D S
+N 4961 0 M 0 -66 D S
+N 6614 0 M 0 -66 D S
 /MM {neg M} def
 /PSL_AH0 0
-(”10) sh mx
-(”5) sh mx
+(-10) sh mx
+(-5) sh mx
 (0) sh mx
 (5) sh mx
 (10) sh mx
 def
-/PSL_A0_y PSL_A0_y 51 add PSL_AH0 add def
+/PSL_A0_y PSL_A0_y 50 add PSL_AH0 add def
 0 PSL_A0_y MM
-(”10) bc Z
-1890 PSL_A0_y MM
-(”5) bc Z
-3780 PSL_A0_y MM
+(-10) bc Z
+1654 PSL_A0_y MM
+(-5) bc Z
+3307 PSL_A0_y MM
 (0) bc Z
-5669 PSL_A0_y MM
+4961 PSL_A0_y MM
 (5) bc Z
-7559 PSL_A0_y MM
+6614 PSL_A0_y MM
 (10) bc Z
-N 378 0 M 0 -34 D S
-N 756 0 M 0 -34 D S
-N 1134 0 M 0 -34 D S
-N 1512 0 M 0 -34 D S
-N 2268 0 M 0 -34 D S
-N 2646 0 M 0 -34 D S
-N 3024 0 M 0 -34 D S
-N 3402 0 M 0 -34 D S
-N 4157 0 M 0 -34 D S
-N 4535 0 M 0 -34 D S
-N 4913 0 M 0 -34 D S
-N 5291 0 M 0 -34 D S
-N 6047 0 M 0 -34 D S
-N 6425 0 M 0 -34 D S
-N 6803 0 M 0 -34 D S
-N 7181 0 M 0 -34 D S
+N 331 0 M 0 -33 D S
+N 661 0 M 0 -33 D S
+N 992 0 M 0 -33 D S
+N 1323 0 M 0 -33 D S
+N 1984 0 M 0 -33 D S
+N 2315 0 M 0 -33 D S
+N 2646 0 M 0 -33 D S
+N 2976 0 M 0 -33 D S
+N 3638 0 M 0 -33 D S
+N 3968 0 M 0 -33 D S
+N 4299 0 M 0 -33 D S
+N 4630 0 M 0 -33 D S
+N 5291 0 M 0 -33 D S
+N 5622 0 M 0 -33 D S
+N 5953 0 M 0 -33 D S
+N 6283 0 M 0 -33 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 3780 T
-26 W
-N 0 0 M 7559 0 D S
-/PSL_A0_y 69 def
+0 3307 T
+25 W
+N 0 0 M 6614 0 D S
+/PSL_A0_y 66 def
 /PSL_A1_y 0 def
-9 W
-N 0 0 M 0 69 D S
-N 1890 0 M 0 69 D S
-N 3780 0 M 0 69 D S
-N 5669 0 M 0 69 D S
-N 7559 0 M 0 69 D S
-N 378 0 M 0 34 D S
-N 756 0 M 0 34 D S
-N 1134 0 M 0 34 D S
-N 1512 0 M 0 34 D S
-N 2268 0 M 0 34 D S
-N 2646 0 M 0 34 D S
-N 3024 0 M 0 34 D S
-N 3402 0 M 0 34 D S
-N 4157 0 M 0 34 D S
-N 4535 0 M 0 34 D S
-N 4913 0 M 0 34 D S
-N 5291 0 M 0 34 D S
-N 6047 0 M 0 34 D S
-N 6425 0 M 0 34 D S
-N 6803 0 M 0 34 D S
-N 7181 0 M 0 34 D S
+8 W
+N 0 0 M 0 66 D S
+N 1654 0 M 0 66 D S
+N 3307 0 M 0 66 D S
+N 4961 0 M 0 66 D S
+N 6614 0 M 0 66 D S
+N 331 0 M 0 33 D S
+N 661 0 M 0 33 D S
+N 992 0 M 0 33 D S
+N 1323 0 M 0 33 D S
+N 1984 0 M 0 33 D S
+N 2315 0 M 0 33 D S
+N 2646 0 M 0 33 D S
+N 2976 0 M 0 33 D S
+N 3638 0 M 0 33 D S
+N 3968 0 M 0 33 D S
+N 4299 0 M 0 33 D S
+N 4630 0 M 0 33 D S
+N 5291 0 M 0 33 D S
+N 5622 0 M 0 33 D S
+N 5953 0 M 0 33 D S
+N 6283 0 M 0 33 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 -3780 T
+0 -3307 T
 0 setlinecap
 %%EndObject
 0 0 TM
@@ -1579,7 +1506,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot line.txt -W3p -Xa0i -Ya0i -R-10/10/-5/5 -Jx6.2992i
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya0i -R-10/10/-5/5 -Jx5.5118i
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_8
 0 setlinecap
@@ -1589,13 +1516,13 @@ V
 50 W
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
-1134 1890 M
-5291 0 D
+992 1654 M
+4630 0 D
 S
 PSL_cliprestore
 U
@@ -1606,7 +1533,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya0i -R-10/10/-5/5 -Jx6.2992i
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya0i -R-10/10/-5/5 -Jx5.5118i
 %@PROJ: xy -10.00000000 10.00000000 -5.00000000 5.00000000 -10.000 10.000 -5.000 5.000 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
@@ -1616,112 +1543,83 @@ V
 17 W
 clipsave
 0 0 M
-7559 0 D
-0 3780 D
--7559 0 D
+6614 0 D
+0 3307 D
+-6614 0 D
 P
 PSL_clip N
-1890 580 M
--303 524 D
--113 197 D
--265 458 D
--75 131 D
-S
-2268 580 M
--322 557 D
--94 164 D
--95 163 D
--113 197 D
+1654 508 M
+-133 229 D
 -132 229 D
+-215 372 D
+-182 316 D
 S
-2646 580 M
--152 262 D
--113 197 D
--246 425 D
--113 197 D
--132 229 D
+1984 508 M
+-347 601 D
+-314 545 D
 S
-3024 580 M
--152 262 D
--113 197 D
--265 458 D
--94 164 D
--132 229 D
+2315 508 M
+-215 372 D
+-248 430 D
+-198 344 D
 S
-3402 580 M
--171 295 D
--94 164 D
--265 458 D
--94 164 D
--95 163 D
--37 66 D
+2646 508 M
+-232 401 D
+-430 745 D
 S
-3780 580 M
--171 295 D
--94 164 D
--95 163 D
--132 230 D
--227 392 D
--37 66 D
+2976 508 M
+-165 286 D
+-463 802 D
+-33 58 D
 S
-4157 580 M
--132 230 D
--227 392 D
--132 230 D
--246 425 D
--18 33 D
+3307 508 M
+-281 487 D
+-364 630 D
+-16 29 D
 S
-4535 580 M
--132 230 D
--246 425 D
--113 197 D
--76 130 D
--132 230 D
--56 98 D
+3638 508 M
+-232 401 D
+-380 659 D
+-50 86 D
 S
-4913 580 M
--132 230 D
--246 425 D
--113 197 D
--76 130 D
--132 230 D
--57 98 D
+3968 508 M
+-479 830 D
+-182 316 D
 S
-5291 580 M
--132 230 D
--265 458 D
--94 164 D
--76 130 D
--132 230 D
--57 98 D
+4299 508 M
+-562 974 D
+-99 172 D
 S
-5669 580 M
--132 230 D
--265 458 D
--94 164 D
--95 163 D
--113 197 D
--57 98 D
+4630 508 M
+-364 630 D
+-298 516 D
 S
-6047 580 M
--132 230 D
--95 163 D
--113 197 D
--246 425 D
--113 197 D
--57 98 D
+4961 508 M
+-133 229 D
+-165 286 D
+-215 373 D
+-149 258 D
 S
-6425 580 M
--548 950 D
--208 360 D
+5291 508 M
+-165 286 D
+-215 373 D
+-248 429 D
+-33 58 D
 S
-6803 580 M
--416 721 D
--340 589 D
+5622 508 M
+-248 430 D
+-116 200 D
+-297 516 D
 S
-7181 580 M
--416 721 D
--340 589 D
+5953 508 M
+-232 401 D
+-347 601 D
+-83 144 D
+S
+6283 508 M
+-198 344 D
+-248 429 D
+-215 373 D
 S
 PSL_cliprestore
 U

--- a/test/grdtrack/crosstrack_cart.sh
+++ b/test/grdtrack/crosstrack_cart.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Test non-orthogonal modifier +d in -C for grdtrack, Cartesian version
 # Also try +r for right-side only
-gmt begin crosstrack_cart
+gmt begin crosstrack_cart ps
 	# Fake Cartesian grid
+	gmt set PS_MEDIA letter
 	gmt grdmath -R-10/10/-5/5 -I0.1 X Y MUL = cart.grd
-	gmt subplot begin 3x1 -Fs16c/8c -Sc -Srl -A -T"Cartesian cross-tracks"
+	gmt subplot begin 3x1 -Fs14c/7c -Sc -Srl -A -T"Cartesian cross-tracks"
 		gmt subplot set 0 -A"No deviation"
 		# Sample it along profiles orthogonal to the line y = 0
 		gmt grdtrack -Gcart.grd -C8/0.1/1 -E-7/0/7/0 -Dline.txt > cross.txt

--- a/test/grdtrack/crosstrack_cart.sh
+++ b/test/grdtrack/crosstrack_cart.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Test non-orthogonal modifier +d in -C for grdtrack, Cartesian version
+# Also try +r for right-side only
+gmt begin crosstrack_cart
+	# Fake Cartesian grid
+	gmt grdmath -R-10/10/-5/5 -I0.1 X Y MUL = cart.grd
+	gmt subplot begin 3x1 -Fs16c/8c -Sc -Srl -A -T"Cartesian cross-tracks"
+		gmt subplot set 0 -A"No deviation"
+		# Sample it along profiles orthogonal to the line y = 0
+		gmt grdtrack -Gcart.grd -C8/0.1/1 -E-7/0/7/0 -Dline.txt > cross.txt
+		# Plot it
+		echo -9 0 9 0 | gmt plot -Jx? -Sv12p+s+e+p0.5p -Gred -W0.5p,-
+		gmt plot line.txt -W3p
+		gmt plot cross.txt -W1p
+		gmt subplot set 1 -A"+30 deviation"
+		# Sample it along profiles with 30 degree deviation to the line y = 0
+		gmt grdtrack -Gcart.grd -C8/0.1/1+d30 -E-7/0/7/0 -Dline.txt > cross.txt
+		# Plot it
+		echo -9 0 9 0 | gmt plot -Jx? -Sv12p+s+e+p0.5p -Gred -W0.5p,-
+		gmt plot line.txt -W3p
+		gmt plot cross.txt -W1p
+		# Sample it along profiles with -30 degree deviation to the line y = 0
+		gmt subplot set 2 -A"-30 deviation, right side only"
+		gmt grdtrack -Gcart.grd -C8/0.1/1+d-30+r -E-7/0/7/0 -Dline.txt > cross.txt
+		# Plot it
+		echo -9 0 9 0 | gmt plot -Jx? -Sv12p+s+e+p0.5p -Gred -W0.5p,-
+		gmt plot line.txt -W3p
+		gmt plot cross.txt -W1p
+	gmt subplot end
+gmt end show

--- a/test/grdtrack/crosstrack_geo.ps
+++ b/test/grdtrack/crosstrack_geo.ps
@@ -1,0 +1,2136 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.3.0_841bc60_2021.08.30 [64-bit] Document from text
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Mon Aug 30 16:31:31 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt text -R0/6.29921/0/9.96279 -Jx1i -N -F+jBC+f28.7825p,Helvetica-Bold,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 6.29921000 0.00000000 9.96279000 0.000 6.299 0.000 9.963 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+3780 12384 M 480 F1
+(Geographic cross-tracks) bc Z
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 8186 TM
+% PostScript produced by:
+%@GMT: gmt plot -Jm6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWeNs -Bxaf -Byaf -Xa0i -Ya6.8132i -R-10/10/-5/5
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 8186 T
+0 A 55 3714 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(No deviation) tl Z
+U
+}!
+9 W
+0 A
+N 0 0 M 0 -69 D S
+N 0 3759 M 0 69 D S
+N 1890 0 M 0 -69 D S
+N 1890 3759 M 0 69 D S
+N 3780 0 M 0 -69 D S
+N 3780 3759 M 0 69 D S
+N 5669 0 M 0 -69 D S
+N 5669 3759 M 0 69 D S
+N 7559 0 M 0 -69 D S
+N 7559 3759 M 0 69 D S
+N 0 0 M -69 0 D S
+N 7559 0 M 69 0 D S
+N 0 1880 M -69 0 D S
+N 7559 1880 M 69 0 D S
+N 0 3759 M -69 0 D S
+N 7559 3759 M 69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 3879 M 171 F0
+(10èW) bc Z
+1890 3879 M (5èW) bc Z
+3780 3879 M (0è) bc Z
+5669 3879 M (5èE) bc Z
+7559 3879 M (10èE) bc Z
+/PSL_AH1 0
+-120 0 M (5èS) mr Z
+(5èS) sw mx
+-120 1880 M (0è) mr Z
+(0è) sw mx
+-120 3759 M (5èN) mr Z
+(5èN) sw mx
+def
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {8 W 0 A [] 0 B} def
+V
+8 W
+[67 33] 0 B
+{1 0 0 C} FS
+O1
+8 W
+V 378 1880 T N 0 0 M 6653 0 D S
+U
+V 7181 1880 T PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+50 -54 D
+-50 -54 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+[] 0 B
+26 W
+0 A
+51 W
+1 A
+N -26 0 M 0 377 D S
+N 7585 0 M 0 377 D S
+0 A
+N -26 377 M 0 376 D S
+N 7585 377 M 0 376 D S
+1 A
+N -26 753 M 0 376 D S
+N 7585 753 M 0 376 D S
+0 A
+N -26 1129 M 0 375 D S
+N 7585 1129 M 0 375 D S
+1 A
+N -26 1504 M 0 376 D S
+N 7585 1504 M 0 376 D S
+0 A
+N -26 1880 M 0 375 D S
+N 7585 1880 M 0 375 D S
+1 A
+N -26 2255 M 0 376 D S
+N 7585 2255 M 0 376 D S
+0 A
+N -26 2631 M 0 375 D S
+N 7585 2631 M 0 375 D S
+1 A
+N -26 3006 M 0 376 D S
+N 7585 3006 M 0 376 D S
+0 A
+N -26 3382 M 0 377 D S
+N 7585 3382 M 0 377 D S
+N 0 -26 M 378 0 D S
+N 0 3785 M 378 0 D S
+1 A
+N 378 -26 M 378 0 D S
+N 378 3785 M 378 0 D S
+0 A
+N 756 -26 M 378 0 D S
+N 756 3785 M 378 0 D S
+1 A
+N 1134 -26 M 378 0 D S
+N 1134 3785 M 378 0 D S
+0 A
+N 1512 -26 M 378 0 D S
+N 1512 3785 M 378 0 D S
+1 A
+N 1890 -26 M 378 0 D S
+N 1890 3785 M 378 0 D S
+0 A
+N 2268 -26 M 378 0 D S
+N 2268 3785 M 378 0 D S
+1 A
+N 2646 -26 M 378 0 D S
+N 2646 3785 M 378 0 D S
+0 A
+N 3024 -26 M 378 0 D S
+N 3024 3785 M 378 0 D S
+1 A
+N 3402 -26 M 378 0 D S
+N 3402 3785 M 378 0 D S
+0 A
+N 3780 -26 M 377 0 D S
+N 3780 3785 M 377 0 D S
+1 A
+N 4157 -26 M 378 0 D S
+N 4157 3785 M 378 0 D S
+0 A
+N 4535 -26 M 378 0 D S
+N 4535 3785 M 378 0 D S
+1 A
+N 4913 -26 M 378 0 D S
+N 4913 3785 M 378 0 D S
+0 A
+N 5291 -26 M 378 0 D S
+N 5291 3785 M 378 0 D S
+1 A
+N 5669 -26 M 378 0 D S
+N 5669 3785 M 378 0 D S
+0 A
+N 6047 -26 M 378 0 D S
+N 6047 3785 M 378 0 D S
+1 A
+N 6425 -26 M 378 0 D S
+N 6425 3785 M 378 0 D S
+0 A
+N 6803 -26 M 378 0 D S
+N 6803 3785 M 378 0 D S
+1 A
+N 7181 -26 M 378 0 D S
+N 7181 3785 M 378 0 D S
+0 A
+5 W
+N -51 0 M 7661 0 D S
+N -51 -51 M 7661 0 D S
+N 7559 -51 M 0 3861 D S
+N 7610 -51 M 0 3861 D S
+N 7610 3759 M -7661 0 D S
+N 7610 3810 M -7661 0 D S
+N 0 3810 M 0 -3861 D S
+N -51 3810 M 0 -3861 D S
+%%EndObject
+0 -8186 TM
+0 A
+FQ
+O0
+0 8186 TM
+% PostScript produced by:
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya6.8132i -R-10/10/-5/5 -Jm6.2992i
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+50 W
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+1134 1880 M
+5291 0 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -8186 TM
+0 A
+FQ
+O0
+0 8186 TM
+% PostScript produced by:
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya6.8132i -R-10/10/-5/5 -Jm6.2992i
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+17 W
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+1134 3231 M
+0 -2703 D
+S
+1462 3231 M
+0 -2703 D
+S
+1791 3231 M
+0 -2703 D
+S
+2121 3231 M
+0 -2703 D
+S
+2452 3231 M
+0 -2703 D
+S
+2783 3231 M
+0 -2703 D
+S
+3115 3231 M
+0 -2703 D
+S
+3447 3231 M
+0 -2703 D
+S
+3780 3231 M
+0 -2703 D
+S
+4112 3231 M
+0 -2703 D
+S
+4444 3231 M
+0 -2703 D
+S
+4776 3231 M
+0 -2703 D
+S
+5107 3231 M
+0 -2703 D
+S
+5438 3231 M
+0 -2703 D
+S
+5768 3231 M
+0 -2703 D
+S
+6097 3231 M
+0 -2703 D
+S
+6425 3231 M
+0 -2703 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -8186 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 4098 TM
+% PostScript produced by:
+%@GMT: gmt plot -Jm6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWens -Bxaf -Byaf -Xa0i -Ya3.4066i -R-10/10/-5/5
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 4098 T
+0 A 55 3714 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(+30 deviation, left-side only) tl Z
+U
+}!
+9 W
+0 A
+N 0 0 M 0 -69 D S
+N 0 3759 M 0 69 D S
+N 1890 0 M 0 -69 D S
+N 1890 3759 M 0 69 D S
+N 3780 0 M 0 -69 D S
+N 3780 3759 M 0 69 D S
+N 5669 0 M 0 -69 D S
+N 5669 3759 M 0 69 D S
+N 7559 0 M 0 -69 D S
+N 7559 3759 M 0 69 D S
+N 0 0 M -69 0 D S
+N 7559 0 M 69 0 D S
+N 0 1880 M -69 0 D S
+N 7559 1880 M 69 0 D S
+N 0 3759 M -69 0 D S
+N 7559 3759 M 69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/PSL_AH1 0
+-120 0 M 171 F0
+(5èS) mr Z
+(5èS) sw mx
+-120 1880 M (0è) mr Z
+(0è) sw mx
+-120 3759 M (5èN) mr Z
+(5èN) sw mx
+def
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {8 W 0 A [] 0 B} def
+V
+8 W
+[67 33] 0 B
+{1 0 0 C} FS
+O1
+8 W
+V 378 1880 T N 0 0 M 6653 0 D S
+U
+V 7181 1880 T PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+50 -54 D
+-50 -54 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+[] 0 B
+26 W
+0 A
+51 W
+1 A
+N -26 0 M 0 377 D S
+N 7585 0 M 0 377 D S
+0 A
+N -26 377 M 0 376 D S
+N 7585 377 M 0 376 D S
+1 A
+N -26 753 M 0 376 D S
+N 7585 753 M 0 376 D S
+0 A
+N -26 1129 M 0 375 D S
+N 7585 1129 M 0 375 D S
+1 A
+N -26 1504 M 0 376 D S
+N 7585 1504 M 0 376 D S
+0 A
+N -26 1880 M 0 375 D S
+N 7585 1880 M 0 375 D S
+1 A
+N -26 2255 M 0 376 D S
+N 7585 2255 M 0 376 D S
+0 A
+N -26 2631 M 0 375 D S
+N 7585 2631 M 0 375 D S
+1 A
+N -26 3006 M 0 376 D S
+N 7585 3006 M 0 376 D S
+0 A
+N -26 3382 M 0 377 D S
+N 7585 3382 M 0 377 D S
+N 0 -26 M 378 0 D S
+N 0 3785 M 378 0 D S
+1 A
+N 378 -26 M 378 0 D S
+N 378 3785 M 378 0 D S
+0 A
+N 756 -26 M 378 0 D S
+N 756 3785 M 378 0 D S
+1 A
+N 1134 -26 M 378 0 D S
+N 1134 3785 M 378 0 D S
+0 A
+N 1512 -26 M 378 0 D S
+N 1512 3785 M 378 0 D S
+1 A
+N 1890 -26 M 378 0 D S
+N 1890 3785 M 378 0 D S
+0 A
+N 2268 -26 M 378 0 D S
+N 2268 3785 M 378 0 D S
+1 A
+N 2646 -26 M 378 0 D S
+N 2646 3785 M 378 0 D S
+0 A
+N 3024 -26 M 378 0 D S
+N 3024 3785 M 378 0 D S
+1 A
+N 3402 -26 M 378 0 D S
+N 3402 3785 M 378 0 D S
+0 A
+N 3780 -26 M 377 0 D S
+N 3780 3785 M 377 0 D S
+1 A
+N 4157 -26 M 378 0 D S
+N 4157 3785 M 378 0 D S
+0 A
+N 4535 -26 M 378 0 D S
+N 4535 3785 M 378 0 D S
+1 A
+N 4913 -26 M 378 0 D S
+N 4913 3785 M 378 0 D S
+0 A
+N 5291 -26 M 378 0 D S
+N 5291 3785 M 378 0 D S
+1 A
+N 5669 -26 M 378 0 D S
+N 5669 3785 M 378 0 D S
+0 A
+N 6047 -26 M 378 0 D S
+N 6047 3785 M 378 0 D S
+1 A
+N 6425 -26 M 378 0 D S
+N 6425 3785 M 378 0 D S
+0 A
+N 6803 -26 M 378 0 D S
+N 6803 3785 M 378 0 D S
+1 A
+N 7181 -26 M 378 0 D S
+N 7181 3785 M 378 0 D S
+0 A
+5 W
+N -51 0 M 7661 0 D S
+N -51 -51 M 7661 0 D S
+N 7559 -51 M 0 3861 D S
+N 7610 -51 M 0 3861 D S
+N 7610 3759 M -7661 0 D S
+N 7610 3810 M -7661 0 D S
+N 0 3810 M 0 -3861 D S
+N -51 3810 M 0 -3861 D S
+%%EndObject
+0 -4098 TM
+0 A
+FQ
+O0
+0 4098 TM
+% PostScript produced by:
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya3.4066i -R-10/10/-5/5 -Jm6.2992i
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+50 W
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+1134 1880 M
+5291 0 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -4098 TM
+0 A
+FQ
+O0
+0 4098 TM
+% PostScript produced by:
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya3.4066i -R-10/10/-5/5 -Jm6.2992i
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+17 W
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+1814 3049 M
+-54 -94 D
+-25 -41 D
+-48 -84 D
+-19 -31 D
+-60 -105 D
+-19 -31 D
+-60 -105 D
+-25 -41 D
+-61 -105 D
+-78 -136 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-66 -115 D
+-19 -31 D
+-42 -73 D
+S
+2142 3049 M
+-73 -125 D
+-67 -115 D
+-66 -115 D
+-19 -31 D
+-60 -105 D
+-25 -41 D
+-61 -105 D
+-78 -136 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-66 -115 D
+-19 -31 D
+-42 -73 D
+S
+2471 3049 M
+-66 -115 D
+-25 -41 D
+-48 -84 D
+-19 -31 D
+-146 -251 D
+-164 -282 D
+-163 -282 D
+-19 -31 D
+-30 -52 D
+S
+2801 3049 M
+-66 -115 D
+-25 -41 D
+-48 -84 D
+-19 -31 D
+-146 -251 D
+-164 -282 D
+-163 -282 D
+-19 -31 D
+-30 -52 D
+S
+3132 3049 M
+-121 -209 D
+-25 -41 D
+-127 -220 D
+-19 -31 D
+-66 -115 D
+-19 -31 D
+-60 -105 D
+-19 -31 D
+-66 -115 D
+-19 -31 D
+-72 -126 D
+-25 -41 D
+-42 -73 D
+S
+3464 3049 M
+-25 -41 D
+-61 -105 D
+-66 -115 D
+-19 -31 D
+-60 -105 D
+-25 -41 D
+-61 -105 D
+-164 -282 D
+-78 -136 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-18 -31 D
+S
+3796 3049 M
+-25 -41 D
+-42 -74 D
+-25 -41 D
+-48 -84 D
+-19 -31 D
+-60 -105 D
+-19 -31 D
+-60 -105 D
+-25 -41 D
+-139 -241 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-66 -115 D
+-19 -31 D
+-30 -52 D
+S
+4128 3049 M
+-49 -83 D
+-36 -63 D
+-19 -31 D
+-127 -220 D
+-25 -41 D
+-61 -105 D
+-78 -136 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-79 -136 D
+-103 -177 D
+S
+4460 3049 M
+-109 -188 D
+-25 -41 D
+-48 -84 D
+-19 -31 D
+-60 -105 D
+-19 -31 D
+-60 -105 D
+-25 -41 D
+-61 -105 D
+-78 -136 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-72 -125 D
+S
+4792 3049 M
+-73 -125 D
+-67 -115 D
+-66 -115 D
+-19 -31 D
+-60 -105 D
+-25 -41 D
+-61 -105 D
+-78 -136 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-66 -115 D
+-19 -31 D
+-42 -73 D
+S
+5125 3049 M
+-25 -41 D
+-48 -84 D
+-19 -31 D
+-127 -220 D
+-19 -31 D
+-60 -105 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-66 -115 D
+-19 -31 D
+-158 -272 D
+-36 -62 D
+S
+5456 3049 M
+-73 -125 D
+-67 -115 D
+-164 -282 D
+-66 -115 D
+-19 -31 D
+-79 -136 D
+-164 -282 D
+-48 -83 D
+S
+5788 3049 M
+-49 -83 D
+-115 -199 D
+-25 -41 D
+-54 -95 D
+-25 -41 D
+-146 -251 D
+-157 -272 D
+-25 -41 D
+-79 -136 D
+-6 -10 D
+S
+6119 3049 M
+-25 -41 D
+-48 -84 D
+-19 -31 D
+-212 -366 D
+-19 -31 D
+-60 -105 D
+-19 -31 D
+-66 -115 D
+-19 -31 D
+-157 -272 D
+-19 -31 D
+-18 -31 D
+S
+6449 3049 M
+-25 -41 D
+-48 -84 D
+-19 -31 D
+-60 -105 D
+-19 -31 D
+-133 -230 D
+-19 -31 D
+-145 -251 D
+-19 -31 D
+-157 -272 D
+-19 -31 D
+-18 -31 D
+S
+6778 3049 M
+-49 -83 D
+-182 -314 D
+-25 -41 D
+-61 -105 D
+-78 -136 D
+-25 -41 D
+-61 -105 D
+-97 -167 D
+-103 -177 D
+S
+7106 3049 M
+-49 -83 D
+-36 -63 D
+-19 -31 D
+-127 -220 D
+-25 -41 D
+-61 -105 D
+-78 -136 D
+-25 -41 D
+-60 -105 D
+-19 -31 D
+-79 -136 D
+-103 -177 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -4098 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 10 TM
+% PostScript produced by:
+%@GMT: gmt plot -Jm6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R-10/10/-5/5
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 10 T
+0 A 55 3714 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+274 F0
+(-30 deviation) tl Z
+U
+}!
+9 W
+0 A
+N 0 0 M 0 -69 D S
+N 0 3759 M 0 69 D S
+N 1890 0 M 0 -69 D S
+N 1890 3759 M 0 69 D S
+N 3780 0 M 0 -69 D S
+N 3780 3759 M 0 69 D S
+N 5669 0 M 0 -69 D S
+N 5669 3759 M 0 69 D S
+N 7559 0 M 0 -69 D S
+N 7559 3759 M 0 69 D S
+N 0 0 M -69 0 D S
+N 7559 0 M 69 0 D S
+N 0 1880 M -69 0 D S
+N 7559 1880 M 69 0 D S
+N 0 3759 M -69 0 D S
+N 7559 3759 M 69 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -120 M 171 F0
+(10èW) tc Z
+1890 -120 M (5èW) tc Z
+3780 -120 M (0è) tc Z
+5669 -120 M (5èE) tc Z
+7559 -120 M (10èE) tc Z
+/PSL_AH1 0
+-120 0 M (5èS) mr Z
+(5èS) sw mx
+-120 1880 M (0è) mr Z
+(0è) sw mx
+-120 3759 M (5èN) mr Z
+(5èN) sw mx
+def
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {8 W 0 A [] 0 B} def
+V
+8 W
+[67 33] 0 B
+{1 0 0 C} FS
+O1
+8 W
+V 378 1880 T N 0 0 M 6653 0 D S
+U
+V 7181 1880 T PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+50 -54 D
+-50 -54 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+[] 0 B
+26 W
+0 A
+51 W
+1 A
+N -26 0 M 0 377 D S
+N 7585 0 M 0 377 D S
+0 A
+N -26 377 M 0 376 D S
+N 7585 377 M 0 376 D S
+1 A
+N -26 753 M 0 376 D S
+N 7585 753 M 0 376 D S
+0 A
+N -26 1129 M 0 375 D S
+N 7585 1129 M 0 375 D S
+1 A
+N -26 1504 M 0 376 D S
+N 7585 1504 M 0 376 D S
+0 A
+N -26 1880 M 0 375 D S
+N 7585 1880 M 0 375 D S
+1 A
+N -26 2255 M 0 376 D S
+N 7585 2255 M 0 376 D S
+0 A
+N -26 2631 M 0 375 D S
+N 7585 2631 M 0 375 D S
+1 A
+N -26 3006 M 0 376 D S
+N 7585 3006 M 0 376 D S
+0 A
+N -26 3382 M 0 377 D S
+N 7585 3382 M 0 377 D S
+N 0 -26 M 378 0 D S
+N 0 3785 M 378 0 D S
+1 A
+N 378 -26 M 378 0 D S
+N 378 3785 M 378 0 D S
+0 A
+N 756 -26 M 378 0 D S
+N 756 3785 M 378 0 D S
+1 A
+N 1134 -26 M 378 0 D S
+N 1134 3785 M 378 0 D S
+0 A
+N 1512 -26 M 378 0 D S
+N 1512 3785 M 378 0 D S
+1 A
+N 1890 -26 M 378 0 D S
+N 1890 3785 M 378 0 D S
+0 A
+N 2268 -26 M 378 0 D S
+N 2268 3785 M 378 0 D S
+1 A
+N 2646 -26 M 378 0 D S
+N 2646 3785 M 378 0 D S
+0 A
+N 3024 -26 M 378 0 D S
+N 3024 3785 M 378 0 D S
+1 A
+N 3402 -26 M 378 0 D S
+N 3402 3785 M 378 0 D S
+0 A
+N 3780 -26 M 377 0 D S
+N 3780 3785 M 377 0 D S
+1 A
+N 4157 -26 M 378 0 D S
+N 4157 3785 M 378 0 D S
+0 A
+N 4535 -26 M 378 0 D S
+N 4535 3785 M 378 0 D S
+1 A
+N 4913 -26 M 378 0 D S
+N 4913 3785 M 378 0 D S
+0 A
+N 5291 -26 M 378 0 D S
+N 5291 3785 M 378 0 D S
+1 A
+N 5669 -26 M 378 0 D S
+N 5669 3785 M 378 0 D S
+0 A
+N 6047 -26 M 378 0 D S
+N 6047 3785 M 378 0 D S
+1 A
+N 6425 -26 M 378 0 D S
+N 6425 3785 M 378 0 D S
+0 A
+N 6803 -26 M 378 0 D S
+N 6803 3785 M 378 0 D S
+1 A
+N 7181 -26 M 378 0 D S
+N 7181 3785 M 378 0 D S
+0 A
+5 W
+N -51 0 M 7661 0 D S
+N -51 -51 M 7661 0 D S
+N 7559 -51 M 0 3861 D S
+N 7610 -51 M 0 3861 D S
+N 7610 3759 M -7661 0 D S
+N 7610 3810 M -7661 0 D S
+N 0 3810 M 0 -3861 D S
+N -51 3810 M 0 -3861 D S
+%%EndObject
+0 -10 TM
+0 A
+FQ
+O0
+0 10 TM
+% PostScript produced by:
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya0i -R-10/10/-5/5 -Jm6.2992i
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+50 W
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+1134 1880 M
+5291 0 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -10 TM
+0 A
+FQ
+O0
+0 10 TM
+% PostScript produced by:
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya0i -R-10/10/-5/5 -Jm6.2992i
+%@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+V
+17 W
+clipsave
+0 0 M
+7559 0 D
+0 3759 D
+-7559 0 D
+P
+PSL_clip N
+453 3049 M
+25 -41 D
+127 -220 D
+19 -31 D
+146 -251 D
+164 -282 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+66 -115 D
+19 -31 D
+60 -105 D
+25 -41 D
+54 -95 D
+25 -41 D
+48 -84 D
+19 -31 D
+42 -73 D
+S
+781 3050 M
+73 -126 D
+19 -31 D
+146 -251 D
+66 -115 D
+19 -31 D
+158 -272 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+66 -115 D
+19 -31 D
+60 -105 D
+25 -41 D
+48 -84 D
+19 -31 D
+61 -105 D
+60 -104 D
+S
+1111 3050 M
+66 -115 D
+73 -126 D
+19 -31 D
+60 -105 D
+25 -41 D
+54 -95 D
+25 -41 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+158 -272 D
+78 -136 D
+25 -41 D
+158 -272 D
+164 -282 D
+145 -251 D
+25 -41 D
+48 -84 D
+19 -31 D
+54 -94 D
+S
+1441 3050 M
+66 -115 D
+73 -126 D
+19 -31 D
+60 -105 D
+25 -41 D
+54 -95 D
+25 -41 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+158 -272 D
+78 -136 D
+25 -41 D
+158 -272 D
+164 -282 D
+145 -251 D
+25 -41 D
+48 -84 D
+19 -31 D
+54 -94 D
+S
+1771 3050 M
+85 -147 D
+19 -31 D
+133 -230 D
+19 -31 D
+60 -105 D
+19 -31 D
+79 -136 D
+157 -272 D
+25 -41 D
+60 -105 D
+25 -41 D
+60 -105 D
+19 -31 D
+72 -126 D
+25 -41 D
+60 -105 D
+19 -31 D
+60 -105 D
+25 -41 D
+60 -105 D
+19 -31 D
+67 -115 D
+66 -115 D
+19 -31 D
+109 -188 D
+S
+2103 3050 M
+54 -95 D
+25 -41 D
+48 -84 D
+19 -31 D
+60 -105 D
+19 -31 D
+60 -105 D
+25 -41 D
+61 -105 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+72 -126 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+164 -282 D
+66 -115 D
+19 -31 D
+60 -105 D
+25 -41 D
+61 -105 D
+67 -115 D
+6 -10 D
+S
+2435 3050 M
+60 -105 D
+19 -31 D
+60 -105 D
+19 -31 D
+146 -251 D
+157 -272 D
+25 -41 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+72 -126 D
+25 -41 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+145 -251 D
+19 -31 D
+60 -105 D
+19 -31 D
+60 -105 D
+25 -41 D
+48 -84 D
+19 -31 D
+48 -84 D
+7 -10 D
+S
+2767 3050 M
+61 -105 D
+60 -105 D
+25 -41 D
+212 -366 D
+19 -31 D
+158 -272 D
+84 -146 D
+19 -31 D
+158 -272 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+66 -115 D
+19 -31 D
+127 -220 D
+25 -41 D
+48 -84 D
+19 -31 D
+S
+3099 3050 M
+97 -168 D
+19 -31 D
+60 -105 D
+25 -41 D
+225 -387 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+72 -126 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+66 -115 D
+19 -31 D
+60 -105 D
+25 -41 D
+61 -105 D
+66 -115 D
+19 -31 D
+97 -167 D
+S
+3431 3050 M
+73 -126 D
+19 -31 D
+146 -251 D
+66 -115 D
+19 -31 D
+158 -272 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+66 -115 D
+19 -31 D
+60 -105 D
+25 -41 D
+48 -84 D
+19 -31 D
+61 -105 D
+60 -104 D
+S
+3764 3050 M
+60 -105 D
+19 -31 D
+61 -105 D
+164 -282 D
+66 -115 D
+19 -31 D
+79 -136 D
+163 -282 D
+19 -31 D
+79 -136 D
+157 -272 D
+25 -41 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+60 -105 D
+19 -31 D
+67 -115 D
+60 -105 D
+25 -41 D
+48 -84 D
+7 -10 D
+S
+4095 3050 M
+219 -377 D
+25 -41 D
+60 -105 D
+19 -31 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+157 -272 D
+19 -31 D
+66 -115 D
+19 -31 D
+158 -272 D
+78 -136 D
+25 -41 D
+61 -105 D
+151 -261 D
+19 -31 D
+61 -105 D
+60 -104 D
+S
+4427 3050 M
+42 -74 D
+25 -41 D
+61 -105 D
+67 -115 D
+157 -272 D
+25 -41 D
+60 -105 D
+19 -31 D
+66 -115 D
+19 -31 D
+79 -136 D
+163 -282 D
+19 -31 D
+158 -272 D
+151 -261 D
+19 -31 D
+60 -105 D
+19 -31 D
+127 -220 D
+25 -41 D
+S
+4758 3050 M
+54 -95 D
+25 -41 D
+48 -84 D
+19 -31 D
+60 -105 D
+19 -31 D
+60 -105 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+164 -282 D
+78 -136 D
+25 -41 D
+151 -262 D
+25 -41 D
+60 -105 D
+19 -31 D
+60 -105 D
+25 -41 D
+146 -251 D
+60 -105 D
+25 -41 D
+49 -84 D
+6 -10 D
+S
+5088 3050 M
+54 -95 D
+25 -41 D
+48 -84 D
+19 -31 D
+60 -105 D
+19 -31 D
+60 -105 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+164 -282 D
+78 -136 D
+25 -41 D
+151 -262 D
+25 -41 D
+139 -241 D
+25 -41 D
+127 -220 D
+25 -41 D
+54 -95 D
+25 -41 D
+49 -84 D
+6 -10 D
+S
+5417 3050 M
+61 -105 D
+60 -105 D
+25 -41 D
+225 -387 D
+163 -282 D
+19 -31 D
+66 -115 D
+19 -31 D
+158 -272 D
+97 -167 D
+66 -115 D
+19 -31 D
+79 -136 D
+66 -115 D
+19 -31 D
+146 -251 D
+54 -94 D
+19 -31 D
+S
+5745 3050 M
+61 -105 D
+60 -105 D
+25 -41 D
+212 -366 D
+19 -31 D
+158 -272 D
+84 -146 D
+19 -31 D
+158 -272 D
+78 -136 D
+25 -41 D
+60 -105 D
+19 -31 D
+79 -136 D
+66 -115 D
+19 -31 D
+127 -220 D
+25 -41 D
+48 -84 D
+19 -31 D
+S
+PSL_cliprestore
+U
+%%EndObject
+0 -10 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/grdtrack/crosstrack_geo.ps
+++ b/test/grdtrack/crosstrack_geo.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000
-%%Title: GMT v6.3.0_841bc60_2021.08.30 [64-bit] Document from text
+%%Title: GMT v6.3.0_d7a32bb_2021.08.30 [64-bit] Document from text
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Aug 30 16:31:31 2021
+%%CreationDate: Tue Aug 31 09:42:31 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -117,39 +117,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/Standard+_Encoding [
+/ISOLatin1+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
-/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
-/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
-/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
-/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
-/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
-/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
-/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
-/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
-/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
-/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
-/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
-/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
-/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
-/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
-/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -700,23 +700,23 @@ FQ
 O0
 1200 1200 TM
 % PostScript produced by:
-%@GMT: gmt text -R0/6.29921/0/9.96279 -Jx1i -N -F+jBC+f28.7825p,Helvetica-Bold,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=readonly
-%@PROJ: xy 0.00000000 6.29921000 0.00000000 9.96279000 0.000 6.299 0.000 9.963 +xy
+%@GMT: gmt text -R0/5.51181/0/8.76536 -Jx1i -N -F+jBC+f27.868p,Helvetica-Bold,black @GMTAPI@-S-I-D-D-N-N-000000 -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 5.51181000 0.00000000 8.76536000 0.000 5.512 0.000 8.765 +xy
 %%BeginObject PSL_Layer_1
 0 setlinecap
 0 setlinejoin
 3.32550952342 setmiterlimit
-PSL_font_encode 1 get 0 eq {Standard+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
-3780 12384 M 480 F1
-(Geographic cross-tracks) bc Z
+PSL_font_encode 1 get 0 eq {ISOLatin1+_Encoding /Helvetica-Bold /Helvetica-Bold PSL_reencode PSL_font_encode 1 1 put} if
+3307 10933 M 464 F1
+(Geographic cross≠tracks) bc Z
 %%EndObject
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
 FQ
 O0
-0 8186 TM
+0 7220 TM
 % PostScript produced by:
-%@GMT: gmt plot -Jm6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWeNs -Bxaf -Byaf -Xa0i -Ya6.8132i -R-10/10/-5/5
+%@GMT: gmt plot -Jm5.5118i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWeNs -Bxaf -Byaf -Xa0i -Ya6.0095i -R-10/10/-5/5
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_1
 0 setlinecap
@@ -724,50 +724,50 @@ O0
 3.32550952342 setmiterlimit
 /PSL_plot_completion {
 V
-0 8186 T
-0 A 55 3714 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-274 F0
+0 7220 T
+0 A 53 3245 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+265 F0
 (No deviation) tl Z
 U
 }!
-9 W
+8 W
 0 A
-N 0 0 M 0 -69 D S
-N 0 3759 M 0 69 D S
-N 1890 0 M 0 -69 D S
-N 1890 3759 M 0 69 D S
-N 3780 0 M 0 -69 D S
-N 3780 3759 M 0 69 D S
-N 5669 0 M 0 -69 D S
-N 5669 3759 M 0 69 D S
-N 7559 0 M 0 -69 D S
-N 7559 3759 M 0 69 D S
-N 0 0 M -69 0 D S
-N 7559 0 M 69 0 D S
-N 0 1880 M -69 0 D S
-N 7559 1880 M 69 0 D S
-N 0 3759 M -69 0 D S
-N 7559 3759 M 69 0 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-0 3879 M 171 F0
-(10èW) bc Z
-1890 3879 M (5èW) bc Z
-3780 3879 M (0è) bc Z
-5669 3879 M (5èE) bc Z
-7559 3879 M (10èE) bc Z
+N 0 0 M 0 -66 D S
+N 0 3289 M 0 67 D S
+N 1654 0 M 0 -66 D S
+N 1654 3289 M 0 67 D S
+N 3307 0 M 0 -66 D S
+N 3307 3289 M 0 67 D S
+N 4961 0 M 0 -66 D S
+N 4961 3289 M 0 67 D S
+N 6614 0 M 0 -66 D S
+N 6614 3289 M 0 67 D S
+N 0 0 M -66 0 D S
+N 6614 0 M 67 0 D S
+N 0 1645 M -66 0 D S
+N 6614 1645 M 67 0 D S
+N 0 3289 M -66 0 D S
+N 6614 3289 M 67 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 3405 M 166 F0
+(10∞W) bc Z
+1654 3405 M (5∞W) bc Z
+3307 3405 M (0∞) bc Z
+4961 3405 M (5∞E) bc Z
+6614 3405 M (10∞E) bc Z
 /PSL_AH1 0
--120 0 M (5èS) mr Z
-(5èS) sw mx
--120 1880 M (0è) mr Z
-(0è) sw mx
--120 3759 M (5èN) mr Z
-(5èN) sw mx
+-116 0 M (5∞S) mr Z
+(5∞S) sw mx
+-116 1645 M (0∞) mr Z
+(0∞) sw mx
+-116 3289 M (5∞N) mr Z
+(5∞N) sw mx
 def
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
 /PSL_vecheadpen {8 W 0 A [] 0 B} def
@@ -777,9 +777,9 @@ V
 {1 0 0 C} FS
 O1
 8 W
-V 378 1880 T N 0 0 M 6653 0 D S
+V 331 1645 T N 0 0 M 5803 0 D S
 U
-V 7181 1880 T PSL_vecheadpen
+V 6283 1645 T PSL_vecheadpen
 17 W
 0 0 M
 -200 54 D
@@ -790,116 +790,116 @@ U
 U
 PSL_cliprestore
 [] 0 B
-26 W
+25 W
 0 A
-51 W
+50 W
 1 A
-N -26 0 M 0 377 D S
-N 7585 0 M 0 377 D S
+N -25 0 M 0 330 D S
+N 6639 0 M 0 330 D S
 0 A
-N -26 377 M 0 376 D S
-N 7585 377 M 0 376 D S
+N -25 330 M 0 329 D S
+N 6639 330 M 0 329 D S
 1 A
-N -26 753 M 0 376 D S
-N 7585 753 M 0 376 D S
+N -25 659 M 0 328 D S
+N 6639 659 M 0 328 D S
 0 A
-N -26 1129 M 0 375 D S
-N 7585 1129 M 0 375 D S
+N -25 987 M 0 329 D S
+N 6639 987 M 0 329 D S
 1 A
-N -26 1504 M 0 376 D S
-N 7585 1504 M 0 376 D S
+N -25 1316 M 0 329 D S
+N 6639 1316 M 0 329 D S
 0 A
-N -26 1880 M 0 375 D S
-N 7585 1880 M 0 375 D S
+N -25 1645 M 0 328 D S
+N 6639 1645 M 0 328 D S
 1 A
-N -26 2255 M 0 376 D S
-N 7585 2255 M 0 376 D S
+N -25 1973 M 0 329 D S
+N 6639 1973 M 0 329 D S
 0 A
-N -26 2631 M 0 375 D S
-N 7585 2631 M 0 375 D S
+N -25 2302 M 0 329 D S
+N 6639 2302 M 0 329 D S
 1 A
-N -26 3006 M 0 376 D S
-N 7585 3006 M 0 376 D S
+N -25 2631 M 0 329 D S
+N 6639 2631 M 0 329 D S
 0 A
-N -26 3382 M 0 377 D S
-N 7585 3382 M 0 377 D S
-N 0 -26 M 378 0 D S
-N 0 3785 M 378 0 D S
+N -25 2960 M 0 329 D S
+N 6639 2960 M 0 329 D S
+N 0 -25 M 331 0 D S
+N 0 3314 M 331 0 D S
 1 A
-N 378 -26 M 378 0 D S
-N 378 3785 M 378 0 D S
+N 331 -25 M 330 0 D S
+N 331 3314 M 330 0 D S
 0 A
-N 756 -26 M 378 0 D S
-N 756 3785 M 378 0 D S
+N 661 -25 M 331 0 D S
+N 661 3314 M 331 0 D S
 1 A
-N 1134 -26 M 378 0 D S
-N 1134 3785 M 378 0 D S
+N 992 -25 M 331 0 D S
+N 992 3314 M 331 0 D S
 0 A
-N 1512 -26 M 378 0 D S
-N 1512 3785 M 378 0 D S
+N 1323 -25 M 331 0 D S
+N 1323 3314 M 331 0 D S
 1 A
-N 1890 -26 M 378 0 D S
-N 1890 3785 M 378 0 D S
+N 1654 -25 M 330 0 D S
+N 1654 3314 M 330 0 D S
 0 A
-N 2268 -26 M 378 0 D S
-N 2268 3785 M 378 0 D S
+N 1984 -25 M 331 0 D S
+N 1984 3314 M 331 0 D S
 1 A
-N 2646 -26 M 378 0 D S
-N 2646 3785 M 378 0 D S
+N 2315 -25 M 331 0 D S
+N 2315 3314 M 331 0 D S
 0 A
-N 3024 -26 M 378 0 D S
-N 3024 3785 M 378 0 D S
+N 2646 -25 M 330 0 D S
+N 2646 3314 M 330 0 D S
 1 A
-N 3402 -26 M 378 0 D S
-N 3402 3785 M 378 0 D S
+N 2976 -25 M 331 0 D S
+N 2976 3314 M 331 0 D S
 0 A
-N 3780 -26 M 377 0 D S
-N 3780 3785 M 377 0 D S
+N 3307 -25 M 331 0 D S
+N 3307 3314 M 331 0 D S
 1 A
-N 4157 -26 M 378 0 D S
-N 4157 3785 M 378 0 D S
+N 3638 -25 M 330 0 D S
+N 3638 3314 M 330 0 D S
 0 A
-N 4535 -26 M 378 0 D S
-N 4535 3785 M 378 0 D S
+N 3968 -25 M 331 0 D S
+N 3968 3314 M 331 0 D S
 1 A
-N 4913 -26 M 378 0 D S
-N 4913 3785 M 378 0 D S
+N 4299 -25 M 331 0 D S
+N 4299 3314 M 331 0 D S
 0 A
-N 5291 -26 M 378 0 D S
-N 5291 3785 M 378 0 D S
+N 4630 -25 M 331 0 D S
+N 4630 3314 M 331 0 D S
 1 A
-N 5669 -26 M 378 0 D S
-N 5669 3785 M 378 0 D S
+N 4961 -25 M 330 0 D S
+N 4961 3314 M 330 0 D S
 0 A
-N 6047 -26 M 378 0 D S
-N 6047 3785 M 378 0 D S
+N 5291 -25 M 331 0 D S
+N 5291 3314 M 331 0 D S
 1 A
-N 6425 -26 M 378 0 D S
-N 6425 3785 M 378 0 D S
+N 5622 -25 M 331 0 D S
+N 5622 3314 M 331 0 D S
 0 A
-N 6803 -26 M 378 0 D S
-N 6803 3785 M 378 0 D S
+N 5953 -25 M 330 0 D S
+N 5953 3314 M 330 0 D S
 1 A
-N 7181 -26 M 378 0 D S
-N 7181 3785 M 378 0 D S
+N 6283 -25 M 331 0 D S
+N 6283 3314 M 331 0 D S
 0 A
 5 W
-N -51 0 M 7661 0 D S
-N -51 -51 M 7661 0 D S
-N 7559 -51 M 0 3861 D S
-N 7610 -51 M 0 3861 D S
-N 7610 3759 M -7661 0 D S
-N 7610 3810 M -7661 0 D S
-N 0 3810 M 0 -3861 D S
-N -51 3810 M 0 -3861 D S
+N -50 0 M 6714 0 D S
+N -50 -50 M 6714 0 D S
+N 6614 -50 M 0 3389 D S
+N 6664 -50 M 0 3389 D S
+N 6664 3289 M -6714 0 D S
+N 6664 3339 M -6714 0 D S
+N 0 3339 M 0 -3389 D S
+N -50 3339 M 0 -3389 D S
 %%EndObject
-0 -8186 TM
+0 -7220 TM
 0 A
 FQ
 O0
-0 8186 TM
+0 7220 TM
 % PostScript produced by:
-%@GMT: gmt plot line.txt -W3p -Xa0i -Ya6.8132i -R-10/10/-5/5 -Jm6.2992i
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya6.0095i -R-10/10/-5/5 -Jm5.5118i
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_2
 0 setlinecap
@@ -909,24 +909,24 @@ V
 50 W
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
-1134 1880 M
-5291 0 D
+992 1645 M
+4630 0 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -8186 TM
+0 -7220 TM
 0 A
 FQ
 O0
-0 8186 TM
+0 7220 TM
 % PostScript produced by:
-%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya6.8132i -R-10/10/-5/5 -Jm6.2992i
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya6.0095i -R-10/10/-5/5 -Jm5.5118i
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_3
 0 setlinecap
@@ -936,73 +936,73 @@ V
 17 W
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
-1134 3231 M
-0 -2703 D
+992 2827 M
+0 -2365 D
 S
-1462 3231 M
-0 -2703 D
+1279 2827 M
+0 -2365 D
 S
-1791 3231 M
-0 -2703 D
+1567 2827 M
+0 -2365 D
 S
-2121 3231 M
-0 -2703 D
+1856 2827 M
+0 -2365 D
 S
-2452 3231 M
-0 -2703 D
+2145 2827 M
+0 -2365 D
 S
-2783 3231 M
-0 -2703 D
+2435 2827 M
+0 -2365 D
 S
-3115 3231 M
-0 -2703 D
+2726 2827 M
+0 -2365 D
 S
-3447 3231 M
-0 -2703 D
+3016 2827 M
+0 -2365 D
 S
-3780 3231 M
-0 -2703 D
+3307 2827 M
+0 -2365 D
 S
-4112 3231 M
-0 -2703 D
+3598 2827 M
+0 -2365 D
 S
-4444 3231 M
-0 -2703 D
+3889 2827 M
+0 -2365 D
 S
-4776 3231 M
-0 -2703 D
+4179 2827 M
+0 -2365 D
 S
-5107 3231 M
-0 -2703 D
+4469 2827 M
+0 -2365 D
 S
-5438 3231 M
-0 -2703 D
+4758 2827 M
+0 -2365 D
 S
-5768 3231 M
-0 -2703 D
+5047 2827 M
+0 -2365 D
 S
-6097 3231 M
-0 -2703 D
+5335 2827 M
+0 -2365 D
 S
-6425 3231 M
-0 -2703 D
+5622 2827 M
+0 -2365 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -8186 TM
+0 -7220 TM
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
 FQ
 O0
-0 4098 TM
+0 3615 TM
 % PostScript produced by:
-%@GMT: gmt plot -Jm6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWens -Bxaf -Byaf -Xa0i -Ya3.4066i -R-10/10/-5/5
+%@GMT: gmt plot -Jm5.5118i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWens -Bxaf -Byaf -Xa0i -Ya3.0047i -R-10/10/-5/5
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_4
 0 setlinecap
@@ -1010,45 +1010,45 @@ O0
 3.32550952342 setmiterlimit
 /PSL_plot_completion {
 V
-0 4098 T
-0 A 55 3714 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-274 F0
-(+30 deviation, left-side only) tl Z
+0 3615 T
+0 A 53 3245 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+265 F0
+(+30 deviation, left≠side only) tl Z
 U
 }!
-9 W
+8 W
 0 A
-N 0 0 M 0 -69 D S
-N 0 3759 M 0 69 D S
-N 1890 0 M 0 -69 D S
-N 1890 3759 M 0 69 D S
-N 3780 0 M 0 -69 D S
-N 3780 3759 M 0 69 D S
-N 5669 0 M 0 -69 D S
-N 5669 3759 M 0 69 D S
-N 7559 0 M 0 -69 D S
-N 7559 3759 M 0 69 D S
-N 0 0 M -69 0 D S
-N 7559 0 M 69 0 D S
-N 0 1880 M -69 0 D S
-N 7559 1880 M 69 0 D S
-N 0 3759 M -69 0 D S
-N 7559 3759 M 69 0 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+N 0 0 M 0 -66 D S
+N 0 3289 M 0 67 D S
+N 1654 0 M 0 -66 D S
+N 1654 3289 M 0 67 D S
+N 3307 0 M 0 -66 D S
+N 3307 3289 M 0 67 D S
+N 4961 0 M 0 -66 D S
+N 4961 3289 M 0 67 D S
+N 6614 0 M 0 -66 D S
+N 6614 3289 M 0 67 D S
+N 0 0 M -66 0 D S
+N 6614 0 M 67 0 D S
+N 0 1645 M -66 0 D S
+N 6614 1645 M 67 0 D S
+N 0 3289 M -66 0 D S
+N 6614 3289 M 67 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 /PSL_AH1 0
--120 0 M 171 F0
-(5èS) mr Z
-(5èS) sw mx
--120 1880 M (0è) mr Z
-(0è) sw mx
--120 3759 M (5èN) mr Z
-(5èN) sw mx
+-116 0 M 166 F0
+(5∞S) mr Z
+(5∞S) sw mx
+-116 1645 M (0∞) mr Z
+(0∞) sw mx
+-116 3289 M (5∞N) mr Z
+(5∞N) sw mx
 def
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
 /PSL_vecheadpen {8 W 0 A [] 0 B} def
@@ -1058,9 +1058,9 @@ V
 {1 0 0 C} FS
 O1
 8 W
-V 378 1880 T N 0 0 M 6653 0 D S
+V 331 1645 T N 0 0 M 5803 0 D S
 U
-V 7181 1880 T PSL_vecheadpen
+V 6283 1645 T PSL_vecheadpen
 17 W
 0 0 M
 -200 54 D
@@ -1071,116 +1071,116 @@ U
 U
 PSL_cliprestore
 [] 0 B
-26 W
+25 W
 0 A
-51 W
+50 W
 1 A
-N -26 0 M 0 377 D S
-N 7585 0 M 0 377 D S
+N -25 0 M 0 330 D S
+N 6639 0 M 0 330 D S
 0 A
-N -26 377 M 0 376 D S
-N 7585 377 M 0 376 D S
+N -25 330 M 0 329 D S
+N 6639 330 M 0 329 D S
 1 A
-N -26 753 M 0 376 D S
-N 7585 753 M 0 376 D S
+N -25 659 M 0 328 D S
+N 6639 659 M 0 328 D S
 0 A
-N -26 1129 M 0 375 D S
-N 7585 1129 M 0 375 D S
+N -25 987 M 0 329 D S
+N 6639 987 M 0 329 D S
 1 A
-N -26 1504 M 0 376 D S
-N 7585 1504 M 0 376 D S
+N -25 1316 M 0 329 D S
+N 6639 1316 M 0 329 D S
 0 A
-N -26 1880 M 0 375 D S
-N 7585 1880 M 0 375 D S
+N -25 1645 M 0 328 D S
+N 6639 1645 M 0 328 D S
 1 A
-N -26 2255 M 0 376 D S
-N 7585 2255 M 0 376 D S
+N -25 1973 M 0 329 D S
+N 6639 1973 M 0 329 D S
 0 A
-N -26 2631 M 0 375 D S
-N 7585 2631 M 0 375 D S
+N -25 2302 M 0 329 D S
+N 6639 2302 M 0 329 D S
 1 A
-N -26 3006 M 0 376 D S
-N 7585 3006 M 0 376 D S
+N -25 2631 M 0 329 D S
+N 6639 2631 M 0 329 D S
 0 A
-N -26 3382 M 0 377 D S
-N 7585 3382 M 0 377 D S
-N 0 -26 M 378 0 D S
-N 0 3785 M 378 0 D S
+N -25 2960 M 0 329 D S
+N 6639 2960 M 0 329 D S
+N 0 -25 M 331 0 D S
+N 0 3314 M 331 0 D S
 1 A
-N 378 -26 M 378 0 D S
-N 378 3785 M 378 0 D S
+N 331 -25 M 330 0 D S
+N 331 3314 M 330 0 D S
 0 A
-N 756 -26 M 378 0 D S
-N 756 3785 M 378 0 D S
+N 661 -25 M 331 0 D S
+N 661 3314 M 331 0 D S
 1 A
-N 1134 -26 M 378 0 D S
-N 1134 3785 M 378 0 D S
+N 992 -25 M 331 0 D S
+N 992 3314 M 331 0 D S
 0 A
-N 1512 -26 M 378 0 D S
-N 1512 3785 M 378 0 D S
+N 1323 -25 M 331 0 D S
+N 1323 3314 M 331 0 D S
 1 A
-N 1890 -26 M 378 0 D S
-N 1890 3785 M 378 0 D S
+N 1654 -25 M 330 0 D S
+N 1654 3314 M 330 0 D S
 0 A
-N 2268 -26 M 378 0 D S
-N 2268 3785 M 378 0 D S
+N 1984 -25 M 331 0 D S
+N 1984 3314 M 331 0 D S
 1 A
-N 2646 -26 M 378 0 D S
-N 2646 3785 M 378 0 D S
+N 2315 -25 M 331 0 D S
+N 2315 3314 M 331 0 D S
 0 A
-N 3024 -26 M 378 0 D S
-N 3024 3785 M 378 0 D S
+N 2646 -25 M 330 0 D S
+N 2646 3314 M 330 0 D S
 1 A
-N 3402 -26 M 378 0 D S
-N 3402 3785 M 378 0 D S
+N 2976 -25 M 331 0 D S
+N 2976 3314 M 331 0 D S
 0 A
-N 3780 -26 M 377 0 D S
-N 3780 3785 M 377 0 D S
+N 3307 -25 M 331 0 D S
+N 3307 3314 M 331 0 D S
 1 A
-N 4157 -26 M 378 0 D S
-N 4157 3785 M 378 0 D S
+N 3638 -25 M 330 0 D S
+N 3638 3314 M 330 0 D S
 0 A
-N 4535 -26 M 378 0 D S
-N 4535 3785 M 378 0 D S
+N 3968 -25 M 331 0 D S
+N 3968 3314 M 331 0 D S
 1 A
-N 4913 -26 M 378 0 D S
-N 4913 3785 M 378 0 D S
+N 4299 -25 M 331 0 D S
+N 4299 3314 M 331 0 D S
 0 A
-N 5291 -26 M 378 0 D S
-N 5291 3785 M 378 0 D S
+N 4630 -25 M 331 0 D S
+N 4630 3314 M 331 0 D S
 1 A
-N 5669 -26 M 378 0 D S
-N 5669 3785 M 378 0 D S
+N 4961 -25 M 330 0 D S
+N 4961 3314 M 330 0 D S
 0 A
-N 6047 -26 M 378 0 D S
-N 6047 3785 M 378 0 D S
+N 5291 -25 M 331 0 D S
+N 5291 3314 M 331 0 D S
 1 A
-N 6425 -26 M 378 0 D S
-N 6425 3785 M 378 0 D S
+N 5622 -25 M 331 0 D S
+N 5622 3314 M 331 0 D S
 0 A
-N 6803 -26 M 378 0 D S
-N 6803 3785 M 378 0 D S
+N 5953 -25 M 330 0 D S
+N 5953 3314 M 330 0 D S
 1 A
-N 7181 -26 M 378 0 D S
-N 7181 3785 M 378 0 D S
+N 6283 -25 M 331 0 D S
+N 6283 3314 M 331 0 D S
 0 A
 5 W
-N -51 0 M 7661 0 D S
-N -51 -51 M 7661 0 D S
-N 7559 -51 M 0 3861 D S
-N 7610 -51 M 0 3861 D S
-N 7610 3759 M -7661 0 D S
-N 7610 3810 M -7661 0 D S
-N 0 3810 M 0 -3861 D S
-N -51 3810 M 0 -3861 D S
+N -50 0 M 6714 0 D S
+N -50 -50 M 6714 0 D S
+N 6614 -50 M 0 3389 D S
+N 6664 -50 M 0 3389 D S
+N 6664 3289 M -6714 0 D S
+N 6664 3339 M -6714 0 D S
+N 0 3339 M 0 -3389 D S
+N -50 3339 M 0 -3389 D S
 %%EndObject
-0 -4098 TM
+0 -3615 TM
 0 A
 FQ
 O0
-0 4098 TM
+0 3615 TM
 % PostScript produced by:
-%@GMT: gmt plot line.txt -W3p -Xa0i -Ya3.4066i -R-10/10/-5/5 -Jm6.2992i
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya3.0047i -R-10/10/-5/5 -Jm5.5118i
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_5
 0 setlinecap
@@ -1190,24 +1190,24 @@ V
 50 W
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
-1134 1880 M
-5291 0 D
+992 1645 M
+4630 0 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -4098 TM
+0 -3615 TM
 0 A
 FQ
 O0
-0 4098 TM
+0 3615 TM
 % PostScript produced by:
-%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya3.4066i -R-10/10/-5/5 -Jm6.2992i
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya3.0047i -R-10/10/-5/5 -Jm5.5118i
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_6
 0 setlinecap
@@ -1217,262 +1217,291 @@ V
 17 W
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
-1814 3049 M
--54 -94 D
--25 -41 D
--48 -84 D
--19 -31 D
--60 -105 D
--19 -31 D
--60 -105 D
--25 -41 D
--61 -105 D
--78 -136 D
--25 -41 D
--60 -105 D
--19 -31 D
--66 -115 D
--19 -31 D
--42 -73 D
+1588 2668 M
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-136 -235 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-18 -32 D
+-13 -21 D
+-68 -117 D
 S
-2142 3049 M
--73 -125 D
--67 -115 D
--66 -115 D
--19 -31 D
--60 -105 D
--25 -41 D
--61 -105 D
--78 -136 D
--25 -41 D
--60 -105 D
--19 -31 D
--66 -115 D
--19 -31 D
--42 -73 D
+1875 2668 M
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-18 -32 D
+-13 -21 D
+-24 -43 D
+-13 -21 D
+-31 -53 D
 S
-2471 3049 M
--66 -115 D
--25 -41 D
--48 -84 D
--19 -31 D
--146 -251 D
--164 -282 D
--163 -282 D
--19 -31 D
--30 -52 D
+2163 2668 M
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-136 -235 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-18 -32 D
+-13 -21 D
+-68 -117 D
 S
-2801 3049 M
--66 -115 D
--25 -41 D
--48 -84 D
--19 -31 D
--146 -251 D
--164 -282 D
--163 -282 D
--19 -31 D
--30 -52 D
+2451 2668 M
+-18 -32 D
+-13 -21 D
+-136 -235 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-111 -192 D
+-13 -21 D
+-12 -21 D
 S
-3132 3049 M
--121 -209 D
--25 -41 D
--127 -220 D
--19 -31 D
--66 -115 D
--19 -31 D
--60 -105 D
--19 -31 D
--66 -115 D
--19 -31 D
--72 -126 D
--25 -41 D
--42 -73 D
+2741 2668 M
+-93 -160 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-111 -192 D
+-13 -21 D
+-31 -53 D
 S
-3464 3049 M
--25 -41 D
--61 -105 D
--66 -115 D
--19 -31 D
--60 -105 D
--25 -41 D
--61 -105 D
--164 -282 D
--78 -136 D
--25 -41 D
--60 -105 D
--19 -31 D
--18 -31 D
+3031 2668 M
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-111 -192 D
+-13 -21 D
+-31 -53 D
 S
-3796 3049 M
--25 -41 D
--42 -74 D
--25 -41 D
--48 -84 D
+3321 2668 M
+-74 -128 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
 -19 -31 D
--60 -105 D
--19 -31 D
--60 -105 D
--25 -41 D
--139 -241 D
--25 -41 D
--60 -105 D
--19 -31 D
--66 -115 D
--19 -31 D
--30 -52 D
+-12 -22 D
+-13 -21 D
+-49 -85 D
 S
-4128 3049 M
--49 -83 D
--36 -63 D
--19 -31 D
--127 -220 D
--25 -41 D
--61 -105 D
--78 -136 D
--25 -41 D
--60 -105 D
--19 -31 D
--79 -136 D
--103 -177 D
+3612 2668 M
+-93 -160 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-111 -192 D
+-13 -21 D
+-31 -53 D
 S
-4460 3049 M
--109 -188 D
--25 -41 D
--48 -84 D
--19 -31 D
--60 -105 D
--19 -31 D
--60 -105 D
--25 -41 D
--61 -105 D
--78 -136 D
--25 -41 D
--60 -105 D
--19 -31 D
--72 -125 D
+3903 2668 M
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-136 -235 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-18 -32 D
+-13 -21 D
+-68 -117 D
 S
-4792 3049 M
--73 -125 D
--67 -115 D
--66 -115 D
--19 -31 D
--60 -105 D
--25 -41 D
--61 -105 D
--78 -136 D
--25 -41 D
--60 -105 D
--19 -31 D
--66 -115 D
--19 -31 D
--42 -73 D
+4193 2668 M
+-18 -32 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-111 -192 D
+-13 -21 D
+-12 -21 D
 S
-5125 3049 M
--25 -41 D
--48 -84 D
--19 -31 D
--127 -220 D
--19 -31 D
--60 -105 D
--25 -41 D
--60 -105 D
--19 -31 D
--66 -115 D
--19 -31 D
--158 -272 D
--36 -62 D
+4484 2668 M
+-130 -224 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-117 -202 D
 S
-5456 3049 M
--73 -125 D
--67 -115 D
--164 -282 D
--66 -115 D
--19 -31 D
--79 -136 D
--164 -282 D
--48 -83 D
+4774 2668 M
+-111 -192 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-136 -234 D
 S
-5788 3049 M
--49 -83 D
--115 -199 D
--25 -41 D
--54 -95 D
--25 -41 D
--146 -251 D
--157 -272 D
--25 -41 D
--79 -136 D
--6 -10 D
+5064 2668 M
+-111 -192 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-111 -192 D
+-13 -21 D
+-12 -21 D
 S
-6119 3049 M
--25 -41 D
--48 -84 D
--19 -31 D
--212 -366 D
--19 -31 D
--60 -105 D
--19 -31 D
--66 -115 D
--19 -31 D
--157 -272 D
--19 -31 D
--18 -31 D
+5354 2668 M
+-37 -64 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-136 -235 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-148 -256 D
+-7 -10 D
 S
-6449 3049 M
--25 -41 D
--48 -84 D
--19 -31 D
--60 -105 D
--19 -31 D
--133 -230 D
--19 -31 D
--145 -251 D
--19 -31 D
--157 -272 D
--19 -31 D
--18 -31 D
+5643 2668 M
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-136 -235 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-18 -32 D
+-13 -21 D
+-68 -117 D
 S
-6778 3049 M
--49 -83 D
--182 -314 D
--25 -41 D
--61 -105 D
--78 -136 D
--25 -41 D
--61 -105 D
--97 -167 D
--103 -177 D
+5930 2668 M
+-55 -96 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-18 -32 D
+-13 -21 D
+-68 -117 D
 S
-7106 3049 M
--49 -83 D
--36 -63 D
--19 -31 D
--127 -220 D
--25 -41 D
--61 -105 D
--78 -136 D
--25 -41 D
--60 -105 D
--19 -31 D
--79 -136 D
--103 -177 D
+6218 2668 M
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-43 -75 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-80 -139 D
+-13 -21 D
+-18 -32 D
+-13 -21 D
+-68 -117 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -4098 TM
+0 -3615 TM
 PSL_plot_completion /PSL_plot_completion {} def
 0 A
 FQ
 O0
-0 10 TM
+0 9 TM
 % PostScript produced by:
-%@GMT: gmt plot -Jm6.2992i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R-10/10/-5/5
+%@GMT: gmt plot -Jm5.5118i -Sv12p+s+e+p0.5p -Gred -W0.5p,- -BWenS -Bxaf -Byaf -Xa0i -Ya0i -R-10/10/-5/5
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_7
 0 setlinecap
@@ -1480,50 +1509,50 @@ O0
 3.32550952342 setmiterlimit
 /PSL_plot_completion {
 V
-0 10 T
-0 A 55 3714 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-274 F0
-(-30 deviation) tl Z
+0 9 T
+0 A 53 3245 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+265 F0
+(≠30 deviation) tl Z
 U
 }!
-9 W
+8 W
 0 A
-N 0 0 M 0 -69 D S
-N 0 3759 M 0 69 D S
-N 1890 0 M 0 -69 D S
-N 1890 3759 M 0 69 D S
-N 3780 0 M 0 -69 D S
-N 3780 3759 M 0 69 D S
-N 5669 0 M 0 -69 D S
-N 5669 3759 M 0 69 D S
-N 7559 0 M 0 -69 D S
-N 7559 3759 M 0 69 D S
-N 0 0 M -69 0 D S
-N 7559 0 M 69 0 D S
-N 0 1880 M -69 0 D S
-N 7559 1880 M 69 0 D S
-N 0 3759 M -69 0 D S
-N 7559 3759 M 69 0 D S
-PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
-0 -120 M 171 F0
-(10èW) tc Z
-1890 -120 M (5èW) tc Z
-3780 -120 M (0è) tc Z
-5669 -120 M (5èE) tc Z
-7559 -120 M (10èE) tc Z
+N 0 0 M 0 -66 D S
+N 0 3289 M 0 67 D S
+N 1654 0 M 0 -66 D S
+N 1654 3289 M 0 67 D S
+N 3307 0 M 0 -66 D S
+N 3307 3289 M 0 67 D S
+N 4961 0 M 0 -66 D S
+N 4961 3289 M 0 67 D S
+N 6614 0 M 0 -66 D S
+N 6614 3289 M 0 67 D S
+N 0 0 M -66 0 D S
+N 6614 0 M 67 0 D S
+N 0 1645 M -66 0 D S
+N 6614 1645 M 67 0 D S
+N 0 3289 M -66 0 D S
+N 6614 3289 M 67 0 D S
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+0 -116 M 166 F0
+(10∞W) tc Z
+1654 -116 M (5∞W) tc Z
+3307 -116 M (0∞) tc Z
+4961 -116 M (5∞E) tc Z
+6614 -116 M (10∞E) tc Z
 /PSL_AH1 0
--120 0 M (5èS) mr Z
-(5èS) sw mx
--120 1880 M (0è) mr Z
-(0è) sw mx
--120 3759 M (5èN) mr Z
-(5èN) sw mx
+-116 0 M (5∞S) mr Z
+(5∞S) sw mx
+-116 1645 M (0∞) mr Z
+(0∞) sw mx
+-116 3289 M (5∞N) mr Z
+(5∞N) sw mx
 def
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
 /PSL_vecheadpen {8 W 0 A [] 0 B} def
@@ -1533,9 +1562,9 @@ V
 {1 0 0 C} FS
 O1
 8 W
-V 378 1880 T N 0 0 M 6653 0 D S
+V 331 1645 T N 0 0 M 5803 0 D S
 U
-V 7181 1880 T PSL_vecheadpen
+V 6283 1645 T PSL_vecheadpen
 17 W
 0 0 M
 -200 54 D
@@ -1546,116 +1575,116 @@ U
 U
 PSL_cliprestore
 [] 0 B
-26 W
+25 W
 0 A
-51 W
+50 W
 1 A
-N -26 0 M 0 377 D S
-N 7585 0 M 0 377 D S
+N -25 0 M 0 330 D S
+N 6639 0 M 0 330 D S
 0 A
-N -26 377 M 0 376 D S
-N 7585 377 M 0 376 D S
+N -25 330 M 0 329 D S
+N 6639 330 M 0 329 D S
 1 A
-N -26 753 M 0 376 D S
-N 7585 753 M 0 376 D S
+N -25 659 M 0 328 D S
+N 6639 659 M 0 328 D S
 0 A
-N -26 1129 M 0 375 D S
-N 7585 1129 M 0 375 D S
+N -25 987 M 0 329 D S
+N 6639 987 M 0 329 D S
 1 A
-N -26 1504 M 0 376 D S
-N 7585 1504 M 0 376 D S
+N -25 1316 M 0 329 D S
+N 6639 1316 M 0 329 D S
 0 A
-N -26 1880 M 0 375 D S
-N 7585 1880 M 0 375 D S
+N -25 1645 M 0 328 D S
+N 6639 1645 M 0 328 D S
 1 A
-N -26 2255 M 0 376 D S
-N 7585 2255 M 0 376 D S
+N -25 1973 M 0 329 D S
+N 6639 1973 M 0 329 D S
 0 A
-N -26 2631 M 0 375 D S
-N 7585 2631 M 0 375 D S
+N -25 2302 M 0 329 D S
+N 6639 2302 M 0 329 D S
 1 A
-N -26 3006 M 0 376 D S
-N 7585 3006 M 0 376 D S
+N -25 2631 M 0 329 D S
+N 6639 2631 M 0 329 D S
 0 A
-N -26 3382 M 0 377 D S
-N 7585 3382 M 0 377 D S
-N 0 -26 M 378 0 D S
-N 0 3785 M 378 0 D S
+N -25 2960 M 0 329 D S
+N 6639 2960 M 0 329 D S
+N 0 -25 M 331 0 D S
+N 0 3314 M 331 0 D S
 1 A
-N 378 -26 M 378 0 D S
-N 378 3785 M 378 0 D S
+N 331 -25 M 330 0 D S
+N 331 3314 M 330 0 D S
 0 A
-N 756 -26 M 378 0 D S
-N 756 3785 M 378 0 D S
+N 661 -25 M 331 0 D S
+N 661 3314 M 331 0 D S
 1 A
-N 1134 -26 M 378 0 D S
-N 1134 3785 M 378 0 D S
+N 992 -25 M 331 0 D S
+N 992 3314 M 331 0 D S
 0 A
-N 1512 -26 M 378 0 D S
-N 1512 3785 M 378 0 D S
+N 1323 -25 M 331 0 D S
+N 1323 3314 M 331 0 D S
 1 A
-N 1890 -26 M 378 0 D S
-N 1890 3785 M 378 0 D S
+N 1654 -25 M 330 0 D S
+N 1654 3314 M 330 0 D S
 0 A
-N 2268 -26 M 378 0 D S
-N 2268 3785 M 378 0 D S
+N 1984 -25 M 331 0 D S
+N 1984 3314 M 331 0 D S
 1 A
-N 2646 -26 M 378 0 D S
-N 2646 3785 M 378 0 D S
+N 2315 -25 M 331 0 D S
+N 2315 3314 M 331 0 D S
 0 A
-N 3024 -26 M 378 0 D S
-N 3024 3785 M 378 0 D S
+N 2646 -25 M 330 0 D S
+N 2646 3314 M 330 0 D S
 1 A
-N 3402 -26 M 378 0 D S
-N 3402 3785 M 378 0 D S
+N 2976 -25 M 331 0 D S
+N 2976 3314 M 331 0 D S
 0 A
-N 3780 -26 M 377 0 D S
-N 3780 3785 M 377 0 D S
+N 3307 -25 M 331 0 D S
+N 3307 3314 M 331 0 D S
 1 A
-N 4157 -26 M 378 0 D S
-N 4157 3785 M 378 0 D S
+N 3638 -25 M 330 0 D S
+N 3638 3314 M 330 0 D S
 0 A
-N 4535 -26 M 378 0 D S
-N 4535 3785 M 378 0 D S
+N 3968 -25 M 331 0 D S
+N 3968 3314 M 331 0 D S
 1 A
-N 4913 -26 M 378 0 D S
-N 4913 3785 M 378 0 D S
+N 4299 -25 M 331 0 D S
+N 4299 3314 M 331 0 D S
 0 A
-N 5291 -26 M 378 0 D S
-N 5291 3785 M 378 0 D S
+N 4630 -25 M 331 0 D S
+N 4630 3314 M 331 0 D S
 1 A
-N 5669 -26 M 378 0 D S
-N 5669 3785 M 378 0 D S
+N 4961 -25 M 330 0 D S
+N 4961 3314 M 330 0 D S
 0 A
-N 6047 -26 M 378 0 D S
-N 6047 3785 M 378 0 D S
+N 5291 -25 M 331 0 D S
+N 5291 3314 M 331 0 D S
 1 A
-N 6425 -26 M 378 0 D S
-N 6425 3785 M 378 0 D S
+N 5622 -25 M 331 0 D S
+N 5622 3314 M 331 0 D S
 0 A
-N 6803 -26 M 378 0 D S
-N 6803 3785 M 378 0 D S
+N 5953 -25 M 330 0 D S
+N 5953 3314 M 330 0 D S
 1 A
-N 7181 -26 M 378 0 D S
-N 7181 3785 M 378 0 D S
+N 6283 -25 M 331 0 D S
+N 6283 3314 M 331 0 D S
 0 A
 5 W
-N -51 0 M 7661 0 D S
-N -51 -51 M 7661 0 D S
-N 7559 -51 M 0 3861 D S
-N 7610 -51 M 0 3861 D S
-N 7610 3759 M -7661 0 D S
-N 7610 3810 M -7661 0 D S
-N 0 3810 M 0 -3861 D S
-N -51 3810 M 0 -3861 D S
+N -50 0 M 6714 0 D S
+N -50 -50 M 6714 0 D S
+N 6614 -50 M 0 3389 D S
+N 6664 -50 M 0 3389 D S
+N 6664 3289 M -6714 0 D S
+N 6664 3339 M -6714 0 D S
+N 0 3339 M 0 -3389 D S
+N -50 3339 M 0 -3389 D S
 %%EndObject
-0 -10 TM
+0 -9 TM
 0 A
 FQ
 O0
-0 10 TM
+0 9 TM
 % PostScript produced by:
-%@GMT: gmt plot line.txt -W3p -Xa0i -Ya0i -R-10/10/-5/5 -Jm6.2992i
+%@GMT: gmt plot line.txt -W3p -Xa0i -Ya0i -R-10/10/-5/5 -Jm5.5118i
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_8
 0 setlinecap
@@ -1665,24 +1694,24 @@ V
 50 W
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
-1134 1880 M
-5291 0 D
+992 1645 M
+4630 0 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -10 TM
+0 -9 TM
 0 A
 FQ
 O0
-0 10 TM
+0 9 TM
 % PostScript produced by:
-%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya0i -R-10/10/-5/5 -Jm6.2992i
+%@GMT: gmt plot cross.txt -W1p -Xa0i -Ya0i -R-10/10/-5/5 -Jm5.5118i
 %@PROJ: merc -10.00000000 10.00000000 -5.00000000 5.00000000 -1113194.908 1113194.908 -553583.847 553583.847 +proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_9
 0 setlinecap
@@ -1692,437 +1721,510 @@ V
 17 W
 clipsave
 0 0 M
-7559 0 D
-0 3759 D
--7559 0 D
+6614 0 D
+0 3289 D
+-6614 0 D
 P
 PSL_clip N
-453 3049 M
-25 -41 D
-127 -220 D
-19 -31 D
-146 -251 D
-164 -282 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-66 -115 D
-19 -31 D
-60 -105 D
-25 -41 D
-54 -95 D
-25 -41 D
-48 -84 D
-19 -31 D
-42 -73 D
+397 2668 M
+18 -32 D
+13 -21 D
+136 -235 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+117 -203 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+19 -32 D
 S
-781 3050 M
-73 -126 D
-19 -31 D
-146 -251 D
-66 -115 D
-19 -31 D
-158 -272 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-66 -115 D
-19 -31 D
-60 -105 D
-25 -41 D
-48 -84 D
-19 -31 D
-61 -105 D
-60 -104 D
+684 2668 M
+18 -32 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+117 -203 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+112 -192 D
 S
-1111 3050 M
-66 -115 D
-73 -126 D
-19 -31 D
-60 -105 D
-25 -41 D
-54 -95 D
-25 -41 D
-60 -105 D
-19 -31 D
-66 -115 D
-19 -31 D
-158 -272 D
-78 -136 D
-25 -41 D
-158 -272 D
-164 -282 D
-145 -251 D
-25 -41 D
-48 -84 D
-19 -31 D
-54 -94 D
+972 2668 M
+18 -32 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+148 -256 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+19 -32 D
 S
-1441 3050 M
-66 -115 D
-73 -126 D
+1260 2668 M
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+148 -256 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
 19 -31 D
-60 -105 D
-25 -41 D
-54 -95 D
-25 -41 D
-60 -105 D
-19 -31 D
-66 -115 D
-19 -31 D
-158 -272 D
-78 -136 D
-25 -41 D
-158 -272 D
-164 -282 D
-145 -251 D
-25 -41 D
-48 -84 D
-19 -31 D
-54 -94 D
+12 -22 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+74 -128 D
 S
-1771 3050 M
-85 -147 D
+1550 2668 M
+74 -128 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
 19 -31 D
-133 -230 D
-19 -31 D
-60 -105 D
-19 -31 D
-79 -136 D
-157 -272 D
-25 -41 D
-60 -105 D
-25 -41 D
-60 -105 D
-19 -31 D
-72 -126 D
-25 -41 D
-60 -105 D
-19 -31 D
-60 -105 D
-25 -41 D
-60 -105 D
-19 -31 D
-67 -115 D
-66 -115 D
-19 -31 D
-109 -188 D
+12 -22 D
+13 -21 D
+24 -43 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+43 -75 D
+13 -21 D
 S
-2103 3050 M
-54 -95 D
-25 -41 D
-48 -84 D
-19 -31 D
-60 -105 D
-19 -31 D
-60 -105 D
-25 -41 D
-61 -105 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-66 -115 D
-19 -31 D
-72 -126 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-164 -282 D
-66 -115 D
-19 -31 D
-60 -105 D
-25 -41 D
-61 -105 D
-67 -115 D
-6 -10 D
+1840 2668 M
+74 -128 D
+13 -21 D
+136 -235 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+148 -256 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+56 -96 D
 S
-2435 3050 M
-60 -105 D
-19 -31 D
-60 -105 D
-19 -31 D
-146 -251 D
-157 -272 D
-25 -41 D
-60 -105 D
-19 -31 D
-66 -115 D
-19 -31 D
-72 -126 D
-25 -41 D
-60 -105 D
-19 -31 D
-66 -115 D
-19 -31 D
-145 -251 D
-19 -31 D
-60 -105 D
-19 -31 D
-60 -105 D
-25 -41 D
-48 -84 D
-19 -31 D
-48 -84 D
-7 -10 D
+2130 2668 M
+93 -160 D
+13 -21 D
+136 -235 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+148 -256 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+37 -64 D
 S
-2767 3050 M
-61 -105 D
-60 -105 D
-25 -41 D
-212 -366 D
+2421 2668 M
+74 -128 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
 19 -31 D
-158 -272 D
-84 -146 D
-19 -31 D
-158 -272 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-66 -115 D
-19 -31 D
-127 -220 D
-25 -41 D
-48 -84 D
-19 -31 D
+12 -22 D
+13 -21 D
+117 -203 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+136 -235 D
+13 -21 D
+43 -75 D
+13 -21 D
 S
-3099 3050 M
-97 -168 D
-19 -31 D
-60 -105 D
-25 -41 D
-225 -387 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-66 -115 D
-19 -31 D
-72 -126 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-66 -115 D
-19 -31 D
-60 -105 D
-25 -41 D
-61 -105 D
-66 -115 D
-19 -31 D
-97 -167 D
+2712 2668 M
+18 -32 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+148 -256 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+19 -32 D
 S
-3431 3050 M
-73 -126 D
+3003 2668 M
+55 -96 D
+13 -21 D
+136 -235 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+18 -32 D
+13 -21 D
+117 -203 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
 19 -31 D
-146 -251 D
-66 -115 D
-19 -31 D
-158 -272 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-66 -115 D
-19 -31 D
-60 -105 D
-25 -41 D
-48 -84 D
-19 -31 D
-61 -105 D
-60 -104 D
+12 -22 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+74 -128 D
 S
-3764 3050 M
-60 -105 D
-19 -31 D
-61 -105 D
-164 -282 D
-66 -115 D
-19 -31 D
-79 -136 D
-163 -282 D
-19 -31 D
-79 -136 D
-157 -272 D
-25 -41 D
-60 -105 D
-19 -31 D
-66 -115 D
-19 -31 D
-60 -105 D
-19 -31 D
-67 -115 D
-60 -105 D
-25 -41 D
-48 -84 D
-7 -10 D
+3293 2668 M
+37 -64 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+117 -203 D
+13 -21 D
+80 -139 D
+13 -21 D
+18 -32 D
+13 -21 D
+80 -139 D
+13 -21 D
+136 -235 D
+13 -21 D
+43 -75 D
+13 -21 D
+37 -64 D
 S
-4095 3050 M
-219 -377 D
-25 -41 D
-60 -105 D
+3584 2668 M
+55 -96 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+18 -32 D
+13 -21 D
+80 -139 D
+13 -21 D
+24 -43 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
 19 -31 D
-60 -105 D
-19 -31 D
-66 -115 D
-19 -31 D
-157 -272 D
-19 -31 D
-66 -115 D
-19 -31 D
-158 -272 D
-78 -136 D
-25 -41 D
-61 -105 D
-151 -261 D
-19 -31 D
-61 -105 D
-60 -104 D
+12 -22 D
+13 -21 D
+80 -139 D
+13 -21 D
+136 -235 D
+13 -21 D
+43 -75 D
+13 -21 D
+18 -32 D
 S
-4427 3050 M
-42 -74 D
-25 -41 D
-61 -105 D
-67 -115 D
-157 -272 D
-25 -41 D
-60 -105 D
+3874 2668 M
+55 -96 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+18 -32 D
+13 -21 D
+117 -203 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
 19 -31 D
-66 -115 D
-19 -31 D
-79 -136 D
-163 -282 D
-19 -31 D
-158 -272 D
-151 -261 D
-19 -31 D
-60 -105 D
-19 -31 D
-127 -220 D
-25 -41 D
+12 -22 D
+13 -21 D
+80 -139 D
+13 -21 D
+136 -235 D
+13 -21 D
+43 -75 D
+13 -21 D
+18 -32 D
 S
-4758 3050 M
-54 -95 D
-25 -41 D
-48 -84 D
+4163 2668 M
+74 -128 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
 19 -31 D
-60 -105 D
-19 -31 D
-60 -105 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-164 -282 D
-78 -136 D
-25 -41 D
-151 -262 D
-25 -41 D
-60 -105 D
-19 -31 D
-60 -105 D
-25 -41 D
-146 -251 D
-60 -105 D
-25 -41 D
-49 -84 D
-6 -10 D
+12 -22 D
+13 -21 D
+80 -139 D
+13 -21 D
+24 -43 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
 S
-5088 3050 M
-54 -95 D
-25 -41 D
-48 -84 D
-19 -31 D
-60 -105 D
-19 -31 D
-60 -105 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-164 -282 D
-78 -136 D
-25 -41 D
-151 -262 D
-25 -41 D
-139 -241 D
-25 -41 D
-127 -220 D
-25 -41 D
-54 -95 D
-25 -41 D
-49 -84 D
-6 -10 D
+4452 2668 M
+18 -32 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+148 -256 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+19 -32 D
 S
-5417 3050 M
-61 -105 D
-60 -105 D
-25 -41 D
-225 -387 D
-163 -282 D
-19 -31 D
-66 -115 D
-19 -31 D
-158 -272 D
-97 -167 D
-66 -115 D
-19 -31 D
-79 -136 D
-66 -115 D
-19 -31 D
-146 -251 D
-54 -94 D
-19 -31 D
+4740 2668 M
+18 -32 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+24 -43 D
+13 -21 D
+18 -32 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+136 -235 D
+13 -21 D
+18 -32 D
 S
-5745 3050 M
-61 -105 D
-60 -105 D
-25 -41 D
-212 -366 D
-19 -31 D
-158 -272 D
-84 -146 D
-19 -31 D
-158 -272 D
-78 -136 D
-25 -41 D
-60 -105 D
-19 -31 D
-79 -136 D
-66 -115 D
-19 -31 D
-127 -220 D
-25 -41 D
-48 -84 D
-19 -31 D
+5027 2668 M
+18 -32 D
+13 -21 D
+80 -139 D
+13 -21 D
+43 -75 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+55 -96 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+80 -139 D
+13 -21 D
+111 -192 D
+13 -21 D
+80 -139 D
+13 -21 D
+136 -235 D
+13 -21 D
+19 -32 D
 S
 PSL_cliprestore
 U
 %%EndObject
-0 -10 TM
+0 -9 TM
 PSL_plot_completion /PSL_plot_completion {} def
 grestore
 PSL_movie_label_completion /PSL_movie_label_completion {} def

--- a/test/grdtrack/crosstrack_geo.sh
+++ b/test/grdtrack/crosstrack_geo.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test non-orthogonal modifier +d in -C for grdtrack, geographic version
-g# Also try +l for left-side only
-mt begin crosstrack_geo png
+# Also try +l for left-side only
+gmt begin crosstrack_geo
 	# Fake geographic grid
 	gmt grdmath -R-10/10/-5/5 -I0.1 -fg X Y MUL = geo.grd
 	gmt subplot begin 3x1 -Fs16c/8c -Sc -Srl -A -T"Geographic cross-tracks"

--- a/test/grdtrack/crosstrack_geo.sh
+++ b/test/grdtrack/crosstrack_geo.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Test non-orthogonal modifier +d in -C for grdtrack, geographic version
 # Also try +l for left-side only
-gmt begin crosstrack_geo
+gmt begin crosstrack_geo ps
 	# Fake geographic grid
+	gmt set PS_MEDIA letter
 	gmt grdmath -R-10/10/-5/5 -I0.1 -fg X Y MUL = geo.grd
-	gmt subplot begin 3x1 -Fs16c/8c -Sc -Srl -A -T"Geographic cross-tracks"
+	gmt subplot begin 3x1 -Fs14c/7c -Sc -Srl -A -T"Geographic cross-tracks"
 		gmt subplot set 0 -A"No deviation"
 		# Sample it along profiles orthogonal to the line y = 0
 		gmt grdtrack -Ggeo.grd -C800k/50k/100k -E-7/0/7/0 -Dline.txt > cross.txt

--- a/test/grdtrack/crosstrack_geo.sh
+++ b/test/grdtrack/crosstrack_geo.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Test non-orthogonal modifier +d in -C for grdtrack, geographic version
+g# Also try +l for left-side only
+mt begin crosstrack_geo png
+	# Fake geographic grid
+	gmt grdmath -R-10/10/-5/5 -I0.1 -fg X Y MUL = geo.grd
+	gmt subplot begin 3x1 -Fs16c/8c -Sc -Srl -A -T"Geographic cross-tracks"
+		gmt subplot set 0 -A"No deviation"
+		# Sample it along profiles orthogonal to the line y = 0
+		gmt grdtrack -Ggeo.grd -C800k/50k/100k -E-7/0/7/0 -Dline.txt > cross.txt
+		# Plot it
+		echo -9 0 9 0 | gmt plot -Jm? -Sv12p+s+e+p0.5p -Gred -W0.5p,-
+		gmt plot line.txt -W3p
+		gmt plot cross.txt -W1p
+		gmt subplot set 1 -A"+30 deviation, left-side only"
+		# Sample it along profiles with 30 degree deviation to the line y = 0
+		gmt grdtrack -Ggeo.grd -C800k/50k/100k+d30+l -E-7/0/7/0 -Dline.txt > cross.txt
+		# Plot it
+		echo -9 0 9 0 | gmt plot -Jm? -Sv12p+s+e+p0.5p -Gred -W0.5p,-
+		gmt plot line.txt -W3p
+		gmt plot cross.txt -W1p
+		# Sample it along profiles with -30 degree deviation to the line y = 0
+		gmt subplot set 2 -A"-30 deviation"
+		gmt grdtrack -Ggeo.grd -C800k/50k/100k+d-30 -E-7/0/7/0 -Dline.txt > cross.txt
+		# Plot it
+		echo -9 0 9 0 | gmt plot -Jm? -Sv12p+s+e+p0.5p -Gred -W0.5p,-
+		gmt plot line.txt -W3p
+		gmt plot cross.txt -W1p
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
See #5718 for background.  This PR adds **-C** modifier **+d** to set a _deviation_ of tracks from being strictly orthogonal.  As the documentation explains, the sense of the deviation is such that when you look in the direction of the input track, a positive deviation will rotate the cross-tracks by that amount in the clockwise direction.  I have added to tests to ensure this all works for both Cartesian and geographic geometries.
I also found that the **+l**|**r** modifiers for Cartesian (only do the left or right half of the profiles) had things backwards - now fixed.
Hopefully @chhei can take this branch for a spin to ensure it works as he expects.