### PR TITLE
For items known to not exist, do not call gmt_M_free

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -2801,7 +2801,7 @@ GMT_LOCAL void gmtio_build_segheader_from_ogr (struct GMT_CTRL *GMT, unsigned in
 	if (gmt_polygon_is_hole (GMT, S))		/* Indicate this is a polygon hole [Default is perimeter] */
 		strcat (buffer, " -Ph");
 	if (S->header && buffer[0] && strcmp (S->header, buffer)) {strcat (buffer, " "); strncat (buffer, S->header, GMT_BUFSIZ-1);}	/* Append rest of previous header */
-	gmt_M_str_free (S->header);
+	if (S->header) gmt_M_str_free (S->header);
 	S->header = strdup (buffer);
 }
 
@@ -8548,8 +8548,10 @@ void gmt_free_table (struct GMT_CTRL *GMT, struct GMT_DATATABLE *table) {
 	if (!table) return;		/* Do not try to free NULL pointer */
 	TH = gmt_get_DT_hidden (table);
 	if (TH->alloc_mode == GMT_ALLOC_EXTERNALLY) return;	/* Not ours to free */
-	for (k = 0; k < table->n_headers; k++) gmt_M_str_free (table->header[k]);
-	gmt_M_free (GMT, table->header);
+	if (table->n_headers) {
+		for (k = 0; k < table->n_headers; k++) gmt_M_str_free (table->header[k]);
+		gmt_M_free (GMT, table->header);
+	}
 	gmt_M_free (GMT, table->min);
 	gmt_M_free (GMT, table->max);
 	for (k = 0; k < 2; k++) gmt_M_str_free (TH->file[k]);

--- a/src/gmt_memory.c
+++ b/src/gmt_memory.c
@@ -567,8 +567,8 @@ void *gmt_memory_func (struct GMT_CTRL *GMT, void *prev_addr, size_t nelem, size
 
 void gmt_free_func (struct GMT_CTRL *GMT, void *addr, bool align, const char *where) {
 	if (addr == NULL) {
-#ifndef DEBUG
-		/* report freeing unallocated memory only in level GMT_MSG_DEBUG (-V4) */
+#ifdef DEBUG
+		/* Report attempt at freeing unallocated memory only in level GMT_MSG_DEBUG (-V4) */
 		gmtlib_report_func (GMT, GMT_MSG_DEBUG, where,
 				"tried to free unallocated memory\n");
 #endif

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6448,7 +6448,7 @@ void gmt_set_basemap_orders (struct GMT_CTRL *GMT, unsigned int frame, unsigned 
 	if (annot == GMT_BASEMAP_ANNOT_AFTER && frame == GMT_BASEMAP_FRAME_BEFORE)
 		annot = GMT_BASEMAP_ANNOT_BEFORE;
 	GMT->current.map.frame.basemap_flag = frame + grid + annot;
-	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Basemap order: Frame = %s  Grid = %s  Tick/ANot = %s\n", place[frame], place[grid/2], place[annot/4]);
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Basemap order: Frame = %s  Grid = %s  Tick/Annot = %s\n", place[frame], place[grid/2], place[annot/4]);
 }
 
 GMT_LOCAL bool gmtplot_z_axis_side (struct GMT_CTRL *GMT, unsigned int axis, unsigned int quadrant) {

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -10282,8 +10282,10 @@ void gmtlib_free_ps_ptr (struct GMT_CTRL *GMT, struct GMT_POSTSCRIPT *P) {
 	P->data = NULL;		/* Whatever we pointed to is now longer known to P */
 	PH->n_alloc = P->n_bytes = 0;
 	/* Use free() to free the headers since they were allocated with strdup */
-	for (k = 0; k < P->n_headers; k++) gmt_M_str_free (P->header[k]);
-	gmt_M_free (GMT, P->header);
+	if (P->n_headers) {
+		for (k = 0; k < P->n_headers; k++) gmt_M_str_free (P->header[k]);
+		gmt_M_free (GMT, P->header);
+	}
 	gmt_M_free (GMT, P->hidden);
 	P->mode = GMT_PS_EMPTY;
 }

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7597,10 +7597,12 @@ void gmtlib_free_cpt_ptr (struct GMT_CTRL *GMT, struct GMT_PALETTE *P) {
 			gmt_M_free (GMT, P->bfn[i].fill);
 	gmt_M_free (GMT, P->data);
 	/* Use free() to free the headers since they were allocated with strdup */
-	for (i = 0; i < P->n_headers; i++) gmt_M_str_free (P->header[i]);
+	if (P->n_headers) {
+		for (i = 0; i < P->n_headers; i++) gmt_M_str_free (P->header[i]);
+		gmt_M_free (GMT, P->header);
+	}
 	P->n_headers = P->n_colors = 0;
 	gmt_M_free (GMT, P->hidden);
-	gmt_M_free (GMT, P->header);
 }
 
 /*! . */


### PR DESCRIPTION
If we call _gmt_M_free_ on a char * pointer that is NULL we will get a "tried to free unallocated memory" message under **-Vd**, which is misleading and not what those checks are trying to discover.  We avoid this by checking if there are any headers before we delete them and this pointer.  That is how we do it for most other containers with headers and now it is done the same way for datasets as well.
