### PR TITLE
Spell out stdin and stdout in documentation

### DIFF
--- a/doc/rst/source/changes.rst
+++ b/doc/rst/source/changes.rst
@@ -1204,7 +1204,7 @@ changes to existing syntax will be backwards compatible:
    modifiers **+1** or **+2** which will compute
    the first or second derivatives of the spline, respectively.
 
-*  :doc:`spectrum1d` can now turn off single-output data to stdout via **-T**
+*  :doc:`spectrum1d` can now turn off single-output data to standard output via **-T**
    or turn off multi-file output via **-N**.
 
 *  :doc:`sphdistance` can now also perform a nearest-neighbor gridding where
@@ -1228,7 +1228,7 @@ A few supplement modules have new features as well:
 *  :doc:`grdgravmag3d <supplements/potential/grdgravmag3d>` adds **-H** to compute magnetic anomaly.
 
 *  :doc:`grdpmodeler <supplements/spotter/grdpmodeler>` can now output more than one model
-   prediction into several grids or as a record written to stdout.  Also gains the **-N** option
+   prediction into several grids or as a record written to standard output.  Also gains the **-N** option
    used by other spotter tools to extend the model duration.
 
 

--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -90,7 +90,7 @@ Optional Arguments
 **-C**\ [*cpt*]
     *cpt* is the CPT to be used. If no *cpt* is appended or no **-C** is given
     then we use the current CPT (modern mode only).  In classic mode, if no **-C**
-    is given then we read stdin.  By default all
+    is given then we read standard input.  By default all
     color changes are annotated. To use a subset, add an extra column to
     the CPT with a L, U, or B to annotate Lower, Upper, or Both
     color segment boundaries (but see **-B**). Like :doc:`grdview`, we can understand

--- a/doc/rst/source/contour.rst
+++ b/doc/rst/source/contour.rst
@@ -62,7 +62,7 @@ provide a second file with network information, such as a triangular
 mesh used for finite element modeling. In addition to contours, the area
 between contours may be painted according to the CPT.
 Alternatively, the *x, y, z* positions of the contour lines may be saved to
-one or more output files (or stdout) and no plot is produced.
+one or more output files (or standard output) and no plot is produced.
 
 Required Arguments
 ------------------

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -471,7 +471,7 @@ Standard input or file, header records
 
 Most of the programs which expect table data input can read either
 standard input or input in one or several files. These programs will try
-to read *stdin* unless you type the filename(s) on the command line
+to read standard input unless you type the filename(s) on the command line
 without the above hyphens. (If the program sees a hyphen, it reads the
 next character as an instruction; if an argument begins without a
 hyphen, it tries to open this argument as a filename).  This feature

--- a/doc/rst/source/explain_contdump.rst_
+++ b/doc/rst/source/explain_contdump.rst_
@@ -1,5 +1,5 @@
     Dump the (x,y,z) coordinates of each contour to one or more output files
-    (or *stdout* if *template* is not given). No plotting will take place.
+    (or standard output if *template* is not given). No plotting will take place.
     If *template* contains one or more of the C-format specifiers %d, %f, %c
     then line segments will be written to different files; otherwise all
     lines are written to the specified file (*template*). The use of the

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -75,14 +75,14 @@ If no module is given then several other options are available:
     List and description of GMT modules.
 
 **--new-script**\ [=\ *L*]
-    Write a GMT modern mode script template to stdout. Optionally append the desired
+    Write a GMT modern mode script template to standard output. Optionally append the desired
     scripting language among *bash*, *csh*, or *batch*.  Default is the main shell
     closest to your current shell (e.g., bash for zsh, csh for tcsh).
 
 **--new-glue**\ =\ *name*
     Write the C code glue needed when building third-party supplements as shared
     libraries.  The *name* is the name of the shared library. Run **gmt** in the directory
-    of the supplement and the glue code will be written to *stdout*.  Including this C code
+    of the supplement and the glue code will be written to standard output.  Including this C code
     when building the shared library means **gmt** can list available modules via the
     **--show-modules**, **--help** options.  We recommend saving the code to gmt\_\ *name*\_glue.c.
 
@@ -93,10 +93,10 @@ If no module is given then several other options are available:
     Show the citation for the latest GMT publication.
 
 **--show-classic**
