### PR TITLE
Remember tile registration and increment

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15511,7 +15511,8 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 						GMT->session.unit_name[GMT->current.setting.proj_length_unit], GMT->current.setting.graphics_dpu, GMT->current.setting.graphics_dpu_unit, this_n_per_degree, opt->arg, file);
 					gmt_M_str_free (opt->arg);
 					opt->arg = strdup (file);
-					d_inc = API->remote_info[k_data2].d_inc;
+					API->tile_inc = d_inc = API->remote_info[k_data2].d_inc;
+					API->tile_reg = API->remote_info[k_data2].reg;
 					strncpy (s_inc, API->remote_info[k_data2].inc, GMT_LEN8);
 					inc_set = true;
 					gmt_M_memcpy (wesn, GMT->common.R.wesn, 4, double);

--- a/test/grdimage/autoresgrid.sh
+++ b/test/grdimage/autoresgrid.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Ensure that the automatic detection of suitable grid resolution works
+# The -R -J and DPU below will request the earth_relief_05m_p tiles.
+
+ps=autoresgrid.ps
+gmt grdimage @earth_relief -Rd -JG13.0550/47.8095/15c+z12000+v60 --GMT_GRAPHICS_DPU=80c > $ps

--- a/test/grdimage/autoresgrid.sh
+++ b/test/grdimage/autoresgrid.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Ensure that the automatic detection of suitable grid resolution works
-# The -R -J and DPU below will request the earth_relief_05m_p tiles.
+# The -R -J and DPU below will request two earth_relief_05m_p tiles.
 
 ps=autoresgrid.ps
-gmt grdimage @earth_relief -Rd -JG13.0550/47.8095/15c+z12000+v60 --GMT_GRAPHICS_DPU=80c > $ps
+gmt grdimage @earth_relief -R-20/20/0/40 -JM10c --GMT_GRAPHICS_DPU=40c -P > $ps


### PR DESCRIPTION
We had a regression on this.  When I started to create the grid headers only based on internal information about a tiled data set, I forgot to update a few places in gmt_init.c so that the increment and registration was stored in the API structure.  This PR addresses this shortcoming.  I also added a small test to make sure this is stable.
