### PR TITLE
Improve stereographic projection checking

### DIFF
--- a/doc/rst/source/cookbook/map-projections.rst
+++ b/doc/rst/source/cookbook/map-projections.rst
@@ -319,7 +319,7 @@ Stereographic Equal-Angle (**-Js** **-JS**)
 
 - The longitude (*lon0*) and latitude (*lat0*) of the projection center.
 - Optionally, the *horizon*, i.e., the number of degrees from the center to the edge (< 180) [default is 90].
-- Scale (via **-Js**) maybe provided in one of three flavors: Append 1:xxxxx (true scale at pole), *slat*\ /1:xxxxx
+- Scale (via **-Js**) may be provided in one of three flavors: Append 1:xxxxx (true scale at pole), *slat*\ /1:xxxxx
   (true scale at standard parallel *slat* for the polar aspect only), or *radius/latitude* (where *radius* is
   distance on map in :ref:`plot-units <plt-units>` from projection center to a particular oblique latitude).
 - Alternatively, simply append map *width* in :ref:`plot-units <plt-units>` (with **-JS**).

--- a/doc/rst/source/cookbook/map-projections.rst
+++ b/doc/rst/source/cookbook/map-projections.rst
@@ -229,7 +229,7 @@ Lambert Azimuthal Equal-Area (**-Ja** **-JA**)
 
 - The longitude (*lon0*) and latitude (*lat0*) of the projection center.
 - Optionally, the *horizon*, i.e., the number of degrees from the center to the edge (<=180) [default is 90].
-- The *scale* as 1:xxxxx or as radius/latitude where radius is the projected distance on the map from projection center
+- The *scale* as 1:xxxxx or as *radius/latitude* where *radius* is the projected distance on the map from projection center
   to an oblique latitude where 0 would be the oblique Equator (with **-Ja**) or map *width*
   :ref:`plot-units <plt-units>` (with **-JA**).
 
@@ -319,9 +319,10 @@ Stereographic Equal-Angle (**-Js** **-JS**)
 
 - The longitude (*lon0*) and latitude (*lat0*) of the projection center.
 - Optionally, the *horizon*, i.e., the number of degrees from the center to the edge (< 180) [default is 90].
-- Scale as 1:xxxxx (true scale at pole), slat/1:xxxxx (true scale at standard parallel slat), or radius/latitude where
-  radius is distance on map in :ref:`plot-units <plt-units>` from projection center to a particular oblique latitude
-  (with **-Js**) or simply map *width* in :ref:`plot-units <plt-units>` (with **-JS**).
+- Scale (via **-Js**) maybe provided in one of three flavors: Append 1:xxxxx (true scale at pole), *slat*\ /1:xxxxx
+  (true scale at standard parallel *slat* for the polar aspect only), or *radius/latitude* (where *radius* is
+  distance on map in :ref:`plot-units <plt-units>` from projection center to a particular oblique latitude).
+- Alternatively, simply append map *width* in :ref:`plot-units <plt-units>` (with **-JS**).
 
 **Description**
 
@@ -409,7 +410,7 @@ Perspective projection (**-Jg** **-JG**)
 **Required Parameters**
 
 - The longitude (*lon0*) and latitude (*lat0*) of the projection center.
-- The *scale* as 1:xxxxx or as radius/latitude where radius is distance on map in :ref:`plot-units <plt-units>` from
+- The *scale* as 1:xxxxx or as *radius/latitude* where *radius* is distance on map in :ref:`plot-units <plt-units>` from
   projection center to a particular oblique latitude (with **-Jg**), or map width in :ref:`plot-units <plt-units>`
   (with **-JG**).
 
@@ -460,7 +461,7 @@ Orthographic projection (**-Jg** **-JG**)
 
 - The longitude (*lon0*) and latitude (*lat0*) of the projection center.
 - Optionally, the *horizon*, i.e., the number of degrees from the center to the edge (<=90) [default is 90].
-- The *scale* as 1:xxxxx or as radius/latitude where radius is distance on map in :ref:`plot-units <plt-units>` from
+- The *scale* as 1:xxxxx or as *radius/latitude* where *radius* is distance on map in :ref:`plot-units <plt-units>` from
   projection center to a particular oblique latitude (with **-Jg**), or map width in :ref:`plot-units <plt-units>`
   (with **-JG**).
 
@@ -499,7 +500,7 @@ Azimuthal Equidistant projection (**-Je** **-JE**)
 
 - The longitude (*lon0*) and latitude (*lat0*) of the projection center.
 - Optionally, the *horizon*, i.e., the number of degrees from the center to the edge (<=180) [default is 180].
-- The *scale* as 1:xxxxx or as radius/latitude where radius is distance on map in :ref:`plot-units <plt-units>` from
+- The *scale* as 1:xxxxx or as *radius/latitude* where *radius* is distance on map in :ref:`plot-units <plt-units>` from
   projection center to a particular oblique latitude (with **-Je**), or map width in :ref:`plot-units <plt-units>`
   (with **-JE**).
 
@@ -538,7 +539,7 @@ Gnomonic projection (**-Jf** **-JF**)
 
 - The longitude (*lon0*) and latitude (*lat0*) of the projection center.
 - Optionally, the *horizon*, i.e., the number of degrees from the center to the edge (<90) [default is 60].
-- The *scale* as 1:xxxxx or as radius/latitude where radius is distance on map in :ref:`plot-units <plt-units>` from
+- The *scale* as 1:xxxxx or as *radius/latitude* where radius is distance on map in :ref:`plot-units <plt-units>` from
   projection center to a particular oblique latitude (with **-Jf**), or map width in :ref:`plot-units <plt-units>`
   (with **-JF**).
 

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -3066,7 +3066,7 @@ GMT_LOCAL int gmtmap_init_stereo (struct GMT_CTRL *GMT, bool *search) {
 	gmtmap_set_polar (GMT);
 
 	if (GMT->current.setting.proj_scale_factor == -1.0) GMT->current.setting.proj_scale_factor = 0.9996;	/* Select default map scale for Stereographic */
-	if (GMT->current.proj.polar  && std_parallel) GMT->current.setting.proj_scale_factor = 1.0;	/* Gave true scale at given parallel set below */
+	if (GMT->current.proj.polar && std_parallel) GMT->current.setting.proj_scale_factor = 1.0;	/* Gave true scale at given parallel set below */
 	/* Equatorial view has a problem with infinite loops.  Until I find a cure
 	  we set projection center latitude to 0.001 so equatorial works for now */
 


### PR DESCRIPTION
Inspired by this [forum post](https://forum.generic-mapping-tools.org/t/projection-errors/2342/4) (a user error), I decided to make a few improvements.  This PR does the following:

1. Adds more comments in the **-Js**|**S** argument parsing section so we know what we are expecting for each case.
2. Gives specific error if the OP case happens (i.e., select **-JS** but _also_ trying to specify distance to an oblique latitude)
3. Be forgiving with **-Js** if the user switches up _radius_/_slat_ and _slat_/_radius_
4. Give error if anyone tries _radius_/_slat_ and we are _not_ in polar aspect.
5. Be a bit clearer in the **-Js** documentation in the cookbook on the three ways to set scale and that one of them requires polar aspect.
6. Italicize parameters radius, slat, etc in the cookbook documentation.

All tests pass.