### PR TITLE
Increase string length for command

### DIFF
--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -580,7 +580,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 		unsigned int io_mode = GMT_WRITE_NORMAL;
 		uint64_t seg, row, rec, col;
 		uint64_t dim[4] = {1, 1, 1, 2};	/* Dataset dimension for one point */
-		char i_file[GMT_VF_LEN] = {""}, o_file[GMT_VF_LEN] = {""}, grid[GMT_LEN128] = {""}, header[GMT_LEN256] = {""}, cmd[GMT_LEN128] = {""};
+		char i_file[GMT_VF_LEN] = {""}, o_file[GMT_VF_LEN] = {""}, grid[GMT_LEN128] = {""}, header[GMT_LEN256] = {""}, cmd[GMT_BUFSIZ] = {""};
 		struct GMT_DATASET *D = NULL;
 		struct GMT_DATASEGMENT *Si = NULL, *So = NULL;
 


### PR DESCRIPTION
Foolishly, the **grdinterpolate** module used a very short string for a _GMT_Call_Module_ call but the file path was so long we exceeded the memory set aside.  This ups that to deal with such cases.
