### PR TITLE
GMT need -fs to read just text

### DIFF
--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -299,7 +299,7 @@ we combine all the individual PDFs into a single PDF file and delete the individ
     gs -dQUIET -dNOPAUSE -sDEVICE=pdfwrite -sOUTPUTFILE=\${BATCH_PREFIX}.pdf -dBATCH \${BATCH_PREFIX}_*.pdf
     rm -f \${BATCH_PREFIX}_*.pdf
     EOF
-    gmt batch main.sh -Sbpre.sh -Sfpost.sh -Tcountries.txt+w"\t" -Ncountries -V -W -Zs
+    gmt batch main.sh -Sbpre.sh -Sfpost.sh -Tcountries.txt+w"\t" -Ncountries -fs -V -W -Zs
 
 Here, the postflight script is not even a GMT script; it simply runs gs (Ghostscript) and deletes what we don't want to keep.
 

--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -299,7 +299,7 @@ we combine all the individual PDFs into a single PDF file and delete the individ
     gs -dQUIET -dNOPAUSE -sDEVICE=pdfwrite -sOUTPUTFILE=\${BATCH_PREFIX}.pdf -dBATCH \${BATCH_PREFIX}_*.pdf
     rm -f \${BATCH_PREFIX}_*.pdf
     EOF
-    gmt batch main.sh -Sbpre.sh -Sfpost.sh -Tcountries.txt+w"\t" -Ncountries -fs -V -W -Zs
+    gmt batch main.sh -Sbpre.sh -Sfpost.sh -Tcountries.txt+w"\t" -Ncountries -V -W -Zs
 
 Here, the postflight script is not even a GMT script; it simply runs gs (Ghostscript) and deletes what we don't want to keep.
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3359,8 +3359,10 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 		*tpos = pos;
 	}
 	if (found_text && col == 0 && !GMT->common.i.select && phys_col_type != GMT_IS_STRING) {	/* Has to be a non-GMT header with just text starting in the first column - treat as header */
-		gmt_M_free (GMT, type);
-		return GMT_NOT_OUTPUT_OBJECT;
+		if (strncmp (GMT->init.module_name, "batch", 5U) && strncmp (GMT->init.module_name, "movie", 5U)) {	/* Make exception for these modules what often will just read text lines */
+			gmt_M_free (GMT, type);
+			return GMT_NOT_OUTPUT_OBJECT;
+		}
 	}
 	*n_columns = col;	/* Pass back the numerical column count */
 	if (GMT->common.i.end)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3358,7 +3358,7 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 		}
 		*tpos = pos;
 	}
-	if (found_text && col == 0 && !GMT->common.i.select) {	/* Has to be a non-GMT header with just text starting in the first column - treat as header */
+	if (found_text && col == 0 && !GMT->common.i.select && phys_col_type != GMT_IS_STRING) {	/* Has to be a non-GMT header with just text starting in the first column - treat as header */
 		gmt_M_free (GMT, type);
 		return GMT_NOT_OUTPUT_OBJECT;
 	}


### PR DESCRIPTION
See the problems with the batch example at the end of #5764. I missed an extra check before I declare no content.  But user needs to give **-fs** to make this work since GMT in general will not process just text records.  The places where we may end up reading text only are in **movie** and **batch**.
