### PR TITLE
Update CMakeLists.txt to not copy the non-existing anim04.mp4 file

### DIFF
--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -73,17 +73,6 @@ if (SPHINX_FOUND)
 				DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif)
 			list (APPEND _animations ${RST_BINARY_DIR}/_images/anim${_num}.gif)
 		endforeach ()
-
-		# copy video files for anim04
-		foreach (_num 04)
-			add_custom_command (
-				OUTPUT ${RST_STATIC_DIR}/anim${_num}.mp4
-				COMMAND ${CMAKE_COMMAND} -E copy_if_different
-				${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.mp4
-				${RST_STATIC_DIR}/anim${_num}.mp4
-				DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/anim${_num}/anim${_num}.gif)
-			list (APPEND _animations ${RST_STATIC_DIR}/anim${_num}.mp4)
-		endforeach ()
 		add_custom_target (animation DEPENDS ${_animations})
 
 		# clean target


### PR DESCRIPTION
**Description of proposed changes**

Anim04 has been updated in #5794. Now there are no gif or mp4 files for anim04. Thus we need to update the corresponding CMakeLists.txt file.