### PR TITLE
Double-check after file lock if file magically is there

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -616,6 +616,12 @@ GMT_LOCAL int gmtremote_get_url (struct GMT_CTRL *GMT, char *url, char *file, ch
 	if ((LF = gmtremote_lock_on (GMT, file)) == NULL)
 		return 1;
 
+	/* If file locking held us up as another process was downloading the same file,
+	 * then that file should now be available.  So we check again if it is before proceeding */
+
+	if (!access (file, F_OK))
+		return GMT_NOERROR;	/* Yes it was! */
+
 	/* Initialize the curl session */
 	if ((Curl = gmtremote_setup_curl (API, url, file, &urlfile, GMT_HASH_TIME_OUT)) == NULL)
 		goto unlocking1;
@@ -1187,6 +1193,12 @@ int gmt_download_file (struct GMT_CTRL *GMT, const char *name, char *url, char *
 	/* Only make a lock if not a query */
 	if (!query && (LF = gmtremote_lock_on (GMT, (char *)name)) == NULL)
 		return 1;
+
+	/* If file locking held us up as another process was downloading the same file,
+	 * then that file should now be available.  So we check again if it is before proceeding */
+
+	if (!access (localfile, F_OK))
+		return GMT_NOERROR;	/* Yes it was! */
 
 	/* Initialize the curl session */
 	if ((Curl = gmtremote_setup_curl (API, url, localfile, &urlfile, 0)) == NULL)


### PR DESCRIPTION
See #5757 for background.  This PR addresses the solution suggested by checking after we pass the file-lock step if the file magically has been created by another process before we start downloading the file as we set out to do.  Closes #5757.
