### PR TITLE
Fix grammatical error in triangulate docs

### DIFF
--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -47,7 +47,7 @@ Description
 
 **triangulate** reads one or more ASCII [or binary] files (or standard
 input) containing x,y[,z] and performs Delaunay triangulation, i.e., it
-find how the points should be connected to give the most equilateral
+finds how the points should be connected to give the most equilateral
 triangulation possible. If a map projection (give **-R** and **-J**) is
 chosen then it is applied before the triangulation is calculated. By
 default, the output is triplets of point id numbers that make up each


### PR DESCRIPTION
This pull request fixes a minor grammatical error in the doc string of the function `triangulate`.



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
