### PR TITLE
Let @J in GMT/OGR files set -fg if implying degree coordinates

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -191,7 +191,7 @@ enum GMTIO_PROJS {
 	GMTIO_EPGS = 0,
 	GMTIO_GMT,
 	GMTIO_PROJ4,
-	GMTIO_GCS
+	GMTIO_WKT
 };
 
 /* These functions are defined and used below but not in any *.h file so we repeat them here */
@@ -753,8 +753,8 @@ GMT_LOCAL void gmtio_ogr_check_if_geographic (struct GMT_CTRL *GMT) {
 			return;
 		}
 	}
-	if (S->proj[GMTIO_GCS]) {	/* See if we have degree units */
-		if (strstr (S->proj[GMTIO_GCS], "UNIT[\"Degree\",0.0174532925199433]")) {
+	if (S->proj[GMTIO_WKT]) {	/* See if we have degree units */
+		if (strstr (S->proj[GMTIO_WKT], "UNIT[\"Degree\",0.0174532925199433]")) {
 			gmt_set_geographic (GMT, GMT_IN);
 			return;
 		}
@@ -883,7 +883,7 @@ GMT_LOCAL bool gmtio_ogr_header_parser (struct GMT_CTRL *GMT, char *record) {
 						if (strstr (Jstring, "+proj=longlat"))	/* +proj=longlat means we have lon/lat degree coordinates and thus should set -fig */
 							gmt_set_geographic (GMT, GMT_IN);
 						break;
-					case 'w': k = GMTIO_GCS;	/* OGR WKT representation */
+					case 'w': k = GMTIO_WKT;	/* OGR WKT representation */
 						if (strstr (Jstring, "Degree"))	/* UNIT as Degree means we have lon/lat degree coordinates and thus should set -fig */
 							gmt_set_geographic (GMT, GMT_IN);
 						break;
@@ -2962,7 +2962,7 @@ GMT_LOCAL int gmtio_prep_ogr_output (struct GMT_CTRL *GMT, struct GMT_DATASET *D
 	TH->ogr->proj[GMTIO_EPGS] = strdup ("\"4326\"");
 	TH->ogr->proj[GMTIO_GMT] = strdup ("\"-Jx1d --PROJ_ELLIPSOID=WGS84\"");
 	TH->ogr->proj[GMTIO_PROJ4] = strdup ("\"+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs\"");
-	TH->ogr->proj[GMTIO_GCS] = strdup ("\"GEOGCS[\"GCS_WGS_1984\",DATUM[\"WGS_1984\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]]\"");
+	TH->ogr->proj[GMTIO_WKT] = strdup ("\"GEOGCS[\"GCS_WGS_1984\",DATUM[\"WGS_1984\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]]\"");
 	TH->ogr->geometry = GMT->common.a.geometry;
 	TH->ogr->n_aspatial = GMT->common.a.n_aspatial;
 	if (TH->ogr->n_aspatial) {	/* Copy over the command-line settings */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -825,10 +825,19 @@ GMT_LOCAL bool gmtio_ogr_header_parser (struct GMT_CTRL *GMT, char *record) {
 
 			case 'J':	/* Dataset projection strings (one of 4 kinds) */
 				switch (p[1]) {
-					case 'e': k = 0;	break;	/* EPSG code */
-					case 'g': k = 1;	break;	/* GMT proj code */
-					case 'p': k = 2;	break;	/* Proj.4 code */
-					case 'w': k = 3;	break;	/* OGR WKT representation */
+					case 'e': k = 0;	/* EPSG code */
+						if (strstr (&p[2], "4326"))	/* 4326 means we have lon/lat degree coordinates and thus should set -fig */
+							gmt_set_geographic (GMT, GMT_IN);
+						break;
+					case 'g': k = 1;	break;	/* GMT proj code. If given then data are projected */
+					case 'p': k = 2;	/* Proj.4 code */
+						if (strstr (&p[2], "+proj=longlat"))	/* +proj=longlat means we have lon/lat degree coordinates and thus should set -fig */
+							gmt_set_geographic (GMT, GMT_IN);
+						break;
+					case 'w': k = 3;	/* OGR WKT representation */
+						if (strstr (&p[2], "Degree"))	/* UNIT as Degree means we have lon/lat degree coordinates and thus should set -fig */
+							gmt_set_geographic (GMT, GMT_IN);
+						break;
 					default:
 						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad OGR/GMT: @J given unknown format (%c)\n", (int)p[1]);
 						GMT->current.io.ogr = GMT_OGR_FALSE;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4319,7 +4319,7 @@ void gmt_set_geographic (struct GMT_CTRL *GMT, unsigned int dir) {
 	/* Eliminate lots of repeated statements to do this: */
 	gmt_set_column_type (GMT, dir, GMT_X, GMT_IS_LON);
 	gmt_set_column_type (GMT, dir, GMT_Y, GMT_IS_LAT);
-	if (dir == GMT_IN) {	/* Default spherical distance calculations are in meters (cannot fail) */
+	if (dir == GMT_IN && GMT->current.io.ogr != GMT_OGR_TRUE) {	/* Default spherical distance calculations are in meters (cannot fail), except if we are still parsing OGR @J strings */
 		int mode = (GMT->common.j.active) ? GMT->common.j.mode : GMT_GREATCIRCLE;
 		(void) gmt_init_distaz (GMT, GMT_MAP_DIST_UNIT, mode, GMT_MAP_DIST);
 	}

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -753,12 +753,6 @@ GMT_LOCAL void gmtio_ogr_check_if_geographic (struct GMT_CTRL *GMT) {
 			return;
 		}
 	}
-	if (S->proj[GMTIO_WKT]) {	/* See if we have degree units */
-		if (strstr (S->proj[GMTIO_WKT], "UNIT[\"Degree\",0.0174532925199433]")) {
-			gmt_set_geographic (GMT, GMT_IN);
-			return;
-		}
-	}
 	/* If we get here we most likely have read projected data, so stick with Cartesian i/o */
 }
 
@@ -780,7 +774,7 @@ GMT_LOCAL bool gmtio_ogr_header_parser (struct GMT_CTRL *GMT, char *record) {
 
 	unsigned int n_aspatial, k, geometry = 0;
 	bool quote;
-	char *p = NULL, *Jstring = NULL;
+	char *p = NULL;
 	struct GMT_OGR *S = NULL;
 
 	if (GMT->current.io.ogr == GMT_OGR_FALSE) return (false);	/* No point parsing further if we KNOW it is not OGR */
@@ -872,25 +866,15 @@ GMT_LOCAL bool gmtio_ogr_header_parser (struct GMT_CTRL *GMT, char *record) {
 					GMT->current.io.ogr = GMT_OGR_FALSE;
 					return (false);					
 				}
-				Jstring = strdup (&p[2]);
 				switch (p[1]) {
-					case 'e': k = GMTIO_EPGS;	/* EPSG code */
-						if (strstr (Jstring, "4326"))	/* 4326 means we have lon/lat degree coordinates and thus should set -fig */
-							gmt_set_geographic (GMT, GMT_IN);
-						break;
+					case 'e': k = GMTIO_EPGS;	break;	/* EPSG code */
 					case 'g': k = GMTIO_GMT;	break;	/* GMT proj code. If given then data are projected */
-					case 'p': k = GMTIO_PROJ4;	/* Proj.4 code */
-						if (strstr (Jstring, "+proj=longlat"))	/* +proj=longlat means we have lon/lat degree coordinates and thus should set -fig */
-							gmt_set_geographic (GMT, GMT_IN);
-						break;
-					case 'w': k = GMTIO_WKT;	/* OGR WKT representation */
-						if (strstr (Jstring, "Degree"))	/* UNIT as Degree means we have lon/lat degree coordinates and thus should set -fig */
-							gmt_set_geographic (GMT, GMT_IN);
-						break;
-					default:	/* We already checked for this above */
+					case 'p': k = GMTIO_PROJ4;	break;	/* Proj.4 code */
+					case 'w': k = GMTIO_WKT;	break;	/* OGR WKT representation */
+					default:	/* We already checked for this above so cannot get here */
 						break;
 				}
-				S->proj[k] = Jstring;
+				S->proj[k] = strdup (&p[2]);;
 				break;
 
 			case 'R':	/* Dataset region */


### PR DESCRIPTION
Basically, if a GMT/OGR file (or a shapefile converted to one under the hood) has projection information that says it is a lon,lat file then we can set **-fg** internally since we know it is in degrees.