### PR TITLE
Improved handling of output grid history in grdedit and grdconvert

### DIFF
--- a/doc/rst/source/grdconvert.rst
+++ b/doc/rst/source/grdconvert.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grdconvert** *ingrid* |-G|\ *outgrid*
-[ |-C|\ **b**\|\ **n**\|\ **o** ]
+[ |-C|\ **b**\|\ **c**\|\ **n**\|\ **p** ]
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -50,11 +50,13 @@ Optional Arguments
 
 .. _-C:
 
-**-Cb**\|\ **n**\|\ **o**
-    Specify what the output grid's command line history should be: Append
-    directive **b** to append the previous and this module's command history,
-    **n** to only write this module's command history, or **o** to instead save
-    only the previous command history [Default].
+**-Cb**\|\ **c**\|\ **n**\|\ **p**
+    Normally, output grids store the current module's command-line history.
+    Use **-C** to specify what the output grid's command history should be:
+    Append directive **b** to write both the previous and the current module's 
+    command histories, **c** to only write the current module's command
+    history, **n** to save no history whatsoever [Default], or select **p**
+    to instead save only the previous command history.
 
 .. _-N:
 

--- a/doc/rst/source/grdconvert.rst
+++ b/doc/rst/source/grdconvert.rst
@@ -13,6 +13,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grdconvert** *ingrid* |-G|\ *outgrid*
+[ |-C|\ **b**\|\ **n**\|\ **o** ]
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -46,6 +47,14 @@ Required Arguments
 
 Optional Arguments
 ------------------
+
+.. _-C:
+
+**-Cb**\|\ **n**\|\ **o**
+    Specify what the output grid's command line history should be.  Append
+    directive **b** to append the previous and this module's command history,
+    **n** to only write this module's command history, or **o** to instead save
+    only the previous command history [Default].
 
 .. _-N:
 

--- a/doc/rst/source/grdconvert.rst
+++ b/doc/rst/source/grdconvert.rst
@@ -51,7 +51,7 @@ Optional Arguments
 .. _-C:
 
 **-Cb**\|\ **n**\|\ **o**
-    Specify what the output grid's command line history should be.  Append
+    Specify what the output grid's command line history should be: Append
     directive **b** to append the previous and this module's command history,
     **n** to only write this module's command history, or **o** to instead save
     only the previous command history [Default].

--- a/doc/rst/source/grdedit.rst
+++ b/doc/rst/source/grdedit.rst
@@ -12,7 +12,9 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdedit** *ingrid* [ |-A| ] [ |-C| ]
+**gmt grdedit** *ingrid*
+[ |-A| ]
+[ |-C|\ **b**\|\ **n**\|\ **o** ]
 [ |SYN_OPT-D2| ]
 [ |-E|\ [**a**\|\ **e**\|\ **h**\|\ **l**\|\ **r**\|\ **t**\|\ **v**] ]
 [ |-G|\ *outgrid* ]
@@ -68,8 +70,11 @@ Optional Arguments
 
 .. _-C:
 
-**-C**
-    Clear the command history from the grid header.
+**-Cb**\|\ **n**\|\ **o**
+    Specify what the output grid's command line history should be: Append
+    directive **b** to append the previous and this module's command history,
+    **n** to only write this module's command history, or **o** to instead save
+    only the previous command history [Default].
 
 .. _-D:
 

--- a/doc/rst/source/grdedit.rst
+++ b/doc/rst/source/grdedit.rst
@@ -14,7 +14,7 @@ Synopsis
 
 **gmt grdedit** *ingrid*
 [ |-A| ]
-[ |-C|\ **b**\|\ **n**\|\ **o** ]
+[ |-C|\ **b**\|\ **c**\|\ **n**\|\ **p** ]
 [ |SYN_OPT-D2| ]
 [ |-E|\ [**a**\|\ **e**\|\ **h**\|\ **l**\|\ **r**\|\ **t**\|\ **v**] ]
 [ |-G|\ *outgrid* ]
@@ -70,11 +70,13 @@ Optional Arguments
 
 .. _-C:
 
