### PR TITLE
Check that font_no is not -1 before using it as index

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8615,12 +8615,12 @@ GMT_LOCAL void gmtplot_prog_indicator_F (struct GMT_CTRL *GMT, double x, double 
 GMT_LOCAL void gmtplot_reset_PSL (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL) {
 	/* Because PSL_*_completion procedures are called at the end of the module but crafted at the start, we must forget we used any fonts, fills, pens in creating them,
 	 * otherwise the next PSL call requesting a fill or pen will not be properly set since PSL may think it is already the current choice. */
-	PSL->internal.font[PSL->current.font_no].encoded = 0;	/* Forget about font encoding */
-	PSL->current.font_no = GMT_NOTSET;					/* Forget what the current font is */
-	PSL->current.linewidth = GMT_NOTSET;              /* Forget we ever set a line width */
-	PSL->current.outline = GMT_NOTSET;					/* Forget we requested polygon outline */
-	gmt_M_memcpy (PSL->current.rgb[PSL_IS_FONT], GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 since text setting must set the color desired */
-	gmt_M_memcpy (PSL->current.rgb[PSL_IS_FILL], GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 since fill setting must set the color desired */
+	if (PSL->current.font_no != GMT_NOTSET) PSL->internal.font[PSL->current.font_no].encoded = 0;	/* Forget about font encoding */
+	PSL->current.font_no   = GMT_NOTSET;		/* Forget what the current font is */
+	PSL->current.linewidth = GMT_NOTSET;		/* Forget we ever set a line width */
+	PSL->current.outline   = GMT_NOTSET;		/* Forget we requested polygon outline */
+	gmt_M_memcpy (PSL->current.rgb[PSL_IS_FONT],   GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 since text setting must set the color desired */
+	gmt_M_memcpy (PSL->current.rgb[PSL_IS_FILL],   GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 since fill setting must set the color desired */
 	gmt_M_memcpy (PSL->current.rgb[PSL_IS_STROKE], GMT->session.no_rgb, 3, double);	/* Reset to -1,-1,-1 since stroke setting must set the color desired */
 }
 


### PR DESCRIPTION
This problem only showed up on a movie example and crashed on Linux but not macOS.  Traced via **valgrind** to line 8618 in _gmt_plot.c_ where apparently the font_no was still uninitialized to -1 and hence not a suitable index!
