### PR TITLE
Use GMT_NOTSET instead of -1 when that is what is meant

### DIFF
--- a/src/dimfilter.c
+++ b/src/dimfilter.c
@@ -133,7 +133,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	C = gmt_M_memory (GMT, NULL, 1, struct DIMFILTER_CTRL);
 
 	/* Initialize values whose defaults are not 0/false/NULL */
-	C->F.filter = C->N.filter = C->D.mode = -1;
+	C->F.filter = C->N.filter = C->D.mode = GMT_NOTSET;
 	C->F.mode = DIMFILTER_MODE_KIND_AVE;
 	C->N.n_sectors = 1;
 	return (C);

--- a/src/gmt_calclock.c
+++ b/src/gmt_calclock.c
@@ -443,7 +443,7 @@ int gmtlib_verify_time_step (struct GMT_CTRL *GMT, int step, char unit) {
 
 	if (step < 0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps must be positive.\n");
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	switch (unit) {
@@ -453,33 +453,33 @@ int gmtlib_verify_time_step (struct GMT_CTRL *GMT, int step, char unit) {
 				GMT_Report (GMT->parent, GMT_MSG_COMPAT, "Unit c for seconds is deprecated; use s.\n");
 				if (step > 60) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in seconds must be <= 60\n");
-					retval = -1;
+					retval = GMT_NOTSET;
 				}
 			}
 			else {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unrecognized time axis unit.\n");
-				retval = -1;
+				retval = GMT_NOTSET;
 			}
 			break;
 		case 's':
 		case 'S':
 			if (step > 60) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in seconds must be <= 60\n");
-				retval = -1;
+				retval = GMT_NOTSET;
 			}
 			break;
 		case 'm':
 		case 'M':
 			if (step > 60) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in minutes must be <= 60\n");
-				retval = -1;
+				retval = GMT_NOTSET;
 			}
 			break;
 		case 'h':
 		case 'H':
 			if (step > 24) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in hours must be <= 24\n");
-				retval = -1;
+				retval = GMT_NOTSET;
 			}
 			break;
 		case 'R':	/* Special Gregorian days: Annotate from start of each week and not first day of month */
@@ -490,14 +490,14 @@ int gmtlib_verify_time_step (struct GMT_CTRL *GMT, int step, char unit) {
 			if (GMT->current.plot.calclock.date.day_of_year) {
 				if (step > 365) {	/* This is probably an error.  */
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in year days must be <= 365\n");
-					retval = -1;
+					retval = GMT_NOTSET;
 				}
 			}
 			else {
 				/* If step is longer than 31 it is probably an error. */
 				if (step > 31) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in days of the month must be <= 31\n");
-					retval = -1;
+					retval = GMT_NOTSET;
 				}
 			}
 			break;
@@ -505,28 +505,28 @@ int gmtlib_verify_time_step (struct GMT_CTRL *GMT, int step, char unit) {
 		case 'K':
 			if (step > 7) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in weekdays must be <= 7\n");
-				retval = -1;
+				retval = GMT_NOTSET;
 			}
 			break;
 		case 'r':	/* Gregorian week.  Special case:  since weeks aren't numbered on Gregorian
 					calendar, we only allow step size = 1 here, for ticking each week start. */
 			if (step != 1) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time step must be 1 for Gregorian weeks\n");
-				retval = -1;
+				retval = GMT_NOTSET;
 			}
 			break;
 		case 'u':	/* ISO week */
 		case 'U':
 			if (step > 52) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in weeks must be <= 52\n");
-				retval = -1;
+				retval = GMT_NOTSET;
 			}
 			break;
 		case 'o':
 		case 'O':
 			if (step > 12) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Time steps in months must be <= 12\n");
-				retval = -1;
+				retval = GMT_NOTSET;
 			}
 			break;
 		case 'y':	/* No check on years */
@@ -537,7 +537,7 @@ int gmtlib_verify_time_step (struct GMT_CTRL *GMT, int step, char unit) {
 			break;
 		default:
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unrecognized time axis unit.\n");
-			retval = -1;
+			retval = GMT_NOTSET;
 			break;
 	}
 	return (retval);
