### PR TITLE
gmt_common_sighandler.c: add aarch64 for freebsd

### DIFF
--- a/src/gmt_common_sighandler.c
+++ b/src/gmt_common_sighandler.c
@@ -85,6 +85,8 @@ void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.mc_rip)
 # elif defined( __arm__)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.arm_pc)
+# elif defined( __aarch64__)
+#  define UC_IP(uc) ((void *) (uc)->uc_mcontext.mc_gpregs.gp_elr)
 # elif defined(__ppc__)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.mc_srr0)
 # else


### PR DESCRIPTION
This fix makes it possible to build on raspi on freebsd.

Should fix #5541.