### PR TITLE
Let gmtget refresh server for -Dcache too

### DIFF
--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -213,6 +213,8 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 
 
 	if (Ctrl->D.active) {	/* Remote data download */
+		gmt_refresh_server (API);	/* Refresh hash and info tables as needed since we need to know what is there */
+
 		if (!strncmp (Ctrl->D.dir, "all", 3U) || !strncmp (Ctrl->D.dir, "data", 4U)) {	/* Want data */
 			bool found;
 			int k;
@@ -221,8 +223,6 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 			char planet[GMT_LEN32] = {""}, group[GMT_LEN32] = {""}, dataset[GMT_LEN64] = {""}, size[GMT_LEN32] = {""}, message[GMT_LEN256] = {""};
 			double world[4] = {-180.0, +180.0, -90.0, +90.0};
 			struct GMT_RECORD *Out = NULL;
-
-			gmt_refresh_server (API);	/* Refresh hash and info tables as needed since we need to know what is there */
 
 			if (Ctrl->Q.active) {	/* Must activate data output machinery for a DATASET with no numerical columns */
 				Out = gmt_new_record (GMT, NULL, message);


### PR DESCRIPTION
The server refresh call only happened for data downloads but the cache section also needs to know the hash table for the cache files.  Closes #5976.