### PR TITLE
Apply scalings in api_get_record_matrix

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -9628,6 +9628,7 @@ struct GMT_RECORD *api_get_record_matrix (struct GMTAPI_CTRL *API, unsigned int 
 			col_pos_out = gmtlib_pick_in_col_number (GMT, (unsigned int)col, &col_pos_in);
 			ij = API->current_get_M_index (S->rec, col_pos_in, M->dim);
 			API->current_get_M_val (&(M->data), ij, &(GMT->current.io.curr_rec[col_pos_out]));
+			GMT->current.io.curr_rec[col_pos_out] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col], GMT->current.io.curr_rec[col_pos_out]);
 		}
 		S->rec++;
 		if ((status = gmtapi_bin_input_memory (GMT, S->n_columns, n_use)) < 0) {	/* Process the data record */


### PR DESCRIPTION
**Description of proposed changes**

Similar to https://github.com/GenericMappingTools/gmt/pull/5291, but for matrices. Unlike that PR, I did not do anything about checking whether GMT_IS_REFERENCE | GMT_IS_DUPLICATE is needed.

All GMT and PyGMT tests pass, except one which is wrong (xref https://github.com/GenericMappingTools/pygmt/issues/1539). I did not test GMT.jl.


Addresses https://github.com/GenericMappingTools/pygmt/issues/1313

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->



**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
