### PR TITLE
Let psconvert -W+g switch to lossless PNG as intermediate format

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -985,8 +985,9 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 			Ctrl->H.active = false;
 	}
 
-	if (!Ctrl->T.active) Ctrl->T.device = GS_DEV_JPG;	/* Default output device if none is specified */
-
+	if (!Ctrl->T.active) {	/* Set default output device if none is specified */
+		Ctrl->T.device = (Ctrl->W.warp) ? GS_DEV_PNG : GS_DEV_JPG;	/* Lossless PNG if we are making a geotiff in the end */
+	}
 	if (Ctrl->T.device > GS_DEV_SVG) {	/* Raster output, apply default -Q for rasters unless already specified */
 		/* For rasters, we should always add -Qt4 unless -Q was set manually.  This will improve the rasterization of text */
 		if (!Ctrl->Q.on[PSC_TEXT]) {	/* Only override if not set */
@@ -2781,6 +2782,8 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 					GMT_Report (API, GMT_MSG_ERROR, "System call [%s] returned error %d.\n", cmd, sys_retval);
 					Return (GMT_RUNTIME_ERROR);
 				}
+				if (!Ctrl->T.active)	/* Get rid of the intermediate JPG file if -T was not set */
+					gmt_remove_file (GMT, out_file);
 			}
 			else if (Ctrl->W.warp && !proj4_cmd)
 				GMT_Report (API, GMT_MSG_ERROR, "Could not find the Proj4 command in the PS file. No conversion performed.\n");


### PR DESCRIPTION
See #5807 for background.  I changed my mind a bit and simply switch to PNG when **-W+g** is set and no **-T** is given.  We then delete the unrequested PNG file at the end.  This bypasses any lossy intermediate format.

@joa-quim, if you wish to modify the current **gdal_translate** call to use **grdgdal** instead then please make those edits - I am not sure how that works.  Alternatively, approve for now and do it later (maybe make an issue request as a reminder).
