### PR TITLE
Add geos to install-dependencies-macos.sh

### DIFF
--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -17,7 +17,7 @@ PACKAGE="${PACKAGE:-false}"
 
 # packages for compiling GMT
 # cmake is pre-installed on GitHub Actions
-packages="ninja curl pcre2 netcdf gdal fftw ghostscript"
+packages="ninja curl pcre2 netcdf gdal geos fftw ghostscript"
 
 # packages for build documentation
 if [ "$BUILD_DOCS" = "true" ]; then


### PR DESCRIPTION
**Description of proposed changes**

The macOS docs build is failing due to a problem with GEOS (https://github.com/GenericMappingTools/gmt/runs/4157819081?check_suite_focus=true). This PR adds GEOS as an explicit dependency to try to resolve the issue.

Probably should to the same for install-dependencies-linux.sh and install-dependencies-windows.sh, but I am not sure which specific package should be added based on https://trac.osgeo.org/geos/#Binaries.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
