### PR TITLE
Let project -G accept increment unit and +n modifier

### DIFF
--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -14,13 +14,13 @@ Synopsis
 
 **gmt project** [ *table* ] |-C|\ *cx*/*cy* [ |-A|\ *azimuth* ]
 [ |-E|\ *bx*/*by* ] [ |-F|\ *flags* ]
-[ |-G|\ *dist*\ [/*colat*][**+c**\|\ **h**] ]
+[ |-G|\ *dist*\ [*unit*] [/*colat*][**+c**][**+h**][**+n**] ]
 [ |-L|\ [**w**\|\ *lmin*/*lmax*] ]
 [ |-N| ] [ |-Q| ] [ |-S| ]
 [ |-T|\ *px*/*py* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *wmin*/*wmax* ]
-[ |-Z|\ *major*\ [*unit*][/*minor*/*azimuth*][**+e**\|\ **n**] ]
+[ |-Z|\ *major*\ [*unit*][/*minor*/*azimuth*][**+e**] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
 [ |SYN_OPT-e| ]
@@ -150,10 +150,10 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *dist*\ [/*colat*][**+c**\|\ **h**]
+**-G**\ *dist*\ [*unit*] [/*colat*][**+c**][**+h**][**+n**]
     Create (*r*, *s*, *p*) output points every *dist* units of *p*, assuming all units are the same unless
-    :math:`x, y, r, s` are set to degrees using |-Q|. No input is read when |-G| is used. The following directives
-    and modifiers are supported:
+    :math:`x, y, r, s` are set to degrees using |-Q|. No input is read when |-G| is used. See `Units`_ for
+    geographic distance units [km]. The following directives and modifiers are supported:
 
     - Optionally, append /*colat* for a small circle instead [Default is a colatitude of 90, i.e., a great circle]. Note,
       when using |-C| and |-E| to generate a circle that goes through the center and end point, the center and end point
@@ -162,6 +162,7 @@ Optional Arguments
       going through the center *cx*/*cy*.
     - Optionally, append **+h** to report the position of the pole as part of the segment header when using |-T|
       [Default is no header].
+    - Optionally, append **+n** to indicate a desired number of points rather than increment. Requires |-C| and |-E|.
 
 .. _-L:
 
@@ -206,7 +207,7 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *major*\ [*unit*][/*minor*/*azimuth*][**+e**\|\ **n**]
+**-Z**\ *major*\ [*unit*][/*minor*/*azimuth*][**+e**]
     Create the coordinates of an ellipse with *major* and *minor* axes given in km (unless |-N| is given for a
     Cartesian ellipse) and the *azimuth* of the major axis in degrees; used in conjunction with |-C| (sets its center)
     and |-G| (sets the distance increment). **Note**: For the Cartesian ellipse (which requires |-N|), we expect
@@ -217,7 +218,6 @@ Optional Arguments
 
     - Append **+e** to adjust the increment set via |-G| so that the ellipse has equal distance increments [Default
       uses the given increment and closes the ellipse].
-    - Append **+n** to set a specific number of unique equidistant points via |-G|.
 
 .. |Add_-bi| replace:: [Default is 2 input columns].
 .. include:: explain_-bi.rst_

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-A|\ *azimuth* ]
 [ |-E|\ *bx*/*by* ]
 [ |-F|\ *flags* ]
-[ |-G|\ *dist*\ [*unit*] [/*colat*][**+c**][**+h**][**+n**] ]
+[ |-G|\ *dist*\ [*unit*][/*colat*][**+c**][**+h**][**+n**] ]
 [ |-L|\ [**w**\|\ *lmin*/*lmax*] ]
 [ |-N| ]
 [ |-Q| ]
@@ -155,7 +155,7 @@ Optional Arguments
 
 .. _-G:
 