-    List classic module names on stdout and exit.
+    List classic module names on standard output and exit.
 
 **--show-classic-core**
-    List classic module names (core only) on stdout and exit.
+    List classic module names (core only) on standard output and exit.
 
 **--show-cores**
     Show number of available cores.
@@ -117,10 +117,10 @@ If no module is given then several other options are available:
     Show the GSHHG data version used.
 
 **--show-modules**
-    List modern module names on stdout and exit.
+    List modern module names on standard output and exit.
 
 **--show-modules-core**
-    List modern module names (core only) on stdout and exit.
+    List modern module names (core only) on standard output and exit.
 
 **--show-library**
     Show the path of the shared GMT library.

--- a/doc/rst/source/gmtconnect.rst
+++ b/doc/rst/source/gmtconnect.rst
@@ -59,7 +59,7 @@ Optional Arguments
 
 **-C**\ [*closed*]
     Write all the already-closed polygons to file *closed* [gmtconnect_closed.txt]
-    and all open segments to *stdout*. No connection will take
+    and all open segments to standard output. No connection will take
     place. Use **-T**\ *cutoff* to set a minimum separation [0], and then
     any existing polygon whose first and last point are separated by less
     that *cutoff* will be considered to be closed.  Note that if

--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -90,7 +90,7 @@ Optional Arguments
 
 **-D**\ [*template*\ [**+o**\ *orig*]]
     For multiple segment data, dump each segment to a separate output
-    file [Default writes a multiple segment file to stdout]. Append a
+    file [Default writes a multiple segment file to standard output]. Append a
     format template for the individual file names; this template
     **must** contain a C format specifier that can format an integer
     argument (the running segment number across all tables); this is

--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -36,7 +36,7 @@ Optional Arguments
 
 PARAMETER
     Provide one or several parameters of interest. The current value of
-    those parameters will be written to *stdout*. For a complete listing
+    those parameters will be written to standard output. For a complete listing
     of available parameters and their meaning, see the :doc:`gmt.conf` man page.
 
 .. _-D:

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -64,12 +64,12 @@ Required Arguments
     If *operand* can be opened as a file it will be read as an ASCII (or
     binary, see **-bi**) table data file. If not
     a file, it is interpreted as a numerical constant or a special
-    symbol (see below). The special argument STDIN means that *stdin*
+    symbol (see below). The special argument STDIN means that standard input
     will be read and placed on the stack; STDIN can appear more than
     once if necessary.
 *outfile*
     The name of a table data file that will hold the final result. If
-    not given then the output is sent to *stdout*.
+    not given then the output is sent to standard output.
 
 Optional Arguments
 ------------------

--- a/doc/rst/source/gmtregress.rst
+++ b/doc/rst/source/gmtregress.rst
@@ -41,7 +41,7 @@ Synopsis
 Description
 -----------
 
-**regress** reads one or more data tables [or *stdin*]
+**regress** reads one or more data tables [or standard input]
 and determines the best linear [weighted] regression model :math:`y(x) = a + b x` for each segment using the chosen parameters.
 The user may specify which data and model components should be reported.  By default, the model will be evaluated at the
 input points, but alternatively you can specify an equidistant range over which to evaluate

--- a/doc/rst/source/gmtspatial.rst
+++ b/doc/rst/source/gmtspatial.rst
@@ -149,7 +149,7 @@ Optional Arguments
     (first **-Z**, then **-L** are scanned), or it is assigned the
     running number that is initialized to *start* [0]. By default the
     input segment that are found to be inside a polygon are written to
-    stdout with the polygon ID encoded in the segment header as
+    standard output with the polygon ID encoded in the segment header as
     **-Z**\ *ID*. Alternatively, append **+r** to just report which
     polygon contains a feature or **+z** to have the IDs added as an
     extra data column on output. Segments that fail to be inside a
