### PR TITLE
Fix double and incorrect gridlines in psscale

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5972,10 +5972,9 @@ void gmt_plot_line (struct GMT_CTRL *GMT, double *x, double *y, unsigned int *pe
 
 void gmt_xy_axis2 (struct GMT_CTRL *GMT, double x0, double y0, double length, double val0, double val1, struct GMT_PLOT_AXIS *A, bool below, bool annotate, unsigned side) {
     /* Only used in psscale.c.  Because gmt_xy_axis does not do gridlines (done in gmt_map_basemap at a higher level),
-     * we must call for gridlines directly here */
+     * we do that separately in psscale.c */
 	if (annotate) side |= GMT_AXIS_BARB;
 	gmt_xy_axis (GMT, x0, y0, length, val0, val1, A, below, side);
-    gmtplot_map_gridlines (GMT, GMT->PSL, GMT->common.R.wesn[XLO], GMT->common.R.wesn[XHI], GMT->common.R.wesn[YLO], GMT->common.R.wesn[YHI]);
 }
 
 void gmt_linearx_grid (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n, double dval) {

--- a/test/pslegend/legcpt.ps
+++ b/test/pslegend/legcpt.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 612 792
 %%HiResBoundingBox: 0 0 612.0000 792.0000             
-%%Title: GMT v6.3.0_9eb0048-dirty_2021.08.16 [64-bit] Document from psbasemap
+%%Title: GMT v6.3.0_fa3f17c-dirty_2021.09.07 [64-bit] Document from psbasemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Aug 16 11:17:13 2021
+%%CreationDate: Tue Sep  7 13:14:35 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -1183,60 +1183,6 @@ S
 4724 0 M
 0 472 D
 S
-0 0 M
-4724 0 D
-S
-0 0 M
-0 472 D
-S
-295 0 M
-0 472 D
-S
-591 0 M
-0 472 D
-S
-886 0 M
-0 472 D
-S
-1181 0 M
-0 472 D
-S
-1476 0 M
-0 472 D
-S
-1772 0 M
-0 472 D
-S
-2067 0 M
-0 472 D
-S
-2362 0 M
-0 472 D
-S
-2657 0 M
-0 472 D
-S
-2953 0 M
-0 472 D
-S
-3248 0 M
-0 472 D
-S
-3543 0 M
-0 472 D
-S
-3839 0 M
-0 472 D
-S
-4134 0 M
-0 472 D
-S
-4429 0 M
-0 472 D
-S
-4724 0 M
-0 472 D
-S
 2362 -446 M 267 F0
 (m) tc Z
 0 setlinecap
@@ -1680,60 +1626,6 @@ N 4606 0 M 0 -42 D S
 N 4665 0 M 0 -42 D S
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 4 W
-0 0 M
-0 472 D
-S
-295 0 M
-0 472 D
-S
-591 0 M
-0 472 D
-S
-886 0 M
-0 472 D
-S
-1181 0 M
-0 472 D
-S
-1476 0 M
-0 472 D
-S
-1772 0 M
-0 472 D
-S
-2067 0 M
-0 472 D
-S
-2362 0 M
-0 472 D
-S
-2657 0 M
-0 472 D
-S
-2953 0 M
-0 472 D
-S
-3248 0 M
-0 472 D
-S
-3543 0 M
-0 472 D
-S
-3839 0 M
-0 472 D
-S
-4134 0 M
-0 472 D
-S
-4429 0 M
-0 472 D
-S
-4724 0 M
-0 472 D
-S
-0 0 M
-4724 0 D
-S
 0 0 M
 0 472 D
 S


### PR DESCRIPTION
When I recently "fixed" the missing gridlines in **psscale** I also seem to have added a second set of unwarranted gridlines.  This PR fixes #5728.  The PS has to be updated as it has two sets of gridlines that triggers a failure after fixing the code.
