### PR TITLE
Let movie and batch man pages warn of piping

### DIFF
--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -239,7 +239,7 @@ from one GMT module into another (e.g., gmt blockmean ..... | gmt surface ...). 
 many instances of your main script simultaneously, odd things can happen when sub-shells are involved.
 In our experience, piping in the context of batch script may corrupt the GMT history files, resulting in
 stray messages from some frames, such as region not set, etc.  Split such pipe constructs into two using
-a temporary file when writing batch main scripts. **Note**: Piping from non-GMT module into a GMT module
+a temporary file when writing batch main scripts. **Note**: Piping from a non-GMT module into a GMT module
 or vice versa is not a problem (e.g., echo ..... | gmt convert ...).
 
 Hints for Batch Makers

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -440,7 +440,7 @@ from one GMT module into another (e.g., gmt blockmean ..... | gmt surface ...). 
 many instances of your main script simultaneously, odd things can happen when sub-shells are involved.
 In our experience, piping in the context of movie script may corrupt the GMT history files, resulting in
 stray messages from some frames, such as region not set, etc.  Split such pipe constructs into two using
-a temporary file when writing movie main scripts. **Note**: Piping from non-GMT module into a GMT module
+a temporary file when writing movie main scripts. **Note**: Piping from a non-GMT module into a GMT module
 or vice versa is not a problem (e.g., echo ..... | gmt plot ...).
 
 Hints for Movie Makers


### PR DESCRIPTION
Piping output form one GMT module into another may involve sub-shells which may not be behaving properly when we run multiple instances in **movie** and **batch**.  This PR adds a section that explains why it is not a good idea and that it can go wrong, and what a solution is.
