### PR TITLE
Remove unused variables in order to kill some warnings

### DIFF
--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -605,7 +605,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 	int n_use, error, out_ID;
 	bool geo, skip;
 
-	char *comp[2] = {"u(x,y)", "v(x,y)"}, *tag[2] = {"u", "v"};
+	char *comp[2] = {"u(x,y)", "v(x,y)"};
 
 	double **X = NULL, *A = NULL, *u = NULL, *v = NULL, *obs = NULL;
 	double *f_x = NULL, *f_y = NULL, *in = NULL, *orig_u = NULL, *orig_v = NULL;
@@ -1232,7 +1232,7 @@ EXTERN_MSC int GMT_gpsgridder (void *V_API, int mode, void *args) {
 		if (Ctrl->C.history) {	/* Write out U,V grids after adding contribution for each eigenvalue */
 			static char *mkind[3] = {"", "Incremental", "Cumulative"};
 			gmt_grdfloat *current[2] = {NULL, NULL}, *previous[2] = {NULL, NULL};
-			double predicted[4], l2_sum_n = 0.0, l2_sum_e = 0.0;
+			double l2_sum_n = 0.0, l2_sum_e = 0.0;
 			struct GMT_SINGULAR_VALUE *eigen = NULL;
 			struct GMT_DATASET *E = NULL;
 			struct GMT_DATASEGMENT *S = NULL;

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4334,7 +4334,7 @@ GMT_LOCAL bool gmtapi_expand_index_image (struct GMT_CTRL *GMT, struct GMT_IMAGE
 	bool new = false;
 	unsigned char *data = NULL;
 	uint64_t node, off[3];
-	unsigned int start_c, c, index;
+	unsigned int c, index;
 	struct GMT_IMAGE *I = NULL;
 	struct GMT_IMAGE_HIDDEN *IH = gmt_get_I_hidden (I_in);
 	struct GMT_GRID_HEADER *h = I_in->header;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5044,14 +5044,14 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args_in) {
 	 * GMT->current.proj structure.  The function returns true if an error is encountered.
 	 */
 
-	int i, j, k = 0, m, n, nlen, slash, l_pos[3], p_pos[3], t_pos[3], d_pos[3], id, project;
+	int i, j, k = 0, n, slash, l_pos[3], p_pos[3], t_pos[3], d_pos[3], id, project;
 	int n_slashes = 0, last_pos = 0, error = 0;
 	unsigned int mod_flag = 0;
 	bool width_given = false;
 	double c, az, GMT_units[3] = {0.01, 0.0254, 1.0};      /* No of meters in a cm, inch, m */
 	char mod, args_cp[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""};
 	char txt_d[GMT_LEN256] = {""}, txt_e[GMT_LEN256] = {""}, last_char = 0, *dd = NULL, *d = NULL, *args;
-	char txt_arr[11][GMT_LEN256], args_buf[GMT_LEN128] = {""};
+	char args_buf[GMT_LEN128] = {""};
 
 	if (args_in == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -J: No argument for parsing\n");
@@ -15398,7 +15398,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 			}
 			if ((k_data = gmt_remote_no_resolution_given (API, opt->arg, &registration)) != GMT_NOTSET) {	/* Gave no resolution, e.g., just "eart_relief" */
 				bool at_least_one = false;
-				char codes[3] = {""}, reg[2] = {'g', 'p'}, unit, dir[GMT_LEN64] = {""}, file[GMT_LEN128] = {""}, *p_dir = NULL;
+				char codes[3] = {""}, reg[2] = {'g', 'p'}, dir[GMT_LEN64] = {""}, file[GMT_LEN128] = {""}, *p_dir = NULL;
 				unsigned int n_to_set = 0, level = GMT->hidden.func_level;	/* Since we will need to increment prematurely since gmtinit_begin_module_sub has not been reached yet */
 				unsigned int k, n_R = 0;
 				int k_data2 = GMT_NOTSET;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8366,7 +8366,7 @@ GMT_LOCAL void gmtio_duplicate_dataset_cols (struct GMT_CTRL *GMT, struct GMT_DA
 /*! . */
 struct GMT_DATASET *gmt_duplicate_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *Din, unsigned int mode, unsigned int *geometry) {
 	/* Make an exact replica, return geometry if not NULL */
-	uint64_t tbl, seg, n_columns;
+	uint64_t tbl, seg;
 	struct GMT_DATASET *D = NULL;
 
 	if (mode & GMT_ALLOC_VIA_ICOLS && GMT->common.i.select) {

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -18438,7 +18438,7 @@ unsigned int gmt_unpack_rgbcolors (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, un
 void gmt_format_region (struct GMT_CTRL *GMT, char *record, double *wesn) {
 	/* Fancy ddd:mm:ssF typeset of -Rw/e/s/n if possible */
 	enum gmt_col_enum type = gmt_get_column_type (GMT, GMT_IN, GMT_X);
-	char text[GMT_LEN64] = {""}, inc[GMT_LEN64] = {""}, save[GMT_LEN64];
+	char text[GMT_LEN64] = {""}, save[GMT_LEN64];
 	if (gmt_M_is_geographic (GMT, GMT_IN)) {	/* Try formal reporting */
 		strcpy (save, GMT->current.setting.format_geo_out);
 		strcpy (GMT->current.setting.format_geo_out, "ddd:mm:ssF");

--- a/src/gmtsplit.c
+++ b/src/gmtsplit.c
@@ -324,7 +324,7 @@ EXTERN_MSC int GMT_gmtsplit (void *V_API, int mode, void *args) {
 	int error = 0;
 
 	uint64_t dim[GMT_DIM_SIZE] = {1, 0, 0, 0};	/* Output dataset will have one table only */
-	uint64_t tbl, col, n_out = 0, k, n, row, seg, seg2 = 0, begin, end, n_total = 0, n_columns = 0, nprofiles = 0, *rec = NULL;
+	uint64_t tbl, n_out = 0, k, n, row, seg, seg2 = 0, begin, end, n_total = 0, n_columns = 0, nprofiles = 0, *rec = NULL;
 
 	size_t n_alloc_seg = 0, n_alloc = 0;
 

--- a/src/grdhisteq.c
+++ b/src/grdhisteq.c
@@ -218,7 +218,7 @@ GMT_LOCAL struct GRDHISTEQ_CELL *grdhisteq_do_hist_equalization_cart (struct GMT
 	/* Do basic Cartesian histogram equalization */
 	uint64_t i, j, nxy;
 	unsigned int n_cells_m1 = 0, current_cell, pad[4];
-	double delta_cell, target, out[3];
+	double delta_cell, target;
 	struct GRDHISTEQ_CELL *cell = NULL;
 	struct GMT_GRID *Orig = NULL;
 
@@ -279,7 +279,7 @@ GMT_LOCAL struct GRDHISTEQ_CELL *grdhisteq_do_hist_equalization_geo (struct GMT_
 	/* Do basic area-weighted histogram equalization */
 	uint64_t i, j, node, nxy = 0;
 	unsigned int n_cells_m1 = 0, current_cell, row, col;
-	double cell_w, delta_w, target_w, wsum = 0.0, out[3];
+	double cell_w, delta_w, target_w, wsum = 0.0;
 	struct GRDHISTEQ_CELL *cell = gmt_M_memory (GMT, NULL, n_cells, struct GRDHISTEQ_CELL);
 	struct GMT_GRID *W = gmt_duplicate_grid (GMT, Grid, GMT_DUPLICATE_ALLOC);
 	struct GMT_OBSERVATION *pair = gmt_M_memory (GMT, NULL, Grid->header->nm, struct GMT_OBSERVATION);

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -356,8 +356,7 @@ GMT_LOCAL int psconvert_parse_new_N_settings (struct GMT_CTRL *GMT, char *arg, s
 	/* Syntax: -N[+f<fade>][+g<fill>][+i][+p<pen>] */
 
 	unsigned int pos = 0, error = 0;
-	int j, k = 0;
-	char p[GMT_LEN128] = {""}, txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, txt_c[GMT_LEN64] = {""}, txt_d[GMT_LEN64] = {""};
+	char p[GMT_LEN128] = {""};
 
 	if (gmt_validate_modifiers (GMT, arg, 'N', "fgip", GMT_MSG_ERROR)) return (1);	/* Bail right away */
 


### PR DESCRIPTION
**Description of proposed changes**

I removed a number of declarations of variables that were not used. The stray variables created warnings. We can better do without. (They were also not used in #ifdef sections). 

This further does not change any behaviours.

**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
