### PR TITLE
Replace unintended magic value by a half of defined constant value

### DIFF
--- a/src/trend1d.c
+++ b/src/trend1d.c
@@ -301,7 +301,7 @@ GMT_LOCAL void trend1d_recompute_weights (struct GMT_CTRL *GMT, struct TREND1D_D
 	if (n_data%2)
 		*scale = MAD_NORMALIZE * work[n_data/2];
 	else
-		*scale = 0.7413 * (work[n_data/2 - 1] + work[n_data/2]);
+		*scale = MAD_NORMALIZE * (work[n_data/2 - 1] + work[n_data/2]) / 2;
 
 	k = 1.5 * (*scale);	/*  Huber[1964] weight; 95% efficient for Normal data  */
 	ksq = k * k;

--- a/src/trend2d.c
+++ b/src/trend2d.c
@@ -260,7 +260,7 @@ GMT_LOCAL void trend2d_recompute_weights (struct GMT_CTRL *GMT, struct TREND2D_D
 	if (n_data%2)
 		*scale = MAD_NORMALIZE * work[n_data/2];
 	else
-		*scale = 0.7413 * (work[n_data/2 - 1] + work[n_data/2]);
+		*scale = MAD_NORMALIZE * (work[n_data/2 - 1] + work[n_data/2]) / 2;
 
 	k = 1.5 * (*scale);	/*  Huber[1964] weight; 95% efficient for Normal data  */
 	ksq = k * k;


### PR DESCRIPTION
Fix magical values usage in the code.