### PR TITLE
surface must pass -rg when calling grdmask internally

### DIFF
--- a/src/surface.c
+++ b/src/surface.c
@@ -2138,7 +2138,8 @@ EXTERN_MSC int GMT_surface (void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 		gmt_disable_bghi_opts (GMT);	/* Do not want any -b -g -h -i to affect the reading input file in grdmask */
-		sprintf (cmd, "%s -G%s -R%g/%g/%g/%g -I%g/%g -NNaN/1/1 -S%s -V%c --GMT_HISTORY=readonly",
+		/* Hardwire -rg since internally, all grids are gridline registered (until output at least) */
+		sprintf (cmd, "%s -G%s -R%g/%g/%g/%g -I%g/%g -NNaN/1/1 -S%s -V%c -rg --GMT_HISTORY=readonly",
 		         input, mask, wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI], GMT->common.R.inc[GMT_X],
 				 GMT->common.R.inc[GMT_Y], Ctrl->M.arg, V_level[GMT->current.setting.verbose]);
 		GMT_Report (API, GMT_MSG_INFORMATION, "Masking grid nodes away from data points via grdmask\n");


### PR DESCRIPTION
See the [forum](https://forum.generic-mapping-tools.org/t/corrupt-surface-outputs-with-max-radius-and-or-gridline-registration/2139/10) for background.  Regardless of the registration requested from **surface**, internally all grids in **surface** are gridline-registered, hence the call to **grdmask** needs **-rg**.  With this PR these variants work:

```
gmt blockmedian @tut_ship.xyz -R245/255/20/30 -I5m -rp | gmt surface -R245/255/20/30 -I5m -M5c -rp -Goutput.nc; gmt grdimage output.nc -JX5c -png output
gmt blockmedian @tut_ship.xyz -R245/255/20/30 -I5m -rg  | gmt surface -R245/255/20/30 -I5m -M5c -rg -Goutput.nc; gmt grdimage output.nc -JX5c -png output
```

Note that if **blockmedian** is run without **-rp** and **surface** uses **-rp** then a less consistent result is obtained due to _user error_.
