### PR TITLE
Set filler status before checking number of tiles

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1596,6 +1596,8 @@ char ** gmt_get_dataset_tiles (struct GMTAPI_CTRL *API, double wesn_in[], int k_
 		GMT_Report (API, GMT_MSG_WARNING, "gmtlib_get_tile_list: Unable to destroy coverage grid.\n");
 	}
 
+	if (need_filler) *need_filler = (partial_tile || n_missing > 0);	/* Incomplete coverage of this data set within wesn */
+
 	*n_tiles = n;
 	if (n == 0) {	/* Nutin' */
 		gmt_M_free (API->GMT, list);
@@ -1608,7 +1610,6 @@ char ** gmt_get_dataset_tiles (struct GMTAPI_CTRL *API, double wesn_in[], int k_
 		API->error = GMT_RUNTIME_ERROR;
 		return NULL;
 	}
-	if (need_filler) *need_filler = (partial_tile || n_missing > 0);	/* Incomplete coverage of this data set within wesn */
 
 	return (list);
 }


### PR DESCRIPTION
This PR fixes an issue when @earth_relief_01s or 03s is requested but there are no 1s or 3s tiles inside the region and hence all we have is the 15s filler tiles.  However, the decision to use the 15s filler came after we have already returned when we found no highres tiles.  The decision is now moved up a few lines.

The bug did not affect any of our tests, just one of my porto-animations...
