### PR TITLE
Consistently describe output grid name and modifiers in rst docs

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -2798,7 +2798,7 @@ Writing grids and images
 Saving images in the common raster formats is possible but, for the time being, only from :doc:`/grdimage` and even
 that is restricted to raster type information. That is, vector data (for instance, coast lines) or text will not
 be saved. To save an image with :doc:`/grdimage` use the **-A**\ *outimg=driver* mechanism, where *driver*
-is the driver code name used by GDAL (e.g. GTiff).
+is the driver code name used by GDAL (e.g. GTiff) (run `gdal_translate --formats` for the full list.)
 
 For all other programs that create grids, it is also possible to save them using GDAL. To do it one need to use
 the =gd appended with the necessary information regarding the driver and the data type to use. Generically,
@@ -2810,6 +2810,10 @@ number of GDAL *-co* options. For example, to write a lossless JPG2000 grid one 
 **+c**\ QUALITY=100\ **+c**\ REVERSIBLE=YES\ **+c**\ YCBCR420=NO
 **Note**: You will have to specify a *nan* value for integer data types unless you wish that all NaN data values
 should be replaced by zero.
+
+Consider setting :term:`IO_NC4_DEFLATION_LEVEL` to reduce file size and to further increase read/write performance.
+Especially when working with subsets of global grids, masks, and grids with repeating grid values, the improvement is
+usually significant.
 
 The NaN data value
 ------------------

--- a/doc/rst/source/dimfilter.rst
+++ b/doc/rst/source/dimfilter.rst
@@ -58,23 +58,22 @@ Required Arguments
 
 .. _-D:
 
-**-D**\ *0-4*
-    Distance *flag* determines how grid (x,y) relates to filter *width*, as follows:
+**-D**\ *flag*
+    Distance *flag* (0-4) determines how grid (x,y) relates to filter *width*, as follows:
 
-    *flag* = 0: grid (x,y) in same units as *width*, Cartesian distances.
-    *flag* = 1: grid (x,y) in degrees, *width* in kilometers, Cartesian distances.
-    *flag* = 2: grid (x,y) in degrees, *width* in km, dx scaled by
-    cos(middle y), Cartesian distances.
+    - *flag* = 0: grid (x,y) in same units as *width*, Cartesian distances.
+    - *flag* = 1: grid (x,y) in degrees, *width* in kilometers, Cartesian distances.
+    - *flag* = 2: grid (x,y) in degrees, *width* in km, dx scaled by
+      cos(middle y), Cartesian distances.
 
     The above options are fastest because they allow weight matrix to be
     computed only once. The next two options are slower because they
     recompute weights for each latitude.
 
-    *flag* = 3: grid (x,y) in degrees, *width* in km, dx scaled by
-    cosine(y), Cartesian distance calculation.
-
-    *flag* = 4: grid (x,y) in degrees, *width* in km, Spherical distance
-    calculation.
+    - *flag* = 3: grid (x,y) in degrees, *width* in km, dx scaled by
+      cosine(y), Cartesian distance calculation.
+    - *flag* = 4: grid (x,y) in degrees, *width* in km, Spherical distance
+      calculation.
 
 .. _-F:
 
@@ -83,20 +82,17 @@ Required Arguments
     non-convolution filters. Append the filter code **x** followed by the full
     diameter *width*. Available convolution filters are:
 
-    (**b**) Boxcar: All weights are equal.
-
-    (**c**) Cosine Arch: Weights follow a cosine arch curve.
-
-    (**g**) Gaussian: Weights are given by the Gaussian function.
-
+    - (**b**) Boxcar: All weights are equal.
+    - (**c**) Cosine Arch: Weights follow a cosine arch curve.
+    - (**g**) Gaussian: Weights are given by the Gaussian function.
+    
     Non-convolution filters are:
 
-    (**m**) Median: Returns median value.
-
-    (**p**) Maximum likelihood probability (a mode estimator): Return
-    modal value. If more than one mode is found we return their average
-    value. Append **+l** or **+h** to the filter width if you rather want to
-    return the smallest or largest of each sector's modal values.
+    - (**m**) Median: Returns median value.
+    - (**p**) Maximum likelihood probability (a mode estimator): Return modal
+      value. If more than one mode is found we return their average value.
+      Append **+l** or **+h** to the filter width if you rather want to return
+      the smallest or largest of each sector's modal values.
 
 .. _-N:
 