-**-Cb**\|\ **n**\|\ **o**
-    Specify what the output grid's command line history should be: Append
-    directive **b** to append the previous and this module's command history,
-    **n** to only write this module's command history, or **o** to instead save
-    only the previous command history [Default].
+**-Cb**\|\ **c**\|\ **n**\|\ **p**
+    Normally, output grids store the current module's command-line history.
+    Use **-C** to specify what the output grid's command history should be:
+    Append directive **b** to write both the previous and the current module's 
+    command histories, **c** to only write the current module's command
+    history, **n** to save no history whatsoever [Default], or select **p**
+    to instead save only the previous command history.
 
 .. _-D:
 

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -671,11 +671,12 @@ enum GMT_enum_curl {GMT_REGULAR_FILE = 0,	/* Regular file the may or may not exi
 	GMT_LOCAL_DIR  = 3,	/* Use the local (current) directory */
 	GMT_REMOTE_DIR = 4}; /* File is on the remote server */
 
-/* COnstants for controlling the written grid history */
+/* Constants for controlling the written grid history via grdedit and grdconvert */
 enum GMT_grid_history {
-	GMT_GRDHISTORY_OLD		= 0,	/* Only save the incoming command history in the output [Default] */
-	GMT_GRDHISTORY_NEW		= 1,	/* Only save this module command history in the output  */
-	GMT_GRDHISTORY_BOTH	= 2		/* Append this module history to prior history  */
+	GMT_GRDHISTORY_NONE	= 0,	/* No output history at all */
+	GMT_GRDHISTORY_OLD	= 1,	/* Only save the previous command history in the output [Default] */
+	GMT_GRDHISTORY_NEW	= 2,	/* Only save the current module command history in the output  */
+	GMT_GRDHISTORY_BOTH	= 3		/* Append current module history to previous history  */
 };
 
 #endif  /* GMT_CONSTANTS_H */

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -671,4 +671,11 @@ enum GMT_enum_curl {GMT_REGULAR_FILE = 0,	/* Regular file the may or may not exi
 	GMT_LOCAL_DIR  = 3,	/* Use the local (current) directory */
 	GMT_REMOTE_DIR = 4}; /* File is on the remote server */
 
