### PR TITLE
No longer need temp fix in grdtrack

### DIFF
--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -751,10 +751,6 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the grdtrack main code ----------------------------*/
 
-	gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
-
-	pad_mode = (GMT->common.n.interpolant > BCR_BILINEAR) ? GMT_GRID_NEEDS_PAD2 : 0;
-
 	cmd = GMT_Create_Cmd (API, options);
 	sprintf (run_cmd, "# %s %s", GMT->init.module_name, cmd);	/* Build command line argument string */
 	gmt_M_free (GMT, cmd);
@@ -763,7 +759,16 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 
 	gmt_M_memset (wesn, 4, double);
 	if (GMT->common.R.active[RSET]) gmt_M_memcpy (wesn, GMT->common.R.wesn, 4, double);	/* Specified a subset */
-	gmt_set_pad (GMT, 2U);	/* Ensure space for BCs in case an API passed pad == 0 */
+
+	pad_mode = (GMT->common.n.interpolant > BCR_BILINEAR) ? GMT_GRID_NEEDS_PAD2 : 0;
+	if (pad_mode) {
+		gmt_grd_set_datapadding (GMT, true);	/* Turn on gridpadding when reading a subset */
+		gmt_set_pad (GMT, 2U);	/* Ensure space for BCR BCs in case an API passed pad == 0 */
+	}
+	else {
+		gmt_grd_set_datapadding (GMT, false);	/* Turn off gridpadding when reading a subset */
+		gmt_set_pad (GMT, 0);	/* Pads not needed since bicubic or b-spline not selected */
+	}
 
 	GC = gmt_M_memory (GMT, NULL, Ctrl->G.n_grids, struct GRD_CONTAINER);
 


### PR DESCRIPTION
In #5283, we added a temporary fix in **grdtrack** to change any request for bicubic interpolation to bilinear if there were no pad associated with the grid (such as was the case when a matrix was passed from PyGMT).  But since #5893  we now ensure there will be a pad via the **GMT_GRID_NEEDS_PAD2** flag, this temporary fix is no longer needed, and this PR removes it.  We also consider the current interpolator selection (**-n**, with default as bicubic) and determine the actual flag based on need.
