### PR TITLE
Implement smart justify -Dj for text -M

### DIFF
--- a/doc/examples/ex17/ex17.bat
+++ b/doc/examples/ex17/ex17.bat
@@ -27,7 +27,7 @@ gmt begin ex17
 	echo @_@%%5%%Example 17.@%%%%@_  We first plot the color geoid image >> tmp.txt
 	echo for the entire region, followed by a gray-shaded @REMetopo5@REM >> tmp.txt
 	echo image that is clipped so it is only visible inside the coastlines. >> tmp.txt
-	gmt text tmp.txt -M -Gwhite -Wthinner -C+tO -D-8p/8p -F+f12,Times-Roman+jRB
+	gmt text tmp.txt -M -Gwhite -Wthinner -C+tO -D8p -F+f12,Times-Roman+jRB
 
 	REM Clean up
 	del geoid.cpt tmp.txt

--- a/doc/examples/ex17/ex17.sh
+++ b/doc/examples/ex17/ex17.sh
@@ -25,7 +25,7 @@ gmt begin ex17
 	gmt colorbar -DjTR+o0.8c/0.2c+w10c/0.5c+h -Cgeoid.cpt -Bx5f1 -By+lm -I
 
 	# Add a text paragraph
-	gmt text -M -Gwhite -Wthinner -C+tO -Dj-8p/8p -F+f12,Times-Roman+jRB <<- END
+	gmt text -M -Gwhite -Wthinner -C+tO -Dj8p -F+f12,Times-Roman+jRB <<- END
 	> 90 -10 12p 8c j
 	@_@%5%Example 17.@%%@_  We first plot the color geoid image
 	for the entire region, followed by a gray-shaded @#etopo5@#

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -184,7 +184,10 @@ GMT_LOCAL void pstext_output_words (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, 
 		gmt_setpen (GMT, &(T->vecpen));
 		PSL_plotsegment (PSL, x, y, x + T->x_offset, y + T->y_offset);
 	}