+/* COnstants for controlling the written grid history */
+enum GMT_grid_history {
+	GMT_GRDHISTORY_OLD		= 0,	/* Only save the incoming command history in the output [Default] */
+	GMT_GRDHISTORY_NEW		= 1,	/* Only save this module command history in the output  */
+	GMT_GRDHISTORY_BOTH	= 2		/* Append this module history to prior history  */
+};
+
 #endif  /* GMT_CONSTANTS_H */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2242,6 +2242,12 @@ void gmt_change_grid_history (struct GMTAPI_CTRL *API, unsigned int mode, struct
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (h);
 
 	switch (mode) {	/* Create the command history per -C directive */
+		case GMT_GRDHISTORY_NONE:	/* No output history at all */
+			if (HH->command)	/* Extra long previous command history */
+				gmt_M_str_free (HH->command);
+			gmt_M_memset (command, GMT_BUFSIZ, char);
+			gmt_M_memset (h->command, GMT_GRID_COMMAND_LEN320, char);
+			break;
 		case GMT_GRDHISTORY_OLD:	/* Only keep old command history */
 			if (HH->command)	/* Extra long previous command history */
 				strncpy (command, HH->command, GMT_BUFSIZ);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4796,19 +4796,19 @@ int gmtlib_nc_put_att_vtext (struct GMT_CTRL *GMT, int ncid, char *name, struct 
 	if (!strcmp (name, "title")) {
 		if (HH->title)
 			ret = nc_put_att_text (ncid, NC_GLOBAL, "title", strlen(HH->title), HH->title);
-		else if (h->title[0])
+		else
 			ret = nc_put_att_text (ncid, NC_GLOBAL, "title", strlen(h->title), h->title);
 	}
 	else if (!strcmp (name, "history")) {
 		if (HH->command)
 			ret = nc_put_att_text (ncid, NC_GLOBAL, "history", strlen(HH->command), HH->command);
-		else if (h->command[0])
+		else
 			ret = nc_put_att_text (ncid, NC_GLOBAL, "history", strlen(h->command), h->command);
 	}
 	else if (!strcmp (name, "description")) {
 		if (HH->remark)
 			ret = nc_put_att_text (ncid, NC_GLOBAL, "description", strlen(HH->remark), HH->remark);
-		else if (h->remark[0])
+		else
 			ret = nc_put_att_text (ncid, NC_GLOBAL, "description", strlen(h->remark), h->remark);
 	}
 	return (ret);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -204,6 +204,7 @@ EXTERN_MSC bool gmt_file_is_cache (struct GMTAPI_CTRL *API, const char *file);
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC void gmt_change_grid_history (struct GMTAPI_CTRL *API, unsigned int mode, struct GMT_GRID_HEADER *h, char *command);
 EXTERN_MSC char *gmt_get_grd_title (struct GMT_GRID_HEADER *h);
 EXTERN_MSC char *gmt_get_grd_remark (struct GMT_GRID_HEADER *h);
 EXTERN_MSC char *gmt_get_grd_command (struct GMT_GRID_HEADER *h);

--- a/src/grdconvert.c
+++ b/src/grdconvert.c
@@ -79,7 +79,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s %s -G%s [-Cb|n|o] [-N] [%s] [%s] "
+	GMT_Usage (API, 0, "usage: %s %s -G%s [-Cb|c|n|p] [-N] [%s] [%s] "
 		"[-Z[+s<fact>][+o<shift>]] [%s] [%s]\n", name, GMT_INGRID, GMT_OUTGRID, GMT_Rgeo_OPT, GMT_V_OPT, GMT_f_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -88,11 +88,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_ingrid_syntax (API, 0, "Name of grid to convert from");
 	gmt_outgrid_syntax (API, 'G', "Set name of the new converted grid file");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n-Cb|n|o");
-	GMT_Usage (API, -2, "Control how the existing and new command history should be handled, via directives:");
-	GMT_Usage (API, 3, "b: Append this command history to the existing history.");
-	GMT_Usage (API, 3, "n: Only save this command history.");
-	GMT_Usage (API, 3, "o: Only save the existing history [Default].");
+	GMT_Usage (API, 1, "\n-Cb|c|n|p");
+	GMT_Usage (API, -2, "Control how the current and previous command histories should be handled, via directives:");
+	GMT_Usage (API, 3, "b: Append the current command's history to the previous history.");
+	GMT_Usage (API, 3, "c: Only save the current command's history.");
+	GMT_Usage (API, 3, "n: Save no history at all [Default].");
+	GMT_Usage (API, 3, "p: Only preserve the previous history.");
 	GMT_Usage (API, 1, "\n-N Do NOT write the header (for native grids only - ignored otherwise). Useful when creating "
 		"files to be used by external programs.");
 	GMT_Option (API, "R,V");
@@ -186,8 +187,9 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONVERT_CTRL *Ctrl, struct GMT
 				Ctrl->C.active = true;
 				switch (opt->arg[0]) {
 					case 'b': Ctrl->C.mode = GMT_GRDHISTORY_BOTH;	break;
-					case 'n': Ctrl->C.mode = GMT_GRDHISTORY_NEW;	break;
-					case 'o': case '\0': Ctrl->C.mode = GMT_GRDHISTORY_OLD;	break;	/* Default */
+					case 'c': Ctrl->C.mode = GMT_GRDHISTORY_NEW;	break;
+					case 'p': Ctrl->C.mode = GMT_GRDHISTORY_OLD;	break;
+					case 'n': case '\0': Ctrl->C.mode = GMT_GRDHISTORY_NONE;	break;	/* Default */
 					default:
 						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Unrecognized directive %s\n", opt->arg);
 						n_errors++;

--- a/src/grdconvert.c
+++ b/src/grdconvert.c
@@ -193,7 +193,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONVERT_CTRL *Ctrl, struct GMT
 				switch (opt->arg[0]) {
 					case 'b': Ctrl->C.mode = GRDCONVERT_BOTH_HIST;	break;
 					case 'n': Ctrl->C.mode = GRDCONVERT_NEW_HIST;	break;
-					case 'o': case ' ': Ctrl->C.mode = GRDCONVERT_OLD_HIST;	break;	/* Default */
+					case 'o': case '\0': Ctrl->C.mode = GRDCONVERT_OLD_HIST;	break;	/* Default */
 					default:
 						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Unrecognized directive %s\n", opt->arg);
 						n_errors++;

--- a/src/grdconvert.c
+++ b/src/grdconvert.c
@@ -315,7 +315,8 @@ EXTERN_MSC int GMT_grdconvert (void *V_API, int mode, void *args) {
 
 	gmt_grd_init (GMT, Grid->header, options, true);
 
-	if (type[GMT_OUT] >= GMT_GRID_IS_NB && type[GMT_OUT] <= GMT_GRID_IS_ND) {	/* Writing default GMT netCDF format */
+	if ((type[GMT_OUT] >= GMT_GRID_IS_NB && type[GMT_OUT] <= GMT_GRID_IS_ND) ||
+		(type[GMT_OUT] >= GMT_GRID_IS_CB && type[GMT_OUT] <= GMT_GRID_IS_CD)) {	/* Writing netCDF grid */
 		char *cmd = GMT_Create_Cmd (API, options);
 		size_t L = GMT_BUFSIZ - strlen (command) - 2;
 		/* Append this module command string to the existing history */

--- a/src/grdconvert.c
+++ b/src/grdconvert.c
@@ -193,7 +193,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONVERT_CTRL *Ctrl, struct GMT
 				switch (opt->arg[0]) {
 					case 'b': Ctrl->C.mode = GRDCONVERT_BOTH_HIST;	break;
 					case 'n': Ctrl->C.mode = GRDCONVERT_NEW_HIST;	break;
-					case 'o': Ctrl->C.mode = GRDCONVERT_OLD_HIST;	break;
+					case 'o': case ' ': Ctrl->C.mode = GRDCONVERT_OLD_HIST;	break;	/* Default */
 					default:
 						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Unrecognized directive %s\n", opt->arg);
 						n_errors++;

--- a/src/grdconvert.c
+++ b/src/grdconvert.c
@@ -37,9 +37,9 @@ struct GRDCONVERT_CTRL {
 		bool active;
 		char *file;
 	} In;
-	struct GRDCONVERT_C {	/* -C[n|o|b] */
+	struct GRDCONVERT_C {	/* -C[b|c|n|p] */
 		bool active;
-		unsigned int mode;	/* 0 = only keep old history, 1 = only keep new history, 2 = append new history to old history */
+		unsigned int mode;	/* see gmt_constants.h */
 	} C;
 	struct GRDCONVERT_G {	/* -G<outgrid> */
 		bool active;

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -49,8 +49,9 @@ struct GRDEDIT_CTRL {
 	struct GRDEDIT_A {	/* -A */
 		bool active;
 	} A;
-	struct GRDEDIT_C {	/* -C */
+	struct GRDEDIT_C {	/* -C[n|o|b] */
 		bool active;
+		unsigned int mode;	/* 0 = only keep old history, 1 = only keep new history, 2 = append new history to old history */
 	} C;
 	struct GRDEDIT_D {	/* -D[+x<xname>][+yyname>][+z<zname>][+s<scale>][+ooffset>][+n<invalid>][+t<title>][+r<remark>] */
 		bool active;
@@ -103,7 +104,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDEDIT_CTRL *C) {	/* Deallo
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s %s [-A] [-C] [%s] [-E[a|e|h|l|r|t|v]] [-G%s] [%s] [-L[+n|p]] "
+	GMT_Usage (API, 0, "usage: %s %s [-A] [-Cb|n|o] [%s] [-E[a|e|h|l|r|t|v]] [-G%s] [%s] [-L[+n|p]] "
 		"[-N<table>] [%s] [-S] [-T] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n", name, GMT_INGRID, GMT_GRDEDIT2D,
 		GMT_OUTGRID, GMT_J_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT,
 		GMT_i_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -114,7 +115,11 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_ingrid_syntax (API, 0, "Name of grid to be modified");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-A Adjust dx/dy to be compatible with the file domain (or new -R).");
-	GMT_Usage (API, 1, "\n-C Remove the command history from the header.");
+	GMT_Usage (API, 1, "\n-Cb|n|o");
+	GMT_Usage (API, -2, "Control how the existing and new command history should be handled, via directives:");
+	GMT_Usage (API, 3, "b: Append this command history to the existing history.");
+	GMT_Usage (API, 3, "n: Only save this command history.");
+	GMT_Usage (API, 3, "o: Only save the existing history [Default].");
 	gmt_grd_info_syntax (API->GMT, 'D');
 	GMT_Usage (API, 1, "\n-E[a|e|h|l|r|t|v]");
 	GMT_Usage (API, -2, "Transform the entire grid (this may exchange x and y). Append operation:");
@@ -176,9 +181,18 @@ static int parse (struct GMT_CTRL *GMT, struct GRDEDIT_CTRL *Ctrl, struct GMT_OP
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->A.active);
 				Ctrl->A.active = true;
 				break;
-			case 'C':	/* Clear history */
+			case 'C':	/* Control history output */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
 				Ctrl->C.active = true;
+				switch (opt->arg[0]) {
+					case 'b': Ctrl->C.mode = GMT_GRDHISTORY_BOTH;	break;
+					case 'n': Ctrl->C.mode = GMT_GRDHISTORY_NEW;	break;
+					case 'o': case '\0': Ctrl->C.mode = GMT_GRDHISTORY_OLD;	break;	/* Default */
+					default:
+						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Unrecognized directive %s\n", opt->arg);
+						n_errors++;
+						break;
+				}
 				break;
 			case 'D':	/* Give grid information */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->D.active);
@@ -268,7 +282,7 @@ EXTERN_MSC int GMT_grdedit (void *V_API, int mode, void *args) {
 
 	double shift_amount = 0.0;
 
-	char *registration[2] = {"gridline", "pixel"}, *out_file = NULL, *projstring = NULL;
+	char *registration[2] = {"gridline", "pixel"}, *out_file = NULL, *projstring = NULL, command[GMT_BUFSIZ] = {""};
 
 	struct GRDEDIT_CTRL *Ctrl = NULL;
 	struct GMT_GRID *G = NULL;
@@ -363,10 +377,10 @@ EXTERN_MSC int GMT_grdedit (void *V_API, int mode, void *args) {
 		}
 	}
 
-	if (Ctrl->C.active) {	/* Wipe history */
-		gmt_M_memset (G->header->command, GMT_GRID_COMMAND_LEN320, char);
-		if (HH->command) gmt_M_str_free (HH->command);	/* Free previous string */
-	}
+	gmt_change_grid_history (API, Ctrl->C.mode, G->header, command);	/* Set grid history per -C mode */
+
+	if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_COMMAND, command, G))
+		Return (API->error);
 
 	if (Ctrl->S.active) {
 		shift_amount = GMT->common.R.wesn[XLO] - G->header->wesn[XLO];

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -104,7 +104,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDEDIT_CTRL *C) {	/* Deallo
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s %s [-A] [-Cb|n|o] [%s] [-E[a|e|h|l|r|t|v]] [-G%s] [%s] [-L[+n|p]] "
+	GMT_Usage (API, 0, "usage: %s %s [-A] [-Cb|c|n|p] [%s] [-E[a|e|h|l|r|t|v]] [-G%s] [%s] [-L[+n|p]] "
 		"[-N<table>] [%s] [-S] [-T] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n", name, GMT_INGRID, GMT_GRDEDIT2D,
 		GMT_OUTGRID, GMT_J_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT,
 		GMT_i_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -115,11 +115,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_ingrid_syntax (API, 0, "Name of grid to be modified");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-A Adjust dx/dy to be compatible with the file domain (or new -R).");
-	GMT_Usage (API, 1, "\n-Cb|n|o");
-	GMT_Usage (API, -2, "Control how the existing and new command history should be handled, via directives:");
-	GMT_Usage (API, 3, "b: Append this command history to the existing history.");
-	GMT_Usage (API, 3, "n: Only save this command history.");
-	GMT_Usage (API, 3, "o: Only save the existing history [Default].");
+	GMT_Usage (API, 1, "\n-Cb|c|n|p");
+	GMT_Usage (API, -2, "Control how the current and previous command histories should be handled, via directives:");
+	GMT_Usage (API, 3, "b: Append the current command's history to the previous history.");
+	GMT_Usage (API, 3, "c: Only save the current command's history.");
+	GMT_Usage (API, 3, "n: Save no history at all [Default].");
+	GMT_Usage (API, 3, "p: Only preserve the previous history.");
 	gmt_grd_info_syntax (API->GMT, 'D');
 	GMT_Usage (API, 1, "\n-E[a|e|h|l|r|t|v]");
 	GMT_Usage (API, -2, "Transform the entire grid (this may exchange x and y). Append operation:");
@@ -181,13 +182,14 @@ static int parse (struct GMT_CTRL *GMT, struct GRDEDIT_CTRL *Ctrl, struct GMT_OP
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->A.active);
 				Ctrl->A.active = true;
 				break;
-			case 'C':	/* Control history output */
+			case 'C':	/* Control history output -Cb|c|n|p */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
 				Ctrl->C.active = true;
 				switch (opt->arg[0]) {
 					case 'b': Ctrl->C.mode = GMT_GRDHISTORY_BOTH;	break;
-					case 'n': Ctrl->C.mode = GMT_GRDHISTORY_NEW;	break;
-					case 'o': case '\0': Ctrl->C.mode = GMT_GRDHISTORY_OLD;	break;	/* Default */
+					case 'c': Ctrl->C.mode = GMT_GRDHISTORY_NEW;	break;
+					case 'p': Ctrl->C.mode = GMT_GRDHISTORY_OLD;	break;
+					case 'n': case '\0': Ctrl->C.mode = GMT_GRDHISTORY_NONE;	break;	/* Default */
 					default:
 						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Unrecognized directive %s\n", opt->arg);
 						n_errors++;

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -49,9 +49,9 @@ struct GRDEDIT_CTRL {
 	struct GRDEDIT_A {	/* -A */
 		bool active;
 	} A;
-	struct GRDEDIT_C {	/* -C[n|o|b] */
+	struct GRDEDIT_C {	/* -C[b|c|n|p] */
 		bool active;
-		unsigned int mode;	/* 0 = only keep old history, 1 = only keep new history, 2 = append new history to old history */
+		unsigned int mode;	/* see gmt_constants.h */
 	} C;
 	struct GRDEDIT_D {	/* -D[+x<xname>][+yyname>][+z<zname>][+s<scale>][+ooffset>][+n<invalid>][+t<title>][+r<remark>] */
 		bool active;


### PR DESCRIPTION
**Description of proposed changes**

These two modules are special in that they only make minor (or no) changes to the grid, and hence one may wish to control what the output grid's history should be.  This was previously not very clear: **grdedit -C** would wipe the history, while **grdconvert** would write the old history if both input and output grids were netCDF and no **-R** was changed.  This PR standardizes the behavior of **grdedit** and **grdconvert** via a common **-C** option (revised for **grdedit** but backwards compatible and new to **grdconvert**):

**-C**[**b**|**c**|**n**|**p**]

**b** will write both command histories separated by a semi-colon
**c** will only write the current module history
**n** will write no history whatsoever [Default if -C is used with no argument]
**p** will write the previous module history

This means the kind of grid no longer matters. Of course, combined histories may be longer than the standard 320 characters and only the netCDF format will handle longer histories, remarks, and titles.

No test are affected that I am aware of.