### PR TITLE
Include gmt_common_byteswap.h for bswap32.

### DIFF
--- a/src/grd2xyz.c
+++ b/src/grd2xyz.c
@@ -24,6 +24,7 @@
  */
 
 #include "gmt_dev.h"
+#include "gmt_common_byteswap.h"
 
 #define THIS_MODULE_CLASSIC_NAME	"grd2xyz"
 #define THIS_MODULE_MODERN_NAME	"grd2xyz"


### PR DESCRIPTION
`src/grd2xyz.c` uses `bswap32` in 6.3.0 but failed to include the header which defines it.

This patch was tested on the Debian s390x porterbox.

Fixes: #6043