### PR TITLE
Document gmt subplot -A for skipping a tag

### DIFF
--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -224,6 +224,7 @@ Optional Arguments (set mode)
     Placement, justification, etc. are all inherited from how **-A** was specified by the
     initial **subplot begin** command.  **Note**: Overriding means you initiate the tag
     machinery with **-A** when **subplot begin** was called, otherwise the option is ignored.
+    To *not* set any tag for this panel, use **-A-**.
 
 .. _subplot_set-C2:
 

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -235,7 +235,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+r Set number using Roman numerals; use +R for uppercase [arabic].");
 	GMT_Usage (API, 3, "+s Append [<dx>/<dy>][/<shade>] to plot a shadow behind the tag panel [Default is 2p/-2p/gray50].");
 	GMT_Usage (API, 3, "+v Number subplots down the columns [subplots are numbered across rows].");
-	GMT_Usage (API, -2, "Note: Use subplot set -A<fixedtag> to override the auto-tag system for one subplot.");
+	GMT_Usage (API, -2, "Note: Use subplot set -A<fixedtag> to override the auto-tag system for one subplot and -A- to skip a tag.");
 	GMT_Option (API, "B-");
 	GMT_Usage (API, -2, "Note: Usually it is better to use -S to organize annotations and ticks than to use -B directly.");
 	GMT_Usage (API, 1, "\n-C[<side>]<clearance>");


### PR DESCRIPTION
When the automatic panel tagging is initiated in **gmt subplot begin -A** we can override the tag for any panel via **gmt subplot set -A**_tag_.  However, we did not document that to skip such a tag entirely one must use **-A-**.  This PR addresses this omission.
