### PR TITLE
Enforce defaults in grdvector

### DIFF
--- a/doc/rst/source/grdvector.rst
+++ b/doc/rst/source/grdvector.rst
@@ -82,6 +82,7 @@ Optional Arguments
 
 **-G**\ *fill*
     Sets color or shade for vector interiors [Default is no fill].
+    Alternatively, the fill may be set via **-Q**.
 
 .. _-I:
 
@@ -148,7 +149,7 @@ Optional Arguments
 .. _-W:
 
 **-W**\ *pen*
-    Set pen attributes used for vector outlines [Default: width =
+    Change the pen attributes used for vector outlines [Default: width =
     default, color = black, style = solid].
 
 .. |Add_-XY| replace:: |Add_-XY_links|

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -325,6 +325,15 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct GMT_
 		}
 	}
 
+	if (!Ctrl->W.active) {	/* Accept -W default pen for stem */
+		GMT_Report (API, GMT_MSG_DEBUG, "Option -W: Not given so we accept default pen\n");
+		Ctrl->W.active = true;
+	}
+	if (!Ctrl->G.active && (Ctrl->Q.S.v.status & PSL_VEC_FILL2)) {	/* Gave fill via +g instead */
+		GMT_Report (API, GMT_MSG_DEBUG, "Option -G: Not given but -Q+g was set so we use it to fill head\n");
+		gmt_M_rgb_copy (Ctrl->G.fill.rgb, Ctrl->Q.S.v.fill.rgb);
+		Ctrl->G.active = true;
+	}
 	gmt_consider_current_cpt (API, &Ctrl->C.active, &(Ctrl->C.file));
 
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.J.active, "Must specify a map projection with the -J option\n");


### PR DESCRIPTION
See #5998 for background. This PR addresses two issues:

1. Given that **-W** has a stated default, we will use it if **-W** is not given - hence a stem shall always be drawn as part of any vector.  We should never apply vector head via **-Q** **+p**_pen_ to the stem pen.
2. If **-G** is not set but **-Q+g**_fill_ is, then we shall fill the head.

All tests pass. Closes #5998.