@@ -161,7 +161,7 @@ Optional Arguments
 **-Q**\ [*unit*][**+c**\ *min*\ [/*max*]][**+h**][**+l**][**+p**][**+s**\ [**a**\|\ **d**]]
     Measure the area of all polygons or length of line segments. Use
     **-Q+h** to append the area to each polygons segment header [Default
-    simply writes the area to stdout]. For polygons we also compute the
+    simply writes the area to standard output]. For polygons we also compute the
     centroid location while for line data we compute the mid-point
     (half-length) position. Append a distance unit to select the unit
     used (see `Units`_). Note that the area will depend on the current

--- a/doc/rst/source/gmtsplit.rst
+++ b/doc/rst/source/gmtsplit.rst
@@ -105,7 +105,7 @@ Optional Arguments
 
 **-N**\ *template*
     Write each segment to a separate output file [Default writes a
-    multiple segment file to stdout]. Append a format template for the
+    multiple segment file to standard output]. Append a format template for the
     individual file names; this template **must** contain a C format
     specifier that can format an integer argument (the running segment
     number across all tables); this is usually %d but could be %08d

--- a/doc/rst/source/grdcontour.rst
+++ b/doc/rst/source/grdcontour.rst
@@ -48,7 +48,7 @@ Description
 **grdcontour** reads a 2-D grid file and produces a contour map by
 tracing each contour through the grid. Various options that affect the plotting
 are available. Alternatively, the *x, y, z* positions of the contour lines
-may be saved to one or more output files (or stdout) and no plot is produced.
+may be saved to one or more output files (or standard output) and no plot is produced.
 
 Required Arguments
 ------------------
@@ -128,7 +128,7 @@ Optional Arguments
 **-D**\ *template*
     Dump contours as data line segments; no plotting takes place.
     Append filename template which may contain C-format specifiers.
-    If no filename template is given we write all lines to stdout.
+    If no filename template is given we write all lines to standard output.
     If filename has no specifiers then we write all lines to a single file.
     If a float format (e.g., %6.2f) is found we substitute the contour z-value.
     If an integer format (e.g., %06d) is found we substitute a running segment count.

--- a/doc/rst/source/grdfft.rst
+++ b/doc/rst/source/grdfft.rst
@@ -87,7 +87,7 @@ Optional Arguments
     the x or y direction instead. No grid file is created. If one grid
     is given then f (i.e., frequency or wave number), power[f],
     and 1 standard deviation in power[f] are written to the file set by
-    **-G** [stdout]. If two grids are given we write f and 8 quantities:
+    **-G** [standard output]. If two grids are given we write f and 8 quantities:
     Xpower[f], Ypower[f], coherent power[f], noise power[f], phase[f],
     admittance[f], gain[f], coherency[f].  Each quantity is followed by
     its own 1-std dev error estimate, hence the output is 17 columns wide.
@@ -143,7 +143,7 @@ Optional Arguments
 
 **-G**\ *outfile*\|\ *table*
     Filename for output netCDF grid file OR 1-D data table (see **-E**).
-    This is optional for -E (spectrum written to stdout) but mandatory for
+    This is optional for -E (spectrum written to standard output) but mandatory for
     all other options that require a grid output.
 
 .. _-I:

--- a/doc/rst/source/grdhisteq.rst
+++ b/doc/rst/source/grdhisteq.rst
@@ -32,7 +32,7 @@ this application, the user might have a grid of flat topography with a
 mountain in the middle. Ordinary gray shading of this file (using
 :doc:`grdimage` or :doc:`grdview`) with a linear mapping from topography to graytone will
 result in most of the image being very dark gray, with the mountain
-being almost white. One could use **grdhisteq** to write to stdout or file an
+being almost white. One could use **grdhisteq** to write to standard output or file an
 ASCII list of those data values which divide the range of the data into
 *n_cells* segments, each of which has an equal area in the image. Using
 **awk** or :doc:`makecpt` one can take this output and build a CPT;

--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -101,14 +101,14 @@ Required Arguments
 **-G**\ *grdfile*
     Name of resulting output file. (1) If options **-R**, **-I**, and
     possibly **-r** are set we produce an equidistant output table. This
-    will be written to stdout unless **-G** is specified. **Note**: For 2-D
+    will be written to standard output unless **-G** is specified. **Note**: For 2-D
     grids the **-G** option is required. (2) If option **-T** is
     selected then **-G** is required and the output file is a 2-D binary
     grid file. Applies to 2-D interpolation only. (3) For 3-D cubes
     the **-G** option is optional.  If set, it can be the name of a 3-D
     cube file or a filename template with a floating-point C-format identifier
     in it so that each layer is written to a 2-D grid file; otherwise
-    we write (*x, y, z, w*) records to stdout. (4) If **-N** is
+    we write (*x, y, z, w*) records to standard output. (4) If **-N** is
     selected then the output is an ASCII (or binary; see
     **-bo**) table; if **-G** is not given then
     this table is written to standard output. Ignored if **-C** or
@@ -201,7 +201,7 @@ Optional Arguments
 **-N**\ *nodefile*
     ASCII file with coordinates of desired output locations **x** in the
     first column(s). The resulting *w* values are appended to each
-    record and written to the file given in **-G** [or stdout if not
+    record and written to the file given in **-G** [or standard output if not
     specified]; see **-bo** for binary output
     instead. This option eliminates the need to specify options **-R**,
     **-I**, and **-r**.

--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -37,7 +37,7 @@ Description
 -----------
 
 Makes legends that can be overlaid on maps. It reads
-specific legend-related information from an input file [or stdin].
+specific legend-related information from an input file [or standard input].
 Unless otherwise noted, annotations will be made using the primary
 annotation font and size in effect (i.e., :term:`FONT_ANNOT_PRIMARY`)
 
@@ -102,8 +102,8 @@ Optional Arguments
 **-M**
     Modern mode only: Read both (1) the hidden auto-generated legend information file created by
     plotting-modules' **-l** option and (2) additional information from input file(s) given on the
-    command line (or via *stdin*) [hidden file only].  For classic mode an input file must be
-    given or else we will read from *stdin*.
+    command line (or via standard input) [hidden file only].  For classic mode an input file must be
+    given or else we will read from standard input.
 
 .. |Add_-R| replace:: |Add_-R_links|
 .. include:: explain_-R.rst_

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -184,7 +184,7 @@ Optional Arguments
 .. _-S:
 
 **-S**\ *mode*
-    Determine a suitable range for the **-T** option from the input table(s) (or stdin).
+    Determine a suitable range for the **-T** option from the input table(s) (or standard input).
     Choose from several types of range determinations:
     **-Sr** will use the data range min/max, **-S**\ *inc*\ [**+d**] will use the data min/max but rounded
     to nearest *inc* (append **+d** to resample to a discrete CPT), **-Sa**\ *scl* will

--- a/doc/rst/source/mask.rst
+++ b/doc/rst/source/mask.rst
@@ -103,7 +103,7 @@ Optional Arguments
 
 **-D**\ *dumpfile*
     Dump the (x,y) coordinates of each clipping polygon to one or more
-    output files (or *stdout* if *template* is not given). No plotting
+    output files (or standard output if *template* is not given). No plotting
     will take place. If *template* contains the C-format specifier %d
     (including modifications like %05d) then polygons will be written to
     different files; otherwise all polygons are written to the specified

--- a/doc/rst/source/rose.rst
+++ b/doc/rst/source/rose.rst
@@ -126,7 +126,7 @@ Optional Arguments
 
 **-I**
     Inquire. Computes statistics needed to specify a useful **-R**. No
-    plot is generated.  The following statistics are written to stdout:
+    plot is generated.  The following statistics are written to standard output:
     *n*, *mean az*, *mean r*, *mean resultant length*, *max bin sum*,
     *scaled mean*, and *linear length sum*. **Note**: You may use **-o**
     to select a subset from this record.

--- a/doc/rst/source/spectrum1d.rst
+++ b/doc/rst/source/spectrum1d.rst
@@ -68,7 +68,7 @@ ASCII unless **-bo** is set) are as follows:
     Signal-to-Noise-Ratio (SNR) is coh / (1 - coh). SNR = 1 when coh = 0.5.
 
 In addition, a single file with all of the above as individual columns will
-be written to *stdout* (unless disabled via **-T**).
+be written to standard output (unless disabled via **-T**).
 
 Required Arguments
 ------------------
@@ -132,7 +132,7 @@ Optional Arguments
 .. _-T:
 
 **-T**
-    Disable the writing of a single composite results table to stdout.  Only individual output
+    Disable the writing of a single composite results table to standard output.  Only individual output
     files for each selected component (see **-C**) will be written.
 
 .. _-W:

--- a/doc/rst/source/supplements/geodesy/earthtide.rst
+++ b/doc/rst/source/supplements/geodesy/earthtide.rst
@@ -30,7 +30,7 @@ Description
 -----------
 
 Compute the three components of solid Earth tides as time-series or grids. Optionally compute also Sun and Moon position in lon,lat.
-The output can be either in the form of a grid or as a table printed to stdout. The format of the table data is:
+The output can be either in the form of a grid or as a table printed to standard output. The format of the table data is:
 *time north east vertical* in units of meters.
 
 

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -157,7 +157,7 @@ Optional Arguments
 **-N**\ *nodefile*
     ASCII file with coordinates of desired output locations **x** in the
     first column(s). The resulting *w* values are appended to each
-    record and written to the file given in **-G** [or stdout if not
+    record and written to the file given in **-G** [or standard output if not
     specified]; see **-bo** for binary output
     instead. This option eliminates the need to specify options **-R**,
     **-I**, and **-r**.

--- a/doc/rst/source/supplements/mgd77/mgd77convert.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77convert.rst
@@ -83,7 +83,7 @@ Optional Arguments
 **-L**\ [**w**][**e**][**+l**]
     Set the level of verification reporting [none] and where to send
     such reports [stderr]. Append a combination of **w** for warnings and
-    **e** for errors, and append **+l** to send such log information to stdout.
+    **e** for errors, and append **+l** to send such log information to standard output.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: /explain_-V.rst_

--- a/doc/rst/source/supplements/mgd77/mgd77magref.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77magref.rst
@@ -52,7 +52,7 @@ Optional Arguments
     contain altitude (in km) and time, respectively, but if one or both
     of these are constant for all records they can be supplied via the
     **-A** option instead and are thus not expected in the input file.
-    If no input file is given we read *stdin*. |br|
+    If no input file is given we read standard input. |br|
     A note about the CM4
     validity domain. The core field of CM4 is valid from 1960-2002.5 but
     the ionospheric and magnetospheric fields are computed after the

--- a/doc/rst/source/supplements/mgd77/mgd77manage.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77manage.rst
@@ -66,7 +66,7 @@ Optional Arguments
 
     **a** Append filename of a single column table to add. File must
     have the same number of rows as the MGD77+ file. If no file is given
-    we read from stdin instead.
+    we read from standard input instead.
 
     **c** Create a new column that derives from existing data or
     formulas for corrections and reference fields. Append **c** for the
@@ -82,7 +82,7 @@ Optional Arguments
 
     **d** Append filename of a two-column table with the first column
     holding distances along track and the second column holding data
-    values. If no file is given we read from stdin instead. Records with
+    values. If no file is given we read from standard input instead. Records with
     matching distances in the MGD77+ file will be assigned the new
     values; at other distances we set them to NaN. Alternatively, give
     upper case **D** instead and we will interpolate the column at all
@@ -135,13 +135,13 @@ Optional Arguments
 
     **n** Append filename of a two-column table with the first column
     holding the record number (0 to nrows - 1) and the second column
-    holding data values. If no file is given we read from stdin instead.
+    holding data values. If no file is given we read from standard input instead.
     Records with matching record numbers in the MGD77+ file will be
     assigned the new values; at other records we set them to NaN.
 
     **t** Append filename of a two-column table with the first column
     holding absolute times along track and the second column holding
-    data values. If no file is given we read from stdin instead. Records
+    data values. If no file is given we read from standard input instead. Records
     with matching times in the MGD77+ file will be assigned the new
     values; at other times we set them to NaN. Alternatively, give upper
     case **T** instead and we will interpolate the column at all record

--- a/doc/rst/source/supplements/potential/gmtflexure.rst
+++ b/doc/rst/source/supplements/potential/gmtflexure.rst
@@ -74,9 +74,9 @@ Required Arguments
     elastic thickness file is given via **-E** then you must also append arguments
     to create the locations used for the calculations; for details on array creation,
     see `Generate 1D Array`_.
-    **-Qq**\ [*loadfile*] is a file (or stdin if not given) with (x,load in Pa)
+    **-Qq**\ [*loadfile*] is a file (or standard input if not given) with (x,load in Pa)
     for all equidistant data locations.  Finally, **-Qt**\ [*topofile*] is a file
-    (or stdin if not given) with (x,load in m or km, positive up); see **-M** for
+    (or standard input if not given) with (x,load in m or km, positive up); see **-M** for
     topography unit used [m].
 
 Optional Arguments

--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -128,7 +128,7 @@ Optional Arguments
 
 **-I**\ **w**\|\ **b**\|\ **c**\|\ **t**\|\ **k**
     Use *ingrid2* and *ingrid1* (a grid with topography/bathymetry) to estimate admittance\|coherence and
-    write it to stdout (**-G** ignored if set). This grid should contain
+    write it to standard output (**-G** ignored if set). This grid should contain
     gravity or geoid for the same region of *ingrid1*. Default
     computes admittance. Output contains 3 or 4 columns. Frequency
     (wavelength), admittance (coherence) one sigma error bar and,

--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -42,7 +42,7 @@ Description
 -----------
 
 **grdseamount** will compute the combined shape of multiple synthetic seamounts given their individual shape
-parameters.  We read from *table* (or stdin) a list of seamount locations and sizes and can evaluate either
+parameters.  We read from *table* (or standard input) a list of seamount locations and sizes and can evaluate either
 Gaussian, parabolic, conical, polynomial or disc shapes, which may be circular or elliptical, and optionally
 truncated. Various scaling options are available to modify the result, including an option to add in
 a background depth (more complicated backgrounds may be added via :doc:`grdmath </grdmath>`).

--- a/doc/rst/source/supplements/potential/talwani3d.rst
+++ b/doc/rst/source/supplements/potential/talwani3d.rst
@@ -93,7 +93,7 @@ Optional Arguments
 **-G**\ *outfile*
     Specify the name of the output data (for grids, see :ref:`Grid File Formats
     <grd_inout_full>`). Required when an equidistant grid is implied for output.
-    If **-N** is used then output is written to stdout unless **-G** specifies an output file.
+    If **-N** is used then output is written to standard output unless **-G** specifies an output file.
 
 .. _-M:
 

--- a/doc/rst/source/supplements/spotter/backtracker.rst
+++ b/doc/rst/source/supplements/spotter/backtracker.rst
@@ -127,7 +127,7 @@ Optional Arguments
 .. _-S:
 
 **-S**\ *filestem*
-    When **-L** is set, the tracks are normally written to *stdout* as a
+    When **-L** is set, the tracks are normally written to standard output as a
     multisegment file. Specify a *filestem* to have each track written
     to *filestem.#*, where *#* is the track number. The track number is
     also copied to the 4th output column.

--- a/doc/rst/source/supplements/spotter/grdrotater.rst
+++ b/doc/rst/source/supplements/spotter/grdrotater.rst
@@ -84,7 +84,7 @@ Optional Arguments
     time is implied then *rotoutline* must contain a C-format specifier
     to format a floating point number (reconstruction time) to text.
     If only one time is implied and **-D** is not set then we write the
-    polygon to stdout (but see **-N**).
+    polygon to standard output (but see **-N**).
 
 .. _-F:
 
@@ -96,7 +96,7 @@ Optional Arguments
 
 **-N**
     Do Not output the rotated polygon outline [Default will write it to
-    stdout, or to a file via **-D**].
+    standard output, or to a file via **-D**].
 
 .. _-R:
 

--- a/doc/rst/source/supplements/spotter/grdspotter.rst
+++ b/doc/rst/source/supplements/spotter/grdspotter.rst
@@ -145,7 +145,7 @@ Optional Arguments
 
 **-W**\ *n\_try*
     Get *n\_try* bootstrap estimates of the maximum CVA location; the
-    longitude and latitude results are written to stdout [Default is no
+    longitude and latitude results are written to standard output [Default is no
     bootstrapping]. Cannot be used with **-M**.
 
 .. _-Z:

--- a/doc/rst/source/supplements/spotter/polespotter.rst
+++ b/doc/rst/source/supplements/spotter/polespotter.rst
@@ -46,7 +46,7 @@ fracture zones and the great circle extensions of abyssal hills
 are expected to intersect at potential rotation poles.  The assumption
 is that abyssal hill lines are meridians and fracture zones are parallels
 with respect to the rotation pole.  Line density may be computed and returned
-via a grid, the great circle lines may be returned via stdout, and the
+via a grid, the great circle lines may be returned via standard output, and the
 intersections of the great circles may be saved to file.  In line mode
 it will determine which line segments are compatible with a given trial
 pole, while in pole mode it will compute chi-squared misfits for all the

--- a/doc/rst/source/supplements/x2sys/x2sys_list.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_list.rst
@@ -33,7 +33,7 @@ Description
 -----------
 
 **x2sys_list** will read the crossover ASCII data base *coedbase.txt*
-(or *stdin*) and extract a subset of the crossovers based on the other
+(or standard input) and extract a subset of the crossovers based on the other
 arguments. The output may be ASCII or binary.
 
 Required Arguments

--- a/doc/rst/source/supplements/x2sys/x2sys_merge.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_merge.rst
@@ -27,7 +27,7 @@ one. That is, it MUST NOT contain any new two tracks intersections (This
 point is NOT checked in the code). This program is useful when, for any
 good reason like file editing NAV correction or whatever, one had to
 recompute only the COEs between the edited files and the rest of the
-database.  The complete data base is written to *stdout*.
+database.  The complete data base is written to standard output.
 
 Required Arguments
 ------------------

--- a/doc/rst/source/supplements/x2sys/x2sys_put.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_put.rst
@@ -33,7 +33,7 @@ Required Arguments
 ------------------
 
 *info.tbf*
-    Name of a single track bin file. If not given, *stdin* will be read.
+    Name of a single track bin file. If not given, standard input will be read.
 
 .. include:: explain_tag.rst_
 

--- a/doc/rst/source/supplements/x2sys/x2sys_report.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_report.rst
@@ -29,7 +29,7 @@ Description
 -----------
 
 **x2sys_report** will read the input crossover ASCII data base
-*coedbase.txt* (or *stdin*) and report on the statistics of crossovers
+*coedbase.txt* (or standard input) and report on the statistics of crossovers
 (*n*, *mean*, *stdev*, *rms*, *weight*) for each track. Options are
 available to let you exclude tracks and limit the output.
 

--- a/doc/rst/source/supplements/x2sys/x2sys_solve.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_solve.rst
@@ -40,7 +40,7 @@ Required Arguments
     :doc:`x2sys_list`. NOTE: If **-bi** is used
     then the first two columns are expected to hold the integer track
     IDs; otherwise we expect the trailing text to hold the text string names
-    of the two tracks. If no file is given we will read from *stdin*.
+    of the two tracks. If no file is given we will read from standard input.
 
 .. include:: explain_tag.rst_
 

--- a/doc/rst/source/tutorial/session-4.rst
+++ b/doc/rst/source/tutorial/session-4.rst
@@ -60,10 +60,10 @@ In addition, the **-B** option can be used to set the title
 and unit label (and optionally to set the annotation-, tick-,
 and grid-line intervals for the color bars.).  Note that the makecpt commands
 above are done in classic mode.  If you run :doc:`/makecpt` in modern mode
-then you usually do not specify an output file via stdout since
+then you usually do not specify an output file via standard output since
 modern mode maintains what is known as the current CPT.  However,
 if you must explicitly name an output CPT then you will need to
-add the -H option for modern mode to allow output to stdout.
+add the -H option for modern mode to allow output to standard output.
 
 ======================================================= ==================================================================================
 Option                                                  Purpose

--- a/doc/rst/source/xyz2grd.rst
+++ b/doc/rst/source/xyz2grd.rst
@@ -107,7 +107,7 @@ Optional Arguments
 **-S**\ [*zfile*]
     Swap the byte-order of the input only. No grid file is produced. You
     must also supply the **-Z** option. The output is written to *zfile*
-    (or stdout if not supplied).
+    (or standard output if not supplied).
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: explain_-V.rst_


### PR DESCRIPTION
Unless we are really discussing specifics of C and file pointer arguments in functions in the API documentation, we shall use terms like standard input and output in the user documentation.  This PR fixes this documentation issue.
