### PR TITLE
Flip frame default for south pole aspect

### DIFF
--- a/doc/examples/ex42/ex42.bat
+++ b/doc/examples/ex42/ex42.bat
@@ -28,7 +28,7 @@ gmt begin ex42
 	echo 6.5 14		>> lines.txt
 	echo 13	11.5	>> lines.txt
 	echo 19	11.5	>> lines.txt
-	gmt plot lines.txt -R0/19/0/25 -Jx1c -B0 -W2p -X-6c -Y-13.5c
+	gmt plot lines.txt -R0/19/0/26 -Jx1c -B0 -W2p -X-6c -Y-13.5c
 	echo 0 13 BEDMAP > tmp.txt
 	echo 0 24 GSHHG >> tmp.txt
 	gmt text tmp.txt -F+f18p+jBL -Dj8p/0

--- a/doc/examples/ex42/ex42.ps
+++ b/doc/examples/ex42/ex42.ps
@@ -1,11 +1,11 @@
 %!PS-Adobe-3.0
 %%BoundingBox: 0 0 595 842
 %%HiResBoundingBox: 0 0 595.0000 842.0000
-%%Title: GMT v6.3.0_c4e2ed5_2021.10.04 [64-bit] Document from grdimage
+%%Title: GMT v6.4.0_1ec2637-dirty_2021.11.22 Document from grdimage
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Mon Oct  4 20:54:18 2021
+%%CreationDate: Wed Nov 24 11:57:48 2021
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -26309,6 +26309,14 @@ N 2625 5249 M 0 76 D S
 N 4897 3937 M 66 38 D S
 N 4897 1312 M 66 -38 D S
 N 2625 0 M 0 -76 D S
+2625 -122 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+152 F0
+(180°) tc Z
+246 1251 M V -60 R (120°W) tc Z U
+246 3998 M V 60 R (60°W) bc Z U
+2625 5371 M (0°) bc Z
+5003 3998 M V -60 R (60°E) bc Z U
+5003 1251 M V 60 R (120°E) tc Z U
 4 W
 clipsave
 2625 2625 M
@@ -36461,6 +36469,14 @@ N 2625 5249 M 0 76 D S
 N 4897 3937 M 66 38 D S
 N 4897 1312 M 66 -38 D S
 N 2625 0 M 0 -76 D S
+2625 -122 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+152 F0
+(180°) tc Z
+246 1251 M V -60 R (120°W) tc Z U
+246 3998 M V 60 R (60°W) bc Z U
+2625 5371 M (0°) bc Z
+5003 3998 M V -60 R (60°E) bc Z U
+5003 1251 M V 60 R (120°E) tc Z U
 3106 4284 M
 7 12 D
 13 6 D
@@ -41406,8 +41422,8 @@ FQ
 O0
 -2835 -6378 TM
 % PostScript produced by:
-%@GMT: gmt plot -R0/19/0/25 -Jx1c -B0 -W2p -X-6c -Y-13.5c
-%@PROJ: xy 0.00000000 19.00000000 0.00000000 25.00000000 0.000 19.000 0.000 25.000 +xy
+%@GMT: gmt plot -R0/19/0/26 -Jx1c -B0 -W2p -X-6c -Y-13.5c
+%@PROJ: xy 0.00000000 19.00000000 0.00000000 26.00000000 0.000 19.000 0.000 26.000 +xy
 %%BeginObject PSL_Layer_9
 0 setlinecap
 0 setlinejoin
@@ -41418,7 +41434,7 @@ V
 clipsave
 0 0 M
 8976 0 D
-0 11811 D
+0 12283 D
 -8976 0 D
 P
 PSL_clip N
@@ -41429,24 +41445,24 @@ PSL_clip N
 S
 PSL_cliprestore
 U
-26 W
+27 W
 0 A
 /PSL_slant_y 0 def /PSL_slant_x 0 def
 2 setlinecap
-N 0 11811 M 0 -11811 D S
+N 0 12283 M 0 -12283 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
 8976 0 T
-N 0 11811 M 0 -11811 D S
+N 0 12283 M 0 -12283 D S
 -8976 0 T
 N 0 0 M 8976 0 D S
 /PSL_A0_y 0 def
 /PSL_A1_y 0 def
 /PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
-0 11811 T
+0 12283 T
 N 0 0 M 8976 0 D S
-0 -11811 T
+0 -12283 T
 0 setlinecap
 %%EndObject
 0 A
@@ -41454,8 +41470,8 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt text -F+f18p+jBL -Dj8p/0 -R0/19/0/25 -Jx1c
-%@PROJ: xy 0.00000000 19.00000000 0.00000000 25.00000000 0.000 19.000 0.000 25.000 +xy
+%@GMT: gmt text -F+f18p+jBL -Dj8p/0 -R0/19/0/26 -Jx1c
+%@PROJ: xy 0.00000000 19.00000000 0.00000000 26.00000000 0.000 19.000 0.000 26.000 +xy
 %%BeginObject PSL_Layer_10
 0 setlinecap
 0 setlinejoin
@@ -41463,7 +41479,7 @@ O0
 clipsave
 0 0 M
 8976 0 D
-0 11811 D
+0 12283 D
 -8976 0 D
 P
 PSL_clip N

--- a/doc/examples/ex42/ex42.sh
+++ b/doc/examples/ex42/ex42.sh
@@ -26,7 +26,7 @@ gmt begin ex42
 	S 0.4c s 0.3c lightbrown 0.25p 0.75c Grounding line
 	EOF
 	# Fancy line
-	gmt plot -R0/19/0/25 -Jx1c -B0 -W2p -X-6c -Y-13.5c <<- EOF
+	gmt plot -R0/19/0/26 -Jx1c -B0 -W2p -X-6c -Y-13.5c <<- EOF
 	0	14
 	6.5	14
 	13	11.5

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10033,6 +10033,9 @@ void gmt_set_undefined_axes (struct GMT_CTRL *GMT, bool conf_update) {
 	}
 	else if (GMT->current.proj.projection == GMT_GNOMONIC || GMT->current.proj.projection == GMT_GENPER)	/* Need to relax to all since hard to guess what works */
 		strcpy (axes, "WESNZ");
+	else if (gmt_M_is_azimuthal (GMT) && doubleAlmostEqual (GMT->current.proj.pars[1], -90.0)) {	/* South polar aspect */
+		strcpy (axes, "WrbNZ");
+	}
 	else if (!doubleAlmostEqual (az, 180.0)) {	/* Rotated, so must adjust */
 		unsigned int quadrant = urint (floor (az / 90.0)) + 1;
 		switch (quadrant) {


### PR DESCRIPTION
See #6055 for background.  The issue was that the default of _WeSn_ only makes sense in the northern hemisphere or when S is not the S pole.  This PR checks if we are doing a South polar azimuthal axpect with the S pole as the latitude parameter, in which csae we flip S to N in the axes defaults.  This also fixes the missing annotations in example 42 which then needed to be 1 cm taller.

Other tests were not affected. Closes #6055.