### PR TITLE
Increase GRAPHICSMAGICK_RMS for oblmerc_down.sh

### DIFF
--- a/test/mapproject/oblmerc_down.sh
+++ b/test/mapproject/oblmerc_down.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# GMT_KNOWN_FAILURE_WINDOWS
+# GRAPHICSMAGICK_RMS = 0.01
 #
 # Tests mapproject for oblique Mercator -R-20/40/-15/65r -Joa-30/60/-75/1:30000000
 # This should be upside down


### PR DESCRIPTION
**Description of proposed changes**

This test only failed on windows due to tiny differences in the gridlines. This PR removes the `GMT_KNOWN_FAILURE_WINDOWS` flag and increases the RMS limit.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Relates to https://github.com/GenericMappingTools/gmt/issues/6068


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
