### PR TITLE
Note that one core is used by the main process and n-1 for jobs or frames

### DIFF
--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -151,7 +151,7 @@ Optional Arguments
     (if too large it will be truncated to the maximum cores available).  Finally,
     give a negative *n* to select (all - *n*) cores (or at least 1 if *n* equals or exceeds all).
     The parallel processing does not depend on OpenMP; new jobs are launched when the previous ones
-    complete.
+    complete. **Note**: One core is reserved by **batch** so in effect *n-1* are used for the jobs.
 
 .. include:: explain_help.rst_
 

--- a/src/batch.c
+++ b/src/batch.c
@@ -219,7 +219,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	/* Number of threads (re-purposed from -x in GMT_Option since this local option is always available and we are not using OpenMP) */
 	GMT_Usage (API, 1, "\n-x[[-]<n>]");
 	GMT_Usage (API, -2, "Limit the number of cores used in job generation [Default uses all %d cores]. "
-		"If <n> is negative then we select (%d - <n>) cores (or at least 1).", API->n_cores, API->n_cores);
+		"If <n> is negative then we select (%d - <n>) cores (or at least 1). Note: 1 core is used by batch itself.", API->n_cores, API->n_cores);
 	GMT_Option (API, ".");
 
 	return (GMT_MODULE_USAGE);

--- a/src/movie.c
+++ b/src/movie.c
@@ -468,7 +468,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	/* Number of threads (re-purposed from -x in GMT_Option since this local option is always available and we are not using OpenMP) */
 	GMT_Usage (API, 1, "\n-x[[-]<n>]");
 	GMT_Usage (API, -2, "Limit the number of cores used in frame generation [Default uses all %d cores]. "
-		"If <n> is negative then we select (%d - <n>) cores (or at least 1).", API->n_cores, API->n_cores);
+		"If <n> is negative then we select (%d - <n>) cores (or at least 1). Note: 1 core is used by movie itself.", API->n_cores, API->n_cores);
 	GMT_Option (API, ".");
 
 	return (GMT_MODULE_USAGE);


### PR DESCRIPTION
The **-x** option in **movie** and **batch** sets the total number of cores to use, but since we need one for the master there are _n-1_ left for frames or jobs.
