### PR TITLE
Allow colorbar length and/or width to be given in percentages

### DIFF
--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -115,7 +115,9 @@ Optional Arguments
     away from the map frame.
     However, you can override any of these with these modifiers:
     Append **+w** followed by the *length* and *width* of the color bar.  If *width* is not
-    specified then it is set to 4% of the given *length*.
+    specified then it is set to 4% of the given *length*. If *length* is not given then it defaults
+    to 80% of the corresponding map side dimension.  If either *length* or *width* end with % then
+    those percentages are used instead to set the dimensions.
     Give a negative *length* to reverse the scale bar, or append **+r**. Append **+h** to get a
     horizontal scale [Default is vertical (**+v**)].
     By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this

--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -117,7 +117,8 @@ Optional Arguments
     Append **+w** followed by the *length* and *width* of the color bar.  If *width* is not
     specified then it is set to 4% of the given *length*. If *length* is not given then it defaults
     to 80% of the corresponding map side dimension.  If either *length* or *width* end with % then
-    those percentages are used instead to set the dimensions.
+    those percentages are used instead to set the dimensions, where *width* is defined as a
+    percentage of the colorbar *length*.
     Give a negative *length* to reverse the scale bar, or append **+r**. Append **+h** to get a
     horizontal scale [Default is vertical (**+v**)].
     By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7121,7 +7121,7 @@ int gmt_scanf_arg (struct GMT_CTRL *GMT, char *s, unsigned int expectation, bool
 	 * since that is only valid on command line and in a data record the "d" mans degree.
 	 */
 
-	unsigned int got, percent = 0;
+	unsigned int got;
 
 	if (s == NULL) {	/* Cannot do anything here */
 		*val = GMT->session.d_NaN;
@@ -7143,9 +7143,6 @@ int gmt_scanf_arg (struct GMT_CTRL *GMT, char *s, unsigned int expectation, bool
 				expectation = GMT_IS_FLOAT;
 			else if (c == 't')		/* Found trailing t - assume Relative time */
 				expectation = GMT_IS_ARGTIME;
-			else if (c == '%') {		/* Found trailing % - assume float in percentage */
-				expectation = GMT_IS_FLOAT; s[len-1] = '\0'; percent = len - 1;
-			}
 			else if (nt > 1 || gmt_not_numeric (GMT, s)) {	/* No number has 2 or more letters at the end, or other junk, so return as NaN */
 				*val = GMT->session.d_NaN;
 				return GMT_IS_NAN;
@@ -7180,7 +7177,6 @@ int gmt_scanf_arg (struct GMT_CTRL *GMT, char *s, unsigned int expectation, bool
 	/* OK, here we have an expectation, now call gmt_scanf */
 
 	got = gmt_scanf (GMT, s, expectation, val);
-	if (percent) { (*val) *= 0.01; s[percent] = '%';}	/* Turn percentage into fraction 0-1 */
 	return (got == GMT_IS_NAN) ? got : expectation;	/* Want to return the actual expectation here since it may be used upstream, unless parsing failed */
 }
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7121,7 +7121,7 @@ int gmt_scanf_arg (struct GMT_CTRL *GMT, char *s, unsigned int expectation, bool
 	 * since that is only valid on command line and in a data record the "d" mans degree.
 	 */
 
-	unsigned int got;
+	unsigned int got, percent = 0;
 
 	if (s == NULL) {	/* Cannot do anything here */
 		*val = GMT->session.d_NaN;
@@ -7143,6 +7143,9 @@ int gmt_scanf_arg (struct GMT_CTRL *GMT, char *s, unsigned int expectation, bool
 				expectation = GMT_IS_FLOAT;
 			else if (c == 't')		/* Found trailing t - assume Relative time */
 				expectation = GMT_IS_ARGTIME;
+			else if (c == '%') {		/* Found trailing % - assume float in percentage */
+				expectation = GMT_IS_FLOAT; s[len-1] = '\0'; percent = len - 1;
+			}
 			else if (nt > 1 || gmt_not_numeric (GMT, s)) {	/* No number has 2 or more letters at the end, or other junk, so return as NaN */
 				*val = GMT->session.d_NaN;
 				return GMT_IS_NAN;
@@ -7177,6 +7180,7 @@ int gmt_scanf_arg (struct GMT_CTRL *GMT, char *s, unsigned int expectation, bool
 	/* OK, here we have an expectation, now call gmt_scanf */
 
 	got = gmt_scanf (GMT, s, expectation, val);
+	if (percent) { (*val) *= 0.01; s[percent] = '%';}	/* Turn percentage into fraction 0-1 */
 	return (got == GMT_IS_NAN) ? got : expectation;	/* Want to return the actual expectation here since it may be used upstream, unless parsing failed */
 }
 

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -531,25 +531,25 @@ static int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT_OP
 					slash[0] = ' ';	/* Replace / with space */
 					if (n_percent == 2) { /* Both length and width given as percentage of plot dimension */
 						sscanf (string, "%lf %lg", &Ctrl->D.scl[GMT_X], &Ctrl->D.scl[GMT_Y]);
-						Ctrl->D.scl[GMT_X] *= 0.01;	Ctrl->D.scl[GMT_Y] *= 0.01;
+						Ctrl->D.scl[GMT_X] *= 0.01;	Ctrl->D.scl[GMT_Y] *= 0.01;	/* Convert to fraction */
 						gmt_M_memset (Ctrl->D.dim, 2U, double);	/* Wipe back to zero */
 					}
 					else {	/* Got one percent and one fixed */
 						if (p < slash) {	/* Gave length in percentage */
 							sscanf (string, "%lf %*s", &Ctrl->D.scl[GMT_X]);
-							Ctrl->D.scl[GMT_X] *= 0.01;
-							Ctrl->D.dim[GMT_X] = 0.0;
+							Ctrl->D.scl[GMT_X] *= 0.01;	/* Convert to fraction */
+							Ctrl->D.dim[GMT_X] = 0.0;	/* Wipe back to zero */
 						}
 						else {	/* Gave width in percentage */
 							sscanf (string, "%*s %lf", &Ctrl->D.scl[GMT_Y]);
-							Ctrl->D.scl[GMT_Y] *= 0.01;
-							Ctrl->D.dim[GMT_Y] = 0.0;
+							Ctrl->D.scl[GMT_Y] *= 0.01;	/* Convert to fraction */
+							Ctrl->D.dim[GMT_Y] = 0.0;	/* Wipe back to zero */
 						}
 					}
 				}
 				else {	/* Only gave width in percentage */
-					Ctrl->D.scl[GMT_X] = atof (string) * 0.01;
-					Ctrl->D.dim[GMT_X] = 0.0;
+					Ctrl->D.scl[GMT_X] = atof (string) * 0.01;	/* Convert to fraction */
+					Ctrl->D.dim[GMT_X] = 0.0;	/* Wipe back to zero */
 				}
 			}
 			else if (n == 1 && fabs (Ctrl->D.dim[GMT_X]) > 0.0)	/* Set height as 4% of width */

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -19,7 +19,7 @@
  * Date:	1-JAN-2010
  * Version:	6 API
  *
- * Brief synopsis: psscale draws a gray scale or color bar either vertically
+ * Brief synopsis: psscale draws a grayscale or color bar either vertically
  * or horizontally, optionally with illumination.
  *
  */

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1991,6 +1991,8 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 
 		if (Ctrl->D.dim[GMT_X] == 0.0) {	/* Automatically set scale width */
 			Ctrl->D.dim[GMT_X] = Ctrl->D.scl[GMT_X] * (Ctrl->D.horizontal ? GMT->current.proj.rect[XHI] : GMT->current.proj.rect[YHI]);
+			if (Ctrl->D.dim[GMT_Y] == 0.0)
+				Ctrl->D.dim[GMT_Y] = Ctrl->D.scl[GMT_Y] * Ctrl->D.dim[GMT_X];
 			if (Ctrl->D.reverse) Ctrl->D.dim[GMT_X] = -Ctrl->D.dim[GMT_X];
 			if (Ctrl->Q.active && GMT->current.map.frame.draw)
 				sprintf (text, "X%gil/%gi", Ctrl->D.dim[GMT_X], Ctrl->D.dim[GMT_Y]);
@@ -2000,8 +2002,6 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 				sprintf (text, "X%gi/%gi", Ctrl->D.dim[GMT_X], Ctrl->D.dim[GMT_Y]);
 			GMT_Report (API, GMT_MSG_DEBUG, "Scale mapping set to -J%s\n", text);
 		}
-		if (Ctrl->D.dim[GMT_Y] == 0.0)
-			Ctrl->D.dim[GMT_Y] = Ctrl->D.scl[GMT_Y] * Ctrl->D.dim[GMT_X];
 		if ((PSL = gmt_plotinit (GMT, options)) == NULL)
 			Return (GMT_RUNTIME_ERROR);
 		gmt_plane_perspective (GMT, GMT->current.proj.z_project.view_plane, GMT->current.proj.z_level);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -543,7 +543,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT_OP
 						else {	/* Gave width in percentage */
 							sscanf (string, "%*s %lf", &Ctrl->D.scl[GMT_Y]);
 							Ctrl->D.scl[GMT_Y] *= 0.01;	/* Convert to fraction */
-							Ctrl->D.dim[GMT_Y] = 0.0;	/* Wipe back to zero */
+							Ctrl->D.dim[GMT_Y] = Ctrl->D.dim[GMT_X] * Ctrl->D.scl[GMT_Y];	/* Wipe back to zero */
 						}
 					}
 				}

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -19,7 +19,7 @@
  * Date:	1-JAN-2010
  * Version:	6 API
  *
- * Brief synopsis: psscale draws a grayscale or color bar either vertically
+ * Brief synopsis: psscale draws a gray scale or color bar either vertically
  * or horizontally, optionally with illumination.
  *
  */

--- a/test/psscale/scale_percent.ps
+++ b/test/psscale/scale_percent.ps
@@ -1,0 +1,1217 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 595 842
+%%HiResBoundingBox: 0 0 595.0000 842.0000
+%%Title: GMT v6.3.0_545cea4_2021.09.16 [64-bit] Document from basemap
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Thu Sep 16 14:48:38 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 9917 def
+/PSL_page_ysize 14033 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt basemap -R0/10/0/10 -JX15c -B
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 7087 M 0 -7087 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -64 0 D S
+N 0 1417 M -64 0 D S
+N 0 2835 M -64 0 D S
+N 0 4252 M -64 0 D S
+N 0 5669 M -64 0 D S
+N 0 7087 M -64 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+161 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+(10) sw mx
+def
+/PSL_A0_y PSL_A0_y 48 add def
+0 PSL_A0_y MM
+(0) mr Z
+1417 PSL_A0_y MM
+(2) mr Z
+2835 PSL_A0_y MM
+(4) mr Z
+4252 PSL_A0_y MM
+(6) mr Z
+5669 PSL_A0_y MM
+(8) mr Z
+7087 PSL_A0_y MM
+(10) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 709 M -32 0 D S
+N 0 2126 M -32 0 D S
+N 0 3543 M -32 0 D S
+N 0 4961 M -32 0 D S
+N 0 6378 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7087 0 T
+24 W
+N 0 7087 M 0 -7087 D S
+-7087 0 T
+N 0 0 M 7087 0 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -64 D S
+N 1417 0 M 0 -64 D S
+N 2835 0 M 0 -64 D S
+N 4252 0 M 0 -64 D S
+N 5669 0 M 0 -64 D S
+N 7087 0 M 0 -64 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 48 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+1417 PSL_A0_y MM
+(2) bc Z
+2835 PSL_A0_y MM
+(4) bc Z
+4252 PSL_A0_y MM
+(6) bc Z
+5669 PSL_A0_y MM
+(8) bc Z
+7087 PSL_A0_y MM
+(10) bc Z
+N 709 0 M 0 -32 D S
+N 2126 0 M 0 -32 D S
+N 3543 0 M 0 -32 D S
+N 4961 0 M 0 -32 D S
+N 6378 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 7087 T
+24 W
+N 0 0 M 7087 0 D S
+0 -7087 T
+0 setlinecap
+0 A
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt colorbar -DJTC+w40%/15% -B -R0/10/0/10 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+2126 7476 T
+24 W
+V N 0 0 T 2835 425 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 1417 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [1417 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[<8E"^"`<(BEB+cn0J?G?8&R'G(?K6t2U9$"aB-78XXcm-\cX^rGe[YRAG<5R^K)^d&KsDMF!0s#K7kpO-A?"tJMbJ\DTD
+^5XsuNO407"oC1.q_^;,2[T"md`LB$eDE")hl2OK;cg5F\Ce@(\7pW+Bb,3iSe@A\M+_cDCQucFO2NVRimpoZ4@\&;^XR\)
+e:!Fc`F*D<+gREOA?CU0>)eWO*[tkf>4++7mP.c!At6NY"F8aYo!X_rm3X@;9i89iWplOUn=6ZRR\BABWU)<3fjTohH`kdY
+2SaZG5fX$/*>\qT/.1lLXR]Yknm/9d>GgsqY4@WPq6(&<Y7),K$C%V%PcP1UXppPr$^/I6ak$d>2ZtQf"t;I0Q!;b\Xm1FR
+l@A8:eIES/;]W5<*OK#kZq%7TX&8?7W:t'a#;qr;)D+(QeK*'&NbX3-C%]NSq?3oD;/8.b24h`0VmIVFFe-hA3h=fTT$rCb
+f7h$K]!.+(cBiL:,[Hb[_-O5IG>/PW^D\)@/\'PXIJ4[?ihep!QG1CVI?-JdT(&nsf0(+!?Q])/+8Jaj)a;\?4k<+d1%^#G
+L;$H'FK-M\RA&MZ*:q#Yo?tu-VA]6.)[<sl"(+FUTF<qBdl9>13$c[,oSmkS>N;r3oY#6(bVkK3+7R@4`_iAtkg)*+3!Ogd
+NeLj1\6Kk+r`dHs4?W-qT(E+\re[Q6ZVq8$ZpHmg#gXp=1J?A'V<mQSO?%E#3?)12K_$\Hq,PE<FC@&=W!4n5YtJj%dTYZd
+1V4W1E#`/7%4eQ*'jV8cGR[r:p$4RW:Y0[(r!d`menq_Qc#a?E_Q@o!enh6GY^.[h$ee$nj1mg"037K#gB.)t"'BiqM@X.7
+@D50Z7!R3*4(cLQBnBKV:b,8APpDeD-a<@k^W-9flZ]oYqOX\GqjaMG.Qa4<?E!AU?S$sQ/sYCk19[KOYKPSi8dW7\E\VBS
+[0U+iC^[E_i#DK/pc!]n4`:4KX`&^P\%7cYms]%t0:0BP[0:sIL%#!pLOO.?kS*jgUDs6T#Fpqd>uTUl5)&Hu9Bo`1ZY+4G
+o.8Pd74*JOJ^[peVnKt3l0PH-r;*8Z"a%n3mZd7#VE/:c3bCQub^q;=bnKg<A,=::*IN\#5JYtHkrm&tn1ME7plU%FJ%A'e
+3dufBE6`SRrg.E;X%m#1ZLA3CcFrS7S&B7Am1R0:hF2_k\pT:rkrI?;n18\YH%qoFc1=`YPL)JmKR3`;;32&f(*p[rKu[Wf
+_ILrfkbq#!&_NuU0Pjs@#du6D#ht[cJ=\(aEToZjd_2kPkoT%o[MsB@gBE#JG!b*W*RM!;]79W7.'D2PY1OqtfF4SkS"Qj'
+,Eu8I:fOTQb,Y5eWd%Oo3Z(u,2R$pj:c2L[Y$Rs@/%%5bF>tn_-;IpS*#_MoT[C,'`3]Yj1+`tn/V7E.Kq1pG]"m%q?#/VY
+f?T$)C1Fm-`^Z?Y_B.i"4jC<A0Cu8Ok*_@o)6gSqH5*_[lXQ@6f.o5;1'RBX:6)SSl>N4!#?W>^`8_)*`t,V=)hQ*?[>c&Y
+7h<(g*ap!F&s"#D)`cV1!fjMp+);fRNZ/>GF$h9nK.#YEPINoB\Ue],2de*o?lIW=:?Q(uE;e]g/p\9L4e(aFkAYk36@2\5
+4_gS%2k4fI>[["((YX5Q7J<=2m60A?Hc/g/`%p+r\\22e%UWWT?YSs9=4t4$eb7:-NBM*[4_u,KNOO\Ga.5-8NV3pna_omM
+2f@R_E%@jDL4cta*LmW-jKrkBf'K8\36bd!)X\:,[fsSM[QsgXHH<*I9TS+^UKDf#*p6`A#rId9YfPcpHA\:PbMX7a(=l+:
+3I79'0]@r^P"D*A,Cu28=(&E]=a63<WtJbUhLLmNS&/D%G(o^On8:75Y70<d%nc@Zq?WDFa7MqX:4YjnV_f,(ib.mD/.fRH
+q;R_tNW2q?/q!<o^])MjjPe<F8_,io%Et*S\+JKXpAGdc3sWpdLX5`?s-)f5nFK..k6(T-)p5q0B62t8hqkYaDkQ*:(Af>?
+rL(La^Ldj[d<&W\Xt37VMdE^.0BdI^!hZ`oWGL6d@>_?15%,r_Z^$T)&!^/aJabk+LA-@FPr8J$oJSV`;W+&:L8'u`SR03G
+GZC-4YU%E^(#`^PZQoi1@I$@]on)\Gn/OTLD.b-h1d)#]p`r"R\O:q;5`\8sI#K,C7ssi8HH;F7k^sDmrH)C:]U/'V`k/pp
+>ohRgcjT<8gZ^Ul][`5#68uBoS*3>QTcIH8j4i;=dC!i\)S4W)YG*O1X=IK734^*<Z7^b]X\7mkCg#Q1ZA:-/$f(9"3j1P#
+a$M`V>W;6o>W^[Tc_<5[$l;$s:3/-aD2+t8afoL(,j8JhO\Tku*q+d&dBU2rN$BB<8)_UQ9e&Z[iNR=@0KShj49Uu]DM/6P
+.NaJi"uO9sBacVRBi*MZ(u:j\n%Z@CNV^+$pAUrq7abWC'__ABpS9rk6,`eBGM3MhGH7>X::o*W$+p*=IrqPrpcAmqo/a]P
+iO9A5`4<m6\H_c.T)B9QeCDairK3jd5AU&/Io<TpKCFX]TaGG5I`i4/h^dB($N*rMs7MA1c'#B#&tC--s74m9IHAMHqm'p"
+pglthKf?d7o+(+C0:_=L5398WRj*7.%b?2lgYt_?n3cD:k5i7,>N:)&DC`H=SX/X0((Rh;9m?:8D!l7JGg-\)F`U)sAZn?8
+LWdQ1B)#7[dD`!L"mCokdrS:Z/9DSsE>4t@VjcP-oE7m)N"bFFs4Ch@n54M-+[/R1d=Vlr#O$X3Y@o$U8$nWNTtC?E]D`T5
+Uc\R2\'o29CONjl^1]>#9=0Onr"F#D;m[Us'?/Q:XeT[tM:VU`!*@WLFQMt9"c];#Ire^]Qi?-O"TI\jpfE5>F<OrZ$_IBV
+_`SiA\'Ed?Flq2Uo7'5WHH?~>
+U
+2 setlinecap
+N 0 0 M 2835 0 D S
+N 0 0 M 0 425 D S
+N 2835 0 M 0 425 D S
+0 425 T
+N 0 0 M 2835 0 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 64 D S
+N 567 0 M 0 64 D S
+N 1134 0 M 0 64 D S
+N 1701 0 M 0 64 D S
+N 2268 0 M 0 64 D S
+N 2835 0 M 0 64 D S
+/MM {M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+161 F0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 48 add def
+0 PSL_A0_y MM
+(0) bc Z
+567 PSL_A0_y MM
+(2) bc Z
+1134 PSL_A0_y MM
+(4) bc Z
+1701 PSL_A0_y MM
+(6) bc Z
+2268 PSL_A0_y MM
+(8) bc Z
+2835 PSL_A0_y MM
+(10) bc Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 283 0 M 0 32 D S
+N 850 0 M 0 32 D S
+N 1417 0 M 0 32 D S
+N 1984 0 M 0 32 D S
+N 2551 0 M 0 32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 -425 T
+0 setlinecap
+-2126 -7476 T
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt colorbar -DJML+w9c/5% -B -R0/10/0/10 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+-602 1417 T
+24 W
+213 0 T
+90 R
+V N 0 0 T 4252 213 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 2126 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [2126 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[=Ce"^%!^'EHKUIGO?pL^51KMF_X$!Xm2WG'A.SGB\7T$[.&0G@6#[h$ln6m.0S841"O"^>o0ahRdTs:Y?k_ZGA`d$pNc>
+I*76?Q8eZ+&+_AknuWJk>JUaH.b=9n=O5<r^7S[55J)Z!Po?oe<VB-dp.\Q\buBst@ttgLLR'EF<pD0:eQ(=2a0oa'G&#(k
+C8VPVViFSP[?IJ&B8psKNH80\F#Qh$mVEE992DZ_0<IlcD=p*F[BJ/hT@UEbY/UHINIf`!ONq^Ic>AB?k"p5gJ$%\^I>#B4
+8:UA2rjC]us4Ura4Q+ilO)Y2C`j6<[4=:>X:==JaepC0>Hbl\-YA&<dl$De9m*%_e=kIqAT^Nle2`K*%*XkrkB,:]M(LkX`
++O+@4XBcI?>oKeM(9E/3K68\rrE$;*$j!E6IZ6Y.('guu"Kod2)q^.)i(`QMK4,,r0l.:RC^UR&cL(rEfbkD0GJR,9mSMr8
+cnMsGS+_Q),&hcP]0Fem!7sBT*\u;.bT8LiLI[?sNu8n`j6R(^6PtLr72m2:KOKj9Yq]Z]:?/3afX%GekLfC'k4!u%q*e3i
+HHFYL?8f3C=4jRNf'jT)h:)Yc^hn"q\&-n9=PWm6HRHH.]c5f?h@&cTn$<PA42X$95.h8NLq>jFk&-7UmKr4nEtA,sg_2k-
+pO^`E(ZsTH-11kBnU4d)IW,#\DoHq_!VAMrpjjOZOk(QNM');V+8Q-OqoTHL-BC]^7jdc$P53M_q(X>rfMm-$RQMXgisG(j
+%!b_t1t0QLns!rQQ0+I3.8J3SBB8S=@6U8O$d>rr3OB@D<Lh*bcS*-C'GjXT?DP(JS!I1PV2EH8(gSbsi/K7Fq,QEh*(ng2
+Y2r%%Z0Pu=#&8k.)\k<jTZuI33H-LV5lET\4!1]%Lu6>On"PM4[p*h_YMEE5pPBIcRYZ>2M:I`6lM\B\!6p4H#>=\PP[j$#
+31E-qm7iXR5qdIV4IujBl%og/.\fa<3f_3$d:jXLq:_`ED;A]"ChoU@NmAugRdb-VHnH#BdIZ73CL$XLl[&)ZD=pPon`<Qr
+jiU*hl3CFN?@+?>F1tE,_Q#QQ)ueu8k[]&+Q2&cV(-BOM^pi9D>34$c>DKgdja0d2jnfA^K?)uHb&Q&tmNIUGnbg9aq9];`
+qlnN/HfA?$:8J)0QZ*m.J[,.%>Oo+io(*geFoK?;nZ(D<H3M'8Qc2Vm28(EQ\\Og"hk$%hSV<?mq_O,-nHTu-GRE/S4=NbS
+<rNeElgX_'ic/)^$U&+fq":S1"?Lrm/0:Nc'+]s*W,psIS:mph7G><u7F:>Aqk.`q??&c#mrUL197a]_c'4d+<pC1[T":KD
+:>NpfD1s$F>A0S7c."Ot'D4uT#ee\G:nN^>e2LkX]@N$MUWS7jeT_hYA?M`^X;+^$[2f$U/V='XH`<SGb[/.=%cS9.kJ2cU
+]E!]Ib_MlGGFjp+bFK#8\T;G/hJ?rPRg&-?c(t%'B#+7gdp[mABs;%&<7hK=:MJ$2ae'!2k"gTR@)9eDCl<lOm.cnE\5mij
+CHMg0.2WNK_ST1;f_1"D@>D]3Y[cY]N^^iI'b,edMh])$GR3Yn#C"(<]!FPW#/ZtY18#H<gX72;Z1NZsESl4]InLkC^s\\^
+[.G8Mm5;u='+VJEJ4$EoiDA<H(d$O,'ooMAJKo0t;=%t3-TD<SKO]"WEObslG(R+BS-Y&-:1>Re\"Q`X>JmGZXm!.OQ?50*
+0nZ$RS'PPV(H6tfE7;Aa]](8[IW8l-TXYS>=PSuj_@79e95sj+lnVfV0'DQ'?rph/.VK8uc*"=?kZSr1f<OYD7_/VU_Mrra
+-?1iR`F>KE't7=tD7<`$kRMTF;'=[@mOlr*4ab%O`I5,?+%D'Kir27b4WkeV%i&dB@DsHJ?NZ@Ha2I"`r!>*8NQtPQPDZ8O
+%ZV,sMeB=qoW3:tB&W?=(W;6"plaXu%/EN,I$MC2`a;f[5u[;JnJ4g7Z1PZn[WmQSj1C3C?kU1L'3,R]3;Q>YitWYbPokF:
++2cDaJUUK]&YIL4)Yd"rq1fSi]U*!>UK[HXXo+X%_/C%F^+Ss3/,B-:We2C"a<.%tT:X/sT2L18jb`mm62pR[:4+<74]IB\
+amfCZSG`>:S8r!,*_rPUjg7)qVVbF5`>S<6S9\&Y\tO?hBA6`k]S^do'ue?UQX3S&M"<7ooB-k7iI#rPnI.%CV\N_:_AF:W
+V0J/<EO6S%(S/qBa2MO7*u0k+QG[J:OEcken,^N,]J\+J7k!f#^3Hik8)3LLmh0i%41t*,ELXJgMr2BhL7WW'X^g08DQrfL
+lc"#+g=lHCG."j&SR3hK&=;"cbJ^6]-F>=tDO/9.,&q$#IXsJN0:M']kDF=gFZc/)'[:*"nqAm"n^GHki`'PQ7@Xde_LbA/
+WF-o3J^5G,aH%"TMIW[EdGcQ<DkmJ"JfP=O_q\\M5'NqbK[1N@#nIXRo%=-3q#4_eSCP(mhad#B/&9A8CsV["%mHb83PM!8
+'rQ7)bBI"RK[W!\LHCA6psf$;o'Q4:[VVF_i-3gWYn^#Oof$b;[c!@<s2?o1S)VA`J)Vf4NW8oG)uTfP2H4LC^X2iJkBccE
+po//QB)L'S)\/3!R,n!MMFRNhpaZh+nSJR1"hl_4YCkq<6&L6gA`1m:?fHtDq749<9LjSa:UTa,NLZXonZduN#Trla%t3Pa
++$%VNIc+5cI8B\A]N7V;lQP/b/`3Gn34@mP[:gG&ZR1/(]&Dt^7[\&O<U,IFP^L#&/IaADn/#LjI"=>F4tiM&<Uj521XHH#
+VN.K_`)F#M5,fCdJ>4)Vd1_f,j4#+l'9C"&p^"8XF]^cE*j!F)&GM*F(&/&S?[6p83I).I].C]igaV[dO5J6#KE'r5oUf#c
+`6IYG^\NlK#''TKr&T#'\E6S9[CGK4]M`#)427:k#(J/2P[2-Y()QpQRP#9jYk*A'kD=9!3C!,AfidZ8pf$Dplu[4c47u*m
+ME%#p"FhgUOe(u/RK!<;a11"~>
+U
+2 setlinecap
+N 0 0 M 4252 0 D S
+N 0 0 M 0 213 D S
+N 4252 0 M 0 213 D S
+-90 R
+-213 0 T
+N 0 4252 M 0 -4252 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -64 0 D S
+N 0 850 M -64 0 D S
+N 0 1701 M -64 0 D S
+N 0 2551 M -64 0 D S
+N 0 3402 M -64 0 D S
+N 0 4252 M -64 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+161 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+(10) sw mx
+def
+/PSL_A0_y PSL_A0_y 48 add def
+0 PSL_A0_y MM
+(0) mr Z
+850 PSL_A0_y MM
+(2) mr Z
+1701 PSL_A0_y MM
+(4) mr Z
+2551 PSL_A0_y MM
+(6) mr Z
+3402 PSL_A0_y MM
+(8) mr Z
+4252 PSL_A0_y MM
+(10) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 425 M -32 0 D S
+N 0 1276 M -32 0 D S
+N 0 2126 M -32 0 D S
+N 0 2976 M -32 0 D S
+N 0 3827 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+213 0 T
+90 R
+-90 R
+-213 0 T
+0 setlinecap
+602 -1417 T
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt colorbar -DJMR+w80%/0.6c -B -R0/10/0/10 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+7476 709 T
+24 W
+283 0 T
+90 R
+V N 0 0 T 5669 283 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 2835 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [2835 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[=su"]U^h'EI'dDXY/FJtUaJ&i24`KAGA>h;-oCh-^I;FpB@mf\M("a0>=:pZ4Wsq&G9;3#(t+..62!gfs+)=Mbk8Q1/iE
+l0hS,5TAod$3iMU$AQj&6_$g$,H^5m>;abcFLHp`S?3_t6^]9U1/51$$oY?#_5;q&(:H'P[XuN)Xc6oHB\OHK_03h=m>Z:n
+K@-hHF=H*=gY&EN(RGK5X%S.a/eqf=D%G5j4ght./+n(f%/[P8mRpUFVsSE&3^>dR<-=;%)B>h!@]BonR]6m>Wr[uk8%@*&
+,IO<%C;J<O1%)HiC<*m:J`F-Oh!7XU[tg0?L](`oq^ES/iDblLe$RRe*8h7m9M\/<MfbETkqkmlf@(V`K3j<.g'+9lTluQb
+$XBc=ip@)>C6s48i,Wbb$?%l5;S1)l*NmtrnaV-F[Hi3&iHipfK6AL(%6%u[P<N2uI(&m7gIU5hg)\n<^4(#;o^gtbmdU[8
+HaWbK!b!Jt'W0^T(CUgf&,M!q6eK01@I4[,qX>n[beF0@cCQ-t_Jnm6s$lbt$tt#l)aQAB6T70/4U2(YS_%0jRpVsq>[f>k
+[_u7g<`dsiJZ\Hbp-rF/Ga#fUfG<?SC54%Up@++9DGURcO6d/@PF^V6m6e08N+/Q7]&6)#f>i8X[jQ:l(pV+[m5)$qHqsE^
+_7g?Gc+g"M^t3\c2e'P2@fLZ3JG8C8H6E,6%f1iG#(IDDHkD-_V2'I4LOWBcLfKIo;iZ_O8,o7&,Ug\[lAnRNa2;G6!hU)\
+;*$-@#P4/.`$mC2T#t[K:QnQ"e=Vl"S-cOD=aX!6D"Sd<9@$Va'8,H1d0nG3q0[LNFKl[m`%3O+/u&ODjjFm<s2kC_Q#nnN
+a0/@DV1$ref.28-?o.N5W88eGD.^7*4h("XcsrPk]BHsR:Y[D1mG`2lBt&2Fkdi]CgrG03\:eJC@C.a?bICn9*8iWXo0If&
+6Q'pb_s,;gkmmX=1ftP8;]efSp@q%51-DC.GVX]1Y'hck?L)^-DU!t?n][%4r7Q="*M/0&cc>$[r.XV1WY`G7<k7j&H21*E
+I-!/e"L!8P?Mb!Yo%-+)hcI>(^OtWd_RIZlDm17rrEB0B/s7h'q3&J`6=0BRF'[OIcc#]VH(,$nikm/1A"+mX9[k:J)FfXG
+U@]Nl<'S1L:[UmE8afj'OB+)[kbg+4q<YQ\q(;86Wu([CqW2ka260gV<VeSc,/$[bi@dbU>.s#Nd-on<nbkIac$q]gnI55U
+O&2IgANlZJSs7uW%[Yq!3FVG;0)HA*;]dUcNB`$^^)rX^ilf@`PTJa5`9sP`k_a@gI&4>L^2j-8^.S<0^?UbBlu$&[!UesJ
+-g\c/&pNh&'=UWDe\Xm^EG]_(?RKPDDkFZKf1k,C4!\b&*E1O!Vj)>:F37\R)JDZqX0FC%'m</Sah+FPi([q/Z!5p;ljhL2
+HEa"*9<_Lo@WmlX#$qR`1)=8)E^',JRId)d2B[&n+.,%n#A)0BK<o1KOK=k[?IfNi5AN;tO>RJ+baJkXiTr"Ql,cZPVV./@
+1Rp8+3SP`j!cFD^SfQF?*/e%aN59@O7cUp2G>pZ4II9Y]+a4(WQohrj*n_u\)!mbO'R(^U^ola+fM1*`D\2>&%YQuRrW(T/
+mb_7'L[59CdXD#?IJR^ajS-Xro6ZV^?A$HbnR-DK4N-"q%]-cHUUq"K8!pp(O`]b`ltCGf4N?.gO!QlHA&k(nisFjkGTn\P
+4,KM5d"\/jcl,\3BZ3atBSiY9/S;4Cal]q^fjlluLMR=\dS8l/o*ZK.$ORg2K`qq]7:_%ilk6Tf>fnZDlf$slMLlCgAO/"V
+"jK?6feqnW]TruAlU:dGlitlKD\RUY8N3t[npU;8l>?@Ro'Q6Znf?/LH(K8IF>rH8pX&>Tebf,H2]O:VPO?aSnH[^!dR-$t
+r*eh%52-5_<?G_3B8J"3iU"Z[,C`=6)J@D/l8-kpkluN1I@a4Z0;pNr0;[*`eQ5Z@Y9o1ZUt:gK)q(4',(3+44+WFQIi.UP
+n)ATgT)(X0,9QE[L55%Brjrb3>C?';s7'1\$2d-1n=P\9V9ep40)3!R`CKln+-`tco<.l]48h,5/cF8[]/Rn,YOt,mi_Aq&
+9DqX>Pb4T6IsK&GiNH%BhdZ5m5>fEaerP0RNi(j3h<??LO,*Q<%kQQb'D["O8U$HAG:Z53.JU?#l7MtAS*Cr73e(F`NR$Ic
+Wisd;r+5OI3pWN0GX6bLbi[5S4A4i+B.QO!\Ig1Z[)GtV.sY#50'8^DToZ78=Ze/s,3Bt*MMIu4GlrI[]q73<3K'TrIFsD5
+X55)Wm7?]/mZd-YTXRS'8[m9I[n&GFH[6?4a1P9\JZheOQ`cOTXX1-4Y%Cbc'N[n.Yfgg<bG7d>FdTpsYElq*\k'E:._S).
+?d,!@Kq9fc""Vj,fiaTYR:>TCMW/`$RWN9JE=+cFQH)"LGe9K&dKt$hpi>@Rku`+&=`Lfj'V.,0<ZE8'%W-1I0O,rGW-!i_
+1"_p9,TS;1&$Q]DZi.hL^88e4Ci<D_VtT+CVY4PILah.QLu"k4l/XJ9`QmaDA5]=7F@UHY0sU\,F?=3krt>)bs2#k^[CR(n
+hs);pV6kpnfDKQlRC"C`gU&Bb7,#07GJ;I3p`"#tD*WU4lg'&"L]>;b6S&GjT7[(cKChA4.R+&<oV^UDs%`G?htciXiO;"n
+2r=D7^!rYG/'hR:&*6H.r>0AJcV=0Nr6/1@WJ`OOW;jfOrsTu2lT]Df7Q]m*3Tr]/X*e=$s+Kjm;;S@UJ%(a7%UYE[<8Xjp
+(W!S\.rW:>j:/h<OmD:JHkl4P`@I5L_XMRljX"#k^;sWZTKLPeVp@r\69G#P?`n@$oJBp@5,CGW98D7;U2:7.:`m_hk[WnQ
+d$d)6>891M4X<0mRQ_kM0+BF#LT:*6eDFIsg`tW\>hm<dPjTqHDJ-Gps6-T_^P0*e2m]"Q&N<<@Yj;<)f1FT"CPn"MV5rN]
+oLf$oTbZ#;g1C&?6;,uXlsf4Rh[B#`f`fh"^PVR7\^ELQMR1u=lqI0^3C>l63fT^,ZT*Z0bYEaS'nI%O#sT1#+7sRI(]~>
+U
+2 setlinecap
+N 0 283 M 5669 0 D S
+N 0 0 M 0 283 D S
+N 5669 0 M 0 283 D S
+-90 R
+N 0 5669 M 0 -5669 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 64 0 D S
+N 0 1134 M 64 0 D S
+N 0 2268 M 64 0 D S
+N 0 3402 M 64 0 D S
+N 0 4535 M 64 0 D S
+N 0 5669 M 64 0 D S
+/MM {exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+161 F0
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+(10) sw mx
+def
+/PSL_A0_y PSL_A0_y 48 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) mr Z
+1134 PSL_A0_y MM
+(2) mr Z
+2268 PSL_A0_y MM
+(4) mr Z
+3402 PSL_A0_y MM
+(6) mr Z
+4535 PSL_A0_y MM
+(8) mr Z
+5669 PSL_A0_y MM
+(10) mr Z
+N 0 567 M 32 0 D S
+N 0 1701 M 32 0 D S
+N 0 2835 M 32 0 D S
+N 0 3969 M 32 0 D S
+N 0 5102 M 32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+90 R
+-90 R
+-283 0 T
+0 setlinecap
+-7476 -709 T
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt colorbar -DJBC+w70% -B -R0/10/0/10 -JX15c
+%@PROJ: xy 0.00000000 10.00000000 0.00000000 10.00000000 0.000 10.000 0.000 10.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+1063 -588 T
+24 W
+V N 0 0 T 4961 198 scale /DeviceRGB setcolorspace
+<< /ImageType 1 /Decode [0 1 0 1 0 1] /Width 2480 /Height 1 /BitsPerComponent 8
+   /ImageMatrix [2480 0 0 -1 0 1] /DataSource currentfile /ASCII85Decode filter /FlateDecode filter
+>> image
+G[=Ce"^%&5(')]W^%]7q@=j3cM:=P-QegKRh;-oCh-^I;FpB@mf\M("a5QER^#u#Uoe$'8*qi#c*K#,&'_?Jrk2T:n(HN?+
+F"H;==<bPc7%e$])!"dS(cmohE@Ou7WDn9n/(hYZWhGV6Cuf-_fXZ);^8Z2<B$OtVo.?KU[cCY\b-a-mCVuHVCF\5%Df;rG
+@']#&bnW:-.s,B?]9mHIRVf[)/&L`:MEP2op#LJ1<9ijK)>8'Lgt/Ap5JFmJeH,S5f4oqCWt"3H\5nAP?)nKWWr\!feJR7G
+'96U=NH2'WRNLQrHRqD,]ac%N?=s=T2ppH!P)%k(IYpYOWVeT6]$ih/i=$7oR@Xn-(@*s7dr>j^f@(&OK3ljpq#t(O\<&R$
+nhMl\Q[$+njd18)_WBXW/%j]r8oM1=543AI^W+<(/\fTO'<Yu]2XhZ6]\t2dZ]EEJI]G-6c.@/$^Ou46am\flhp(Uu"8;<_
+quU:T)\g<\pBu]\pk+#=n.>5qGF1VS?QU?NO81_ba2J_k%:M5Gd_?AV"To[8js/M*BDAe6:#S)Lf^(_M+g<u>aBo9jJM.8:
+KNHf,=2es+Xl4Em7UR0[PIA0Dh[XB+,AI$:r8""Upg-ceGb=@++7Ken3o_VP3iEF67(YY&_;1^(h.(,ZVu3mZT("bp$bi:I
+?])&>54CGsqaU#JQM,eU^(2985L=uN,9?C_LCF/ULO>5>I\jrrdGa!E&[C&PEUp&Q3r0(%PFrqc.$%#aa2;FK!N1TE<)-&>
+_8aT2ne@J::)0[<aO;rQ1U?)00UpA)3Pi%eF)Wb&X.2\4k3(+qb([i_G*-gM*4WpRQR\?,!QO6D("@_E!F;O,:&XQ"j]^r]
+::X^)fmk[,H_YTpp"Cs7OZg/lo:a2_j`]q',>[/F]C!JGculgH%s?Qp6hcG23Te\)2N4*AZ:t.,k6![W3uug3*m-/t*);i]
+UtZiLVSTk5R.>JOZnn:EOi(,_KI=)RC$ehj``f8ReMSQaj>0#8(sg4>lL8&KHp/<H1LBjZY'TW-Z-&oHlH5I.cmt_s-$]*H
+I-i/[BY==1q;1fLIYTH/Hn4*#K5L,Ff?./QOgKMs9D/jC@4ZWs\[q.@BCc#!\BKRBqXB=]oba$UHGi:jB_bMip@1N3")Rqs
+^@Ik?f/eYoMRgVgKotr4gY1i"PW,^Ni#D;7]ImNsHA/QNf2n3'ko5"AH-toZnH/RtSsS?,K@\$QBD#oiO2_IeBjCM`.Ij4=
+bi`qffe4`Fa'lN^`ad/djhKb!d,mDP/06QILcm.-0\XP7BB*[E\1hEh\56EjINP^*^XlT\`u]4ZXHij1iT^_2NAV>mi0oMW
+`GN#%dT0VBh1Fr<D8pb@RrI3ENCNg+%G2h84a'M%LRh>onnXn>.U3EWWN36`FX;3&>Cg)/Q=Djs)0CYu90MJO:YmUM0u"!?
+B>B5J-Y!2Nc'T%?@-0T8cNe"+`IXFuE)>,%*1SkoLLeZJos/2FqH;9eK</dk@FeE1#\QqIbW!Y8N14ETK$@]K7+e#JOY_P1
+hia"8`K#YSfeK]?3uYP]\YImKm;keW%_3fla5#Voo@Qf`_dMZ?Tt!bP&D36ggl2g/cM(]O_O`H25VLj+2r?!t+7)Ytp>c&5
+pV?t&Hc(F1]`qZm6'e*]Yb_RE_KL]%fl"]@fAZW5[L4(sFrnV`[WKAr/03\Og0kschU3H@YdB#r@6n*WM4\&"##?[]NMdQ!
+_UAiqiot7e3.mjF2P2;@/nbIPYYF(]IU5;R4MROD?;SuS0.^dm(U4G-@X\Vf+"lZAZ1[U,)R;\7=V)!C5t_boc*+ATijES&
+>UQ\`p_u.or:!2@]1LeZglh,Y[jnlKH`OX=HPq$`47bT)/o`i9JbN"8]uka_f+!Kb_o2MaY5!P<TQhm*"Wpbd0kQp6;<9P&
+Ga<_D$l;]ORd_cfBk%>dTff)4S*l6].F7$2H9lgR]Tc#A/$Ga^Y9qHE`9U"c%HU<S88fqq-dYE^_tf>`XtcN]Vn<Q#fE]Du
+kD.2.r7qLNooHh$++KQJ^b7MKIl9Gi5/X#:pppCC8,;6OmAotN(\mitp'lIDhs0+4dCt)^Is>OHKcaZ:5J>EmI]iY?%(kK%
+:UT(hjR5mOZ&c;4O7^h9I'btpdf+Ki9mE>GcR.Xug8)@7j?*3/2T9oFRsI_sG#N[=VW7"=CGZ-#eR)`@NL,osB\#U2H9lhJ
+B&dt/ZYYZlN';j<NGt_lQ)BQnlq(cuS9MhDO"6:UO"-4;r50k-89rSGbT9UKQRuW@1fV!r44:gb4lU>a\kChXggO!fMqc1P
+Flb47An]5&&i\C(2]->:l]pe#CMV<TibEI59mNSF6<miL/lOC)Nq8UqCAEe,7EU<aklPigc'qdgc;i/@Q.aj#;VisEVOT`C
+,+U>]';sR,;oHe^!mI&X::--2d-U;akr<[aE_JJS=r]u;7[B<0Lr3X=QoPSAc5`i(68JgMdm;tY3IQDmm4\1.BmiY%50D`d
+,Y[TZ9;M7qHcRYlMplQQ=.7p@R+titM,!87P]g#LTS`(9U[?".s!8N:r!S"if#h$0I&ha194\JLfDKR@9\GZM2Z8PNU29bZ
+GMMCXr!bP`2IO9<lYF8b_gfJJ+o5UC.JS*F8Gb,<q]S5ncbB/RNV^ccI#YnX[m&M)hV-RfH;F7"kPqK9p8,D!_G0p_ebBN"
+k+[9=f#F)a:Rpt$pp$%\aAEoDTT-8/5-1f5@#'6KpZlM]e^iTZ-/UH.A0^cVCD_uF>Lhi)YSql+=LH4mjY^:s]rJhFfiT(t
+Xs@A+("nL7gVObkkA^ZO:3kEFT#'Lr7jq.PbH[t0-Xg.9]PJ`pVU,Y2EEnqR;]`?D8$H!e_r;j$_,BoU\6fXp8ON1J9#u@;
+bBoJcMpYhi:2rd$H+UQqrl8mk\,7ap(,u1Z2i8Q=li3jJ`3nTn^Z<r).ekC'')tgBKt(Am#(J;5P[>Ue<\F6N0O?.[&Ej'c
+k:,SOF8e[BMmN2Hpm8iRq!$cpEU(m@'Rm>I$3!n7U,_,0,6%mm7+X^~>
+U
+2 setlinecap
+N 0 198 M 4961 0 D S
+N 0 0 M 0 198 D S
+N 4961 0 M 0 198 D S
+N 0 0 M 4961 0 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -64 D S
+N 992 0 M 0 -64 D S
+N 1984 0 M 0 -64 D S
+N 2976 0 M 0 -64 D S
+N 3969 0 M 0 -64 D S
+N 4961 0 M 0 -64 D S
+/MM {neg M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+161 F0
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+(10) sh mx
+def
+/PSL_A0_y PSL_A0_y 48 add PSL_AH0 add def
+0 PSL_A0_y MM
+(0) bc Z
+992 PSL_A0_y MM
+(2) bc Z
+1984 PSL_A0_y MM
+(4) bc Z
+2976 PSL_A0_y MM
+(6) bc Z
+3969 PSL_A0_y MM
+(8) bc Z
+4961 PSL_A0_y MM
+(10) bc Z
+N 496 0 M 0 -32 D S
+N 1488 0 M 0 -32 D S
+N 2480 0 M 0 -32 D S
+N 3472 0 M 0 -32 D S
+N 4465 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 setlinecap
+-1063 588 T
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psscale/scale_percent.ps
+++ b/test/psscale/scale_percent.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
-%%BoundingBox: 0 0 595 842
-%%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.3.0_545cea4_2021.09.16 [64-bit] Document from basemap
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.3.0_6295c04_2021.09.16 [64-bit] Document from basemap
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Sep 16 14:48:38 2021
+%%CreationDate: Thu Sep 16 14:57:51 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -117,39 +117,39 @@
   { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
   ifelse
 }!
-/ISOLatin1+_Encoding [
+/Standard+_Encoding [
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
 /.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
-/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
 /space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
-/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
 /zero		/one		/two		/three		/four		/five		/six		/seven
 /eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
 /at		/A		/B		/C		/D		/E		/F		/G
 /H		/I		/J		/K		/L		/M		/N		/O
 /P		/Q		/R		/S		/T		/U		/V		/W
 /X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
-/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
 /h		/i		/j		/k		/l		/m		/n		/o
 /p		/q		/r		/s		/t		/u		/v		/w
-/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
-/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
-/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
-/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
-/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
-/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
-/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
-/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
-/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
-/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
-/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
-/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
-/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
-/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
-/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
-/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
-/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
 ] def
 /PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
 /F0 {/Helvetica Y}!
@@ -688,8 +688,8 @@ end
 %%BeginPageSetup
 V 0.06 0.06 scale
 %%EndPageSetup
-/PSL_page_xsize 9917 def
-/PSL_page_ysize 14033 def
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
 /PSL_plot_completion {} def
 /PSL_movie_label_completion {} def
 /PSL_movie_prog_indicator_completion {} def
@@ -722,7 +722,7 @@ N 0 5669 M -64 0 D S
 N 0 7087 M -64 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 161 F0
 (0) sw mx
 (2) sw mx
@@ -866,7 +866,7 @@ N 2268 0 M 0 64 D S
 N 2835 0 M 0 64 D S
 /MM {M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 161 F0
 (0) sh mx
 (2) sh mx
@@ -969,7 +969,7 @@ N 0 3402 M -64 0 D S
 N 0 4252 M -64 0 D S
 /MM {neg exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 161 F0
 (0) sw mx
 (2) sw mx
@@ -1074,7 +1074,7 @@ N 0 4535 M 64 0 D S
 N 0 5669 M 64 0 D S
 /MM {exch M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 161 F0
 (0) sw mx
 (2) sw mx
@@ -1174,7 +1174,7 @@ N 3969 0 M 0 -64 D S
 N 4961 0 M 0 -64 D S
 /MM {neg M} def
 /PSL_AH0 0
-PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 161 F0
 (0) sh mx
 (2) sh mx

--- a/test/psscale/scale_percent.sh
+++ b/test/psscale/scale_percent.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Test implementation of giving width and/or height of color bar in percentages
+# when -B is not used.
+gmt begin scale_percent ps
+	gmt makecpt -Cturbo -T0/10
+	gmt basemap -R0/10/0/10 -JX15c -B
+	gmt colorbar -DJTC+w40%/15% -B
+	gmt colorbar -DJML+w9c/5% -B
+	gmt colorbar -DJMR+w80%/0.6c -B
+	gmt colorbar -DJBC+w70% -B
+gmt end show


### PR DESCRIPTION
If either of these are given in percentages then their values replace the default percentage values of 80% and 5% for length and width, respectively.  I have added this information to the usage and documentation, and added a test script that tries various combination of percentages and actual dimensions:

```
gmt begin scale_percent ps
        gmt makecpt -Cturbo -T0/10
        gmt basemap -R0/10/0/10 -JX15c -B
        gmt colorbar -DJTC+w40%/15% -B
        gmt colorbar -DJML+w9c/5% -B
        gmt colorbar -DJMR+w80%/0.6c -B
        gmt colorbar -DJBC+w70% -B
gmt end show
```

which yields

![scale_percent](https://user-images.githubusercontent.com/26473567/133715410-871980fb-dc98-440b-acbb-82d7fb8810ee.png)

Closes #5771.