### PR TITLE
Add safety valve in grdsample on wesn wrapping

### DIFF
--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -279,6 +279,12 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 			}
 		}
 		if (!wrap_360_o && !wrap_360_i) {	/* Can only shrink wesn_i if there is no 360-wrapping going on */
+			if (gmt_M_x_is_lon (GMT, GMT_IN)) {	/* Must carefully check the longitude overlap between these two wesn_? arrays */
+				if ((wesn_o[XLO] - wesn_i[XLO]) > 360.0)
+					wesn_i[XLO] += 360.0, wesn_i[XHI] += 360.0;
+				if ((wesn_o[XLO] - wesn_i[XLO]) < -360.0)
+					wesn_i[XLO] -= 360.0, wesn_i[XHI] -= 360.0;
+			}
 			k = 0;
 			while (wesn_i[XLO] < wesn_o[XLO]) wesn_i[XLO] += Gin->header->inc[GMT_X], k++;	/* Now on or inside boundary */
 			if (wesn_i[XLO] > Gin->header->wesn[XLO] && k) wesn_i[XLO] -= Gin->header->inc[GMT_X];	/* Now exactly on boundary or just outside but still inside input grid south boundary */

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -282,7 +282,7 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 			if (gmt_M_x_is_lon (GMT, GMT_IN)) {	/* Must carefully check the longitude overlap between these two wesn_? arrays */
 				if ((wesn_o[XLO] - wesn_i[XLO]) >= 360.0)
 					wesn_i[XLO] += 360.0, wesn_i[XHI] += 360.0;
-				if ((wesn_o[XLO] - wesn_i[XLO]) <= -360.0)
+				else if ((wesn_o[XLO] - wesn_i[XLO]) <= -360.0)
 					wesn_i[XLO] -= 360.0, wesn_i[XHI] -= 360.0;
 			}
 			k = 0;

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -280,9 +280,9 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 		}
 		if (!wrap_360_o && !wrap_360_i) {	/* Can only shrink wesn_i if there is no 360-wrapping going on */
 			if (gmt_M_x_is_lon (GMT, GMT_IN)) {	/* Must carefully check the longitude overlap between these two wesn_? arrays */
-				if ((wesn_o[XLO] - wesn_i[XLO]) > 360.0)
+				if ((wesn_o[XLO] - wesn_i[XLO]) >= 360.0)
 					wesn_i[XLO] += 360.0, wesn_i[XHI] += 360.0;
-				if ((wesn_o[XLO] - wesn_i[XLO]) < -360.0)
+				if ((wesn_o[XLO] - wesn_i[XLO]) <= -360.0)
 					wesn_i[XLO] -= 360.0, wesn_i[XHI] -= 360.0;
 			}
 			k = 0;


### PR DESCRIPTION
**Description of proposed changes**

I ran into this problem when a particular command  like this:

`gmt grdimage @earth_relief -Rd -JG-157.912943668/22.8394244388/24c+z33.5419653831+v60  -Ctopo.cpt --GMT_GRAPHICS_DPU=100c -I+d > t.ps`

and **grdsample** is resampling a portion of the 15s tile.  However, there is confusion between two sets of regions (_wesn_i_ and _wesn_o_ in the code) and in this case they end up being off by 360 between them.  This is not detected since it is not a global grid.  I am surprised this situation has not appeared before. Anyway, the added code is another safety value that ensures the two regions are compatible and deals with any 360 shifts before the critical adjustments below.

All tests pass, including my example above.
