### PR TITLE
Place gmt_common_byteswap.h in gmt_dev.h

### DIFF
--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -124,6 +124,8 @@ extern "C" {
 #	define GMT_LOCAL static
 #endif
 
+#include "gmt_common_byteswap.h"    /* Byte-swap inline functions */
+
 #include "gmt_common_math.h" /* Shared math functions */
 #include "gmt.h"             /* All GMT high-level API */
 #include "gmt_private.h"     /* API declaration needed by libraries */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -85,7 +85,6 @@
 
 #include "gmt_dev.h"
 #include "gmt_internals.h"
-#include "gmt_common_byteswap.h"
 
 struct GRD_PAD {	/* Local structure */
 	double wesn[4];

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -154,7 +154,6 @@
 
 #include "gmt_dev.h"
 #include "gmt_internals.h"
-#include "gmt_common_byteswap.h"
 
 #ifdef HAVE_DIRENT_H_
 #	include <dirent.h>

--- a/src/grd2xyz.c
+++ b/src/grd2xyz.c
@@ -24,7 +24,6 @@
  */
 
 #include "gmt_dev.h"
-#include "gmt_common_byteswap.h"
 
 #define THIS_MODULE_CLASSIC_NAME	"grd2xyz"
 #define THIS_MODULE_MODERN_NAME	"grd2xyz"

--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -54,7 +54,6 @@
  */
 
 #include "gmt_dev.h"
-#include "gmt_common_byteswap.h"
 
 #define THIS_MODULE_CLASSIC_NAME	"img2grd"
 #define THIS_MODULE_MODERN_NAME	"img2grd"

--- a/src/x2sys/x2sys.c
+++ b/src/x2sys/x2sys.c
@@ -103,7 +103,6 @@
  */
 
 #include "gmt_dev.h"
-#include "gmt_common_byteswap.h"
 #include "gmt_internals.h"
 #include "mgd77/mgd77.h"
 #include "x2sys.h"


### PR DESCRIPTION
The recent 6.3 release snafu with **grd2xyz -T** needing that include file for bigendian architectures shows that it is better to place these includes in _gmt_dev.h_ so always available than to forget it in one module after an update.