### PR TITLE
Simplify bundle by avoiding ghostscript version number in paths

### DIFF
--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -6,11 +6,13 @@
 # List of executables whose shared libraries must also be included
 #
 # Exceptions:
-# For now (6.2.0), need to do a few things manually first, like
+# For now (6.3.0), need to do a few things manually first, like
 #   1. Separate install command to avoid version number in GraphicsMagick directory name
+#   2. Separate install command to avoid version number in GhostScript directory name
 #
 # Notes:
 #   1. This is tested on macports where gs is a symbolic link to gsc.
+
 GSVERSION=$1	# Get the version of gs from build-release.sh
 
 if [ $(which cmake) = "/opt/local/bin/cmake" ]; then
@@ -99,7 +101,7 @@ if [ ! "X$EXESHARED" = "X" ]; then
 fi
 cat << EOF
 
-# Place the ghostscript support file while skipping the version directory
+# Place the ghostscript support files while skipping the version directory
 install (DIRECTORY
 	/opt/local/share/ghostscript/${GSVERSION}/Resource
 	/opt/local/share/ghostscript/${GSVERSION}/lib

--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -11,6 +11,7 @@
 #
 # Notes:
 #   1. This is tested on macports where gs is a symbolic link to gsc.
+GSVERSION=$1	# Get the version of gs from build-release.sh
 
 if [ $(which cmake) = "/opt/local/bin/cmake" ]; then
 	distro=MacPorts
@@ -35,9 +36,9 @@ EXELINKS=/opt/local/bin/gs
 # 1c. List of executables whose shared libraries have already been included via other shared libraries
 #     Use full path if you need something not in your path
 EXEONLY=
-# 1d. Shared directories to be added
+# 1d. Shared directories to be added (except ghostscript which we do separately)
 #     Use full path if you need something not in your path
-EXESHARED="gdal /opt/local/share/ghostscript /opt/local/lib/proj8/share/proj"
+EXESHARED="gdal /opt/local/lib/proj8/share/proj"
 #-----------------------------------------
 # 2a. Add the executables to the list given their paths
 rm -f ${TMPDIR}/raw.lis
@@ -98,6 +99,16 @@ if [ ! "X$EXESHARED" = "X" ]; then
 fi
 cat << EOF
 
+# Place the ghostscript support file while skipping the version directory
+install (DIRECTORY
+	/opt/local/share/ghostscript/${GSVERSION}/Resource
+	/opt/local/share/ghostscript/${GSVERSION}/lib
+	/opt/local/share/ghostscript/${GSVERSION}/iccprofiles
+	/opt/local/share/ghostscript/fonts
+	DESTINATION share/ghostscript
+	COMPONENT Runtime)
+
+#
 # Place the licenses for runtime dependencies
 install (DIRECTORY
 	../../admin/Licenses

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -120,7 +120,7 @@ cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
 rm -rf build
 mkdir build
 # 2b. Build list of external programs and shared libraries
-admin/build-macos-external-list.sh > build/add_macOS_cpack.txt
+admin/build-macos-external-list.sh ${G_ver} > build/add_macOS_cpack.txt
 if [ $? -ne 0 ]; then
 	echo 'build-release.sh: Error: Requires either MacPorts of HomeBrew' >&2
 	exit 1

--- a/cmake/dist/startup_macosx.sh.in
+++ b/cmake/dist/startup_macosx.sh.in
@@ -16,14 +16,14 @@ tell application "Terminal" to set size of front window to {$w, ${dim[1]}}
 EOF
   export PATH="${BUNDLE_RESOURCES}/@GMT_BINDIR@:${PATH}"
   export PROJ_LIB="${BUNDLE_RESOURCES}/share/proj"
-  export GS_LIB="${BUNDLE_RESOURCES}/share/ghostscript/@GMT_CONFIG_GS_VERSION@/Resource/Init"
+  export GS_LIB="${BUNDLE_RESOURCES}/share/ghostscript/Resource/Init"
   export MAGICK_CONFIGURE_PATH=${BUNDLE_RESOURCES}/lib/GraphicsMagick/config
 
   function gmt () { "${BUNDLE_RESOURCES}/@GMT_BINDIR@/gmt" "$@"; }
   export -f gmt
   unset DYLD_LIBRARY_PATH
   gmt
-  echo -e "Note 1: If you want to use GMT outside of this terminal or in scripts, then follow these steps:\n        a) export GMTHOME=${BUNDLE_RESOURCES}\n        b) add \$GMTHOME/bin to your path\n        c) export PROJ_LIB=\$GMTHOME/share/proj\n        d) export GS_LIB=\$GMTHOME/share/ghostscript/@GMT_CONFIG_GS_VERSION@/Resource/Init\n        e) export MAGICK_CONFIGURE_PATH=\$GMTHOME/lib/GraphicsMagick/config"
+  echo -e "Note 1: If you want to use GMT outside of this terminal or in scripts, then follow these steps:\n        a) export GMTHOME=${BUNDLE_RESOURCES}\n        b) add \$GMTHOME/bin to your path\n        c) export PROJ_LIB=\$GMTHOME/share/proj\n        d) export GS_LIB=\$GMTHOME/share/ghostscript/Resource/Init\n        e) export MAGICK_CONFIGURE_PATH=\$GMTHOME/lib/GraphicsMagick/config"
   echo -e "Note 2: GMT may use Ghostscript, GraphicsMagick, FFmpeg, and GDAL executables; see\n        ${BUNDLE_RESOURCES}/share/Licenses for details.\n"
 
   _usershell=$(dscl . -read "/Users/$USER" UserShell)


### PR DESCRIPTION
While _ghostscript_ always places a bunch of resourses under a share directory with the version number, for the bundle we strip off that number so that the **GS_LIB** variable does not depend on that version. This revises what we did in #6026.
