### PR TITLE
Add +f modifier to grdgradient -Q to specify file

### DIFF
--- a/doc/rst/source/grdgradient.rst
+++ b/doc/rst/source/grdgradient.rst
@@ -16,7 +16,7 @@ Synopsis
 [ |-A|\ *azim*\ [/*azim2*] ] [ |-D|\ [**a**][**c**][**o**][**n**] ]
 [ |-E|\ [**m**\|\ **s**\|\ **p**]\ *azim/elev*\ [**+a**\ *ambient*][**+d**\ *diffuse*][**+p**\ *specular*][**+s**\ *shine*] ]
 [ |-N|\ [**e**\|\ **t**][*amp*][**+a**\ *ambient*][**+s**\ *sigma*][**+o**\ *offset*] ]
-[ |-Q|\ **c**\|\ **r**\|\ **R** ]
+[ |-Q|\ **c**\|\ **r**\|\ **R**\ [**+f**\ *file*]]
 [ |SYN_OPT-R| ] [ |-S|\ *slopefile* ]
 [ |SYN_OPT-V| ] [ |SYN_OPT-f| ]
 [ |SYN_OPT-n| ]
@@ -132,7 +132,7 @@ Optional Arguments
 
 .. _-Q:
 
-**-Qc**\|\ **r**\|\ **R**
+**-Qc**\|\ **r**\|\ **R**\ [**+f**\ *file*]
     Controls how normalization via **-N** is carried out.  When multiple grids
     should be normalized the same way (i.e., with the same *offset* and/or *sigma*),
     we must pass these values via **-N**.  However, this is inconvenient if we
@@ -141,6 +141,8 @@ Optional Arguments
     for this run then do not specify **-G**. For subsequent runs, just use
     **-Qr** to read these values.  Using **-QR** will read then delete the
     statistics file. See :ref:`Tiles <grdgradient:Tiles>` for more information.
+    Optionally, append **+f**\ *file* to write/read the statistics to/from the
+    specified *file*.
 
 .. |Add_-R| replace:: Using the **-R** option will select a subsection of *ingrid* grid. If this subsection
     exceeds the boundaries of the grid, only the common region will be extracted. |Add_-R_links|

--- a/test/grdgradient/illum_norm_control.sh
+++ b/test/grdgradient/illum_norm_control.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Test the generation of illumination with saving and reading the normalization parameters
+
+ps=illum_classic.ps
+
+gmt grdmath -R-15/15/-15/15 -I0.3 X Y HYPOT DUP 2 MUL PI MUL 8 DIV COS EXCH NEG 10 DIV EXP MUL = somb.nc
+
+gmt grd2cpt somb.nc -Cjet > pal.cpt
+
+gmt grdgradient somb.nc -A225 -Nt0.75 -Qc+fstatistics.txt
+
+gmt grdgradient somb.nc -A225 -Gintensity.nc -Nt0.75+o+s -Qr+fstatistics.txt
+
+gmt grdview somb.nc -JX6i -JZ2i -B5 -Bz0.5 -BSEwnZ -N-1+gwhite -Qi100 -Iintensity.nc -X1.5i -Cpal.cpt \
+	-R-15/15/-15/15/-1/1 -p120/30 > $ps
+
+rm -f somb.nc intensity.nc pal.cpt statistics.txt


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a new +f<file> modifier to the grdgradient -Q option to allow the user to specify what file should be created or read.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #5852 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
