### PR TITLE
Handle deprecation of function for MB-system

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -48,7 +48,7 @@
  *  gmt_check_z_io:     Fill in implied missing row/column
  * gmt_set_geographic
  * gmt_set_cartesian
- * gmt_input_is_nan_proxy
+ * gmt_input_col_is_nan_proxy
  * gmtlib_write_tableheader
  * gmt_fgets
  * gmt_skip_xy_duplicates
@@ -3661,7 +3661,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 			else				/* Default column order */
 				col_pos = col_no;
 			n_convert = gmt_scanf (GMT, token, gmt_M_type (GMT, GMT_IN, col_pos), &val);
-			if (n_convert != GMT_IS_NAN && gmt_input_is_nan_proxy (GMT, val, col_pos))	/* Input matched no-data setting, so change to NaN */
+			if (n_convert != GMT_IS_NAN && gmt_input_col_is_nan_proxy (GMT, val, col_pos))	/* Input matched no-data setting, so change to NaN */
 				n_convert = GMT_IS_NAN;
 			if (n_convert == GMT_IS_NAN) {	/* Got a NaN or it failed to decode the string */
 				if (GMT->current.setting.io_nan_records || !GMT->current.io.skip_if_NaN[col_pos]) {	/* This field (or all fields) can be NaN so we pass it on */
@@ -4321,7 +4321,7 @@ void gmt_set_cartesian (struct GMT_CTRL *GMT, unsigned int dir) {
 /*! Handles non-proxy checking for input z values.  If the input value equals
  * the non_proxy then we return true so the value can be replaced by a NaN.
  */
-bool gmt_input_is_nan_proxy (struct GMT_CTRL *GMT, double value, unsigned int col) {
+bool gmt_input_col_is_nan_proxy (struct GMT_CTRL *GMT, double value, unsigned int col) {
 	if (!GMT->common.d.active[GMT_IN]) return false;	/* Not active */
 	if (col < GMT->common.d.first_col[GMT_IN]) return false;	/* Not in column range */
 
@@ -4613,7 +4613,7 @@ int gmtlib_process_binary_input (struct GMT_CTRL *GMT, uint64_t n_read) {
 	/* Determine if this was a segment header, and if so return */
 	for (col_no = n_NaN = 0; col_no < n_read; col_no++) {
 		if (!gmt_M_is_dnan (GMT->current.io.curr_rec[col_no])) {	/* Clean data */
-			if (gmt_input_is_nan_proxy (GMT, GMT->current.io.curr_rec[col_no], col_no))	/* Input matched no-data setting, so change to NaN */
+			if (gmt_input_col_is_nan_proxy (GMT, GMT->current.io.curr_rec[col_no], col_no))	/* Input matched no-data setting, so change to NaN */
 				GMT->current.io.curr_rec[col_no] = GMT->session.d_NaN;
 			else if (GMT->common.i.select)	/* Cannot check here, done in gmtio_bin_colselect instead when order is set */
 				continue;

--- a/src/gmt_mb.h
+++ b/src/gmt_mb.h
@@ -32,6 +32,6 @@
 #define gmt_M_grd_is_global gmt_grd_is_global
 #define GMT_c_OPT	"-c<ncopies>"	/* OBSOLETE */
 
-#define gmt_input_is_nan_proxy (GMT,value) gmt_input_col_is_nan_proxy (GMT,value,0)    /* Deprecated in GMT 6.3.0 */
+#define gmt_input_is_nan_proxy(GMT,value) gmt_input_col_is_nan_proxy(GMT,value,0)    /* Deprecated in GMT 6.3.0 */
 
 #endif /* GMT_MB_H */

--- a/src/gmt_mb.h
+++ b/src/gmt_mb.h
@@ -32,4 +32,6 @@
 #define gmt_M_grd_is_global gmt_grd_is_global
 #define GMT_c_OPT	"-c<ncopies>"	/* OBSOLETE */
 
+#define gmt_input_is_nan_proxy (GMT,value) gmt_input_col_is_nan_proxy (GMT,value,0)    /* Deprecated in GMT 6.3.0 */
+
 #endif /* GMT_MB_H */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -332,7 +332,7 @@ EXTERN_MSC int gmt_remove_file (struct GMT_CTRL *GMT, const char *file);
 EXTERN_MSC int gmt_rename_file (struct GMT_CTRL *GMT, const char *oldfile, const char *newfile, unsigned int mode);
 EXTERN_MSC void gmt_format_abstime_output (struct GMT_CTRL *GMT, double dt, char *text);
 EXTERN_MSC int gmt_ascii_output_col (struct GMT_CTRL *GMT, FILE *fp, double x, uint64_t col);
-EXTERN_MSC bool gmt_input_is_nan_proxy (struct GMT_CTRL *GMT, double value, unsigned int col);
+EXTERN_MSC bool gmt_input_col_is_nan_proxy (struct GMT_CTRL *GMT, double value, unsigned int col);
 EXTERN_MSC bool gmt_is_a_blank_line (char *line);
 EXTERN_MSC void gmt_set_geographic (struct GMT_CTRL *GMT, unsigned int dir);
 EXTERN_MSC void gmt_set_cartesian (struct GMT_CTRL *GMT, unsigned int dir);

--- a/src/grd2xyz.c
+++ b/src/grd2xyz.c
@@ -550,7 +550,7 @@ EXTERN_MSC int GMT_grd2xyz (void *V_API, int mode, void *args) {
 				if ((io.x_missing && io.gmt_i == io.x_period) || (io.y_missing && io.gmt_j == 0)) continue;
 				if (GMT->common.d.active[GMT_OUT] && gmt_M_is_dnan (d_value))	/* Grid node is NaN and -d was set, so change to nan-proxy */
 					d_value = GMT->common.d.nan_proxy[GMT_OUT];
-				else if (gmt_input_is_nan_proxy (GMT, d_value, GMT_X))	/* The inverse: Grid node is nan-proxy and -di was set, so change to NaN */
+				else if (gmt_input_col_is_nan_proxy (GMT, d_value, GMT_X))	/* The inverse: Grid node is nan-proxy and -di was set, so change to NaN */
 					d_value = GMT->session.d_NaN;
 				write_error = GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 				if (write_error == GMT_NOTSET) n_suppressed++;	/* Bad value caught by -s[r] */
@@ -774,14 +774,14 @@ EXTERN_MSC int GMT_grd2xyz (void *V_API, int mode, void *args) {
 					out[GMT_Y] = G->data[ij];
 					if (GMT->common.d.active[GMT_OUT] && gmt_M_is_dnan (out[GMT_Y]))	/* Input matched no-data setting, so change to NaN */
 						out[GMT_Y] = GMT->common.d.nan_proxy[GMT_OUT];
-					else if (gmt_input_is_nan_proxy (GMT, out[GMT_Y], GMT_Y))
+					else if (gmt_input_col_is_nan_proxy (GMT, out[GMT_Y], GMT_Y))
 						out[GMT_Y] = GMT->session.d_NaN;
 				}
 				else {
 					out[GMT_X] = x[col];	out[GMT_Y] = y[row];	out[GMT_Z] = G->data[ij];
 					if (GMT->common.d.active[GMT_OUT] && gmt_M_is_dnan (out[GMT_Z]))	/* Input matched no-data setting, so change to NaN */
 						out[GMT_Z] = GMT->common.d.nan_proxy[GMT_OUT];
-					else if (gmt_input_is_nan_proxy (GMT, out[GMT_Z], GMT_Z))
+					else if (gmt_input_col_is_nan_proxy (GMT, out[GMT_Z], GMT_Z))
 						out[GMT_Z] = GMT->session.d_NaN;
 				}
 				if (Ctrl->W.area) out[w_col] = W->data[ij] * A_scale;	/* Converts area from km^2 to user-selected unit (if active) */

--- a/src/xyz2grd.c
+++ b/src/xyz2grd.c
@@ -641,7 +641,7 @@ EXTERN_MSC int GMT_xyz2grd (void *V_API, int mode, void *args) {
 				Return (GMT_RUNTIME_ERROR);
 			}
 			ij_gmt = io.get_gmt_ij (&io, Grid, ij);	/* Convert input order to output node (with padding) as per -Z */
-			Grid->data[ij_gmt] = (gmt_input_is_nan_proxy (GMT, in[zcol], zcol)) ? GMT->session.f_NaN : (gmt_grdfloat)in[zcol];
+			Grid->data[ij_gmt] = (gmt_input_col_is_nan_proxy (GMT, in[zcol], zcol)) ? GMT->session.f_NaN : (gmt_grdfloat)in[zcol];
 			ij++;
 		}
 		else {	/* Get x, y, z */


### PR DESCRIPTION
See #5966 for background.  Solution is to rename the function and add a backwards compatible macro for the old function in gmt_mb.h to handle this change. We just pass col = 0 sa the missing third argument since any column checking was dong outside the function before 6.3.0.
