### PR TITLE
Forgot check on dry-run or not

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15483,7 +15483,8 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					strncpy (s_inc, API->remote_info[k_data2].inc, GMT_LEN8);
 					inc_set = true;
 				}
-				goto dry_run;
+				if (dry_run)
+					goto dry_run;
 			}
 			if ((c = strchr (opt->arg, '+'))) {	/* Maybe have things like -I@earth_relief_30m+d given to grdimage */
 				c[0] = '\0';


### PR DESCRIPTION
See #5823 for the failure.  The problem was I had a goto line that should only be reached if we are during **grdcut -D,** not **grdimage** and other modules.  So it skipped assembling the grid...
