### PR TITLE
Better auto-resolution selection for grids and images

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14824,25 +14824,15 @@ GMT_LOCAL int gmtinit_compare_resolutions (const void *point_1, const void *poin
 	return (0);
 }
 
-GMT_LOCAL double gmtinit_map_diagonal_degree (struct GMT_CTRL *GMT) {
-	/* Return a diagonal or representative distance in degrees across the map */
-	double X = GMT->common.R.wesn[XHI] - GMT->common.R.wesn[XLO];
+GMT_LOCAL double gmtinit_map_vertical_degree (struct GMT_CTRL *GMT) {
+	/* Return the max latitude separation in degrees across the map */
 	double Y = GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO];
-	double D = gmtlib_great_circle_dist_degree (GMT, GMT->common.R.wesn[XLO], GMT->common.R.wesn[YLO], GMT->common.R.wesn[XHI], GMT->common.R.wesn[YHI]);	/* "Diagonal" great circle distance in degrees */
-	/* For some global projections the D here may be 180 even though we see a full 360 degrees in longitude.  Hence these checks */
-	if (Y > D) D = Y;
-	if (X > D) D = X;
-	return (D);
+	return (Y);
 }
 
-GMT_LOCAL double gmtinit_map_diagonal_inches (struct GMT_CTRL *GMT, double D) {
-	/* Return a diagonal or representative distance in degrees across the map */
-	/* For some global projections the D here may be 180 even though we see a full 360 degrees in longitude.  Hence these checks */
-	double L;
-	if (doubleAlmostEqual (D, 360.0) || gmt_M_360_range (GMT->common.R.wesn[XLO], GMT->common.R.wesn[XHI]))	/* Global maps */
-		L = GMT->current.map.width;
-	else
-		L = hypot (GMT->current.map.height, GMT->current.map.width);	/* Approximate or actual "Diagonal" length of map in inches */
+GMT_LOCAL double gmtinit_map_vertical_inches (struct GMT_CTRL *GMT) {
+	/* Return the max map height in inches */
+	double L = GMT->current.map.height;
 	return (L);
 }
 
@@ -15462,12 +15452,12 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					}
 				}
 				dpi = GMT->current.setting.graphics_dpu; if (GMT->current.setting.graphics_dpu_unit == 'c') dpi *= 2.54;	/* Convert dpc to dpi */
-				D = gmtinit_map_diagonal_degree (GMT);	/* Approximate "Diagonal" or representative great circle distance in degrees */
-				L = gmtinit_map_diagonal_inches (GMT, D);	/* Approximate or actual "Diagonal" length of map in inches */
-				this_n_per_degree = 2.0 * L * dpi / D;	/* Number of equivalent nodes per degree needed (factor of 2 added for good measure) */
+				D = gmtinit_map_vertical_degree (GMT);	/* Map latitudinal extent in degrees */
+				L = gmtinit_map_vertical_inches (GMT);	/* Map height in inches */
+				this_n_per_degree = L * dpi / D;	/* Number of equivalent nodes per degree needed */
 				R = gmt_remote_resolutions (API, opt->arg, &n_R);	/* List of available resolutions for this family */
