### PR TITLE
Add @earth_age_10m to the CI cache

### DIFF
--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -46,6 +46,7 @@ jobs:
                 @earth_day_01d \
                 @earth_day_20m \
                 @earth_night_20m \
+                @earth_age_10m \
                 @earth_age_06m \
                 @earth_age_02m \
                 @earth_mask_05m \

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -10,7 +10,7 @@ on:
   # Uncomment the "push:" line to manually re-cache data artifacts in pushes
   #push:
   # Uncomment the 'pull_request:' line to manually re-cache data artifacts in PRs
-  #pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -10,7 +10,7 @@ on:
   # Uncomment the "push:" line to manually re-cache data artifacts in pushes
   #push:
   # Uncomment the 'pull_request:' line to manually re-cache data artifacts in PRs
-  pull_request:
+  #pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'


### PR DESCRIPTION
**Description of proposed changes**

`test/grdimage/twogrids.sh` was failing at https://github.com/GenericMappingTools/gmt/runs/4242161710?check_suite_focus=true due to a curl timeout. This PR caches @earth_age_10m to resolve the issue.
<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
