### PR TITLE
WIP Remove session-specific directory if module is given Ctrl-C

### DIFF
--- a/src/gmt.c
+++ b/src/gmt.c
@@ -70,6 +70,7 @@ int main (int argc, char *argv[]) {
 	sigaction (SIGINT,  &act, NULL);
 #endif
 	act.sa_flags = SA_SIGINFO;
+	sigaction (SIGINT,  &act, NULL);
 	sigaction (SIGILL,  &act, NULL);
 	sigaction (SIGFPE,  &act, NULL);
 	sigaction (SIGBUS,  &act, NULL);

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -65,12 +65,8 @@ int main (int argc, char *argv[]) {
 	struct sigaction act;
 	sigemptyset(&act.sa_mask); /* Empty mask of signals to be blocked during execution of the signal handler */
 	act.sa_sigaction = sig_handler;
-#if 0 /* summit 2016 decision: disable CTRL-C interrupt feature */
-	act.sa_flags = SA_SIGINFO | SA_NODEFER; /* Do not prevent the signal from being received from within its own signal handler. */
-	sigaction (SIGINT,  &act, NULL);
-#endif
 	act.sa_flags = SA_SIGINFO;
-	sigaction (SIGINT,  &act, NULL);
+	sigaction (SIGINT,  &act, NULL);	/* This will also wipe a session work directory */
 	sigaction (SIGILL,  &act, NULL);
 	sigaction (SIGFPE,  &act, NULL);
 	sigaction (SIGBUS,  &act, NULL);

--- a/src/gmt_common_sighandler.c
+++ b/src/gmt_common_sighandler.c
@@ -184,7 +184,7 @@ void sig_handler(int sig_num, siginfo_t *info, void *ucontext) {
 	array [1] = info->si_addr; /* address of faulting instruction */
 
 	if (sig_num == SIGINT) {
-		/* catch ctrl-c and remove modern session directory */
+		/* catch ctrl-c and remove modern session directory before exit*/
 		gmtlib_terminate_session ();
 		exit (EXIT_FAILURE);
 	}

--- a/src/gmt_common_sighandler.c
+++ b/src/gmt_common_sighandler.c
@@ -184,16 +184,9 @@ void sig_handler(int sig_num, siginfo_t *info, void *ucontext) {
 	array [1] = info->si_addr; /* address of faulting instruction */
 
 	if (sig_num == SIGINT) {
-		/* catch ctrl-c */
-		int c;
-		struct sigaction act, oldact;
+		/* catch ctrl-c and remove modern session directory */
 		gmtlib_terminate_session ();
-		sigemptyset (&act.sa_mask);
-		act.sa_flags = 0;
-		act.sa_handler = SIG_DFL; /* restore default action (do not catch SIGINT again) */
-		sigaction (SIGINT, &act, &oldact); /* change signal handler */
-		sigaction (SIGINT, &oldact, NULL); /* restore old action */
-		return;
+		exit (EXIT_FAILURE);
 	}
 	else {
 #ifdef HAVE_STRSIGNAL

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18807,7 +18807,7 @@ void gmtlib_terminate_session () {
 	char dir[PATH_MAX] = {""};
 	if (global_API == NULL || global_API->session_dir == NULL || global_API->session_name == NULL) return;	/* Cannot check */
 	snprintf (dir, PATH_MAX, "%s/gmt_session.%s", global_API->session_dir, global_API->session_name);
-	GMT_Report (global_API, GMT_MSG_NOTICE, "Try to remove session directory %s\n", dir);
+	GMT_Report (global_API, GMT_MSG_NOTICE, "Remove session directory %s before exiting due to Ctrl-C\n", dir);
 	if (!access (dir, F_OK)) {	/* Session directory exist, try to remove it */
 		if (gmt_remove_dir (global_API, dir, false))
 			GMT_Report (global_API, GMT_MSG_WARNING, "Unable to remove session directory %s [permissions?]\n", dir);


### PR DESCRIPTION
See #5730 for background.  This PR reinstates a check for **SIG_INT** but the sig_handler has been changed to simply call _gmtlib_terminate_session_ () which will delete the current session directory so that we do not leave useless junk behind.  Closes #5730.

We need to test this a bit though. Again, not supported on Windows unless @joa-quim knows how it works there.  Run a modern mode command and hit Ctrl-C before it finishes.  You should see a message like this

```
cd ~
rm -f .gmt/server/earth/earth_relief/earth_relief_30s_p/N60E000.earth_relief_30s_p.nc
(base) pwessel@macnut:~-> gmt grdimage @earth_relief_30s -R10/15/60/65 -png t -V
begin [INFORMATION]: Creating a workflow directory /Users/pwessel/.gmt/sessions/gmt_session.1
grdimage [INFORMATION]: Read header from file /Users/pwessel/.gmt/sessions/gmt_session.1/=tiled_97_PX.000000
grdblend [INFORMATION]: Reading Data Table from file /Users/pwessel/.gmt/sessions/gmt_session.1/=tiled_97_PX.000000
grdblend [INFORMATION]: Downloading earth_relief_30s_p/ tile 1 of 1 [N60E000]
grdblend [INFORMATION]: Convert SRTM tile from JPEG2000 to netCDF grid [/Users/pwessel/.gmt/server/earth/earth_relief/earth_relief_30s_p/N60E000.earth_relief_30s_p.nc]
grdconvert [INFORMATION]: File /Users/pwessel/.gmt/server/earth/earth_relief/earth_relief_30s_p/N60E000.earth_relief_30s_p.jp2 reads with GDAL driver JP2OpenJPEG
grdconvert [INFORMATION]: Translating file /Users/pwessel/.gmt/server/earth/earth_relief/earth_relief_30s_p/N60E000.earth_relief_30s_p.jp2 (format gd = Import/export through GDAL) to file /Users/pwessel/.gmt/server/earth/earth_relief/earth_relief_30s_p/N60E000.earth_relief_30s_p.nc (format ns = GMT netCDF format (16-bit integer), CF-1.7)
grdconvert [INFORMATION]: File /Users/pwessel/.gmt/server/earth/earth_relief/earth_relief_30s_p/N60E000.earth_relief_30s_p.jp2 reads with GDAL driver JP2OpenJPEG
grdconvert [INFORMATION]: Reading grid from file /Users/pwessel/.gmt/server/earth/earth_relief/earth_relief_30s_p/N60E000.earth_relief_30s_p.jp2
grdconvert [INFORMATION]: Set boundary condition for all edges: natural
grdconvert [INFORMATION]: Set boundary condition for left   edge: natural
grdconvert [INFORMATION]: Set boundary condition for right  edge: natural
grdconvert [INFORMATION]: Set boundary condition for bottom edge: natural
grdconvert [INFORMATION]: Set boundary condition for top    edge: natural
grdconvert [INFORMATION]: Writing grid to file /Users/pwessel/.gmt/server/earth/earth_relief/earth_relief_30s_p/N60E000.earth_relief_30s_p.nc=ns+s0.5+o0
^Cgrdconvert [NOTICE]: Remove session directory /Users/pwessel/.gmt/sessions/gmt_session.1 before exiting due to Ctrl-C
```
The session directory should have been removed and you can run the same command (without Ctrl-C) and it will not complain about being in a modern mode session already.

This PR also makes a few changes in gmt.c by now listening for SIG_INT and then doing the above if caught.

Note: If you are running a modern mode _script_ and you hit Ctrl-C then there are complications:

1. If your script follows the guidelines from gmt --new-script then you have the -e option to bash and the script will quit if there is a failure.  Otherwise the script will continue and the next GMT commands will complain about no session.
2. Your Ctrl->C may also happen to hit a non-GMT command in the script and of course no session dir will be deleted.

We cannot control those things, but we can control interrupting a module.

We could also explain all of this, the way we ensure session continuity etc to preempt dumb things like running gmt begin in one terminal and running the next command in another terminal, or putting a gmt modern mode script in the background (prompt$ my_long_script.sh &) and then run another script in the same terminal.  I think that will cause interference.