@@ -881,8 +881,8 @@ void gmt_format_calendar (struct GMT_CTRL *GMT, char *date, char *clock, struct 
 		/* Now undo Y2K fix to make a 2-digit year here if necessary */
 
 		if (D->day_of_year) {		/* Using the year and day-of-year as date entries */
-			if (D->item_pos[0] != -1) ival[D->item_pos[0]] = (D->Y2K_year) ? abs (calendar.year) % 100 : calendar.year;
-			if (D->item_pos[3] != -1) ival[D->item_pos[3]] = calendar.day_y;
+			if (D->item_pos[0] != GMT_NOTSET) ival[D->item_pos[0]] = (D->Y2K_year) ? abs (calendar.year) % 100 : calendar.year;
+			if (D->item_pos[3] != GMT_NOTSET) ival[D->item_pos[3]] = calendar.day_y;
 		}
 		else if (D->iso_calendar) {	/* Using ISO year, week and day-of-week entries. Order is fixed to be y-m-d */
 			ival[0] = (D->Y2K_year) ? abs (calendar.iso_y) % 100 : calendar.iso_y;
@@ -890,9 +890,9 @@ void gmt_format_calendar (struct GMT_CTRL *GMT, char *date, char *clock, struct 
 			ival[2] = calendar.iso_d;
 		}
 		else {				/* Gregorian calendar entries */
-			if (D->item_pos[0] != -1) ival[D->item_pos[0]] = (D->Y2K_year) ? abs (calendar.year) % 100 : calendar.year;
-			if (D->item_pos[1] != -1) ival[D->item_pos[1]] = calendar.month;
-			if (D->item_pos[2] != -1) ival[D->item_pos[2]] = calendar.day_m;
+			if (D->item_pos[0] != GMT_NOTSET) ival[D->item_pos[0]] = (D->Y2K_year) ? abs (calendar.year) % 100 : calendar.year;
+			if (D->item_pos[1] != GMT_NOTSET) ival[D->item_pos[1]] = calendar.month;
+			if (D->item_pos[2] != GMT_NOTSET) ival[D->item_pos[2]] = calendar.day_m;
 		}
 		gmt_M_memset (date, GMT_LEN16, char);			/* To set all to zero */
 		if (D->mw_text)	{						/* Must write month or week name */

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -143,12 +143,12 @@ GMT_LOCAL int gmtdcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **
 	struct GMT_DCW_STATE *State = NULL;
 	struct GMT_DCW_COUNTRY_STATE *Country_State = NULL;
 
-	if (!gmtdcw_get_path (GMT, "dcw-countries", ".txt", path)) return -1;
+	if (!gmtdcw_get_path (GMT, "dcw-countries", ".txt", path)) return GMT_NOTSET;
 
 	/* Get countries first */
 	if ((fp = fopen (path, "r")) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open file %s [permission trouble?]\n", path);
-		return -1;
+		return GMT_NOTSET;
 	}
 	Country = gmt_M_memory (GMT, NULL, n_alloc, struct GMT_DCW_COUNTRY);
 	k = 0;
@@ -168,12 +168,12 @@ GMT_LOCAL int gmtdcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **
 	/* Get states */
 	if (!gmtdcw_get_path (GMT, "dcw-states", ".txt", path)) {
 		gmt_M_free (GMT, Country);
-		return -1;
+		return GMT_NOTSET;
 	}
 	if ((fp = fopen (path, "r")) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open file %s [permission trouble?]\n", path);
 		gmt_M_free (GMT, Country);
-		return -1;
+		return GMT_NOTSET;
 	}
 	State = gmt_M_memory (GMT, NULL, n_alloc, struct GMT_DCW_STATE);
 	k = 0;	n = 1;
@@ -219,11 +219,11 @@ GMT_LOCAL int gmtdcw_comp_countries (const void *p1, const void *p2) {
 
 GMT_LOCAL int gmtdcw_find_country (char *code, struct GMT_DCW_COUNTRY *list, int n) {
 	/* Basic binary search for country with given code and an alphabetically sorted list */
-	int low = 0, high = n, mid, last = -1, way;
+	int low = 0, high = n, mid, last = GMT_NOTSET, way;
 
 	while (low < high) {
 		mid = (low + high) / 2;
-		if (mid == last) return (-1);	/* No such code */
+		if (mid == last) return (GMT_NOTSET);	/* No such code */
 		way = strcmp (code, list[mid].code);
 		if (way > 0) low = mid;
 		else if (way < 0) high = mid;
@@ -246,13 +246,13 @@ GMT_LOCAL int gmtdcw_find_state (struct GMT_CTRL *GMT, char *scode, char *ccode,
 	if (check && !strncmp (ccode, "CN", 2U) && isdigit (scode[0])) {	/* Must switch to 2-character code */
 		unsigned int k = 0, id = atoi (scode);
 		while (k < DCW_N_CHINA_PROVINCES && id > gmtdcw_CN_codes[k].id) k++;
-		if (k == DCW_N_CHINA_PROVINCES) return (-1);	/* No such integer ID found in the list */
-		if (id < gmtdcw_CN_codes[k].id) return (-1);	/* No such integer ID found in the list */
+		if (k == DCW_N_CHINA_PROVINCES) return (GMT_NOTSET);	/* No such integer ID found in the list */
+		if (id < gmtdcw_CN_codes[k].id) return (GMT_NOTSET);	/* No such integer ID found in the list */
 		GMT_Report (GMT->parent, GMT_MSG_NOTICE, "FYI, Chinese province code %d is deprecated. Use %s instead\n", id, gmtdcw_CN_codes[k].code);
 		scode = gmtdcw_CN_codes[k].code;
 	}
 	for (i = 0; i < ns; i++) if (!strcmp (scode, slist[i].code) && !strcmp (ccode, slist[i].country)) return (i);
-	return (-1);
+	return (GMT_NOTSET);
 }
 
 GMT_LOCAL bool gmtdcw_country_has_states (char *code, struct GMT_DCW_COUNTRY_STATE *st_country, unsigned int n) {
@@ -473,14 +473,14 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 			want_state = true;
 		}
 		ks = gmtdcw_find_country (code, GMT_DCW_country, GMT_DCW_COUNTRIES);
-		if (ks == -1) {
+		if (ks == GMT_NOTSET) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "No country code matching %s (skipped)\n", code);
 			continue;
 		}
 		k = ks;
 		if (want_state) {
 			item = gmtdcw_find_state (GMT, state, code, GMT_DCW_state, GMT_DCW_STATES, new_CN_codes);
-			if (item == -1) {
+			if (item == GMT_NOTSET) {
 				GMT_Report (GMT->parent, GMT_MSG_WARNING, "Country %s does not have a state named %s (skipped)\n", code, state);
 				continue;
 			}
@@ -573,21 +573,21 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 		k = seg = 0;
 		done = false;
 	        while (!done) {
-			first = -1;
-			while (first == -1 && k < np) {	/* Look for next start of segment marker */
+			first = GMT_NOTSET;
+			while (first == GMT_NOTSET && k < np) {	/* Look for next start of segment marker */
 				if (gmt_M_is_dnan (lon[k])) {
 					hole = (lat[k] > 0.0);
 					first = k + 1;	/* Start of segment */
 				}
 				k++;
 			}
-			if (first == -1) { done = true; continue;}	/* No more segments */
-			last = -1;
-			while (last == -1 && k < np) {/* Look for next end of segment marker (or end of line) */
+			if (first == GMT_NOTSET) { done = true; continue;}	/* No more segments */
+			last = GMT_NOTSET;
+			while (last == GMT_NOTSET && k < np) {/* Look for next end of segment marker (or end of line) */
 				if (gmt_M_is_dnan (lon[k])) last = k - 1;	/* End of segment */
 				k++;
 			}
-			if (last == -1) last = np - 1;	/* End of last segment */
+			if (last == GMT_NOTSET) last = np - 1;	/* End of last segment */
 			k--;	/* Back to last segment marker  which will be the next start marker */
 			P->n_rows = last - first + 1;	/* Number of points in this segment */
 			P->data[GMT_X] = &lon[first];

--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -76,7 +76,7 @@ GMT_LOCAL int gdal_decode_columns (struct GMT_CTRL *GMT, char *txt, int *whichBa
  * Returns -1 in case no world file is found.
  */
 GMT_LOCAL int record_geotransform (char *gdal_filename, GDALDatasetH hDataset, double *adfGeoTransform) {
-	int status = -1;
+	int status = GMT_NOTSET;
 	char generic_buffer[5000];
 
 	if (GDALGetGeoTransform(hDataset, adfGeoTransform) == CE_None)
@@ -93,7 +93,7 @@ GMT_LOCAL int record_geotransform (char *gdal_filename, GDALDatasetH hDataset, d
 	if (status == 1)
 		return (0);
 
-	return (-1);
+	return (GMT_NOTSET);
 }
 
 /************************************************************************/
@@ -335,7 +335,7 @@ GMT_LOCAL int populate_metadata (struct GMT_CTRL *GMT, struct GMT_GDALREAD_OUT_C
 	if (hDataset == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open %s.\n", gdal_filename);
 		gmtlib_GDALDestroyDriverManager(GMT->parent);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	gmt_M_tic (GMT);
@@ -418,7 +418,7 @@ GMT_LOCAL int populate_metadata (struct GMT_CTRL *GMT, struct GMT_GDALREAD_OUT_C
 			GDALClose(hDataset);
 			gmtlib_GDALDestroyDriverManager(GMT->parent);
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Quitting with error\n");
-			return(-1);
+			return(GMT_NOTSET);
 		}
 
 		anSrcWin[0] = irint ((dfULX - adfGeoTransform[0]) / adfGeoTransform[1]);
@@ -432,7 +432,7 @@ GMT_LOCAL int populate_metadata (struct GMT_CTRL *GMT, struct GMT_GDALREAD_OUT_C
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Computed -srcwin falls outside raster size of %dx%d.\n",
 			            GDALGetRasterXSize(hDataset), GDALGetRasterYSize(hDataset));
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Quitting with error\n");
-			return(-1);
+			return(GMT_NOTSET);
 		}
 		Ctrl->RasterXsize = nXSize = anSrcWin[2];
 		Ctrl->RasterYsize = nYSize = anSrcWin[3];
@@ -857,7 +857,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 	if (error) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_gdalread: Failed to decode the specified Sub-region\n");
 		gmt_M_free (GMT, whichBands);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	if (prhs->P.active)
@@ -904,7 +904,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 
 	if (metadata_only) {	/* Just get the header info and return with it */
 		if (populate_metadata (GMT, Ctrl, gdal_filename, got_R, nXSize[0], nYSize, dfULX, dfULY, dfLRX, dfLRY, z_min, z_max, first_layer))
-			return(-1);
+			return(GMT_NOTSET);
 
 		/* Return registration based on data type of first band. Byte is pixel reg otherwise set grid registration */
 		if (!Ctrl->hdr[6]) {		/* Grid registration */
@@ -922,7 +922,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 	if (hDataset == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_gdalread: gdal_open failed %s\n", CPLGetLastErrorMsg());
 		gmt_M_free (GMT, whichBands);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	/* Some formats (typically DEMs) have their origin at Bottom Left corner.
@@ -962,7 +962,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 			GDALClose(hDataset);
 			gmtlib_GDALDestroyDriverManager(GMT->parent);
 			gmt_M_free (GMT, whichBands);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 
 		if (got_R) {	/* Region in map coordinates */
@@ -988,7 +988,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 				XDim, YDim);
 			gmtlib_GDALDestroyDriverManager(GMT->parent);
 			gmt_M_free (GMT, whichBands);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		yOrigin = anSrcWin[1];	/* These can now be set */
 		nYSize  = anSrcWin[3];
@@ -1013,7 +1013,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 					XDim, YDim);
 				gmtlib_GDALDestroyDriverManager(GMT->parent);
 				gmt_M_free (GMT, whichBands);
-				return (-1);
+				return (GMT_NOTSET);
 			}
 		}
 	}
@@ -1137,7 +1137,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "gdalread: failure to allocate enough memory\n");
 				gmtlib_GDALDestroyDriverManager(GMT->parent);
 				gmt_M_free (GMT, whichBands);
-				return(-1);
+				return(GMT_NOTSET);
 			}
 		}
 		else {

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2087,7 +2087,7 @@ void gmt_grd_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, struct 
 		/* Set the variables that are not initialized to 0/false/NULL */
 		header->z_scale_factor = 1.0;
 		HH->row_order   	   = k_nc_start_south; /* S->N */
-		HH->z_id         	  = -1;
+		HH->z_id         	   = GMT_NOTSET;
 		header->n_bands        = 1; /* Grids have at least one band but images may have 3 (RGB) or 4 (RGBA) */
 		header->z_min          = GMT->session.d_NaN;
 		header->z_max          = GMT->session.d_NaN;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -278,7 +278,7 @@ static struct GMT_parameter GMT_keyword_active[]= {
 	{ 0, "TIME_UNIT"},
 	{ 0, "TIME_WEEK_START"},
 	{ 0, "TIME_Y2K_OFFSET_YEAR"},
-	{ -1, NULL}
+	{ GMT_NOTSET, NULL}
 };
 
 #include "gmt_keycases.h"				/* Get all the default case values */
@@ -583,7 +583,7 @@ GMT_LOCAL int gmtinit_get_section (struct GMTAPI_CTRL *API, char *arg, char sepa
 		*sx = j;	/* Return position of separator that was removed */
 	}
 	else if (last_s) {	/* Must be the last section since it is missing a trailing separator */
-		*sx = -1;	/* Nothing to chop */
+		*sx = GMT_NOTSET;	/* Nothing to chop */
 		s0 = last_s + 1;	/* Start position of last section */
 	}
 	return s0;	/* Return start position in arg of current section (i.e., at arg[s0]) */
@@ -750,7 +750,7 @@ GMT_LOCAL int gmtinit_get_psl_encoding (const char *encoding) {
 	/* Return the specified encoding ID */
 	int k = 0, match = 0;
 	while (PSL_ISO_name[k] && (match = strcmp (encoding, PSL_ISO_name[k])) != 0) k++;
-	return (match == 0) ? k : -1;
+	return (match == 0) ? k : GMT_NOTSET;
 }
 
 GMT_LOCAL int gmtinit_get_uservalue (struct GMT_CTRL *GMT, char *txt, int type, double *value, char *err_msg) {
@@ -765,7 +765,7 @@ GMT_LOCAL int gmtinit_get_uservalue (struct GMT_CTRL *GMT, char *txt, int type, 
 
 /*! . */
 GMT_LOCAL int gmtinit_parse_h_option (struct GMT_CTRL *GMT, char *item) {
-	int i, k = 1, error = 0, col = -1;
+	int i, k = 1, error = 0, col = GMT_NOTSET;
 	unsigned int pos = 0;
 	char p[GMT_BUFSIZ] = {""}, *c = NULL;
 
@@ -1353,7 +1353,7 @@ GMT_LOCAL int gmtinit_parse_f_option (struct GMT_CTRL *GMT, char *arg) {
 
 	char copy[GMT_BUFSIZ] = {""}, p[GMT_BUFSIZ] = {""};
 	unsigned int dir, k = 1, c, pos = 0, code, *col = NULL;
-	int64_t i, start = -1, stop = -1, inc;
+	int64_t i, start = GMT_NOTSET, stop = GMT_NOTSET, inc;
 	enum gmt_enum_units unit = GMT_IS_METER;
 	enum gmt_col_enum ctype;
 
@@ -1505,7 +1505,7 @@ GMT_LOCAL int gmtinit_trend_modifiers (struct GMT_CTRL *GMT, char option, char *
 
 	if (dim >= 2) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "INTERNAL Failure in gmtinit_trend_modifiers: was passed dim >= 2 (%u)\n", dim);
-		return -1;
+		return GMT_NOTSET;
 	}
 
 	/* Gave one or more modifiers */
@@ -1515,11 +1515,11 @@ GMT_LOCAL int gmtinit_trend_modifiers (struct GMT_CTRL *GMT, char option, char *
 			case 'o':	/* Origin of axes */
 				if ((k = GMT_Get_Values (GMT->parent, &p[1], M->origin, 2)) < 1) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Unable to parse the +o arguments (%s)\n", option, &p[1]);
-					return -1;
+					return GMT_NOTSET;
 				}
 				else if (k != sdim) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Did not provide %u arguments to +o\n", option, dim);
-					return -1;
+					return GMT_NOTSET;
 				}
 				for (k = 0; k < sdim; k++) M->got_origin[k] = true;
 				break;
@@ -1529,17 +1529,17 @@ GMT_LOCAL int gmtinit_trend_modifiers (struct GMT_CTRL *GMT, char option, char *
 			case 'l':
 				if ((k = GMT_Get_Values (GMT->parent, &p[1], M->period, 2)) < 1) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Unable to parse the +l argument (%s)\n", option, &p[1]);
-					return -1;
+					return GMT_NOTSET;
 				}
 				else if (k != sdim) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Did not provide %u arguments to +l\n", option, dim);
-					return -1;
+					return GMT_NOTSET;
 				}
 				for (k = 0; k < sdim; k++) M->got_period[k] = true;
 				break;
 			default:
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Unrecognized modifier +%s\n", option, p);
-				return -1;
+				return GMT_NOTSET;
 				break;
 		}
 	}
@@ -1617,14 +1617,14 @@ GMT_LOCAL int gmtinit_parse_model1d (struct GMT_CTRL *GMT, char option, char *in
 
 	if (!in_arg || !in_arg[0]) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: No arguments given!\n", option);
-		return -1;	/* No arg given */
+		return GMT_NOTSET;	/* No arg given */
 	}
 	/* Deal with backwards compatibilities for GMT4: -N[f]<nmodel>[r] */
 	arg = gmtinit_old_trendsyntax (GMT, option, in_arg);	/* Returns a possibly recreated option string */
 	if ((c = strchr (arg, '+'))) {	/* Gave one or more modifiers */
 		if (gmtinit_trend_modifiers (GMT, option, c, 1U, M)) {
 			gmt_M_str_free (arg);
-			return -1;
+			return GMT_NOTSET;
 		}
 		c[0] = '\0';	/* Chop off modifiers in arg before processing the model settings */
 	}
@@ -1633,7 +1633,7 @@ GMT_LOCAL int gmtinit_parse_model1d (struct GMT_CTRL *GMT, char option, char *in
 		if (!strchr ("CFSPcfspx", p[0])) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Bad basis function type (%c)\n", option, p[0]);
 			gmt_M_str_free (arg);
-			return -1;
+			return GMT_NOTSET;
 		}
 		this_range = &p[1];
 		single = false;
@@ -1652,7 +1652,7 @@ GMT_LOCAL int gmtinit_parse_model1d (struct GMT_CTRL *GMT, char option, char *in
 		else if ((step = gmtlib_parse_index_range (GMT, this_range, &xstart, &xstop)) != 1) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Bad basis function order (%s)\n", option, this_range);
 			gmt_M_str_free (arg);
-			return -1;
+			return GMT_NOTSET;
 		}
 		if (!single && islower (p[0])) xstart = 0;	/* E.g., p3 should become p0-3 */
 		if (p[0] == 'p') n_p++;
@@ -1706,7 +1706,7 @@ GMT_LOCAL int gmtinit_parse_model1d (struct GMT_CTRL *GMT, char option, char *in
 			if (n_model == GMT_N_MAX_MODEL) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Exceeding max basis functions (%d) \n", option, GMT_N_MAX_MODEL);
 				gmt_M_str_free (arg);
-				return -1;
+				return GMT_NOTSET;
 			}
 		}
 	}
@@ -1723,7 +1723,7 @@ GMT_LOCAL int gmtinit_parse_model1d (struct GMT_CTRL *GMT, char option, char *in
 		for (j = k+1; j < n_model; j++) {
 			if (M->term[k].kind == M->term[j].kind && M->term[k].order[GMT_X] == M->term[j].order[GMT_X] && M->term[k].order[GMT_Y] == M->term[j].order[GMT_Y] && M->term[k].type == M->term[j].type) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Basis %c%u occurs more than once in -%c!\n", name[M->term[k].kind], M->term[k].order[GMT_X], option);
-				return -1;
+				return GMT_NOTSET;
 			}
 		}
 	}
@@ -1800,7 +1800,7 @@ GMT_LOCAL int gmtinit_count_xy_terms (char *txt, int64_t *xstart, int64_t *xstop
 				}
 				break;
 			default:	/* Bad args */
-				return -1;
+				return GMT_NOTSET;
 				break;
 		}
 	}
@@ -1835,19 +1835,19 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 
 	if (!in_arg || !in_arg[0]) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: No arguments given!\n", option);
-		return -1;	/* No arg given */
+		return GMT_NOTSET;	/* No arg given */
 	}
 	/* Deal with backwards compatibilities: -N<nmodel>[r] for 2-D */
 	arg = gmtinit_old_trendsyntax (GMT, option, in_arg);
 	if ((c = strchr (arg, '+'))) {	/* Gave one or more modifiers */
-		if (gmtinit_trend_modifiers (GMT, option, c, 2U, M)) return -1;
+		if (gmtinit_trend_modifiers (GMT, option, c, 2U, M)) return GMT_NOTSET;
 		c[0] = '\0';	/* Chop off modifiers in arg before processing settings */
 	}
 	while ((gmt_strtok (arg, ",", &pos, p))) {
 		/* Here, p will be one instance of [P|p|F|f|C|c|S|s][x|y]<list-of-terms> */
 		if (!strchr ("CFSPcfsp", p[0])) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Bad basis function type (%c)\n", option, p[0]);
-			return -1;
+			return GMT_NOTSET;
 		}
 		this_range = &p[1];
 		n_parts = 1;	/* Normally just one basis function at the time but f implies both c and s */
@@ -1865,12 +1865,12 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 		}
 		else if ((step = gmtlib_parse_index_range (GMT, this_range, &xstart, &xstop)) != 1) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Bad basis function order (%s)\n", option, this_range);
-			return -1;
+			return GMT_NOTSET;
 		}
 		if (islower (p[0])) xstart = ystart = 0;
 		if (kind != GMT_POLYNOMIAL && !got_intercept) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Cosine|Sine cannot start with order 0.  Use p0 to add a constant\n", option);
-			return -1;
+			return GMT_NOTSET;
 		}
 		/* Here we have range and kind */
 
@@ -1900,7 +1900,7 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 						n_model++;
 						if (n_model == GMT_N_MAX_MODEL) {
 							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Exceeding max basis functions (%d) \n", option, GMT_N_MAX_MODEL);
-							return -1;
+							return GMT_NOTSET;
 						}
 					}
 					break;
@@ -1918,7 +1918,7 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 							n_model++;
 							if (n_model == GMT_N_MAX_MODEL) {
 								GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Exceeding max basis functions (%d) \n", option, GMT_N_MAX_MODEL);
-								return -1;
+								return GMT_NOTSET;
 							}
 						}
 					}
@@ -1935,7 +1935,7 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 					n_model++;
 					if (n_model == GMT_N_MAX_MODEL) {
 						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Exceeding max basis functions (%d) \n", option, GMT_N_MAX_MODEL);
-						return -1;
+						return GMT_NOTSET;
 					}
 					if (ystart) {
 						M->term[n_model].kind = GMT_COSINE;
@@ -1944,7 +1944,7 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 						n_model++;
 						if (n_model == GMT_N_MAX_MODEL) {
 							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Exceeding max basis functions (%d) \n", option, GMT_N_MAX_MODEL);
-							return -1;
+							return GMT_NOTSET;
 						}
 					}
 					break;
@@ -1960,7 +1960,7 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 						n_model++;
 						if (n_model == GMT_N_MAX_MODEL) {
 							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Exceeding max basis functions (%d) \n", option, GMT_N_MAX_MODEL);
-							return -1;
+							return GMT_NOTSET;
 						}
 					}
 					if (ystart) {
@@ -1970,7 +1970,7 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 						n_model++;
 						if (n_model == GMT_N_MAX_MODEL) {
 							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Exceeding max basis functions (%d) \n", option, GMT_N_MAX_MODEL);
-							return -1;
+							return GMT_NOTSET;
 						}
 					}
 					break;
@@ -1984,7 +1984,7 @@ GMT_LOCAL int gmtinit_parse_model2d (struct GMT_CTRL *GMT, char option, char *in
 		for (j = k+1; j < n_model; j++) {
 			if (M->term[k].kind == M->term[j].kind && M->term[k].order[GMT_X] == M->term[j].order[GMT_X] && M->term[k].order[GMT_Y] == M->term[j].order[GMT_Y] && M->term[k].type == M->term[j].type) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Basis %cx%uy%u occurs more than once!\n", option, name[M->term[k].kind], M->term[k].order[GMT_X], M->term[k].order[GMT_Y]);
-				return -1;
+				return GMT_NOTSET;
 			}
 		}
 	}
