### PR TITLE
Allow -Ecode+L to list for specific country

### DIFF
--- a/doc/rst/source/coast.rst
+++ b/doc/rst/source/coast.rst
@@ -121,10 +121,10 @@ Optional Arguments
     NA (North America), or SA (South America).  Append **+l** to
     just list the countries and their codes [no data extraction or plotting takes place].
     Use **+L** to see states/territories for Argentina, Australia, Brazil, Canada, China, India, Russia and the US.
-    Finally, you can append **+l**\|\ **+L** to **-E**\ =\ *continent* to only list countries in that continent;
-    repeat if more than one continent is requested.
+    Finally, you can append **+l**\|\ **+L** to **-E**\ =\ *continent* or **-E**\ *code to only list
+    countries in that continent or country; repeat if more than one continent or country is requested.
     To set up clip paths based on your selection, append **+c** or **+C** for inside or outside (area between selection
-    and the map boundary) clipping, respectively.  To plot instead,
+    and the map boundary) clipping, res pectively.  To plot instead,
     append **+p**\ *pen* to draw polygon outlines [no outline] and
     **+g**\ *fill* to fill them [no fill].  One of **+c**\|\ **C**\|\ **g**\|\ **p** must be
     specified unless **-M** is in effect, in which case only one **-E** option can be given;

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -741,8 +741,12 @@ unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F) {
 		if (search) {	/* Listed continent(s) */
 			bool found = false;
 			for (kk = 0; kk < F->n_items; kk++) {
-				if (F->item[kk]->codes[0] == '=' && strstr (F->item[kk]->codes, GMT_DCW_country[i].continent))
-					found = true;
+				if (F->item[kk]->codes[0] == '=') {
+					if (strstr (F->item[kk]->codes, GMT_DCW_country[i].continent))
+						found = true;
+				}
+				else if (strncmp (F->item[kk]->codes, GMT_DCW_country[i].code, 2U) == 0)
+						found = true;
 			}
 			if (!found) continue;
 		}
@@ -790,7 +794,7 @@ void gmt_DCW_option (struct GMTAPI_CTRL *API, char option, unsigned int plot) {
 	}
 	GMT_Usage (API, 3, "+l Just list the countries and their codes [no %s takes place].", action2[plot]);
 	GMT_Usage (API, 3, "+L List states/territories for Argentina, Australia, Brazil, Canada, China, India, Russia and the US. "
-		"Select =<continent>+l|L to only list countries from that continent (repeatable).");
+		"Select =<continent>+l|L to only list countries from that continent or <code>+L for that country(repeatable).");
 	if (plot == 1)
 		GMT_Usage (API, 3, "+p Draw outline using given <pen> [none].");
 	GMT_Usage (API, 3, "+z Add -Z<countrycode> to multisegment headers if extracting polygons.");

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -754,8 +754,10 @@ unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F) {
 			sprintf (string, "%s [%s]", GMT_DCW_continents[k++], GMT_DCW_country[i].continent);
 			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 		}
-		sprintf (string, "%s\t%s", GMT_DCW_country[i].code, GMT_DCW_country[i].name);
-		GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+		if ((list_mode & 2) == 0) {
+			sprintf (string, "%s\t%s", GMT_DCW_country[i].code, GMT_DCW_country[i].name);
+			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+		}
 		if ((list_mode & 2) && gmtdcw_country_has_states (GMT_DCW_country[i].code, GMT_DCW_country_with_state, GMT_DCW_N_COUNTRIES_WITH_STATES)) {
 			for (j = 0; j < GMT_DCW_STATES; j++) {
 				if (!strcmp (GMT_DCW_country[i].code, GMT_DCW_state[j].country)) {


### PR DESCRIPTION
See the [forum](https://forum.generic-mapping-tools.org/t/dcw-get-list-of-states-within-a-country/2076) for background. This PR extends the list mechanism from just continents to also allow countries:

```
gmt coast -EAR+L
gmt coast -EUS+L
gmt pscoast -EUS+L -EAR+L
gmt coast -E=AS+L -EAR+L
```
