### PR TITLE
Prevent warnings of w/e/s/n rounding if obtained via DCW

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2450,8 +2450,8 @@ int gmtlib_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GR
 }
 
 int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_HEADER *header) {
-	/* Most places we wish to warn if w/e/s/n is sloppy */
-	return gmtlib_adjust_loose_wesn (GMT, wesn, header, GMT_MSG_WARNING);
+	/* Most places we wish to warn if w/e/s/n is sloppy except when via DCW that must be rounded */
+	return gmtlib_adjust_loose_wesn (GMT, wesn, header, GMT->common.R.via_polygon ? GMT_MSG_INFORMATION : GMT_MSG_WARNING);
 }
 
 void gmt_scale_and_offset_f (struct GMT_CTRL *GMT, gmt_grdfloat *data, size_t length, double scale, double offset) {

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8660,6 +8660,7 @@ int gmt_parse_R_option (struct GMT_CTRL *GMT, char *arg) {
 	 * -Rg|d as global shorthand for 0/360/-90/90 or -180/180/-90/90
 	 * -R[L|C|R][B|M|T]<x0>/<y0>/<n_columns>/<n_rows>
 	 * -R[g|d]w/e/s/n[/z0/z1][+r]
+	 * -R<countrycodes>
 	 */
 
 	length = strlen (item) - 1;


### PR DESCRIPTION
When we use the DCW data to get a region (e.g., **-RNO**) and this is used for getting a grid subset, we should not give nasty warnings about the w/e/s/n not being multiples of increments, like here:

```
$ gmt grdcut -RNO -Gno.nc @earth_relief_30m
grdcut [WARNING]: (w - x_min) must equal (NX + eps) * x_inc), where NX is an integer and |eps| <= 0.0001.
grdcut [WARNING]: w reset from -9.079889 to -9.5
grdcut [WARNING]: (e - x_min) must equal (NX + eps) * x_inc), where NX is an integer and |eps| <= 0.0001.
grdcut [WARNING]: e reset from 33.497093 to 34
grdcut [WARNING]: (s - y_min) must equal (NY + eps) * y_inc), where NY is an integer and |eps| <= 0.0001.
grdcut [WARNING]: s reset from 57.966579 to 57.5
grdcut [WARNING]: (n - y_min) must equal (NY + eps) * y_inc), where NY is an integer and |eps| <= 0.0001.
grdcut [WARNING]: n reset from 80.834053 to 81.5
```

Since the w/e/s/n is obtained _indirectly_ and not immediately known to the user, it is considered a different situation than when a user gives incompatible w/e/s/n _directly_, like -R-9.079889/33.497093/57.966579/80.834053.  For **-RNO** and similar cases, this message should instead be considered **INFORMATION** and only shown if **-Vi** has been set.  This PR makes that distinction.

This PR has no effect on tests.