### PR TITLE
Add two -R shorthands for projected coordinates

### DIFF
--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -19,8 +19,10 @@ The **-R** option defines the map region or data domain of interest. It may be s
 
 #. **-R**\ *xmin*/*xmax*/*ymin*/*ymax*\ **+u**\ *unit*. Append **+u**\ *unit* to the option 1 to specify a region in
    projected units (e.g., UTM meters) where *xmin*/*xmax*/*ymin*/*ymax* are Cartesian projected coordinates compatible
-   with the chosen projection and *unit* is an allowable :ref:`distance unit <dist-units>`. The coordinates are relative
-   to the standard longitude and latitude indicated in the projection (**-J**).
+   with the chosen projection and *unit* is an allowable :ref:`distance unit <dist-units>` [e]. The coordinates are relative
+   to the standard longitude and latitude indicated in the projection (**-J**).  For square projected regions centered
+   on (0,0) you may use the short-hand **-R**\ *radius*\ [**+u**\ *unit*] while for rectangular regions you may use
+   **-R**\ *xhalf*/*yhalf*\ [**+u**\ *unit*].
 
 #. **-R**\ *xlleft*/*ylleft*/*xuright*/*yuright*\ **+r**. This form is useful for map projections that are oblique,
    making meridians and parallels poor choices for map boundaries. Here, we instead specify the lower left corner and