-	x += T->x_offset;	y += T->y_offset;	/* Move to the actual reference point */
+	if (Ctrl->D.justify)	/* Smart offset according to justification (from Dave Huang) */
+		gmt_smart_justify (GMT, T->block_justify, T->paragraph_angle, T->x_offset, T->y_offset, &x, &y, Ctrl->D.justify);
+	else
+		x += T->x_offset,	y += T->y_offset;	/* Move to the actual reference point */
 	if (T->boxflag) {	/* Need to lay down the box first, then place text */
 		int mode = 0;
 		struct GMT_FILL *fill = NULL;

--- a/test/pstext/para_offset.ps
+++ b/test/pstext/para_offset.ps
@@ -1,0 +1,2141 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.3.0_36e05aa_2021.11.12 [64-bit] Document from text
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Fri Nov 12 13:25:14 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt text -R-8/8/-8/8 -Jx1c -Bafg3 -M -F+f+a+j -C0 -Glightpink
+%@PROJ: xy -8.00000000 8.00000000 -8.00000000 8.00000000 -8.000 8.000 -8.000 8.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+945 0 M
+0 7559 D
+S
+2362 0 M
+0 7559 D
+S
+3780 0 M
+0 7559 D
+S
+5197 0 M
+0 7559 D
+S
+6614 0 M
+0 7559 D
+S
+0 945 M
+7559 0 D
+S
+0 2362 M
+7559 0 D
+S
+0 3780 M
+7559 0 D
+S
+0 5197 M
+7559 0 D
+S
+0 6614 M
+7559 0 D
+S
+clipsave
+0 0 M
+7559 0 D
+0 7559 D
+-7559 0 D
+P
+PSL_clip N
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+PSL_font_encode 5 get 0 eq {Standard+_Encoding /Times-Bold /Times-Bold PSL_reencode PSL_font_encode 5 1 put} if
+{1 0.714 0.757 C} FS
+O0
+/PSL_setfont {
+  /f exch def
+  /k1 exch def
+  /fz PSL_size k1 get def
+  /fn PSL_fnt k1 get def
+  fn PSL_lastfn eq fz PSL_lastfz eq and not {
+    fz PSL_fontname fn get Y
+    /PSL_lastfn fn def
+    /PSL_lastfz fz def
+  } if
+  /fc PSL_color k1 get def
+  fc PSL_lastfc ne {
+    /PSL_c fc 3 mul def
+    0 1 2 {PSL_c add PSL_rgb exch get} for C
+    /PSL_lastfc fc def
+  } if
+  f 32 and 32 eq {
+    /PSL_UL fz 0.075 mul def
+    fz 0.025 mul W
+    /PSL_show {PSL_ushow} def
+  }
+  {
+    /PSL_show {ashow} def
+  } ifelse
+}!
+/PSL_setfont2 {
+  /f exch def
+  /k1 exch def
+  /fz PSL_size k1 get def
+  /fn PSL_fnt k1 get def
+  fn PSL_lastfn eq fz PSL_lastfz eq and not {
+    fz PSL_fontname fn get Y
+    /PSL_lastfn fn def
+    /PSL_lastfz fz def
+  } if
+}!
+/PSL_wordheight {
+  0 0 M false charpath flattenpath pathbbox /up exch def pop /down exch def pop newpath
+  down PSL_ymin lt {/PSL_ymin down def} if
+  up PSL_ymax gt {/PSL_ymax up def} if
+}!
+/PSL_ushow {
+  currentpoint /y0 exch def /x0 exch def
+  ashow
+  currentpoint pop /x1 exch def
+  x0 y0 PSL_UL sub M x1 y0 PSL_UL sub L S
+  x1 y0 M
+}!
+/PSL_placeword {
+  /k exch def
+  /flag PSL_flag k get def
+  k flag PSL_setfont
+  /sshow {ashow} def
+  PSL_col 0 eq {
+    /PSL_t 0 def
+    flag 4 and 4 eq {
+      pr_char 0 (    ) ashow
+    } if
+  }
+  {
+    /f PSL_flag k 1 sub get def
+    /PSL_t f 3 and def
+    f 32 and 32 eq flag 32 and 32 eq and {/sshow {PSL_ushow} def} if
+  } ifelse
+  /thisword_bshift PSL_bshift k get def
+  thisword_bshift 0.0 ne {0 thisword_bshift G} if
+  flag 8 and 8 eq {
+    pr_char 0 PSL_spaces PSL_t get sshow
+    k PSL_composite
+  } if
+  flag 24 and 0 eq {
+    pr_char 0 PSL_spaces PSL_t get sshow pr_char 0 PSL_word k get PSL_show
+    PSL_width k get 0 gt {/PSL_col PSL_col 1 add def} if
+  } if
+  thisword_bshift 0.0 ne {0 thisword_bshift neg G} if
+}!
+/PSL_composite {
+  /k1 exch def
+  /k2 k1 1 add def
+  /char1 PSL_word k1 get def
+  /char2 PSL_word k2 get def
+  /flag2 PSL_flag k2 get def
+  /w1 char1 stringwidth pop def
+  flag2 64 and 64 eq {
+    /fn2 PSL_fnt k2 get def
+    fz PSL_fontname fn2 get Y
+  } if
+  /w2 char2 stringwidth pop def
+  /delta w1 w2 sub 2 div PSL_scale mul def
+  delta 0.0 gt {
+    /dx1 0 def
+    /dx2 delta def
+  }
+  {
+    /dx1 delta neg def
+    /dx2 0 def
+  } ifelse
+  dx1 0 G currentpoint
+  flag2 64 and 64 eq {
+   /fn1 PSL_fnt k1 get def
+    fz PSL_fontname fn1 get Y
+  } if
+  pr_char 0 char1 PSL_show M
+  delta 0 G
+  flag2 64 and 64 eq {
+    fz PSL_fontname fn2 get Y
+  } if
+  pr_char 0 char2 ashow
+  dx2 0 G
+}!
+/PSL_expand {
+  /k1 exch def
+  /extra PSL_parwidth previous_linewidth sub comp_width add def
+  PSL_CRLF k1 PSL_n1 eq or {/spread 0 def} {/spread extra def} ifelse
+  /PSL_scale previous_linewidth 0.0 gt {PSL_parwidth previous_linewidth div} {1.0} ifelse def
+  /ndiv lsum ncomp sub def
+  ndiv 0 eq {/ndiv 1 def} if
+  PSL_parjust 4 eq {/pr_char spread ndiv div def} {/pr_char 0 def} ifelse
+  PSL_parjust 2 eq {extra 2 div 0 G} if
+  PSL_parjust 3 eq {extra 0 G} if
+  /PSL_col 0 def
+}!
+/PSL_textjustifier {
+  /PSL_mode exch def
+  /PSL_col 0 def
+  /PSL_ybase 0 def
+  /PSL_parheight 0 def
+  /PSL_ymin 0 def
+  /PSL_ymax 0 def
+  /PSL_top 0 def
+  /PSL_bottom 0 def
+  /last_font PSL_fnt 0 get def
+  /last_size PSL_size 0 get def
+  /last_color PSL_color 0 get def
+  /previous_linewidth 0 def
+  /stop 0 def
+  /start 0 def
+  /lsum 0 def
+  /line 0 def
+  /ncomp 0 def
+  /comp_width 0 def
+  0 1 PSL_n1 {
+    /i exch def
+    /thisflag PSL_flag i get def
+    i 0 eq {
+      /PSL_t 0 def
+      /lastflag 0 def
+    }
+    { /lastflag PSL_flag i 1 sub get def
+      /PSL_t lastflag 3 and def
+    } ifelse
+    i thisflag PSL_setfont2
+    /thisword_width PSL_width i get def
+    /comp_add 0 def
+    /compw_add 0 def
+    /PSL_tabwidth (    ) stringwidth pop def
+    /PSL_spacewidths PSL_spaces {stringwidth pop} forall 3 array astore def
+    /ccount PSL_count i get def
+    thisflag 4 and 4 eq {
+      /thisword_width thisword_width PSL_tabwidth add def
+      /ccount ccount 4 add def
+    } if
+    lastflag 8 and 8 eq {/PSL_t 0 def /comp_add 1 def /compw_add thisword_width def} if
+    /new_linewidth previous_linewidth thisword_width add PSL_spacewidths PSL_t get add def
+    /PSL_CRLF thisword_width 0.0 eq thisflag 16 and 0 eq and def
+    /special thisflag 16 and 16 eq {true} {thisword_width 0.0 gt} ifelse def
+    new_linewidth PSL_parwidth le special and
+    {
+      PSL_col 0 eq {
+        /PSL_ymin 0 def
+        /PSL_ymax 0 def
+      } if
+      /stop stop 1 add def
+      /PSL_col PSL_col 1 add def
+      /previous_linewidth new_linewidth def
+      /lsum lsum ccount add PSL_t add def
+      /ncomp ncomp comp_add add def
+      /comp_width comp_width compw_add add def
+    }
+    {
+      1 PSL_mode eq {
+        start PSL_expand
+        start PSL_placeword
+      }
+      {PSL_word start get PSL_wordheight
+      } ifelse
+      /last stop 1 sub def
+      /start start 1 add def
+      1 PSL_mode eq {
+        start 1 last {PSL_placeword} for
+      }
+      {start 1 last {PSL_word exch get PSL_wordheight} for
+        line 0 eq { /PSL_top PSL_ymax def} if
+      } ifelse
+      /start stop def
+      /PSL_ybase PSL_ybase PSL_linespace sub def
+      1 PSL_mode eq {0 PSL_ybase M} if
+      /stop stop 1 add def
+      /previous_linewidth thisword_width def
+      /lsum ccount def
+      /ncomp comp_add def
+      /comp_width compw_add def
+      /PSL_col 0 def
+      /line line 1 add def
+    } ifelse
+  } for
+  /last stop 1 sub def
+  last PSL_n lt {
+    /PSL_CRLF true def
+    1 PSL_mode eq {
+      start PSL_expand
+      start PSL_placeword
+      /start start 1 add def
+      start 1 last {PSL_placeword} for
+    }
+    { /PSL_ymin 0 def
+      PSL_word start get PSL_wordheight
+      /start start 1 add def
+      start 1 last {PSL_word exch get PSL_wordheight} for
+      line 0 eq {
+        /PSL_top PSL_ymax def
+      } if
+    } ifelse
+  } if
+  /PSL_bottom PSL_ymin def
+  /PSL_parheight PSL_ybase neg PSL_top add PSL_bottom sub def
+} def
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 3 def
+/PSL_n1 2 def
+/PSL_y0 3780 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(Original) (X) (Multiline.)
+3 array astore def
+/PSL_fnt
+0 0 0
+3 array astore def
+/PSL_size
+200 200 200
+3 array astore def
+/PSL_flag
+1 1 0
+3 array astore def
+/PSL_bshift
+0 0 0
+3 array astore def
+/PSL_color
+0 0 0
+3 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 3 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 3 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 3780 3780 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 6 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight 2 div def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 3780 3780 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 6 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight 2 div def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 7559 M 0 -7559 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M -65 0 D S
+N 0 945 M -65 0 D S
+N 0 1890 M -65 0 D S
+N 0 2835 M -65 0 D S
+N 0 3780 M -65 0 D S
+N 0 4724 M -65 0 D S
+N 0 5669 M -65 0 D S
+N 0 6614 M -65 0 D S
+N 0 7559 M -65 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+163 F0
+(”8) sw mx
+(”6) sw mx
+(”4) sw mx
+(”2) sw mx
+(0) sw mx
+(2) sw mx
+(4) sw mx
+(6) sw mx
+(8) sw mx
+def
+/PSL_A0_y PSL_A0_y 49 add def
+0 PSL_A0_y MM
+(”8) mr Z
+945 PSL_A0_y MM
+(”6) mr Z
+1890 PSL_A0_y MM
+(”4) mr Z
+2835 PSL_A0_y MM
+(”2) mr Z
+3780 PSL_A0_y MM
+(0) mr Z
+4724 PSL_A0_y MM
+(2) mr Z
+5669 PSL_A0_y MM
+(4) mr Z
+6614 PSL_A0_y MM
+(6) mr Z
+7559 PSL_A0_y MM
+(8) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 472 M -33 0 D S
+N 0 1417 M -33 0 D S
+N 0 2362 M -33 0 D S
+N 0 3307 M -33 0 D S
+N 0 4252 M -33 0 D S
+N 0 5197 M -33 0 D S
+N 0 6142 M -33 0 D S
+N 0 7087 M -33 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+7559 0 T
+24 W
+N 0 7559 M 0 -7559 D S
+-7559 0 T
+N 0 0 M 7559 0 D S
+/PSL_A0_y 65 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -65 D S
+N 945 0 M 0 -65 D S
+N 1890 0 M 0 -65 D S
+N 2835 0 M 0 -65 D S
+N 3780 0 M 0 -65 D S
+N 4724 0 M 0 -65 D S
+N 5669 0 M 0 -65 D S
+N 6614 0 M 0 -65 D S
+N 7559 0 M 0 -65 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”8) sh mx
+(”6) sh mx
+(”4) sh mx
+(”2) sh mx
+(0) sh mx
+(2) sh mx
+(4) sh mx
+(6) sh mx
+(8) sh mx
+def
+/PSL_A0_y PSL_A0_y 49 add PSL_AH0 add def
+0 PSL_A0_y MM
+(”8) bc Z
+945 PSL_A0_y MM
+(”6) bc Z
+1890 PSL_A0_y MM
+(”4) bc Z
+2835 PSL_A0_y MM
+(”2) bc Z
+3780 PSL_A0_y MM
+(0) bc Z
+4724 PSL_A0_y MM
+(2) bc Z
+5669 PSL_A0_y MM
+(4) bc Z
+6614 PSL_A0_y MM
+(6) bc Z
+7559 PSL_A0_y MM
+(8) bc Z
+N 472 0 M 0 -33 D S
+N 1417 0 M 0 -33 D S
+N 2362 0 M 0 -33 D S
+N 3307 0 M 0 -33 D S
+N 4252 0 M 0 -33 D S
+N 5197 0 M 0 -33 D S
+N 6142 0 M 0 -33 D S
+N 7087 0 M 0 -33 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 7559 T
+24 W
+N 0 0 M 7559 0 D S
+0 -7559 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -M -F+f+a+j -Dj3c -C0 -Glightgray -R-8/8/-8/8 -Jx1c
+%@PROJ: xy -8.00000000 8.00000000 -8.00000000 8.00000000 -8.000 8.000 -8.000 8.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7559 0 D
+0 7559 D
+-7559 0 D
+P
+PSL_clip N
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+PSL_font_encode 5 get 0 eq {Standard+_Encoding /Times-Bold /Times-Bold PSL_reencode PSL_font_encode 5 1 put} if
+{0.827 A} FS
+/PSL_setfont {
+  /f exch def
+  /k1 exch def
+  /fz PSL_size k1 get def
+  /fn PSL_fnt k1 get def
+  fn PSL_lastfn eq fz PSL_lastfz eq and not {
+    fz PSL_fontname fn get Y
+    /PSL_lastfn fn def
+    /PSL_lastfz fz def
+  } if
+  /fc PSL_color k1 get def
+  fc PSL_lastfc ne {
+    /PSL_c fc 3 mul def
+    0 1 2 {PSL_c add PSL_rgb exch get} for C
+    /PSL_lastfc fc def
+  } if
+  f 32 and 32 eq {
+    /PSL_UL fz 0.075 mul def
+    fz 0.025 mul W
+    /PSL_show {PSL_ushow} def
+  }
+  {
+    /PSL_show {ashow} def
+  } ifelse
+}!
+/PSL_setfont2 {
+  /f exch def
+  /k1 exch def
+  /fz PSL_size k1 get def
+  /fn PSL_fnt k1 get def
+  fn PSL_lastfn eq fz PSL_lastfz eq and not {
+    fz PSL_fontname fn get Y
+    /PSL_lastfn fn def
+    /PSL_lastfz fz def
+  } if
+}!
+/PSL_wordheight {
+  0 0 M false charpath flattenpath pathbbox /up exch def pop /down exch def pop newpath
+  down PSL_ymin lt {/PSL_ymin down def} if
+  up PSL_ymax gt {/PSL_ymax up def} if
+}!
+/PSL_ushow {
+  currentpoint /y0 exch def /x0 exch def
+  ashow
+  currentpoint pop /x1 exch def
+  x0 y0 PSL_UL sub M x1 y0 PSL_UL sub L S
+  x1 y0 M
+}!
+/PSL_placeword {
+  /k exch def
+  /flag PSL_flag k get def
+  k flag PSL_setfont
+  /sshow {ashow} def
+  PSL_col 0 eq {
+    /PSL_t 0 def
+    flag 4 and 4 eq {
+      pr_char 0 (    ) ashow
+    } if
+  }
+  {
+    /f PSL_flag k 1 sub get def
+    /PSL_t f 3 and def
+    f 32 and 32 eq flag 32 and 32 eq and {/sshow {PSL_ushow} def} if
+  } ifelse
+  /thisword_bshift PSL_bshift k get def
+  thisword_bshift 0.0 ne {0 thisword_bshift G} if
+  flag 8 and 8 eq {
+    pr_char 0 PSL_spaces PSL_t get sshow
+    k PSL_composite
+  } if
+  flag 24 and 0 eq {
+    pr_char 0 PSL_spaces PSL_t get sshow pr_char 0 PSL_word k get PSL_show
+    PSL_width k get 0 gt {/PSL_col PSL_col 1 add def} if
+  } if
+  thisword_bshift 0.0 ne {0 thisword_bshift neg G} if
+}!
+/PSL_composite {
+  /k1 exch def
+  /k2 k1 1 add def
+  /char1 PSL_word k1 get def
+  /char2 PSL_word k2 get def
+  /flag2 PSL_flag k2 get def
+  /w1 char1 stringwidth pop def
+  flag2 64 and 64 eq {
+    /fn2 PSL_fnt k2 get def
+    fz PSL_fontname fn2 get Y
+  } if
+  /w2 char2 stringwidth pop def
+  /delta w1 w2 sub 2 div PSL_scale mul def
+  delta 0.0 gt {
+    /dx1 0 def
+    /dx2 delta def
+  }
+  {
+    /dx1 delta neg def
+    /dx2 0 def
+  } ifelse
+  dx1 0 G currentpoint
+  flag2 64 and 64 eq {
+   /fn1 PSL_fnt k1 get def
+    fz PSL_fontname fn1 get Y
+  } if
+  pr_char 0 char1 PSL_show M
+  delta 0 G
+  flag2 64 and 64 eq {
+    fz PSL_fontname fn2 get Y
+  } if
+  pr_char 0 char2 ashow
+  dx2 0 G
+}!
+/PSL_expand {
+  /k1 exch def
+  /extra PSL_parwidth previous_linewidth sub comp_width add def
+  PSL_CRLF k1 PSL_n1 eq or {/spread 0 def} {/spread extra def} ifelse
+  /PSL_scale previous_linewidth 0.0 gt {PSL_parwidth previous_linewidth div} {1.0} ifelse def
+  /ndiv lsum ncomp sub def
+  ndiv 0 eq {/ndiv 1 def} if
+  PSL_parjust 4 eq {/pr_char spread ndiv div def} {/pr_char 0 def} ifelse
+  PSL_parjust 2 eq {extra 2 div 0 G} if
+  PSL_parjust 3 eq {extra 0 G} if
+  /PSL_col 0 def
+}!
+/PSL_textjustifier {
+  /PSL_mode exch def
+  /PSL_col 0 def
+  /PSL_ybase 0 def
+  /PSL_parheight 0 def
+  /PSL_ymin 0 def
+  /PSL_ymax 0 def
+  /PSL_top 0 def
+  /PSL_bottom 0 def
+  /last_font PSL_fnt 0 get def
+  /last_size PSL_size 0 get def
+  /last_color PSL_color 0 get def
+  /previous_linewidth 0 def
+  /stop 0 def
+  /start 0 def
+  /lsum 0 def
+  /line 0 def
+  /ncomp 0 def
+  /comp_width 0 def
+  0 1 PSL_n1 {
+    /i exch def
+    /thisflag PSL_flag i get def
+    i 0 eq {
+      /PSL_t 0 def
+      /lastflag 0 def
+    }
+    { /lastflag PSL_flag i 1 sub get def
+      /PSL_t lastflag 3 and def
+    } ifelse
+    i thisflag PSL_setfont2
+    /thisword_width PSL_width i get def
+    /comp_add 0 def
+    /compw_add 0 def
+    /PSL_tabwidth (    ) stringwidth pop def
+    /PSL_spacewidths PSL_spaces {stringwidth pop} forall 3 array astore def
+    /ccount PSL_count i get def
+    thisflag 4 and 4 eq {
+      /thisword_width thisword_width PSL_tabwidth add def
+      /ccount ccount 4 add def
+    } if
+    lastflag 8 and 8 eq {/PSL_t 0 def /comp_add 1 def /compw_add thisword_width def} if
+    /new_linewidth previous_linewidth thisword_width add PSL_spacewidths PSL_t get add def
+    /PSL_CRLF thisword_width 0.0 eq thisflag 16 and 0 eq and def
+    /special thisflag 16 and 16 eq {true} {thisword_width 0.0 gt} ifelse def
+    new_linewidth PSL_parwidth le special and
+    {
+      PSL_col 0 eq {
+        /PSL_ymin 0 def
+        /PSL_ymax 0 def
+      } if
+      /stop stop 1 add def
+      /PSL_col PSL_col 1 add def
+      /previous_linewidth new_linewidth def
+      /lsum lsum ccount add PSL_t add def
+      /ncomp ncomp comp_add add def
+      /comp_width comp_width compw_add add def
+    }
+    {
+      1 PSL_mode eq {
+        start PSL_expand
+        start PSL_placeword
+      }
+      {PSL_word start get PSL_wordheight
+      } ifelse
+      /last stop 1 sub def
+      /start start 1 add def
+      1 PSL_mode eq {
+        start 1 last {PSL_placeword} for
+      }
+      {start 1 last {PSL_word exch get PSL_wordheight} for
+        line 0 eq { /PSL_top PSL_ymax def} if
+      } ifelse
+      /start stop def
+      /PSL_ybase PSL_ybase PSL_linespace sub def
+      1 PSL_mode eq {0 PSL_ybase M} if
+      /stop stop 1 add def
+      /previous_linewidth thisword_width def
+      /lsum ccount def
+      /ncomp comp_add def
+      /comp_width compw_add def
+      /PSL_col 0 def
+      /line line 1 add def
+    } ifelse
+  } for
+  /last stop 1 sub def
+  last PSL_n lt {
+    /PSL_CRLF true def
+    1 PSL_mode eq {
+      start PSL_expand
+      start PSL_placeword
+      /start start 1 add def
+      start 1 last {PSL_placeword} for
+    }
+    { /PSL_ymin 0 def
+      PSL_word start get PSL_wordheight
+      /start start 1 add def
+      start 1 last {PSL_word exch get PSL_wordheight} for
+      line 0 eq {
+        /PSL_top PSL_ymax def
+      } if
+    } ifelse
+  } if
+  /PSL_bottom PSL_ymin def
+  /PSL_parheight PSL_ybase neg PSL_top add PSL_bottom sub def
+} def
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 4 def
+/PSL_n1 3 def
+/PSL_y0 2362 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(TR) (Offset) (X) (Multiline.)
+4 array astore def
+/PSL_fnt
+0 0 0 0
+4 array astore def
+/PSL_size
+200 200 200 200
+4 array astore def
+/PSL_flag
+1 1 1 0
+4 array astore def
+/PSL_bshift
+0 0 0 0
+4 array astore def
+/PSL_color
+0 0 0 0
+4 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 4 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 4 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 2362 2362 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 11 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 2362 2362 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 11 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+{0.827 A} FS
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 4 def
+/PSL_n1 3 def
+/PSL_y0 2362 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(TL) (Offset) (X) (Multiline.)
+4 array astore def
+/PSL_fnt
+0 0 0 0
+4 array astore def
+/PSL_size
+200 200 200 200
+4 array astore def
+/PSL_flag
+1 1 1 0
+4 array astore def
+/PSL_bshift
+0 0 0 0
+4 array astore def
+/PSL_color
+0 0 0 0
+4 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 4 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 4 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 5197 2362 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 9 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 5197 2362 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 9 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+{0.827 A} FS
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 4 def
+/PSL_n1 3 def
+/PSL_y0 5197 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(BR) (Offset) (X) (Multiline.)
+4 array astore def
+/PSL_fnt
+0 0 0 0
+4 array astore def
+/PSL_size
+200 200 200 200
+4 array astore def
+/PSL_flag
+1 1 1 0
+4 array astore def
+/PSL_bshift
+0 0 0 0
+4 array astore def
+/PSL_color
+0 0 0 0
+4 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 4 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 4 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 2362 5197 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 3 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 2362 5197 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 3 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+{0.827 A} FS
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 4 def
+/PSL_n1 3 def
+/PSL_y0 5197 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(BL) (Offset) (X) (Multiline.)
+4 array astore def
+/PSL_fnt
+0 0 0 0
+4 array astore def
+/PSL_size
+200 200 200 200
+4 array astore def
+/PSL_flag
+1 1 1 0
+4 array astore def
+/PSL_bshift
+0 0 0 0
+4 array astore def
+/PSL_color
+0 0 0 0
+4 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 4 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 4 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 5197 5197 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 1 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 5197 5197 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 1 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+{0.827 A} FS
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 4 def
+/PSL_n1 3 def
+/PSL_y0 2362 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(TC) (Offset) (X) (Multiline.)
+4 array astore def
+/PSL_fnt
+0 0 0 0
+4 array astore def
+/PSL_size
+200 200 200 200
+4 array astore def
+/PSL_flag
+1 1 1 0
+4 array astore def
+/PSL_bshift
+0 0 0 0
+4 array astore def
+/PSL_color
+0 0 0 0
+4 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 4 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 4 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 3780 2362 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 10 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 3780 2362 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 10 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 0 def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+{0.827 A} FS
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 4 def
+/PSL_n1 3 def
+/PSL_y0 5197 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(BC) (Offset) (X) (Multiline.)
+4 array astore def
+/PSL_fnt
+0 0 0 0
+4 array astore def
+/PSL_size
+200 200 200 200
+4 array astore def
+/PSL_flag
+1 1 1 0
+4 array astore def
+/PSL_bshift
+0 0 0 0
+4 array astore def
+/PSL_color
+0 0 0 0
+4 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 4 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 4 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 3780 5197 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 2 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 3780 5197 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 2 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+{0.827 A} FS
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 4 def
+/PSL_n1 3 def
+/PSL_y0 3780 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(ML) (Offset) (X) (Multiline.)
+4 array astore def
+/PSL_fnt
+0 0 0 0
+4 array astore def
+/PSL_size
+200 200 200 200
+4 array astore def
+/PSL_flag
+1 1 1 0
+4 array astore def
+/PSL_bshift
+0 0 0 0
+4 array astore def
+/PSL_color
+0 0 0 0
+4 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 4 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 4 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 5197 3780 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 5 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight 2 div def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 5197 3780 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 5 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight 2 div def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+/PSL_linespace 151 def
+/PSL_parwidth 1417 def
+/PSL_parjust 2 def
+{0.827 A} FS
+/PSL_fontname
+/Times-Bold
+1 array astore def
+/PSL_n 4 def
+/PSL_n1 3 def
+/PSL_y0 3780 def
+/PSL_spaces [() ( ) (  ) ] def
+/PSL_lastfn -1 def
+/PSL_lastfz -1 def
+/PSL_lastfc -1 def
+/PSL_UL 0 def
+/PSL_show {ashow} def
+/PSL_word
+(MR) (Offset) (X) (Multiline.)
+4 array astore def
+/PSL_fnt
+0 0 0 0
+4 array astore def
+/PSL_size
+200 200 200 200
+4 array astore def
+/PSL_flag
+1 1 1 0
+4 array astore def
+/PSL_bshift
+0 0 0 0
+4 array astore def
+/PSL_color
+0 0 0 0
+4 array astore def
+/PSL_rgb
+-1 -1 -1
+3 array astore def
+/PSL_width 4 array def
+/PSL_max_word_width 0 def
+0 1 PSL_n1 {
+  /i edef
+  PSL_size i get PSL_fontname PSL_fnt i get get Y
+  PSL_width i PSL_word i get stringwidth pop put
+  PSL_width i get PSL_max_word_width gt { /PSL_max_word_width PSL_width i get def} if
+} for
+PSL_max_word_width PSL_parwidth gt { /PSL_parwidth PSL_max_word_width def } if
+/PSL_count 4 array def
+0 1 PSL_n1 {PSL_count exch dup PSL_word exch get length put} for
+1 1 PSL_n1 {
+  /k edef
+  PSL_flag k get 16 and 16 eq {
+    /k1 k 1 sub def
+    /w1 PSL_width k1 get def
+    /w2 PSL_width k get def
+    PSL_width k1 w1 w2 gt {w1} {w2} ifelse put
+    PSL_width k 0 put
+    PSL_count k 0 put
+  } if
+} for
+V 2362 3780 T
+/PSL_xgap 0 def
+/PSL_ygap 0 def
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 7 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight 2 div def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+/XL PSL_xgap neg def
+/XR PSL_parwidth PSL_xgap add def
+/YT PSL_ygap def
+/YB PSL_parheight PSL_ygap add neg def
+XL YT M XL YB L XR YB L XR YT L
+FO U
+0 A
+V 2362 3780 T
+0 0 M
+0 PSL_textjustifier
+/PSL_justify 7 def
+/PSL_x0 PSL_parwidth PSL_justify 1 sub 4 mod 0.5 mul neg mul def
+/PSL_y0 PSL_parheight 2 div def
+/PSL_txt_y0 PSL_top neg def
+PSL_x0 PSL_y0 T
+0 PSL_txt_y0 T
+0 0 M
+1 PSL_textjustifier U
+PSL_cliprestore
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/pstext/para_offset.sh
+++ b/test/pstext/para_offset.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 # Ensure that -Dj works for pstext -M
 # See https://github.com/GenericMappingTools/gmt/issues/5981
 gmt begin para_offset