@@ -106,24 +102,21 @@ Required Arguments
     set to 1, the secondary filter is not effective. Available secondary
     filters **x** are:
 
-    (**l**) Lower: Return the minimum of all filtered values.
-
-    (**u**) Upper: Return the maximum of all filtered values.
-
-    (**a**) Average: Return the mean of all filtered values.
-
-    (**m**) Median: Return the median of all filtered values.
-
-    (**p**) Mode: Return the mode of all filtered values:
-    If more than one mode is found we return their average
-    value. Append **+l** or **+h** to the sectors if you rather want to
-    return the smallest or largest of the modal values.
+    - (**l**) Lower: Return the minimum of all filtered values.
+    - (**u**) Upper: Return the maximum of all filtered values.
+    - (**a**) Average: Return the mean of all filtered values.
+    - (**m**) Median: Return the median of all filtered values.
+    - (**p**) Mode: Return the mode of all filtered values: If more than one
+      mode is found we return their average value. Append **+l** or **+h** to
+      the sectors if you rather want to return the smallest or largest of the
+      modal values.
 
 .. _-G:
 
-**-G**\ *outgrid*
-    *outgrid* is the name of the binary output grid file. (See
-    :ref:`Grid File Formats <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/explain_grd_inout.rst_
+++ b/doc/rst/source/explain_grd_inout.rst_
@@ -63,4 +63,28 @@ double quotes.
 .. ingrid-syntax-ends
 .. outgrid-syntax-begins
 
+**-G**\ *outgrid*\ [=\ *ID*][**+d**\ *divisor*][**+n**\ *invalid*]
+[**+o**\ *offset*\|\ **a**][**+s**\ *scale*\|\ **a**]
+[:*driver*\ [*dataType*][**+c**\ *options*]]
+
+    |Add_outgrid| Optionally, append =\ *ID* for writing a specific file format
+    (:ref:`See full description <grd_inout_full>`). The following modifiers are
+    supported:
+
+        - **+d** - Divide data values by given *divisor* [Default is 1].
+        - **+n** - Replace data values matching *invalid* with a NaN.
+        - **+o** - Offset data values by the given *offset*, or append **a** for
+          automatic range offset to preserve precision for integer grids
+          [Default is 0].
+        - **+s** - Scale data values by the given *scale*, or append **a** for
+          automatic scaling to preserve precision for integer grids [Default
+          is 1].
+
+    Note: Any offset is added before any scaling. **+sa** also sets **+oa**
+    (unless overridden). To write specific formats via GDAL, use = *gd*
+    and supply *driver* (and optionally *dataType*) and/or one or more
+    concatenated GDAL **-co** options using **+c**. See
+    the :ref:`"Writing grids and images" cookbook section <Write-grids-images>`
+    for more details.
+
 .. outgrid-syntax-ends

--- a/doc/rst/source/gmtbinstats.rst
+++ b/doc/rst/source/gmtbinstats.rst
@@ -75,8 +75,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Give the name of the output grid file.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/grdclip.rst
+++ b/doc/rst/source/grdclip.rst
@@ -44,8 +44,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    *outgrid* is the modified output grid file. (See :ref:`Grid File Formats <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/grdconvert.rst
+++ b/doc/rst/source/grdconvert.rst
@@ -39,36 +39,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*\ [=*ID*[**+d**\ *divisor*][**+n**\ *invalid*]][**+o**\ *offset*][**+s**\ *scale*][*:driver*\ [/*datatype*]]]
-    The grid file to be written. Append format =\ *ID* code if not a
-    standard COARDS-compliant netCDF grid file. If =\ *ID* is set (see
-    below), you may optionally append  any of **+s**\ *scale*,
-    **+o**\ *offset*, and **+n**\ *invalid*.  These modifiers are
-    particularly practical when storing the data as integers, by
-    first removing an offset and then scaling down the values.
-    Since the scale and offset are applied in reverse order when
-    reading, this does not affect the data values (except for
-    round-offs).  The **+n** modifier let you append a value
-    that represents 'Not-a-Number' (for floating-point grids this is
-    unnecessary since the IEEE NaN is used; however integers need a
-    value which means no data available). You may specify **+s**\ *a*
-    for auto-adjusting the scale and/or offset of packed integer grids
-    (=\ *ID*\ **+s**\ *a* is a shorthand for =\ *ID*\ **+s**\ *a*\ **+o**\ *a*).
-    When *ID*\ =\ *gd*, the file will be saved using the
-    GDAL library. Append the format *:driver* and optionally the output
-    *datatype*. The driver names are those used by GDAL itself (e.g.,
-    netCDF, GTiFF, etc.; run **gdal_translate --formats** for the full list),
-    and the data type is one of
-    *u8*\|\ *u16*\|\ *i16*\|\ *u32*\|\ *i32*\|\ *float32*,
-    where *i*' and *u* denote signed and unsigned integers respectively.
-    The default type is *float32*. Note also that both driver names and
-    data types are case insensitive.
-    See Section :ref:`grid-file-format` of the GMT Technical Reference and Cookbook for more information.
-
-    Consider setting :term:`IO_NC4_DEFLATION_LEVEL`
-    to reduce file size and to further increase read/write performance.
-    Especially when working with subsets of global grids, masks, and grids with
-    repeating grid values, the improvement is usually significant.
+.. |Add_outgrid| replace:: Give the name of the output converted grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/grdcut.rst
+++ b/doc/rst/source/grdcut.rst
@@ -51,8 +51,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    This is the output grid file.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/grdedit.rst
+++ b/doc/rst/source/grdedit.rst
@@ -91,9 +91,11 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Normally, **grdedit** will overwrite the existing grid with the modified grid.
+.. |Add_outgrid| replace:: Normally, **grdedit** will overwrite the existing grid with the modified grid.
     Use **-G** to write the modified grid to the file *outgrid* instead.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. |Add_-J| replace:: Use the **-J** syntax to save the georeferencing info as CF-1 compliant
     metadata in netCDF grids. This metadata will be recognized by GDAL.

--- a/doc/rst/source/grdfill.rst
+++ b/doc/rst/source/grdfill.rst
@@ -54,8 +54,10 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    This is the output grid file.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-N:
 

--- a/doc/rst/source/grdfilter.rst
+++ b/doc/rst/source/grdfilter.rst
@@ -49,33 +49,28 @@ Required Arguments
 
 .. _-D:
 
-**-D**\ *distance_flag*
+**-D**\ *flag*
     Distance *flag* tells how grid (x,y) relates to filter *width* as
     follows:
 
-    *flag* = p: grid (px,py) with *width* an odd number of pixels;
-    Cartesian distances.
-
-    *flag* = 0: grid (x,y) same units as *width*, Cartesian distances.
-
-    *flag* = 1: grid (x,y) in degrees, *width* in kilometers, Cartesian
-    distances.
-
-    *flag* = 2: grid (x,y) in degrees, *width* in km, dx scaled by
-    cos(middle y), Cartesian distances.
+    - *flag* = p: grid (px,py) with *width* an odd number of pixels;
+      Cartesian distances.
+    - *flag* = 0: grid (x,y) same units as *width*, Cartesian distances.
+    - *flag* = 1: grid (x,y) in degrees, *width* in kilometers, Cartesian
+      distances.
+    - *flag* = 2: grid (x,y) in degrees, *width* in km, dx scaled by
+      cos(middle y), Cartesian distances.
 
     The above options are fastest because they allow weight matrix to be
     computed only once. The next three options are slower because they
     recompute weights for each latitude.
 
-    *flag* = 3: grid (x,y) in degrees, *width* in km, dx scaled by
-    cosine(y), Cartesian distance calculation.
-
-    *flag* = 4: grid (x,y) in degrees, *width* in km, Spherical distance
-    calculation.
-
-    *flag* = 5: grid (x,y) in Mercator **-Jm**\ 1 img units, *width* in
-    km, Spherical distance calculation.
+    - *flag* = 3: grid (x,y) in degrees, *width* in km, dx scaled by
+      cosine(y), Cartesian distance calculation.
+    - *flag* = 4: grid (x,y) in degrees, *width* in km, Spherical distance
+      calculation.
+    - *flag* = 5: grid (x,y) in Mercator **-Jm**\ 1 img units, *width* in
+      km, Spherical distance calculation.
 
 .. _-F:
 
@@ -92,58 +87,49 @@ Required Arguments
 
     Convolution filters (and their codes) are:
 
-    (**b**) Boxcar: All weights are equal.
-
-    (**c**) Cosine Arch: Weights follow a cosine arch curve.
-
-    (**g**) Gaussian: Weights are given by the Gaussian function, where
-    *width* is 6 times the conventional Gaussian sigma.
-
-    (**f**) Custom: Weights are given by the precomputed values in the
-    filter weight grid file *weight*, which must have odd dimensions;
-    also requires **-D0** and output spacing must match input spacing or
-    be integer multiples.
-
-    (**o**) Operator: Weights are given by the precomputed values in the
-    filter weight grid file *weight*, which must have odd dimensions;
-    also requires **-D0** and output spacing must match input spacing or
-    be integer multiples. Weights are assumed to sum to zero so no
-    accumulation of weight sums and normalization will be done.
+    - (**b**) Boxcar: All weights are equal.
+    - (**c**) Cosine Arch: Weights follow a cosine arch curve.
+    - (**g**) Gaussian: Weights are given by the Gaussian function, where
+      *width* is 6 times the conventional Gaussian sigma.
+    - (**f**) Custom: Weights are given by the precomputed values in the
+      filter weight grid file *weight*, which must have odd dimensions;
+      also requires **-D0** and output spacing must match input spacing or
+      be integer multiples.
+    - (**o**) Operator: Weights are given by the precomputed values in the
+      filter weight grid file *weight*, which must have odd dimensions;
+      also requires **-D0** and output spacing must match input spacing or
+      be integer multiples. Weights are assumed to sum to zero so no
+      accumulation of weight sums and normalization will be done.
 
     Non-convolution filters (and their codes) are:
 
-    (**m**) Median: Returns median value. To select another quantile
-    append **+q**\ *quantile* in the 0-1 range [Default is 0.5, i.e., median].
-
-    (**p**) Maximum likelihood probability (a mode estimator): Return
-    modal value. If more than one mode is found we return their average
-    value. Append **+l** or **+u** if you rather want
-    to return the lowermost or uppermost of the modal values.
-
-    (**h**) Histogram mode (another mode estimator): Return the modal
-    value as the center of the dominant peak in a histogram. Append /*binwidth* to
-    specify the binning interval.  Use modifier **+c** to center the
-    bins on multiples of *binwidth* [Default has bin edges that are
-    multiples of *binwidth*].  If more than one mode is found we return their average
-    value. Append **+l** or **+u** if you rather want
-    to return the lowermost or uppermost of the modal values.
-
-    (**l**) Lower: Return the minimum of all values.
-
-    (**L**) Lower: Return minimum of all positive values only.
-
-    (**u**) Upper: Return maximum of all values.
-
-    (**U**) Upper: Return maximum or all negative values only.
+    - (**m**) Median: Returns median value. To select another quantile
+      append **+q**\ *quantile* in the 0-1 range [Default is 0.5, i.e., median].
+    - (**p**) Maximum likelihood probability (a mode estimator): Return
+      modal value. If more than one mode is found we return their average
+      value. Append **+l** or **+u** if you rather want
+      to return the lowermost or uppermost of the modal values.
+    - (**h**) Histogram mode (another mode estimator): Return the modal
+      value as the center of the dominant peak in a histogram. Append /*binwidth* to
+      specify the binning interval.  Use modifier **+c** to center the
+      bins on multiples of *binwidth* [Default has bin edges that are
+      multiples of *binwidth*].  If more than one mode is found we return their average
+      value. Append **+l** or **+u** if you rather want
+      to return the lowermost or uppermost of the modal values.
+    - (**l**) Lower: Return the minimum of all values.
+    - (**L**) Lower: Return minimum of all positive values only.
+    - (**u**) Upper: Return maximum of all values.
+    - (**U**) Upper: Return maximum or all negative values only.
 
     In the case of **L**\|\ **U** it is possible that no data passes
     the initial sign test; in that case the filter will return NaN.
 
 .. _-G:
 
-**-G**\ *outgrid*
-    *outgrid* is the output grid file of the filter. (See :ref:`Grid File Formats
-    <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output filtered grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/grdgdal.rst
+++ b/doc/rst/source/grdgdal.rst
@@ -61,8 +61,11 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outfile*
-    Output file name. *outfile* is the name of the output grid (or image) file. When saving images, the GDAL machinery is picked by default.
+.. |Add_outgrid| replace:: Give the name of the output grid (or images) file. When saving images, the GDAL machinery is
+    picked by default.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/grdgradient.rst
+++ b/doc/rst/source/grdgradient.rst
@@ -44,9 +44,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Name of the output grid file for the directional derivative. (See :ref:`Grid File Formats
-    <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output grid file for the directional derivative.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/grdhisteq.rst
+++ b/doc/rst/source/grdhisteq.rst
@@ -79,9 +79,10 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Name of output 2-D grid file. Used with **-N** only. (See :ref:`Grid File Formats
-    <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output grid file. Used with |-N| only.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-N:
 

--- a/doc/rst/source/grdlandmask.rst
+++ b/doc/rst/source/grdlandmask.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdlandmask** |-G|\ *mask_grd_file*
+**gmt grdlandmask** |-G|\ *outgrid*
 |SYN_OPT-I|
 |SYN_OPT-R|
 [ |SYN_OPT-Area| ]
@@ -41,8 +41,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *mask_grd_file*
-    Name of resulting output mask grid file. (See :ref:`Grid File Formats <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output mask grid.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/grdmask.rst
+++ b/doc/rst/source/grdmask.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdmask** *table* |-G|\ *mask_grd_file*
+**gmt grdmask** *table* |-G|\ *outgrid*
 |SYN_OPT-I|
 |SYN_OPT-R|
 [ |-A|\ [**m**\|\ **p**\|\ **x**\|\ **y**\|\ **r**\|\ **t**] ]
@@ -61,9 +61,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *mask_grd_file*
-    Name of resulting output mask grid file. (See :ref:`Grid File Formats
-    <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output mask grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/grdproject.rst
+++ b/doc/rst/source/grdproject.rst
@@ -56,9 +56,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Specify the name of the output grid file. (See :ref:`Grid File Formats
-    <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. |Add_-J| replace:: |Add_-J_links|
 .. include:: explain_-J.rst_

--- a/doc/rst/source/grdsample.rst
+++ b/doc/rst/source/grdsample.rst
@@ -53,9 +53,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    The name of the output grid file. (See
-    :ref:`Grid File Formats <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/nearneighbor.rst
+++ b/doc/rst/source/nearneighbor.rst
@@ -77,8 +77,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Give the name of the output grid file.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/sph2grd.rst
+++ b/doc/rst/source/sph2grd.rst
@@ -47,9 +47,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *grdfile*
-    *grdfile* is the name of the binary output grid file. (See
-    :ref:`Grid File Formats <grd_inout_full>`).
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/sphdistance.rst
+++ b/doc/rst/source/sphdistance.rst
@@ -56,9 +56,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *grdfile*
-    Name of the output grid to hold the computed distances (but see **-E**
-    for other node value options).
+.. |Add_outgrid| replace:: Give the name of the output distance grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/sphinterpolate.rst
+++ b/doc/rst/source/sphinterpolate.rst
@@ -52,8 +52,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *grdfile*
-    Name of the output grid to hold the interpolation.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/supplements/geodesy/earthtide.rst
+++ b/doc/rst/source/supplements/geodesy/earthtide.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt earthtide**
 |-T|\ [*min/max*\ /]\ *inc*\ [**+i**\|\ **n**] \|\ |-T|\ *file*\|\ *list*
-|-G|\ *grdfile*
+|-G|\ *outgrid*
 [ |-C|\ *x|e,y|n,z|v* ]
 [ |SYN_OPT-I| ]
 [ |-L|\ *lon/lat* ]
@@ -37,17 +37,19 @@ The output can be either in the form of a grid or as a table printed to stdout. 
 Required Arguments
 ------------------
 
-Either **-G**, **-S** or **-L**
+Either |-G|, |-S| or |-L| must be provided.
 
 .. _-G:
 
-**-G**\ *grdfile*
-    Write one or more tide component directly to grids; no table data are written to standard output.
-    If more than one component are specified via **-C** then *grdfile* must contain the format flag %s
-    so that we can embed the component code in the file names (*n* for north; *e* for east and *v* for vertical).
-    If only one component is selected with **-C** than no code is appended to grid name (an no need to
+.. |Add_outgrid| replace:: Write one or more tide component directly to grids; no table data are written to standard
+    output. If more than one component are specified via **-C** then *outgrid* must contain the format flag %s so that
+    we can embed the component code in the file names (*n* for north; *e* for east and *v* for vertical).
+    If only one component is selected with **-C** than no code is appended to grid name (and no need to
     set the format flag %s). The grid(s) are computed at the time set by **-T**, if that option is used, or
     at the *now* time calculated in UTC from the computer clock.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-S:
 

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt gpsgridder** [ *table* ]
-|-G|\ *outfile*
+|-G|\ *outgrid*
 [ |-C|\ [[**n**\|\ **r**\|\ **v**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**][**+n**] ]
 [ |-E|\ [*misfitfile*] ]
 [ |-F|\ [**d**\|\ **f**]\ *fudge* ]
@@ -78,16 +78,15 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outfile*
-    Name of resulting output file(s). (1) If options **-R**, **-I**, and
-    possibly **-r** are set we produce two equidistant output grids. In
-    this case, we take *outfile* and append "_u" and "_v" before the extension, respectively.
-    (2) If option **-T** is selected then **-R**, **-I** cannot be given
-    as the *maskgrid* determines the region and increments. The two output
-    filenames are generated as under (1).
-    (3) If **-N** is selected then the output is a single ASCII (or binary; see
-    **-bo**) table written to *outfile*; if **-G** is not given then
-    this table is written to standard output.
+.. |Add_outgrid| replace:: Name of resulting output grids(s). (1) If options |-R|, |-I|, and possibly **-r** are set
+    we produce two equidistant output grids. In this case, we take *outgrid* and append "_u" and "_v" before the extension,
+    respectively. (2) If option |-T| is selected then |-R|, |-I| cannot be given as the *maskgrid* determines the region
+    and increments. The two output grid names are generated as under (1). (3) If |-N| is selected then the output is a
+    single ASCII (or binary; see **-bo**) table written to *outfile*; if **-G** is not given then this table is written to
+    standard output.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/supplements/img/img2grd.rst
+++ b/doc/rst/source/supplements/img/img2grd.rst
@@ -46,8 +46,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *grdfile*
-    *grdfile* is the name of the output grid file.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-R:
 

--- a/doc/rst/source/supplements/potential/gmtgravmag3d.rst
+++ b/doc/rst/source/supplements/potential/gmtgravmag3d.rst
@@ -16,7 +16,7 @@ Synopsis
 [ |-C|\ *density* ]
 [ |-E|\ *thickness* ]
 [ |-F|\ *xy_file* ]
-[ |-G|\ *outputgrid* ]
+[ |-G|\ *outgrid* ]
 [ |-H|\ *f_dec*/*f_dip*/*m_int*/*m_dec*/*m_dip* ]
 [ |-L|\ *z_observation* ]
 [ |-S|\ *radius* ]
@@ -57,8 +57,10 @@ Required Arguments (not all)
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Output the gravity or magnetic anomaly at nodes of this grid file.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-M:
 

--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt gravfft** *ingrid* [ *ingrid2* ]
-|-G|\ *outfile*
+|-G|\ *outgrid*
 [ |-C|\ *n/wavelength/mean\_depth*/**t**\|\ **b**\|\ **w** ]
 [ |-D|\ *density*\|\ *rhogrid* ]
 [ |-E|\ *n_terms* ]
@@ -70,9 +70,11 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outfile*
-    Specify the name of the output grid file or the 1-D spectrum table
-    (see **-E**). (See :ref:`Grid File Formats <grd_inout_full>`).
+.. |Add_outgrid| replace:: Specify the name of the output grid file or the 1-D spectrum table
+    (see |-E|)
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -93,12 +93,14 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outfile*
-    If **-T** is set then *grdfile* must be a filename template that contains
+.. |Add_outgrid| replace:: If |-T| is set then *outgrid* must be a filename template that contains
     a floating point format (C syntax).  If the filename template also contains
     either %s (for unit name) or %c (for unit letter) then we use the corresponding time
-    (in units specified in **-T**) to generate the individual file names, otherwise
+    (in units specified in |-T|) to generate the individual file names, otherwise
     we use time in years with no unit.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/supplements/potential/grdgravmag3d.rst
+++ b/doc/rst/source/supplements/potential/grdgravmag3d.rst
@@ -58,8 +58,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Output the gravity anomaly at nodes of this grid file.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt grdseamount** [ *table* ]
-|-G|\ *grdfile*
+|-G|\ *outgrid*
 |SYN_OPT-I|
 |SYN_OPT-R|
 [ |-A|\ [*out*/*in*] ]
@@ -64,13 +64,13 @@ Required Arguments (if **-L** not given)
 
 .. _-G:
 
-**-G**\ *grdfile*
-    Specify the name of the output grid file (see :ref:`Grid File Formats <grd_inout_full>`).
-    If **-T** is set then *grdfile* must be a filename template that contains
-    a floating point format (C syntax).  If the filename template also contains
-    either %s (for unit name) or %c (for unit letter) then we use the corresponding time
-    (in units specified in **-T**) to generate the individual file names, otherwise
-    we use time in years with no unit.
+.. |Add_outgrid| replace:: Give the name of the output grid file. If |-T| is set then *outgrid* must be a filename
+    template that contains a floating point format (C syntax).  If the filename template also contains
+    either %s (for unit name) or %c (for unit letter) then we use the corresponding time (in units specified in |-T|)
+    to generate the individual file names, otherwise we use time in years with no unit.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/supplements/segy/segy2grd.rst
+++ b/doc/rst/source/supplements/segy/segy2grd.rst
@@ -49,8 +49,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *grdfile*
-    *grdfile* is the name of the binary output grid file.
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/supplements/spotter/grdpmodeler.rst
+++ b/doc/rst/source/supplements/spotter/grdpmodeler.rst
@@ -75,14 +75,16 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Name of output grid. This is the grid with the model predictions
+.. |Add_outgrid| replace:: Name of output grid. This is the grid with the model predictions
     given the specified rotations. **Note**: If you specified more than one
     model prediction in **-S** then the filename *must* be a template
     that contains the format %s; this will be replaced with the corresponding
     tags az, dist, stage, vel, omega, dlon, dlat, lon, lat.
     If the **-G** option is not used then we create no grids and instead
     write *lon, lat, age, predictions* records to standard output.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/supplements/spotter/grdrotater.rst
+++ b/doc/rst/source/supplements/spotter/grdrotater.rst
@@ -57,11 +57,13 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Name of output grid. This is the grid with the data reconstructed
+.. |Add_outgrid| replace:: Name of output grid. This is the grid with the data reconstructed
     according to the specified rotation. If more than one reconstruction
     time is implied then *outgrid* must contain a C-format specifier
     to format a floating point number (reconstruction time) to text.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/supplements/spotter/grdspotter.rst
+++ b/doc/rst/source/supplements/spotter/grdspotter.rst
@@ -55,8 +55,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Specify name for output CVA grid file.
+.. |Add_outgrid| replace::  Specify name for output CVA grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/supplements/spotter/hotspotter.rst
+++ b/doc/rst/source/supplements/spotter/hotspotter.rst
@@ -55,8 +55,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Specify name for output grid file.
+.. |Add_outgrid| replace::  Specify name for output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/supplements/spotter/polespotter.rst
+++ b/doc/rst/source/supplements/spotter/polespotter.rst
@@ -86,14 +86,16 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *outgrid*
-    Specify name for output grid.  For spot mode we will accumulate
+.. |Add_outgrid| replace::  Specify name for output grid.  For spot mode we will accumulate
     great circle line density for the grid.  Each bin that is crossed
     by a great circle is incremented by 1, multiplied by cos(latitude),
     the length of the fracture zone or abyssal line segment used to
-    define the great circle, and any overall weight set via **-E**.
+    define the great circle, and any overall weight set via |-E|.
     In pole mode we return the chi-squared misfit surface.  Not used
     in line mode.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/surface.rst
+++ b/doc/rst/source/surface.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt surface** [ *table* ] |-G|\ *outputfile.nc*
+**gmt surface** [ *table* ] |-G|\ *outgrid*
 |SYN_OPT-I|
 |SYN_OPT-R|
 [ |-A|\ *aspect_ratio*\|\ **m** ]
@@ -78,9 +78,11 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *outputfile.nc*
-    Output file name. Output is a binary 2-D *.nc* file. Note that the
+.. |Add_outgrid| replace:: Give the name of the output grid file. Note that the
     smallest grid dimension must be at least 4.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -16,7 +16,7 @@ Synopsis
 [ |-C|\ *slpfile* ]
 [ |-D|\ **x**\|\ **y** ]
 [ |-E|\ *empty* ]
-[ |-G|\ *grdfile* ]
+[ |-G|\ *outgrid* ]
 [ |SYN_OPT-I| ]
 [ |-J|\ *parameters* ]
 [ |-M| ]
@@ -96,14 +96,16 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *grdfile*
-    Use triangulation to grid the data onto an even grid (specified with
-    **-R** **-I**). Append the name of the output grid file. The
+.. |Add_outgrid| replace:: Use triangulation to grid the data onto an even grid (specified with
+    |-R| and |-I|). Append the name of the output grid file. The
     interpolation is performed in the original coordinates, so if your
     triangles are close to the poles you are better off projecting all
     data to a local coordinate system before using **triangulate** (this
     is true of all gridding routines) or instead select **sphtriangulate**.
     For natural nearest neighbor gridding you must add **-Qn**.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/doc/rst/source/xyz2grd.rst
+++ b/doc/rst/source/xyz2grd.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt xyz2grd** [ *table* ] |-G|\ *grdfile*
+**gmt xyz2grd** [ *table* ] |-G|\ *outgrid*
 |SYN_OPT-I|
 |SYN_OPT-R|
 [ |-A|\ [**d**\|\ **f**\|\ **l**\|\ **m**\|\ **n**\|\ **r**\|\ **S**\|\ **s**\|\ **u**\|\ **z**] ]
@@ -59,10 +59,10 @@ Required Arguments
 
 .. _-G:
 
-**-G**\ *grdfile*
-    *grdfile* is the name of the binary output grid file. (See
-    :ref:`Grid File Formats <grd_inout_full>`).
-
+.. |Add_outgrid| replace:: Give the name of the output grid file.
+.. include:: /explain_grd_inout.rst_
+    :start-after: outgrid-syntax-begins
+    :end-before: outgrid-syntax-ends
 
 .. _-I:
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7747,7 +7747,7 @@ void gmt_outgrid_syntax (struct GMTAPI_CTRL *API, char option, char *message) {
 	GMT_Usage (API, 3, "+n Replace data values matching <invalid> with a NaN.");
 	GMT_Usage (API, 3, "+o Offset data values by the given <offset>, or append a for automatic range offset to preserve precision for integer grids [0].");
 	GMT_Usage (API, 3, "+s Scale data values by the given <scale>, or append a for automatic range scale to preserve precision for integer grids [1].");
-	GMT_Usage (API, -2, "Note: Any offset is added after any scaling, and +sa also sets +oa (unless overridden). "
+	GMT_Usage (API, -2, "Note: Any offset is added before any scaling, and +sa also sets +oa (unless overridden). "
 		"To write specific formats via GDAL, use <ID> = gd and supply <driver> (and optionally <dataType> and/or one or more concatenated GDAL -co <options> using +c).");
 }
 


### PR DESCRIPTION
**Description of proposed changes**

Equivalent of https://github.com/GenericMappingTools/gmt/pull/5612 for html docs build from ReST.

One point to note - in `gmt_outgrid_syntax` and the updated syntax for explain_grd_inout.rst, I updated "Note: Any offset is added after any scaling" to "Note: Any offset is added before any scaling". Previously, the order for both input and output was documented as the same which would not preserve values round-trip. I think probably just copy/paste issue.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
