### PR TITLE
Ignore -C0/0 in terms of actually subtracting values

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -527,7 +527,8 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 				if (opt->arg[0]) {	/* Also gave shifts */
 					n_errors += gmt_M_check_condition (GMT, sscanf (opt->arg, "%lf/%lf", &Ctrl->C.easting, &Ctrl->C.northing) != 2,
 					                                 "Option -C: Expected -C[<false_easting>/<false_northing>]\n");
-					Ctrl->C.shift = true;
+					if (!(gmt_M_is_zero (Ctrl->C.easting) && gmt_M_is_zero (Ctrl->C.northing)))	/* Only shift if both is nonzero */
+						Ctrl->C.shift = true;
 				}
 				will_need_RJ = true;	/* Since -C is used with projections only */
 				if (p) p[0] = '+';	/* Restore modifier */


### PR DESCRIPTION
**mapproject -C**_xorig/yorig_ is used to define a local origin, but if given 0/0 then we do not need to subtract anything.
