### PR TITLE
Better handling of trailing text in sample1d output

### DIFF
--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -58,7 +58,7 @@ Required Arguments
     This is one or more ASCII [of binary, see
     **-bi**] files with one column containing the
     independent *time* variable (which must be monotonically in/de-creasing)
-    and the remaining columns holding other data values. If no file is
+    and any number of optional columns holding other data values. If no file is
     provided, **sample1d** reads from standard input.
 
 Optional Arguments

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -14,6 +14,7 @@ Synopsis
 
 **gmt sample1d** [ *table* ]
 [ |-A|\ [**f**\|\ **p**\|\ **m**\|\ **r**\|\ **R**][**+d**][**+l**] ]
+[ |-E| ]
 [ |-F|\ **l**\|\ **a**\|\ **c**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**] ]
 [ |-N|\ *col* ]
 [ |-T|\ [*min/max*\ /]\ *inc*\ [**+a**][**+i**\|\ **n**][**+u**] ]
@@ -80,6 +81,14 @@ Optional Arguments
     **+l** if distances should be measured along rhumb lines (loxodromes).
     **Note**: Calculation mode for loxodromes is spherical, hence **-je**
     cannot be used in combination with **+l**.
+
+.. _-E:
+
+**-E**
+    If the input dataset contains records with trailing text then we will attempt
+    to add these to output records that exactly match the input times.  Output records
+    that have no matching input record times will have no trailing text appended [Default
+    ignores trailing text].
 
 .. _-F:
 
@@ -156,15 +165,8 @@ Optional Arguments
 
 .. include:: explain_array.rst_
 
-Trailing Text Notes
--------------------
-
-If the input dataset contains records with trailing text then we will attempt
-to add these to output records that exactly match the input times.  Output records
-that have no matching input record times will have no trailing text appended.
-
-Smoothing Spline Notes
-----------------------
+Notes
+-----
 
 The smoothing spline *s(t)* requires a fit parameter *p* that allows for the trade-off between an
 exact interpolation (fitting the data exactly; large *p*) to minimizing curvature (*p* approaching 0).

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -156,8 +156,15 @@ Optional Arguments
 
 .. include:: explain_array.rst_
 
-Notes
------
+Trailing Text Notes
+-------------------
+
+If the input dataset contains records with trailing text then we will attempt
+to add these to output records that exactly match the input times.  Output records
+that have no matching input record times will have no trailing text appended.
+
+Smoothing Spline Notes
+----------------------
 
 The smoothing spline *s(t)* requires a fit parameter *p* that allows for the trade-off between an
 exact interpolation (fitting the data exactly; large *p*) to minimizing curvature (*p* approaching 0).
@@ -189,55 +196,39 @@ Examples
 
 To resample the file profiles.tdgmb, which contains
 (time,distance,gravity,magnetics,bathymetry) records, at 1km equidistant
-intervals using Akima's spline, use
-
-   ::
+intervals using Akima's spline, use::
 
     gmt sample1d profiles.tdgmb -N1 -Fa -T1 > profiles_equi_d.tdgmb
 
 To resample the file depths.dt at positions listed in the file
-grav_pos.dg, using a cubic spline for the interpolation, use
-
-   ::
+grav_pos.dg, using a cubic spline for the interpolation, use::
 
     gmt sample1d depths.txt -Tgrav_pos.dg -Fc > new_depths.txt
 
 To resample the file points.txt every 0.01 from 0-6, using a cubic spline for the
-interpolation, but output the first derivative instead (the slope), try
-
-   ::
+interpolation, but output the first derivative instead (the slope), try::
 
     gmt sample1d points.txt -T0/6/0.01 -Fc+d1 > slopes.txt
 
 To resample the file track.txt which contains lon, lat, depth every 2
-nautical miles, use
-
-   ::
+nautical miles, use::
 
     gmt sample1d track.txt -T2n -AR > new_track.txt
 
 To do approximately the same, but make sure the original points are
