### PR TITLE
Ensure blockm* avoids unneeded work when -G is used

### DIFF
--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -106,7 +106,7 @@ Optional Arguments
     Write one or more fields directly to grids; no table data are written to
     standard output.  If more than one fields are specified via **-A** then
     *grdfile* must contain the format flag %s so that we can embed the field
-    code in the file names.
+    code in the file names.  **Note**: Option **-C** is irrelevant and not allowed.
 
 .. _-S:
 

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -124,7 +124,8 @@ Optional Arguments
     Write one or more fields directly to grids; no table data are written to
     standard output.  If more than one fields are specified via **-A** then
     *grdfile* must contain the format flag %s so that we can embed the field
-    code in the file names.
+    code in the file names.  **Note**: Options **-C** and **-Q** are irrelevant
+    and not allowed.
 
 .. _-Q:
 

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -131,7 +131,8 @@ Optional Arguments
     Write one or more fields directly to grids; no table data are written to
     standard output.  If more than one fields are specified via **-A** then
     *grdfile* must contain the format flag %s so that we can embed the field
-    code in the file names.
+    code in the file names.  **Note**: Options **-C** and **-Q** are irrelevant
+    and not allowed.
 
 .. _-Q:
 

--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -97,7 +97,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (!API->external) {
 		GMT_Usage (API, 1, "\n-G<grdfile>");
 		GMT_Usage (API, -2, "Specify output grid file name; no table results will be written to standard output. "
-			"If more than one field is set via -A then <grdfile> must contain %%s to format field code.");
+			"If more than one field is set via -A then <grdfile> must contain %%s to format field code. Option -C is not allowed.");
 	}
 	GMT_Usage (API, 1, "\n-S[m|n|s|w]");
 	GMT_Usage (API, -2, "Select the quantity to be reported per block as z:");
@@ -266,6 +266,9 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEAN_CTRL *Ctrl, struct GMT_
 			Ctrl->A.selected[0] = true;
 			Ctrl->A.n_selected = 1;
 		}
+		n_errors += gmt_M_check_condition (GMT, Ctrl->C.active,
+			"Option -C: Cannot be combined with -G\n");
+		Ctrl->C.active = true;	/* But we set it under the hood to avoid computing mean of x and y */
 	}
 
 	n_errors += gmt_M_check_condition (GMT, !GMT->parent->external && Ctrl->A.active && !Ctrl->G.active, "Option -A requires -G\n");

--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -88,7 +88,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (!API->external) {
 		GMT_Usage (API, 1, "\n-G<grdfile>");
 		GMT_Usage (API, -2, "Specify output grid file name; no table results will be written to standard output. "
-			"If more than one field is set via -A then <grdfile> must contain %%s to format field code.");
+			"If more than one field is set via -A then <grdfile> must contain %%s to format field code. Options -C and -Q are not allowed.");
 	}
 	GMT_Usage (API, 1, "\n-Q Quicker; get median z and x,y at that z [Default gets median x, median y, median z].");
 	GMT_Usage (API, 1, "\n-T<q>");
@@ -305,6 +305,11 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEDIAN_CTRL *Ctrl, struct GM
 				n_errors++;
 			}
 		}
+		n_errors += gmt_M_check_condition (GMT, Ctrl->C.active,
+			"Option -C: Cannot be combined with -G\n");
+		n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active,
+			"Option -Q: Cannot be combined with -G\n");
+		Ctrl->C.active = true;	/* But we set it under the hood to avoid computing modes of x and y */
 	}
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.R.active[RSET], "Must specify -R option\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->T.quantile <= 0.0 || Ctrl->T.quantile >= 1.0,
@@ -442,7 +447,7 @@ EXTERN_MSC int GMT_blockmedian (void *V_API, int mode, void *args) {
 	duplicate_col = (gmt_M_360_range (Grid->header->wesn[XLO], Grid->header->wesn[XHI]) && Grid->header->registration == GMT_GRID_NODE_REG);	/* E.g., lon = 0 column should match lon = 360 column */
 	half_dx = 0.5 * Grid->header->inc[GMT_X];
 	go_quickly = (Ctrl->Q.active) ? 1 : 0;
-	if (Ctrl->C.active && go_quickly == 1) {
+	if (!Ctrl->G.active && Ctrl->C.active && go_quickly == 1) {
 		GMT_Report (API, GMT_MSG_WARNING, "-C overrides -Q\n");
 		go_quickly = 0;
 	}

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -105,7 +105,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (!API->external) {
 		GMT_Usage (API, 1, "\n-G<grdfile>");
 		GMT_Usage (API, -2, "Specify output grid file name; no table results will be written to standard output. "
-			"If more than one field is set via -A then <grdfile> must contain %%s to format field code.");
+			"If more than one field is set via -A then <grdfile> must contain %%s to format field code. Options -C and -Q are not allowed.");
 	}
 	GMT_Usage (API, 1, "\n-Q Quicker; get mode z and mean x,y [Default gets mode x, mode y, mode z].");
 	GMT_Option (API, "V");
@@ -308,6 +308,11 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_
 				n_errors++;
 			}
 		}
+		n_errors += gmt_M_check_condition (GMT, Ctrl->C.active,
+			"Option -C: Cannot be combined with -G\n");
+		n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active,
+			"Option -Q: Cannot be combined with -G\n");
+		Ctrl->C.active = true;	/* But we set it under the hood to avoid computing modes of x and y */
 	}
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.R.active[RSET], "Must specify -R option\n");
 	n_errors += gmt_M_check_condition (GMT, GMT->common.R.inc[GMT_X] <= 0.0 || GMT->common.R.inc[GMT_Y] <= 0.0,
@@ -559,7 +564,7 @@ EXTERN_MSC int GMT_blockmode (void *V_API, int mode, void *args) {
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input table data\n");
 
-	if (Ctrl->C.active && Ctrl->Q.active) {
+	if (!Ctrl->G.active && Ctrl->C.active && Ctrl->Q.active) {
 		GMT_Report (API, GMT_MSG_WARNING, "-C overrides -Q\n");
 		Ctrl->Q.active = false;
 	}
@@ -902,7 +907,7 @@ EXTERN_MSC int GMT_blockmode (void *V_API, int mode, void *args) {
 				GridOut[k]->data[node] = (gmt_grdfloat)out[field[k]];
 		}
 		else
-		GMT_Put_Record (API, GMT_WRITE_DATA, Out);	/* Write this to output */
+			GMT_Put_Record (API, GMT_WRITE_DATA, Out);	/* Write this to output */
 
 		n_cells_filled++;
 		first_in_cell = first_in_new_cell;


### PR DESCRIPTION
We clearly do not want to compute things like median and modal block coordinates when making a grid since only z-values are relevant output.  This PR disallows the various **-C -Q** options but quietly sets **-C** under the hood.  Docs updated as well.  Tests pass.
