### PR TITLE
CI: Install optional gdal executables from vcpkg

### DIFF
--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -10,7 +10,7 @@ on:
   # Uncomment the "push:" line to manually re-cache data artifacts in pushes
   #push:
   # Uncomment the 'pull_request:' line to manually re-cache data artifacts in PRs
-  #pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -10,7 +10,7 @@ on:
   # Uncomment the "push:" line to manually re-cache data artifacts in pushes
   #push:
   # Uncomment the 'pull_request:' line to manually re-cache data artifacts in PRs
-  pull_request:
+  #pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -19,7 +19,7 @@ PACKAGE="${PACKAGE:-false}"
 WIN_PLATFORM=x64-windows
 
 # install libraries
-vcpkg install netcdf-c gdal[tools] pcre2 fftw3[core,threads] clapack openblas --triplet ${WIN_PLATFORM}
+vcpkg install netcdf-c gdal[core,tools] pcre2 fftw3[core,threads] clapack openblas --triplet ${WIN_PLATFORM}
 # Executable files search for DLL files in the directories listed in the PATH environment variable.
 echo "${VCPKG_INSTALLATION_ROOT}/installed/${WIN_PLATFORM}/bin" >> $GITHUB_PATH
 # Tools like gdal_translate, ogr2ogr are located in tools/gdal

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -19,7 +19,7 @@ PACKAGE="${PACKAGE:-false}"
 WIN_PLATFORM=x64-windows
 
 # install libraries
-vcpkg install netcdf-c gdal pcre2 fftw3[core,threads] clapack openblas --triplet ${WIN_PLATFORM}
+vcpkg install netcdf-c gdal[tools] pcre2 fftw3[core,threads] clapack openblas --triplet ${WIN_PLATFORM}
 # Executable files search for DLL files in the directories listed in the PATH environment variable.
 echo "${VCPKG_INSTALLATION_ROOT}/installed/${WIN_PLATFORM}/bin" >> $GITHUB_PATH
 # Tools like gdal_translate, ogr2ogr are located in tools/gdal


### PR DESCRIPTION
**Description of proposed changes**

In this PR (https://github.com/microsoft/vcpkg/pull/19243), vcpkg no longer builds GDAL's executables by default. We need to add the `[tools]` parameter to re-enable building the executables.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
