### PR TITLE
Add --show-gshhg and --show-dcw to gmt

### DIFF
--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -107,8 +107,14 @@ If no module is given then several other options are available:
 **--show-dataserver**
     Show URL of the remote GMT data server.
 
+**--show-dcw**
+    Show the DCW data version used.
+
 **--show-doi**
     Show the DOI of the current release.
+
+**--show-gshhg**
+    Show the GSHHG data version used.
 
 **--show-modules**
     List modern module names on stdout and exit.

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -190,6 +190,14 @@ int main (int argc, char *argv[]) {
 				status = GMT_NOERROR;
 			}
 
+			/* Show DCW version of the current release */
+			else if (!strncmp (argv[arg_n], "--show-dcw", 10U)) {
+				char version[16] = {""};
+				gmt_DCW_version (api_ctrl, version);
+				fprintf(stdout, "%s\n", version);
+				status = GMT_NOERROR;
+			}
+
 			/* Show DOI of the current release */
 			else if (!strncmp (argv[arg_n], "--show-doi", 10U)) {
 				fprintf(stdout, "%s\n", GMT_VERSION_DOI);
@@ -199,6 +207,14 @@ int main (int argc, char *argv[]) {
 			/* Show the directory that contains the 'gmt' executable */
 			else if (!strncmp (argv[arg_n], "--show-bindir", 10U)) {
 				fprintf (stdout, "%s\n", api_ctrl->GMT->init.runtime_bindir);
+				status = GMT_NOERROR;
+			}
+
+			/* Show GSHHG version of the current release */
+			else if (!strncmp (argv[arg_n], "--show-gshhg", 10U)) {
+				char version[16] = {""};
+				gmt_shore_version (api_ctrl, version);
+				fprintf(stdout, "%s\n", version);
 				status = GMT_NOERROR;
 			}
 
@@ -344,7 +360,9 @@ int main (int argc, char *argv[]) {
 			fprintf (stderr, "  --show-cores        Show number of available cores.\n");
 			fprintf (stderr, "  --show-datadir      Show directory/ies with user data.\n");
 			fprintf (stderr, "  --show-dataserver   Show URL of the remote GMT data server.\n");
+			fprintf (stderr, "  --show-dcw          Show the DCW data version used.\n");
 			fprintf (stderr, "  --show-doi          Show the DOI for the current release.\n");
+			fprintf (stderr, "  --show-gshhg        Show the GSHHG data version used.\n");
 			fprintf (stderr, "  --show-library      Show path of the shared GMT library.\n");
 			fprintf (stderr, "  --show-modules      Show all modern module names.\n");
 			fprintf (stderr, "  --show-modules-core Show all modern module names (core only).\n");

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -192,7 +192,7 @@ int main (int argc, char *argv[]) {
 
 			/* Show DCW version of the current release */
 			else if (!strncmp (argv[arg_n], "--show-dcw", 10U)) {
-				char version[16] = {""};
+				char version[16] = {"unknown"};
 				gmt_DCW_version (api_ctrl, version);
 				fprintf(stdout, "%s\n", version);
 				status = GMT_NOERROR;
@@ -212,7 +212,7 @@ int main (int argc, char *argv[]) {
 
 			/* Show GSHHG version of the current release */
 			else if (!strncmp (argv[arg_n], "--show-gshhg", 10U)) {
-				char version[16] = {""};
+				char version[16] = {"unknown"};
 				gmt_shore_version (api_ctrl, version);
 				fprintf(stdout, "%s\n", version);
 				status = GMT_NOERROR;

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -285,6 +285,7 @@ int gmt_DCW_version (struct GMTAPI_CTRL *API, char *version) {
 	gmt_M_err_trap (gmt_nc_open (GMT, path, NC_NOWRITE, &cdfid));
 
 	/* Get global attributes */
+	gmt_M_memset (version, strlen (version), char);
 	gmt_M_err_trap (nc_get_att_text (cdfid, NC_GLOBAL, "version", version));
 	gmt_nc_close (GMT, cdfid);
 

--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -270,6 +270,27 @@ GMT_LOCAL bool gmtdcw_country_has_states (char *code, struct GMT_DCW_COUNTRY_STA
 #define GMT_DCW_PLOTTING	1
 #define GMT_DCW_CLIPPING	2
 
+int gmt_DCW_version (struct GMTAPI_CTRL *API, char *version) {
+	/* Write DCW version into version which must have at least 8 positions */
+	int cdfid, err;
+	char path[PATH_MAX] = {""};
+	struct GMT_CTRL *GMT = API->GMT;
+	
+	if (version == NULL)
+		return (GMT_PTR_IS_NULL);
+
+	if (!gmtdcw_get_path (GMT, "dcw-gmt", ".nc", path))
+		return (GMT_FILE_NOT_FOUND);
+
+	gmt_M_err_trap (gmt_nc_open (GMT, path, NC_NOWRITE, &cdfid));
+
+	/* Get global attributes */
+	gmt_M_err_trap (nc_get_att_text (cdfid, NC_GLOBAL, "version", version));
+	gmt_nc_close (GMT, cdfid);
+
+	return (GMT_NOERROR);
+}
+
 struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F, double wesn[], unsigned int mode) {
 	/* Given comma-separated names, read the corresponding netCDF variables.
  	 * mode = GMT_DCW_REGION	: Return the joint w/e/s/n limits

--- a/src/gmt_dcw.h
+++ b/src/gmt_dcw.h
@@ -61,6 +61,7 @@ struct GMT_DCW_SELECT {	/* -F<DWC-options> */
 	struct GMT_OPTION *options;	/* Pointer to the GMT options */
 };
 
+EXTERN_MSC int gmt_DCW_version (struct GMTAPI_CTRL *API, char *version);
 EXTERN_MSC unsigned int gmt_DCW_list (struct GMT_CTRL *GMT, struct GMT_DCW_SELECT *F);
 EXTERN_MSC unsigned int gmt_DCW_parse (struct GMT_CTRL *GMT, char option, char *args, struct GMT_DCW_SELECT *F);
 EXTERN_MSC void gmt_DCW_option (struct GMTAPI_CTRL *API, char option, unsigned int plot);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -629,6 +629,7 @@ EXTERN_MSC struct GMT_DATASEGMENT * gmt_get_smallcircle (struct GMT_CTRL *GMT, d
 
 /* gmt_shore.c: */
 
+EXTERN_MSC int gmt_shore_version (struct GMTAPI_CTRL *API, char *version);
 EXTERN_MSC int gmt_set_levels (struct GMT_CTRL *GMT, char *info, struct GMT_SHORE_SELECT *I);
 EXTERN_MSC int gmt_get_shore_bin (struct GMT_CTRL *GMT, unsigned int b, struct GMT_SHORE *c);
 EXTERN_MSC int gmt_get_br_bin (struct GMT_CTRL *GMT, unsigned int b, struct GMT_BR *c, unsigned int *level, unsigned int n_levels);

--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -444,6 +444,7 @@ int gmt_shore_version (struct GMTAPI_CTRL *API, char *version) {
 	gmt_M_err_trap (gmt_nc_open (GMT, path, NC_NOWRITE, &cdfid));
 
 	/* Get global attributes */
+	gmt_M_memset (version, strlen (version), char);
 	gmt_M_err_trap (nc_get_att_text (cdfid, NC_GLOBAL, "version", version));
 
 	gmt_nc_close (GMT, cdfid);

--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -428,6 +428,29 @@ GMT_LOCAL int gmtshore_res_to_int (char res) {
 
 /* Main Public GMT shore functions */
 
+int gmt_shore_version (struct GMTAPI_CTRL *API, char *version) {
+	/* Write GSHHG version into version which must have at least 8 positions */
+	int cdfid, err;
+	char path[PATH_MAX] = {""};
+	struct GMT_CTRL *GMT = API->GMT;
+
+	if (version == NULL)
+		return (GMT_PTR_IS_NULL);
+
+	if (!gmtshore_getpathname (GMT, "binned_GSHHS_c", path, true, true))
+		return (GMT_FILE_NOT_FOUND); /* Failed to find file */
+
+	/* Open shoreline file */
+	gmt_M_err_trap (gmt_nc_open (GMT, path, NC_NOWRITE, &cdfid));
+
+	/* Get global attributes */
+	gmt_M_err_trap (nc_get_att_text (cdfid, NC_GLOBAL, "version", version));
+
+	gmt_nc_close (GMT, cdfid);
+
+	return (GMT_NOERROR);
+}
+
 int gmt_set_levels (struct GMT_CTRL *GMT, char *info, struct GMT_SHORE_SELECT *I) {
 	/* Decode GMT's -A option for coastline levels */
 	int n;


### PR DESCRIPTION
Because these versions may not be available during compilation (they can be obtained later on the fly), we cannot compile in these versions.  This PR adds two tiny functions to read the versions and them report them from **gmt**.  Closes #6037.
