### PR TITLE
features.rst: format references to  cpt's consistently

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1535,8 +1535,8 @@ Automatic CPTs
 
 A few modules (:doc:`/grdimage`, :doc:`/grdview`) that expects a CPT option will
 provide a default CPT if none is provided.  By default, the default CPT is the
-"turbo" color table, but this is overridden if the user uses the @eart_relief
-(we select "geo") or @srtm_relief (we select "srtm") data sets.  After selection,
+*turbo* color table, but this is overridden if the user uses the @eart_relief
+(we select *geo*) or @srtm_relief (we select *srtm*) data sets.  After selection,
 these CPTs are read and scaled to match the range of the grid values. You may append
 **+i**\ *dz* to the CPT to have the exact range rounded to nearest multiple of *dz*.
 This is helpful if you plan to place a colorbar and prefer start and stop *z*-values

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1535,7 +1535,7 @@ Automatic CPTs
 
 A few modules (:doc:`/grdimage`, :doc:`/grdview`) that expects a CPT option will
 provide a default CPT if none is provided.  By default, the default CPT is the
-*turbo* color table, but this is overridden if the user uses the @eart_relief
+*turbo* color table, but this is overridden if the user uses the @earth_relief
 (we select *geo*) or @srtm_relief (we select *srtm*) data sets.  After selection,
 these CPTs are read and scaled to match the range of the grid values. You may append
 **+i**\ *dz* to the CPT to have the exact range rounded to nearest multiple of *dz*.


### PR DESCRIPTION
Change references from e.g. "geo" -> *geo*