### PR TITLE
Truncate version to 6.x in deploy-gh-pages.sh

### DIFF
--- a/ci/deploy-gh-pages.sh
+++ b/ci/deploy-gh-pages.sh
@@ -13,11 +13,11 @@ set -x -e
 if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
     # Get the tag name without the "refs/tags/" part
     version="${GITHUB_REF#refs/*/}"
-    # Truncate the version to 6.x
-    if [[ "${GITHUB_REF#refs/*/}" =~ ^6\.[0-9]+.[0-9]+ ]]; then
+    # Truncate the version to X.Y
+    if [[ "${GITHUB_REF#refs/*/}" =~ ^[6-9]\.[0-9]+\.[0-9]+ ]]; then
         version="${version%.*}"
     fi
-elif [[ "$GITHUB_EVENT_NAME" == "push" ]] && [[ "${GITHUB_REF#refs/*/}" =~ ^6\.[0-9]+$ ]]; then
+elif [[ "$GITHUB_EVENT_NAME" == "push" ]] && [[ "${GITHUB_REF#refs/*/}" =~ ^[6-9]\.[0-9]+$ ]]; then
     version="${GITHUB_REF#refs/*/}"
 elif [[ "$GITHUB_EVENT_NAME" == "push" ]] && [[ "${GITHUB_REF#refs/*/}" == "master" ]]; then
     version=dev

--- a/ci/deploy-gh-pages.sh
+++ b/ci/deploy-gh-pages.sh
@@ -13,6 +13,10 @@ set -x -e
 if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
     # Get the tag name without the "refs/tags/" part
     version="${GITHUB_REF#refs/*/}"
+    # Truncate the version to 6.x
+    if [[ "${GITHUB_REF#refs/*/}" =~ ^6\.[0-9]+.[0-9]+ ]]; then
+        version="${version%.*}"
+    fi
 elif [[ "$GITHUB_EVENT_NAME" == "push" ]] && [[ "${GITHUB_REF#refs/*/}" =~ ^6\.[0-9]+$ ]]; then
     version="${GITHUB_REF#refs/*/}"
 elif [[ "$GITHUB_EVENT_NAME" == "push" ]] && [[ "${GITHUB_REF#refs/*/}" == "master" ]]; then


### PR DESCRIPTION
**Description of proposed changes**


In preparation for the 6.3 release, this PR updates the version variable used in the deploy-gh-pages.sh script, so that a 6.3 directory will be used rather than 6.3.0.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #5306 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
