### PR TITLE
Check if unit is nonzero before passing to a print statement

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16797,7 +16797,10 @@ int gmt_set_measure_unit (struct GMT_CTRL *GMT, char unit) {
 	int k;
 
 	if ((k = gmt_get_dim_unit (GMT, unit)) < 0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad plot measure selected (%c); use c, i, or p.\n", unit);
+		if (unit)
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad plot measure selected (%c); use c, i, or p.\n", unit);
+		else
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "No plot measure selected; use c, i, or p.\n");
 		return (GMT_MAP_BAD_MEASURE_UNIT);
 	}
 	GMT->current.setting.proj_length_unit = k;


### PR DESCRIPTION
It messes up the message if a char 0 is attempted to be printed by %c.

Before: 

```
gmt mapproject -R0/60/0/60 -JM6i -D    
mapproject [ERROR]: Bad plot measure selected (mapproject (mapproject.c:909(GMT_mapproject)): Bad measurement unit.  Choose among c|i|p [-D]
```

After:

```
gmt mapproject -R0/60/0/60 -JM6i -D
mapproject [ERROR]: No plot measure selected; use c, i, or p.
mapproject (mapproject.c:909(GMT_mapproject)): Bad measurement unit.  Choose among c|i|p [-D]
```