### PR TITLE
Let gmt usage message spell out standard input and output

### DIFF
--- a/src/docs.c
+++ b/src/docs.c
@@ -139,7 +139,7 @@ EXTERN_MSC int GMT_docs (void *V_API, int mode, void *args) {
 				Return (GMT_RUNTIME_ERROR);
 			}
 			else if (print_url) {
-				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reporting local file %s to stdout\n", name);
+				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reporting local file %s to standard output\n", name);
 				printf ("%s\n", opt->arg);
 			}
 			else {	/* Open in suitable viewer */
@@ -299,7 +299,7 @@ EXTERN_MSC int GMT_docs (void *V_API, int mode, void *args) {
 			called = true;
 
 			if (print_url) {
-				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reporting URL %s to stdout\n", URL);
+				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Reporting URL %s to standard output\n", URL);
 				printf ("%s\n", URL);
 			}
 			else {

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14190,7 +14190,7 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 				void *content = NULL;
 				size_t n_read = 0;
 
-				GMT_Report (API, GMT_MSG_DEBUG, "gmtinit_get_region_from_data: Must save stdin to a temporary file.\n");
+				GMT_Report (API, GMT_MSG_DEBUG, "gmtinit_get_region_from_data: Must save standard input to a temporary file.\n");
 
 				if ((fp = gmt_create_tempfile (API, "gmt_saved_stdin", NULL, tmpfile)) == NULL) {	/* Not good... */
 					GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Could not create and open temporary file name %s.\n", tmpfile);
@@ -14199,7 +14199,7 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 				file = tmpfile;
 
 				/* Dump stdin to that temp file */
-				GMT_Report (API, GMT_MSG_DEBUG, "gmtinit_get_region_from_data: Send stdin to %s.\n", file);
+				GMT_Report (API, GMT_MSG_DEBUG, "gmtinit_get_region_from_data: Send standard input to %s.\n", file);
 				if ((content = malloc (GMT_BUFSIZ)) == NULL) {
 					GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Unable to allocate %d bytes for buffer.\n", GMT_BUFSIZ);
 				    fclose (fp);
@@ -14219,7 +14219,7 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 					return API->error;	/* Failure to make new option or append to list */
 				if ((tmp = GMT_Make_Option (API, GMT_OPT_INFILE, file)) == NULL || (*options = GMT_Append_Option (API, tmp, *options)) == NULL)
 					return API->error;	/* Failure to append option to calling module option list */
-				GMT_Report (API, GMT_MSG_DEBUG, "gmtinit_get_region_from_data: Replace stdin input with -<%s.\n", file);
+				GMT_Report (API, GMT_MSG_DEBUG, "gmtinit_get_region_from_data: Replace standard input with -<%s.\n", file);
 			}
 
 			/* Here we have all the input options OR a single tempfile input option.  Now look for special modifiers and add those too */

--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -121,7 +121,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-D[+t]");
 	GMT_Usage (API, -2, "Dry-run mode. No grid is written but its domain and increment will be "
-		"written to stdout in w e s n dx dy numerical format.  Append +t to instead receive text strings -Rw/e/s/n -Idx/dy.");
+		"written to standard output in w e s n dx dy numerical format.  Append +t to instead receive text strings -Rw/e/s/n -Idx/dy.");
 	GMT_Usage (API, 1, "\n-F<polygontable>[+c][+i]");
 	GMT_Usage (API, -2, "Specify a multi-segment closed polygon table that describes the grid subset "
 		"to be extracted (nodes between grid boundary and polygons will be set to NaN).");

--- a/src/mgd77/mgd77magref.c
+++ b/src/mgd77/mgd77magref.c
@@ -97,7 +97,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Here, (<lon>, <lat>) is the geocentric position on the ellipsoid [but see -G], "
 		"<alt> is the altitude in km positive above the ellipsoid, and "
 		"<time> is the time of data acquisition, in <date>T<clock> format (but see -A+y). "
-		"We read <stdin> if no input file is given.");
+		"We read standard input if no input file is given.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-A+a<alt>+t<date>+y");
 	GMT_Usage (API, -2, "Adjust how the input records are interpreted. Append modifiers:");

--- a/src/psternary.c
+++ b/src/psternary.c
@@ -438,7 +438,7 @@ EXTERN_MSC int GMT_psternary (void *V_API, int mode, void *args) {
 
 	if (Ctrl->M.active) {	/* Just print the converted data and exit */
 		if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POINT, GMT_WRITE_NORMAL, NULL, Ctrl->Out.file, D) != GMT_NOERROR) {
-			GMT_Report (API, GMT_MSG_ERROR, "Unable to write x,y file to stdout\n");
+			GMT_Report (API, GMT_MSG_ERROR, "Unable to write x,y file to standard output\n");
 			Return (API->error);
 		}
 		Return (GMT_NOERROR);

--- a/src/seis/pssac.c
+++ b/src/seis/pssac.c
@@ -653,7 +653,7 @@ EXTERN_MSC int GMT_pssac (void *V_API, int mode, void *args) {	/* High-level fun
 
 	read_from_ascii = (Ctrl->In.n == 0) || (Ctrl->In.n == 1 && !issac(Ctrl->In.file[0]));
 	if (read_from_ascii) {      /* Got a ASCII file or read from stdin */
-		GMT_Report (API, GMT_MSG_INFORMATION, "Reading from saclist file or stdin\n");
+		GMT_Report (API, GMT_MSG_INFORMATION, "Reading from saclist file or standard input\n");
 		if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_OK) {    /* Register data input */
 			Return (API->error);
 		}

--- a/src/spectrum1d.c
+++ b/src/spectrum1d.c
@@ -651,7 +651,7 @@ static int parse (struct GMT_CTRL *GMT, struct SPECTRUM1D_CTRL *Ctrl, struct GMT
 				if (opt->arg[0]) {
 					if (opt->arg[0] == '+') {	/* Obsolete syntax */
 						if (gmt_M_compat_check (GMT, 5)) {
-							GMT_Report (API, GMT_MSG_COMPAT, "Modifier -N+<file> is deprecated; use -N in the future to save to stdout.\n");
+							GMT_Report (API, GMT_MSG_COMPAT, "Modifier -N+<file> is deprecated; use -N in the future to save to standard output.\n");
 							if (n_files++ == 0) Ctrl->Out.file = strdup (&opt->arg[1]);
 						}
 						else {


### PR DESCRIPTION
We shall only use stdin and stdout in specific technical descriptions but otherwise use standard input and standard output, to match the user documentation (#6061).