### PR TITLE
Reset header zmin and zmax before getting grid subregion

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5198,6 +5198,8 @@ start_over_import_grid:		/* We may get here if we cannot honor a GMT_IS_REFERENC
 			else
 				G_obj->data = gmt_M_memory_aligned (GMT, NULL, G_obj->header->size, gmt_grdfloat);
 
+			G_obj->header->z_min = DBL_MAX;
+			G_obj->header->z_max = -DBL_MAX;
 			for (row = j0, row_out = 0; row <= j1; row++, row_out++) {
 				ij = gmt_M_ijp (G_obj->header, row_out, 0);	/* Position in output grid at start of current row */
 				for (col = i0; col <= i1; col++, ij++) {


### PR DESCRIPTION
**Description of proposed changes**

This is a partial fix for the bug reported in https://github.com/GenericMappingTools/gmt/issues/5294. Previously the header zmin and zmax were not reset prior to comparing to data values in the grid subregion, such that the min/max for the entire grid was always chosen.

There's still an additional issue where the region extracted for a virtual file might be offset by one row relative to the region extracted for an actual file, leading to a slight difference in the z-range:
```
grdimage [INFORMATION]: Auto-stretching CPT file geo to fit data range -3893 to 3195.5

grdimage [INFORMATION]: Auto-stretching CPT file geo to fit data range -3824.5 to 3195.5
```

 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Addresses #5294 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
