### PR TITLE
Simplify conversions between km and degrees

### DIFF
--- a/doc/rst/source/explain_-icols.rst_
+++ b/doc/rst/source/explain_-icols.rst_
@@ -1,2 +1,2 @@
-**-i**\ *cols*\ [**+l**][**+d**\ *divisor*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]] :ref:`(more ...) <-icols_full>`
+**-i**\ *cols*\ [**+l**][**+d**\ *divisor*][**+s**\ *scale*\|\ **d**\|\ **k**][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]] :ref:`(more ...) <-icols_full>`
     Select input columns and transformations (0 is first column, **t** is trailing text, append *word* to read one word only).

--- a/doc/rst/source/explain_-icols_full.rst_
+++ b/doc/rst/source/explain_-icols_full.rst_
@@ -3,7 +3,7 @@ The **-i** option
 
 **Syntax**
 
-**-i**\ *cols*\ [**+l**][**+d**\ *divisor*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
+**-i**\ *cols*\ [**+l**][**+d**\ *divisor*][**+s**\ *scale*\|\ **d**\|\ **k**][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
     Select specific data columns for primary input, in arbitrary order.
 
 **Description**
@@ -16,7 +16,8 @@ one of the following modifiers to any column or column range to transform the in
 
 - **+l** to take the **log10** of the input values.
 - **+d** to divide the input values by the factor *divisor* [default is 1].
-- **+s** to multiply the input values by the factor *scale* [default is 1].
+- **+s** to multiply the input values by the factor *scale* [default is 1]. Alternatively, give **d** to convert
+  km to degrees or **k** to convert degrees to km.
 - **+o** to add the given *offset* to the input values [default is 0].
 
 To read from a given column until the end of the record, leave off *stop* when specifying the column range. Normally,

--- a/doc/rst/source/std-opts-classic.rst
+++ b/doc/rst/source/std-opts-classic.rst
@@ -44,7 +44,7 @@ Common Options (Classic Mode)
      - :ref:`Segment data by detecting gaps <-g_full>`
    * - **-h**\ [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\ *remark*][**+t**\ *title*]
      - :ref:`ASCII tables have header record[s] <-h_full>`
-   * - **-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
+   * - **-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*\|\ **d**\|\ **k**][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
      - :ref:`Selection of input columns <-icols_full>`
    * - **-je**\|\ **f**\|\ **g**
      - :ref:`Mode of spherical distance calculation <-distcalc_full>`

--- a/doc/rst/source/std-opts.rst
+++ b/doc/rst/source/std-opts.rst
@@ -40,7 +40,7 @@ Common Options
      - :ref:`Segment data by detecting gaps <-g_full>`
    * - **-h**\ [**i**\|\ **o**][*n*][**+c**][**+d**][**+m**\ *segheader*][**+r**\ *remark*][**+t**\ *title*]
      - :ref:`ASCII tables have header record[s] <-h_full>`
-   * - **-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
+   * - **-i**\ *cols*\ [**+l**][**+d**\ *divide*][**+s**\ *scale*\|\ **d**\|\ **k**][**+o**\ *offset*][,\ *...*][,\ **t**\ [*word*]]
      - :ref:`Selection of input columns <-icols_full>`
    * - **-je**\|\ **f**\|\ **g**
      - :ref:`Mode of spherical distance calculation <-distcalc_full>`

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7703,7 +7703,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 			GMT_Usage (API, 3, "+l Take log10 of column before any other transformations.");
 			GMT_Usage (API, 3, "+d Divide column by appended <divisor>.");
 			GMT_Usage (API, 3, "+o Add to column the appended <offset>.");
-			GMT_Usage (API, 3, "+s Multiply column by appended <scale>.");
+			GMT_Usage (API, 3, "+s Multiply column by appended <scale> or give d (convert km to degree) or k (degree to km)");
 			break;
 
 		case 'A':	/* -j option for spherical distance calculation mode */
@@ -9113,10 +9113,17 @@ int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 				pos_p = 0;	/* Reset to start of new word */
 				while (gmt_getmodopt (GMT, 'i', c, "dlos", &pos_p, word, &uerr) && uerr == 0) {
 					switch (word[0]) {
+						case 'd': convert |= 1;	scale = 1.0 / atof (&word[1]); break;
 						case 'l': convert |= 2; break;
 						case 'o': convert |= 1; offset = atof (&word[1]); break;
-						case 's': convert |= 1; scale  = atof (&word[1]); break;
-						case 'd': convert |= 1; scale  = 1.0 / atof (&word[1]); break;
+						case 's':	/* Must check for special codes k (convert degrees to km) and d (convert km to degrees) */
+							convert |= 1;
+							switch (word[1]) {
+								case 'k': scale = GMT->current.proj.DIST_KM_PR_DEG; break;
+								case 'd': scale = 1.0 / GMT->current.proj.DIST_KM_PR_DEG; break;
+								default: scale  = atof (&word[1]); break;
+							}
+							break;
 						default: break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
 					}
 				}

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -126,7 +126,7 @@
 #define GMT_f_OPT	"-f[i|o]<colinfo>"
 #define GMT_g_OPT	"-gx|y|z|d|X|Y|D<gap>[<unit>][+a][+c<col>][+n|p]"
 #define GMT_h_OPT	"-h[i|o][<nrecs>][+c][+d][+m<segheader>][+r<remark>][+t<title>]"
-#define GMT_i_OPT	"-i<cols>[+l][+d<divisor>][+s<scale>][+o<offset>][,...][,t[<word>]]"
+#define GMT_i_OPT	"-i<cols>[+l][+d<divisor>][+s<scale>|d|k][+o<offset>][,...][,t[<word>]]"
 #define GMT_j_OPT	"-je|f|g"
 #define GMT_l_OPT	"-l[<label>][+D<pen>][+G<gap>][+H<header>][+L[<code>/]<txt>][+N<cols>][+S<size>[/<height>]][+V[<pen>]][+f<font>][+g<fill>][+j<just>][+o<dx>[/<dy>]][+p<pen>][+s<scale>][+w<width>]"
 #ifdef DEBUG


### PR DESCRIPTION
Users (like myself...) who have data columns representing distances on the Earth (or other planets) may need to convert between arc and distance units (mostly degrees and km).  This is an awkward thing to do via proxies like +s111.195.  In **grdmath** we have operators **DEG2KM** and **KM2DEG** for this.  For tables I have now implemented special arguments **d** and **k** to **-i**_col_**+s**.  So, `-i0+sk` will convert spherical degrees in column one to km, using the prevailing mean ellipse radius.
No effect on any existing tests, and I checked that both codes work correctly.
