### PR TITLE
Remove the experimental label for grdlandmask -E

### DIFF
--- a/src/grdlandmask.c
+++ b/src/grdlandmask.c
@@ -173,7 +173,6 @@ static int parse (struct GMT_CTRL *GMT, struct GRDLANDMASK_CTRL *Ctrl, struct GM
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->E.active);
 				Ctrl->E.active = true;
 				if (opt->arg[0]) {	/* Trace lines through grid */
-					GMT_Report (API, GMT_MSG_WARNING, "-E<values> is presently being tested and is considered experimental\n");
 					Ctrl->E.linetrace = true;
 					j = pos = 0;
 					strncpy (line, opt->arg,  GMT_LEN256-1);


### PR DESCRIPTION
Since the **-E** option in **grdlandmask** has been available for at least 2-3 years now with no complaints (yet), we need to remove the experimental warning label.
