### PR TITLE
Must distribute gmt_common_sighandler.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -664,7 +664,7 @@ if (BUILD_DEVELOPER)
 	install (FILES postscriptlight.h gmt_common_math.h gmt_common_string.h gmt_common.h gmt_constants.h gmt_contour.h
 		gmt_dcw.h gmt_decorate.h gmt_defaults.h gmt_error.h gmt_error_codes.h gmt_fft.h gmt_gdalread.h gmt_grd.h
 		gmt_grdio.h gmt_hash.h gmt_io.h gmt_macros.h gmt_memory.h gmt_modern.h gmt_nan.h gmt_notposix.h gmt_plot.h
-		gmt_private.h gmt_project.h gmt_prototypes.h gmt_psl.h gmt_shore.h gmt_symbol.h gmt_synopsis.h
+		gmt_private.h gmt_project.h gmt_prototypes.h gmt_psl.h gmt_shore.h gmt_common_sighandler.h gmt_symbol.h gmt_synopsis.h
 		gmt_texture.h gmt_time.h gmt_types.h gmt_dev.h gmt_customio.h gmt_hidden.h gmt_mb.h gmt_remote.h
 		DESTINATION ${GMT_INCLUDEDIR}
 		COMPONENT Runtime)


### PR DESCRIPTION
Due to the changes related to checking for Ctrl-C we now include _gmt_common_sighandler.h_ from _gmt_dev.h_. However, we forgot to add it to the CMakeLists.txt entry for which include files should go into include/gmt.  I learned this the hard way when **mbsystem** failed to compile.