--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -20,9 +20,9 @@ The **-R** option defines the map region or data domain of interest. It may be s
 #. **-R**\ *xmin*/*xmax*/*ymin*/*ymax*\ **+u**\ *unit*. Append **+u**\ *unit* to the option 1 to specify a region in
    projected units (e.g., UTM meters) where *xmin*/*xmax*/*ymin*/*ymax* are Cartesian projected coordinates compatible
    with the chosen projection and *unit* is an allowable :ref:`distance unit <dist-units>` [e]. The coordinates are relative
-   to the standard longitude and latitude indicated in the projection (**-J**).  For square projected regions centered
-   on (0,0) you may use the short-hand **-R**\ *radius*\ [**+u**\ *unit*] while for rectangular regions you may use
-   **-R**\ *xhalf*/*yhalf*\ [**+u**\ *unit*]. These short-hands require the **+u** modifier.
+   to the standard longitude and latitude indicated in the projection (**-J**).  For projected regions centered on
+   (0,0) you may use the short-hand **-R**\ *halfwidth*\ [/*halfheight*]\ **+u**\ *unit*, where *halfheight* defaults
+   to *halfwidth if not given. This short-hand requires the **+u** modifier.
 
 #. **-R**\ *xlleft*/*ylleft*/*xuright*/*yuright*\ **+r**. This form is useful for map projections that are oblique,
    making meridians and parallels poor choices for map boundaries. Here, we instead specify the lower left corner and

--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -22,7 +22,7 @@ The **-R** option defines the map region or data domain of interest. It may be s
    with the chosen projection and *unit* is an allowable :ref:`distance unit <dist-units>` [e]. The coordinates are relative
    to the standard longitude and latitude indicated in the projection (**-J**).  For square projected regions centered
    on (0,0) you may use the short-hand **-R**\ *radius*\ [**+u**\ *unit*] while for rectangular regions you may use
-   **-R**\ *xhalf*/*yhalf*\ [**+u**\ *unit*].
+   **-R**\ *xhalf*/*yhalf*\ [**+u**\ *unit*]. These short-hands require the **+u** modifier.
 
 #. **-R**\ *xlleft*/*ylleft*/*xuright*/*yuright*\ **+r**. This form is useful for map projections that are oblique,
    making meridians and parallels poor choices for map boundaries. Here, we instead specify the lower left corner and

--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -6,10 +6,7 @@
 
     1. **-R**\ *west*/*east*/*south*/*north*\ [**+u**\ *unit*]. This is the standard way to specify geographic regions
        when using map projections where meridians and parallels are rectilinear. The coordinates may be specified in
-       decimal degrees or in [±]dd:mm[:ss.xxx][**W**\|\ **E**\|\ **S**\|\ **N**] format. Optionally, append
-       **+u**\ *unit* to specify a region in projected units (e.g., UTM meters) where *west*/*east*/*south*/*north* are
-       Cartesian projected coordinates compatible with the chosen projection (**-J**) and *unit* is an allowable
-       :ref:`distance unit <dist-units>`; we inversely project to determine the actual rectangular geographic region.
+       decimal degrees or in [±]dd:mm[:ss.xxx][**W**\|\ **E**\|\ **S**\|\ **N**] format.
 
     #. **-R**\ *west*/*south*/*east*/*north*\ **+r**. This form is useful for map projections that are oblique,
        making meridians and parallels poor choices for map boundaries. Here, we instead specify the lower left corner
@@ -35,6 +32,12 @@
         - **+e** to adjust the region boundaries to be multiples of the steps indicated by *inc*, *xinc*/*yinc*, or
           *winc*/*einc*/*sinc*/*ninc*, while ensuring that the bounding box extends by at least 0.25 times the increment
           [default is no adjustment].
+
+    #. **-R**\ *xmin*/*xmax*/*ymin*/*ymax*\ [**+u**\ *unit*] specifies a region in projected units (e.g., UTM meters)
+       where *xmin*/*xmax*/*ymin*/*ymax* are Cartesian projected coordinates compatible with the chosen projection
+       (**-J**) and *unit* is an allowable :ref:`distance unit <dist-units>` [e]; we inversely project to determine the
+       actual rectangular geographic region. For square projected regions centered on (0,0) you may use the short-hand
+       **-R**\ *radius*\ [**+u**\ *unit*] while for rectangular regions you may use **-R**\ *xhalf*/*yhalf*\ [**+u**\ *unit*].
 
     #. **-R**\ *justify*\ *lon0*/*lat0*/*nx*/*ny*, where *justify* is a 2-character combination of
        **L**\|\ **C**\|\ **R** (for left, center, or right) and **T**\|\ **M**\|\ **B** (for top, middle, or bottom)

--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -36,9 +36,9 @@
     #. **-R**\ *xmin*/*xmax*/*ymin*/*ymax*\ [**+u**\ *unit*] specifies a region in projected units (e.g., UTM meters)
        where *xmin*/*xmax*/*ymin*/*ymax* are Cartesian projected coordinates compatible with the chosen projection
        (**-J**) and *unit* is an allowable :ref:`distance unit <dist-units>` [e]; we inversely project to determine the
-       actual rectangular geographic region. For square projected regions centered on (0,0) you may use the short-hand
-       **-R**\ *radius*\ **+u**\ *unit* while for rectangular regions you may use **-R**\ *xhalf*/*yhalf*\ **+u**\ *unit*.
-       These short-hands require the **+u** modifier.
+       actual rectangular geographic region. For projected regions centered on (0,0) you may use the short-hand
+       **-R**\ *halfwidth*\ [/*halfheight*]\ **+u**\ *unit*, where *halfheight* defaults to *halfwidth if not given.
+       This short-hand requires the **+u** modifier.
 
     #. **-R**\ *justify*\ *lon0*/*lat0*/*nx*/*ny*, where *justify* is a 2-character combination of
        **L**\|\ **C**\|\ **R** (for left, center, or right) and **T**\|\ **M**\|\ **B** (for top, middle, or bottom)

--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -37,7 +37,8 @@
        where *xmin*/*xmax*/*ymin*/*ymax* are Cartesian projected coordinates compatible with the chosen projection
        (**-J**) and *unit* is an allowable :ref:`distance unit <dist-units>` [e]; we inversely project to determine the
        actual rectangular geographic region. For square projected regions centered on (0,0) you may use the short-hand
-       **-R**\ *radius*\ [**+u**\ *unit*] while for rectangular regions you may use **-R**\ *xhalf*/*yhalf*\ [**+u**\ *unit*].
+       **-R**\ *radius*\ **+u**\ *unit* while for rectangular regions you may use **-R**\ *xhalf*/*yhalf*\ **+u**\ *unit*.
+       These short-hands require the **+u** modifier.
 
     #. **-R**\ *justify*\ *lon0*/*lat0*/*nx*/*ny*, where *justify* is a 2-character combination of
        **L**\|\ **C**\|\ **R** (for left, center, or right) and **T**\|\ **M**\|\ **B** (for top, middle, or bottom)

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7104,8 +7104,8 @@ GMT_LOCAL void gmtinit_explain_R_geo (struct GMT_CTRL *GMT) {
 	GMT_Usage (API, -2, "Specify the min/max coordinates of your data region in user units. "
 		"Use dd:mm[:ss] for regions given in arc degrees, minutes [and seconds]. "
 		"Use -R<xmin>/<xmax>/<ymin>/<ymax>[+u<unit>] for regions given in projected coordinates, "
-		"with <unit> selected from %s [e]. For square or rectangular projected regions centered "
-		"on (0,0), you may use -R<radius>+u<unit> and -R<xhalf>/<yhalf>>+u<unit>, respectively. "
+		"with <unit> selected from %s [e]. If +u is set, square or rectangular projected regions centered "
+		"on (0,0) may be set via -R<radius>+u<unit> and -R<xhalf>/<yhalf>>+u<unit>, respectively. "
 		"Use [yyyy[-mm[-dd]]]T[hh[:mm[:ss[.xxx]]]] format for time axes. "
 		"Append +r if -R specifies the coordinates of the lower left and "
 		"upper right corners of a rectangular area.", GMT_LEN_UNITS2_DISPLAY);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7104,7 +7104,8 @@ GMT_LOCAL void gmtinit_explain_R_geo (struct GMT_CTRL *GMT) {
 	GMT_Usage (API, -2, "Specify the min/max coordinates of your data region in user units. "
 		"Use dd:mm[:ss] for regions given in arc degrees, minutes [and seconds]. "
 		"Use -R<xmin>/<xmax>/<ymin>/<ymax>[+u<unit>] for regions given in projected coordinates, "
-		"with <unit> selected from %s. [e] "
+		"with <unit> selected from %s [e]. For square or rectangular projected regions centered "
+		"on (0,0), you may use -R<radius>+u<unit> and -R<xhalf>/<yhalf>>+u<unit>, respectively. "
 		"Use [yyyy[-mm[-dd]]]T[hh[:mm[:ss[.xxx]]]] format for time axes. "
 		"Append +r if -R specifies the coordinates of the lower left and "
 		"upper right corners of a rectangular area.", GMT_LEN_UNITS2_DISPLAY);
@@ -8879,23 +8880,43 @@ int gmt_parse_R_option (struct GMT_CTRL *GMT, char *arg) {
 		GMT->common.R.oblique = false;
 	i = pos = 0;
 	gmt_M_memset (p, 6, double);
-	while ((gmt_strtok (string, "/", &pos, text))) {
-		if (i > 5) {
-			error++;
-			return (error);		/* Have to break out here to avoid segv on p[6]  */
+	if (inv_project || scale_coord) {	/* Plain floating points in selected distance units */
+		int nc;
+		gmt_strrepc (string, '/', ' ');	/* Replace the slashes with spaces to easy parsing */
+		nc = sscanf (string, "%lf %lf %lf %lf", &p[XLO], &p[XHI], &p[YLO], &p[YHI]);
+		i = 4;	/* So test below shows we found 4 coordinates (unless we fail) */
+		if (nc == 1) {	/* Got -R<radius>+u<unit> for a square area in projected or scaled units centered on (0,0) */
+			double r = p[XLO];
+			p[XLO] = p[YLO] = -r;	/* Start at negative radius value */
+			p[XHI] = p[YHI] = +r;	/* Stop at positive radius value */
 		}
-		/* Figure out what column corresponds to a token to get col_type[GMT_IN] flag  */
-		if (i > 3)
-			icol = 2;
-		else if (GMT->common.R.oblique)
-			icol = i%2;
-		else
-			icol = i/2;
-		if (icol < 2 && GMT->current.setting.io_lonlat_toggle[GMT_IN]) icol = 1 - icol;	/* col_types were swapped */
-		if (inv_project)	/* input is distance units */
-			p[i] = atof (text);
-		else {
-			bool maybe_time = gmtlib_maybe_abstime (GMT, text, &no_T);	/* Will flag things like 1999-12-03 or 2000/09/4 as abstime with missing T */
+		else if (nc == 2) {	/* Got -R<halfwidth/<halfhight>>+u<unit> for a rectangular area in projected or scaled units centered on (0,0) */
+			double x2 = p[XLO], y2 = p[XHI];
+			p[XLO] = -x2;	p[XHI] = +x2;	/* Half width centered on 0 */
+			p[YLO] = -y2;	p[YHI] = +y2;	/* Half width centered on 0 */
+		}
+		else if (nc != 4) {	/* Error */
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Could not parse %s into projected or scaled Cartesian coordinates!\n", text);
+			error++;
+			i = nc;
+		}
+	}
+	else {	/* Other types of coordinates */
+		bool maybe_time;
+		while ((gmt_strtok (string, "/", &pos, text))) {
+			if (i > 5) {
+				error++;
+				return (error);		/* Have to break out here to avoid segv on p[6]  */
+			}
+			/* Figure out what column corresponds to a token to get col_type[GMT_IN] flag  */
+			if (i > 3)
+				icol = 2;
+			else if (GMT->common.R.oblique)
+				icol = i%2;
+			else
+				icol = i/2;
+			if (icol < 2 && GMT->current.setting.io_lonlat_toggle[GMT_IN]) icol = 1 - icol;	/* col_types were swapped */
+			maybe_time = gmtlib_maybe_abstime (GMT, text, &no_T);	/* Will flag things like 1999-12-03 or 2000/09/4 as abstime with missing T */
 			if (maybe_time || gmt_M_type (GMT, GMT_IN, icol) == GMT_IS_UNKNOWN || gmt_M_type (GMT, GMT_IN, icol) == GMT_IS_FLOAT) {	/* Because abstime specs must be parsed carefully we must do more checking */
 				/* Here, -J or -f may have ben set, proceed with caution */
 				if (no_T) strcat (text, "T");	/* Add the missing trailing 'T' in an ISO date */
@@ -8923,10 +8944,10 @@ int gmt_parse_R_option (struct GMT_CTRL *GMT, char *arg) {
 				expect_to_read = (gmt_M_type (GMT, GMT_IN, icol) & GMT_IS_RATIME) ? GMT_IS_ARGTIME : gmt_M_type (GMT, GMT_IN, icol);
 				error += gmt_verify_expectations (GMT, expect_to_read, gmt_scanf (GMT, text, expect_to_read, &p[i]), text);
 			}
-		}
-		if (error) return (error);
+			if (error) return (error);
 
-		i++;
+			i++;
+		}
 	}
 	if (GMT->common.R.oblique) {
 		gmt_M_double_swap (p[2], p[1]);	/* So w/e/s/n makes sense */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7104,8 +7104,8 @@ GMT_LOCAL void gmtinit_explain_R_geo (struct GMT_CTRL *GMT) {
 	GMT_Usage (API, -2, "Specify the min/max coordinates of your data region in user units. "
 		"Use dd:mm[:ss] for regions given in arc degrees, minutes [and seconds]. "
 		"Use -R<xmin>/<xmax>/<ymin>/<ymax>[+u<unit>] for regions given in projected coordinates, "
-		"with <unit> selected from %s [e]. If +u is set, square or rectangular projected regions centered "
-		"on (0,0) may be set via -R<radius>+u<unit> and -R<xhalf>/<yhalf>>+u<unit>, respectively. "
+		"with <unit> selected from %s [e]. If +u is set, projected regions centered on (0,0) may be"
+		"set via -R<halfwidth>[/<halfheight>]+u<unit>, where <halfheight> defaults to <halfwidth> if not given. "
 		"Use [yyyy[-mm[-dd]]]T[hh[:mm[:ss[.xxx]]]] format for time axes. "
 		"Append +r if -R specifies the coordinates of the lower left and "
 		"upper right corners of a rectangular area.", GMT_LEN_UNITS2_DISPLAY);

--- a/test/pscoast/pscoast_R_shorthand.ps
+++ b/test/pscoast/pscoast_R_shorthand.ps
@@ -1,0 +1,3399 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000             
+%%Title: GMT v6.4.0_3a397f3-dirty_2021.12.04 Document from pscoast
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec  5 09:54:19 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/ISOLatin1+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/bullet		/ellipsis	/trademark	/emdash		/endash		/fi		/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/minus		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c 		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/scaron
+/OE		/dagger		/daggerdbl	/Lslash		/fraction	/guilsinglleft	/Scaron		/guilsinglright
+/oe		/Ydieresis	/Zcaron		/lslash		/perthousand	/quotedblbase	/quotedblleft	/quotedblright
+/dotlessi	/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/quotesinglbase	/ring		/cedilla	/quotesingle	/hungarumlaut	/ogonek		/caron
+/space		/exclamdown	/cent		/sterling	/currency	/yen		/brokenbar	/section
+/dieresis	/copyright	/ordfeminine	/guillemotleft	/logicalnot	/hyphen		/registered	/macron
+/degree		/plusminus	/twosuperior	/threesuperior	/acute		/mu		/paragraph	/periodcentered
+/cedilla	/onesuperior	/ordmasculine	/guillemotright	/onequarter	/onehalf	/threequarters	/questiondown
+/Agrave		/Aacute		/Acircumflex	/Atilde		/Adieresis	/Aring		/AE		/Ccedilla
+/Egrave		/Eacute		/Ecircumflex	/Edieresis	/Igrave		/Iacute		/Icircumflex	/Idieresis
+/Eth		/Ntilde		/Ograve		/Oacute		/Ocircumflex	/Otilde		/Odieresis	/multiply
+/Oslash		/Ugrave		/Uacute		/Ucircumflex	/Udieresis	/Yacute		/Thorn		/germandbls
+/agrave		/aacute		/acircumflex	/atilde		/adieresis	/aring		/ae		/ccedilla
+/egrave		/eacute		/ecircumflex	/edieresis	/igrave		/iacute		/icircumflex	/idieresis
+/eth		/ntilde		/ograve		/oacute		/ocircumflex	/otilde		/odieresis	/divide
+/oslash		/ugrave		/uacute		/ucircumflex	/udieresis	/yacute		/thorn		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+PSLevel 1 gt { << /WhiteIsOpaque true >> setpagedevice } if
+PSLevel 1 gt { << /PageSize [612 792] /ImagingBBox null >> setpagedevice } if
+%%EndSetup
+
+%%Page: 1 1
+
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+-3307 PSL_xorig sub PSL_page_xsize 2 div add 945 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -R300+un -JA204/21/14c -Glightgray -Baf -K -P -Xc -Y2c
+%@PROJ: laea -161.64374564 -150.35625436 15.80260600 26.11839632 -555600.000 555600.000 -555600.001 555599.999 +proj=laea +lat_0=21 +lon_0=204 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%GMTBoundingBox: -198.42519685 56.6929133858 396.850393701 396.850393713
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 756 0 M -2 -83 D S
+N 921 6614 M 3 84 D S
+N 2032 0 M -1 -83 D S
+N 2114 6614 M 1 84 D S
+N 3307 0 M 0 -83 D S
+N 3307 6614 M 0 84 D S
+N 4583 0 M 0 -83 D S
+N 4500 6614 M -1 84 D S
+N 5858 0 M 2 -83 D S
+N 5693 6614 M -2 84 D S
+N 0 64 M -83 3 D S
+N 6614 64 M 84 3 D S
+N 0 1383 M -83 2 D S
+N 6614 1383 M 84 2 D S
+N 0 2702 M -83 3 D S
+N 6614 2702 M 84 3 D S
+N 0 4022 M -83 3 D S
+N 6614 4022 M 84 3 D S
+N 0 5342 M -83 3 D S
+N 6614 5342 M 84 3 D S
+N 119 0 M -2 -42 D S
+N 324 6614 M 2 42 D S
+N 756 0 M -1 -42 D S
+N 921 6614 M 1 42 D S
+N 1394 0 M -1 -42 D S
+N 1518 6614 M 1 42 D S
+N 2032 0 M -1 -42 D S
+N 2114 6614 M 1 42 D S
+N 2669 0 M 0 -42 D S
+N 2711 6614 M 0 42 D S
+N 3307 0 M 0 -42 D S
+N 3307 6614 M 0 42 D S
+N 3945 0 M 0 -42 D S
+N 3904 6614 M -1 42 D S
+N 4583 0 M 0 -42 D S
+N 4500 6614 M -1 42 D S
+N 5220 0 M 1 -42 D S
+N 5097 6614 M -1 42 D S
+N 5858 0 M 1 -42 D S
+N 5693 6614 M -1 42 D S
+N 6496 0 M 1 -42 D S
+N 6290 6614 M -2 42 D S
+N 0 64 M -42 1 D S
+N 6614 64 M 42 1 D S
+N 0 723 M -42 2 D S
+N 6614 723 M 42 2 D S
+N 0 1383 M -42 1 D S
+N 6614 1383 M 42 1 D S
+N 0 2042 M -42 2 D S
+N 6614 2042 M 42 2 D S
+N 0 2702 M -42 2 D S
+N 6614 2702 M 42 2 D S
+N 0 3362 M -42 1 D S
+N 6614 3362 M 42 1 D S
+N 0 4022 M -42 2 D S
+N 6614 4022 M 42 2 D S
+N 0 4682 M -42 2 D S
+N 6614 4682 M 42 2 D S
+N 0 5342 M -42 2 D S
+N 6614 5342 M 42 2 D S
+N 0 6002 M -42 2 D S
+N 6614 6002 M 42 2 D S
+754 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(-160°) tc Z
+924 6781 M (-160°) bc Z
+2031 -167 M (-158°) tc Z
+2115 6781 M (-158°) bc Z
+3307 -167 M (-156°) tc Z
+3307 6781 M (-156°) bc Z
+4583 -167 M (-154°) tc Z
+4499 6781 M (-154°) bc Z
+5860 -167 M (-152°) tc Z
+5691 6781 M (-152°) bc Z
+/PSL_AH1 0
+-167 67 M (16°) mr Z
+6781 67 M (16°) ml Z
+(16°) sw mx
+-167 1385 M (18°) mr Z
+6781 1385 M (18°) ml Z
+(18°) sw mx
+-167 2705 M (20°) mr Z
+6781 2705 M (20°) ml Z
+(20°) sw mx
+-167 4025 M (22°) mr Z
+6781 4025 M (22°) ml Z
+(22°) sw mx
+-167 5345 M (24°) mr Z
+6781 5345 M (24°) ml Z
+(24°) sw mx
+(26°) sw mx
+def
+799 3998 M
+-94 -73 D
+-3 -63 D
+100 67 D
+0 69 D
+P
+{0.827 A} FS
+O0
+FO
+3765 2649 M
+-367 179 D
+-33 -50 D
+44 -130 D
+P
+FO
+2072 3522 M
+22 49 D
+1 -45 D
+91 -44 D
+103 35 D
+-45 100 D
+-36 -31 D
+-37 33 D
+-86 167 D
+-85 -86 D
+-100 -3 D
+103 -184 D
+P
+FO
+3307 3108 M
+-2 65 D
+-148 95 D
+-145 -27 D
+-70 89 D
+-58 -34 D
+34 -112 D
+100 -19 D
+31 -131 D
+P
+FO
+989 3992 M
+198 -89 D
+72 59 D
+24 123 D
+-64 61 D
+-111 -5 D
+-88 -48 D
+P
+FO
+2689 3361 M
+92 -20 D
+87 74 D
+-338 44 D
+-36 -80 D
+P
+FO
+2687 3205 M
+21 -71 D
+99 51 D
+-81 77 D
+-74 -8 D
+P
+FO
+2925 3038 M
+-42 -54 D
+92 14 D
+P
+FO
+3409 2648 M
+3 -11 D
+-145 -167 D
+109 -252 D
+-13 -173 D
+78 -57 D
+70 -56 D
+106 148 D
+329 139 D
+107 115 D
+-110 78 D
+-15 65 D
+-52 -5 D
+2 81 D
+-79 80 D
+-34 16 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 -1 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-6 0 D
+P
+FO
+25 W
+0 A
+2 setlinecap
+N 0 0 M 0 6614 D S
+N 6614 0 M 0 6614 D S
+N 0 0 M 6614 0 D S
+N 0 6614 M 6614 0 D S
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R300+un -JA204/21/14c -O -K -F+cBL+f13p -Dj0.1c
+%@PROJ: laea -161.64374564 -150.35625436 15.80260600 26.11839632 -555600.000 555600.000 -555600.001 555599.999 +proj=laea +lat_0=21 +lon_0=204 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+6614 0 D
+0 6614 D
+-6614 0 D
+P
+PSL_clip N
+47 47 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+217 F0
+(­R300+un ­JA204/21/14c) bl Z
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 7559 TM
+
+% PostScript produced by:
+%@GMT: gmt pscoast -R500/300+uk -JS11/60/14c -Glightgray -Baf -O -K -Y16c
+%@PROJ: stere 1.21500281 20.78499719 56.93027235 62.79255453 -500000.000 500000.000 -300000.000 300000.000 +proj=stere +lat_0=60 +lon_0=11 +k=0.9996 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 908 0 M -7 -83 D S
+N 1268 3969 M 8 83 D S
+N 2908 0 M -1 -83 D S
+N 2968 3969 M 2 83 D S
+N 4904 0 M 5 -83 D S
+N 4664 3969 M -5 83 D S
+N 6377 3969 M -12 83 D S
+N 0 2209 M -83 11 D S
+N 6614 2209 M 84 11 D S
+N 237 3969 M 6 41 D S
+N 101 0 M -5 -42 D S
+N 582 3969 M 5 41 D S
+N 505 0 M -4 -42 D S
+N 926 3969 M 4 41 D S
+N 908 0 M -4 -42 D S
+N 1268 3969 M 4 41 D S
+N 1310 0 M -3 -42 D S
+N 1610 3969 M 3 41 D S
+N 1710 0 M -2 -42 D S
+N 1950 3969 M 3 41 D S
+N 2110 0 M -2 -42 D S
+N 2290 3969 M 2 41 D S
+N 2510 0 M -2 -42 D S
+N 2629 3969 M 2 41 D S
+N 2908 0 M 0 -42 D S
+N 2968 3969 M 1 41 D S
+N 3307 0 M 0 -42 D S
+N 3307 3969 M 0 41 D S
+N 3706 0 M 0 -42 D S
+N 3646 3969 M -1 41 D S
+N 4105 0 M 1 -42 D S
+N 3985 3969 M -1 41 D S
+N 4504 0 M 2 -42 D S
+N 4324 3969 M -2 41 D S
+N 4904 0 M 2 -42 D S
+N 4664 3969 M -3 41 D S
+N 5304 0 M 4 -42 D S
+N 5005 3969 M -4 41 D S
+N 5706 0 M 4 -42 D S
+N 5346 3969 M -4 41 D S
+N 6109 0 M 4 -42 D S
+N 5688 3969 M -4 41 D S
+N 6513 0 M 5 -42 D S
+N 6032 3969 M -5 41 D S
+N 6377 3969 M -6 41 D S
+N 0 721 M -42 5 D S
+N 6614 721 M 42 5 D S
+N 0 1465 M -42 5 D S
+N 6614 1465 M 42 5 D S
+N 0 2209 M -42 6 D S
+N 6614 2209 M 42 6 D S
+N 0 2954 M -42 6 D S
+N 6614 2954 M 42 6 D S
+N 0 3700 M -42 6 D S
+N 6614 3700 M 42 6 D S
+901 -167 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+200 F0
+(5°) tc Z
+1276 4135 M (5°) bc Z
+2907 -167 M (10°) tc Z
+2970 4135 M (10°) bc Z
+4909 -167 M (15°) tc Z
+4659 4135 M (15°) bc Z
+6365 4135 M (20°) bc Z
+/PSL_AH1 0
+-167 2220 M (60°) mr Z
+6781 2220 M (60°) ml Z
+(60°) sw mx
+def
+1186 2076 M
+-5 94 D
+P
+{0.827 A} FS
+O0
+FO
+1229 2073 M
+9 63 D
+-10 -63 D
+P
+FO
+1351 2063 M
+7 36 D
+13 -38 D
+38 -3 D
+18 8 D
+58 185 D
+67 4 D
+-13 69 D
+214 95 D
+-10 -66 D
+124 107 D
+-45 -65 D
+83 -3 D
+-113 -10 D
+-58 -62 D
+-66 -228 D
+63 246 D
+-117 -20 D
+-109 -124 D
+16 -65 D
+66 11 D
+-105 -36 D
+-14 -50 D
+175 -13 D
+269 -17 D
+277 -14 D
+216 -9 D
+223 -7 D
+209 -5 D
+101 -2 D
+30 1982 D
+-499 0 D
+1 -2 D
+-2 2 D
+-344 0 D
+8 -46 D
+-46 35 D
+49 -61 D
+79 13 D
+-80 -55 D
+-126 106 D
+-15 -79 D
+-13 87 D
+-60 0 D
+-2 -45 D
+-29 45 D
+-29 0 D
+-44 -49 D
+-11 49 D
+-109 -21 D
+-4 -41 D
+157 -38 D
+-161 -17 D
+190 7 D
+54 -129 D
+148 -52 D
+-133 25 D
+-33 -117 D
+80 -17 D
+-114 -2 D
+58 142 D
+-89 130 D
+-63 -26 D
+11 -58 D
+-59 43 D
+73 -147 D
+-39 -64 D
+-56 204 D
+-131 -68 D
+42 -63 D
+-63 29 D
+123 -129 D
+-96 -3 D
+-15 73 D
+-52 -97 D
+33 133 D
+-84 -4 D
+13 -65 D
+-75 89 D
+-33 -51 D
+71 -52 D
+-60 -41 D
+-34 123 D
+-78 27 D
+0 -70 D
+101 -67 D
+-74 -57 D
+-20 37 D
+1 -64 D
+98 24 D
+183 -36 D
+-88 -5 D
+23 -30 D
+361 -16 D
+-124 -40 D
+-142 42 D
+32 -63 D
+-53 63 D
+-41 -77 D
+27 81 D
+-119 -18 D
+27 52 D
+-180 12 D
+65 -31 D
+-102 -39 D
+66 -13 D
+-49 -48 D
+-60 32 D
+-7 -81 D
+148 -2 D
+-149 -33 D
+138 7 D
+22 -28 D
+-79 19 D
+58 -32 D
+-80 -21 D
+234 -62 D
+-214 38 D
+-96 -37 D
+66 1 D
+-49 -24 D
+12 -54 D
+212 17 D
+-250 -41 D
+7 -48 D
+104 -34 D
+-78 17 D
+44 -75 D
+67 -31 D
+237 90 D
+-9 -52 D
+63 25 D
+86 -59 D
+17 118 D
+55 2 D
+-24 -56 D
+139 -44 D
+65 77 D
+-86 -109 D
+138 24 D
+-4 179 D
+109 64 D
+-105 -139 D
+35 -73 D
+105 19 D
+-124 -57 D
+35 -38 D
+-80 36 D
+-75 -23 D
+47 -127 D
+-28 -54 D
+-20 93 D
+-68 -44 D
+57 105 D
+-125 87 D
+-93 -118 D
+5 46 D
+-52 -21 D
+9 46 D
+-106 29 D
+-172 -34 D
+-16 -56 D
+-110 83 D
+-51 -33 D
+57 -54 D
+-32 -66 D
+-35 69 D
+20 -100 D
+59 -35 D
+102 83 D
+21 -34 D
+-72 -15 D
+-49 -50 D
+59 -103 D
+-172 142 D
+78 -70 D
+25 -80 D
+-53 34 D
+51 -92 D
+169 152 D
+-15 -46 D
+46 21 D
+-38 -202 D
+-103 -17 D
+-53 81 D
+10 -109 D
+-65 2 D
+58 -28 D
+-53 -38 D
+79 -121 D
+133 181 D
+-62 -93 D
+47 -18 D
+-69 -56 D
+73 17 D
+-11 -93 D
+-72 20 D
+-64 -53 D
+P
+2389 3007 M
+299 -20 D
+-124 -35 D
+-213 63 D
+P
+2220 2591 M
+67 -59 D
+-77 25 D
+11 40 D
+P
+2071 2160 M
+53 -38 D
+-86 8 D
+P
+2418 2343 M
+109 -40 D
+6 -58 D
+-119 100 D
+P
+1718 3463 M
+4 -1 D
+-116 -8 D
+P
+1689 3247 M
+-30 87 D
+33 -92 D
+P
+2278 2133 M
+-1 2 D
+32 -65 D
+P
+2434 3388 M
+218 -14 D
+-224 14 D
+P
+FO
+1592 3746 M
+44 36 D
+-71 56 D
+-25 -96 D
+-96 11 D
+23 -60 D
+-40 10 D
+80 -23 D
+P
+FO
+1254 2470 M
+65 -81 D
+65 18 D
+21 160 D
+-43 7 D
+-54 -120 D
+-54 17 D
+P
+FO
+1219 3434 M
+-29 -54 D
+122 63 D
+-105 46 D
+-49 -33 D
+P
+FO
+1110 2244 M
+55 -29 D
+14 132 D
+-60 76 D
+P
+FO
+1155 2914 M
+-19 64 D
+-53 -135 D
+92 48 D
+-1 58 D
+P
+FO
+1229 3544 M
+35 -48 D
+13 76 D
+P
+FO
+1610 3930 M
+41 -19 D
+2 42 D
+P
+FO
+1132 2513 M
+86 -64 D
+-28 65 D
+P
+FO
+1143 2617 M
+-45 15 D
+118 -140 D
+P
+FO
+1132 2486 M
+19 -87 D
+64 -23 D
+P
+FO
+1073 3050 M
+34 -10 D
+-34 13 D
+P
+FO
+1120 2766 M
+20 -30 D
+-20 31 D
+P
+FO
+1213 3231 M
+48 -17 D
+-45 18 D
+P
+FO
+1631 3858 M
+61 9 D
+-61 -6 D
+P
+FO
+1145 2185 M
+18 -38 D
+P
+FO
+1228 3490 M
+40 -16 D
+-40 17 D
+P
+FO
+1067 2493 M
+20 29 D
+P
+FO
+1103 2579 M
+33 -31 D
+-32 32 D
+P
+FO
+1124 3238 M
+41 3 D
+-40 -2 D
+P
+FO
+1162 2606 M
+34 -26 D
+-33 27 D
+P
+FO
+1680 3849 M
+-60 -14 D
+105 -12 D
+P
+FO
+1472 2174 M
+-15 -69 D
+16 70 D
+P
+FO
+1055 2827 M
+9 64 D
+P
+FO
+1078 2777 M
+51 -64 D
+-51 65 D
+P
+FO
+1158 2779 M
+8 -76 D
+-7 76 D
+P
+FO
+1141 2623 M
+-20 65 D
+-28 -22 D
+P
+FO
+1456 3776 M
+53 25 D
+-53 -24 D
+P
+FO
+1054 2527 M
+14 59 D
+P
+FO
+1160 2800 M
+-21 29 D
+20 -29 D
+P
+FO
+1143 3406 M
+42 -22 D
+-42 23 D
+P
+FO
+1148 3325 M
+26 -24 D
+-25 25 D
+P
+FO
+1182 2940 M
+22 -40 D
+-22 41 D
+P
+FO
+1425 3807 M
+35 -22 D
+-34 23 D
+P
+FO
+1170 3259 M
+-19 40 D
+-23 -44 D
+P
+FO
+1678 3969 M
+8 -6 D
+P
+FO
+1382 3730 M
+33 -16 D
+-33 17 D
+P
+FO
+1215 3168 M
+40 4 D
+-40 -3 D
+P
+FO
+2946 1987 M
+49 84 D
+15 -54 D
+51 48 D
+1 -6 D
+-9 -73 D
+295 -2 D
+287 2 D
+301 6 D
+134 4 D
+-26 86 D
+7 -4 D
+22 -82 D
+271 10 D
+324 16 D
+230 14 D
+345 25 D
+237 20 D
+243 23 D
+202 21 D
+222 25 D
+61 7 D
+-24 79 D
+-20 -47 D
+-72 62 D
+4 -61 D
+-122 175 D
+77 -60 D
+37 26 D
+-67 13 D
+3 44 D
+-81 -11 D
+-108 186 D
+-84 -86 D
+-54 103 D
+-161 11 D
+61 59 D
+-45 37 D
+27 58 D
+-74 39 D
+35 47 D
+-39 -7 D
+10 185 D
+-51 44 D
+69 -19 D
+-51 20 D
+45 -2 D
+-69 73 D
+48 14 D
+-72 84 D
+62 9 D
+-66 11 D
+70 27 D
+-52 9 D
+53 30 D
+-53 47 D
+136 -65 D
+-78 220 D
+39 226 D
+56 8 D
+-103 44 D
+-30 121 D
+41 53 D
+106 -101 D
+-33 60 D
+63 20 D
+-3 27 D
+-2670 0 D
+-30 -1982 D
+P
+3112 2781 M
+104 -217 D
+75 -15 D
+-34 87 D
+84 -71 D
+17 -114 D
+50 -29 D
+-21 -145 D
+-17 117 D
+-170 163 D
+P
+3294 2537 M
+21 -29 D
+-18 30 D
+P
+4609 2720 M
+104 -66 D
+64 25 D
+-35 -120 D
+-24 69 D
+-69 -39 D
+-83 89 D
+8 74 D
+34 -29 D
+P
+4758 3874 M
+68 -48 D
+-114 -45 D
+26 -119 D
+-85 163 D
+80 -28 D
+14 55 D
+44 -22 D
+-35 45 D
+P
+5636 2467 M
+-63 -136 D
+-125 -56 D
+-7 -97 D
+-117 5 D
+96 36 D
+2 59 D
+215 193 D
+P
+3021 2567 M
+93 -269 D
+-28 -130 D
+-69 402 D
+P
+4948 2917 M
+57 -107 D
+-130 112 D
+P
+5443 2526 M
+-3 -43 D
+-102 3 D
+106 41 D
+P
+5296 3484 M
+53 -72 D
+-109 36 D
+51 36 D
+P
+5399 3011 M
+47 -34 D
+-153 -6 D
+101 42 D
+P
+3632 3761 M
+-8 -362 D
+-71 145 D
+75 220 D
+P
+3755 3747 M
+70 -92 D
+-88 53 D
+13 39 D
+P
+3538 2291 M
+35 -90 D
+-71 63 D
+34 32 D
+P
+3561 3966 M
+26 -59 D
+-121 62 D
+P
+5272 3430 M
+61 -52 D
+-81 21 D
+17 31 D
+P
+5024 3556 M
+36 -59 D
+-76 20 D
+36 42 D
+P
+4780 2188 M
+52 -54 D
+-79 29 D
+22 29 D
+P
+5170 3291 M
+34 -100 D
+-86 90 D
+52 14 D
+P
+4907 2767 M
+22 -33 D
+-93 1 D
+68 32 D
+P
+3875 2739 M
+-14 -57 D
+-26 56 D
+40 2 D
+P
+3506 3437 M
+-2 5 D
+34 -65 D
+P
+4364 2703 M
+67 -80 D
+-70 79 D
+P
+3387 3218 M
+41 -205 D
+-42 207 D
+P
+5299 2174 M
+-39 -24 D
+42 27 D
+P
+3585 2942 M
+67 -129 D
+-74 132 D
+P
+5433 2628 M
+-20 -46 D
+20 47 D
+P
+4802 2891 M
+9 -39 D
+-16 38 D
+P
+5660 2219 M
+-61 -16 D
+63 18 D
+P
+3860 3851 M
+-2 4 D
+104 -96 D
+P
+3334 2277 M
+1 3 D
+9 -95 D
+P
+3851 2316 M
+1 1 D
+31 -32 D
+P
+2949 2391 M
+18 -134 D
+-22 136 D
+P
+5038 2965 M
+-33 -63 D
+33 69 D
+P
+4095 3212 M
+171 -171 D
+-174 173 D
+P
+5026 2464 M
+-63 -70 D
+61 73 D
+P
+4585 2844 M
+-11 -76 D
+9 77 D
+P
+4706 3206 M
+24 -33 D
+-29 32 D
+P
+4091 3552 M
+62 -40 D
+-67 40 D
+P
+4361 2596 M
+-31 -55 D
+33 61 D
+P
+4943 2152 M
+1 1 D
+30 -58 D
+P
+4002 2689 M
+40 -41 D
+-44 44 D
+P
+FO
+2999 1986 M
+-2 4 D
+-11 -4 D
+P
+FO
+6604 2319 M
+-20 34 D
+14 10 D
+-15 110 D
+-96 38 D
+67 -66 D
+-22 -99 D
+-16 90 D
+-59 -31 D
+60 -140 D
+64 -10 D
+-2 36 D
+16 -50 D
+10 48 D
+4 -5 D
+P
+FO
+6425 2312 M
+35 -12 D
+-15 52 D
+36 -34 D
+-35 101 D
+-20 -107 D
+P
+FO
+5978 2502 M
+25 -97 D
+75 -40 D
+-99 138 D
+P
+FO
+5541 3236 M
+38 -5 D
+-39 11 D
+P
+FO
+6040 2305 M
+35 -24 D
+-35 25 D
+P
+FO
+5478 3913 M
+63 -79 D
+P
+FO
+6125 2307 M
+45 -39 D
+-44 40 D
+P
+FO
+6614 2301 M
+-10 18 D
+5 -35 D
+5 -7 D
+P
+FO
+6598 2363 M
+16 12 D
+0 86 D
+-31 12 D
+P
+FO
+2908 0 M
+4 219 D
+-25 -9 D
+-150 -210 D
+P
+FO
+2928 1307 M
+-43 85 D
+3 -1 D
+40 -83 D
+6 391 D
+-68 66 D
+32 -24 D
+36 -39 D
+4 268 D
+-3 -1 D
+3 5 D
+0 13 D
+-7 0 D
+-6 0 D
+-7 0 D
+-277 6 D
+-324 11 D
+-317 15 D
+-270 16 D
+-262 19 D
+-10 -34 D
+-124 -71 D
+74 -63 D
+44 63 D
+9 -78 D
+127 65 D
+-104 -79 D
+-59 29 D
+-54 -117 D
+-76 64 D
+-62 -144 D
+39 183 D
+-40 -108 D
+-14 51 D
+-70 -86 D
+32 -194 D
+20 111 D
+-1 -89 D
+35 67 D
+23 -92 D
+31 125 D
+-54 13 D
+64 28 D
+-7 -179 D
+95 60 D
+-13 64 D
+-68 -27 D
+77 104 D
+17 -51 D
+73 -3 D
+-71 -16 D
+18 -72 D
+143 202 D
+-23 -90 D
+123 24 D
+-125 -32 D
+-101 -112 D
+79 -21 D
+-3 51 D
+24 -56 D
+-64 -5 D
+11 -34 D
+154 33 D
+-140 -36 D
+-70 -78 D
+63 -2 D
+-119 -38 D
+70 -78 D
+-36 -8 D
+25 -40 D
+81 60 D
+146 22 D
+-207 -71 D
+58 -76 D
+-150 107 D
+-55 -81 D
+18 104 D
+-72 32 D
+36 -79 D
+-41 28 D
+-44 -153 D
+54 -152 D
+275 -230 D
+89 -31 D
+8 45 D
+20 -57 D
+87 50 D
+-158 -122 D
+92 -51 D
+37 103 D
+9 -49 D
+55 1 D
+-82 -24 D
+44 3 D
+0 -43 D
+41 51 D
+-33 -70 D
+61 37 D
+-37 -70 D
+54 54 D
+161 -50 D
+140 47 D
+37 117 D
+1 -78 D
+67 -18 D
+18 71 D
+49 -9 D
+151 183 D
+65 15 D
+9 106 D
+27 -40 D
+76 71 D
+12 53 D
+-65 -4 D
+147 50 D
+-52 63 D
+75 -13 D
+-11 49 D
+109 33 D
+-86 111 D
+57 -60 D
+49 25 D
+4 -86 D
+55 -9 D
+16 42 D
+P
+2186 1989 M
+118 -128 D
+-73 31 D
+40 -63 D
+-73 53 D
+-12 108 D
+P
+2646 1522 M
+91 -125 D
+-119 107 D
+28 22 D
+P
+2093 1840 M
+109 -75 D
+-113 77 D
+P
+2351 1496 M
+0 -221 D
+-3 224 D
+P
+2206 1589 M
+135 -49 D
+-142 49 D
+P
+2487 1977 M
+81 -180 D
+-83 181 D
+P
+2062 1157 M
+16 -173 D
+-20 179 D
+P
+2619 1290 M
+64 -47 D
+-69 48 D
+P
+2491 1120 M
+-72 -46 D
+72 49 D
+P
+1653 1047 M
+-34 -166 D
+33 170 D
+P
+1595 883 M
+1 0 D
+-20 -71 D
+P
+2531 1480 M
+-96 0 D
+97 3 D
+P
+1999 1932 M
+-1 3 D
+29 -51 D
+P
+2196 1407 M
+64 -140 D
+-68 146 D
+P
+FO
+1371 2061 M
+6 -18 D
+32 15 D
+P
+FO
+1242 2072 M
+-8 -7 D
+56 -81 D
+47 9 D
+14 70 D
+P
+FO
+1228 2073 M
+0 -1 D
+1 0 D
+0 1 D
+P
+FO
+1186 2076 M
+0 -1 D
+P
+FO
+1119 1913 M
+51 -17 D
+-2 -9 D
+17 -54 D
+38 24 D
+-69 130 D
+P
+FO
+1206 1911 M
+59 -20 D
+0 123 D
+-53 45 D
+-23 -69 D
+P
+FO
+1425 1533 M
+-29 -46 D
+66 15 D
+-32 31 D
+P
+FO
+1105 1494 M
+44 -51 D
+-3 201 D
+P
+FO
+1316 1923 M
+37 -68 D
+38 23 D
+-75 48 D
+P
+FO
+1184 1483 M
+26 -31 D
+-8 64 D
+P
+FO
+1166 2001 M
+19 -36 D
+-18 37 D
+P
+FO
+2744 1162 M
+31 26 D
+-31 -25 D
+P
+FO
+1291 1360 M
+37 0 D
+P
+FO
+2751 1131 M
+27 39 D
+P
+FO
+1252 1420 M
+79 -37 D
+-78 39 D
+P
+FO
+1331 1439 M
+42 19 D
+-42 -16 D
+P
+FO
+1135 2080 M
+41 -13 D
+P
+FO
+1568 747 M
+40 -36 D
+-39 38 D
+P
+FO
+1420 1475 M
+2 -1 D
+39 11 D
+P
+FO
+1251 1400 M
+50 -26 D
+-50 31 D
+P
+FO
+2709 1149 M
+47 5 D
+-47 -2 D
+P
+FO
+1317 1863 M
+29 -20 D
+-29 21 D
+P
+FO
+1214 1519 M
+16 -32 D
+-16 33 D
+P
+FO
+4073 1996 M
+25 -95 D
+-28 95 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 0 D
+-154 2 D
+-9 -79 D
+-45 79 D
+-6 0 D
+-7 0 D
+-48 -16 D
+-4 -268 D
+35 -38 D
+-35 35 D
+-6 -391 D
+7 -15 D
+-7 14 D
+-1 -42 D
+8 21 D
+74 -17 D
+7 75 D
+28 -54 D
+37 165 D
+7 -160 D
+31 273 D
+-98 100 D
+53 -28 D
+20 60 D
+12 -71 D
+55 33 D
+-49 202 D
+104 53 D
+-7 -104 D
+-28 77 D
+-28 -81 D
+38 -174 D
+-39 -76 D
+35 -86 D
+43 12 D
+9 -111 D
+37 38 D
+60 -74 D
+40 56 D
+31 -75 D
+-64 -83 D
+87 -296 D
+-35 -50 D
+52 -18 D
+-58 -102 D
+97 80 D
+-41 -80 D
+38 32 D
+-7 -93 D
+53 155 D
+19 -56 D
+32 26 D
+-115 -171 D
+15 -107 D
+102 32 D
+-84 -55 D
+32 -74 D
+64 65 D
+-14 44 D
+56 115 D
+-56 55 D
+-83 -71 D
+82 97 D
+81 1 D
+-88 -364 D
+71 -35 D
+-59 -71 D
+101 3 D
+-49 -36 D
+55 -120 D
+-22 -76 D
+38 -38 D
+41 70 D
+-3 -98 D
+1762 0 D
+-24 59 D
+97 140 D
+-29 72 D
+-63 9 D
+15 41 D
+46 -42 D
+-40 99 D
+62 -11 D
+-10 32 D
+-133 111 D
+130 -101 D
+-107 111 D
+47 30 D
+82 -39 D
+-2 96 D
+-25 -38 D
+-40 43 D
+62 40 D
+-53 63 D
+54 -10 D
+-59 96 D
+45 35 D
+-41 -16 D
+-36 44 D
+60 14 D
+-150 70 D
+127 -31 D
+78 48 D
+-76 87 D
+-227 9 D
+288 1 D
+40 32 D
+-37 19 D
+82 15 D
+-52 1 D
+14 56 D
+32 -37 D
+128 61 D
+-27 76 D
+50 -38 D
+-24 46 D
+41 -5 D
+-14 221 D
+25 -95 D
+31 36 D
+-7 -126 D
+82 -83 D
+10 158 D
+170 129 D
+-91 67 D
+43 1 D
+-29 48 D
+82 -79 D
+43 30 D
+-76 35 D
+50 -10 D
+38 26 D
+-58 27 D
+48 0 D
+-70 44 D
+3 -78 D
+-45 29 D
+-97 -44 D
+-8 77 D
+96 -21 D
+-31 58 D
+281 244 D
+-138 -16 D
+75 80 D
+-33 63 D
+76 -80 D
+8 48 D
+-73 31 D
+-15 49 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 0 D
+-7 -1 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-6 0 D
+-7 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 -1 D
+-6 0 D
+-7 0 D
+-7 0 D
+-7 0 D
+-6 -1 D
+-7 0 D
+-7 0 D
+-7 0 D
+-7 -1 D
+P
+5184 1689 M
+116 -27 D
+82 47 D
+-6 69 D
+83 -56 D
+16 52 D
+108 -28 D
+-16 47 D
+133 -106 D
+-8 154 D
+64 -123 D
+71 -25 D
+26 73 D
+-102 86 D
+-22 -22 D
+3 73 D
+-51 0 D
+76 52 D
+1 -103 D
+53 -25 D
+0 36 D
+52 -63 D
+-20 -126 D
+98 -36 D
+-40 -85 D
+-106 28 D
+2 -39 D
+-90 57 D
+7 -52 D
+-70 -7 D
+32 71 D
+-96 4 D
+-87 88 D
+-275 -64 D
+P
+5647 1688 M
+-67 2 D
+76 -57 D
+P
+5838 1660 M
+-1 3 D
+-54 15 D
+73 -73 D
+P
+5560 1733 M
+-2 0 D
+-24 -43 D
+48 -55 D
+P
+5772 1680 M
+-3 5 D
+29 -88 D
+78 -11 D
+P
+5738 1670 M
+-1 2 D
+15 -57 D
+P
+5870 1641 M
+-5 -1 D
+17 -36 D
+P
+5505 1765 M
+-3 1 D
+2 -38 D
+P
+4464 1504 M
+-49 -165 D
+44 -20 D
+10 41 D
+20 -41 D
+-100 -256 D
+-174 -77 D
+-40 -86 D
+-50 7 D
+21 67 D
+-76 -2 D
+-154 -194 D
+19 91 D
+-118 -78 D
+117 197 D
+-88 120 D
+38 1 D
+-31 115 D
+60 -107 D
+37 186 D
+68 19 D
+148 -129 D
+-78 270 D
+35 68 D
+38 -48 D
+3 45 D
+144 39 D
+32 -63 D
+124 3 D
+P
+4119 1034 M
+-21 -38 D
+50 -14 D
+-25 51 D
+P
+4270 1507 M
+-48 -15 D
+27 -30 D
+21 41 D
+P
+4394 1137 M
+-55 10 D
+8 -63 D
+45 49 D
+P
+3628 1595 M
+20 -60 D
+37 12 D
+-34 -93 D
+115 -134 D
+-7 -77 D
+-136 246 D
+36 -311 D
+-86 337 D
+37 -39 D
+P
+4809 1161 M
+-23 -180 D
+55 -44 D
+-116 -103 D
+-171 -453 D
+-38 111 D
+60 263 D
+85 244 D
+137 202 D
+13 -37 D
+P
+4628 603 M
+-3 -2 D
+-41 -64 D
+P
+5030 1543 M
+91 -37 D
+8 40 D
+99 -31 D
+121 49 D
+-264 -150 D
+-62 90 D
+-123 0 D
+127 42 D
+P
+4881 643 M
+12 -56 D
+114 -4 D
+7 -101 D
+-50 79 D
+-14 -64 D
+-51 54 D
+-20 94 D
+P
+4909 575 M
+30 -39 D
+P
+5586 1402 M
+44 -60 D
+-44 25 D
+-46 -47 D
+-18 88 D
+P
+3735 1520 M
+27 -126 D
+62 55 D
+-12 -114 D
+-82 70 D
+2 118 D
+P
+5488 1301 M
+79 -81 D
+-59 -8 D
+-27 77 D
+-91 20 D
+P
+3268 1572 M
+7 -58 D
+-67 29 D
+14 47 D
+20 -46 D
+27 31 D
+P
+4020 1739 M
+65 -185 D
+-109 141 D
+38 -15 D
+2 61 D
+P
+4579 1045 M
+52 -128 D
+-56 101 D
+-44 -41 D
+44 65 D
+P
+4301 1666 M
+24 -48 D
+-48 20 D
+23 34 D
+P
+5153 2015 M
+4 -42 D
+-53 48 D
+51 0 D
+P
+4683 1759 M
+-15 -89 D
+-37 78 D
+49 14 D
+P
+5025 1350 M
+16 -34 D
+-68 -2 D
+49 36 D
+P
+5664 1361 M
+25 -49 D
+-46 0 D
+19 51 D
+P
+3858 1743 M
+84 -76 D
+49 -152 D
+-137 230 D
+P
+4574 1323 M
+-29 -116 D
+-59 44 D
+88 73 D
+P
+4653 1170 M
+-16 -117 D
+-56 90 D
+70 29 D
+P
+5086 973 M
+129 -14 D
+-138 -61 D
+4 72 D
+P
+5387 806 M
+42 -36 D
+-104 27 D
+61 10 D
+P
+5203 1080 M
+59 -56 D
+-85 -4 D
+26 62 D
+P
+4950 1625 M
+0 -37 D
+-38 24 D
+38 16 D
+P
+5153 1316 M
+79 -58 D
+-89 1 D
+8 58 D
+P
+3887 464 M
+-63 -67 D
+34 89 D
+29 -19 D
+P
+5426 1260 M
+68 -76 D
+-112 77 D
+P
+3338 1945 M
+57 -227 D
+-60 230 D
+P
+4105 1860 M
+67 -209 D
+-70 212 D
+P
+5202 520 M
+-38 60 D
+68 24 D
+P
+4952 969 M
+-86 -4 D
+88 9 D
+P
+3390 1592 M
+-64 -122 D
+62 127 D
+P
+3837 1642 M
+-2 3 D
+28 -60 D
+P
+4187 1801 M
+13 -86 D
+-14 87 D
+P
+3873 169 M
+-89 -70 D
+86 74 D
+P
+4816 821 M
+-63 -18 D
+62 21 D
+P
+4542 1845 M
+-7 -59 D
+6 62 D
+P
+4645 26 M
+-1 -26 D
+-2 0 D
+1 29 D
+P
+6139 2044 M
+-64 -11 D
+62 13 D
+P
+4691 1349 M
+-53 -15 D
+52 17 D
+P
+5324 371 M
+9 -43 D
+-13 46 D
+P
+5223 1425 M
+-40 10 D
+40 -7 D
+P
+4897 1319 M
+-48 -28 D
+47 29 D
+P
+4017 1932 M
+34 -78 D
+-35 82 D
+P
+4532 1646 M
+-12 -67 D
+11 69 D
+P
+4243 365 M
+-23 -72 D
+23 76 D
+P
+4836 229 M
+6 -42 D
+P
+4407 1801 M
+-13 -60 D
+12 61 D
+P
+4646 1510 M
+-39 -38 D
+41 42 D
+P
+3992 1431 M
+-1 5 D
+32 -62 D
+P
+3911 558 M
+-36 -46 D
+39 50 D
+P
+4208 290 M
+-12 -42 D
+8 42 D
+P
+4453 1054 M
+-16 -43 D
+16 46 D
+P
+4636 1827 M
+10 -35 D
+-13 38 D
+P
+3804 1261 M
+-8 -43 D
+8 46 D
+P
+3853 626 M
+-25 -49 D
+24 51 D
+P
+FO
+2938 1974 M
+8 13 D
+-4 0 D
+-4 0 D
+P
+FO
+3116 0 M
+-37 209 D
+93 109 D
+-260 -99 D
+-4 -219 D
+P
+FO
+6272 0 M
+-4 41 D
+107 72 D
+-17 61 D
+93 83 D
+-67 41 D
+-13 112 D
+6 90 D
+43 -16 D
+66 85 D
+-44 73 D
+-63 -7 D
+-13 -72 D
+-46 64 D
+-202 -308 D
+47 -104 D
+-31 -100 D
+46 -115 D
+36 0 D
+14 9 D
+-4 -9 D
+P
+FO
+5703 0 M
+37 152 D
+-59 -59 D
+-20 -93 D
+P
+FO
+6454 630 M
+39 -43 D
+2 63 D
+77 38 D
+-69 18 D
+-49 -74 D
+P
+FO
+3374 0 M
+13 12 D
+-77 -12 D
+P
+FO
+6117 1758 M
+23 -39 D
+62 98 D
+-86 -56 D
+P
+FO
+6461 995 M
+22 -41 D
+40 26 D
+-62 16 D
+P
+FO
+5827 1373 M
+30 -75 D
+-26 132 D
+P
+FO
+6271 2009 M
+-21 44 D
+-23 -56 D
+P
+FO
+3307 1295 M
+11 -34 D
+23 46 D
+P
+FO
+6022 1392 M
+-36 -35 D
+64 59 D
+P
+FO
+6179 1679 M
+14 -41 D
+26 16 D
+-50 32 D
+P
+FO
+6204 1512 M
+2 1 D
+24 32 D
+P
+FO
+6089 1421 M
+47 76 D
+P
+FO
+5969 1672 M
+62 -8 D
+-62 9 D
+P
+FO
+6040 1330 M
+63 60 D
+-63 -59 D
+P
+FO
+5540 889 M
+60 -29 D
+-60 30 D
+P
+FO
+6233 1851 M
+35 57 D
+P
+FO
+3263 1379 M
+21 -30 D
+-21 31 D
+P
+FO
+6197 1836 M
+66 78 D
+P
+FO
+3241 1321 M
+36 9 D
+-36 -7 D
+P
+FO
+6211 1605 M
+37 30 D
+-37 -27 D
+P
+FO
+3525 414 M
+34 11 D
+-34 -9 D
+P
+FO
+3306 1184 M
+21 -38 D
+-20 38 D
+P
+FO
+5543 489 M
+39 -25 D
+-39 26 D
+P
+FO
+6169 1735 M
+36 19 D
+-36 -16 D
+P
+FO
+6191 1758 M
+45 14 D
+-45 -13 D
+P
+FO
+6162 1705 M
+35 3 D
+-35 -2 D
+P
+FO
+6062 1709 M
+36 -16 D
+-36 18 D
+P
+FO
+5819 1257 M
+49 -30 D
+-48 31 D
+P
+FO
+5966 1336 M
+13 36 D
+-14 -37 D
+P
+FO
+3603 217 M
+22 31 D
+P
+FO
+6261 1659 M
+17 30 D
+P
+FO
+6025 1320 M
+25 33 D
+-25 -29 D
+P
+FO
+3139 1776 M
+20 -30 D
+-19 30 D
+P
+FO
+6061 1685 M
+37 -15 D
+-37 17 D
+P
+FO
+25 W
+0 A
+2 setlinecap
+N 0 0 M 0 3969 D S
+N 6614 0 M 0 3969 D S
+N 0 0 M 6614 0 D S
+N 0 3969 M 6614 0 D S
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+
+% PostScript produced by:
+%@GMT: gmt pstext -R500/300+uk -JS11/60/14c -O -F+cBL+f13p -Dj0.1c
+%@PROJ: stere 1.21500281 20.78499719 56.93027235 62.79255453 -500000.000 500000.000 -300000.000 300000.000 +proj=stere +lat_0=60 +lon_0=11 +k=0.9996 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+6614 0 D
+0 3969 D
+-6614 0 D
+P
+PSL_clip N
+47 47 M PSL_font_encode 0 get 0 eq {ISOLatin1+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+217 F0
+(­R500/300+uk ­JS11/60/14c) bl Z
+PSL_cliprestore
+%%EndObject
+
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+
+%%Trailer
+
+end
+%%EOF

--- a/test/pscoast/pscoast_R_shorthand.sh
+++ b/test/pscoast/pscoast_R_shorthand.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Introduce the two -R shorthands for projected regions centered on (0,0)
+
+ps=pscoast_R_shorthand.ps
+
+gmt pscoast -R300+un -JA204/21/14c -Glightgray -Baf -K -P -Xc -Y2c > $ps
+echo "-R300+un -JA204/21/14c" | gmt pstext -R -J -O -K -F+cBL+f13p -Dj0.1c >> $ps
+gmt pscoast -R500/300+uk -JS11/60/14c -Glightgray -Baf -O -K -Y16c >> $ps
+echo "-R500/300+uk -JS11/60/14c" | gmt pstext -R -J -O -F+cBL+f13p -Dj0.1c >> $ps


### PR DESCRIPTION
**Description of proposed changes**

This PR is in response to #6090 and introduces two short-hand forms of the general projected region set via **-R**_xmin/xmax/ymin/ymax_[**+u**_unit_]:

1. For a square region centered on (0,0) you can use  **-R**_radius_**+u**_unit_ instead of **-R**_-radius/+radius/-radius/+radius_[**+u**_unit_].
2. For a rectangular region centered on (0,0) you can use  **-R**_halfwidth/halfheight_**+u**_unit_ instead of **-R**_-halfwidth/+halfwidth/-halfheight/+halfheight_[**+u**_unit_].

Note: For these shorthands the **+u** modifier is required.  Below is a short test result added as part of PR:

![pscoast_R_shorthand](https://user-images.githubusercontent.com/26473567/144762013-d858ee54-a83d-49b4-a439-b2295e660f1f.png)

Closes #6090.