-				for (k = 0; k < n_R; k++) {
-					R[k].resolution = R[k].resolution - this_n_per_degree;	/* Compute deviation from desired resolution */
+				for (k = 0; k < n_R; k++) {	/* Compute deviation from desired resolution */
+					R[k].resolution = R[k].resolution - this_n_per_degree;
 					if (registration != GMT_NOTSET && reg[registration] != R[k].reg) continue;	/* Skip this registration */
 					if (R[k].resolution >= 0.0) at_least_one = true;	/* At least one resolution will be adequate */
 				}
@@ -15491,9 +15481,10 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 					return NULL;
 				}
 				else {	/* Replace entry with correct version */
-					GMT_Report (API, GMT_MSG_INFORMATION, "Given -R%s -J%s, representative distances D_g = %g degrees, D_m = %g %s and dpu = %g%c (this_n_per_degree = %lg) we replace %s by %s\n",
+					GMT_Report (API, GMT_MSG_INFORMATION, "Given -R%s -J%s, representative distances D_y = %g degrees, D_h = %g %s and dpu = %g%c (this_n_per_degree = %lg) we replace %s by %s\n",
 						GMT->common.R.string, GMT->common.J.string, D, L * GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit],
-						GMT->session.unit_name[GMT->current.setting.proj_length_unit], GMT->current.setting.graphics_dpu, GMT->current.setting.graphics_dpu_unit, 0.5 * this_n_per_degree, opt->arg, file);
+						GMT->session.unit_name[GMT->current.setting.proj_length_unit], GMT->current.setting.graphics_dpu, GMT->current.setting.graphics_dpu_unit, this_n_per_degree, opt->arg, file);
+					//printf ("%g\t%g\t%lg\t%d\t%s\n", D, L * GMT->session.u2u[GMT_INCH][GMT->current.setting.proj_length_unit], this_n_per_degree, irint (1.0 / API->remote_info[k_data2].d_inc), file);
 					gmt_M_str_free (opt->arg);
 					opt->arg = strdup (file);
 					d_inc = API->remote_info[k_data2].d_inc;


### PR DESCRIPTION
**Description of proposed changes**

I have been tinkering with how to determine a suitable remote grid image resolution that would work well with all projections.  My initial attempts (in master) examined both longitude and diagonal degree range for a map.  However, longitudes are difficult as the longitude range can suddenly jump from a small range to 360 if a pole enters the region.  So this PR only considers the latitude range (_Y_) relative to the map height (_H_).  Then, the required number of grid nodes per degree is computed via `N_f = L * dpi / D,` where _dpi_ is the desired dots-per-inch needed.  We then use the next higher actual _N_r_ of the nearest grid resolution.  I am testing this with a zoom from 100,000 km altitude to 10 km altitude over a fixed point (Vienna).  The movie script is

```
#!/usr/bin/env bash
lat=47.8095
lon=13.0550
dpc=100
cat << EOF > pre.sh
gmt begin
	gmt math -T1/5/720+n 10 T POW -o1 -I = altitude.txt
	gmt makecpt -Cgeo -H > topo.cpt
gmt end
EOF
cat << EOF > main.sh
gmt begin
	gmt grdimage @earth_relief -Rd -JG$lon/$lat/14.9c+z\${MOVIE_COL0}+v60 -Yc -Xc -B0 -Ctopo.cpt -I+d --GMT_GRAPHICS_DPU=${dpc}c --MAP_FRAME_PEN=faint
	echo $lon $lat | gmt plot -SE-10 -Gred@50
	L=\$(gmt grdcut @earth_relief -Rd -JG$lon/$lat/14.9c+z\${MOVIE_COL0}+v60 -D+t --GMT_GRAPHICS_DPU=${dpc}c)
	echo \${L} | gmt text -F+cTR+jTR+f8p
	echo "altitude = \${MOVIE_COL0} L = \${L}"
gmt end
EOF
gmt movie main.sh -Sbpre.sh -NZoom_Relief_${dpc}c -Taltitude.txt -C15cx15cx100 -D24 -H8 -M0,png -Fmp4 -Lc0+f12p+t"Altitude = %6.1lf km" -V
```

The movie can be seen on [YouTube](https://youtu.be/JJ0PDYBXzpo).  Via debug dump I have captured both _N_f_ and _N_r_ and for this wide range of altitudes it looks like this:

![summary](https://user-images.githubusercontent.com/26473567/138369008-90e6489f-7b84-4cdc-8c6c-cafa7ed5c45f.jpg)

As you can see, the selected grid resolution (blue) is always equal or higher than the required, until we run out of even higher resolutions after 1 arc second around 25 km altitude.  Please view the movie and see how it transitions between resolutions.  Since the data sets are not always exactly the same you will notice the jumps to the better data but it is pretty good I think. Remember that making a movie with variable resolution like this is the most extreme case of this.  Static plots will not experience this of course.

Given the stability that using Y brings to computing the required nodes per degree, I recommend you approve this PR.