### PR TITLE
Clean up aspects of SVD function usage in GMT

### DIFF
--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt greenspline** [ *table* ]
 |-G|\ *grdfile*
 [ |-A|\ *gradfile*\ **+f**\ **1**\|\ **2**\|\ **3**\|\ **4**\|\ **5** ]
-[ |-C|\ [[**n**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**] ]
+[ |-C|\ [[**n**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**][**+n**] ]
 [ |SYN_OPT-D3| ]
 [ |-E|\ [*misfitfile*] ]
 [ |-I|\ *xinc*\ [/*yinc*\ [/*zinc*]] ]
@@ -142,14 +142,14 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [[**n**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**]
+**-C**\ [[**n**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**][**+n**]
     Find an approximate surface fit: Solve the linear system for the
     spline coefficients by SVD and eliminate the contribution from all
     eigenvalues whose ratio to the largest eigenvalue is less than *value*
     [Default uses Gauss-Jordan elimination to solve the linear system
     and fit the data exactly]. Optionally, append **+f**\ *file* to save the
     eigenvalues to the specified file for further analysis.
-    If a negative *value* is given then **+f**\ *file* is required and
+    If **+n** is given then **+f**\ *file* is also required and
     execution will stop after saving the eigenvalues, i.e., no surface
     output is produced.  Specify **-Cn**\ *value* to retain only the *value* largest
     eigenvalues; append % if *value* is the *percentage* of eigenvalues
@@ -436,7 +436,7 @@ Considerations
 
 #. The inversion for coefficients can become numerically unstable when
    data neighbors are very close compared to the overall span of the data.
-   You can remedy this by pre-processing the data, e.g., by averaging
+   You can remedy this by preprocessing the data, e.g., by averaging
    closely spaced neighbors. Alternatively, you can improve stability by
    using the SVD solution and discard information associated with the
    smallest eigenvalues (see **-C**).

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt gpsgridder** [ *table* ]
 |-G|\ *outfile*
-[ |-C|\ [**n**]\ *value*\ [**+f**\ *file*] ]
+[ |-C|\ [[**n**]\ *value*\ [%]][**+f**\ *file*][**+n**] ]
 [ |-E|\ [*misfitfile*] ]
 [ |-F|\ [**d**\|\ **f**]\ *fudge* ]
 [ |SYN_OPT-I| ]
@@ -77,18 +77,18 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [**n**]\ *value*\ [**+f**\ *file*]
+**-C**\ [[**n**]\ *value*\ [%]][**+f**\ *file*][**+n**]
     Find an approximate surface fit: Solve the linear system for the
     spline coefficients by SVD and eliminate the contribution from all
     eigenvalues whose ratio to the largest eigenvalue is less than *value*
     [Default uses Gauss-Jordan elimination to solve the linear system
-    and fit the data exactly]. If *value* is in 0–1 range the we assume
-    it is the fraction of eigenvalues to keep.  Optionally, append **+f**\ *file* to save the
+    and fit the data exactly]. Append % if *value* is the *percentage* of eigenvalues
+    to use instead.  Optionally, append **+f**\ *file* to save the
     eigenvalue ratios to the specified file for further analysis.
-    If a negative *value* is given then **+f**\ *file* is required and
+    If **+n** is given then **+f**\ *file* is also required and
     execution will stop after saving the eigenvalues, i.e., no surface
     output is produced.  Specify **-Cn**\ *value* to retain only the *value* largest eigenvalues.
-    **Note**: 1/4 of the total number of data constraints is a good starting point
+    **Note**: ~25% of the total number of data constraints is a good starting point
     for further experiments.
 
 .. _-E:

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt gpsgridder** [ *table* ]
 |-G|\ *outfile*
-[ |-C|\ [[**n**]\ *value*\ [%]][**+f**\ *file*][**+n**] ]
+[ |-C|\ [[**n**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**][**+n**] ]
 [ |-E|\ [*misfitfile*] ]
 [ |-F|\ [**d**\|\ **f**]\ *fudge* ]
 [ |SYN_OPT-I| ]
@@ -76,20 +76,6 @@ Optional Arguments
 ------------------
 
 .. _-C:
-
-**-C**\ [[**n**]\ *value*\ [%]][**+f**\ *file*][**+n**]
-    Find an approximate surface fit: Solve the linear system for the
-    spline coefficients by SVD and eliminate the contribution from all
-    eigenvalues whose ratio to the largest eigenvalue is less than *value*
-    [Default uses Gauss-Jordan elimination to solve the linear system
-    and fit the data exactly]. Append % if *value* is the *percentage* of eigenvalues
-    to use instead.  Optionally, append **+f**\ *file* to save the
-    eigenvalue ratios to the specified file for further analysis.
-    If **+n** is given then **+f**\ *file* is also required and
-    execution will stop after saving the eigenvalues, i.e., no surface
-    output is produced.  Specify **-Cn**\ *value* to retain only the *value* largest eigenvalues.
-    **Note**: ~25% of the total number of data constraints is a good starting point
-    for further experiments.
 
 **-C**\ [[**n**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**][**+n**]
     Find an approximate surface fit: Solve the linear system for the

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -91,6 +91,26 @@ Optional Arguments
     **Note**: ~25% of the total number of data constraints is a good starting point
     for further experiments.
 
+**-C**\ [[**n**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**][**+n**]
+    Find an approximate surface fit: Solve the linear system for the
+    spline coefficients by SVD and eliminate the contribution from all
+    eigenvalues whose ratio to the largest eigenvalue is less than *value*
+    [Default uses Gauss-Jordan elimination to solve the linear system
+    and fit the data exactly]. Optionally, append **+f**\ *file* to save the
+    eigenvalues to the specified file for further analysis.
+    If **+n** is given then **+f**\ *file* is also required and
+    execution will stop after saving the eigenvalues, i.e., no surface
+    output is produced.  Specify **-Cn**\ *value* to retain only the *value*
+    largest eigenvalues; append % if *value* is the *percentage* of eigenvalues
+    to use instead.  The two other modifiers (**+c** and **i**) can be used to
+    write intermediate grids, two (*u* and *v*) per eigenvalue, and we will
+    automatically insert "_cum_###" or "_inc_###" before the file extension,
+    using a fixed integer format for the eigenvalue number starting at 0.  The
+    **+i** modifier will write the **i**\ ncremental contributions to the grids
+    for each eigenvalue, while **+c** will instead produce the **c**\ umulative
+    sum of these contributions. Use both modifiers to write both types of
+    intermediate grids.
+
 .. _-E:
 
 **-E**\ [*misfitfile*]

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -60,17 +60,15 @@ Required Arguments
 .. _-G:
 
 **-G**\ *outfile*
-    Name of resulting output file. (1) If options **-R**, **-I**, and
+    Name of resulting output file(s). (1) If options **-R**, **-I**, and
     possibly **-r** are set we produce two equidistant output grids. In
-    this case, *outfile* must be a name template containing the C format
-    specifier %s, which will be replaced with u and v, respectively.
+    this case, we take *outfile* and append "_u" and "_v" before the extension, respectively.
     (2) If option **-T** is selected then **-R**, **-I** cannot be given
-    as the *maskgrid* determines the region and increments. Again, the
-    *outfile* must be a name template for the two output grids.
+    as the *maskgrid* determines the region and increments. The two output
+    filenames are generated as under (1).
     (3) If **-N** is selected then the output is a single ASCII (or binary; see
     **-bo**) table written to *outfile*; if **-G** is not given then
-    this table is written to standard output. The **-G** option is ignored
-    if **-C** or **-C**\ 0 is given.
+    this table is written to standard output.
 
 Optional Arguments
 ------------------

--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -39,8 +39,9 @@
 /* Control structure for gpsgridder */
 
 struct GPSGRIDDER_CTRL {
-	struct GPSGRIDDER_C {	/* -C[n]<cutoff>[+f<file>] */
+	struct GPSGRIDDER_C {	/* -C[[n]<cutoff>[%]][+f<file>][+n] */
 		bool active;
+		bool dryrun;	/* Only report eigenvalues */
 		unsigned int movie;	/* Undocumented and not-yet-working movie mode +m incremental grids, +M total grids vs eigenvalue */
 		unsigned int mode;
 		double value;
@@ -85,33 +86,46 @@ struct GPSGRIDDER_CTRL {
 };
 
 enum Gpsgridded_enum {	/* Indices for coeff array for normalization */
-	GSP_MEAN_X	= 0,
-	GSP_MEAN_Y	= 1,
-	GSP_MEAN_U	= 2,
-	GSP_MEAN_V	= 3,
-	GSP_SLP_UX	= 4,
-	GSP_SLP_UY	= 5,
-	GSP_SLP_VX	= 6,
-	GSP_SLP_VY	= 7,
-	GSP_RANGE_U	= 8,
-	GSP_RANGE_V	= 9,
-	GSP_LENGTH	= 10,
-	GMT_U		= 2,	/* Index into input/output rows */
-	GMT_V		= 3,
-	GMT_WU		= 2,	/* Index into X row vector with x,y[,du,dv] */
-	GMT_WV		= 3,
-	GPS_TREND	= 1,	/* Remove/Restore linear trend */
-	GPS_NORM	= 2,	/* Normalize residual data to 0-1 range */
-	GPS_FUNC_Q	= 0,	/* Next 3 are indices into G[] */
-	GPS_FUNC_P	= 1,	/* Next 3 are indices into G[] */
-	GPS_FUNC_W	= 2,	/* Next 3 are indices into G[] */
-	GPS_TOP_N   = 1,	/* Modes for -C */
-	GPS_FUDGE_R = 1,	/* Modes for -F */
-	GPS_FUDGE_F = 2,
-	GPS_GOT_SIG = 0,	/* Modes for -W */
-	GPS_GOT_W   = 1,
-	GPS_MISFIT  = 1,	/* Modes for -E */
+	GPSGRIDDER_MEAN_X		= 0,
+	GPSGRIDDER_MEAN_Y		= 1,
+	GPSGRIDDER_MEAN_U		= 2,
+	GPSGRIDDER_MEAN_V		= 3,
+	GPSGRIDDER_SLP_UX		= 4,
+	GPSGRIDDER_SLP_UY		= 5,
+	GPSGRIDDER_SLP_VX		= 6,
+	GPSGRIDDER_SLP_VY		= 7,
+	GPSGRIDDER_RANGE_U		= 8,
+	GPSGRIDDER_RANGE_V		= 9,
+	GPSGRIDDER_LENGTH		= 10,
+	GPSGRIDDER_U			= 2,	/* Index into input/output rows */
+	GPSGRIDDER_V			= 3,
+	GPSGRIDDER_WU			= 2,	/* Index into X row vector with x,y[,du,dv] */
+	GPSGRIDDER_WV			= 3,
+	GPSGRIDDER_TREND		= 1,	/* Remove/Restore linear trend */
+	GPSGRIDDER_NORM			= 2,	/* Normalize residual data to 0-1 range */
+	GPSGRIDDER_FUNC_Q		= 0,	/* Next 3 are indices into G[] */
+	GPSGRIDDER_FUNC_P		= 1,	/* Next 3 are indices into G[] */
+	GPSGRIDDER_FUNC_W		= 2,	/* Next 3 are indices into G[] */
+	GPSGRIDDER_FUDGE_R		= 1,	/* Modes for -F */
+	GPSGRIDDER_FUDGE_F		= 2,
+	GPSGRIDDER_GOT_SIG		= 0,	/* Modes for -W */
+	GPSGRIDDER_GOT_W		= 1,
+	GPSGRIDDER_MISFIT		= 1,	/* Modes for -E */
+	GPSGRIDDER_NO_MOVIE		= 0,
+	GPSGRIDDER_INC_MOVIE	= 1,
+	GPSGRIDDER_CUM_MOVIE	= 2
 };
+
+GMT_LOCAL void gpsgridder_set_filename (char *name, unsigned int k, unsigned int width, unsigned int mode, unsigned int comp, char *file) {
+	/* Turn name, eigenvalue number k, precision width, mode and comp into a filename, e.g.,
+	 * ("solution.grd", 33, 3, GPSGRIDDER_INC_MOVIE, 1, file) will give solution_v_inc_033.grd */
+	unsigned int s = strlen (name) - 1;
+	static char *type[3] = {"", "inc", "cum"}, *uv = {"u", "v"};
+	while (name[s] != '.') s--;	/* Wind backwards to start of extension */
+	name[s] = '\0';	/* Temporarily chop off extension */
+	sprintf (file, "%s_%s_%s_%*.*d.%s", name, uv[comp], type[mode], width, width, k, &name[s+1]);
+	name[s] = '.';	/* Restore original name */
+}
 
 static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
 	struct GPSGRIDDER_CTRL *C;
@@ -136,7 +150,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *C) {	/* Dea
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<table>] -G<outfile> [-C[n]<val>[+f<file>]] [-E<misfitfile>] [-Fd|f<val>] [-I<dx>[/<dy>] "
+	GMT_Usage (API, 0, "usage: %s [<table>] -G<outfile> [-C[[n]<val>[%%]][+f<file>][+n]] [-E<misfitfile>] [-Fd|f<val>] [-I<dx>[/<dy>] "
 		"[-L] [-N<nodefile>] [%s] [-S<nu>] [-T<maskgrid>] [%s] [-W[+s|w]] [%s] [%s] [%s] [%s] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s]%s[%s] [%s]\n", name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_d_OPT, GMT_e_OPT,
 		GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_n_OPT, GMT_o_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_x_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -159,14 +173,14 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"contain the format specifier \"%%s\" which will be replaced with u or v.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 
-	GMT_Usage (API, 1, "\n-C[n]<val>[+f<file>]");
+	GMT_Usage (API, 1, "\n-C[[n]<val>[%%]][+f<file>][+n]");
 	GMT_Usage (API, -2, "Solve by SVD and eliminate eigenvalues whose ratio to largest eigenvalue is less than <val> [0]. "
-		"Optionally append +f<filename> to save the eigenvalues to this file. "
-		"A negative cutoff will stop execution after saving the eigenvalues. "
-		"Use -C<val> to select only the largest <val> eigenvalues [all]. "
-		"If <val> is in 0-1 range we assume it is the fraction of eigenvalues to use. "
-		"Note: ~1/4 of the total number of data constraints is a good starting point "
+		"Use -Cn to select only the largest <val> eigenvalues [all]. "
+		"Use <val>%% to select a percentage of the eigenvalues instead [100] "
 		"[Default uses Gauss-Jordan elimination to solve the linear system].");
+	GMT_Usage (API, 3, "+f Save the eigenvalues to <filename>.");
+	GMT_Usage (API, 3, "+n Stop execution after reporting the eigenvalues - no solution is computed.");
+	GMT_Usage (API, -2, "Note: ~25%% of the total number of data constraints is a good starting point.");
 	GMT_Usage (API, 1, "\n-E[<misfitfile>]");
 	GMT_Usage (API, -2, "Evaluate spline at input locations and report statistics on the misfit. "
 		"If <misfitfile> is given then we write individual location misfits to that file.");
@@ -227,42 +241,62 @@ static int parse (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *Ctrl, struct GMT
 
 			case 'C':	/* Solve by SVD */
 				Ctrl->C.active = true;
-				if (opt->arg[0] == 'n') Ctrl->C.mode = GPS_TOP_N;
+				if (opt->arg[0] == 'n') Ctrl->C.mode = GMT_SVD_EIGEN_NUMBER_CUTOFF;
 				k = (Ctrl->C.mode) ? 1 : 0;
-				if (gmt_get_modifier (opt->arg, 'f', p))
-					Ctrl->C.file = strdup (p);
-				if (gmt_get_modifier (opt->arg, 'm', p))
-					Ctrl->C.movie = 1;
-				else if (gmt_get_modifier (opt->arg, 'M', p))
-					Ctrl->C.movie = 2;
+				if ((c = gmt_first_modifier (GMT, opt->arg, "cifmMn"))) {	/* Process any modifiers */
+					pos = 0;	/* Reset to start of new word */
+					while (gmt_getmodopt (GMT, 'C', c, "cifmMn", &pos, p, &n_errors) && n_errors == 0) {
+						switch (p[0]) {
+							case 'c': Ctrl->C.movie |= GPSGRIDDER_CUM_MOVIE; break;
+							case 'i': Ctrl->C.movie |= GPSGRIDDER_INC_MOVIE; break;
+							case 'f': Ctrl->C.file = strdup (&p[1]); break;
+							case 'm': Ctrl->C.movie = GPSGRIDDER_INC_MOVIE; break;
+							case 'M': Ctrl->C.movie = GPSGRIDDER_CUM_MOVIE; break;
+							case 'n': Ctrl->C.dryrun = true; break;
+							default: break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
+						}
+					}
+					c[0] = '\0';
+				}				
 				if (strchr (opt->arg, '/')) {	/* Old-style file specification */
 					if (gmt_M_compat_check (API->GMT, 5)) {	/* OK */
 						sscanf (&opt->arg[k], "%lf/%s", &Ctrl->C.value, p);
 						Ctrl->C.file = strdup (p);
 					}
 					else {
-						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Expected -C[n]<val>[+f<file>]\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Expected -C[[n]<cut>[%]][+f<file>][+n]\n");
 						n_errors++;
 					}
 				}
-				else
-					Ctrl->C.value = (opt->arg[k]) ? atof (&opt->arg[k]) : 0.0;
+				else if (opt->arg[k]) {	/* See if we got any value argument */
+					if (strchr (opt->arg, '%')) {	/* Got percentages of largest eigenvalues */
+						Ctrl->C.value = 0.01 * atof (&opt->arg[k]);
+						Ctrl->C.mode = GMT_SVD_EIGEN_PERCENT_CUTOFF;
+						if (Ctrl->C.value < 0.0 || Ctrl->C.value > 1.0) {
+							GMT_Report (API, GMT_MSG_ERROR, "Option -C: Percentage must be in 0-100%% range!\n");
+							n_errors++;
+						}
+					}
+					else	/* Got ratio cutoff */
+						Ctrl->C.value = atof (&opt->arg[k]);
+				}
+				if (Ctrl->C.value < 0.0) Ctrl->C.dryrun = true, Ctrl->C.value = 0.0;	/* Deprecated syntax */
 				break;
 			case 'E':	/* Evaluate misfit -E[<file>]*/
 				Ctrl->E.active = true;
 				if (opt->arg[0]) {
 					Ctrl->E.file = strdup (opt->arg);
-					Ctrl->E.mode = GPS_MISFIT;
+					Ctrl->E.mode = GPSGRIDDER_MISFIT;
 				}
 				break;
 			case 'F':	/* Fudge factor  */
 				Ctrl->F.active = true;
 				if (opt->arg[0] == 'd') {	/* Specify the delta radius in user units */
-					Ctrl->F.mode = GPS_FUDGE_R;
+					Ctrl->F.mode = GPSGRIDDER_FUDGE_R;
 					Ctrl->F.fudge = atof (&opt->arg[1]);
 				}
 				else if (opt->arg[0] == 'f') {	/* Specify factor used with r_min to set delta radius */
-					Ctrl->F.mode = GPS_FUDGE_F;
+					Ctrl->F.mode = GPSGRIDDER_FUDGE_F;
 					Ctrl->F.fudge = atof (&opt->arg[1]);
 				}
 				else {
@@ -310,11 +344,11 @@ static int parse (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *Ctrl, struct GMT
 			case 'W':	/* Expect data weights in last two columns */
 				Ctrl->W.active = true;
 				if (opt->arg[0] == 'w')	/* Deprecated syntax -Ww */
-					Ctrl->W.mode = GPS_GOT_W;	/* Got weights instead of sigmas */
+					Ctrl->W.mode = GPSGRIDDER_GOT_W;	/* Got weights instead of sigmas */
 				else if (strstr (opt->arg, "+w"))
-					Ctrl->W.mode = GPS_GOT_W;	/* Got weights instead of sigmas */
+					Ctrl->W.mode = GPSGRIDDER_GOT_W;	/* Got weights instead of sigmas */
 				else if (opt->arg[0] == '\0' || strstr (opt->arg, "+s"))
-					Ctrl->W.mode = GPS_GOT_SIG;	/* Got sigmas instead of weights [Default] */
+					Ctrl->W.mode = GPSGRIDDER_GOT_SIG;	/* Got sigmas instead of weights [Default] */
 				break;
 #ifdef DEBUG
 			case 'Z':	/* Dump matrices */
@@ -329,7 +363,7 @@ static int parse (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *Ctrl, struct GMT
 
 	n_errors += gmt_M_check_condition (GMT, !(GMT->common.R.active[RSET] || Ctrl->N.active || Ctrl->T.active), "No output locations specified (use either [-R -I], -N, or -T)\n");
 	n_errors += gmt_check_binary_io (GMT, 4 + 2*Ctrl->W.active);
-	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->C.value < 0.0 && !Ctrl->C.file, "Option -C: Must specify file name for eigenvalues if cut < 0\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->C.dryrun && !Ctrl->C.file, "Option -C: Must specify file name for eigenvalues if cut < 0\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->T.active && !Ctrl->T.file, "Option -T: Must specify mask grid file name\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && !Ctrl->N.file, "Option -N: Must specify node file name\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && Ctrl->N.file && gmt_access (GMT, Ctrl->N.file, R_OK), "Option -N: Cannot read file %s!\n", Ctrl->N.file);
@@ -342,23 +376,23 @@ static int parse (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *Ctrl, struct GMT
 
 /* GENERAL NUMERICAL FUNCTIONS */
 
-/* Normalization parameters are stored in the coeff array which holds up to GSP_LENGTH terms:
- * coeff[GSP_MEAN_X]:	The mean x coordinate
- * coeff[GSP_MEAN_Y]:	The mean y coordinate
- * coeff[GSP_MEAN_U]:	The mean u observation
- * coeff[GSP_MEAN_V]:	The mean v observation
- * coeff[GSP_SLP_UX]:	The linear x-slope for u
- * coeff[GSP_SLP_UY]:	The linear y-slope for u
- * coeff[GSP_SLP_VX]:	The linear x-slope for v
- * coeff[GSP_SLP_VY]:	The linear y-slope for v
- * coeff[GSP_RANGE_U]:	The largest |range| of the detrended u data
- * coeff[GSP_RANGE_V]:	The largest |range| of the detrended v data
+/* Normalization parameters are stored in the coeff array which holds up to GPSGRIDDER_LENGTH terms:
+ * coeff[GPSGRIDDER_MEAN_X]:	The mean x coordinate
+ * coeff[GPSGRIDDER_MEAN_Y]:	The mean y coordinate
+ * coeff[GPSGRIDDER_MEAN_U]:	The mean u observation
+ * coeff[GPSGRIDDER_MEAN_V]:	The mean v observation
+ * coeff[GPSGRIDDER_SLP_UX]:	The linear x-slope for u
+ * coeff[GPSGRIDDER_SLP_UY]:	The linear y-slope for u
+ * coeff[GPSGRIDDER_SLP_VX]:	The linear x-slope for v
+ * coeff[GPSGRIDDER_SLP_VY]:	The linear y-slope for v
+ * coeff[GPSGRIDDER_RANGE_U]:	The largest |range| of the detrended u data
+ * coeff[GPSGRIDDER_RANGE_V]:	The largest |range| of the detrended v data
  */
 
 GMT_LOCAL void gpsgridder_do_gps_normalization (struct GMTAPI_CTRL *API, double **X, double *u, double *v, uint64_t n_uv, unsigned int mode, double *coeff) {
 	/* We always remove/restore the mean observation values.  mode is a combination of bitflags that affects what we do:
-	 * Bit GPS_TREND will also remove linear trend
-	 * Bit GPS_NORM will normalize residuals by full range
+	 * Bit GPSGRIDDER_TREND will also remove linear trend
+	 * Bit GPSGRIDDER_NORM will normalize residuals by full range
 	 */
 
 	uint64_t i;
@@ -366,27 +400,27 @@ GMT_LOCAL void gpsgridder_do_gps_normalization (struct GMTAPI_CTRL *API, double 
 	char *type[4] = {"Remove mean", "Remove 2-D linear trend\n", "Remove mean and normalize data", "Remove 2-D linear trend and normalize data"};
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Normalization mode: %s.\n", type[mode]);
-	gmt_M_memset (coeff, GSP_LENGTH, double);
+	gmt_M_memset (coeff, GPSGRIDDER_LENGTH, double);
 	for (i = 0; i < n_uv; i++) {	/* Find mean u and v-values */
-		coeff[GSP_MEAN_U] += u[i];
-		coeff[GSP_MEAN_V] += v[i];
-		if ((mode & GPS_TREND) == 0) continue;	/* Else we also sum up x and y to get their means */
-		coeff[GSP_MEAN_X] += X[i][GMT_X];
-		coeff[GSP_MEAN_Y] += X[i][GMT_Y];
+		coeff[GPSGRIDDER_MEAN_U] += u[i];
+		coeff[GPSGRIDDER_MEAN_V] += v[i];
+		if ((mode & GPSGRIDDER_TREND) == 0) continue;	/* Else we also sum up x and y to get their means */
+		coeff[GPSGRIDDER_MEAN_X] += X[i][GMT_X];
+		coeff[GPSGRIDDER_MEAN_Y] += X[i][GMT_Y];
 	}
-	coeff[GSP_MEAN_U] /= n_uv;	/* Average u value to remove/restore */
-	coeff[GSP_MEAN_V] /= n_uv;	/* Average v value to remove/restore */
+	coeff[GPSGRIDDER_MEAN_U] /= n_uv;	/* Average u value to remove/restore */
+	coeff[GPSGRIDDER_MEAN_V] /= n_uv;	/* Average v value to remove/restore */
 
-	if (mode & GPS_TREND) {	/* Solve for LS plane using deviations from mean x,y,u,v */
+	if (mode & GPSGRIDDER_TREND) {	/* Solve for LS plane using deviations from mean x,y,u,v */
 		double xx, yy, uu, vv, sxx, sxy, sxu, sxv, syy, syu, syv;
 		sxx = sxy = sxu = sxv = syy = syu = syv = 0.0;
-		coeff[GSP_MEAN_X] /= n_uv;	/* Mean x */
-		coeff[GSP_MEAN_Y] /= n_uv;	/* Mean y */
+		coeff[GPSGRIDDER_MEAN_X] /= n_uv;	/* Mean x */
+		coeff[GPSGRIDDER_MEAN_Y] /= n_uv;	/* Mean y */
 		for (i = 0; i < n_uv; i++) {
-			xx = X[i][GMT_X] - coeff[GSP_MEAN_X];
-			yy = X[i][GMT_Y] - coeff[GSP_MEAN_Y];
-			uu = u[i] - coeff[GSP_MEAN_U];
-			vv = v[i] - coeff[GSP_MEAN_V];
+			xx = X[i][GMT_X] - coeff[GPSGRIDDER_MEAN_X];
+			yy = X[i][GMT_Y] - coeff[GPSGRIDDER_MEAN_Y];
+			uu = u[i] - coeff[GPSGRIDDER_MEAN_U];
+			vv = v[i] - coeff[GPSGRIDDER_MEAN_V];
 			/* xx,yy,uu,vv are residuals relative to their mean values */
 			sxx += (xx * xx);
 			sxu += (xx * uu);
@@ -400,21 +434,21 @@ GMT_LOCAL void gpsgridder_do_gps_normalization (struct GMTAPI_CTRL *API, double 
 		d = sxx*syy - sxy*sxy;
 		if (d != 0.0) {
 			d = 1.0 / d;	/* Se we can multiply below */
-			coeff[GSP_SLP_UX] = (sxu*syy - sxy*syu) * d;
-			coeff[GSP_SLP_UY] = (sxx*syu - sxy*sxu) * d;
-			coeff[GSP_SLP_VX] = (sxv*syy - sxy*syv) * d;
-			coeff[GSP_SLP_VY] = (sxx*syv - sxy*sxv) * d;
+			coeff[GPSGRIDDER_SLP_UX] = (sxu*syy - sxy*syu) * d;
+			coeff[GPSGRIDDER_SLP_UY] = (sxx*syu - sxy*sxu) * d;
+			coeff[GPSGRIDDER_SLP_VX] = (sxv*syy - sxy*syv) * d;
+			coeff[GPSGRIDDER_SLP_VY] = (sxx*syv - sxy*sxv) * d;
 		}
 	}
 
 	/* Remove planes (or just the means) */
 
 	for (i = 0; i < n_uv; i++) {	/* Also find min/max or residuals in the process */
-		u[i] -= coeff[GSP_MEAN_U];	/* Always remove mean u value */
-		v[i] -= coeff[GSP_MEAN_V];	/* Always remove mean v value */
-		if (mode & GPS_TREND) {	/* Also remove planar trends */
-			u[i] -= (coeff[GSP_SLP_UX] * (X[i][GMT_X] - coeff[GSP_MEAN_X]) + coeff[GSP_SLP_UY] * (X[i][GMT_Y] - coeff[GSP_MEAN_Y]));
-			v[i] -= (coeff[GSP_SLP_VX] * (X[i][GMT_X] - coeff[GSP_MEAN_X]) + coeff[GSP_SLP_VY] * (X[i][GMT_Y] - coeff[GSP_MEAN_Y]));
+		u[i] -= coeff[GPSGRIDDER_MEAN_U];	/* Always remove mean u value */
+		v[i] -= coeff[GPSGRIDDER_MEAN_V];	/* Always remove mean v value */
+		if (mode & GPSGRIDDER_TREND) {	/* Also remove planar trends */
+			u[i] -= (coeff[GPSGRIDDER_SLP_UX] * (X[i][GMT_X] - coeff[GPSGRIDDER_MEAN_X]) + coeff[GPSGRIDDER_SLP_UY] * (X[i][GMT_Y] - coeff[GPSGRIDDER_MEAN_Y]));
+			v[i] -= (coeff[GPSGRIDDER_SLP_VX] * (X[i][GMT_X] - coeff[GPSGRIDDER_MEAN_X]) + coeff[GPSGRIDDER_SLP_VY] * (X[i][GMT_Y] - coeff[GPSGRIDDER_MEAN_Y]));
 		}
 		/* Find adjusted min/max for u and v */
 		if (u[i] < umin) umin = u[i];
@@ -422,43 +456,43 @@ GMT_LOCAL void gpsgridder_do_gps_normalization (struct GMTAPI_CTRL *API, double 
 		if (v[i] < vmin) vmin = v[i];
 		if (v[i] > vmax) vmax = v[i];
 	}
-	if (mode & GPS_NORM) {	/* Normalize by u,v ranges */
+	if (mode & GPSGRIDDER_NORM) {	/* Normalize by u,v ranges */
 		double du, dv;
-		coeff[GSP_RANGE_U] = MAX (fabs(umin), fabs(umax));	/* Determine u range */
-		coeff[GSP_RANGE_V] = MAX (fabs(vmin), fabs(vmax));	/* Determine v range */
+		coeff[GPSGRIDDER_RANGE_U] = MAX (fabs(umin), fabs(umax));	/* Determine u range */
+		coeff[GPSGRIDDER_RANGE_V] = MAX (fabs(vmin), fabs(vmax));	/* Determine v range */
 		/* Select the maximum range of the two ranges */
-        coeff[GSP_RANGE_U] = MAX (coeff[GSP_RANGE_U],coeff[GSP_RANGE_V]);
-		coeff[GSP_RANGE_V] = coeff[GSP_RANGE_U];
-		if (coeff[GSP_RANGE_U] == 0.0) coeff[GSP_RANGE_U] = 1.0;	/* do no harm */
-		if (coeff[GSP_RANGE_V] == 0.0) coeff[GSP_RANGE_V] = 1.0;	/* do no harm */
-		du = 1.0 / coeff[GSP_RANGE_U];
-		dv = 1.0 / coeff[GSP_RANGE_V];
+        coeff[GPSGRIDDER_RANGE_U] = MAX (coeff[GPSGRIDDER_RANGE_U],coeff[GPSGRIDDER_RANGE_V]);
+		coeff[GPSGRIDDER_RANGE_V] = coeff[GPSGRIDDER_RANGE_U];
+		if (coeff[GPSGRIDDER_RANGE_U] == 0.0) coeff[GPSGRIDDER_RANGE_U] = 1.0;	/* do no harm */
+		if (coeff[GPSGRIDDER_RANGE_V] == 0.0) coeff[GPSGRIDDER_RANGE_V] = 1.0;	/* do no harm */
+		du = 1.0 / coeff[GPSGRIDDER_RANGE_U];
+		dv = 1.0 / coeff[GPSGRIDDER_RANGE_V];
 		for (i = 0; i < n_uv; i++) {	/* Normalize 0-1 */
 			u[i] *= du;
 			v[i] *= dv;
 		}
 	}
 
-	/* Recover u(x,y) = u[i] * coeff[GSP_RANGE_U] + coeff[GSP_MEAN_U] + coeff[GSP_SLP_UX]*(x-coeff[GSP_MEAN_X]) + coeff[GSP_SLP_UY]*(y-coeff[GSP_MEAN_Y]) */
+	/* Recover u(x,y) = u[i] * coeff[GPSGRIDDER_RANGE_U] + coeff[GPSGRIDDER_MEAN_U] + coeff[GPSGRIDDER_SLP_UX]*(x-coeff[GPSGRIDDER_MEAN_X]) + coeff[GPSGRIDDER_SLP_UY]*(y-coeff[GPSGRIDDER_MEAN_Y]) */
 	GMT_Report (API, GMT_MSG_INFORMATION, "2-D Normalization coefficients: uoff = %g uxslope = %g xmean = %g uyslope = %g ymean = %g urange = %g\n",
-		coeff[GSP_MEAN_U], coeff[GSP_SLP_UX], coeff[GSP_MEAN_X], coeff[GSP_SLP_UY], coeff[GSP_MEAN_Y], coeff[GSP_RANGE_U]);
-	/* Recover v(x,y) = v[i] * coeff[GSP_RANGE_V] + coeff[GSP_MEAN_V] + coeff[GSP_SLP_VX]*(x-coeff[GSP_MEAN_X]) + coeff[GSP_SLP_VY]*(y-coeff[GSP_MEAN_Y]) */
+		coeff[GPSGRIDDER_MEAN_U], coeff[GPSGRIDDER_SLP_UX], coeff[GPSGRIDDER_MEAN_X], coeff[GPSGRIDDER_SLP_UY], coeff[GPSGRIDDER_MEAN_Y], coeff[GPSGRIDDER_RANGE_U]);
+	/* Recover v(x,y) = v[i] * coeff[GPSGRIDDER_RANGE_V] + coeff[GPSGRIDDER_MEAN_V] + coeff[GPSGRIDDER_SLP_VX]*(x-coeff[GPSGRIDDER_MEAN_X]) + coeff[GPSGRIDDER_SLP_VY]*(y-coeff[GPSGRIDDER_MEAN_Y]) */
 	GMT_Report (API, GMT_MSG_INFORMATION, "2-D Normalization coefficients: voff = %g vxslope = %g xmean = %g vyslope = %g ymean = %g vrange = %g\n",
-		coeff[GSP_MEAN_V], coeff[GSP_SLP_VX], coeff[GSP_MEAN_X], coeff[GSP_SLP_VY], coeff[GSP_MEAN_Y], coeff[GSP_RANGE_V]);
+		coeff[GPSGRIDDER_MEAN_V], coeff[GPSGRIDDER_SLP_VX], coeff[GPSGRIDDER_MEAN_X], coeff[GPSGRIDDER_SLP_VY], coeff[GPSGRIDDER_MEAN_Y], coeff[GPSGRIDDER_RANGE_V]);
 }
 
 GMT_LOCAL void gpsgridder_undo_gps_normalization (double *X, unsigned int mode, double *coeff) {
  	/* Here, X holds x,y,u,v */
-	if (mode & GPS_NORM) {	/* Scale back up by residual data range (if we normalized by range) */
-		X[GMT_U] *= coeff[GSP_RANGE_U];
-		X[GMT_V] *= coeff[GSP_RANGE_V];
+	if (mode & GPSGRIDDER_NORM) {	/* Scale back up by residual data range (if we normalized by range) */
+		X[GPSGRIDDER_U] *= coeff[GPSGRIDDER_RANGE_U];
+		X[GPSGRIDDER_V] *= coeff[GPSGRIDDER_RANGE_V];
 	}
 	/* Add in mean data values */
-	X[GMT_U] += coeff[GSP_MEAN_U];
-	X[GMT_V] += coeff[GSP_MEAN_V];
-	if (mode & GPS_TREND) {					/* Restore residual trends */
-		X[GMT_U] += coeff[GSP_SLP_UX] * (X[GMT_X] - coeff[GSP_MEAN_X]) + coeff[GSP_SLP_UY] * (X[GMT_Y] - coeff[GSP_MEAN_Y]);
-		X[GMT_V] += coeff[GSP_SLP_VX] * (X[GMT_X] - coeff[GSP_MEAN_X]) + coeff[GSP_SLP_VY] * (X[GMT_Y] - coeff[GSP_MEAN_Y]);
+	X[GPSGRIDDER_U] += coeff[GPSGRIDDER_MEAN_U];
+	X[GPSGRIDDER_V] += coeff[GPSGRIDDER_MEAN_V];
+	if (mode & GPSGRIDDER_TREND) {					/* Restore residual trends */
+		X[GPSGRIDDER_U] += coeff[GPSGRIDDER_SLP_UX] * (X[GMT_X] - coeff[GPSGRIDDER_MEAN_X]) + coeff[GPSGRIDDER_SLP_UY] * (X[GMT_Y] - coeff[GPSGRIDDER_MEAN_Y]);
+		X[GPSGRIDDER_V] += coeff[GPSGRIDDER_SLP_VX] * (X[GMT_X] - coeff[GPSGRIDDER_MEAN_X]) + coeff[GPSGRIDDER_SLP_VY] * (X[GMT_Y] - coeff[GPSGRIDDER_MEAN_Y]);
 	}
 }
 
@@ -487,7 +521,7 @@ GMT_LOCAL void gpsgridder_get_gps_dxdy (struct GMT_CTRL *GMT, double *X0, double
 
 GMT_LOCAL void gpsgridder_evaluate_greensfunctions (struct GMT_CTRL *GMT, double *X0, double *X1, double par[], bool geo, double G[]) {
 	/* Evaluate the Green's functions q(x), p(x), and w(x), here placed in
-	 * G[GPS_FUNC_Q], G[GPS_FUNC_P], and G[GPS_FUNC_W].
+	 * G[GPSGRIDDER_FUNC_Q], G[GPSGRIDDER_FUNC_P], and G[GPSGRIDDER_FUNC_W].
 	 * Here, par[0] holds Poisson's ratio, par[1] holds delta_r^2 (to prevent singularity) */
 	double dx, dy, dx2, dy2, dr2, c1, c2, c2_dr2, dr2_fudge, dx2_fudge, dy2_fudge, dxdy_fudge;
 
@@ -507,12 +541,12 @@ GMT_LOCAL void gpsgridder_evaluate_greensfunctions (struct GMT_CTRL *GMT, double
 	c1 = (3.0 - par[0]) / 2.0;	/* The half is here since we will take log of r^2, not r */
 	c2 = (1.0 + par[0]);
 
-	G[GPS_FUNC_Q] = G[GPS_FUNC_P] = c1 * log (dr2_fudge);
+	G[GPSGRIDDER_FUNC_Q] = G[GPSGRIDDER_FUNC_P] = c1 * log (dr2_fudge);
 	dr2_fudge = 1.0 / dr2_fudge;	/* Get inverse squared radius */
 	c2_dr2 = c2 * dr2_fudge;		/* Do this multiplication once */
-	G[GPS_FUNC_Q] +=  c2_dr2 * dy2_fudge;
-	G[GPS_FUNC_P] +=  c2_dr2 * dx2_fudge;
-	G[GPS_FUNC_W]  = -c2_dr2 * dxdy_fudge;
+	G[GPSGRIDDER_FUNC_Q] +=  c2_dr2 * dy2_fudge;
+	G[GPSGRIDDER_FUNC_P] +=  c2_dr2 * dx2_fudge;
+	G[GPSGRIDDER_FUNC_W]  = -c2_dr2 * dxdy_fudge;
 }
 
 GMT_LOCAL void gpsgridder_dump_system (double *A, double *obs, uint64_t n_params, char *string) {
@@ -542,7 +576,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 
 	double **X = NULL, *A = NULL, *u = NULL, *v = NULL, *obs = NULL;
 	double *f_x = NULL, *f_y = NULL, *in = NULL, *orig_u = NULL, *orig_v = NULL;
-	double mem, r, par[2], norm[GSP_LENGTH], var_sum = 0.0;
+	double mem, r, par[2], norm[GPSGRIDDER_LENGTH], var_sum = 0.0;
 	double err_sum = 0.0, err_sum_u = 0.0, err_sum_v = 0.0, r_min, r_max, G[3], *A_orig = NULL;
 	double *V = NULL, *s = NULL, *ssave = NULL, *b = NULL;
 
@@ -578,7 +612,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 
 	gmt_enable_threads (GMT);	/* Set number of active threads, if supported */
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input table data\n");
-	gmt_M_memset (norm, GSP_LENGTH, double);
+	gmt_M_memset (norm, GPSGRIDDER_LENGTH, double);
 	gmt_M_memset (&info, 1, struct GMT_GRID_INFO);
 
 	geo = gmt_M_is_geographic (GMT, GMT_IN);
@@ -593,7 +627,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		gmt_init_distaz (GMT, 'X', 0, GMT_MAP_DIST);
 	}
 
-	normalize = (Ctrl->L.active) ? GPS_NORM : GPS_TREND + GPS_NORM;	/* Do not de-plane if -L, always remove mean and normalize */
+	normalize = (Ctrl->L.active) ? GPSGRIDDER_NORM : GPSGRIDDER_TREND + GPSGRIDDER_NORM;	/* Do not de-plane if -L, always remove mean and normalize */
 
 	/* Now we are ready to take on some input values */
 
@@ -649,13 +683,13 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		for (i = 0; !skip && i < n_uv; i++) {
 			r = gpsgridder_get_gps_radius (GMT, X[i], X[n_uv]);
 			if (gmt_M_is_zero (r)) {	/* Duplicates will produce a zero point separation */
-				if (doubleAlmostEqualZero (in[GMT_U], u[i]) && doubleAlmostEqualZero (in[GMT_V], v[i])) {
+				if (doubleAlmostEqualZero (in[GPSGRIDDER_U], u[i]) && doubleAlmostEqualZero (in[GPSGRIDDER_V], v[i])) {
 					GMT_Report (API, GMT_MSG_ERROR, "Data constraint %" PRIu64 " is identical to %" PRIu64 " and will be skipped\n", n_read, i);
 					skip = true;
 					n_skip++;
 				}
 				else {
-					GMT_Report (API, GMT_MSG_ERROR, "Data constraint %" PRIu64 " and %" PRIu64 " occupy the same location but differ in observation (%.12g/%.12g vs %.12g/%.12g)\n", n_read, i, in[GMT_U], u[i], in[GMT_V], v[i]);
+					GMT_Report (API, GMT_MSG_ERROR, "Data constraint %" PRIu64 " and %" PRIu64 " occupy the same location but differ in observation (%.12g/%.12g vs %.12g/%.12g)\n", n_read, i, in[GPSGRIDDER_U], u[i], in[GPSGRIDDER_V], v[i]);
 					n_duplicates++;
 				}
 			}
@@ -666,16 +700,16 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		}
 		n_read++;
 		if (skip) continue;	/* Current point was an exact duplicate of a previous point */
-		u[n_uv] = in[GMT_U];	v[n_uv] = in[GMT_V];	/* Save current u,v data pair */
+		u[n_uv] = in[GPSGRIDDER_U];	v[n_uv] = in[GPSGRIDDER_V];	/* Save current u,v data pair */
 		if (Ctrl->W.active) {	/* Got sigmas (or weights) in cols 4 and 5 */
-			X[n_uv][GMT_WU] = in[4];	/* First just copy over what we got */
-			X[n_uv][GMT_WV] = in[5];
-			if (Ctrl->W.mode == GPS_GOT_SIG) {	/* Got sigmas, so create weights from them */
-				err_sum_u += X[n_uv][GMT_WU]*X[n_uv][GMT_WU];	/* Update u variance */
-				err_sum_v += X[n_uv][GMT_WV]*X[n_uv][GMT_WV];	/* Update v variance */
-				err_sum += X[n_uv][GMT_WU]*X[n_uv][GMT_WU] + X[n_uv][GMT_WV]*X[n_uv][GMT_WV];	/* Update combined data variance */
-				X[n_uv][GMT_WU] = 1.0 / X[n_uv][GMT_WU];	/* We will square these weights later */
-				X[n_uv][GMT_WV] = 1.0 / X[n_uv][GMT_WV];	/* We will square these weights later */
+			X[n_uv][GPSGRIDDER_WU] = in[4];	/* First just copy over what we got */
+			X[n_uv][GPSGRIDDER_WV] = in[5];
+			if (Ctrl->W.mode == GPSGRIDDER_GOT_SIG) {	/* Got sigmas, so create weights from them */
+				err_sum_u += X[n_uv][GPSGRIDDER_WU]*X[n_uv][GPSGRIDDER_WU];	/* Update u variance */
+				err_sum_v += X[n_uv][GPSGRIDDER_WV]*X[n_uv][GPSGRIDDER_WV];	/* Update v variance */
+				err_sum += X[n_uv][GPSGRIDDER_WU]*X[n_uv][GPSGRIDDER_WU] + X[n_uv][GPSGRIDDER_WV]*X[n_uv][GPSGRIDDER_WV];	/* Update combined data variance */
+				X[n_uv][GPSGRIDDER_WU] = 1.0 / X[n_uv][GPSGRIDDER_WU];	/* We will square these weights later */
+				X[n_uv][GPSGRIDDER_WV] = 1.0 / X[n_uv][GPSGRIDDER_WV];	/* We will square these weights later */
 			}
 		}
 		var_sum += u[n_uv] * u[n_uv] + v[n_uv] * v[n_uv];
@@ -701,7 +735,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 	GMT_Report (API, GMT_MSG_INFORMATION, "Found %" PRIu64 " unique data constraints\n", n_uv);
 	if (n_skip) GMT_Report (API, GMT_MSG_WARNING, "Skipped %" PRIu64 " data constraints as duplicates\n", n_skip);
 
-	if (Ctrl->W.active && Ctrl->W.mode == GPS_GOT_SIG) {	/* Able to report mean uncertainties */
+	if (Ctrl->W.active && Ctrl->W.mode == GPSGRIDDER_GOT_SIG) {	/* Able to report mean uncertainties */
 		err_sum_u = sqrt (err_sum_u / n_uv);
 		err_sum_v = sqrt (err_sum_v / n_uv);
 		err_sum = sqrt (0.5 * err_sum / n_uv);
@@ -782,7 +816,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 	}
 	else {	/* Fill in an equidistant output table or grid */
 		/* Need a full-fledged Grid creation since we are writing it to who knows where */
-		for (k = 0; k < 2; k++) {
+		for (k = GMT_X; k <= GMT_Y; k++) {
 			if ((Out[k] = GMT_Create_Data (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, NULL,
 			                               NULL, GMT->common.R.registration, GMT_NOTSET, NULL)) == NULL) {
 					for (p = 0; p < n_uv; p++) gmt_M_free (GMT, X[p]);
@@ -803,7 +837,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 	/* Initialize the Green's function machinery */
 
 	par[0] = Ctrl->S.nu;	/* Poisson's ratio */
-	if (Ctrl->F.mode == GPS_FUDGE_R)
+	if (Ctrl->F.mode == GPSGRIDDER_FUDGE_R)
 		par[1] = Ctrl->F.fudge;		/* Small fudge radius to avoid singularity for r = 0 */
 	else
 		par[1] = Ctrl->F.fudge * r_min;		/* Small fudge factor*r_min to avoid singularity for r = 0 */
@@ -832,9 +866,9 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 			Gvu_ij = Gu_ij + off;		/* Index for Gvu term in equation for v */
 			Gv_ij  = Guv_ij + off;		/* Index for Gv term in equation for v */
 			gpsgridder_evaluate_greensfunctions (GMT, X[col], X[row], par, geo, G);
-			A[Gu_ij]  = G[GPS_FUNC_Q];
-			A[Gv_ij]  = G[GPS_FUNC_P];
-			A[Guv_ij] = A[Gvu_ij] = G[GPS_FUNC_W];
+			A[Gu_ij]  = G[GPSGRIDDER_FUNC_Q];
+			A[Gv_ij]  = G[GPSGRIDDER_FUNC_P];
+			A[Guv_ij] = A[Gvu_ij] = G[GPSGRIDDER_FUNC_W];
 		}
 	}
 
@@ -867,8 +901,8 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		/* 1. Transpose A and set diagonal matrix with squared weights (here a vector) S */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Create S = W'*W diagonal matrix, A', and compute A' * S\n");
 		for (row = 0; row < n_uv; row++) {	/* Set S, the diagonal squared weights (=1/sigma^2) matrix if given sigma, else use weights as they are */
-			S[row]      = (Ctrl->W.mode == GPS_GOT_SIG) ? X[row][GMT_WU] * X[row][GMT_WU] : X[row][GMT_WU];
-			S[row+n_uv] = (Ctrl->W.mode == GPS_GOT_SIG) ? X[row][GMT_WV] * X[row][GMT_WV] : X[row][GMT_WV];
+			S[row]      = (Ctrl->W.mode == GPSGRIDDER_GOT_SIG) ? X[row][GPSGRIDDER_WU] * X[row][GPSGRIDDER_WU] : X[row][GPSGRIDDER_WU];
+			S[row+n_uv] = (Ctrl->W.mode == GPSGRIDDER_GOT_SIG) ? X[row][GPSGRIDDER_WV] * X[row][GPSGRIDDER_WV] : X[row][GPSGRIDDER_WV];
 		}
 		for (row = 0; row < n_params; row++) {	/* Transpose A */
 			for (col = 0; col < n_params; col++) {
@@ -930,7 +964,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 			/* Sort eigenvalues into ascending order */
 			gmt_sort_array (GMT, eig, n_params, GMT_DOUBLE);
 			for (i = 0, j = n_params-1; i < n_params; i++, j--) {
-				E->table[0]->segment[0]->data[GMT_X][i] = i + 1.0;	/* Let 1 be x-value of the first eigenvalue */
+				E->table[0]->segment[0]->data[GMT_X][i] = i;	/* Let 0 be x-value of the first eigenvalue */
 				E->table[0]->segment[0]->data[GMT_Y][i] = eig[j];
 			}
 			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_SET, NULL, Ctrl->C.file, E) != GMT_NOERROR) {
@@ -941,7 +975,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_INFORMATION, "Eigen-values s(i) saved to %s\n", Ctrl->C.file);
 			gmt_M_free (GMT, eig);
 
-			if (Ctrl->C.value < 0.0) {	/* Only wanted eigen-values; we are done */
+			if (Ctrl->C.dryrun) {	/* Only wanted eigen-values; we are done */
 				for (p = 0; p < n_uv; p++) gmt_M_free (GMT, X[p]);
 				gmt_M_free (GMT, X);
 				gmt_M_free (GMT, s);
@@ -949,7 +983,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 				gmt_M_free (GMT, A);
 				gmt_M_free (GMT, u);
 				gmt_M_free (GMT, v);
-				for (k = 0; k < 2; k++)
+				for (k = GMT_X; k <= GMT_Y; k++)
 					gmt_free_grid (GMT, &Out[k], true);
 				Return (GMT_NOERROR);
 			}
@@ -963,7 +997,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		}
 		GMT_Report (API, GMT_MSG_INFORMATION, "[%d of %" PRIu64 " eigen-values used]\n", n_use, n_params);
 
-		if (Ctrl->C.movie == 0) {
+		if (Ctrl->C.movie == GPSGRIDDER_NO_MOVIE) {
 			gmt_M_free (GMT, s);
 			gmt_M_free (GMT, V);
 			gmt_M_free (GMT, b);
@@ -984,7 +1018,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 			Return (error);
 		}
 	}
-	if (Ctrl->C.movie == 0) gmt_M_free (GMT, A);
+	if (Ctrl->C.movie == GPSGRIDDER_NO_MOVIE) gmt_M_free (GMT, A);
 
 	f_x = obs;			/* Just a different name for clarity since obs vector now holds all body forces f_x, f_y */
 	f_y = &obs[n_uv];	/* Halfway down the array we find the start of the f_y body forces */
@@ -1004,7 +1038,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		struct GMT_DATASEGMENT *S = NULL;
 		predicted = gmt_M_memory (GMT, NULL, n_params, double);	/* To hold predictions */
 		gmt_matrix_matrix_mult (GMT, A_orig, obs, n_params, n_params, 1U, predicted);	/* predicted = A * alpha are normalized predictions at data points */
-		if (Ctrl->E.mode == GPS_MISFIT) {	/* Want to write out prediction errors */
+		if (Ctrl->E.mode == GPSGRIDDER_MISFIT) {	/* Want to write out prediction errors */
 			if ((E = GMT_Create_Data (API, GMT_IS_DATASET, GMT_IS_NONE, 0, e_dim, NULL, NULL, 0, 0, NULL)) == NULL) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to create a data set for saving misfit estimates\n");
 				if (Ctrl->C.movie) {
@@ -1022,25 +1056,25 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		for (j = 0; j < n_uv; j++) {	/* For each data constraint pair (u,v) */
 			here[GMT_X] = X[j][GMT_X];
 			here[GMT_Y] = X[j][GMT_Y];
-			here[GMT_U] = predicted[j];
-			here[GMT_V] = predicted[j+n_uv];
+			here[GPSGRIDDER_U] = predicted[j];
+			here[GPSGRIDDER_V] = predicted[j+n_uv];
 #if 0
-			here[GMT_U] = here[GMT_V] = 0.0;	/* Initialize before we sum up */
+			here[GPSGRIDDER_U] = here[GPSGRIDDER_V] = 0.0;	/* Initialize before we sum up */
 			for (p = 0; p < n_uv; p++) {
 				gpsgridder_evaluate_greensfunctions (GMT, X[p], here, par, geo, G);
-				here[GMT_U] += (f_x[p] * G[GPS_FUNC_Q] + f_y[p] * G[GPS_FUNC_W]);
-				here[GMT_V] += (f_x[p] * G[GPS_FUNC_W] + f_y[p] * G[GPS_FUNC_P]);
+				here[GPSGRIDDER_U] += (f_x[p] * G[GPSGRIDDER_FUNC_Q] + f_y[p] * G[GPSGRIDDER_FUNC_W]);
+				here[GPSGRIDDER_V] += (f_x[p] * G[GPSGRIDDER_FUNC_W] + f_y[p] * G[GPSGRIDDER_FUNC_P]);
 			}
 #endif
 			gpsgridder_undo_gps_normalization (here, normalize, norm);
-			dev_u = orig_u[j] - here[GMT_U];
-			dev_v = orig_v[j] - here[GMT_V];
-			pvar_sum += here[GMT_U] * here[GMT_U] + here[GMT_V] * here[GMT_V];
+			dev_u = orig_u[j] - here[GPSGRIDDER_U];
+			dev_v = orig_v[j] - here[GPSGRIDDER_V];
+			pvar_sum += here[GPSGRIDDER_U] * here[GPSGRIDDER_U] + here[GPSGRIDDER_V] * here[GPSGRIDDER_V];
 
 			rms += pow (dev_u, 2.0) + pow (dev_v, 2.0);
-			if (Ctrl->W.active && Ctrl->W.mode == GPS_GOT_SIG) {	/* If data had uncertainties we also compute the chi2 sum */
-				chi2u = pow (dev_u * X[j][GMT_WU], 2.0);
-				chi2v = pow (dev_v * X[j][GMT_WV], 2.0);
+			if (Ctrl->W.active && Ctrl->W.mode == GPSGRIDDER_GOT_SIG) {	/* If data had uncertainties we also compute the chi2 sum */
+				chi2u = pow (dev_u * X[j][GPSGRIDDER_WU], 2.0);
+				chi2v = pow (dev_v * X[j][GPSGRIDDER_WV], 2.0);
 				chi2u_sum += chi2u;
 				chi2v_sum += chi2v;
 			}
@@ -1059,19 +1093,19 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 			mean += dev_v / m2;
 			std += dev_v * (orig_v[j] - mean_v);
 			/* Do rms sums */
-			dev_u = orig_u[j] - here[GMT_U];
+			dev_u = orig_u[j] - here[GPSGRIDDER_U];
 			rms_u += dev_u * dev_u;
-			dev_v = orig_v[j] - here[GMT_V];
+			dev_v = orig_v[j] - here[GPSGRIDDER_V];
 			rms_v += dev_v * dev_v;
 			rms += dev_u * dev_u + dev_v * dev_v;
-			if (Ctrl->E.mode == GPS_MISFIT) {	/* Save information in output dataset */
+			if (Ctrl->E.mode == GPSGRIDDER_MISFIT) {	/* Save information in output dataset */
 				for (p = 0; p < 2; p++)
 					S->data[p][j] = X[j][p];
 				S->data[p++][j] = orig_u[j];
-				S->data[p++][j] = here[GMT_U];
+				S->data[p++][j] = here[GPSGRIDDER_U];
 				S->data[p++][j] = dev_u;
 				S->data[p++][j] = orig_v[j];
-				S->data[p++][j] = here[GMT_V];
+				S->data[p++][j] = here[GPSGRIDDER_V];
 				S->data[p][j]   = dev_v;
 				if (Ctrl->W.active) {	/* Add the chi^2 terms */
 					S->data[++p][j] = chi2u;
@@ -1085,7 +1119,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		std_u = (m > 1)  ? sqrt (std_u / (m-1.0)) : GMT->session.d_NaN;
 		std_v = (m > 1)  ? sqrt (std_v / (m-1.0)) : GMT->session.d_NaN;
 		std   = (m2 > 1) ? sqrt (std / (m2-1.0))  : GMT->session.d_NaN;
-		if (Ctrl->W.active && Ctrl->W.mode == GPS_GOT_SIG) {
+		if (Ctrl->W.active && Ctrl->W.mode == GPSGRIDDER_GOT_SIG) {
 			GMT_Report (API, GMT_MSG_INFORMATION, "Separate u Misfit: N = %u\tMean = %g\tStd.dev = %g\tRMS = %g\tChi^2 = %g\n", n_uv, mean_u, std_u, rms_u, chi2u_sum);
 			GMT_Report (API, GMT_MSG_INFORMATION, "Separate v Misfit: N = %u\tMean = %g\tStd.dev = %g\tRMS = %g\tChi^2 = %g\n", n_uv, mean_v, std_v, rms_v, chi2v_sum);
 			GMT_Report (API, GMT_MSG_INFORMATION, "Total u,v Misfit : N = %u\tMean = %g\tStd.dev = %g\tRMS = %g\tChi^2 = %g\n", n_params, mean, std, rms, chi2u_sum + chi2v_sum);
@@ -1100,7 +1134,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		gmt_M_free (GMT, orig_v);
 		gmt_M_free (GMT, predicted);
 		gmt_M_free (GMT, A_orig);
-		if (Ctrl->E.mode == GPS_MISFIT) {	/* Want to write out prediction errors */
+		if (Ctrl->E.mode == GPSGRIDDER_MISFIT) {	/* Want to write out prediction errors */
 			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_SET, NULL, Ctrl->E.file, E) != GMT_NOERROR) {
 				Return (API->error);
 			}
@@ -1137,11 +1171,12 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 			for (row = 0; row < T->segment[seg]->n_rows; row++) {
 				out[GMT_X] = T->segment[seg]->data[GMT_X][row];
 				out[GMT_Y] = T->segment[seg]->data[GMT_Y][row];
-				out[GMT_U] = out[GMT_V] = 0.0;	/* Initialize before adding up terms */
+				out[GPSGRIDDER_U] = out[GPSGRIDDER_V] = 0.0;	/* Initialize before adding up terms */
 				for (p = 0; p < n_uv; p++) {
+					if (f_x[p] == 0.0 && f_y[p] == 0.0) continue;	/* Note: The f_x and f_y are not sorted so must loop over all then skip the zeros */
 					gpsgridder_evaluate_greensfunctions (GMT, X[p], out, par, geo, G);
-					out[GMT_U] += (f_x[p] * G[GPS_FUNC_Q] + f_y[p] * G[GPS_FUNC_W]);
-					out[GMT_V] += (f_x[p] * G[GPS_FUNC_W] + f_y[p] * G[GPS_FUNC_P]);
+					out[GPSGRIDDER_U] += (f_x[p] * G[GPSGRIDDER_FUNC_Q] + f_y[p] * G[GPSGRIDDER_FUNC_W]);
+					out[GPSGRIDDER_V] += (f_x[p] * G[GPSGRIDDER_FUNC_W] + f_y[p] * G[GPSGRIDDER_FUNC_P]);
 				}
 				gpsgridder_undo_gps_normalization (out, normalize, norm);
 				GMT_Put_Record (API, GMT_WRITE_DATA, Rec);
@@ -1156,6 +1191,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		}
 	}
 	else {	/* Output on equidistant lattice */
+		unsigned int width = urint (floor (log10 ((double)n_params))) + 1;	/* Width of maximum integer needed */
 		int64_t col, row, p, e; /* On Windows 'for' index variables must be signed, so redefine these 3 inside this block only */
 		char file[PATH_MAX] = {""};
 		double *xp = NULL, *yp = NULL, V[4] = {0.0, 0.0, 0.0, 0.0};
@@ -1164,16 +1200,20 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		xp = Out[GMT_X]->x;
 		yp = Out[GMT_X]->y;
 		if (Ctrl->C.movie) {	/* Write out U,V grids after adding contribution for each eigenvalue */
-			gmt_grdfloat *tmp[2] = {NULL, NULL};
-			if (Ctrl->C.movie == 1) {	/* Need temp arrays to capture increments */
-				for (k = 0; k < 2; k++) tmp[k] = gmt_M_memory_aligned (GMT, NULL, Out[GMT_X]->header->size, gmt_grdfloat);
-			}
+			static char *mkind[3] = {"", "Incremental", "Cumulative"};
+			gmt_grdfloat *current[2] = {NULL, NULL}, *previous[2] = {NULL, NULL};
+			for (k = GMT_X; k <= GMT_Y; k++) current[k]  = gmt_M_memory_aligned (GMT, NULL, Out[GMT_X]->header->size, gmt_grdfloat);
+			if (Ctrl->C.movie & GREENSPLINE_INC_MOVIE)
+				for (k = GMT_X; k <= GMT_Y; k++) previous[k] = gmt_M_memory_aligned (GMT, NULL, Out[GMT_X]->header->size, gmt_grdfloat);
 
 			for (e = 1; e <= (int64_t)n_params; e++) {	/* For each eigenvalue */
 				GMT_Report (API, GMT_MSG_INFORMATION, "Add contribution from eigenvalue %" PRIu64 "\n", e);
 				/* Update solution for e eigenvalues only */
 				gmt_M_memcpy (s, ssave, n_params, double);
-				(void)gmt_solve_svd (GMT, A, (unsigned int)n_params, (unsigned int)n_params, V, s, b, 1U, obs, (double)e, GPS_TOP_N);
+				(void)gmt_solve_svd (GMT, A, (unsigned int)n_params, (unsigned int)n_params, V, s, b, 1U, obs, (double)e, GMT_SVD_EIGEN_NUMBER_CUTOFF);
+#ifdef _OPENMP
+#pragma omp parallel for private(row,V,col,ij,p,G) shared(Out,yp,xp,n_uv,GMT,X,par,geo,f_x,f_y,normalize,norm)
+#endif
 				for (row = 0; row < Out[GMT_X]->header->n_rows; row++) {
 					V[GMT_Y] = yp[row];
 					for (col = 0; col < Out[GMT_X]->header->n_columns; col++) {
@@ -1181,33 +1221,45 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 						if (gmt_M_is_fnan (Out[GMT_X]->data[ij])) continue;	/* Only evaluate solution where mask is not NaN */
 						V[GMT_X] = xp[col];
 						/* Here, (V[GMT_X], V[GMT_Y]) are the current output coordinates */
-						for (p = 0, V[GMT_U] = V[GMT_V] = 0.0; p < (int64_t)n_uv; p++) {	/* Initialize before adding up all body forces */
+						for (p = 0, V[GPSGRIDDER_U] = V[GPSGRIDDER_V] = 0.0; p < (int64_t)n_uv; p++) {	/* Initialize before adding up all body forces */
+							if (f_x[p] == 0.0 && f_y[p] == 0.0) continue;	/* Note: The f_x and f_y are not sorted so must loop over all then skip the zeros */
 							gpsgridder_evaluate_greensfunctions (GMT, X[p], V, par, geo, G);
-							V[GMT_U] += (f_x[p] * G[GPS_FUNC_Q] + f_y[p] * G[GPS_FUNC_W]);
-							V[GMT_V] += (f_x[p] * G[GPS_FUNC_W] + f_y[p] * G[GPS_FUNC_P]);
+							V[GPSGRIDDER_U] += (f_x[p] * G[GPSGRIDDER_FUNC_Q] + f_y[p] * G[GPSGRIDDER_FUNC_W]);
+							V[GPSGRIDDER_V] += (f_x[p] * G[GPSGRIDDER_FUNC_W] + f_y[p] * G[GPSGRIDDER_FUNC_P]);
 						}
 						gpsgridder_undo_gps_normalization (V, normalize, norm);
-						Out[GMT_X]->data[ij] = (gmt_grdfloat)V[GMT_U];
-						Out[GMT_Y]->data[ij] = (gmt_grdfloat)V[GMT_V];
+						Out[GMT_X]->data[ij] = (gmt_grdfloat)V[GPSGRIDDER_U];
+						Out[GMT_Y]->data[ij] = (gmt_grdfloat)V[GPSGRIDDER_V];
 					}
 				}
-				for (k = 0; k < 2; k++) {	/* Write the two grids with u(x,y) and v(xy) */
-					gmt_grd_init (GMT, Out[k]->header, options, true);
-					snprintf (Out[k]->header->remark, GMT_GRID_REMARK_LEN160, "Strain component %s", comp[k]);
-					sprintf (file, Ctrl->G.file, tag[k], (int)e);
-					if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, Out[k])) Return (API->error);
-					if (Ctrl->C.movie == 1) {
-						gmt_M_grd_loop (GMT, Out[k], row, col, ij) Out[k]->data[ij] -= tmp[k][ij];	/* Incremental improvement since last time */
-						gmt_M_grd_loop (GMT, Out[k], row, col, ij) tmp[k][ij] += Out[k]->data[ij];	/* Current solution */
+				for (k = GMT_X; k <= GMT_Y; k++)gmt_M_memcpy (current[k], Out[k]->data, Out[k]->header->size, gmt_grdfloat);	/* Save current solutions */
+
+				if (Ctrl->C.movie & GREENSPLINE_CUM_MOVIE) {	/* Write out the cumulative solution first */
+					for (k = GMT_X; k <= GMT_Y; k++) {	/* Write the two grids with u(x,y) and v(xy) */
+						gpsgridder_set_filename (Ctrl->G.file, e, width, GPSGRIDDER_CUM_MOVIE, k, file) {
+						snprintf (Out[k]->header->remark, GMT_GRID_REMARK_LEN160, "%s Strain component %s for eigenvalue # %d", mkind[GPSGRIDDER_INC_MOVIE], comp[k], (int)e);
+						if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, Out[k]))
+							Return (API->error);				/* Update solution for k eigenvalues only */
+						if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, Out[k]) != GMT_NOERROR)
+							Return (API->error);
 					}
-					if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, Out[k]) != GMT_NOERROR) {
-						Return (API->error);
+				}
+				if (Ctrl->C.movie & GREENSPLINE_INC_MOVIE) {	/* Want to write out incremental solution due to this eigenvalue */
+					for (k = GMT_X; k <= GMT_Y; k++) {	/* Incremental improvement since last time */
+						gmt_M_grd_loop (GMT, Out[k], row, col, ij) Out[k]->data[ij] = current[k][ij] - previous[k][ij];
+						gmt_M_memcpy (previous[k], current[k], Out[k]->header->size, gmt_grdfloat);	/* Save current solution which will be previous for next eigenvalue */
+						gpsgridder_set_filename (Ctrl->G.file, e, width, GPSGRIDDER_INC_MOVIE, k, file) {
+						snprintf (Out[k]->header->remark, GMT_GRID_REMARK_LEN160, "%s Strain component %s for eigenvalue # %d", mkind[GPSGRIDDER_CUM_MOVIE], comp[k], (int)e);
+						if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, Out[k]))
+							Return (API->error);
+						if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, Out[k]) != GMT_NOERROR)
+							Return (API->error);
 					}
 				}
 			}
-			if (Ctrl->C.movie == 1) {
-				for (k = 0; k < 2; k++) gmt_M_free_aligned (GMT, tmp[k]);
-			}
+			for (k = GMT_X; k <= GMT_Y; k++) gmt_M_free_aligned (GMT, current[k]);
+			if (Ctrl->C.movie == 1)
+				for (k = GMT_X; k <= GMT_Y; k++) gmt_M_free_aligned (GMT, previous[k]);
 			gmt_M_free (GMT, A);
 			gmt_M_free (GMT, s);
 			gmt_M_free (GMT, v);
@@ -1226,17 +1278,18 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 					if (gmt_M_is_fnan (Out[GMT_X]->data[ij])) continue;	/* Only evaluate solution where mask is not NaN */
 					V[GMT_X] = xp[col];
 					/* Here, (V[GMT_X], V[GMT_Y]) are the current output coordinates */
-					for (p = 0, V[GMT_U] = V[GMT_V] = 0.0; p < (int64_t)n_uv; p++) {	/* Initialize before adding up terms */
+					for (p = 0, V[GPSGRIDDER_U] = V[GPSGRIDDER_V] = 0.0; p < (int64_t)n_uv; p++) {	/* Initialize before adding up terms */
+						if (f_x[p] == 0.0 && f_y[p] == 0.0) continue;	/* Note: The f_x and f_y are not sorted so must loop over all then skip the zeros */
 						gpsgridder_evaluate_greensfunctions (GMT, X[p], V, par, geo, G);
-						V[GMT_U] += (f_x[p] * G[GPS_FUNC_Q] + f_y[p] * G[GPS_FUNC_W]);
-						V[GMT_V] += (f_x[p] * G[GPS_FUNC_W] + f_y[p] * G[GPS_FUNC_P]);
+						V[GPSGRIDDER_U] += (f_x[p] * G[GPSGRIDDER_FUNC_Q] + f_y[p] * G[GPSGRIDDER_FUNC_W]);
+						V[GPSGRIDDER_V] += (f_x[p] * G[GPSGRIDDER_FUNC_W] + f_y[p] * G[GPSGRIDDER_FUNC_P]);
 					}
 					gpsgridder_undo_gps_normalization (V, normalize, norm);
-					Out[GMT_X]->data[ij] = (gmt_grdfloat)V[GMT_U];
-					Out[GMT_Y]->data[ij] = (gmt_grdfloat)V[GMT_V];
+					Out[GMT_X]->data[ij] = (gmt_grdfloat)V[GPSGRIDDER_U];
+					Out[GMT_Y]->data[ij] = (gmt_grdfloat)V[GPSGRIDDER_V];
 				}
 			}
-			for (k = 0; k < 2; k++) {	/* Write the two grids with u(x,y) and v(xy) */
+			for (k = GMT_X; k <= GMT_Y; k++) {	/* Write the two grids with u(x,y) and v(xy) */
 				gmt_grd_init (GMT, Out[k]->header, options, true);
 				snprintf (Out[k]->header->remark, GMT_GRID_REMARK_LEN160, "Strain component %s", comp[k]);
 				sprintf (file, Ctrl->G.file, tag[k]);

--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -280,8 +280,11 @@ static int parse (struct GMT_CTRL *GMT, struct GPSGRIDDER_CTRL *Ctrl, struct GMT
 							n_errors++;
 						}
 					}
-					else	/* Got ratio cutoff */
+					else {	/* Got ratio cutoff */
 						Ctrl->C.value = atof (&opt->arg[k]);
+						if (Ctrl->C.value >= 0.0 && Ctrl->C.value < 1.0) /* Old style fraction */
+							Ctrl->C.mode = GMT_SVD_EIGEN_PERCENT_CUTOFF;
+					}
 				}
 				if (Ctrl->C.value < 0.0) Ctrl->C.dryrun = true, Ctrl->C.value = 0.0;	/* Deprecated syntax */
 				break;

--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -1218,7 +1218,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 			if (Ctrl->C.movie & GPSGRIDDER_INC_MOVIE)
 				for (k = GMT_X; k <= GMT_Y; k++) previous[k] = gmt_M_memory_aligned (GMT, NULL, Out[GMT_X]->header->size, gmt_grdfloat);
 
-			for (e = 0; e < (int64_t)n_params; e++) {	/* For each eigenvalue */
+			for (e = 0; e < (int64_t)n_use; e++) {	/* For each eigenvalue selected */
 				GMT_Report (API, GMT_MSG_INFORMATION, "Add contribution from eigenvalue %" PRIu64 "\n", e);
 				/* Update solution for e eigenvalues only */
 				gmt_M_memcpy (s, ssave, n_params, double);

--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -1203,7 +1203,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		}
 	}
 	else {	/* Output on equidistant lattice */
-		unsigned int width = urint (floor (log10 ((double)n_params))) + 1;	/* Width of maximum integer needed */
+		unsigned int width = urint (floor (log10 ((double)n_use))) + 1;	/* Width of maximum integer needed */
 		int64_t col, row, p, e; /* On Windows 'for' index variables must be signed, so redefine these 3 inside this block only */
 		char file[PATH_MAX] = {""};
 		double *xp = NULL, *yp = NULL, V[4] = {0.0, 0.0, 0.0, 0.0};

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -93,6 +93,13 @@
 
 #define GMT_JPEG_DEF_QUALITY	90	/* Default JPG quality value for psconvert -Tj */
 
+/*! Constants for use with calls to gmt_solve_svd (used in greenspline and geodesy/gpsgridder) */
+enum GMT_enum_svd {
+	GMT_SVD_EIGEN_RATIO_CUTOFF		= 0,	/* Only use eigenvalues whose ratio to the first exceeds a cutoff [0 = all] */
+	GMT_SVD_EIGEN_NUMBER_CUTOFF		= 1,	/* Only use the first N largest eigenvalues */
+	GMT_SVD_EIGEN_PERCENT_CUTOFF	= 2		/* Only use a percentage of the (sorted) eigenvalues */
+};
+
 /*! whether to ignore/read/write history file gmt.history */
 enum GMT_enum_history {
 	/*! 0 */	GMT_HISTORY_OFF = 0,

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -69,7 +69,7 @@ struct GREENSPLINE_CTRL {
 	struct GREENSPLINE_C {	/* -C[[n]<cutoff>[%]][+c][+f<file>][+i][+n] */
 		bool active;
 		bool dryrun;	/* Only report eigenvalues */
-		unsigned int movie;	/* Undocumented and not-yet-working movie mode +m incremental grids, +M total grids vs eigenvalue */
+		unsigned int movie;
 		unsigned int mode;
 		double value;
 		char *file;

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -66,8 +66,9 @@ struct GREENSPLINE_CTRL {
 		unsigned int mode;	/* 0 = azimuths, 1 = directions, 2 = dx,dy components, 3 = dx, dy, dz components */
 		char *file;
 	} A	;
-	struct GREENSPLINE_C {	/* -C[n]<cutoff>[+f<file>] */
+	struct GREENSPLINE_C {	/* -C[[n]<cutoff>[%]][+c][+f<file>][+i][+n] */
 		bool active;
+		bool dryrun;	/* Only report eigenvalues */
 		unsigned int movie;	/* Undocumented and not-yet-working movie mode +m incremental grids, +M total grids vs eigenvalue */
 		unsigned int mode;
 		double value;
@@ -161,9 +162,7 @@ enum Greenspline_modes {	/* Various integer mode flags */
 	GSP_GOT_WEIGHTS			= 1,
 	GREENSPLINE_NO_MOVIE		= 0,
 	GREENSPLINE_INC_MOVIE		= 1,
-	GREENSPLINE_CUM_MOVIE		= 2,
-	GREENSPLINE_EIGEN_RATIO		= 0,
-	GREENSPLINE_EIGEN_CUTOFF	= 1
+	GREENSPLINE_CUM_MOVIE		= 2
 };
 
 #ifndef M_LOG_2
@@ -228,7 +227,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *C) {	/* De
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<table>] -G<outfile> [-A<gradientfile>+f<format>] [-C[[n]<val>[%%]][+c][+f<file>][+i]] "
+	GMT_Usage (API, 0, "usage: %s [<table>] -G<outfile> [-A<gradientfile>+f<format>] [-C[[n]<val>[%%]][+c][+f<file>][+i][+n]] "
 		"[-D<information>] [-E[<misfitfile>]] [-I<dx>[/<dy>[/<dz>]]] [-L] [-N<nodefile>] [-Q<az>] "
 		"[-R<xmin>/<xmax[/<ymin>/<ymax>[/<zmin>/<zmax>]]] [-Sc|l|t|r|p|q[<pars>]] [-T<maskgrid>] "
 		"[%s] [-W[w]] [-Z<mode>] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s [%s]%s[%s] [%s]\n",
@@ -258,9 +257,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "4: X, Vcomponents.");
 	GMT_Usage (API, 3, "5: X, Vunit-vector, Vmagnitude.");
 	GMT_Usage (API, -2, "Here, X = (x, y[, z]) is the position vector, V = (Vx, Vy[, Vz]) is the gradient vector.");
-	GMT_Usage (API, 1, "\n-C[[n]<val>[%%]][+c][+f<file>][+i]");
+	GMT_Usage (API, 1, "\n-C[[n]<val>[%%]][+c][+f<file>][+i][+n");
 	GMT_Usage (API, -2, "Solve by SVD and eliminate eigenvalues whose ratio to largest eigenvalue is less than <val> [0]. "
-		"A negative cutoff will stop execution after reporting the eigenvalues. "
 		"Use -Cn to select only the largest <val> eigenvalues [all]. "
 		"Use <val>%% to select a percentage of the eigenvalues instead [100] "
 		"[Default uses Gauss-Jordan elimination to solve the linear system].");
@@ -269,6 +267,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"and extension and we will insert _cum_### before the extension.");
 	GMT_Usage (API, 3, "+f Save the eigenvalues to <filename>.");
 	GMT_Usage (API, 3, "+i As +c but save incremental results, inserting _inc_### before the extension.");
+	GMT_Usage (API, 3, "+n Stop execution after reporting the eigenvalues - no solution is computed.");
 	gmt_grdcube_info_syntax (API->GMT, 'D');
 	GMT_Usage (API, 1, "\n-E[<misfitfile>]");
 	GMT_Usage (API, -2, "Evaluate solution at input locations and report misfit statistics. "
@@ -494,34 +493,46 @@ static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GM
 				break;
 			case 'C':	/* Solve by SVD */
 				Ctrl->C.active = true;
-				if (opt->arg[0] == 'n') Ctrl->C.mode = GREENSPLINE_EIGEN_CUTOFF;
+				if (opt->arg[0] == 'n') Ctrl->C.mode = GMT_SVD_EIGEN_NUMBER_CUTOFF;
 				k = (Ctrl->C.mode) ? 1 : 0;
-				if (gmt_get_modifier (opt->arg, 'f', p))
-					Ctrl->C.file = strdup (p);
-				if (gmt_get_modifier (opt->arg, 'i', p))
-					Ctrl->C.movie |= GREENSPLINE_INC_MOVIE;
-				if (gmt_get_modifier (opt->arg, 'c', p))
-					Ctrl->C.movie |= GREENSPLINE_CUM_MOVIE;
-				if (gmt_get_modifier (opt->arg, 'm', p))	/* Deprecated for +i only and no +c allowed */
-					Ctrl->C.movie = GREENSPLINE_INC_MOVIE;
-				else if (gmt_get_modifier (opt->arg, 'M', p))
-					Ctrl->C.movie = GREENSPLINE_CUM_MOVIE;
+				if ((c = gmt_first_modifier (GMT, opt->arg, "cifmMn"))) {	/* Process any modifiers */
+					pos = 0;	/* Reset to start of new word */
+					while (gmt_getmodopt (GMT, 'C', c, "cifmMn", &pos, p, &n_errors) && n_errors == 0) {
+						switch (p[0]) {
+							case 'c': Ctrl->C.movie |= GREENSPLINE_CUM_MOVIE; break;
+							case 'i': Ctrl->C.movie |= GREENSPLINE_INC_MOVIE; break;
+							case 'f': Ctrl->C.file = strdup (&p[1]); break;
+							case 'm': Ctrl->C.movie = GREENSPLINE_INC_MOVIE; break;
+							case 'M': Ctrl->C.movie = GREENSPLINE_CUM_MOVIE; break;
+							case 'n': Ctrl->C.dryrun = true; break;
+							default: break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
+						}
+					}
+					c[0] = '\0';
+				}				
 				if (strchr (opt->arg, '/')) {	/* Old-style file specification */
 					if (gmt_M_compat_check (API->GMT, 5)) {	/* OK */
 						sscanf (&opt->arg[k], "%lf/%s", &Ctrl->C.value, p);
 						Ctrl->C.file = strdup (p);
 					}
 					else {
-						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Expected -C[n]<cut>[+c][+f<file>][+i]\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Expected -C[[n]<cut>[%]][+c][+f<file>][+i][+n]\n");
 						n_errors++;
 					}
 				}
-				else {
-					if (opt->arg[k])	/* Check if we got percentages or a value */
-						Ctrl->C.value = (Ctrl->C.mode && strchr (opt->arg, '%')) ? 0.01 * atof (&opt->arg[k]) : atof (&opt->arg[k]);
-					else
-						Ctrl->C.value = 0.0;
+				else if (opt->arg[k]) {	/* See if we got any value argument */
+					if (strchr (opt->arg, '%')) {	/* Got percentages of largest eigenvalues */
+						Ctrl->C.value = 0.01 * atof (&opt->arg[k]);
+						Ctrl->C.mode = GMT_SVD_EIGEN_PERCENT_CUTOFF;
+						if (Ctrl->C.value < 0.0 || Ctrl->C.value > 1.0) {
+							GMT_Report (API, GMT_MSG_ERROR, "Option -C: Percentage must be in 0-100%% range!\n");
+							n_errors++;
+						}
+					}
+					else	/* Got ratio cutoff */
+						Ctrl->C.value = atof (&opt->arg[k]);
 				}
+				if (Ctrl->C.value < 0.0) Ctrl->C.dryrun = true, Ctrl->C.value = 0.0;	/* Deprecated syntax */
 				break;
 			case 'D':
 				if (gmt_M_compat_check (API->GMT, 6) && strlen (opt->arg) == 1) {	/* Old -D<mode> option supported for backwards compatibility (now -Z) */
@@ -759,7 +770,7 @@ static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GM
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.mode == LINEAR_1D && Ctrl->Z.mode > 3, "Option -Sl: Cannot select -Z4 or higher\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->I.active && (Ctrl->I.inc[GMT_X] <= 0.0 || (dimension > 1 && Ctrl->I.inc[GMT_Y] <= 0.0) || (dimension == 3 && Ctrl->I.inc[GMT_Z] <= 0.0)), "Option -I: Must specify positive increment(s)\n");
 	n_errors += gmt_M_check_condition (GMT, dimension == 2 && !Ctrl->N.active && !(Ctrl->G.active  || Ctrl->G.file), "Option -G: Must specify output grid file name\n");
-	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->C.value < 0.0 && !Ctrl->C.file, "Option -C: Must specify file name for eigenvalues if cut < 0\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->C.dryrun && !Ctrl->C.file, "Option -C: Must specify file name for eigenvalues if +n is set");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->T.active && !Ctrl->T.file, "Option -T: Must specify mask grid file name\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->T.active && dimension != 2, "Option -T: Only applies to 2-D gridding\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && !Ctrl->N.file, "Option -N: Must specify node file name\n");
@@ -2283,7 +2294,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_INFORMATION, "Eigen-values saved to %s\n", Ctrl->C.file);
 			gmt_M_free (GMT, eig);
 
-			if (Ctrl->C.value < 0.0) {	/* We are done */
+			if (Ctrl->C.dryrun) {	/* We are done */
 				for (p = 0; p < nm; p++) gmt_M_free (GMT, X[p]);
 				gmt_M_free (GMT, X);
 				gmt_M_free (GMT, s);
@@ -2513,17 +2524,15 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 			gmt_grdfloat *current = NULL, *previous = NULL;
 			static char *mkind[3] = {"", "Incremental", "Cumulative"};
 			char file[PATH_MAX] = {""};
-			if (Ctrl->C.movie) {
-				current  = gmt_M_memory_aligned (GMT, NULL, Out->header->size, gmt_grdfloat);
-				if (Ctrl->C.movie & GREENSPLINE_INC_MOVIE)
-					previous = gmt_M_memory_aligned (GMT, NULL, Out->header->size, gmt_grdfloat);
-			}
+			current  = gmt_M_memory_aligned (GMT, NULL, Out->header->size, gmt_grdfloat);
+			if (Ctrl->C.movie & GREENSPLINE_INC_MOVIE)
+				previous = gmt_M_memory_aligned (GMT, NULL, Out->header->size, gmt_grdfloat);
 			gmt_grd_init (GMT, Out->header, options, true);
 
 			for (k = 0; k < n_use; k++) {	/* Only loop over the first n_use eigenvalues (if restricted) */
 				GMT_Report (API, GMT_MSG_INFORMATION, "Evaluate spline for eigenvalue # %d\n", (int)k);
 				gmt_M_memcpy (s, ssave, nm, double);	/* Restore original values before call */
-				(void)gmt_solve_svd (GMT, A, (unsigned int)nm, (unsigned int)nm, v, s, b, 1U, obs, (double)k, 1);
+				(void)gmt_solve_svd (GMT, A, (unsigned int)nm, (unsigned int)nm, v, s, b, 1U, obs, (double)k, GMT_SVD_EIGEN_NUMBER_CUTOFF);
 				if (Ctrl->Q.active) {	/* Derivatives of solution */
 #ifdef _OPENMP
 #pragma omp parallel for private(row,V,col,ij,p,wp,r,C,part) shared(Grid,yp,xp,nm,GMT,Ctrl,X,G,par,Lz,alpha,Out,normalize,norm)
@@ -2568,7 +2577,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 						}
 					}	/* End of row-loop [OpenMP] */
 				}
-				if (Ctrl->C.movie) gmt_M_memcpy (current, Out->data, Out->header->size, gmt_grdfloat);	/* Save current solution */
+				gmt_M_memcpy (current, Out->data, Out->header->size, gmt_grdfloat);	/* Save current solution */
 
 				if (Ctrl->C.movie & GREENSPLINE_CUM_MOVIE) {	/* Write out the cumulative solution first */
 					if (strchr (Ctrl->G.file, '%'))	/* Gave a template, use it to write one of the two types of grids */
@@ -2578,9 +2587,8 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 					snprintf (Out->header->remark, GMT_GRID_REMARK_LEN160, "%s (-S%s). %s contribution for eigenvalue # %d", method[Ctrl->S.mode], Ctrl->S.arg, mkind[GREENSPLINE_CUM_MOVIE], (int)k+1);
 					if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, Out))
 						Return (API->error);				/* Update solution for k eigenvalues only */
-					if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, Out) != GMT_NOERROR) {
+					if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, Out) != GMT_NOERROR)
 						Return (API->error);
-					}
 				}
 				if (Ctrl->C.movie & GREENSPLINE_INC_MOVIE) {	/* Want to write out incremental solution due to this eigenvalue */
 					gmt_M_grd_loop (GMT, Out, row, col, ij) Out->data[ij] = current[ij] - previous[ij];	/* Incremental improvement since last time */
@@ -2592,16 +2600,14 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 					snprintf (Out->header->remark, GMT_GRID_REMARK_LEN160, "%s (-S%s). %s contribution for eigenvalue # %d", method[Ctrl->S.mode], Ctrl->S.arg, mkind[GREENSPLINE_INC_MOVIE], (int)k+1);
 					if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, Out))
 						Return (API->error);				/* Update solution for k eigenvalues only */
-					if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, Out) != GMT_NOERROR) {
+					if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, file, Out) != GMT_NOERROR)
 						Return (API->error);
-					}
 				}
 			}
-			if (Ctrl->C.movie) {	/* Free temporary arrays */
-				gmt_M_free_aligned (GMT, current);
-				if (Ctrl->C.movie & GREENSPLINE_INC_MOVIE)
-					gmt_M_free_aligned (GMT, previous);
-			}
+			/* Free temporary arrays */
+			gmt_M_free_aligned (GMT, current);
+			if (Ctrl->C.movie & GREENSPLINE_INC_MOVIE)
+				gmt_M_free_aligned (GMT, previous);
 			gmt_M_free (GMT, A);
 			gmt_M_free (GMT, s);
 			gmt_M_free (GMT, v);
@@ -2626,6 +2632,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 							V[GMT_X] = xp[col];
 							/* Here, V holds the current output coordinates */
 							for (p = 0, wp = 0.0; p < (int64_t)nm; p++) {	/* Loop over Green's function components */
+								if (alpha[p] == 0.0) continue;	/* Note: The alpha's are not sorted so must loop over all then skip the zeros */
 								r = greenspline_get_radius (GMT, V, X[p], dimension);
 								C = greenspline_get_dircosine (GMT, Ctrl->Q.dir, V, X[p], dimension, false);
 								part = dGdr (GMT, r, par, Lz) * C;
@@ -2648,6 +2655,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 							V[GMT_X] = xp[col];
 							/* Here, V holds the current output coordinates */
 							for (p = 0, wp = 0.0; p < (int64_t)nm; p++) {	/* Loop over Green's function components */
+								if (alpha[p] == 0.0) continue;	/* Note: The alpha's are not sorted so must loop over all then skip the zeros */
 								r = greenspline_get_radius (GMT, V, X[p], dimension);
 								part = G (GMT, r, par, Lz);
 								wp += alpha[p] * part;

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -529,8 +529,11 @@ static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GM
 							n_errors++;
 						}
 					}
-					else	/* Got ratio cutoff */
+					else {	/* Got ratio cutoff */
 						Ctrl->C.value = atof (&opt->arg[k]);
+						if (Ctrl->C.value >= 0.0 && Ctrl->C.value < 1.0) /* Old style fraction */
+							Ctrl->C.mode = GMT_SVD_EIGEN_PERCENT_CUTOFF;
+					}
 				}
 				if (Ctrl->C.value < 0.0) Ctrl->C.dryrun = true, Ctrl->C.value = 0.0;	/* Deprecated syntax */
 				break;


### PR DESCRIPTION
Consolidate SVD operations and constants via a new set of constants in _gmt_constants.h_.  These are just used in **greenspline** and **gpsgridder** for now.

Also update the **gpsgridder** cumulative and incremental grid output based on **greenspline -C**.  Add **+n** for dry-runs (no grids, just eigenvalues) instead of relying on a negative argument.  Simplified file name via -G in **gpsgridder** following the lead in **greenspline**.  These changes are backward compatible.  Finalized the **-C+c+i** stuff in **gpsgridder** based on how it works in **greenspline**.  Have a new movie example that tests this and works.  Minor speed-ups by checking for zero eigen-values in the loops.


