### PR TITLE
pstext -Dj cannot be used with -M

### DIFF
--- a/doc/rst/source/text.rst
+++ b/doc/rst/source/text.rst
@@ -142,7 +142,8 @@ Optional Arguments
     **-DJ** will shorten diagonal offsets at corners by
     sqrt(2). Optionally, append **+v** which will draw
     a line from the original point to the shifted point; append a *pen*
-    to change the attributes for this line.
+    to change the attributes for this line.  **Note**: The **-Dj**\|\ **J**
+    selection cannot be used with paragraph mode (|-M|).
 
 .. _-F:
 

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -347,7 +347,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-D[j|J]<dx>[/<dy>][+v[<pen>]]");
 	GMT_Usage (API, -2, "Add <dx>,<dy> to the text origin AFTER projecting with -J. If <dy> is not given it equals <dx> [0/0]. "
 		"Use -Dj to move text origin away from point (direction determined by text's justification). "
-		"Upper case -DJ will shorten diagonal shifts at corners by sqrt(2). Optional modifier:");
+		"Upper case -DJ will shorten diagonal shifts at corners by sqrt(2). Cannot be used with -M. Optional modifier:");
 	GMT_Usage (API, 3, "+v: Draw line from text to original point; optionally append a <pen> [%s].", gmt_putpen (API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Usage (API, 1, "\n-F[+a[<angle>]][+c[<justify>]][+f[<font>]][+h|l|r[<first>]|+t<text>|+z[<fmt>]][+j[<justify>]]");
 	GMT_Usage (API, -2, "Specify values for text attributes that apply to all text records:");


### PR DESCRIPTION
See #5981 for background. This PR documents this limitation.