--- a/test/pstext/para_offset.sh
+++ b/test/pstext/para_offset.sh
@@ -1,0 +1,38 @@
+#! /usr/bin/env bash
+# Ensure that -Dj works for pstext -M
+# See https://github.com/GenericMappingTools/gmt/issues/5981
+gmt begin para_offset
+	# First one in the center
+    gmt text  -R-8/8/-8/8 -Jx1c -Bafg3 -M -F+f+a+j -C0 -Glightpink <<- EOF
+	> 0 0 12p,Times-Bold,black 0 CM 0.32c 3c c
+	Original  X
+	Multiline.
+	EOF
+	# Then place then at the other 8 justification points
+    gmt text -M -F+f+a+j -Dj3c -C0 -Glightgray <<- EOF
+	> 0 0 12p,Times-Bold,black 0 TR 0.32c 3c c
+	TR Offset   X
+	Multiline.
+	> 0 0 12p,Times-Bold,black 0 TL 0.32c 3c c
+	TL Offset   X
+	Multiline.
+	> 0 0 12p,Times-Bold,black 0 BR 0.32c 3c c
+	BR Offset   X
+	Multiline.
+	> 0 0 12p,Times-Bold,black 0 BL 0.32c 3c c
+	BL Offset   X
+	Multiline.
+	> 0 0 12p,Times-Bold,black 0 TC 0.32c 3c c
+	TC Offset   X
+	Multiline.
+	> 0 0 12p,Times-Bold,black 0 BC 0.32c 3c c
+	BC Offset   X
+	Multiline.
+	> 0 0 12p,Times-Bold,black 0 ML 0.32c 3c c
+	ML Offset   X
+	Multiline.
+	> 0 0 12p,Times-Bold,black 0 MR 0.32c 3c c
+	MR Offset   X
+	Multiline.
+	EOF
+gmt end show


### PR DESCRIPTION
This was a lot easier than what it seemed like yesterday.  Coffee works.  I added a new test (_para_offset.sh_) that demonstrates it works for a fixed` -Dj3c` and various justifications.  Curiously, _ex17_ failed and I found that (probably) due to the bug, we had incorrectly used` -Dj-8p/8p` to shift the paragraph instead of the correct setting `-Dj8p` (which did not work until now).

Closes #598

![para_offset](https://user-images.githubusercontent.com/26473567/141597217-24c0a697-3035-49e3-bfed-36e33dd5a6ab.jpg)