### PR TITLE
Change number of listed options in dimfilter distance_flag docstring

### DIFF
--- a/doc/rst/source/dimfilter.rst
+++ b/doc/rst/source/dimfilter.rst
@@ -67,7 +67,7 @@ Required Arguments
     cos(middle y), Cartesian distances.
 
     The above options are fastest because they allow weight matrix to be
-    computed only once. The next three options are slower because they
+    computed only once. The next two options are slower because they
     recompute weights for each latitude.
 
     *flag* = 3: grid (x,y) in degrees, *width* in km, dx scaled by


### PR DESCRIPTION
The `dimfilter` `distance_flag` parameter docstring refers to "The next three options" followed by only two options. This pull request changes "three" to "two".



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
