### PR TITLE
Use verbose code macro where the codes are needed

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6046,7 +6046,7 @@ GMT_LOCAL void gmtinit_def_us_locale (struct GMT_CTRL *GMT) {
 
 /*! . */
 int gmt_get_V (char arg) {
-	/* Parse the verbosity selection.  Using -Vqewticd, but backwards compatible with -Vqntcvld */
+	/* Parse the verbosity selection.  Using -Vqewticd [GMT_VERBOSE_CODES], but backwards compatible with -Vqntcvld */
 	int mode = GMT_MSG_QUIET;
 	switch (arg) {
 		case 'q': case '0': mode = GMT_MSG_QUIET;	break;	/* -Vq */

--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -1355,7 +1355,7 @@ EXTERN_MSC int GMT_grdfilter (void *V_API, int mode, void *args) {
 	if (Ctrl->F.highpass) {
 		if (GMT->common.R.active[RSET] || GMT->common.R.active[ISET] || GMT->common.R.active[GSET]) {	/* Must resample result so grids are coregistered */
 			char in_string[GMT_VF_LEN], out_string[GMT_VF_LEN], cmd[GMT_LEN256];
-			static char *V_level = "qntcvld";
+			static char *V_level = GMT_VERBOSE_CODES;
 
 			/* Here we low-passed filtered onto a coarse grid but to get high-pass we must sample the low-pass result at the original resolution */
 			/* Create a virtual file for the low-pass filtered grid */

--- a/src/surface.c
+++ b/src/surface.c
@@ -2111,7 +2111,7 @@ EXTERN_MSC int GMT_surface (void *V_API, int mode, void *args) {
 
 	if (Ctrl->M.active) {	/* Want to mask the grid first */
 		char input[GMT_VF_LEN] = {""}, mask[GMT_VF_LEN] = {""}, cmd[GMT_LEN256] = {""};
-		static char *V_level = "qntcvld";
+		static char *V_level = GMT_VERBOSE_CODES;
 		struct GMT_GRID *Gmask = NULL;
 		struct GMT_VECTOR *V = NULL;
 		double *data[2] = {NULL, NULL};

--- a/src/surface_experimental.c
+++ b/src/surface_experimental.c
@@ -2431,7 +2431,7 @@ int GMT_surface_mt (void *V_API, int mode, void *args) {
 
 	if (Ctrl->M.active) {	/* Want to mask the grid first */
 		char input[GMT_VF_LEN] = {""}, mask[GMT_VF_LEN] = {""}, cmd[GMT_LEN256] = {""};
-		static char *V_level = "qntcvld";
+		static char *V_level = GMT_VERBOSE_CODES;
 		struct GMT_GRID *Gmask = NULL;
 		struct GMT_VECTOR *V = NULL;
 		double *data[2] = {NULL, NULL};


### PR DESCRIPTION
Since we have changed the **-V**_codes_ line-up over the years we added a macro called **GMT_VERBOSE_CODES** to centralize these once and for all:

`gmt_constants.h:#define GMT_VERBOSE_CODES	"q ewticd"	/* List of valid codes to -V (the blank is for NOT GMT_MSG_NOTICE ICE which is not user selectable */`

However, in a few modules we still were using a hardwired string with previous values (without the essential gap for **GMT_MSG_NOTICE**), resulting in the wrong verbosity being used when these modules called other modules.
