### PR TITLE
CI: Test Ubuntu 21.10 and Debian 11 in docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@
 name: Docker
 
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
**Description of proposed changes**

Ubuntu 21.10 was released several days ago and Ubuntu 20.10 is no longer supported. 

This PR removes 20.10 from our docker pool and adds Ubuntu 21.10 and Debian 11. This PR also adds EOL information for each release, so that we know when we should remove each release.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