-included, use
-
-   ::
+included, use::
 
     gmt sample1d track.txt -T2n -Af > new_track.txt
 
-To obtain a rhumb line (loxodrome) sampled every 5 km instead, use
-
-   ::
+To obtain a rhumb line (loxodrome) sampled every 5 km instead, use::
 
     gmt sample1d track.txt -T5k -AR+l > new_track.txt
 
-To sample temperatures.txt every month from 2000 to 2018, use
-
-   ::
+To sample temperatures.txt every month from 2000 to 2018, use::
 
     gmt sample1d temperatures.txt -T2000T/2018T/1o > monthly_temp.txt
 
-To use a smoothing spline on a topographic profile for a given fit parameter, try
-
-   ::
+To use a smoothing spline on a topographic profile for a given fit parameter, try::
 
     gmt sample1d @topo_crossection.txt -T300/500/0.1 -Fs0.001 > smooth.txt
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -1092,6 +1092,7 @@ int gmt_ascii_output_no_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double
 }
 
 GMT_LOCAL void gmtio_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, char *txt) {
+	/* Output the trailing text, if it is not NULL */
 	if (GMT->common.o.word) {	/* Must output a specific word from the trailing text only */
 		char *word = NULL, *orig = strdup (txt), *trail = orig;
 		uint64_t col = 0;
@@ -1106,8 +1107,8 @@ GMT_LOCAL void gmtio_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, char 
 		fprintf (fp, "\n");
 		gmt_M_str_free (orig);
 	}
-	else	/* Output the whole enchilada */
-		fprintf (fp, "%s\n", txt);
+	else	/* Output the whole enchilada (unless NULL) */
+		(txt) ? fprintf (fp, "%s\n", txt) : fprintf (fp, "\n");
 }
 
 /*! . */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -1091,7 +1091,7 @@ int gmt_ascii_output_no_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double
 	return ((e < 0) ? GMT_NOTSET : 0);
 }
 
-GMT_LOCAL void gmtio_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, char *txt) {
+GMT_LOCAL void gmtio_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, bool separator, char *txt) {
 	/* Output the trailing text, if it is not NULL */
 	if (GMT->common.o.word) {	/* Must output a specific word from the trailing text only */
 		char *word = NULL, *orig = strdup (txt), *trail = orig;
@@ -1101,14 +1101,14 @@ GMT_LOCAL void gmtio_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, char 
 				col++;
 		}
 		if (word)	/* Only write word if not NULL */
-			fprintf (fp, "%s", word);
+			(separator && GMT->current.setting.io_col_separator[0]) ? fprintf (fp, "%s%s", GMT->current.setting.io_col_separator, word) :  fprintf (fp, "%s", word);
 		else
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Trailing text did not have %" PRIu64 " words - no trailing word written\n", GMT->common.o.w_col);
-		fprintf (fp, "\n");
 		gmt_M_str_free (orig);
 	}
-	else	/* Output the whole enchilada (unless NULL) */
-		(txt) ? fprintf (fp, "%s\n", txt) : fprintf (fp, "\n");
+	else if	(txt) /* Output the whole enchilada (unless NULL) */
+		(separator && GMT->current.setting.io_col_separator[0]) ? fprintf (fp, "%s%s", GMT->current.setting.io_col_separator, txt) : fprintf (fp, "%s", txt);
+	fprintf (fp, "\n");
 }
 
 /*! . */
@@ -1116,7 +1116,7 @@ int gmtlib_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t 
 
 	if (gmt_skip_output (GMT, ptr, n)) return (GMT_NOTSET);	/* Record was skipped via -s[a|r] */
 
-	gmtio_output_trailing_text (GMT, fp, txt);
+	gmtio_output_trailing_text (GMT, fp, false, txt);
 
 	return (0);
 }
