### PR TITLE
Unpin sphinx and bump docutils to v0.17

### DIFF
--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y --no-install-recommends --no-install-suggests $packages
 # Install more packages for building documentation
 if [ "$BUILD_DOCS" = "true" ]; then
     sudo snap install pngquant
-    pip3 install --user docutils==0.16 sphinx==3.5.4
+    pip3 install --user docutils==0.17 sphinx
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -38,7 +38,7 @@ fi
 brew install ${packages}
 
 if [ "$BUILD_DOCS" = "true" ]; then
-	pip3 install --user docutils==0.16 sphinx==3.5.4
+	pip3 install --user docutils==0.17 sphinx
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -33,7 +33,7 @@ choco install ninja
 choco install ghostscript --version 9.50
 
 if [ "$BUILD_DOCS" = "true" ]; then
-    pip install --user docutils==0.16 sphinx==3.5.4
+    pip install --user docutils==0.17 sphinx
     # Add sphinx to PATH
     echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
 

--- a/ci/vercel-docs.sh
+++ b/ci/vercel-docs.sh
@@ -11,7 +11,7 @@ yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.r
 yum install cmake3 ninja-build libcurl-devel netcdf-devel
 # Install Python packages
 # importlib-resources is required for Python <3.7
-pip install docutils==0.16 sphinx==3.5.4 importlib-resources
+pip install docutils==0.17 sphinx importlib-resources
 
 # Install latest gs
 curl -SLO https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9533/ghostscript-9.53.3-linux-x86_64.tgz


### PR DESCRIPTION
**Description of proposed changes**

https://github.com/GenericMappingTools/gmt/pull/6012 bumped sphinx_rtd_theme to v0.1.0, which means we should be able to build the docs with docutils v0.17. This PR also unpins sphinx to check if https://github.com/GenericMappingTools/gmt/issues/5211 was resolved by later sphinx or sphinx_rtd_theme releases.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Reverts https://github.com/GenericMappingTools/gmt/pull/5212


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
