### PR TITLE
Require -G when -Tr is used for gmtbinstats

### DIFF
--- a/src/gmtbinstats.c
+++ b/src/gmtbinstats.c
@@ -289,7 +289,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTBINSTATS_CTRL *Ctrl, struct GM
 			n_errors += gmt_M_check_condition (GMT, Ctrl->E.active, "Option -Th: The -E option is not allowed for hexagonal tiling\n");
 		}
 		else {
-			n_errors += gmt_M_check_condition (GMT, !Ctrl->G.active, "Option -Tr: The -G option is a required argument when -Tr is used\n");
+			n_errors += gmt_M_check_condition (GMT, !Ctrl->G.active, "Option -Tr: -G is a required argument when -Tr is used\n");
 		}
 		n_errors += gmt_M_check_condition (GMT, Ctrl->S.active, "Option -T: No search radius -S can be set for tiling\n");
 	}

--- a/src/gmtbinstats.c
+++ b/src/gmtbinstats.c
@@ -288,6 +288,9 @@ static int parse (struct GMT_CTRL *GMT, struct GMTBINSTATS_CTRL *Ctrl, struct GM
 			n_errors += gmt_M_check_condition (GMT, !doubleAlmostEqual (GMT->common.R.inc[GMT_X], GMT->common.R.inc[GMT_Y]), "Option -Th: Give a single argument reflecting desired y-increment\n");
 			n_errors += gmt_M_check_condition (GMT, Ctrl->E.active, "Option -Th: The -E option is not allowed for hexagonal tiling\n");
 		}
+		else {
+			n_errors += gmt_M_check_condition (GMT, !Ctrl->G.active, "Option -Tr: The -G option is a required argument when -Tr is used\n");
+		}
 		n_errors += gmt_M_check_condition (GMT, Ctrl->S.active, "Option -T: No search radius -S can be set for tiling\n");
 	}
 	else {


### PR DESCRIPTION
**Description of proposed changes**

For gmtbinstats, **-Th** writes to standard output or the file given to **-G**, whereas **-Tr** only writes to the grid named in **-G**. I think this check should avoid confusion when going between rectangular and hexagonal binning.

For example, this redirects the hexagon center and statistic to `ave.txt`:

```
gmt binstats test_data.txt -R0/5/0/3 -I1 -Th -Cg > ave.txt
```

Changing **-Th** to **-Tr** results in an empty file without any explanation to the user, which is not good.

The other option would be to make the behavior for **-Tr** more similar to **-Th**, in that when **-G** is not set the bin center and computed statistic are written to stdout.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->



**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
