### PR TITLE
Add extra arg to gmt_cat_cpt_strings

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -415,7 +415,7 @@ EXTERN_MSC uint64_t gmt_make_equidistant_array (struct GMT_CTRL *GMT, double min
 EXTERN_MSC double * gmt_duplicate_array (struct GMT_CTRL *GMT, double *array, uint64_t n);
 EXTERN_MSC bool gmt_is_barcolumn (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);
 EXTERN_MSC unsigned int gmt_get_columbar_bands (struct GMT_CTRL *GMT, struct GMT_SYMBOL *S);
-EXTERN_MSC char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *label, unsigned int n);
+EXTERN_MSC char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *label, unsigned int n, unsigned int *n_set);
 EXTERN_MSC bool gmt_same_fill (struct GMT_CTRL *GMT, struct GMT_FILL *F1, struct GMT_FILL *F2);
 EXTERN_MSC unsigned int gmt_contour_first_pos (struct GMT_CTRL *GMT, char *arg);
 EXTERN_MSC unsigned int gmt_contour_A_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct CONTOUR_ARGS *A);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7744,7 +7744,7 @@ unsigned int gmt_validate_cpt_parameters (struct GMT_CTRL *GMT, struct GMT_PALET
 	return GMT_NOERROR;
 }
 
-char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *in_label, unsigned int n) {
+char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *in_label, unsigned int n, unsigned int *n_set) {
 	/* Generate categorical labels for n categories from the label magic argument.
 	 * Note: If n = 12 and label = M then we create month names.
 	 * Note: If n = 7 and label = D then we create day names
@@ -7827,6 +7827,7 @@ char ** gmt_cat_cpt_strings (struct GMT_CTRL *GMT, char *in_label, unsigned int 
 			Clabel[k] = strdup (string);
 		}
 	}
+	*n_set = k;	/* How many we actually set */
 	return Clabel;
 }
 

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -890,8 +890,9 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	if (Ctrl->F.cat) {	/* Flag as a categorical CPT */
 		Pout->categorical = GMT_CPT_CATEGORICAL_VAL;
 		if (Ctrl->F.label) {	/* Want categorical labels */
-			char **label = gmt_cat_cpt_strings (GMT, Ctrl->F.label, Pout->n_colors);
-			for (unsigned int k = 0; k < Pout->n_colors; k++) {
+			unsigned int ns = 0;
+			char **label = gmt_cat_cpt_strings (GMT, Ctrl->F.label, Pout->n_colors, &ns);
+			for (unsigned int k = 0; k < MIN (Pout->n_colors, ns); k++) {
 				if (Pout->data[k].label) gmt_M_str_free (Pout->data[k].label);
 				Pout->data[k].label = label[k];	/* Now the job of the CPT to free these strings */
 			}

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -677,17 +677,17 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 	if (Ctrl->F.active) Pout->model = Ctrl->F.model;
 	if (Ctrl->F.cat) {	/* Flag as a categorical CPT */
 		bool got_key_file= (Ctrl->F.key && !gmt_access (GMT, Ctrl->F.key, R_OK));	/* Want categorical labels read from file */
+		unsigned int ns = 0;
 		Pout->categorical = GMT_CPT_CATEGORICAL_VAL;
 		if (Ctrl->F.label || (Ctrl->F.key && !got_key_file)) {	/* Want auto-categorical labels appended to each CPT record */
-			char **label = gmt_cat_cpt_strings (GMT, (Ctrl->F.label) ? Ctrl->F.label : Ctrl->F.key, Pout->n_colors);
-			for (unsigned int k = 0; k < Pout->n_colors; k++) {
+			char **label = gmt_cat_cpt_strings (GMT, (Ctrl->F.label) ? Ctrl->F.label : Ctrl->F.key, Pout->n_colors, &ns);
+			for (unsigned int k = 0; k < MIN (Pout->n_colors, ns); k++) {
 				if (Pout->data[k].label) gmt_M_str_free (Pout->data[k].label);
 				if (label[k]) Pout->data[k].label = label[k];	/* Now the job of the CPT to free these strings */
 			}
 			gmt_M_free (GMT, label);	/* But the master array can go */
 		}
 		if (Ctrl->F.key) {	/* Want categorical labels */
-			unsigned int ns;
 			char **keys = NULL;
 			if (got_key_file) {	/* Got a file with category keys */
 				ns = gmt_read_list (GMT, Ctrl->F.key, &keys);
@@ -699,8 +699,8 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 					GMT_Report (API, GMT_MSG_WARNING, "The categorical keys file %s had %d entries but only %d are needed - skipping the extra keys\n", Ctrl->F.key, ns, Pout->n_colors);
 			}
 			else	/* Got comma-separated keys */
-				keys = gmt_cat_cpt_strings (GMT, Ctrl->F.key, Pout->n_colors);
-			for (unsigned int k = 0; k < Pout->n_colors; k++) {
+				keys = gmt_cat_cpt_strings (GMT, Ctrl->F.key, Pout->n_colors, &ns);
+			for (unsigned int k = 0; k < MIN (Pout->n_colors, ns); k++) {
 				if (Pout->data[k].key) gmt_M_str_free (Pout->data[k].key);
 				if (k < ns && keys[k]) {
 					Pout->data[k].key = keys[k];	/* Now the job of the CPT to free these strings */


### PR DESCRIPTION
This function returns an array of keys but not its length, making it difficult to test if we got what is expected. Now we return that value as well so we can use it in assignments.  Hopefully, closes #5859, @joa-quim; please give it a test.
