### PR TITLE
add crossref to grdinterpolate

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -2579,7 +2579,7 @@ indicate the second layer of the 3-D variable "slp" use as file name: ``file.nc?
 
 When you supply the numerical value for the third variable using
 "(*level*)", GMT will pick the layer closest to that value. No
-interpolation is performed.
+interpolation is performed (for such interpolations, see :doc:`/grdinterpolate`).
 
 Note that the question mark, brackets and parentheses have special
 meanings on Unix-based platforms. Therefore, you will need to either


### PR DESCRIPTION
In the cookbook's netcdf layer discussion which mentions there is no interpolation when you specify a layer by value (it picks the nearest layer to that value), I added a crosslink to **grdinterpolate** to see how to do 3-D interpolations between layers.
