### PR TITLE
movie.rst: create table for preset video formats

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -66,7 +66,7 @@ Required Arguments
 
 **-C**\ *canvassize*
     Specify the canvas size used when composing the movie frames. You can choose from a
-    set of preset formats (see Table :ref:`Presets <tbl-presets>) or specify a custom layout.
+    set of preset formats (see Table :ref:`Presets <tbl-presets>`) or specify a custom layout.
     **Note**: Your :term:`PROJ_LENGTH_UNIT` setting determines if **movie** sets
     you up to work with the SI or US canvas dimensions.  Instead of a named format you can
     request a custom format directly by giving *width*\ x\ *height*\ x\ *dpu*,

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -81,6 +81,26 @@ Required Arguments
     request a custom format directly by giving *width*\ x\ *height*\ x\ *dpu*,
     where *dpu* is the dots-per-unit pixel density (pixel density is set automatically for the named formats).
 
+    =================================== ================ ============
+    Preset format                       Pixel dimensions Alias
+    =================================== ================ ============
+    *16:9 (24x13.5 cm or 9.6x5.4 inch)*
+    4320p                               7680 x 4320      8k and uhd-2
+    2160p                               3840 x 2160      4k and uhd
+    1080p                               1920 x 1080      hd
+    720p                                1280 x 720
+    540p                                960 x 540
+    480p                                854 x 480
+    360p                                640 x 360
+    240p                                426 x 240
+    *4:3 (24x18 cm or 9.6x7.2 inch)*
+    uxga                                1600 x 1200
+    sxga+                               1400 x 1050
+    xga                                 1024 x 768
+    svga                                800 x 600
+    dvd                                 640 x 480
+    =================================== ================ ============
+
 .. _-N:
 
 **-N**\ *prefix*

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -66,20 +66,13 @@ Required Arguments
 
 **-C**\ *canvassize*
     Specify the canvas size used when composing the movie frames. You can choose from a
-    set of preset formats or specify a custom layout.  The named 16:9 ratio
-    formats have a canvas dimension of 24 x 13.5 cm *or* 9.6 x 5.4 inch and are
-    (with pixel dimensions given in parenthesis):
-    **4320p** (7680 x 4320), **2160p** (3840 x 2160), **1080p** (1920 x 1080), **720p** (1280 x 720),
-    **540p** (960 x 540), **480p** (854 x 480), **360p** (640 x 360), and **240p** (426 x 240).
-    We also accept **8k** or **uhd-2** to mean **4320p**, **4k** or **uhd** to mean **2160p**, and **hd** to mean **1080p**.
-    The recognized 4:3 ratio formats have a canvas dimension of 24 x 18 cm *or* 9.6 x 7.2 inch
-    and are (with pixel dimensions given in parenthesis):
-    **uxga** (1600 x 1200), **sxga+** (1400 x 1050), **xga** (1024 x 768),
-    **svga** (800 x 600), and **dvd** (640 x 480).
+    set of preset formats (see Table :ref:`Presets <tbl-presets>) or specify a custom layout.
     **Note**: Your :term:`PROJ_LENGTH_UNIT` setting determines if **movie** sets
     you up to work with the SI or US canvas dimensions.  Instead of a named format you can
     request a custom format directly by giving *width*\ x\ *height*\ x\ *dpu*,
     where *dpu* is the dots-per-unit pixel density (pixel density is set automatically for the named formats).
+    
+    .. _tbl-presets:
 
     =================================== ================ ============
     Preset format                       Pixel dimensions Alias


### PR DESCRIPTION
Create table of preset video formats. Easier to read. Consider removing the descriptions in the paragraph.