### PR TITLE
Better srtm_tiles.nc allows for better checks

### DIFF
--- a/doc/scripts/GMT_SRTM.sh
+++ b/doc/scripts/GMT_SRTM.sh
@@ -4,7 +4,7 @@ gmt begin GMT_SRTM
 	gmt set GMT_THEME cookbook
 	gmt set MAP_FRAME_TYPE plain
 	gmt coast -R-180/180/-60/60 -JQ0/15c -B -BWStr -Dc -A5000 -Glightgray --FORMAT_GEO_MAP=dddF
-	echo "1	red" > t.cpt
+	echo "1	red 2 red" > t.cpt
 	gmt grdmath @srtm_tiles.nc 0 NAN = t.nc
 	gmt grdimage t.nc -Ct.cpt
 	gmt coast -Dc -A5000 -W0.25p

--- a/src/gmt_remote.h
+++ b/src/gmt_remote.h
@@ -59,6 +59,12 @@ struct GMT_DATA_HASH {			/* Holds file hashes (probably SHA256) */
 	size_t size;				/* File size in bytes */
 };
 
+enum GMT_tile_coverage {	/* Values in any tile coverage grid (e.g., srtm_tiles.nc) */
+	GMT_NO_TILE      = 0,	/* No high-resolution data for this tile */
+	GMT_PARTIAL_TILE = 1,	/* There is data, but part of tile is ocean */
+	GMT_FULL_TILE    = 2	/* There is complete coverage on land */
+};
+
 #define GMT_SRTM_ONLY	1	/* Mode so that when srtm_relief* is used we do not blend in earth_relief_15s */
 
 #define GMT_HASH_SERVER_FILE "gmt_hash_server.txt"


### PR DESCRIPTION
The soon-to-be-updated _srtm_tiles.nc_ (attached) now has three values: 0 means no SRTM data for this 1x1 tile, 1 if there is data but tile is partially in the ocean, and 2 if data and fully on land.  Previously, we only have values 0 and 1, with 1 indicating a file but we had no way of knowing if ocean filler would be needed, so we had to add `@earth_relief_15s` tiles no matter what, even if the region was entirely on land.  Because of the need for backwards compatibility, the new file should work well with GMT 6.2 and earlier since the check was only on whether of not a node was zero or not.  For 6.3 it will now be able to distinguish complete land tiles from mixed tiles.  This PR also adds a few more checks, such as

- Allowing for a future tile coverage grid to not be forced to be 0/360 by considering possible 360-wrapping
- Add a few named enums to make the code easier to read

After a minor fix to GMT_SRTM.sh doc script (just letting both 1 and 2 be red) this passes all the tests, as well as solves #5876.  However, we should make sure it also works the same as before with GMT 6.2.

@meghanrjones, would you be able to move your ~/.gmt/cache/srtm_tiles.nc file to somewhere else and install the attached on instead, then run all the tests with GMT 6.2.0 version?

[srtm_tiles.nc.zip](https://github.com/GenericMappingTools/gmt/files/7377672/srtm_tiles.nc.zip)

Once that passes then we can remove the WIP and approve/merge.

