### PR TITLE
Handle longer strings for netCDF history, remark and title

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2396,37 +2396,51 @@ GMT_LOCAL int gmtapi_open_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID
 /*! . */
 GMT_LOCAL void gmtapi_update_grd_item (struct GMTAPI_CTRL *API, unsigned int mode, void *arg, size_t length, struct GMT_GRID_HEADER *H) {
 	/* Place desired text in string (fixed size array) which can hold up to length bytes in header but unlimited in the hidden structure */
+	size_t lim = GMT_BUFSIZ - 1;
 	static char buffer[GMT_BUFSIZ];
+	char *txt = (mode & GMT_COMMENT_IS_OPTION) ? GMT_Create_Cmd (API, arg) : (char *)arg;
 
 	gmt_M_memset (buffer, GMT_BUFSIZ, char);    /* Start with a clean slate */
-	strncat (buffer, arg, GMT_BUFSIZ-1);     /* Append new text */
-	if (strlen (buffer) >= length) {    /* Must place in hidden structure */
+	if (mode & GMT_COMMENT_IS_OPTION) { /* Must start with module name since it is not part of the option args */
+		strncat (buffer, API->GMT->init.module_name, GMT_BUFSIZ);
+		lim -= strlen (buffer) + 1; /* Remaining characters that we can use */
+		strncat (buffer, " ", lim);
+	}
+	strncat (buffer, txt, lim);     /* Append new text */
+    if (mode & GMT_COMMENT_IS_OPTION) gmt_M_free (API->GMT, txt);
+	if (strlen (buffer) >= length) {    /* Must place full string versions in hidden structure */
 		struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (H);
-		if (mode & GMT_COMMENT_IS_TITLE) {
+		if (mode & GMT_COMMENT_IS_TITLE) {    /* Place title */
 			if (HH->title) gmt_M_str_free (HH->title);  /* Free previous string */
 			HH->title = strdup (buffer);
+			GMT_Report (API, GMT_MSG_WARNING,
+				"Title string exceeds upper length of %d characters (will be truncated in non-netCDF grid files)\n", length);
 		}
-		if (mode & GMT_COMMENT_IS_COMMAND) {
+		if (mode & GMT_COMMENT_IS_COMMAND) {   /* Place command string */
 			if (HH->command) gmt_M_str_free (HH->command);  /* Free previous string */
 			HH->command = strdup (buffer);
+			GMT_Report (API, GMT_MSG_WARNING,
+				"Command string exceeds upper length of %d characters (will be truncated in non-netCDF grid files)\n", length);
 		}
-		if (mode & GMT_COMMENT_IS_REMARK) {
+		if (mode & GMT_COMMENT_IS_REMARK) {   /* Place remark */
 			if (HH->remark) gmt_M_str_free (HH->remark);  /* Free previous string */
 			HH->remark = strdup (buffer);
+			GMT_Report (API, GMT_MSG_WARNING,
+				"Remark string exceeds upper length of %d characters (will be truncated in non-netCDF grid files)\n", length);
 		}
 	}
-	/* Place possibly truncated item in the grid/image header */
-	if (mode & GMT_COMMENT_IS_TITLE) {
+	/* Place possibly truncated item in the traditional grid/image header */
+	if (mode & GMT_COMMENT_IS_TITLE) {    /* Place title */
 		gmt_M_memset (H->title, length, char);    /* Wipe string completely */
-		strncpy (H->title, buffer, length);   /* Only copy over max length bytes */
+		strncpy (H->title, buffer, length-1);   /* Only copy over max length-1 bytes so last byte is 0 */
 	}
-	if (mode & GMT_COMMENT_IS_COMMAND) {
+	if (mode & GMT_COMMENT_IS_COMMAND) {  /* Place command string */
 		gmt_M_memset (H->command, length, char);    /* Wipe string completely */
-		strncpy (H->command, buffer, length);   /* Only copy over max length bytes */
+		strncpy (H->command, buffer, length-1);   /* Only copy over max length-1 bytes so last byte is 0 */
 	}
-	if (mode & GMT_COMMENT_IS_REMARK) {
+	if (mode & GMT_COMMENT_IS_REMARK) {  /* Place remark */
 		gmt_M_memset (H->remark, length, char);    /* Wipe string completely */
-		strncpy (H->remark, buffer, length);   /* Only copy over max length bytes */
+		strncpy (H->remark, buffer, length-1);   /* Only copy over max length-1 bytes so last byte is 0 */
 	}
 }
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2395,67 +2395,67 @@ GMT_LOCAL int gmtapi_open_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID
 
 /*! . */
 GMT_LOCAL void gmtapi_update_grd_item (struct GMTAPI_CTRL *API, unsigned int mode, void *arg, size_t length, struct GMT_GRID_HEADER *H) {
-    /* Place desired text in string (fixed size array) which can hold up to length bytes */
-    static char buffer[GMT_BUFSIZ];
+	/* Place desired text in string (fixed size array) which can hold up to length bytes in header but unlimited in the hidden structure */
+	static char buffer[GMT_BUFSIZ];
 
-    gmt_M_memset (buffer, GMT_BUFSIZ, char);    /* Start with a clean slate */
-    strncat (buffer, arg, GMT_BUFSIZ-1);     /* Append new text */
-    if (strlen (buffer) >= length) {    /* Must place in hidden structure */
-          struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (H);
-          if (mode & GMT_COMMENT_IS_TITLE) {
-                if (HH->title) gmt_M_str_free (HH->title);  /* Free previous string */
-                HH->title = strdup (buffer);
-          }
-          if (mode & GMT_COMMENT_IS_COMMAND) {
-                if (HH->command) gmt_M_str_free (HH->command);  /* Free previous string */
-                HH->command = strdup (buffer);
-          }
-          if (mode & GMT_COMMENT_IS_REMARK) {
-                if (HH->remark) gmt_M_str_free (HH->remark);  /* Free previous string */
-                HH->remark = strdup (buffer);
-          }
-    }
-    /* Place possibly truncated item in the grid/image header */
-    if (mode & GMT_COMMENT_IS_TITLE) {
-        gmt_M_memset (H->title, length, char);    /* Wipe string completely */
-        strncpy (H->title, buffer, length);   /* Only copy over max length bytes */
-    }
-    if (mode & GMT_COMMENT_IS_COMMAND) {
-        gmt_M_memset (H->command, length, char);    /* Wipe string completely */
-        strncpy (H->command, buffer, length);   /* Only copy over max length bytes */
-    }
-    if (mode & GMT_COMMENT_IS_REMARK) {
-        gmt_M_memset (H->remark, length, char);    /* Wipe string completely */
-        strncpy (H->remark, buffer, length);   /* Only copy over max length bytes */
-    }
+	gmt_M_memset (buffer, GMT_BUFSIZ, char);    /* Start with a clean slate */
+	strncat (buffer, arg, GMT_BUFSIZ-1);     /* Append new text */
+	if (strlen (buffer) >= length) {    /* Must place in hidden structure */
+		struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (H);
+		if (mode & GMT_COMMENT_IS_TITLE) {
+			if (HH->title) gmt_M_str_free (HH->title);  /* Free previous string */
+			HH->title = strdup (buffer);
+		}
+		if (mode & GMT_COMMENT_IS_COMMAND) {
+			if (HH->command) gmt_M_str_free (HH->command);  /* Free previous string */
+			HH->command = strdup (buffer);
+		}
+		if (mode & GMT_COMMENT_IS_REMARK) {
+			if (HH->remark) gmt_M_str_free (HH->remark);  /* Free previous string */
+			HH->remark = strdup (buffer);
+		}
+	}
+	/* Place possibly truncated item in the grid/image header */
+	if (mode & GMT_COMMENT_IS_TITLE) {
+		gmt_M_memset (H->title, length, char);    /* Wipe string completely */
+		strncpy (H->title, buffer, length);   /* Only copy over max length bytes */
+	}
+	if (mode & GMT_COMMENT_IS_COMMAND) {
+		gmt_M_memset (H->command, length, char);    /* Wipe string completely */
+		strncpy (H->command, buffer, length);   /* Only copy over max length bytes */
+	}
+	if (mode & GMT_COMMENT_IS_REMARK) {
+		gmt_M_memset (H->remark, length, char);    /* Wipe string completely */
+		strncpy (H->remark, buffer, length);   /* Only copy over max length bytes */
+	}
 }
 
 /*! . */
 GMT_LOCAL void gmtapi_update_txt_item (struct GMTAPI_CTRL *API, unsigned int mode, void *arg, size_t length, char string[]) {
     /* Place desired text in string (fixed size array) which can hold up to length bytes */
-    size_t lim;
-    static char buffer[GMT_BUFSIZ];
-    char *txt = (mode & GMT_COMMENT_IS_OPTION) ? GMT_Create_Cmd (API, arg) : (char *)arg;
-    gmt_M_memset (buffer, GMT_BUFSIZ, char);    /* Start with a clean slate */
-    if ((mode & GMT_COMMENT_IS_OPTION) == 0 && (mode & GMT_COMMENT_IS_RESET) == 0 && string[0])
-        strncat (buffer, string, length-1); /* Use old text if we are not resetting */
-    lim = length - strlen (buffer) - 1; /* Remaining characters that we can use */
-    if (mode & GMT_COMMENT_IS_OPTION) { /* Must start with module name since it is not part of the option args */
-        strncat (buffer, API->GMT->init.module_name, lim);
-        lim = length - strlen (buffer) - 1; /* Remaining characters that we can use */
-        strncat (buffer, " ", lim);
-    }
-    lim = length - strlen (buffer) - 1; /* Remaining characters that we can use */
-    strncat (buffer, txt, lim);     /* Append new text */
-    gmt_M_memset (string, length, char);    /* Wipe string completely */
-    strncpy (string, buffer, length);   /* Only copy over max length bytes */
-    if (mode & GMT_COMMENT_IS_OPTION) gmt_M_free (API->GMT, txt);
+	size_t lim;
+	static char buffer[GMT_BUFSIZ];
+	char *txt = (mode & GMT_COMMENT_IS_OPTION) ? GMT_Create_Cmd (API, arg) : (char *)arg;
+	gmt_M_memset (buffer, GMT_BUFSIZ, char);    /* Start with a clean slate */
+	if ((mode & GMT_COMMENT_IS_OPTION) == 0 && (mode & GMT_COMMENT_IS_RESET) == 0 && string[0])
+		strncat (buffer, string, length-1); /* Use old text if we are not resetting */
+	lim = length - strlen (buffer) - 1; /* Remaining characters that we can use */
+	if (mode & GMT_COMMENT_IS_OPTION) { /* Must start with module name since it is not part of the option args */
+		strncat (buffer, API->GMT->init.module_name, lim);
+		lim = length - strlen (buffer) - 1; /* Remaining characters that we can use */
+		strncat (buffer, " ", lim);
+	}
+	lim = length - strlen (buffer) - 1; /* Remaining characters that we can use */
+	strncat (buffer, txt, lim);     /* Append new text */
+	gmt_M_memset (string, length, char);    /* Wipe string completely */
+	strncpy (string, buffer, length);   /* Only copy over max length bytes */
+	if (mode & GMT_COMMENT_IS_OPTION) gmt_M_free (API->GMT, txt);
 }
 
 /*! . */
 GMT_LOCAL void gmtapi_GI_comment (struct GMTAPI_CTRL *API, unsigned int mode, void *arg, struct GMT_GRID_HEADER *H) {
 	/* Replace or Append either command or remark field with text or command-line options */
-	if (mode & GMT_COMMENT_IS_REMARK) 	gmtapi_update_grd_item (API, mode, arg, GMT_GRID_REMARK_LEN160, H);
+	if (mode & GMT_COMMENT_IS_REMARK) 	gmtapi_update_grd_item (API, mode, arg, GMT_GRID_REMARK_LEN160,      H);
 	else if (mode & GMT_COMMENT_IS_COMMAND) gmtapi_update_grd_item (API, mode, arg, GMT_GRID_COMMAND_LEN320, H);
 	else if (mode & GMT_COMMENT_IS_TITLE)   gmtapi_update_grd_item (API, mode, arg, GMT_GRID_TITLE_LEN80,    H);
 	else if (mode & GMT_COMMENT_IS_NAME_X)  gmtapi_update_txt_item (API, mode, arg, GMT_GRID_UNIT_LEN80,     H->x_units);

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1904,7 +1904,7 @@ GMT_LOCAL int gmtgrdio_decode_grdcube_info (struct GMT_CTRL *GMT, char *input, u
 	if (old)	/* Old grid syntax: -D<xname>/<yname>/<zname>/<scale>/<offset>/<invalid>/<title>/<remark> */
 		gmtgrdio_decode_grd_h_info_old (GMT, input, h);
 	else {	/* New syntax: -D[+x<xname>][+yyname>][+z<zname>][+d<dname>][+s<scale>][+o<offset>][+n<invalid>][+t<title>][+r<remark>] plus [+v<name>] for 3D */
-		char word[GMT_LEN512] = {""};
+		char word[GMT_BUFSIZ] = {""};
 		unsigned int pos = 0;
 		double d;
 		while (gmt_getmodopt (GMT, 'D', input, modifiers, &pos, word, &uerr) && uerr == 0) {
@@ -1968,7 +1968,7 @@ GMT_LOCAL int gmtgrdio_decode_grdcube_info (struct GMT_CTRL *GMT, char *input, u
 					gmt_M_memset (h->remark, GMT_GRID_REMARK_LEN160, char);
 					if (strlen(word) > GMT_GRID_REMARK_LEN160) {
 						GMT_Report (GMT->parent, GMT_MSG_WARNING,
-							"Remark string exceeds upper length of %d characters (truncated)\n",
+							"Remark string exceeds upper length of %d characters (will truncated in non-netCDF grid files)\n",
 							GMT_GRID_REMARK_LEN160);
 						if (HH->remark) gmt_M_str_free (HH->remark);	/* Free previous string */
 						HH->remark = strdup (&word[1]);
@@ -1979,7 +1979,7 @@ GMT_LOCAL int gmtgrdio_decode_grdcube_info (struct GMT_CTRL *GMT, char *input, u
 					gmt_M_memset (HH->varname, GMT_GRID_VARNAME_LEN80, char);
 					if (strlen(word) > GMT_GRID_VARNAME_LEN80)
 						GMT_Report (GMT->parent, GMT_MSG_WARNING,
-							"data variable name exceeds upper length of %d characters (will truncated in non-netCDF grid files)\n",
+							"data variable name exceeds upper length of %d characters (truncated)\n",
 							GMT_GRID_VARNAME_LEN80);
 					if (word[1]) strncpy (HH->varname, &word[1], GMT_GRID_VARNAME_LEN80-1);
 					break;

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1957,7 +1957,7 @@ GMT_LOCAL int gmtgrdio_decode_grdcube_info (struct GMT_CTRL *GMT, char *input, u
 					gmt_M_memset (h->title, GMT_GRID_TITLE_LEN80, char);
 					if (strlen(word) > GMT_GRID_TITLE_LEN80) {
 						GMT_Report (GMT->parent, GMT_MSG_WARNING,
-							"Title string exceeds upper length of %d characters (will truncated in non-netCDF grid files)\n",
+							"Title string exceeds upper length of %d characters (will be truncated in non-netCDF grid files)\n",
 							GMT_GRID_TITLE_LEN80);
 						if (HH->title) gmt_M_str_free (HH->title);	/* Free previous string */
 						HH->title = strdup (&word[1]);
@@ -1968,7 +1968,7 @@ GMT_LOCAL int gmtgrdio_decode_grdcube_info (struct GMT_CTRL *GMT, char *input, u
 					gmt_M_memset (h->remark, GMT_GRID_REMARK_LEN160, char);
 					if (strlen(word) > GMT_GRID_REMARK_LEN160) {
 						GMT_Report (GMT->parent, GMT_MSG_WARNING,
-							"Remark string exceeds upper length of %d characters (will truncated in non-netCDF grid files)\n",
+							"Remark string exceeds upper length of %d characters (will be truncated in non-netCDF grid files)\n",
 							GMT_GRID_REMARK_LEN160);
 						if (HH->remark) gmt_M_str_free (HH->remark);	/* Free previous string */
 						HH->remark = strdup (&word[1]);

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1904,7 +1904,7 @@ GMT_LOCAL int gmtgrdio_decode_grdcube_info (struct GMT_CTRL *GMT, char *input, u
 	if (old)	/* Old grid syntax: -D<xname>/<yname>/<zname>/<scale>/<offset>/<invalid>/<title>/<remark> */
 		gmtgrdio_decode_grd_h_info_old (GMT, input, h);
 	else {	/* New syntax: -D[+x<xname>][+yyname>][+z<zname>][+d<dname>][+s<scale>][+o<offset>][+n<invalid>][+t<title>][+r<remark>] plus [+v<name>] for 3D */
-		char word[GMT_LEN256] = {""};
+		char word[GMT_LEN512] = {""};
 		unsigned int pos = 0;
 		double d;
 		while (gmt_getmodopt (GMT, 'D', input, modifiers, &pos, word, &uerr) && uerr == 0) {
@@ -1955,25 +1955,31 @@ GMT_LOCAL int gmtgrdio_decode_grdcube_info (struct GMT_CTRL *GMT, char *input, u
 					break;
 				case 't':	/* Revise the title */
 					gmt_M_memset (h->title, GMT_GRID_TITLE_LEN80, char);
-					if (strlen(word) > GMT_GRID_TITLE_LEN80)
+					if (strlen(word) > GMT_GRID_TITLE_LEN80) {
 						GMT_Report (GMT->parent, GMT_MSG_WARNING,
-							"WTitle string exceeds upper length of %d characters (truncated)\n",
+							"Title string exceeds upper length of %d characters (will truncated in non-netCDF grid files)\n",
 							GMT_GRID_TITLE_LEN80);
+						if (HH->title) gmt_M_str_free (HH->title);	/* Free previous string */
+						HH->title = strdup (&word[1]);
+					}
 					if (word[1]) strncpy (h->title, &word[1], GMT_GRID_TITLE_LEN80-1);
 					break;
 				case 'r':	/* Revise the title */
 					gmt_M_memset (h->remark, GMT_GRID_REMARK_LEN160, char);
-					if (strlen(word) > GMT_GRID_REMARK_LEN160)
+					if (strlen(word) > GMT_GRID_REMARK_LEN160) {
 						GMT_Report (GMT->parent, GMT_MSG_WARNING,
 							"Remark string exceeds upper length of %d characters (truncated)\n",
 							GMT_GRID_REMARK_LEN160);
+						if (HH->remark) gmt_M_str_free (HH->remark);	/* Free previous string */
+						HH->remark = strdup (&word[1]);
+					}
 					if (word[1]) strncpy (h->remark, &word[1], GMT_GRID_REMARK_LEN160-1);
 					break;
 				case 'v':	/* Set the data netCDF variable name */
 					gmt_M_memset (HH->varname, GMT_GRID_VARNAME_LEN80, char);
 					if (strlen(word) > GMT_GRID_VARNAME_LEN80)
 						GMT_Report (GMT->parent, GMT_MSG_WARNING,
-							"data variable name exceeds upper length of %d characters (truncated)\n",
+							"data variable name exceeds upper length of %d characters (will truncated in non-netCDF grid files)\n",
 							GMT_GRID_VARNAME_LEN80);
 					if (word[1]) strncpy (HH->varname, &word[1], GMT_GRID_VARNAME_LEN80-1);
 					break;
@@ -1983,6 +1989,24 @@ GMT_LOCAL int gmtgrdio_decode_grdcube_info (struct GMT_CTRL *GMT, char *input, u
 		}
 	}
 	return (int)uerr;
+}
+
+char *gmt_get_grd_title (struct GMT_GRID_HEADER *h) {
+	/* Return pointer to full grid header */
+	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (h);
+	return (HH->title ? HH->title : h->title);
+}
+
+char *gmt_get_grd_remark (struct GMT_GRID_HEADER *h) {
+	/* Return pointer to full grid header */
+	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (h);
+	return (HH->remark  ? HH->remark  : h->remark );
+}
+
+char *gmt_get_grd_command (struct GMT_GRID_HEADER *h) {
+	/* Return pointer to full grid header */
+	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (h);
+	return (HH->command  ? HH->command  : h->command );
 }
 
 int gmt_decode_grd_h_info (struct GMT_CTRL *GMT, char *input, struct GMT_GRID_HEADER *h) {
@@ -2073,11 +2097,16 @@ void gmt_grd_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, struct 
 	int i;
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
 
-	if (update)	/* Only clean the command history */
+	if (update) {	/* Only clean the command history */
 		gmt_M_memset (header->command, GMT_GRID_COMMAND_LEN320, char);
+		if (HH->command) gmt_M_str_free (HH->command);	/* Free previous string */
+	}
 	else {		/* Wipe the slate clean */
 		void *ptr = HH->index_function;	/* Keep these two */
 		char mem[4];
+		if (HH->command) gmt_M_str_free (HH->command);	/* Free previous string */
+		if (HH->title)   gmt_M_str_free (HH->title);	/* Free previous string */
+		if (HH->remark)  gmt_M_str_free (HH->remark);	/* Free previous string */
 		gmt_M_memcpy (mem, header->mem_layout, 4, char);
 		gmt_M_memset (header, 1, struct GMT_GRID_HEADER);
 		HH->index_function = ptr;
@@ -2112,14 +2141,15 @@ void gmt_grd_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, struct 
 		int argc = 0, k_data;
 		char **argv = NULL, *c = NULL;
 		char file[GMT_LEN64] = {""}, *txt = NULL;
+		char command[GMT_BUFSIZ] = {""};
 
 		if ((argv = GMT_Create_Args (API, &argc, options)) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not create argc, argv from linked structure options!\n");
 			return;
 		}
-		strncpy (header->command, GMT->init.module_name, GMT_GRID_COMMAND_LEN320-1);
-		len = strlen (header->command);
-		for (i = 0; len < GMT_GRID_COMMAND_LEN320 && i < argc; i++) {
+		strncpy (command, GMT->init.module_name, GMT_BUFSIZ-1);
+		len = strlen (command);
+		for (i = 0; len < GMT_BUFSIZ && i < argc; i++) {
 			if (gmt_file_is_tiled_list (API, argv[i], &k_data, NULL, NULL)) {	/* Want to replace the tiled list with the original @earth_relief_xxx name instead */
 				snprintf (file, GMT_LEN64, "@%s", API->remote_info[k_data].file);
 				txt = file;
@@ -2133,14 +2163,17 @@ void gmt_grd_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, struct 
 			else
 				txt = argv[i];
 			len += strlen (txt) + 1;
-			if (len >= GMT_GRID_COMMAND_LEN320) continue;
-			strcat (header->command, " ");
-			strcat (header->command, txt);
+			if (len >= GMT_BUFSIZ) continue;
+			strcat (command, " ");
+			strcat (command, txt);
 		}
-		if (len < GMT_GRID_COMMAND_LEN320)
+		strncpy (header->command, command, GMT_GRID_COMMAND_LEN320-1);
+		if (len < GMT_GRID_COMMAND_LEN320)	/* Fits in regular header string */
 			header->command[len] = 0;
-		else /* Must truncate */
+		else { /* Must truncate and store the full version in the hidden structure */
 			header->command[GMT_GRID_COMMAND_LEN320-1] = 0;
+			HH->command = strdup (command);
+		}
 		snprintf (header->title, GMT_GRID_TITLE_LEN80, "Produced by %s", GMT->init.module_name);
 		GMT_Destroy_Args (API, argc, &argv);
 	}
@@ -2860,6 +2893,9 @@ void gmt_free_header (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER **header) {
 		gmt_M_str_free (h->ProjRefPROJ4);
 	}
 	gmt_M_str_free (HH->pocket);
+	if (HH->title)   gmt_M_str_free (HH->title);
+	if (HH->command) gmt_M_str_free (HH->command);
+	if (HH->remark)  gmt_M_str_free (HH->remark);
 	gmt_M_free (GMT, h->hidden);
 	gmt_M_free (GMT, *header);
 }

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -158,6 +158,9 @@ struct GMT_GRID_HEADER_HIDDEN {
 	unsigned int reset_pad;          /* true in cases where we need a subset from a memory grid and must compute node index separately */
 	char name[GMT_GRID_NAME_LEN256]; /* Actual name of the file after any ?<varname> and =<stuff> has been removed */
 	char varname[GMT_GRID_VARNAME_LEN80];/* NetCDF: variable name */
+	char *title;					 /* Title string not limited to GMT_GRID_TITLE_LEN80 characters */
+	char *command;					 /* Command/history string not limited to GMT_GRID_TITLE_LEN80 characters */
+	char *remark;					 /* Remark/description string not limited to GMT_GRID_REMARK_LEN160 characters */
 	int row_order;                   /* NetCDF: k_nc_start_south if S->N, k_nc_start_north if N->S */
 	int z_id;                        /* NetCDF: id of z field */
 	int ncid;                        /* NetCDF: file ID */

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -166,6 +166,8 @@ EXTERN_MSC void * gmtlib_ascii_textinput (struct GMT_CTRL *GMT, FILE *fp, uint64
 EXTERN_MSC double gmtlib_get_map_interval (struct GMT_CTRL *GMT, unsigned int type, struct GMT_PLOT_AXIS_ITEM *T);
 EXTERN_MSC unsigned int gmtlib_log_array (struct GMT_CTRL *GMT, double min, double max, double delta, double **array);
 EXTERN_MSC int gmtlib_nc_get_att_text (struct GMT_CTRL *GMT, int ncid, int varid, char *name, char *text, size_t textlen);
+EXTERN_MSC int gmtlib_nc_get_att_vtext (struct GMT_CTRL *GMT, int ncid, int varid, char *name, struct GMT_GRID_HEADER *h, char *text, size_t textlen);
+EXTERN_MSC int gmtlib_nc_put_att_vtext (struct GMT_CTRL *GMT, int ncid, char *name, struct GMT_GRID_HEADER *h);
 EXTERN_MSC int gmtlib_akima (struct GMT_CTRL *GMT, double *x, double *y, uint64_t nx, double *c);
 EXTERN_MSC int gmtlib_cspline (struct GMT_CTRL *GMT, double *x, double *y, uint64_t n, double *c);
 EXTERN_MSC bool gmtlib_annot_pos (struct GMT_CTRL *GMT, double min, double max, struct GMT_PLOT_AXIS_ITEM *T, double coord[], double *pos);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -62,6 +62,7 @@
  * gmtlib_process_binary_input
  * gmtlib_nc_get_att_text
  * gmtlib_nc_get_att_vtext
+ * gmtlib_nc_put_att_vtext
  * gmtlib_io_banner
  * gmt_get_cols
  * gmt_set_cols

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -630,11 +630,11 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		/* Create enough memory to store the x- and y-coordinate values */
 		double *xy = gmt_M_memory (GMT, NULL, MAX (header->n_columns,header->n_rows), double);
 		/* Get global information */
-		if (gmtlib_nc_get_att_text (GMT, ncid, NC_GLOBAL, "title", header->title, GMT_GRID_TITLE_LEN80))
-			gmtlib_nc_get_att_text (GMT, ncid, z_id, "long_name", header->title, GMT_GRID_TITLE_LEN80);
-		if (gmtlib_nc_get_att_text (GMT, ncid, NC_GLOBAL, "history", header->command, GMT_GRID_COMMAND_LEN320))
-			gmtlib_nc_get_att_text (GMT, ncid, NC_GLOBAL, "source", header->command, GMT_GRID_COMMAND_LEN320);
-		gmtlib_nc_get_att_text (GMT, ncid, NC_GLOBAL, "description", header->remark, GMT_GRID_REMARK_LEN160);
+		if (gmtlib_nc_get_att_vtext (GMT, ncid, NC_GLOBAL, "title", header, header->title, GMT_GRID_TITLE_LEN80))
+			gmtlib_nc_get_att_vtext (GMT, ncid, z_id, "long_name", header, header->title, GMT_GRID_TITLE_LEN80);
+		if (gmtlib_nc_get_att_vtext (GMT, ncid, NC_GLOBAL, "history", header, header->command, GMT_GRID_COMMAND_LEN320))
+			gmtlib_nc_get_att_vtext (GMT, ncid, NC_GLOBAL, "source", header, header->command, GMT_GRID_COMMAND_LEN320);
+		gmtlib_nc_get_att_vtext (GMT, ncid, NC_GLOBAL, "description", header, header->remark, GMT_GRID_REMARK_LEN160);
 		header->registration = GMT_GRID_NODE_REG;
 		if (!nc_get_att_int (ncid, NC_GLOBAL, "node_offset", &i)) {	/* GMT wrote the registration in the grid */
 			header->registration = i;
@@ -955,9 +955,9 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		const int *nc_vers = gmtnc_netcdf_libvers();
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "netCDF Library version: %d\n", *nc_vers);
 		gmt_M_err_trap (nc_put_att_text (ncid, NC_GLOBAL, "Conventions", strlen(GMT_NC_CONVENTION), GMT_NC_CONVENTION));
-		if (header->title[0]) gmt_M_err_trap (nc_put_att_text (ncid, NC_GLOBAL, "title", strlen(header->title), header->title));
-		gmt_M_err_trap (nc_put_att_text (ncid, NC_GLOBAL, "history", strlen(header->command), header->command));
-		if (header->remark[0]) gmt_M_err_trap (nc_put_att_text (ncid, NC_GLOBAL, "description", strlen(header->remark), header->remark));
+		gmt_M_err_trap (gmtlib_nc_put_att_vtext (GMT, ncid, "title", header));
+		gmt_M_err_trap (gmtlib_nc_put_att_vtext (GMT, ncid, "history", header));
+		gmt_M_err_trap (gmtlib_nc_put_att_vtext (GMT, ncid, "description", header));
 		gmt_M_err_trap (nc_put_att_text (ncid, NC_GLOBAL, "GMT_version", strlen(GMT_VERSION), (const char *) GMT_VERSION));
 		if (header->registration == GMT_GRID_PIXEL_REG) {
 			int reg = header->registration;

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -204,6 +204,9 @@ EXTERN_MSC bool gmt_file_is_cache (struct GMTAPI_CTRL *API, const char *file);
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC char *gmt_get_grd_title (struct GMT_GRID_HEADER *h);
+EXTERN_MSC char *gmt_get_grd_remark (struct GMT_GRID_HEADER *h);
+EXTERN_MSC char *gmt_get_grd_command (struct GMT_GRID_HEADER *h);
 EXTERN_MSC uint64_t gmt_get_active_layers (struct GMT_CTRL *GMT, struct GMT_CUBE *U, double *range, uint64_t *start_k, uint64_t *stop_k);
 EXTERN_MSC void gmt_grd_set_datapadding (struct GMT_CTRL *GMT, bool set);
 EXTERN_MSC void gmt_grd_set_cartesian (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, unsigned int direction);

--- a/src/grdconvert.c
+++ b/src/grdconvert.c
@@ -216,7 +216,7 @@ EXTERN_MSC int GMT_grdconvert (void *V_API, int mode, void *args) {
 	int error = 0;
 	unsigned int hmode, type[2] = {0, 0};
 	char fname[2][GMT_BUFSIZ];
-	char command[GMT_GRID_COMMAND_LEN320] = {""};
+	char command[GMT_BUFSIZ] = {""};
 	struct GMT_GRID *Grid = NULL;
 	struct GMT_GRID_HEADER_HIDDEN *HH = NULL;
 	struct GRDCONVERT_CTRL *Ctrl = NULL;
@@ -309,8 +309,8 @@ EXTERN_MSC int GMT_grdconvert (void *V_API, int mode, void *args) {
 
 	/* When converting from netcdf to netcdf, we will keep the old command, so we need to make a copy of it now */
 	command[0] = '\n';	command[1] = '\t';
-	strcat(command, "(old cmd) ");
-	strncat(command, Grid->header->command, GMT_GRID_COMMAND_LEN320-13);
+	strcat (command, "(old cmd) ");
+	strncat (command, Grid->header->command, GMT_BUFSIZ-13);
 
 	gmt_grd_init (GMT, Grid->header, options, true);
 

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -365,6 +365,7 @@ EXTERN_MSC int GMT_grdedit (void *V_API, int mode, void *args) {
 
 	if (Ctrl->C.active) {	/* Wipe history */
 		gmt_M_memset (G->header->command, GMT_GRID_COMMAND_LEN320, char);
+		if (HH->command) gmt_M_str_free (HH->command);	/* Free previous string */
 	}
 
 	if (Ctrl->S.active) {

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -1000,9 +1000,9 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 		}
 		else if (!(Ctrl->T.active || (Ctrl->I.active && Ctrl->I.status == GRDINFO_GIVE_REG_ROUNDED))) {
 			char *gtype[2] = {"Cartesian grid", "Geographic grid"};
-			sprintf (record, "%s: Title: %s", HH->name, header->title);		GMT_Put_Record (API, GMT_WRITE_DATA, Out);
-			sprintf (record, "%s: Command: %s", HH->name, header->command);	GMT_Put_Record (API, GMT_WRITE_DATA, Out);
-			sprintf (record, "%s: Remark: %s", HH->name, header->remark);	GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			sprintf (record, "%s: Title: %s", HH->name, gmt_get_grd_title (header));		GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			sprintf (record, "%s: Command: %s", HH->name, gmt_get_grd_command (header));	GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			sprintf (record, "%s: Remark: %s", HH->name, gmt_get_grd_remark (header));		GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			if (header->registration == GMT_GRID_NODE_REG || header->registration == GMT_GRID_PIXEL_REG)
 				sprintf (record, "%s: %s node registration used [%s]", HH->name, type[header->registration], gtype[gmt_M_is_geographic (GMT, GMT_IN)]);
 			else


### PR DESCRIPTION
See #6078 for motivation and context. The length limits on the three grid header attributes _title_, _command_, and _remark_ were set back in the last century and because they are fixed array sizes in the GMT grid header they cannot be changed without breaking compatibility.  The solution is to add pointers to the _hidden_ grid header structure that is not part of the API and hence store strings that exceed the limits here.  This PR does this juggling where we may need to use one of the other of the strings.

Tests pass, and longer strings work and give a warning:

```
gmt grdedit -D+t"I am going to add a very long title that should be much longer than 80 characters, in fact it is probably way longer than 100 by the time I am tired of adding random words"+r"Junk that changes the structures starting at is a breaking change. But the C struct GMT_GRID_HEADER could eventually be used to add/read new attributes in the nc files with extended info" t.nc
grdedit [WARNING]: Title string exceeds upper length of 80 characters (will truncated in non-netCDF grid files)
grdedit [WARNING]: Remark string exceeds upper length of 160 characters (truncated)

gmt grdinfo t.nc
t.nc: Title: I am going to add a very long title that should be much longer than 80 characters, in fact it is probably way longer than 100 by the time I am tired of adding random words
t.nc: Command: grdmath -R0/2/0/2 -I1 X = t.nc
t.nc: Remark: Junk that changes the structures starting at is a breaking change. But the C struct GMT_GRID_HEADER could eventually be used to add/read new attributes in the nc files with extended info
t.nc: Gridline node registration used [Cartesian grid]
t.nc: Grid file format: nf = GMT netCDF format (32-bit float), CF-1.7
t.nc: x_min: 0 x_max: 2 x_inc: 1 name: x n_columns: 3
t.nc: y_min: 0 y_max: 2 y_inc: 1 name: y n_rows: 3
t.nc: v_min: 0 v_max: 2 name: z
t.nc: scale_factor: 1 add_offset: 0
t.nc: format: classic
```

Converting to native binary, for instance, will only give the truncated versions.

This PR will also need to be testing in GMT.jl (@joa-quim) and PyGMT (@meghanrjones) to make sure there are no surprises.