@@ -2359,7 +2359,7 @@ GMT_LOCAL int gmtinit_parse_p_option (struct GMT_CTRL *GMT, char *item) {
 /*! . */
 bool gmt_parse_s_option (struct GMT_CTRL *GMT, char *item) {
 	unsigned int error = 0, n, pos = 0;
-	int64_t i, start = -1, stop = -1, inc;
+	int64_t i, start = GMT_NOTSET, stop = GMT_NOTSET, inc;
 	char p[GMT_BUFSIZ] = {""}, tmp[GMT_MAX_COLUMNS] = {""}, *ca = NULL, *cr = NULL;
 	/* Parse the -s option.  Full syntax: -s[<cols>][+a][+r] Old syntax was -s[<cols>][r|a] */
 
@@ -2396,7 +2396,7 @@ bool gmt_parse_s_option (struct GMT_CTRL *GMT, char *item) {
 	else if (item[n-1] == 'r') GMT->current.setting.io_nan_mode = GMT_IO_NAN_KEEP, n--;	/* Old syntax set -sr */
 	if (n == 0) return (false);		/* No column arguments to process */
 	/* Here we have user-supplied column information */
-	for (i = 0; i < GMT_MAX_COLUMNS; i++) tmp[i] = -1;
+	for (i = 0; i < GMT_MAX_COLUMNS; i++) tmp[i] = GMT_NOTSET;
 	while (!error && (gmt_strtok (item, ",", &pos, p))) {	/* While it is not empty, process it */
 		if ((inc = gmtlib_parse_index_range (GMT, p, &start, &stop)) == 0) return (true);
 
@@ -2404,7 +2404,7 @@ bool gmt_parse_s_option (struct GMT_CTRL *GMT, char *item) {
 		for (i = start; i <= stop; i += inc) tmp[i] = true;
 	}
 	/* Count and set array of NaN-columns */
-	for (i = n = 0; i < GMT_MAX_COLUMNS; i++) if (tmp[i] != -1) GMT->current.io.io_nan_col[n++] = (unsigned int)i;
+	for (i = n = 0; i < GMT_MAX_COLUMNS; i++) if (tmp[i] != GMT_NOTSET) GMT->current.io.io_nan_col[n++] = (unsigned int)i;
 	if (error || n == 0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -s: Unable to decode columns from %s\n", item);
 		return true;
@@ -2735,7 +2735,7 @@ GMT_LOCAL int gmtinit_savedefaults (struct GMT_CTRL *GMT, char *file) {
 		fpo = GMT->session.std[GMT_OUT];
 	else if ((fpo = fopen (file, "w")) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not create file %s\n", file);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	fprintf (fpo, "#\n# GMT %d.%d.%d Defaults file\n", GMT_MAJOR_VERSION, GMT_MINOR_VERSION, GMT_RELEASE_VERSION);
@@ -3138,7 +3138,7 @@ GMT_LOCAL int gmtinit_put_history (struct GMT_CTRL *GMT) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Unable to determine a writable directory - gmt history not updated.\n");
 		return (GMT_NOERROR);
 	}
-	if ((fp = fopen (hfile, "w")) == NULL) return (-1);	/* Not OK to be unsuccessful in creating this file */
+	if ((fp = fopen (hfile, "w")) == NULL) return (GMT_NOTSET);	/* Not OK to be unsuccessful in creating this file */
 
 	/* When we get here the file is open */
 	if (!gmtlib_file_lock (GMT, fileno(fp)))
@@ -3806,7 +3806,7 @@ GMT_LOCAL int gmtinit_decode_tinfo (struct GMT_CTRL *GMT, int axis, char flag, c
 			gmt_M_str_free (A->file_custom);
 			A->file_custom = strdup (&in[1]);
 			A->special = GMT_CUSTOM;
-			if (gmtinit_init_custom_annot (GMT, A, n_int)) return (-1);	/* See what ticks, anots, gridlines etc are requested */
+			if (gmtinit_init_custom_annot (GMT, A, n_int)) return (GMT_NOTSET);	/* See what ticks, anots, gridlines etc are requested */
 			for (k = 0; k < GMT_N_AXIS_ITEMS; k++) {
 				if (n_int[k] == 0) continue;
 				flag = list[k];
@@ -4196,9 +4196,9 @@ GMT_LOCAL int gmtinit_parse5_B_frame_setting (struct GMT_CTRL *GMT, char *in) {
 
 	/* First determine that the given -B<in> string is indeed the framesetting option.  If not return -1 */
 
-	if (strchr ("pxy", in[0])) return (-1);	/* -B[p[xy] is definitively not the frame settings (-Bz and -Bs are tricker; see below) */
-	if (strchr ("afg", in[0])) return (-1);	/* -Ba|f|g is definitively not the frame settings; looks like axes settings */
-	if (!gmtlib_B_is_frame (GMT, in)) return (-1);		/* No, nothing matched */
+	if (strchr ("pxy", in[0])) return (GMT_NOTSET);	/* -B[p[xy] is definitively not the frame settings (-Bz and -Bs are tricker; see below) */
+	if (strchr ("afg", in[0])) return (GMT_NOTSET);	/* -Ba|f|g is definitively not the frame settings; looks like axes settings */
+	if (!gmtlib_B_is_frame (GMT, in)) return (GMT_NOTSET);		/* No, nothing matched */
 
 	/* OK, here we are pretty sure this is a frame -B statement */
 
@@ -5918,18 +5918,18 @@ GMT_LOCAL int gmtinit_scanf_epoch (struct GMT_CTRL *GMT, char *s, int64_t *rata_
 
 	i = 0;
 	while (s[i] && s[i] == ' ') i++;
-	if (!(s[i])) return (-1);
+	if (!(s[i])) return (GMT_NOTSET);
 	if (strchr (&s[i], 'W') ) {	/* ISO calendar string, date with or without clock */
-		if (sscanf (&s[i], "%5d-W%2d-%1d%[^0-9:-]%2d:%2d:%lf", &yy, &mo, &dd, tt, &hh, &mm, &ss) < 3) return (-1);
-		if (gmtlib_iso_ywd_is_bad (yy, mo, dd) ) return (-1);
+		if (sscanf (&s[i], "%5d-W%2d-%1d%[^0-9:-]%2d:%2d:%lf", &yy, &mo, &dd, tt, &hh, &mm, &ss) < 3) return (GMT_NOTSET);
+		if (gmtlib_iso_ywd_is_bad (yy, mo, dd) ) return (GMT_NOTSET);
 		rd = gmtlib_rd_from_iywd (GMT, yy, mo, dd);
 	}
 	else {				/* Gregorian calendar string, date with or without clock */
-		if (sscanf (&s[i], "%5d-%2d-%2d%[^0-9:-]%2d:%2d:%lf", &yy, &mo, &dd, tt, &hh, &mm, &ss) < 3) return (-1);
-		if (gmtlib_g_ymd_is_bad (yy, mo, dd) ) return (-1);
+		if (sscanf (&s[i], "%5d-%2d-%2d%[^0-9:-]%2d:%2d:%lf", &yy, &mo, &dd, tt, &hh, &mm, &ss) < 3) return (GMT_NOTSET);
+		if (gmtlib_g_ymd_is_bad (yy, mo, dd) ) return (GMT_NOTSET);
 		rd = gmt_rd_from_gymd (GMT, yy, mo, dd);
 	}
-	if (gmt_M_hms_is_bad (hh, mm, ss)) return (-1);
+	if (gmt_M_hms_is_bad (hh, mm, ss)) return (GMT_NOTSET);
 
 	*rata_die = rd;								/* Rata day number of epoch */
 	*t0 =  (GMT_HR2SEC_F * hh + GMT_MIN2SEC_F * mm + ss) * GMT_SEC2DAY;	/* Fractional day (0<= t0 < 1) since rata_die of epoch */
@@ -5949,7 +5949,7 @@ GMT_LOCAL int gmtinit_load_encoding (struct GMT_CTRL *GMT) {
 	struct GMT_ENCODING *enc = &GMT->current.setting.ps_encoding;
 
 	snprintf (symbol, GMT_LEN256, "PSL_%s", enc->name);	/* Prepend the PSL_ prefix */
-	if ((k = gmtinit_get_psl_encoding (symbol)) == -1) {
+	if ((k = gmtinit_get_psl_encoding (symbol)) == GMT_NOTSET) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot find the %s encoding\n", symbol);
 		return GMT_RUNTIME_ERROR;
 	}
@@ -6052,7 +6052,7 @@ int gmt_get_V (char arg) {
 		case 'i': case 'l': case '3':  case '\0': mode = GMT_MSG_INFORMATION;	break;	/* -V[i] [was -Vl] */
 		case 'c': case '1': mode = GMT_MSG_COMPAT;	break;	/* -Vc */
 		case 'd': case '4': mode = GMT_MSG_DEBUG;	break;	/* -Vd */
-		default: mode = -1;
+		default: mode = GMT_NOTSET;
 	}
 	return mode;
 }
@@ -7028,7 +7028,7 @@ GMT_LOCAL struct GMT_CTRL *gmtinit_new_GMT_ctrl (struct GMTAPI_CTRL *API, const 
 	GMT->current.proj.xyz_pos[GMT_X] = GMT->current.proj.xyz_pos[GMT_Y] = GMT->current.proj.xyz_pos[GMT_Z] = true;
 	GMT->current.proj.z_project.view_azimuth = 180.0;
 	GMT->current.proj.z_project.view_elevation = 90.0;
-	GMT->current.proj.z_project.plane = -1;	/* Initialize no perspective projection */
+	GMT->current.proj.z_project.plane = GMT_NOTSET;	/* Initialize no perspective projection */
 	GMT->current.proj.z_project.level = 0.0;
 	for (i = 0; i < 4; i++) GMT->current.proj.edge[i] = true;
 	gmtlib_grdio_init (GMT);
@@ -9108,7 +9108,7 @@ int gmt_parse_i_option (struct GMT_CTRL *GMT, char *arg) {
 	bool new_style;
 	unsigned int k = 0, pos = 0, pos_p, uerr = 0;
 	int convert;
-	int64_t i, start = -1, stop = -1, inc;
+	int64_t i, start = GMT_NOTSET, stop = GMT_NOTSET, inc;
 	double scale, offset;
 
 	if (!arg || !arg[0]) return (GMT_PARSE_ERROR);	/* -i requires an argument */
@@ -9357,7 +9357,7 @@ int gmt_parse_o_option (struct GMT_CTRL *GMT, char *arg) {
 	char copy[GMT_BUFSIZ] = {""}, p[GMT_BUFSIZ] = {""};
 	unsigned int pos = 0;
 	uint64_t k = 0;
-	int64_t i, start = -1, stop = -1, inc;
+	int64_t i, start = GMT_NOTSET, stop = GMT_NOTSET, inc;
 
 	if (!arg || !arg[0]) return (GMT_PARSE_ERROR);	/* -o requires an argument */
 
@@ -9889,7 +9889,7 @@ GMT_LOCAL int gmtinit_loaddefaults (struct GMT_CTRL *GMT, char *file, bool theme
 	char line[GMT_BUFSIZ] = {""}, keyword[GMT_LEN256] = {""}, value[GMT_BUFSIZ] = {""};
 	FILE *fp = NULL;
 
-	if ((fp = fopen (file, "r")) == NULL) return (-1);
+	if ((fp = fopen (file, "r")) == NULL) return (GMT_NOTSET);
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reading GMT Default parameters from file: %s\n", file);
 	while (fgets (line, GMT_BUFSIZ, fp)) {
 		rec++;
@@ -13418,12 +13418,12 @@ int gmt_hash_lookup (struct GMT_CTRL *GMT, const char *key, struct GMT_HASH *has
 
 	i = gmtinit_hash (GMT, key, n_hash);			/* Get initial hash key */
 
-	if (i < 0 || (ui = i) >= n) return (-1);	/* Bad key */
-	if (hashnode[ui].n_id == 0) return (-1);	/* No entry for this hash value */
+	if (i < 0 || (ui = i) >= n) return (GMT_NOTSET);	/* Bad key */
+	if (hashnode[ui].n_id == 0) return (GMT_NOTSET);	/* No entry for this hash value */
 	/* Must search among the entries with identical hash value ui, starting at item k = 0 */
 	k = 0;
 	while (k < hashnode[ui].n_id && strcmp (hashnode[ui].key[k], key)) k++;
-	if (k == hashnode[ui].n_id) return (-1);	/* Bad key; no match found */
+	if (k == hashnode[ui].n_id) return (GMT_NOTSET);	/* Bad key; no match found */
 	return (hashnode[ui].id[k]);			/* Return array index that goes with this key */
 }
 
@@ -13503,7 +13503,7 @@ int gmt_get_ellipsoid (struct GMT_CTRL *GMT, char *name) {
 				&pol_radius, &GMT->current.setting.ref_ellipsoid[i].flattening);
 			if (n != 5) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure while decoding user ellipsoid parameters (%s)\n", line);
-				return -1;
+				return GMT_NOTSET;
 			}
 
 			if (pol_radius == 0.0) {} /* Ignore semi-minor axis */
@@ -13523,7 +13523,7 @@ int gmt_get_ellipsoid (struct GMT_CTRL *GMT, char *name) {
 		}
 	}
 
-	return (-1);
+	return (GMT_NOTSET);
 }
 
 /*! . */
@@ -14775,13 +14775,13 @@ void gmtinit_complete_RJ (struct GMT_CTRL *GMT, char *codes, struct GMT_OPTION *
 		/* Must dig around in the history array */
 		gmt_M_memset (str, 3, char);
 		str[0] = codes[j];
-		if ((id = gmt_get_option_id (0, str)) == -1) continue;	/* Not an option we have history for yet */
+		if ((id = gmt_get_option_id (0, str)) == GMT_NOTSET) continue;	/* Not an option we have history for yet */
 		if (codes[j] == 'R' && !GMT->current.ps.active) id++;		/* Examine -RG history if not a plotter */
 		if (GMT->init.history[id] == NULL) continue;	/* No history for this option */
 		if (codes[j] == 'J') {	/* Must now search for actual option since -J only has the code (e.g., -JM) */
 			/* Continue looking for -J<code> */
 			str[1] = GMT->init.history[id][0];
-			if ((id = gmt_get_option_id (id + 1, str)) == -1) continue;	/* Not an option we have history for yet */
+			if ((id = gmt_get_option_id (id + 1, str)) == GMT_NOTSET) continue;	/* Not an option we have history for yet */
 			if (GMT->init.history[id] == NULL) continue;	/* No history for this option */
 		}
 		GMT_Update_Option (GMT->parent, opt, GMT->init.history[id]);	/* Failure to update option */
@@ -17184,7 +17184,7 @@ unsigned int gmt_check_scalingopt (struct GMT_CTRL *GMT, char option, char unit,
 	if ((smode = gmtlib_get_unit_number (GMT, unit)) == GMT_IS_NOUNIT) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "GMT ERROR Option -%c: Only append one of %s|%s\n",
 		            option, GMT_DIM_UNITS_DISPLAY, GMT_LEN_UNITS2_DISPLAY);
-		return -1;
+		return GMT_NOTSET;
 	}
 	mode = (unsigned int)smode;
 	switch (mode) {
@@ -17929,8 +17929,8 @@ int gmt_init_time_system_structure (struct GMT_CTRL *GMT, struct GMT_TIME_SYSTEM
 
 int gmt_get_option_id (int start, char *this_option) {
 	/* Search the GMT_unique_option list starting at given position for this_option */
-	int k, id = -1;
-	for (k = start; k < GMT_N_UNIQUE && id == -1; k++)
+	int k, id = GMT_NOTSET;
+	for (k = start; k < GMT_N_UNIQUE && id == GMT_NOTSET; k++)
 		if (!strcmp (GMT_unique_option[k], this_option)) id = k;	/* Got entry index into history array for requested option */
 	return (id);
 }
@@ -17959,13 +17959,13 @@ int gmt_set_missing_options (struct GMT_CTRL *GMT, char *options) {
 		/* Must dig around in the history array */
 		gmt_M_memset (str, 3, char);
 		str[0] = options[j];
-		if ((id = gmt_get_option_id (0, str)) == -1) continue;	/* Not an option we have history for yet */
+		if ((id = gmt_get_option_id (0, str)) == GMT_NOTSET) continue;	/* Not an option we have history for yet */
 		if (options[j] == 'R' && !GMT->current.ps.active) id++;		/* Examine -RG history if not a plotter */
 		if (GMT->init.history[id] == NULL) continue;	/* No history for this option */
 		if (options[j] == 'J') {	/* Must now search for actual option since -J only has the code (e.g., -JM) */
 			/* Continue looking for -J<code> */
 			str[1] = GMT->init.history[id][0];
-			if ((id = gmt_get_option_id (id + 1, str)) == -1) continue;	/* Not an option we have history for yet */
+			if ((id = gmt_get_option_id (id + 1, str)) == GMT_NOTSET) continue;	/* Not an option we have history for yet */
 			if (GMT->init.history[id] == NULL) continue;	/* No history for this option */
 		}
 		/* Here we should have a parsable command option */
@@ -18341,7 +18341,7 @@ int gmt_get_graphics_id (struct GMT_CTRL *GMT, const char *format) {
 	gmt_M_unused(GMT);
 	while (gmt_session_format[code] && strncmp (format, gmt_session_format[code], strlen (gmt_session_format[code])))
 		code++;
-	return (gmt_session_format[code]) ? code : -1;
+	return (gmt_session_format[code]) ? code : GMT_NOTSET;
 }
 
 /*! . */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -998,7 +998,7 @@ GMT_LOCAL int gmtio_bin_output (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, doub
 	double val;
 	gmt_M_unused (txt);
 
-	if (gmt_skip_output (GMT, ptr, n)) return (-1);	/* Record was skipped via -s[a|r] */
+	if (gmt_skip_output (GMT, ptr, n)) return (GMT_NOTSET);	/* Record was skipped via -s[a|r] */
 	if (GMT->current.setting.io_lonlat_toggle[GMT_OUT])		/* Write lat/lon instead of lon/lat */
 		gmt_M_double_swap (ptr[GMT_X], ptr[GMT_Y]);
 	n_out = (GMT->common.o.select) ? GMT->common.o.n_cols : n;
@@ -1021,7 +1021,7 @@ int gmt_ascii_output_no_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double
 	double val;
 	gmt_M_unused (txt);
 
-	if (gmt_skip_output (GMT, ptr, n)) return (-1);	/* Record was skipped via -s[a|r] */
+	if (gmt_skip_output (GMT, ptr, n)) return (GMT_NOTSET);	/* Record was skipped via -s[a|r] */
 	n_out = (GMT->common.o.select) ? GMT->common.o.n_cols : n;
 
 	last = n_out - 1;				/* Last filed, need to output linefeed instead of delimiter */
@@ -1046,7 +1046,7 @@ int gmt_ascii_output_no_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double
 
 		wn += e;
 	}
-	return ((e < 0) ? -1 : 0);
+	return ((e < 0) ? GMT_NOTSET : 0);
 }
 
 GMT_LOCAL void gmtio_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, char *txt) {
@@ -1071,7 +1071,7 @@ GMT_LOCAL void gmtio_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, char 
 /*! . */
 int gmtlib_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt) {
 
-	if (gmt_skip_output (GMT, ptr, n)) return (-1);	/* Record was skipped via -s[a|r] */
+	if (gmt_skip_output (GMT, ptr, n)) return (GMT_NOTSET);	/* Record was skipped via -s[a|r] */
 
 	gmtio_output_trailing_text (GMT, fp, txt);
 
@@ -1084,7 +1084,7 @@ GMT_LOCAL int gmtio_ascii_output_with_text (struct GMT_CTRL *GMT, FILE *fp, uint
 	int e = 0, wn = 0;
 	double val;
 
-	if (gmt_skip_output (GMT, ptr, n)) return (-1);	/* Record was skipped via -s[a|r] */
+	if (gmt_skip_output (GMT, ptr, n)) return (GMT_NOTSET);	/* Record was skipped via -s[a|r] */
 	n_out = (GMT->common.o.select) ? GMT->common.o.n_cols : n;
 
 	for (i = 0; i < n_out && e >= 0; i++) {		/* Keep writing all fields unless there is a read error (e == -1) */
@@ -1107,7 +1107,7 @@ GMT_LOCAL int gmtio_ascii_output_with_text (struct GMT_CTRL *GMT, FILE *fp, uint
 	}
 	gmtio_output_trailing_text (GMT, fp, txt);
 
-	return ((e < 0) ? -1 : 0);
+	return ((e < 0) ? GMT_NOTSET : 0);
 }
 
 GMT_LOCAL int gmtio_ascii_output (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt) {
@@ -1821,7 +1821,7 @@ GMT_LOCAL bool gmtio_get_ymdj_order (struct GMT_CTRL *GMT, char *text, struct GM
 	const size_t s_length = strlen(text);
 
 	gmt_M_memset (S, 1, struct GMT_DATE_IO);
-	for (i = 0; i < 4; i++) S->item_order[i] = S->item_pos[i] = -1;	/* Meaning not encountered yet */
+	for (i = 0; i < 4; i++) S->item_order[i] = S->item_pos[i] = GMT_NOTSET;	/* Meaning not encountered yet */
 
 	n_y = n_m = n_d = n_j = n_w = n_delim = 0;
 
@@ -1907,7 +1907,7 @@ GMT_LOCAL bool gmtio_get_ymdj_order (struct GMT_CTRL *GMT, char *text, struct GM
 	S->Y2K_year = (n_y == 2);		/* Must supply the century when reading and take it out when writing */
 	S->truncated_cal_is_ok = true;		/* May change in the next loop */
 	for (i = 1, last = S->item_order[0]; S->truncated_cal_is_ok && i < 4; i++) {
-		if (S->item_order[i] == -1) continue;
+		if (S->item_order[i] == GMT_NOTSET) continue;
 		if (S->item_order[i] < last) S->truncated_cal_is_ok = false;
 		last = S->item_order[i];
 	}
@@ -1944,8 +1944,8 @@ GMT_LOCAL int gmtio_get_hms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 	char *p = NULL;
 	ptrdiff_t off;
 
-	for (i = 0; i < 3; i++) S->order[i] = -1;	/* Meaning not encountered yet */
-	sequence[0] = sequence[1] = sequence[2] = -1;
+	for (i = 0; i < 3; i++) S->order[i] = GMT_NOTSET;	/* Meaning not encountered yet */
+	sequence[0] = sequence[1] = sequence[2] = GMT_NOTSET;
 
 	S->delimiter[0][0] = S->delimiter[0][1] = S->delimiter[1][0] = S->delimiter[1][1] = 0;
 	n_h = n_m = n_s = n_x = n_dec = n_delim = 0;
@@ -2039,7 +2039,7 @@ GMT_LOCAL int gmtio_get_hms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 	for (i = 0; i < 3; i++) S->order[i] = sequence[i];
 	big_to_small = true;		/* May change in the next loop */
 	for (i = 1, last = S->order[0]; big_to_small && i < 3; i++) {
-		if (S->order[i] == -1) continue;
+		if (S->order[i] == GMT_NOTSET) continue;
 		if (S->order[i] < last) big_to_small = false;
 		last = S->order[i];
 	}
@@ -2074,11 +2074,11 @@ GMT_LOCAL int gmtio_get_dms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 	size_t i1, i;
 	bool big_to_small;
 
-	for (i = 0; i < 3; i++) S->order[i] = -1;	/* Meaning not encountered yet */
+	for (i = 0; i < 3; i++) S->order[i] = GMT_NOTSET;	/* Meaning not encountered yet */
 
 	n_d = n_m = n_s = n_x = n_dec = n_delim = n_period = 0;
 	S->delimiter[0][0] = S->delimiter[0][1] = S->delimiter[1][0] = S->delimiter[1][1] = 0;
-	sequence[0] = sequence[1] = sequence[2] = -1;
+	sequence[0] = sequence[1] = sequence[2] = GMT_NOTSET;
 
 	S->range = GMT_IS_M180_TO_P180_RANGE;			/* -180/+180 range, may be overwritten below by + or - */
 	S->decimal = S->no_sign = false;
@@ -2168,7 +2168,7 @@ GMT_LOCAL int gmtio_get_dms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 	for (i = 0; i < 3; i++) S->order[i] = sequence[i];
 	big_to_small = true;		/* May change in the next loop */
 	for (i = 1, last = S->order[0]; big_to_small && i < 3; i++) {
-		if (S->order[i] == -1) continue;
+		if (S->order[i] == GMT_NOTSET) continue;
 		if (S->order[i] < last) big_to_small = false;
 		last = S->order[i];
 	}
@@ -2223,23 +2223,23 @@ GMT_LOCAL int gmtio_scanf_clock (struct GMT_CTRL *GMT, char *s, double *val) {
 				hh_limit = 12;
 				break;
 			default:
-				return (-1);
+				return (GMT_NOTSET);
 				break;
 		}
 	}
 
 	k = sscanf (s, GMT->current.io.clock_input.format, &hh, &mm, &ss);
-	if (k == 0) return (-1);
-	if (hh < 0 || hh > hh_limit) return (-1);
+	if (k == 0) return (GMT_NOTSET);
+	if (hh < 0 || hh > hh_limit) return (GMT_NOTSET);
 
 	x = (double)(add_noon + 3600*hh);
 	if (k > 1) {
-		if (mm < 0 || mm > 59) return (-1);
+		if (mm < 0 || mm > 59) return (GMT_NOTSET);
 		x += 60*mm;
 	}
 	if (k > 2) {
 		x += ss;
-		if (x > 86401.0) return (-1);
+		if (x > 86401.0) return (GMT_NOTSET);
 	}
 	*val = x;
 	return (0);
@@ -2255,15 +2255,15 @@ GMT_LOCAL int gmtio_scanf_ISO_calendar (struct GMT_CTRL *GMT, char *s, int64_t *
 
 	int k, n, ival[3];
 
-	if ((n = sscanf (s, GMT->current.io.date_input.format, &ival[0], &ival[1], &ival[2])) <= 0) return (-1);
+	if ((n = sscanf (s, GMT->current.io.date_input.format, &ival[0], &ival[1], &ival[2])) <= 0) return (GMT_NOTSET);
 
 	/* Handle possible missing bits */
 	for (k = n; k < 3; k++) ival[k] = 1;
 
-	if (ival[1] < 1 || ival[1] > 53) return (-1);
-	if (ival[2] < 1 || ival[2] > 7) return (-1);
+	if (ival[1] < 1 || ival[1] > 53) return (GMT_NOTSET);
+	if (ival[2] < 1 || ival[2] > 7) return (GMT_NOTSET);
 	if (GMT->current.io.date_input.Y2K_year) {
-		if (ival[0] < 0 || ival[0] > 99) return (-1);
+		if (ival[0] < 0 || ival[0] > 99) return (GMT_NOTSET);
 		ival[0] = gmtlib_y2_to_y4_yearfix (GMT, ival[0]);
 	}
 	*rd = gmtlib_rd_from_iywd (GMT, ival[0], ival[1], ival[2]);
@@ -2283,17 +2283,17 @@ GMT_LOCAL int gmtio_scanf_g_calendar (struct GMT_CTRL *GMT, char *s, int64_t *rd
 		/* Calendar uses year and day of year format.  */
 		if ( (k = sscanf (s, GMT->current.io.date_input.format,
 			&ival[GMT->current.io.date_input.item_order[0]],
-			&ival[GMT->current.io.date_input.item_order[1]]) ) == 0) return (-1);
+			&ival[GMT->current.io.date_input.item_order[1]]) ) == 0) return (GMT_NOTSET);
 		if (k < 2) {
-			if (!GMT->current.io.date_input.truncated_cal_is_ok) return (-1);
+			if (!GMT->current.io.date_input.truncated_cal_is_ok) return (GMT_NOTSET);
 			ival[1] = 1;	/* Set first day of year  */
 		}
 		if (GMT->current.io.date_input.Y2K_year) {
-			if (ival[0] < 0 || ival[0] > 99) return (-1);
+			if (ival[0] < 0 || ival[0] > 99) return (GMT_NOTSET);
 			ival[0] = gmtlib_y2_to_y4_yearfix (GMT, ival[0]);
 		}
 		k = (gmtlib_is_gleap (ival[0])) ? 366 : 365;
-		if (ival[3] < 1 || ival[3] > k) return (-1);
+		if (ival[3] < 1 || ival[3] > k) return (GMT_NOTSET);
 		*rd = gmt_rd_from_gymd (GMT, ival[0], 1, 1) + ival[3] - 1;
 		return (0);
 	}
@@ -2315,32 +2315,32 @@ GMT_LOCAL int gmtio_scanf_g_calendar (struct GMT_CTRL *GMT, char *s, int64_t *rd
 				            &ival[GMT->current.io.date_input.item_order[1]], month);
 				break;
 			default:
-				return (-1);
+				return (GMT_NOTSET);
 				break;
 		}
 		gmt_str_toupper (month);
 		for (i = ival[1] = 0; i < 12 && ival[1] == 0; i++) {
 			if (!strcmp (month, GMT->current.language.month_name[3][i])) ival[1] = i + 1;
 		}
-		if (ival[1] == 0) return (-1);	/* No match for month name */
+		if (ival[1] == 0) return (GMT_NOTSET);	/* No match for month name */
 	}
 	else if ((k = sscanf (s, GMT->current.io.date_input.format, &ival[GMT->current.io.date_input.item_order[0]],
 	                      &ival[GMT->current.io.date_input.item_order[1]], &ival[GMT->current.io.date_input.item_order[2]])) == 0)
-		return (-1);
+		return (GMT_NOTSET);
 	if (k < 3) {
 		if (GMT->current.io.date_input.truncated_cal_is_ok) {
 			ival[2] = 1;	/* Set first day of month  */
 			if (k == 1) ival[1] = 1;	/* Set first month of year */
 		}
 		else
-			return (-1);
+			return (GMT_NOTSET);
 	}
 	if (GMT->current.io.date_input.Y2K_year) {
-		if (ival[0] < 0 || ival[0] > 99) return (-1);
+		if (ival[0] < 0 || ival[0] > 99) return (GMT_NOTSET);
 		ival[0] = gmtlib_y2_to_y4_yearfix (GMT, ival[0]);
 	}
 
-	if (gmtlib_g_ymd_is_bad (ival[0], ival[1], ival[2]) ) return (-1);
+	if (gmtlib_g_ymd_is_bad (ival[0], ival[1], ival[2]) ) return (GMT_NOTSET);
 
 	*rd = gmt_rd_from_gymd (GMT, ival[0], ival[1], ival[2]);
 	return (0);
@@ -3159,7 +3159,7 @@ GMT_LOCAL void * gmtio_bin_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, i
 	do {	/* Keep reading until (1) EOF, (2) got a segment record, or (3) a valid data record */
 		n_use = gmtio_n_cols_needed_for_gaps (GMT, *n);
 		gmtio_update_prev_rec (GMT, n_use);
-		if (gmtio_get_binary_input (GMT, fp, n_use)) { *retval = -1; GMT->current.io.data_record_number_in_tbl[GMT_IN] = 0; return (NULL); }	/* EOF */
+		if (gmtio_get_binary_input (GMT, fp, n_use)) { *retval = GMT_NOTSET; GMT->current.io.data_record_number_in_tbl[GMT_IN] = 0; return (NULL); }	/* EOF */
 		GMT->current.io.rec_no++;
 		GMT->current.io.data_record_number_in_set[GMT_IN]++;
 		GMT->current.io.data_record_number_in_tbl[GMT_IN]++;
@@ -3461,7 +3461,7 @@ GMT_LOCAL inline int gmtio_reached_EOF (struct GMT_CTRL *GMT) {
 	GMT->current.io.data_record_number_in_tbl[GMT_IN] = GMT->current.io.data_record_number_in_seg[GMT_IN] = 0;
 	GMT->current.io.has_previous_rec = false;
 
-	return (-1);
+	return (GMT_NOTSET);
 }
 
 /*! This is the lowest-most input function in GMT.  All ASCII table data are read via
@@ -3956,7 +3956,7 @@ GMT_LOCAL void * gmtio_nc_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, in
 
 		if (GMT->current.io.nrec == GMT->current.io.ndim) {	/* Reading past last record means EOF for netCDF files */
 			GMT->current.io.status = GMT_IO_EOF;
-			*retval = -1;
+			*retval = GMT_NOTSET;
 			return (NULL);
 		}
 		/* Just get values from current row in the mem_coord arrays */
@@ -4571,10 +4571,10 @@ void gmt_set_tableheader (struct GMT_CTRL *GMT, int direction, bool true_false) 
 int gmt_z_output (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *data, char *txt) {
 	int err;
 	gmt_M_unused (txt);
-	if (gmt_skip_output (GMT, data, n)) return (-1);	/* Record was skipped via -s[a|r] */
+	if (gmt_skip_output (GMT, data, n)) return (GMT_NOTSET);	/* Record was skipped via -s[a|r] */
 	err = GMT->current.io.write_item (GMT, fp, n, data);
 	/* Cast below since the output functions are declared with uint64_t but cannot really exceed 4096... SHould change uint64_t to uint32_t */
-	return (err ? -1 : 0);	/* Return -1 if failed, else n items written */
+	return (err ? GMT_NOTSET : 0);	/* Return -1 if failed, else n items written */
 }
 
 /* gmt_z_input and gmt_z_output are used in grd2xyz/xyz2grd to fascilitate reading of one-col items via the general i/o machinery
@@ -5439,28 +5439,28 @@ int gmt_access (struct GMT_CTRL *GMT, const char* filename, int mode) {
 	int err, k_data;
 	struct stat S;
 
-	if (!filename || !filename[0]) return (-1);		/* No file given */
+	if (!filename || !filename[0]) return (GMT_NOTSET);		/* No file given */
 	if (gmt_M_file_is_memory (filename)) return (0);	/* Memory location always exists */
 	if (gmt_file_is_cache (GMT->parent, filename))			/* Must be a cache file */
 		first = gmt_download_file_if_not_found (GMT, filename, 0);
 
-	if ((cleanfile = gmt_get_filename (GMT->parent, &filename[first], gmtlib_valid_filemodifiers (GMT))) == NULL) return (-1);	/* Likely not a valid filename */
+	if ((cleanfile = gmt_get_filename (GMT->parent, &filename[first], gmtlib_valid_filemodifiers (GMT))) == NULL) return (GMT_NOTSET);	/* Likely not a valid filename */
 	strncpy (file, cleanfile, PATH_MAX-1);
 	gmt_M_str_free (cleanfile);
 	if (mode == W_OK)
 		return (access (file, mode));	/* When writing, only look in current directory */
 	err = stat (file, &S);	/* Stat the argument */
 	if (!err && S_ISDIR (S.st_mode))	/* Path exists, but it is a directory */
-		return (-1);
+		return (GMT_NOTSET);
 	if (mode == R_OK || mode == F_OK) {	/* Look in special directories when reading or just checking for existence */
 		char path[PATH_MAX] = {""};
 		if ((k_data = gmt_remote_no_extension (GMT->parent, filename)) != GMT_NOTSET)	/* A remote @filename_xxm|s grid without extension */
 			strcat (file, GMT->parent->remote_info[k_data].ext);	/* Must supply the .extension */
-		return (gmt_getdatapath (GMT, file, path, mode) ? 0 : -1);
+		return (gmt_getdatapath (GMT, file, path, mode) ? 0 : GMT_NOTSET);
 	}
 	/* If we get here then mode is bad (X_OK)? */
 	GMT_Report (GMT->parent, GMT_MSG_ERROR, "GMT: Bad mode (%d) passed to gmt_access\n", mode);
-	return (-1);
+	return (GMT_NOTSET);
 }
 
 /*! . */
@@ -5500,7 +5500,7 @@ void * gmtlib_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int 
 		if (!p) {	/* Ran out of records */
 			GMT->current.io.status = GMT_IO_EOF;
 			*n = 0ULL;
-			*status = -1;
+			*status = GMT_NOTSET;
 			return (NULL);
 		}
 		if (strchr (GMT->current.setting.io_head_marker_in, line[0])) {	/* Got a file header, take action and return */
@@ -6888,7 +6888,7 @@ int gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 		/* Level 0: degrees only. index 0 is integer degrees, index 1 is [possibly] fractional degrees */
 
 		sprintf (GMT->current.plot.format[0][0], "%%d");		/* ddd */
-		if (S->order[1] == -1 && S->n_sec_decimals > 0) /* ddd.xxx format */
+		if (S->order[1] == GMT_NOTSET && S->n_sec_decimals > 0) /* ddd.xxx format */
 			snprintf (GMT->current.plot.format[0][1], GMT_LEN64, "%%d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
 		else						/* ddd format */
 			sprintf (GMT->current.plot.format[0][1], "%%d");
@@ -6910,7 +6910,7 @@ int gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 			strcat (GMT->current.plot.format[1][1], fmt);
 		}
 		strcat (GMT->current.plot.format[1][0], "%02d");
-		if (S->order[2] == -1 && S->n_sec_decimals > 0) /* ddd:mm.xxx format */
+		if (S->order[2] == GMT_NOTSET && S->n_sec_decimals > 0) /* ddd:mm.xxx format */
 			snprintf (fmt, GMT_LEN256, "%%02d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);
 		else						/* ddd:mm format */
 			sprintf (fmt, "%%02d");
@@ -9416,7 +9416,7 @@ int gmt_mkdir (const char *path)
 	if (len >= PATH_MAX) {	/* Make sure we don't exceed limits */
 		errno = ENAMETOOLONG;
 		perror ("gmt_mkdir (too long) error");
-		return -1;
+		return GMT_NOTSET;
 	}
 	strcpy (_path, path);	/* Copy string so its mutable */
 
@@ -9435,7 +9435,7 @@ int gmt_mkdir (const char *path)
 			{
 				if (errno != EEXIST) {	/* Failed to make or visit intermediate directory */
 					perror ("gmt_mkdir (intermediate) error");
-					return -1;
+					return GMT_NOTSET;
 				}
 			}
 			*p = sep;	/* Reset the separator */
@@ -9452,7 +9452,7 @@ int gmt_mkdir (const char *path)
 	{
 		if (errno != EEXIST) {
 			perror ("gmt_mkdir (last dir) error");
-			return -1;
+			return GMT_NOTSET;
 		}
 	}
 

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -6690,16 +6690,16 @@ double gmt_az_backaz (struct GMT_CTRL *GMT, double lonE, double latE, double lon
 GMT_LOCAL double gmtmap_auto_time_increment (double inc, char *unit) {
 	/* Given the first guess interval inc, determine closest time unit and return
 	 * the number of seconds in that unit and its code */
-	int k, kk = -1;
+	int k, kk = GMT_NOTSET;
 	double f;
 	static char units[6]  = {'S', 'M', 'H', 'D', 'O', 'Y'};
 	static double incs[6] = {1.0, GMT_MIN2SEC_F, GMT_HR2SEC_F, GMT_DAY2SEC_F, GMT_MON2SEC_F, GMT_YR2SEC_F};
-	for (k = 5; kk == -1 && k >= 0; k--) {	/* Find the largest time unit that is smaller than guess interval */
+	for (k = 5; kk == GMT_NOTSET && k >= 0; k--) {	/* Find the largest time unit that is smaller than guess interval */
 		f = inc / incs[k];
 		if (irint (f) >= 1)
 			kk = k;
 	}
-	if (kk == -1) kk = 0;	/* Safety valve */
+	if (kk == GMT_NOTSET) kk = 0;	/* Safety valve */
 	*unit = units[kk];
 	return (incs[kk]);
 }
@@ -7224,7 +7224,7 @@ bool gmt_map_outside (struct GMT_CTRL *GMT, double lon, double lat) {
 	GMT->current.map.prev_y_status = GMT->current.map.this_y_status;
 	if (GMT->current.map.outside == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_map_outside: FATAL ERROR - the pointer to the projection function is NULL.\n");
-		return -1;
+		return GMT_NOTSET;
 	}
 	return ((*GMT->current.map.outside) (GMT, lon, lat));
 }
@@ -9002,11 +9002,11 @@ int gmt_set_datum (struct GMT_CTRL *GMT, char *text, struct GMT_DATUM *D) {
 		char ellipsoid[GMT_LEN256] = {""}, dr[GMT_LEN256] = {""};
 		if (sscanf (text, "%[^:]:%s", ellipsoid, dr) != 2) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Malformed <ellipsoid>:<dr> argument!\n");
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		if (sscanf (dr, "%lf,%lf,%lf", &D->xyz[GMT_X], &D->xyz[GMT_Y], &D->xyz[GMT_Z]) != 3) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Malformed <x>,<y>,<z> argument!\n");
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		if ((i = gmt_get_ellipsoid (GMT, ellipsoid)) >= 0) {	/* This includes looking for format <a>,<1/f> */
 			D->a = GMT->current.setting.ref_ellipsoid[i].eq_radius;
@@ -9015,22 +9015,22 @@ int gmt_set_datum (struct GMT_CTRL *GMT, char *text, struct GMT_DATUM *D) {
 		}
 		else {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Ellipsoid %s not recognized!\n", ellipsoid);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 	}
 	else {		/* Gave a Datum ID tag [ 0-(GMT_N_DATUMS-1)] */
 		int k;
 		if (sscanf (text, "%d", &i) != 1) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Malformed or unrecognized <datum> argument (%s)!\n", text);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		if (i < 0 || i >= GMT_N_DATUMS) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Datum ID (%d) outside valid range (0-%d)!\n", i, GMT_N_DATUMS-1);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		if ((k = gmt_get_ellipsoid (GMT, GMT->current.setting.proj_datum[i].ellipsoid)) < 0) {	/* This should not happen... */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Ellipsoid %s not recognized!\n", GMT->current.setting.proj_datum[i].ellipsoid);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		D->a = GMT->current.setting.ref_ellipsoid[k].eq_radius;
 		D->f = GMT->current.setting.ref_ellipsoid[k].flattening;

--- a/src/gmt_mgg_header2.c
+++ b/src/gmt_mgg_header2.c
@@ -48,7 +48,7 @@ GMT_LOCAL int gmtmggheader2_swap_mgg_header (MGG_GRID_HEADER_2 *header) {
 	if (header->version == (GRD98_MAGIC_NUM + GRD98_VERSION)) return (0);	/* Version matches, No need to swap */
 	version = header->version;
 	gmtmggheader2_swap_long (&version);
-	if (version != (GRD98_MAGIC_NUM + GRD98_VERSION)) return (-1);		/* Cannot make sense of header */
+	if (version != (GRD98_MAGIC_NUM + GRD98_VERSION)) return (GMT_NOTSET);		/* Cannot make sense of header */
 	/* Here we come when we do need to swap */
 	gmtmggheader2_swap_long (&header->version);
 	gmtmggheader2_swap_long (&header->length);
@@ -201,13 +201,13 @@ int gmtlib_is_mgg2_grid (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header) {
 		return (GMT_GRDIO_READ_FAILED);
 	}
 
-	/* Swap header bytes if necessary; ok is 0|1 if successful and -1 if bad file */
+	/* Swap header bytes if necessary; ok is 0|1 if successful and GMT_NOTSET if bad file */
 	ok = gmtmggheader2_swap_mgg_header (&mggHeader);
 
 	/* Check the magic number and size of header */
-	if (ok == -1) {
+	if (ok == GMT_NOTSET) {
 		gmt_fclose (GMT, fp);
-		return (-1);	/* Not this kind of file */
+		return (GMT_NOTSET);	/* Not this kind of file */
 	}
 	header->type = GMT_GRID_IS_RF;
 	gmt_fclose (GMT, fp);
@@ -231,11 +231,11 @@ int gmt_mgg2_read_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 		return (GMT_GRDIO_READ_FAILED);
 	}
 
-	/* Swap header bytes if necessary; ok is 0|1 if successful and -1 if bad file */
+	/* Swap header bytes if necessary; ok is 0|1 if successful and GMT_NOTSET if bad file */
 	ok = gmtmggheader2_swap_mgg_header (&mggHeader);
 
 	/* Check the magic number and size of header */
-	if (ok == -1) {
+	if (ok == GMT_NOTSET) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unrecognized header, expected 0x%04X saw 0x%04X\n",
 		            GRD98_MAGIC_NUM + GRD98_VERSION, mggHeader.version);
 		gmt_fclose (GMT, fp);
@@ -310,7 +310,7 @@ int gmt_mgg2_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 			return (GMT_GRDIO_READ_FAILED);
 		}
 		swap_all = gmtmggheader2_swap_mgg_header (&mggHeader);
-		if (swap_all == -1) {
+		if (swap_all == GMT_NOTSET) {
 			gmt_fclose (GMT, fp);
 			return (GMT_GRDIO_GRD98_BADMAGIC);
 		}

--- a/src/gmt_stat.c
+++ b/src/gmt_stat.c
@@ -150,7 +150,7 @@ GMT_LOCAL int gmtstat_ln_gamma_r (struct GMT_CTRL *GMT, double x, double *lngam)
 		return (0);
 	}
 	GMT_Report (GMT->parent, GMT_MSG_WARNING, "Ln Gamma:  Bad x (x <= 0).\n");
-	return (-1);
+	return (GMT_NOTSET);
 }
 
 GMT_LOCAL void gmtstat_gamma_ser (struct GMT_CTRL *GMT, double *gamser, double a, double x, double *gln) {
@@ -160,7 +160,7 @@ GMT_LOCAL void gmtstat_gamma_ser (struct GMT_CTRL *GMT, double *gamser, double a
 	int n;
 	double sum, del, ap;
 
-	if (gmtstat_ln_gamma_r (GMT, a, gln) == -1) {
+	if (gmtstat_ln_gamma_r (GMT, a, gln) == GMT_NOTSET) {
 		*gamser = GMT->session.d_NaN;
 		return;
 	}
@@ -195,7 +195,7 @@ GMT_LOCAL void gmtstat_gamma_cf (struct GMT_CTRL *GMT, double *gammcf, double a,
 	double gold = 0.0, g, fac = 1.0, b1 = 1.0;
 	double b0 = 0.0, anf, ana, an, a1, a0 = 1.0;
 
-	if (gmtstat_ln_gamma_r (GMT, a, gln) == -1) {
+	if (gmtstat_ln_gamma_r (GMT, a, gln) == GMT_NOTSET) {
 		*gln = GMT->session.d_NaN;
 		return;
 	}
@@ -282,11 +282,11 @@ GMT_LOCAL int gmtstat_inc_beta (struct GMT_CTRL *GMT, double a, double b, double
 
 	if (a <= 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_inc_beta:  Bad a (a <= 0).\n");
-		return(-1);
+		return(GMT_NOTSET);
 	}
 	if (b <= 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_inc_beta:  Bad b (b <= 0).\n");
-		return(-1);
+		return(GMT_NOTSET);
 	}
 	if (x > 0.0 && x < 1.0) {
 		gmtstat_ln_gamma_r(GMT, a, &gama);
@@ -326,7 +326,7 @@ GMT_LOCAL int gmtstat_inc_beta (struct GMT_CTRL *GMT, double a, double b, double
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_inc_beta:  Bad x (x > 1).\n");
 		*ibeta = 1.0;
 	}
-	return (-1);
+	return (GMT_NOTSET);
 }
 
 GMT_LOCAL int gmtstat_f_q (struct GMT_CTRL *GMT, double chisq1, uint64_t nu1, double chisq2, uint64_t nu2, double *prob) {
@@ -360,7 +360,7 @@ GMT_LOCAL int gmtstat_f_q (struct GMT_CTRL *GMT, double chisq1, uint64_t nu1, do
 
 	if (nu1 <= 0 || nu2 <= 0 || chisq1 < 0.0 || chisq2 < 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_f_q:  Bad argument(s).\n");
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	/* Extreme cases evaluate immediately:  */
@@ -379,7 +379,7 @@ GMT_LOCAL int gmtstat_f_q (struct GMT_CTRL *GMT, double chisq1, uint64_t nu1, do
 
 	if (gmtstat_inc_beta (GMT, 0.5*nu2, 0.5*nu1, chisq2/(chisq2+chisq1), prob) ) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_f_q:  Trouble in gmtstat_inc_beta call.\n");
-		return (-1);
+		return (GMT_NOTSET);
 	}
 	return (0);
 }
@@ -412,7 +412,7 @@ GMT_LOCAL int gmtstat_f_test_new (struct GMT_CTRL *GMT, double chisq1, uint64_t 
 	if (chisq1 <= 0.0 || chisq2 <= 0.0 || nu1 < 1 || nu2 < 1) {
 		*prob = GMT->session.d_NaN;
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_f_test_new: Bad argument(s).\n");
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	gmtstat_f_q (GMT, chisq1, nu1, chisq2, nu2, &q);
@@ -473,11 +473,11 @@ GMT_LOCAL int gmtstat_f_test (struct GMT_CTRL *GMT, double chisq1, uint64_t nu1,
 
 	if (chisq1 <= 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_f_test:  Chi-Square One <= 0.0\n");
-		return(-1);
+		return(GMT_NOTSET);
 	}
 	if (chisq2 <= 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_f_test:  Chi-Square Two <= 0.0\n");
-		return(-1);
+		return(GMT_NOTSET);
 	}
 	if (chisq1 > chisq2) {
 		f = chisq1/chisq2;
@@ -491,11 +491,11 @@ GMT_LOCAL int gmtstat_f_test (struct GMT_CTRL *GMT, double chisq1, uint64_t nu1,
 	}
 	if (gmtstat_inc_beta(GMT, 0.5*df2, 0.5*df1, df2/(df2+df1*f), &p1) ) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_f_test:  Trouble on 1st gmtstat_inc_beta call.\n");
-		return(-1);
+		return(GMT_NOTSET);
 	}
 	if (gmtstat_inc_beta(GMT, 0.5*df1, 0.5*df2, df1/(df1+df2/f), &p2) ) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtstat_f_test:  Trouble on 2nd gmtstat_inc_beta call.\n");
-		return(-1);
+		return(GMT_NOTSET);
 	}
 	*prob = p1 + (1.0 - p2);
 	return (0);
@@ -540,7 +540,7 @@ GMT_LOCAL int gmtstat_student_t_a (struct GMT_CTRL *GMT, double t, uint64_t n, d
 	if (t < 0.0 || n == 0) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmtstat_student_t_a:  Bad argument(s).\n");
 		*prob = GMT->session.d_NaN;
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	if (t == 0.0) {
@@ -1829,7 +1829,7 @@ int gmt_median (struct GMT_CTRL *GMT, double *x, uint64_t n, double xmin, double
 		else {	/* If we get here, I made a mistake!  */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Internal goof in gmt_median; please report to developers!\n");
 			*med = GMT->session.d_NaN;
-			return -1;
+			return GMT_NOTSET;
 		}
 
 	} while (!finished);
@@ -1950,7 +1950,7 @@ int gmt_mode (struct GMT_CTRL *GMT, double *x, uint64_t n, uint64_t j, bool sort
 		length = x[i + j] - x[i];
 		if (length < 0.0) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_mode: Array not sorted in non-decreasing order.\n");
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		else if (length == short_length) {	/* Possibly multiple mode */
 			switch (mode_selection) {
@@ -2006,7 +2006,7 @@ int gmt_mode_f (struct GMT_CTRL *GMT, gmt_grdfloat *x, uint64_t n, uint64_t j, b
 		length = x[i + j] - x[i];
 		if (length < 0.0) {
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_mode_f: Array not sorted in non-decreasing order.\n");
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		else if (length == short_length) {	/* Possibly multiple mode */
 			switch (mode_selection) {

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -308,16 +308,16 @@ GMT_LOCAL int gmtsupport_parse_pattern_old (struct GMT_CTRL *GMT, char *line, st
 	}
 	/* Determine if there are colorizing options applied, i.e. [:F<rgb>B<rgb>] */
 	len = (int)MIN(strlen (fill->pattern),PATH_MAX) - 1;
-	for (i = 0, pos = -1; i < len && fill->pattern[i] && pos == -1; i++)
+	for (i = 0, pos = GMT_NOTSET; i < len && fill->pattern[i] && pos == GMT_NOTSET; i++)
 		if (i < len && fill->pattern[i] == ':' && (fill->pattern[i+1] == 'B' || fill->pattern[i+1] == 'F')) pos = i;	/* THe extra i < len is needed to defeat cppcheck confusion */
-	if (pos > -1) fill->pattern[pos] = '\0';
+	if (pos != GMT_NOTSET) fill->pattern[pos] = '\0';
 	fill->pattern_no = atoi (fill->pattern);
-	if (fill->pattern_no == 0) fill->pattern_no = -1;
+	if (fill->pattern_no == 0) fill->pattern_no = GMT_NOTSET;
 
 	/* See if fore- and background colors are given */
 
 	len = (int)strlen (line);
-	for (i = 0, pos = -1; line[i] && pos == -1; i++) if (line[i] == ':' && i < len && (line[i+1] == 'B' || line[i+1] == 'F')) pos = i;
+	for (i = 0, pos = GMT_NOTSET; line[i] && pos == GMT_NOTSET; i++) if (line[i] == ':' && i < len && (line[i+1] == 'B' || line[i+1] == 'F')) pos = i;
 	pos++;
 
 	if (pos > 0 && line[pos]) {	/* Gave colors */

--- a/src/grdfft.c
+++ b/src/grdfft.c
@@ -495,7 +495,7 @@ GMT_LOCAL bool grdfft_parse_f_string (struct GMT_CTRL *GMT, struct F_INFO *f_inf
 	else if (line[i] == 'y') {
 		i++;	f_info->k_type = GMT_FFT_K_IS_KY;
 	}
-	fourvals[0] = fourvals[1] = fourvals[2] = fourvals[3] = -1.0;
+	fourvals[0] = fourvals[1] = fourvals[2] = fourvals[3] = GMT_NOTSET;
 
 	n_tokens = pos = 0;
 	while ((gmt_strtok (&line[i], "/", &pos, p))) {
@@ -504,7 +504,7 @@ GMT_LOCAL bool grdfft_parse_f_string (struct GMT_CTRL *GMT, struct F_INFO *f_inf
 			return (true);
 		}
 		if(p[0] == '-')
-			fourvals[n_tokens] = -1.0;
+			fourvals[n_tokens] = GMT_NOTSET;
 		else {
 			if ((sscanf(p, "%lf", &fourvals[n_tokens])) != 1) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, " Cannot read token %d.\n", n_tokens);
@@ -522,7 +522,7 @@ GMT_LOCAL bool grdfft_parse_f_string (struct GMT_CTRL *GMT, struct F_INFO *f_inf
 	if (f_info->kind == GRDFFT_FILTER_BW && n_tokens == 3) n_tokens = 2;	/* So we don't check the order as a wavelength */
 
 	for (i = 1; i < n_tokens; i++) {
-		if (fourvals[i] == -1.0 || fourvals[i-1] == -1.0) continue;
+		if (fourvals[i] == GMT_NOTSET || fourvals[i-1] == GMT_NOTSET) continue;
 		if (fourvals[i] > fourvals[i-1]) descending = false;
 	}
 	if (!(descending)) {
@@ -552,14 +552,14 @@ GMT_LOCAL bool grdfft_parse_f_string (struct GMT_CTRL *GMT, struct F_INFO *f_inf
 		f_info->filter = &grdfft_cosine_weight_grdfft;
 	}
 	else if (f_info->kind == GRDFFT_FILTER_BW) {	/* Butterworth specification */
-		f_info->llambda[j] = (fourvals[0] == -1.0) ? -1.0 : fourvals[0] / TWO_PI;	/* TWO_PI is used to counteract the 2*pi in the wavenumber */
-		f_info->hlambda[j] = (fourvals[1] == -1.0) ? -1.0 : fourvals[1] / TWO_PI;
+		f_info->llambda[j] = (fourvals[0] == GMT_NOTSET) ? -1.0 : fourvals[0] / TWO_PI;	/* TWO_PI is used to counteract the 2*pi in the wavenumber */
+		f_info->hlambda[j] = (fourvals[1] == GMT_NOTSET) ? -1.0 : fourvals[1] / TWO_PI;
 		f_info->bw_order = 2.0 * fourvals[2];
 		f_info->filter = &grdfft_bw_weight;
 	}
 	else {	/* Gaussian half-amp specifications */
-		f_info->llambda[j] = (fourvals[0] == -1.0) ? -1.0 : fourvals[0] / TWO_PI;	/* TWO_PI is used to counteract the 2*pi in the wavenumber */
-		f_info->hlambda[j] = (fourvals[1] == -1.0) ? -1.0 : fourvals[1] / TWO_PI;
+		f_info->llambda[j] = (fourvals[0] == GMT_NOTSET) ? -1.0 : fourvals[0] / TWO_PI;	/* TWO_PI is used to counteract the 2*pi in the wavenumber */
+		f_info->hlambda[j] = (fourvals[1] == GMT_NOTSET) ? -1.0 : fourvals[1] / TWO_PI;
 		f_info->filter = &grdfft_gauss_weight;
 	}
 	f_info->arg = f_info->kind - GRDFFT_FILTER_EXP;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1791,7 +1791,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 		else if (header_work->ProjRefEPSG)
 			Out->header->ProjRefEPSG = header_work->ProjRefEPSG;
 		else {
-			for (k = 0, id = -1; id == -1 && k < GMT_N_PROJ4; k++)
+			for (k = 0, id = GMT_NOTSET; id == GMT_NOTSET && k < GMT_N_PROJ4; k++)
 				if (GMT->current.proj.proj4[k].id == this_proj) id = k;
 			if (id >= 0) 			/* Valid projection for creating world file info */
 				img_ProjectionRefPROJ4 = gmt_export2proj4(GMT);	/* Get the proj4 string */
@@ -1882,9 +1882,9 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			/* Check that we found an unused r/g/b value so that colormasking will work as advertised */
 			index = (gmt_M_u255(P->bfn[GMT_NAN].rgb[0])*256 + gmt_M_u255(P->bfn[GMT_NAN].rgb[1]))*256 + gmt_M_u255(P->bfn[GMT_NAN].rgb[2]);	/* The index into the cube for the selected NaN color */
 			if (rgb_used[index]) {	/* This r/g/b already appears in the image as a non-NaN color; we must find a replacement NaN color */
-				for (index = 0, ks = -1; ks == -1 && index < 256*256*256; index++)	/* Examine the entire cube */
+				for (index = 0, ks = GMT_NOTSET; ks == GMT_NOTSET && index < 256*256*256; index++)	/* Examine the entire cube */
 					if (!rgb_used[index]) ks = index;	/* Use this unused entry instead */
-				if (ks == -1) {	/* This is really really unlikely, meaning image uses all 256^3 colors */
+				if (ks == GMT_NOTSET) {	/* This is really really unlikely, meaning image uses all 256^3 colors */
 					GMT_Report (API, GMT_MSG_WARNING, "Colormasking will fail as there is no unused color that can represent transparency\n");
 					done = true;
 				}

--- a/src/mgd77/mgd77.c
+++ b/src/mgd77/mgd77.c
@@ -608,7 +608,7 @@ static void mgd77_place_text (struct GMT_CTRL *GMT, int dir, char *struct_member
 
 static int mgd77_find_cruise_id (struct GMT_CTRL *GMT, char *name, char **cruises, unsigned int n_cruises, bool sorted) {
 	gmt_M_unused(GMT);
-	if (!cruises) return (-1);	/* Null pointer passed */
+	if (!cruises) return (GMT_NOTSET);	/* Null pointer passed */
 
 	if (sorted) {	/* cruises array is lexically sorted; use binary search */
 		int low = 0, high, mid, last = MGD77_NOT_SET, way;
@@ -957,7 +957,7 @@ int MGD77_Order_Columns (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct M
 
 	for (i = 0; i < F->n_constraints; i++) {	/* Determine column and info numbers from column name */
 		F->Constraint[i].col = MGD77_Get_Column (GMT, F->Constraint[i].name, F);
-		if (F->Constraint[i].col == -1) {
+		if (F->Constraint[i].col == GMT_NOTSET) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Requested column %s is not a data column [for auxiliary data tests use -D, -Q, -S]!\n", F->Constraint[i].name);
 			return (MGD77_ERROR_NOSUCHCOLUMN);
 		}
@@ -1752,7 +1752,7 @@ static int mgd77_write_header_record_cdf (struct GMT_CTRL *GMT, char *file, stru
 	time_t now;
 	char string[128] = {""};
 
-	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_WRITE_MODE)) return (-1);	/* Basically creates the full path */
+	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_WRITE_MODE)) return (GMT_NOTSET);	/* Basically creates the full path */
 
 	MGD77_nc_status (GMT, gmt_nc_create (GMT, F->path, NC_NOCLOBBER, &F->nc_id));	/* Create the file */
 
@@ -1960,7 +1960,7 @@ static int mgd77_read_data_cdf (struct GMT_CTRL *GMT, char *file, struct MGD77_C
 	double scale, offset, *values = NULL;
 	struct MGD77_E77_APPLY E;
 
-	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_READ_MODE)) return (-1);	/* Basically sets the path */
+	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_READ_MODE)) return (GMT_NOTSET);	/* Basically sets the path */
 
 	gmt_M_memset (apply_bits, MGD77_N_SETS, bool);
 	gmt_M_memset (&E, 1, struct MGD77_E77_APPLY);
@@ -2306,7 +2306,7 @@ static int mgd77_read_header_record_cdf (struct GMT_CTRL *GMT, char *file, struc
 	size_t count[2] = {0, 0}, length;
 	char name[32] = {""}, text[GMT_BUFSIZ] = {""};
 
-	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_READ_MODE)) return (-1);			/* Basically sets the path */
+	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_READ_MODE)) return (GMT_NOTSET);			/* Basically sets the path */
 
 	MGD77_nc_status (GMT, gmt_nc_open (GMT, F->path, NC_NOWRITE, &F->nc_id));	/* Open the file */
 
@@ -2338,7 +2338,7 @@ static int mgd77_read_header_record_cdf (struct GMT_CTRL *GMT, char *file, struc
 	/* DETERMINE DIMENSION OF GMT_TIME-SERIES */
 
 	MGD77_nc_status (GMT, nc_inq_unlimdim (F->nc_id, &F->nc_recid));		/* Get id of unlimited dimension */
-	if (F->nc_recid == -1) {	/* We are in deep trouble */
+	if (F->nc_recid == GMT_NOTSET) {	/* We are in deep trouble */
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No record dimension in file %s - cannot read contents\n", file);
 		return (MGD77_ERROR_NOT_MGD77PLUS);
 	}
@@ -2534,7 +2534,7 @@ static int mgd77_write_file_asc (struct GMT_CTRL *GMT, char *file, struct MGD77_
 	/* Will write all MGD77 records in current file */
 	int err = 0;
 
-	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_WRITE_MODE)) return (-1);
+	if (!F->path[0] && MGD77_Open_File (GMT, file, F, MGD77_WRITE_MODE)) return (GMT_NOTSET);
 	switch (F->format) {
 		case MGD77_FORMAT_TBL:
 			err = MGD77_Write_Header_Record_m77 (GMT, file, F, &S->H);  /* Will write the entire 24-section header structure */
@@ -3481,7 +3481,7 @@ int MGD77_Verify_Header (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct M
 		}
 		H->errors[kind]++;
 	}
-	i = -1;
+	i = GMT_NOTSET;
 	if (P->Magnetics_Ref_Field_Code[0] OR_TRUE) {
 		i = mgd77_atoi (P->Magnetics_Ref_Field_Code);
 		if ((!((i >= 0 && i <= MGD77_IGRF_LAST_ID) || i == 88)) OR_TRUE) {	/* MGD77_IGRF_LAST_ID is some future IGRF id, e.g., IGRF 2035! or whatever */
@@ -3511,7 +3511,7 @@ int MGD77_Verify_Header (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct M
 	yr1 = (H->meta.Departure[0]) ? H->meta.Departure[0] : atoi (P->Survey_Departure_Year);
 	yr2 = (H->meta.Arrival[0]) ? H->meta.Arrival[0] : atoi (P->Survey_Arrival_Year);
 
-	if (yr1 && yr2 && ref_field_code != -1 && ref_field_code != 99) {
+	if (yr1 && yr2 && ref_field_code != GMT_NOTSET && ref_field_code != 99) {
 		char m_model[16] = {""};
 		if (ref_field_code == 88) {
 			if (!strncmp(P->Magnetics_Ref_Field,"IGRF",4U)) {
@@ -3667,7 +3667,7 @@ int MGD77_Verify_Header (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct M
 			if (H->meta.ten_box[iy][ix] == 1) {
 				if (F->verbose_level & 2) fprintf (fp_err, "Y-W-%s-H16-06: Ten Degree Identifier %d not marked in header but block was crossed\n", F->NGDC_id, i);
 			}
-			else if (H->meta.ten_box[iy][ix] == -1) {
+			else if (H->meta.ten_box[iy][ix] == GMT_NOTSET) {
 				if (F->verbose_level & 2) fprintf (fp_err, "Y-W-%s-H16-06: Ten Degree Identifier %d marked in header but was not crossed\n", F->NGDC_id, i);
 			}
 		}
@@ -3881,7 +3881,7 @@ int MGD77_Select_Header_Item (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, cha
 
 	if (match == 0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No header item matched your string %s\n", item);
-		return -1;
+		return -GMT_NOTSET;
 	}
 	if (match > 1) {	/* More than one.  See if any of the multiple matches is a full name */
 		int n_exact;
@@ -4311,7 +4311,7 @@ GMT_LOCAL int mgd77_compare_L (const void *p1, const void *p2) {
 
 int MGD77_Path_Expand (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct GMT_OPTION *options, char ***list) {
 	/* Traverse the MGD77 directories in search of files matching the given arguments (or get all if none).
-	 * Returns -1 if unable to open a list file,
+	 * Returns GMT_NOTSET if unable to open a list file,
 	 * otherwise returns number of paths found */
 
 	int i;
@@ -4343,7 +4343,7 @@ int MGD77_Path_Expand (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct GMT
 		FILE *fp = NULL;
 		if ((fp = gmt_fopen (GMT, flist, "r")) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to open file list %s\n", flist);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		while (gmt_fgets (GMT, line, GMT_BUFSIZ, fp)) {
 			gmt_chop (line);	/* Get rid of CR/LF issues */
@@ -4365,7 +4365,7 @@ int MGD77_Path_Expand (struct GMT_CTRL *GMT, struct MGD77_CONTROL *F, struct GMT
 			if (opt->arg[0] == '=') continue;	/* Already dealt with file list */
 			/* Strip off any extension in case a user gave 12345678.mgd77 */
 			for (i = (int)strlen (opt->arg)-1; i >= 0 && opt->arg[i] != '.'; --i); /* Wind back to last period (or get i == -1) */
-			if (i == -1) {	/* No extension present */
+			if (i == GMT_NOTSET) {	/* No extension present */
 				strncpy (this_arg, opt->arg, GMT_BUFSIZ-1);
 				length = strlen (this_arg);
 				/* Test to determine if we are given NGDC IDs (2-,4-,8-char integer tags) or an arbitrary survey name */
@@ -4662,7 +4662,7 @@ int MGD77_carter_init (struct GMT_CTRL *GMT, struct MGD77_CARTER *C) {
 	/* This routine must be called once before using carter table stuff.
 	It reads the carter.d file and loads the appropriate arrays.
 	It sets carter_not_initialized = false upon successful completion
-	and returns 0.  If failure occurs, it returns -1.  */
+	and returns 0.  If failure occurs, it returns GMT_NOTSET.  */
 
 	FILE *fp = NULL;
 	char buffer [GMT_BUFSIZ] = {""};
@@ -4675,28 +4675,28 @@ int MGD77_carter_init (struct GMT_CTRL *GMT, struct MGD77_CARTER *C) {
 	gmt_getsharepath (GMT, "mgg", "carter", ".d", buffer, R_OK);
 	if ( (fp = fopen (buffer, "r")) == NULL) {
  		GMT_Report (GMT->parent, GMT_MSG_ERROR, "MGD77_carter_init: Cannot open r %s\n", buffer);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	for (i = 0; i < 5; i++) {	/* Skip 4 headers, read 1 line */
 		if (!fgets (buffer, GMT_BUFSIZ, fp)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure while reading Carter records\n");
         	fclose (fp);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 	}
 
 	if ((i = atoi (buffer)) != N_CARTER_CORRECTIONS) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "MGD77_carter_init: Incorrect correction key (%d), should be %d\n", i, N_CARTER_CORRECTIONS);
        	fclose (fp);
-		return(-1);
+		return(GMT_NOTSET);
 	}
 
 	for (i = 0; i < N_CARTER_CORRECTIONS; i++) {
 		if (!fgets (buffer, GMT_BUFSIZ, fp)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "MGD77_carter_init: Could not read correction # %d\n", i);
        		fclose (fp);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		C->carter_correction[i] = (short)atoi (buffer);
 	}
@@ -4707,21 +4707,21 @@ int MGD77_carter_init (struct GMT_CTRL *GMT, struct MGD77_CARTER *C) {
 		if (!fgets (buffer, GMT_BUFSIZ, fp)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure while reading Carter offset records\n");
        		fclose (fp);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 	}
 
 	if ((i = atoi (buffer)) != N_CARTER_OFFSETS) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "MGD77_carter_init: Incorrect offset key (%d), should be %d\n", i, N_CARTER_OFFSETS);
        	fclose (fp);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	for (i = 0; i < N_CARTER_OFFSETS; i++) {
 		if (!fgets (buffer, GMT_BUFSIZ, fp)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "MGD77_carter_init: Could not read offset # %d\n", i);
        		fclose (fp);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		C->carter_offset[i] = (short)atoi (buffer);
 	}
@@ -4732,21 +4732,21 @@ int MGD77_carter_init (struct GMT_CTRL *GMT, struct MGD77_CARTER *C) {
 		if (!fgets (buffer, GMT_BUFSIZ, fp)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure while reading Carter zone records\n");
        		fclose (fp);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 	}
 
 	if ((i = atoi (buffer)) != N_CARTER_BINS) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "MGD77_carter_init: Incorrect zone key (%d), should be %d\n", i, N_CARTER_BINS);
        	fclose (fp);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	for (i = 0; i < N_CARTER_BINS; i++) {
 		if (!fgets (buffer, GMT_BUFSIZ, fp)) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "MGD77_carter_init: Could not read offset # %d\n", i);
        		fclose (fp);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 		C->carter_zone[i] = (short)atoi (buffer);
 	}
@@ -4760,13 +4760,13 @@ int MGD77_carter_init (struct GMT_CTRL *GMT, struct MGD77_CARTER *C) {
 }
 
 int MGD77_carter_get_bin (struct GMT_CTRL *GMT, double lon, double lat, int *bin) {
-	/* Calculate Carter bin #.  Returns 0 if OK, -1 if error.  */
+	/* Calculate Carter bin #.  Returns 0 if OK, GMT_NOTSET if error.  */
 
 	int latdeg, londeg;
 
 	if (lat < -90.0 || lat > 90.0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in MGD77_carter_get_bin: Latitude domain error (%g)\n", lat);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 	while (lon >= 360.0) lon -= 360.0;
 	while (lon < 0.0) lon += 360.0;
@@ -4781,17 +4781,17 @@ int MGD77_carter_get_bin (struct GMT_CTRL *GMT, double lon, double lat, int *bin
 
 int MGD77_carter_get_zone (struct GMT_CTRL *GMT, int bin, struct MGD77_CARTER *C, int *zone) {
 	/* Sets value pointed to by zone to the Carter zone corresponding to
-		the bin "bin".  Returns 0 if successful, -1 if bin out of
+		the bin "bin".  Returns 0 if successful, GMT_NOTSET if bin out of
 		range.  */
 
 	if (!C->initialized && MGD77_carter_init(GMT, C) ) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in MGD77_carter_get_zone: Initialization failure.\n");
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	if (bin < 0 || bin >= N_CARTER_BINS) {
 		fprintf (GMT->session.std[GMT_ERR], "In MGD77_carter_get_zone: Input bin out of range [0-%d]: %d.\n", N_CARTER_BINS, bin);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 	*zone = C->carter_zone[bin];
 	return (MGD77_NO_ERROR);
@@ -4818,7 +4818,7 @@ int MGD77_carter_twt_from_xydepth (struct GMT_CTRL *GMT, double lon, double lat,
 int MGD77_carter_depth_from_twt (struct GMT_CTRL *GMT, int zone, double twt_in_msec, struct MGD77_CARTER *C, double *depth_in_corr_m) {
 	/* Given two-way travel time of echosounder in milliseconds, and
 		Carter Zone number, finds depth in Carter corrected meters.
-		Returns (0) if OK, -1 if error condition.  */
+		Returns (0) if OK, GMT_NOTSET if error condition.  */
 
 	int	i, nominal_z1500, low_hundred, part_in_100;
 
@@ -4828,15 +4828,15 @@ int MGD77_carter_depth_from_twt (struct GMT_CTRL *GMT, int zone, double twt_in_m
 	}
 	if (!C->initialized && MGD77_carter_init(GMT, C) ) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_depth_from_twt: Initialization failure.\n");
-		return (-1);
+		return (GMT_NOTSET);
 	}
 	if (zone < 1 || zone > N_CARTER_ZONES) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_depth_from_twt: Zone out of range [1-%d]: %d\n", N_CARTER_ZONES, zone);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 	if (twt_in_msec < 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_depth_from_twt: Negative twt: %g msec\n", twt_in_msec);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	nominal_z1500 = irint (0.75 * twt_in_msec);
@@ -4851,7 +4851,7 @@ int MGD77_carter_depth_from_twt (struct GMT_CTRL *GMT, int zone, double twt_in_m
 
 	if (i >= (C->carter_offset[zone] - 1) ) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_depth_from_twt: twt too big: %g msec\n", twt_in_msec);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	part_in_100 = irint (fmod ((double)nominal_z1500, 100.0));
@@ -4860,7 +4860,7 @@ int MGD77_carter_depth_from_twt (struct GMT_CTRL *GMT, int zone, double twt_in_m
 
 		if ( i == (C->carter_offset[zone] - 2) ) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_depth_from_twt: twt too big: %g msec\n", twt_in_msec);
-			return (-1);
+			return (GMT_NOTSET);
 		}
 
 		*depth_in_corr_m = (double)C->carter_correction[i] + 0.01 * part_in_100 * (C->carter_correction[i+1] - C->carter_correction[i]);
@@ -4876,7 +4876,7 @@ int MGD77_carter_depth_from_twt (struct GMT_CTRL *GMT, int zone, double twt_in_m
 int MGD77_carter_twt_from_depth (struct GMT_CTRL *GMT, int zone, double depth_in_corr_m, struct MGD77_CARTER *C, double *twt_in_msec) {
 	/*  Given Carter zone and depth in Carter corrected meters,
 	finds the two-way travel time of the echosounder in milliseconds.
-	Returns -1 upon error, 0 upon success.  */
+	Returns GMT_NOTSET upon error, 0 upon success.  */
 
 	int	min, max, guess;
 	double	fraction;
@@ -4887,15 +4887,15 @@ int MGD77_carter_twt_from_depth (struct GMT_CTRL *GMT, int zone, double depth_in
 	}
 	if (!C->initialized && MGD77_carter_init (GMT, C) ) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_twt_from_depth: Initialization failure.\n");
-		return (-1);
+		return (GMT_NOTSET);
 	}
 	if (zone < 1 || zone > N_CARTER_ZONES) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_twt_from_depth: Zone out of range [1-%d]: %d\n", N_CARTER_ZONES, zone);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 	if (depth_in_corr_m < 0.0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_twt_from_depth: Negative depth: %g m\n", depth_in_corr_m);
-		return(-1);
+		return(GMT_NOTSET);
 	}
 
 	if (depth_in_corr_m <= 100.0) {	/* No correction applies.  */
@@ -4908,7 +4908,7 @@ int MGD77_carter_twt_from_depth (struct GMT_CTRL *GMT, int zone, double depth_in
 
 	if (depth_in_corr_m > C->carter_correction[max]) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "In MGD77_carter_twt_from_depth: Depth too big: %g m.\n", depth_in_corr_m);
-		return (-1);
+		return (GMT_NOTSET);
 	}
 
 	if (depth_in_corr_m == C->carter_correction[max]) {	/* Hit last entry in table exactly  */

--- a/src/mgd77/mgd77track.c
+++ b/src/mgd77/mgd77track.c
@@ -695,7 +695,7 @@ EXTERN_MSC int GMT_mgd77track (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "Failure while reading header sequence for cruise %s\n", list[argno]);
 			continue;
 		}
-		last_julian = -1;
+		last_julian = GMT_NOTSET;
 
 		if (abs (Ctrl->A.mode) == 2)	/* Use MGD77 cruise ID */
 			strncpy (name, D->H.mgd77[use]->Survey_Identifier, GMT_LEN64-1);

--- a/src/nearneighbor.c
+++ b/src/nearneighbor.c
@@ -98,11 +98,11 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct NEARNEIGHBOR_CTRL *C) {	/* D
 }
 
 GMT_LOCAL struct NEARNEIGHBOR_NODE *nearneighbor_add_new_node (struct GMT_CTRL *GMT, unsigned int n) {
-	/* Allocate and initialize a new node to have -1 in all the n datum sectors */
+	/* Allocate and initialize a new node to have GMT_NOTSET in all the n datum sectors */
 	struct NEARNEIGHBOR_NODE *new_node = gmt_M_memory (GMT, NULL, 1U, struct NEARNEIGHBOR_NODE);
 	new_node->distance = gmt_M_memory (GMT, NULL, n, gmt_grdfloat);
 	new_node->datum = gmt_M_memory (GMT, NULL, n, int64_t);
-	while (n > 0) new_node->datum[--n] = -1;
+	while (n > 0) new_node->datum[--n] = GMT_NOTSET;
 
 	return (new_node);
 }
@@ -111,7 +111,7 @@ GMT_LOCAL void nearneighbor_assign_node (struct GMT_CTRL *GMT, struct NEARNEIGHB
 	/* Allocates node space if not already used and updates the value if closer to node than the current value */
 
 	if (!(*node)) *node = nearneighbor_add_new_node (GMT, n_sector);
-	if ((*node)->datum[sector] == -1 || (*node)->distance[sector] > distance) {
+	if ((*node)->datum[sector] == GMT_NOTSET || (*node)->distance[sector] > distance) {
 		(*node)->distance[sector] = (gmt_grdfloat)distance;
 		(*node)->datum[sector] = id;
 	}

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -1027,7 +1027,7 @@ EXTERN_MSC int GMT_pscoast (void *V_API, int mode, void *args) {
 	}
 	if (clip_to_extend_lines) gmt_map_clip_on (GMT, GMT->session.no_rgb, 3);
 
-	last_pen_level = -1;
+	last_pen_level = GMT_NOTSET;
 
 	if (clipping) PSL_beginclipping (PSL, xtmp, ytmp, 0, GMT->session.no_rgb, 1);	/* Start clippath */
 
@@ -1193,7 +1193,7 @@ EXTERN_MSC int GMT_pscoast (void *V_API, int mode, void *args) {
 
 		GMT_Report (API, GMT_MSG_INFORMATION, "Adding Rivers...");
 		if (!Ctrl->M.active) PSL_comment (PSL, "Start of River segments\n");
-		last_k = -1;
+		last_k = GMT_NOTSET;
 
 		for (ind = 0; ind < r.nb; ind++) {	/* Loop over necessary bins only */
 
@@ -1264,7 +1264,7 @@ EXTERN_MSC int GMT_pscoast (void *V_API, int mode, void *args) {
 
 		step = MAX (fabs(GMT->common.R.wesn[XLO] - GMT->common.R.wesn[XHI]), fabs (GMT->common.R.wesn[YHI] - GMT->common.R.wesn[YLO])) / 4.0;
 
-		last_k = -1;
+		last_k = GMT_NOTSET;
 
 		for (ind = 0; ind < b.nb; ind++) {	/* Loop over necessary bins only */
 

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -323,14 +323,14 @@ GMT_LOCAL void pscontour_sort_and_plot_ticks (struct GMT_CTRL *GMT, struct PSL_C
 
 		/* Now try to find a data point inside this contour */
 
-		for (j = 0, k = -1; k < 0 && j < nn; j++) {
+		for (j = 0, k = GMT_NOTSET; k == GMT_NOTSET && j < nn; j++) {
 			if (gmt_M_y_is_outside (GMT, y[j], ymin, ymax)) continue;	/* Outside y-range */
 			if (gmt_M_y_is_outside (GMT, x[j], xmin, xmax)) continue;	/* Outside x-range (YES, use gmt_M_y_is_outside since projected x-coordinates)*/
 
 			inside = gmt_non_zero_winding (GMT, x[j], y[j], save[pol].x, save[pol].y, np);
 			if (inside == 2) k = j;	/* OK, this point is inside */
 		}
-		if (k < 0) continue;	/* Unable to determine */
+		if (k == GMT_NOTSET) continue;	/* Unable to determine */
 		save[pol].high = (z[k] > save[pol].cval);
 
 		if (save[pol].high && !I->high) continue;	/* Do not tick highs */

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1948,14 +1948,14 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 
 		len = strlen (ps_file);
 		j = (unsigned int)len - 1;
-		pos_file = -1;
-		pos_ext = -1;	/* In case file has no extension */
+		pos_file = GMT_NOTSET;
+		pos_ext  = GMT_NOTSET;	/* In case file has no extension */
 		for (i = 0; i < len; i++, j--) {
-			if (pos_ext < 0 && ps_file[j] == '.') pos_ext = j;	/* Beginning of file extension */
-			if (pos_file < 0 && (ps_file[j] == '/' || ps_file[j] == '\\')) pos_file = j + 1;	/* Beginning of file name */
+			if (pos_ext == GMT_NOTSET && ps_file[j] == '.') pos_ext = j;	/* Beginning of file extension */
+			if (pos_file == GMT_NOTSET && (ps_file[j] == '/' || ps_file[j] == '\\')) pos_file = j + 1;	/* Beginning of file name */
 		}
-		if (pos_ext == -1) pos_ext = (unsigned int)len;	/* File has no extension */
-		if (!Ctrl->D.active || pos_file == -1) pos_file = 0;	/* File either has no leading directory or we want to use it */
+		if (pos_ext == GMT_NOTSET) pos_ext = (unsigned int)len;	/* File has no extension */
+		if (!Ctrl->D.active || pos_file == GMT_NOTSET) pos_file = 0;	/* File either has no leading directory or we want to use it */
 
 		/* Adjust to a tight BoundingBox if user requested so */
 

--- a/src/sphinterpolate.c
+++ b/src/sphinterpolate.c
@@ -89,7 +89,7 @@ GMT_LOCAL int sphinterpolate_get_args (struct GMT_CTRL *GMT, char *arg, double p
 	m = sscanf (arg, "%[^/]/%[^/]/%s", txt_a, txt_b, txt_c);
 	if (m < 1) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "%s\n", msg);
-		m = -1;
+		m = GMT_NOTSET;
 	}
 	par[0] = atof (txt_a);
 	if (m >= 2) par[1] = atof (txt_b);

--- a/src/spotter/backtracker.c
+++ b/src/spotter/backtracker.c
@@ -387,7 +387,7 @@ static int parse (struct GMT_CTRL *GMT, struct BACKTRACKER_CTRL *Ctrl, struct GM
 #define SPOTTER_FWD  +1
 
 GMT_LOCAL int backtracker_spotter_track (struct GMT_CTRL *GMT, int way, double xp[], double yp[], double tp[], unsigned int np, struct EULER p[], unsigned int ns, double d_km, double t_zero, unsigned int time_flag, double wesn[], double **c) {
-	int n = -1;
+	int n = GMT_NOTSET;
 	/* Call either spotter_forthtrack (way = 1) or spotter_backtrack (way = -1) */
 
 	switch (way) {

--- a/src/spotter/grdspotter.c
+++ b/src/spotter/grdspotter.c
@@ -424,7 +424,7 @@ GMT_LOCAL int64_t grdspotter_get_flowline (struct GMT_CTRL *GMT, double xx, doub
 
 	/* Find the first point on the flowline inside the desired CVA region */
 
-	for (m = 0, ky = 2, first = -1; m < n_track && first == -1; m++, ky += step) {	/* For each point along flowline */
+	for (m = 0, ky = 2, first = GMT_NOTSET; m < n_track && first == GMT_NOTSET; m++, ky += step) {	/* For each point along flowline */
 		if (c[ky] < wesn[YLO] || c[ky] > wesn[YHI]) continue;	/* Latitude outside region */
 		kx = ky - 1;						/* Index for the x-coordinate */
 		while (c[kx] > wesn[XHI]) c[kx] -= TWO_PI;		/* Elaborate W/E test because of 360 periodicity */
@@ -440,7 +440,7 @@ GMT_LOCAL int64_t grdspotter_get_flowline (struct GMT_CTRL *GMT, double xx, doub
 
 	/* Here we know searching from the end will land inside the grid eventually so last can never exit as -1 */
 
-	for (m = n_track - 1, ky = step * m + 2, last = -1; m >= 0 && last == -1; m--, ky -= step) {	/* For each point along flowline */
+	for (m = n_track - 1, ky = step * m + 2, last = GMT_NOTSET; m >= 0 && last == GMT_NOTSET; m--, ky -= step) {	/* For each point along flowline */
 		if (c[ky] < wesn[YLO] || c[ky] > wesn[YHI]) continue;	/* Latitude outside region */
 		kx = ky - 1;						/* Index for the x-coordinate */
 		while (c[kx] > wesn[XHI]) c[kx] -= TWO_PI;		/* Elaborate W/E test because of 360 periodicity */

--- a/src/spotter/spotter.c
+++ b/src/spotter/spotter.c
@@ -1416,9 +1416,9 @@ bool spotter_conf_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double 
 
 	/* Find the unique rotation in question */
 
-	for (i = 0, k = -1; k < 0 && i < np; ++i) if (doubleAlmostEqualZero (p[i].t_start, t))
+	for (i = 0, k = GMT_NOTSET; k < 0 && i < np; ++i) if (doubleAlmostEqualZero (p[i].t_start, t))
 		k = i;
-	if (k == -1) return (true);	/* Did not match finite rotation time */
+	if (k == GMT_NOTSET) return (true);	/* Did not match finite rotation time */
 
 	/* Make M(x), the skew-symmetric matrix needed to compute cov of rotated point */
 

--- a/src/x2sys/x2sys.c
+++ b/src/x2sys/x2sys.c
@@ -327,7 +327,7 @@ int x2sys_initialize (struct GMT_CTRL *GMT, char *TAG, char *fname, struct GMT_I
 	X->TAG = strdup (TAG);
 	X->info = gmt_M_memory (GMT, NULL, n_alloc, struct X2SYS_DATA_INFO);
 	X->file_type = X2SYS_ASCII;
-	X->x_col = X->y_col = X->t_col = -1;
+	X->x_col = X->y_col = X->t_col = GMT_NOTSET;
 	X->ms_flag = '>';	/* Default multisegment header flag */
 	sprintf (line, "%s/%s.%s", TAG, fname, X2SYS_FMT_EXT);
 	X->dist_flag = 0;	/* Cartesian distances */

--- a/src/x2sys/x2sys_binlist.c
+++ b/src/x2sys/x2sys_binlist.c
@@ -371,7 +371,7 @@ EXTERN_MSC int GMT_x2sys_binlist (void *V_API, int mode, void *args) {
 
 		last_bin_index = UINT_MAX;
 		last_not_set = true;
-		last_bin_col = last_bin_row = -1;
+		last_bin_col = last_bin_row = GMT_NOTSET;
 		for (row = 0; row < p.n_rows; row++) {
 			if (x2sysbinlist_outside (data[s->x_col][row], data[s->y_col][row], &B, s->geographic)) continue;
 			if (x2sys_err_fail (GMT, x2sys_bix_get_index (GMT, data[s->x_col][row], data[s->y_col][row], &this_bin_col,

--- a/src/x2sys/x2sys_datalist.c
+++ b/src/x2sys/x2sys_datalist.c
@@ -235,7 +235,7 @@ EXTERN_MSC int GMT_x2sys_datalist (void *V_API, int mode, void *args) {
 	char **trk_name = NULL, **ignore = NULL;
 	char fmt_record[GMT_BUFSIZ] = {""};
 
-	int error = 0, this_col, xpos = -1, ypos = -1, tpos = -1;
+	int error = 0, this_col, xpos = GMT_NOTSET, ypos = GMT_NOTSET, tpos = GMT_NOTSET;
 	bool cmdline_files, gmt_formatting = false, skip, *adj_col = NULL;
 	unsigned int ocol, bad, n_data_col_out = 0, k, n_ignore = 0, cmode;
 	uint64_t row, trk_no, n_tracks;


### PR DESCRIPTION
We have lots of -1 in the code.  Sometimes it is a sign, sometimes is is a counter that will be incremented to 0, etc.  But often it is a return value that means not set.  We use **GMT_NOTSET** for this, but not everywhere.  To make the code more readable I have replaced lots of -1 when I am sure they mean not set.
