### PR TITLE
Clean up vector documentation

### DIFF
--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -39,11 +39,8 @@ end point (**e**) of a line segment:
 
     **+h**\ *shape* sets the shape of the vector head (range -2/2). Default
     is controlled by :term:`MAP_VECTOR_SHAPE` [default is :doc:`theme dependent </theme-settings>`].
-    A zero value produces no notch (e.g., the dashed line in the figure). Positive values
-    moves the notch toward the head apex while a negative value moves away. The example above
-    uses **+h**\ 0.5.
-
-    **+l** draws half-arrows, using only the left side of specified heads [both sides].
+    A zero value produces no notch. Positive values moves the notch toward the head apex while a
+    negative value moves it away. The example above uses **+h**\ 0.5.
 
     **+m** places a vector head at the mid-point the vector path [none].
     Append **f** or **r** for forward or reverse direction of the vector [forward].
@@ -70,8 +67,6 @@ end point (**e**) of a line segment:
     **+q** means the input *direction*, *length* data instead represent the *start* and *stop*
     opening angles of the arc segment relative to the given point. See **+o** to specify
     a specific pole for the arc [north pole].
-
-    **+r** draws half-arrows, using only the right side of specified heads [both sides].
 
     **+t**\ [**b**\|\ **e**]\ *trim* will shift the beginning or end point (or both)
     along the vector segment by the given *trim*; append suitable unit (**c**, **i**, or **p**). If the modifiers

--- a/doc/rst/source/grdvector.rst
+++ b/doc/rst/source/grdvector.rst
@@ -101,7 +101,7 @@ Optional Arguments
 
 **-Q**\ *parameters*
     Modify vector parameters. For vector heads, append vector head
-    *size* [Default is 0, i.e., stick-plot]. See VECTOR ATTRIBUTES for
+    *size* [Default is 0, i.e., stick-plot]. See See `Vector Attributes`_ for
     specifying additional attributes.
 
 .. |Add_-R| replace:: Specify a subset of the grid. |Add_-R_links|


### PR DESCRIPTION
This PR fixes a few minor issues in the documentation related to vector symbols:

1. There were references to deprecated syntax (**+l,** **+r**) in the _explain_vectors.rst_ file
2. We referred to a dashed line meant to show what **+h**0 does but it is not shown on the figure
3. **grdvector** had a badly formatted cross-link to the vector attributes section
