### PR TITLE
Be more strict when skipping tests

### DIFF
--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -33,7 +33,7 @@ if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
 	# RUNNER_OS is an environmental variables defined by GitHub Actions
 	# RUNNER_OS is Linux, macOS or Windows
 	os=$(echo "$RUNNER_OS" | tr '[:lower:]' '[:upper:]')
-	known2fail=$(grep "GMT_KNOWN_FAILURE_${os}" "$script" -c)
+	known2fail=$(grep "GMT_KNOWN_FAILURE_${os}" "$script" -c -w)
 	# Check if the test is known to fail on all platforms
 	if [ "$known2fail" = 0 ]; then
 		known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c -w)

--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -36,7 +36,7 @@ if [ "@GMT_ENABLE_KNOWN2FAIL@" = "ON" ]; then
 	known2fail=$(grep "GMT_KNOWN_FAILURE_${os}" "$script" -c)
 	# Check if the test is known to fail on all platforms
 	if [ "$known2fail" = 0 ]; then
-		known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c)
+		known2fail=$(grep "GMT_KNOWN_FAILURE" "$script" -c -w)
 	fi
 else
 	known2fail=0


### PR DESCRIPTION
**Description of proposed changes**

Currently, a test with `GMT_KNOWN_FAILURE` in the script will be skipped on all platforms, even if it is designated as a failure on only a specific OS (e.g., `GMT_KNOWN_FAILURE_WINDOWS`). This PR updates gmtest.in to only skip tests that either have `GMT_KNOWN_FAILURE` (without trailing text) or `GMT_KNOWN_FAILURE_${os}` exactly.

This will work well for the CI but will not skip tests locally unless the user defines $RUNNER_OS, but I think it is better to lean towards skipping fewer tests so we do not miss anything.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Relates to https://github.com/GenericMappingTools/gmt/issues/6072, which actually fails on all OS's but was skipped due to the grep check for `GMT_KNOWN_FAILURE`.


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
