### PR TITLE
Fix freeing of pairs array

### DIFF
--- a/src/x2sys/x2sys_cross.c
+++ b/src/x2sys/x2sys_cross.c
@@ -318,7 +318,7 @@ GMT_LOCAL int x2syscross_combo_ok (char *name_1, char *name_2, struct X2SYS_CROS
 }
 
 GMT_LOCAL void x2syscross_free_pairs (struct GMT_CTRL *GMT, struct X2SYS_CROSS_PAIR *pair, uint64_t n_pairs) {
-	/* Free the array of pairs */
+	/* Free the strings in the array of pairs */
 	uint64_t k;
 	for (k = 0; k < n_pairs; k++) {
 		gmt_M_str_free (pair[k].id1);
@@ -1034,7 +1034,7 @@ EXTERN_MSC int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 
 	/* Free up other arrays */
 
-	if (Ctrl->A.active) {
+	if (Ctrl->A.active) {	/* Free strings in pairs, then pairs itself */
 		x2syscross_free_pairs (GMT, pair, n_pairs);
 		gmt_M_free (GMT, pair);
 	}

--- a/src/x2sys/x2sys_cross.c
+++ b/src/x2sys/x2sys_cross.c
@@ -317,16 +317,13 @@ GMT_LOCAL int x2syscross_combo_ok (char *name_1, char *name_2, struct X2SYS_CROS
 	return (false);
 }
 
-GMT_LOCAL void x2syscross_free_pairs (struct GMT_CTRL *GMT, struct X2SYS_CROSS_PAIR **pair, uint64_t n_pairs) {
+GMT_LOCAL void x2syscross_free_pairs (struct GMT_CTRL *GMT, struct X2SYS_CROSS_PAIR *pair, uint64_t n_pairs) {
 	/* Free the array of pairs */
 	uint64_t k;
-	struct X2SYS_CROSS_PAIR *P = *pair;
 	for (k = 0; k < n_pairs; k++) {
-		gmt_M_str_free (P[k].id1);
-		gmt_M_str_free (P[k].id2);
+		gmt_M_str_free (pair[k].id1);
+		gmt_M_str_free (pair[k].id2);
 	}
-	gmt_M_free (GMT, pair);
-
 }
 
 GMT_LOCAL bool x2syscross_is_outside_region (struct GMT_CTRL *GMT, double lon, double lat, bool geo) {
@@ -360,7 +357,7 @@ GMT_LOCAL void x2syscross_local_xy_to_geo (double *x, double *y, int plat) {
 
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
-#define Crashout(code) {gmt_M_free (GMT, duplicate); x2syscross_free_pairs (GMT, &pair, n_pairs); x2sys_free_list (GMT, trk_name, n_tracks); if (fpC) fclose (fpC); x2sys_end (GMT, s); Return (error);}
+#define Crashout(code) {gmt_M_free (GMT, duplicate); x2syscross_free_pairs (GMT, pair, n_pairs); gmt_M_free (GMT, pair); x2sys_free_list (GMT, trk_name, n_tracks); if (fpC) fclose (fpC); x2sys_end (GMT, s); Return (error);}
 
 EXTERN_MSC int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 	char **trk_name = NULL;			/* Name of tracks */
@@ -1037,7 +1034,11 @@ EXTERN_MSC int GMT_x2sys_cross (void *V_API, int mode, void *args) {
 
 	/* Free up other arrays */
 
-	if (Ctrl->A.active) x2syscross_free_pairs (GMT, &pair, n_pairs);
+	if (Ctrl->A.active) {
+		x2syscross_free_pairs (GMT, pair, n_pairs);
+		gmt_M_free (GMT, pair);
+	}
+
 	gmt_M_free (GMT, Out);
 	gmt_M_free (GMT, xdata[SET_A]);
 	gmt_M_free (GMT, xdata[SET_B]);


### PR DESCRIPTION
The pair array itself needs to be freed at the same level it was allocated.  Closes #5937.