@@ -1143,12 +1143,12 @@ GMT_LOCAL int gmtio_ascii_output_with_text (struct GMT_CTRL *GMT, FILE *fp, uint
 
 		e = gmt_ascii_output_col (GMT, fp, val, col);	/* Write one item without any separator at the end */
 
-		if (GMT->current.setting.io_col_separator[0])		/* Not last field, and a separator is required */
+		if (i < (n_out-1) && GMT->current.setting.io_col_separator[0])		/* Not last field, and a separator is required */
 			fprintf (fp, "%s", GMT->current.setting.io_col_separator);
 
 		wn += e;
 	}
-	gmtio_output_trailing_text (GMT, fp, txt);
+	gmtio_output_trailing_text (GMT, fp, true, txt);
 
 	return ((e < 0) ? GMT_NOTSET : 0);
 }

--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -426,12 +426,12 @@ EXTERN_MSC int GMT_sample1d (void *V_API, int mode, void *args) {
 	if ((Din = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, 0, GMT_READ_NORMAL, NULL, NULL, NULL)) == NULL) {
 		Return (API->error);
 	}
-	if (Din->n_columns < 2) {
-		GMT_Report (API, GMT_MSG_ERROR, "Input data have %d column(s) but at least 2 are needed\n", (int)Din->n_columns);
+	if (Din->n_columns < 1) {
+		GMT_Report (API, GMT_MSG_ERROR, "Input data have no data column(s) but at least 1 is needed\n");
 		Return (GMT_DIM_TOO_SMALL);
 	}
-	if (Din->n_columns < 3 && Ctrl->W.active) {
-		GMT_Report (API, GMT_MSG_ERROR, "Input data have %d column(s) but at least 3 are needed since -W is used\n", (int)Din->n_columns);
+	if (Din->n_columns < 2 && Ctrl->W.active) {
+		GMT_Report (API, GMT_MSG_ERROR, "Input data have %d column(s) but at least 2 are needed since -W is used\n", (int)Din->n_columns);
 		Return (GMT_DIM_TOO_SMALL);
 	}
 	if (Ctrl->N.active && Ctrl->N.col >= Din->n_columns) {	/*  */
@@ -565,21 +565,22 @@ EXTERN_MSC int GMT_sample1d (void *V_API, int mode, void *args) {
 					GMT_Report (API, GMT_MSG_ERROR, "Failure in gmt_intpol near row %d!\n", result+1);
 					return (result);
 				}
-				if (Ctrl->E.active && S->text) {	/* Copy over any trailing text if input times are matched exactly in output */
-					for (k = row = 0; k < m; k++) {	/* For all output times */
-						while (row < S->n_rows && S->data[Ctrl->N.col][row] < Sout->data[Ctrl->N.col][k]) row++;	/* Wind to next potential matching input time */
-						if (row < S->n_rows && doubleAlmostEqualZero (S->data[Ctrl->N.col][row], Sout->data[Ctrl->N.col][k]) && S->text[row]) {	/* Matching time and we have text */
-							if (Sout->text == NULL) {	/* Must allocate text array the first time */
-								if ((Sout->text = gmt_M_memory (GMT, NULL, m, char *)) == NULL) {
-									GMT_Report(API, GMT_MSG_ERROR, "Unable to allocate trailing text for egment %" PRIu64 " in table %" PRIu64 ".\n", seg, tbl);
-									Return (GMT_MEMORY_ERROR);
-								}
+			}
+			if (Ctrl->E.active && S->text) {	/* Copy over any trailing text if input times are matched exactly in output */
+				for (k = row = 0; k < m; k++) {	/* For all output times */
+					while (row < S->n_rows && S->data[Ctrl->N.col][row] < Sout->data[Ctrl->N.col][k]) row++;	/* Wind to next potential matching input time */
+					if (row < S->n_rows && doubleAlmostEqualZero (S->data[Ctrl->N.col][row], Sout->data[Ctrl->N.col][k]) && S->text[row]) {	/* Matching time and we have text */
+						if (Sout->text == NULL) {	/* Must allocate text array the first time */
+							if ((Sout->text = gmt_M_memory (GMT, NULL, m, char *)) == NULL) {
+								GMT_Report(API, GMT_MSG_ERROR, "Unable to allocate trailing text for egment %" PRIu64 " in table %" PRIu64 ".\n", seg, tbl);
+								Return (GMT_MEMORY_ERROR);
 							}
-							Sout->text[k] = strdup (S->text[row++]);	/* Duplicate trailing text on output */
 						}
+						Sout->text[k] = strdup (S->text[row++]);	/* Duplicate trailing text on output */
 					}
 				}
 			}
+
 			if (Ctrl->T.T.spatial) {	/* Free up memory used */
 				gmt_M_free (GMT, dist_in);	gmt_M_free (GMT, t_out);
 				gmt_M_free (GMT, lon);		gmt_M_free (GMT, lat);

--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -556,6 +556,20 @@ EXTERN_MSC int GMT_sample1d (void *V_API, int mode, void *args) {
 					GMT_Report (API, GMT_MSG_ERROR, "Failure in gmt_intpol near row %d!\n", result+1);
 					return (result);
 				}
+				if (S->text) {	/* Copy over any trailing text if input times are matched exactly in output */
+					for (k = row = 0; k < m; k++) {	/* For all output times */
+						while (row < S->n_rows && S->data[Ctrl->N.col][row] < Sout->data[Ctrl->N.col][k]) row++;	/* Wind to next potential matching input time */
+						if (row < S->n_rows && doubleAlmostEqualZero (S->data[Ctrl->N.col][row], Sout->data[Ctrl->N.col][k]) && S->text[row]) {	/* Matching time and we have text */
+							if (Sout->text == NULL) {	/* Must allocate text array the first time */
+								if ((Sout->text = gmt_M_memory (GMT, NULL, m, char *)) == NULL) {
+									GMT_Report(API, GMT_MSG_ERROR, "Unable to allocate trailing text for egment %" PRIu64 " in table %" PRIu64 ".\n", seg, tbl);
+									Return (GMT_MEMORY_ERROR);
+								}
+							}
+							Sout->text[k] = strdup (S->text[row++]);	/* Duplicate trailing text on output */
+						}
+					}
+				}
 			}
 			if (Ctrl->T.T.spatial) {	/* Free up memory used */
 				gmt_M_free (GMT, dist_in);	gmt_M_free (GMT, t_out);


### PR DESCRIPTION
See forum [post](https://forum.generic-mapping-tools.org/t/best-way-to-make-time-file-for-movie-fill-inn-date-gaps/2421/5) for discussion.  If input records have trailing text then if there are output records at the same times then these should inherit any input trailing text:

**in.txt:**

```
1967-01-01 6 A B
1967-01-08 5
1967-01-12 7 C D
1967-01-15 1 E
1967-01-20 2 F G
```

```
gmt sample1d -fT --TIME_UNIT=d -I1 -Fa in.txt
1967-01-01T00:00:00	6	A B
1967-01-02T00:00:00	5.60489000795	
1967-01-03T00:00:00	5.33262655712	
1967-01-04T00:00:00	5.15995229261	
1967-01-05T00:00:00	5.06360985953	
1967-01-06T00:00:00	5.02034190299	
1967-01-07T00:00:00	5.00689106812	
1967-01-08T00:00:00	5	
1967-01-09T00:00:00	5.31835669826	
1967-01-10T00:00:00	6.0269814984	
1967-01-11T00:00:00	6.72211554934	
1967-01-12T00:00:00	7	C D
1967-01-13T00:00:00	5.59980754838	
1967-01-14T00:00:00	2.9098328522	
1967-01-15T00:00:00	1	E
1967-01-16T00:00:00	0.364936170213	
1967-01-17T00:00:00	0.130553191489	
1967-01-18T00:00:00	0.31370212766	
1967-01-19T00:00:00	0.931234042553	
1967-01-20T00:00:00	2	F G
```