-**-G**\ *dist*\ [*unit*] [/*colat*][**+c**][**+h**][**+n**]
+**-G**\ *dist*\ [*unit*][/*colat*][**+c**][**+h**][**+n**]
     Create (*r*, *s*, *p*) output points every *dist* units of *p*, assuming all units are the same unless
     :math:`x, y, r, s` are set to degrees using |-Q|. No input is read when |-G| is used. See `Units`_ for
     selecting geographic distance units [km]. The following directives and modifiers are supported:
@@ -167,7 +167,8 @@ Optional Arguments
       going through the center *cx*/*cy*.
     - Optionally, append **+h** to report the position of the pole as part of the segment header when using |-T|
       [Default is no header].
-    - Optionally, append **+n** to indicate a desired number of points rather than an increment. Requires |-C| and |-E|, or |-Z|.
+    - Optionally, append **+n** to indicate a desired number of points rather than an increment. Requires |-C| and |-E| or |-Z|
+      so that a length can be computed.
 
 .. _-L:
 

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -12,11 +12,16 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt project** [ *table* ] |-C|\ *cx*/*cy* [ |-A|\ *azimuth* ]
-[ |-E|\ *bx*/*by* ] [ |-F|\ *flags* ]
+**gmt project** [ *table* ]
+|-C|\ *cx*/*cy*
+[ |-A|\ *azimuth* ]
+[ |-E|\ *bx*/*by* ]
+[ |-F|\ *flags* ]
 [ |-G|\ *dist*\ [*unit*] [/*colat*][**+c**][**+h**][**+n**] ]
 [ |-L|\ [**w**\|\ *lmin*/*lmax*] ]
-[ |-N| ] [ |-Q| ] [ |-S| ]
+[ |-N| ]
+[ |-Q| ]
+[ |-S| ]
 [ |-T|\ *px*/*py* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *wmin*/*wmax* ]
@@ -153,7 +158,7 @@ Optional Arguments
 **-G**\ *dist*\ [*unit*] [/*colat*][**+c**][**+h**][**+n**]
     Create (*r*, *s*, *p*) output points every *dist* units of *p*, assuming all units are the same unless
     :math:`x, y, r, s` are set to degrees using |-Q|. No input is read when |-G| is used. See `Units`_ for
-    geographic distance units [km]. The following directives and modifiers are supported:
+    selecting geographic distance units [km]. The following directives and modifiers are supported:
 
     - Optionally, append /*colat* for a small circle instead [Default is a colatitude of 90, i.e., a great circle]. Note,
       when using |-C| and |-E| to generate a circle that goes through the center and end point, the center and end point
@@ -162,7 +167,7 @@ Optional Arguments
       going through the center *cx*/*cy*.
     - Optionally, append **+h** to report the position of the pole as part of the segment header when using |-T|
       [Default is no header].
-    - Optionally, append **+n** to indicate a desired number of points rather than increment. Requires |-C| and |-E|.
+    - Optionally, append **+n** to indicate a desired number of points rather than an increment. Requires |-C| and |-E|, or |-Z|.
 
 .. _-L:
 

--- a/src/project.c
+++ b/src/project.c
@@ -857,7 +857,7 @@ EXTERN_MSC int GMT_project (void *V_API, int mode, void *args) {
 				L = hypot (Ctrl->C.x - Ctrl->E.x, Ctrl->C.y - Ctrl->E.y);
 			Ctrl->G.inc = L / (Ctrl->G.inc - 1.0);
 		}
-		else if (gmt_M_is_geographic (GMT, GMT_IN) && Ctrl->G.unit != 'k')
+		else if (Ctrl->Q.active && Ctrl->G.unit != 'k')
 			Ctrl->G.inc *= 0.001 / GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in km */
 	}
 	else if (!Ctrl->N.active) {	/* Decode and set the various output column types in the geographic case */

--- a/test/project/ellipses.sh
+++ b/test/project/ellipses.sh
@@ -6,5 +6,5 @@
 
 gmt begin ellipses ps
 	gmt project -N -Z4/3/0+e -G0.1 -C2/1 | gmt plot -R-2/5/-2/5 -Jx1.5c -Bafg1 -W1p -Glightgray
-	gmt project -Z400/300/0+e -G10 -C2/1 | gmt plot -Jm1.5c -Bafg1 -W1p -Glightgray -Y13c
+	gmt project -Z400/300/0+e -G10 -C2/1 -Q | gmt plot -Jm1.5c -Bafg1 -W1p -Glightgray -Y13c
 gmt end show


### PR DESCRIPTION
**Description of proposed changes**

The distance increment set in **project** has long been required to be in km, whereas most places in GMT we can specify what unit we want (e.g., 30n for 30 nautical miles or 2d for 2 spherical degrees) but not so in **project**.  We were also unable to specify the _number of points_, which is pretty handy when you give a start and stop point and want to generate intermediate points. Thus, this PR:

1. Adds the capability of providing the increment with the desired unit appended
2. Adds modifier **+n** to indicate that the increment is number of points instead (which requires either **-C** and **-E** or **-Z**).
3. Removes **+n** from **-Z** but in a backwards compatible way.

All tests pass except an undetected error in ellipses.sh where **-Q** was not passed so **-G**10 was interpreted (as it should be) as degrees.  The script was updated to use **-Q**.
