### PR TITLE
Add a tutorial version in Julia

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -45,6 +45,7 @@ Quick links
         gallery
         animations
         tutorial
+        tutorial_jl
 
     ---
 

--- a/doc/rst/source/tutorial/intro_jl.rst
+++ b/doc/rst/source/tutorial/intro_jl.rst
@@ -1,0 +1,32 @@
+Introduction
+============
+
+Historical highlights
+---------------------
+
+The GMT system was initiated in late 1987 at Lamont-Doherty Earth Observatory, Columbia University by graduate students
+Paul Wessel and Walter H. F. Smith. Version 1 was officially introduced to Lamont scientists in July 1988. GMT 1
+migrated by word of mouth (and tape) to other institutions in the United States, UK, Japan, and France and attracted
+a small following. Paul took a Post-doctoral position at SOEST in December 1989 and continued the GMT development.
+Version 2.0 was released with an article in EOS, October 1991, and quickly spread worldwide. Version 3.0 in 1993
+which was released with another article in EOS on August 15, 1995. A major upgrade to GMT 4.0 took place in Oct 2004.
+Finally, in 2013 we released the new GMT 5 series and we have updated this tutorial to reflect the changes in style
+and syntax. However, GMT 5 is generally backwards compatible with GMT 4 syntax. In October 2019 we released the current
+version GMT 6. GMT is used by tens of thousands of users worldwide in a broad range of disciplines.
+
+Philosophy
+----------
+
+GMT is written in the ANSI C programming language (very portable), is POSIX compliant, and is independent of hardware
+constraints (e.g., memory). GMT was deliberately written for command-line usage, not a windows environment, in order
+to maximize flexibility. We standardized early on to use PostScript output instead of other graphics formats. Apart
+from the built-in support for coastlines, GMT completely decouples data retrieval from the main GMT modules. GMT uses
+architecture-independent file formats.
+
+GMT installation considerations
+-------------------------------
+
+See the `install guide <https://github.com/GenericMappingTools/gmt/blob/master/INSTALL.md>`_
+for instructions and to make sure you have all required dependencies installed.
+Alternatively, you can build GMT from source by following the
+`building guide <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`_.

--- a/doc/rst/source/tutorial/intro_jl.rst
+++ b/doc/rst/source/tutorial/intro_jl.rst
@@ -30,3 +30,9 @@ See the `install guide <https://github.com/GenericMappingTools/gmt/blob/master/I
 for instructions and to make sure you have all required dependencies installed.
 Alternatively, you can build GMT from source by following the
 `building guide <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`_.
+
+See also the general information about `Julia https://julialang.org/learning/getting-started/`_
+as well as the introduction to the Julia wrapper at
+https://www.generic-mapping-tools.org/GMT.jl/dev/usage/ and the very recomendable
+`Quick Learn https://www.generic-mapping-tools.org/GMT.jl/dev/quick_learn/`_. Complement with the instructions on how to
+install `GMT.jl https://github.com/GenericMappingTools/GMT.jl#install`_

--- a/doc/rst/source/tutorial/session-1_jl.rst
+++ b/doc/rst/source/tutorial/session-1_jl.rst
@@ -1,0 +1,308 @@
+Session One
+===========
+
+Tutorial setup
+--------------
+
+#. GMT man pages, documentation, and gallery example scripts are available from the GMT.jl documentation web page
+   available from https://www.generic-mapping-tools.org/GMT.jl/dev/.
+
+#. We recommend you create a sub-directory called *tutorial*,
+   cd into that directory, and run the commands there to keep things tidy.
+
+#. As we discuss GMT principles it may be a good idea to consult :doc:`the GMT Cookbook </cookbook>`
+   for more detailed explanations (but the CookBook is not translated into the GMT.jl syntax).
+
+#. The tutorial data sets are distributed via the GMT cache server.
+   You will therefore find that all the data files have a "@" prepended to
+   their names. This will ensure the file is copied from the server
+   before being used, hence you do not need to download any of the
+   data manually. The only downside is that you will need an Internet
+   connection to run the examples by cut and paste.
+
+#. Please cd into the directory *tutorial*. We are now ready to start.
+
+
+Input data
+~~~~~~~~~~
+
+A GMT module may or may not take input data/files. Four different
+types of input are recognized (more details can be found in :doc:`/cookbook/file-formats`):
+
+#. Data tables.
+   These are rectangular tables with a fixed number of columns and
+   unlimited number of rows. We distinguish between two groups:
+
+    * ASCII (Preferred unless files are huge)
+
+    * Binary (to speed up input/output)
+
+    * In memory GMTdataset or plain Julia matrices.
+
+   Such tables may have segment headers and can therefore hold any number of
+   subsets such as individual line segments or polygons.
+
+#. Gridded dated sets.
+   These are data matrices (evenly spaced in two coordinates) that come in two flavors:
+
+    * Grid-line registration
+
+    * Pixel registration
+
+   You may choose among several file formats (even define your own format),
+   but the GMT default is the architecture-independent netCDF format.
+
+   The other alternative is to use Julia in-memory data in the form of GMTgrids.
+
+#. Color palette table (For imaging, color plots, and contour maps). We will discuss these later.
+
+
+Job Control
+~~~~~~~~~~~
+
+GMT modules may get operational parameters from several places:
+
+#. Supplied command line options/switches or module defaults.
+
+#. Short-hand notation to select previously used option arguments.
+
+#. Implicitly using GMT defaults for a variety of parameters (stored in :doc:`/gmt.conf`).
+
+#. May use hidden support data like coastlines or PostScript patterns.
+
+Output data
+~~~~~~~~~~~
+
+There are 5 general categories of output produced by GMT:
+
+#. PostScript plot commands.
+
+#. Data Table(s).
+
+#. Gridded data set(s).
+
+#. Statistics & Summaries.
+
+#. Warnings and Errors, written to the REPL
+
+
+Laboratory Exercises
+--------------------
+
+We will begin our adventure by making some simple plot axes and coastline basemaps. We will do this in order
+to introduce the all-important common options **frame**, **proj**, and **region** and to familiarize ourselves
+with a few selected GMT projections. The GMT modules we will utilize are :doc:`/basemap` and
+`basemap <https://www.generic-mapping-tools.org/GMT.jl/dev/coast/>`_.
+Please consult their manual pages for reference.
+
+Linear projection
+~~~~~~~~~~~~~~~~~
+
+We start by making the basemap frame for a linear *x-y* plot. We want it to go from 10 to 70 in *x* and from
+-3 to 8 in *y*, with automatic annotation intervals. Finally, we let the canvas be painted light red and have
+dimensions of 10 by 7.5 centimeters. Here's how we do it:
+
+   ::
+
+    basemap(region=(10,70,-3,8), proj=:linear, figsize=(10,7.5),
+            frame=(fill=:lightred, title="My first plot"), show=true)
+
+This script will open the result in a PNG viewer and it should look like :ref:`our example 1 below <gmt_tut_1_jl>`.
+Examine the :doc:`/basemap` documentation so you understand what each option means.
+
+.. _gmt_tut_1_jl:
+
+.. figure:: /_images/GMT_tut_1.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 1.
+
+Exercises:
+
+#. Try change the **proj=:linear** values.
+
+#. Try change the **frame** values.
+
+#. Change title and canvas color.
+
+
+Logarithmic projection
+~~~~~~~~~~~~~~~~~~~~~~
+
+We next will show how to do a basemap for a log–log plot. We have no data set yet but we will imagine that the
+raw *x* data range from 3 to 9613 and that *y* ranges from 10^20 to 10^24. One possibility is
+
+   ::
+
+    basemap(region=(1,10000,1e20,1e25), proj=:loglog, figsize=(12,8), xaxis=(annot=2, label="Wavelength (m)"),
+            yaxis=(annot=1, ticks=3, scale=:pow, label="Power (W)"), frame=(axes=:WS,), show=true)
+
+Make sure your plot looks like :ref:`our example 2 below <gmt_tut_2_jl>`
+
+.. _gmt_tut_2_jl:
+
+.. figure:: /_images/GMT_tut_2.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 2.
+
+Exercises:
+
+#. Do not use **proj**\ =:loglog the axes lengths.
+
+#. Leave the **scale**\ =:pow out of the **frame** string.
+
+#. Add **grid**\ =3 to **xaxis** and **yaxis** settings.
+
+Mercator projection
+~~~~~~~~~~~~~~~~~~~
+
+Despite the problems of extreme horizontal exaggeration at high latitudes, the conformal Mercator projection
+(**proj=:merc**) remains the stalwart of location maps used by scientists. It is one of several cylindrical
+projections offered by GMT; here we will only have time to focus on one such projection. The complete syntax is simply
+
+**proj=:merc**
+
+To make coastline maps we use `basemap <https://www.generic-mapping-tools.org/GMT.jl/dev/coast/>`_ which automatically
+will access the GMT coastline, river and border data base derived from the GSHHG database [See *Wessel and Smith*, 1996].
+In addition to the common switches we may need to use some of several coast-specific options:
+
+============== ================================================================================================
+Option         Purpose
+============== ================================================================================================
+**area**       Exclude small features or those of high hierarchical levels (see `GSHHG <https://github.com/GenericMappingTools/gshhg-gmt#readme>`_.)
+**resolution** Select data resolution (**f**\ ull, **h**\ igh, **i**\ ntermediate, **l**\ ow, or **c**\ rude)
+**land**       Set color of dry areas (default does not paint)
+**rivers**     Draw rivers (chose features from one or more hierarchical categories)
+**map_scale**  Plot map scale (length scale can be km, miles, or nautical miles)
+**borders**    Draw political borders (including US state borders)
+**ocean**      Set color for wet areas (default does not paint)
+**shore**      Draw coastlines and set pen thickness
+============== ================================================================================================
+
+One of **shore**, **land**, **ocean** must be selected. Our first coastline example is from Latin America:
+
+   ::
+
+    coast(region=(-90,-70,0,20), proj=:merc, land=:chocolate, show=true)
+
+Your plot should look like :ref:`our example 3 below <gmt_tut_3_jl>`
+
+.. _gmt_tut_3_jl:
+
+.. figure:: /_images/GMT_tut_3.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 3.
+
+Exercises:
+
+#. Add the **verbose** option.
+#. Try **region=**\ (270,290,0,20) instead. What happens to the annotations?
+#. Edit your gmt.conf file, change :term:`FORMAT_GEO_MAP`
+   to another setting (see the :doc:`/gmt.conf` documentation), and plot again.
+#. Pick another region and change land color.
+#. Pick a region that includes the north or south poles.
+#. Try **shore**\ ="0.25\ **p**" instead of (or in addition to) **land**.
+
+Albers projection
+~~~~~~~~~~~~~~~~~
+
+The Albers projection (**poj=:albers**) is an equal-area conical projection;
+its conformal cousin is the Lambert conic projection (**proj=:lambert**).
+Their usages are almost identical so we will only use the Albers here.
+The general syntax is
+
+    proj=(name=:albers, center=(lon_0,lat_0), parallels=(lat_1,lat_2))
+
+where (*lon_0, lat_0*) is the map (projection) center and *lat_1, lat_2*
+are the two standard parallels where the cone intersects the Earth's surface.
+We try the following command:
+
+   ::
+
+    coast(region=(-130,-70,24,52), proj=(name=:albers, center=(-100,35), parallels=(33,45)),
+          title="Conic Projection", borders=((type=1, pen=:thicker), (type=2, pen=:thinnest)),
+          area=500, land=:gray, coast=:thinnest, show=true)
+
+Your plot should look like :ref:`our example 4 below <gmt_tut_4_jl>`
+
+.. _gmt_tut_4_jl:
+
+.. figure:: /_images/GMT_tut_4.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 4.
+
+Exercises:
+
+#. Change the parameter :term:`MAP_GRID_CROSS_SIZE_PRIMARY` to make grid crosses instead of gridlines.
+
+#. Change **region** to a rectangular box specification instead of minimum and maximum values.
+
+Orthographic projection
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The azimuthal orthographic projection (**proj=:ortho**) is one of several projections with similar syntax and
+behavior; the one we have chosen mimics viewing the Earth from space at an infinite distance; it is neither
+conformal nor equal-area. The syntax for this projection is
+
+    proj=(name=:ortho, center=(lon_0,lat_0))
+
+where (*lon_0, lat_0*) is the center of the map (projection). As an example we will try
+
+   ::
+
+    coast(region=:global360, proj=(name=:ortho, center=(280,30)), frame=(annot=:a, grid=:a),
+          area=5000, land=:white, ocean=:DarkTurquoise, show=true)
+
+Your plot should look like :ref:`our example 5 below <gmt_tut_5_jl>`
+
+.. _gmt_tut_5_jl:
+
+.. figure:: /_images/GMT_tut_5.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 5
+
+Exercises:
+
+#. Use the rectangular option in **region** to make a rectangular map showing the US only.
+
+Eckert IV and VI projection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We conclude the survey of map projections with the Eckert IV and VI projections, two of several projections
+used for global thematic maps; They are both equal-area projections whose syntax is
+
+    proj=(name=:EckertIV, center=lon_0)
+    proj=(name=:EckertVI, center=lon_0)
+
+The *lon_0* is the central meridian (which takes precedence over the mid-value implied by the **region** setting).
+A simple Eckert VI world map is thus generated by
+
+   ::
+
+    coast(region=:global360, proj=(name=:EckertVI, center=180), frame=(annot=:a, grid=:a), resolution=:crude,
+          area=5000, land=:chocolate, shore=:thinnest, ocean=:DarkTurquoise, show=true)
+
+Your plot should look like :ref:`our example 6 below <gmt_tut_6_jl>`
+
+.. _gmt_tut_6_jl:
+
+.. figure:: /_images/GMT_tut_6.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 6
+
+Exercises:
+
+#. Center the map on Greenwich.
+
+#. Add a map scale with **map_scale**.

--- a/doc/rst/source/tutorial/session-2_jl.rst
+++ b/doc/rst/source/tutorial/session-2_jl.rst
@@ -1,0 +1,407 @@
+Session Two
+===========
+
+General Information
+-------------------
+
+There are 18 GMT modules that directly create (or add overlays to) plots; the remaining 45 are mostly concerned
+with data processing. This session will focus on the task of plotting lines, symbols, and text on maps. We will
+build on the skills we acquired while familiarizing ourselves with the various GMT map projections as well as
+how to select a data domain and boundary annotations.
+
+======================== ====================================================================
+Program                  Purpose
+======================== ====================================================================
+**BASEMAPS**
+basemap                  Create an empty basemap frame with optional scale
+coast                    Plot coastlines, filled continents, rivers, and political borders
+legend                   Create legend overlay
+**POINTS AND LINES**
+wiggle                   Draw spatial time-series along their (*x,y*)-tracks
+plot                     Plot symbols, polygons, and lines in 2-D
+plot3d                   Plot symbols, polygons, and lines in 3-D
+**HISTOGRAMS**
+histogram                Plot a rectangular histogram
+rose                     Plot a polar histogram(sector/rose diagram)
+**CONTOURS**
+grdcontour               Contouring of grids
+contour                  Direct contouring/imaging of (*x,y,z*) data by optimal triangulation
+**SURFACES**
+grdimage                 Project and plot grids or images
+grdvector                Plot vector fields from grids
+grdview                  3-D perspective imaging of grids
+**UTILITIES**
+clip                     Use polygon files to initiate custom clipping paths
+image                    Plot Sun raster files
+mask                     Create clipping paths or generate overlay to mask
+colorbar                 Plot gray scale or color scale bar
+text                     Plot text strings
+======================== ====================================================================
+
+Plotting lines and symbols, `plot <https://www.generic-mapping-tools.org/GMT.jl/dev/plot/>`_ is one of the most frequently
+used modules in GMT. In addition to the common command line switches
+it has numerous specific options, and expects different file formats
+depending on what action has been selected. These circumstances make
+`plot <https://www.generic-mapping-tools.org/GMT.jl/dev/plot/>`_ harder to master than most GMT tools. The table below
+shows an abbreviated list of the options:
+
+================================================================== ===================================================================
+Option                                                             Purpose
+================================================================== ===================================================================
+**steps**                                                          Suppress line interpolation along great circles
+**cmap**\ *=cpt*                                                   Let symbol color be determined from *z*-values and the *cpt* file
+**error_bars**\ =(x|y|X|Y=true, wiskers=true, cap=width, pen=pen,  Draw selected error bars with specified attributes
+              colored=true, cline=true, csymbol=true)
+**fill**\ =\ *fill*                                                Set color for symbol or fill for polygons
+**close**\ [*options*]                                             Explicitly close polygons or create polygon
+**no_clip**\ *=true* [**no_clip**\ *=:c*\|\ **no_clip**\ *=:r*]    Do Not clip symbols at map borders
+**symbol**\ *=(symb=name, size=val, unit=unity)*                   Select one of several symbols
+**pen**\ =\ *pen*                                                  Set *pen* for line or symbol outline
+================================================================== ===================================================================
+
+The symbols can either be transparent (using **pen** only, not **fill**)
+or solid (**fill**, with optional outline using **pen**). The **symbol** or **marker**
+option takes the code for the desired symbol and optional size information.
+If no symbol is given it is expected to be given in the last column of each record in the input
+file. The *size* is optional since individual sizes for
+symbols may also be provided by the input data. The main symbols available to
+us are shown in the table below:
+
++------------------------------------+-------------------------------------------------------------------------------------------+
+| Option                             | Symbol                                                                                    |
++====================================+===========================================================================================+
+| **marker**\ ="-"                   | horizontal dash; *size* is length of dash                                                 |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:star                 | st\ **a**\ r; *size* is radius of circumscribing circle                                   |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:bar                  | **b**\ ar; *size* is bar width, set *unit* be **u** if *size* is in *x*-units             |
++------------------------------------+-------------------------------------------------------------------------------------------+
+|                                    |  Bar extends from *base* [0] to the *y*-value                                             |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:circle               | **c**\ ircle; *size* is the diameter                                                      |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:d                    | **d**\ iamond; *size* is its side                                                         |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:ellipse              | **e**\ llipse; *direction* (CCW from horizontal), *major*, and *minor* axes               |
++------------------------------------+-------------------------------------------------------------------------------------------+
+|                                    | are read from the input file                                                              |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:Ellipse              | **E**\ llipse; *azimuth* (CW from vertical), *major*, and *minor* axes in kilometers      |
++------------------------------------+-------------------------------------------------------------------------------------------+
+|                                    | are read from the input file                                                              |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:octagon              | octa\ **g**\ on; *size* is its side                                                       |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:hexagon              | **h**\ exagon; *size* is its side                                                         |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:inverted_tri         | **i**\ nverted triangle; *size* is its side                                               |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ ="kustom/size"         | **k**\ ustom symbol; *size* is its side                                                   |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:pentagon             | pe\ **n**\ tagon; *size* is its side                                                      |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:point                | **p**\ oint; no size needed (1 pixel at current resolution is used)                       |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:rectangle            | **r**\ ect, *width* and *height* are read from input file                                 |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:square               | **s**\ quare, *size* is its side                                                          |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:triangle             | **t**\ riangle; *size* is its side                                                        |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:vector  *params*     | **v**\ ector; *direction* (CCW from horizontal) and *length* are read from input data     |
++------------------------------------+-------------------------------------------------------------------------------------------+
+|                                    | Append parameters of the vector; see :doc:`/plot` for syntax.                             |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:Vector  *params*     | **V**\ ector, except *azimuth* (degrees east of north) is expected instead of *direction* |
++------------------------------------+-------------------------------------------------------------------------------------------+
+|                                    | The angle on the map is calculated based on the chosen map projection                     |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:wedge                | pie **w**\ edge; *start* and *stop* directions (CCW from horizontal) are read from input  |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ =:cross                | cross; *size* is length of crossing lines                                                 |
++------------------------------------+-------------------------------------------------------------------------------------------+
+| **marker**\ ="y-dash"              | vertical dash; *size* is length of dash                                                   |
++------------------------------------+-------------------------------------------------------------------------------------------+
+
+The symbol option in `plot <https://www.generic-mapping-tools.org/GMT.jl/dev/plot/>`_. Lower case symbols (**a, c, d, g, h, i, n, s, t, x**)
+will fit inside a circle of given diameter. Upper case symbols (**A, C, D, G, H, I, N, S, T, X**)
+will have area equal to that of a circle of given diameter.
+
+Because some symbols require more input data than others, and because the size of symbols as well as their color
+can be determined from the input data, the format of data can be confusing. The general format for the input data
+is (optional items are in brackets []):
+
+   ::
+
+    x y [ z ] [ size ] [ sigma_x ] [ sigma_y ] [ symbol ]
+
+Thus, the only required input columns are the first two which must contain the longitude and latitude (or *x* and *y*).
+The remaining items apply when one (or more) of the following conditions are met:
+
+#. If you want the color of each symbol to be determined individually, supply a CPT with the **cmap** option
+   and let the 3rd data column contain the *z*-values to be used with the CPT.
+
+#. If you want the size of each symbol to be determined individually, append the size in a separate column.
+
+#. To draw error bars, use the **error_bars** option and give one or two
+   additional data columns with the *dx* and *dy* values; the form of
+   **error_bars** determines if one (**error_bars=(x=true,)** and/or **error_bars=(y=true,)**)
+   columns are needed. If **wiskers**\ =true is given then
+   we will instead draw a "box-and-whisker" symbol and the *sigma_x* (or
+   *sigma_y*) must represent 4 columns containing the minimum, the 25 and 75%
+   quartiles, and the maximum value. The given *x* (or *y*) coordinate is taken as the 50%
+   quantile (median).
+
+#. If you draw vectors with **marker=**\ *vector* then *size* is actually two columns containing the *direction*
+   and *length* of each vector.
+
+#. If you draw ellipses (**marker=**\ *ellipse*) then *size* is actually three
+   columns containing the *direction* and the *major* and *minor*
+   axes in plot units (with **marker=**\ *Ellipse* we expect *azimuth* instead and axes
+   lengths in km).
+
+Before we try some examples we need to review two key switches; they
+specify pen attributes and symbol or polygon fill. Please consult
+the :ref:`General Features <GMT_General_Features>` section the
+GMT Technical Reference and Cookbook before experimenting
+with the examples below.
+
+Examples:
+
+We will start off using the file tut_data.txt in your directory. Using the GMT utility :doc:`/gmtinfo`
+we find the extent of the data region:
+
+   ::
+
+    gmtinfo("@tut_data.txt")
+
+which returns
+
+   ::
+
+    tut_data.txt: N = 7   <1/5>   <1/5>
+
+telling us that the file tut_data.txt has 7 records and gives the
+minimum and maximum values for the first two columns. Given our
+knowledge of how to set up linear projections with **region** and **proj=:linear**,
+try the following:
+
+#. Plot the data as transparent circles of size 0.75 centimeters.
+
+#. Plot the data as solid white circles instead.
+
+#. Plot the data using 0.5" stars, making them red with a thick (width = 1.5p), dashed pen.
+
+To simply plot the data as a line we choose no symbol and specify a pen thickness instead:
+
+   ::
+
+    plot("@tut_data.txt", region=(0,6,0,6), pen=:thinner, aspect=:equal, show=true)
+
+Your plot should look like :ref:`our example 7 below <gmt_tut_7_jl>`
+
+.. _gmt_tut_7_jl:
+
+.. figure:: /_images/GMT_tut_7.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 7
+
+Exercises:
+
+#. Plot the data as a green-blue polygon instead.
+
+#. Try using a predefined pattern.
+
+A common question is : "How can I plot symbols connected by a line
+with plot?". The surprising answer is that we must call `plot <https://www.generic-mapping-tools.org/GMT.jl/dev/plot/>`_ twice.
+While this sounds cumbersome there is a reason for this:  Basically,
+polygons need to be kept in memory since they may need to be clipped,
+hence computer memory places a limit on how large polygons we may plot.
+Symbols, on the other hand, can be plotted one at the time so there
+is no limit to how many symbols one may plot. Therefore, to connect
+symbols with a line we must use the overlay approach:
+
+   ::
+
+    plot("@tut_data.txt", region=(0,6,0,6), pen=:thinner, marker=:inverted_tri,
+         markersize=0.5, aspect=:equal, show=true)
+
+Your plot should look like :ref:`our example 8 below <gmt_tut_8_jl>`. The
+two-step procedure also makes it easy to plot the line over the symbols
+instead of symbols over the line, as here.
+
+.. _gmt_tut_8_jl:
+
+.. figure:: /_images/GMT_tut_8.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 8
+
+Our final `plot <https://www.generic-mapping-tools.org/GMT.jl/dev/plot/>`_ example involves a more complicated scenario in
+which we want to plot the epicenters of several earthquakes over the background of a coastline basemap. We want the symbols
+to have a size that reflects the magnitude of the earthquakes, and that their color should reflect the depth of the hypocenter.
+The first few lines in the remote tut_quakes.ngdc looks like this:
+
+   ::
+
+    Historical Tsunami Earthquakes from the NCEI Database
+    Year  Mo  Da  Lat+N  Long+E  Dep  Mag
+    1987  01  04  49.77  149.29  489  4.1
+    1987  01  09  39.90  141.68  067  6.8
+
+Thus the file has three header records (including the blank line), but we are only interested in columns
+5, 4, 6, and 7. In addition to extract those columns we must also scale the magnitudes into symbols sizes
+in centimeters. Given their range it looks like multiplying the magnitude by 0.1 will work well for symbol
+sizes in cm. Reformatting this file to comply with the `plot <https://www.generic-mapping-tools.org/GMT.jl/dev/plot/>`_
+input format can be done in a number of ways. Here, we simply use the common column selection option **incol**
+and its :ref:`scaling/offset capabilities <-icols_full>`. To skip the first 3 header records and then select
+the 4th, 3rd, 5th, and 6th column and scale the last column by 0.1, we would use
+
+   ::
+
+    incols="4,3,5,6s0.1", header=3
+
+(Remember that 0 is the first column).  We will follow conventional color schemes for seismicity and assign red
+to shallow quakes (depth 0-100 km), green to intermediate quakes
+(100-300 km), and blue to deep earthquakes (depth > 300 km). The
+quakes.cpt file establishes the relationship between depth and color:
+
+   ::
+
+    # color palette for seismicity
+    #z0  color   z1 color
+    0    red    100 red
+    100  green  300 green
+    300  blue  1000 blue
+
+Apart from comment lines (starting with #), each record in the CPT governs the color of a symbol whose
+*z* value falls in the range between *z_0* and *z_1*. If the colors for the lower and upper levels differ
+then an intermediate color will be linearly interpolated given the *z* value. Here, we have chosen
+constant color intervals. You may wish to consult the :ref:`Color palette tables <CPT_section>` section
+in the Cookbook. This color table was generated as part of the script (below).
+
+We may now complete our example using the Mercator projection:
+
+   ::
+
+    C = makecpt(cmap="red,green,blue", range="0,100,300,10000");
+    coast(region=(130,150,35,50), land=:gray, proj=:merc)
+    plot!("@tut_quakes.ngdc", incols="4,3,5,6s0.1", header=3, symbol="cc", markerline=:faint, color=C, show=true)
+
+where the second **c** used in the **symbol** option ensures that symbols
+sizes are interpreted to be in cm. Your plot should look like :ref:`our example 9 below <gmt_tut_9_jl>`
+
+.. _gmt_tut_9_jl:
+
+.. figure:: /_images/GMT_tut_9.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 9
+
+
+More exercises
+~~~~~~~~~~~~~~
+
+#. Select another symbol.
+
+#. Let the deep earthquakes be cyan instead of blue.
+
+Plotting text strings
+---------------------
+
+In many situations we need to annotate plots or maps with text strings;
+in GMT this is done using `text <https://www.generic-mapping-tools.org/GMT.jl/dev/text/>`_. Apart from the common
+switches, there are 8 options that are particularly useful.
+
+===================================================================== ===================================================
+Option                                                                Purpose
+===================================================================== ===================================================
+**clearance**\ =\ *(margin=(dx,dy),)*                                 Spacing between text and the text box (see **pen**)
+**offset**\ =([away=true, corners=true,] shift=(dx,dy) [,line=pen])   Offsets the projected location of the strings
+**attrib**\ *params*                                                  Set font, justify, angle values or source
+**fill**\ =_fill_                                                     Fills the text bos using specified fill
+**list**\ =true                                                       Lists the font ids and exits
+**noclip**\ =true                                                     Deactivates clipping at the borders
+**shade**\ =true                                                      Plot a shadow behind the text box.
+**pen**\ =\ *pen*                                                     Draw the outline of text box
+===================================================================== ===================================================
+
+The input data to `text <https://www.generic-mapping-tools.org/GMT.jl/dev/text/>`_ is expected to contain the following information:
+
+   ::
+
+    [ x   y ]  [ font]  [ angle ] [ justify ]   my text
+
+The *font* is the optional font to use, the *angle* is the angle (measured counterclockwise) between the
+text's baseline and the horizontal, *justify* indicates which anchor point on the text-string should
+correspond to the given *x, y* location, and *my text* is the text string or sentence to plot. See the
+Technical reference for the relevant two-character codes used for justification.
+
+The text string can be one or several words and may include octal codes for
+special characters and escape-sequences used to select subscripts or symbol
+fonts. The escape sequences that are recognized by GMT are given below:
+
+================== =============================================================
+Code               Effect
+================== =============================================================
+@\~	             Turns symbol font on or off
+@+	                Turns superscript on or off
+@-	                Turns subscript on or off
+@\#	             Turns small caps on or off
+@\_	             Turns underline on or off
+@\%\ *font*\ %     Switches to another font; @\%\% resets to previous font
+@:\ *size*:	       Switches to another font size; @:: resets to previous size
+@;\ *color*;       Switches to another font color; @;; resets to previous color
+@!	                Creates one composite character of the next two characters
+@@	                Prints the @ sign itself
+================== =============================================================
+
+Note that these escape sequences (as well as octal codes) can be
+used anywhere in GMT, including in arguments to the **frame** option.
+A chart of octal codes can be found in Appendix F in the GMT
+Technical Reference. For accented European characters you must
+set :term:`PS_CHAR_ENCODING` to ISOLatin1 in your :doc:`/gmt.conf` file.
+
+We will demonstrate `text <https://www.generic-mapping-tools.org/GMT.jl/dev/text/>`_ with the following script:
+
+   ::
+
+    T = text_record(
+       1  1  It's P@al, not Pal!
+       1  2  Try @%33%ZapfChancery@%% today
+       1  3  @~D@~g@-b@- = 2@~pr@~G@~D@~h.
+       1  4  University of Hawaii at M@!a\225noa
+    );
+    text(T, region=(0,7,0,5), font=(30, "Times-Roman", :DarkOrange), jutify=:BL)
+
+Your plot should look like :ref:`our example 10 below <gmt_tut_10_jl>`
+
+.. _gmt_tut_10_jl:
+
+.. figure:: /_images/GMT_tut_10.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 10
+
+===== ======== ==== ======
+Code  Effect   Code Effect
+===== ======== ==== ======
+@E    Æ        @e   æ
+@O    Ø        @o   ø
+@A    Å        @a   å
+@C    Ç        @c   ç
+@N    Ñ        @n   ñ
+@U    Ü        @u   ü
+@s    ß
+===== ======== ==== ======
+
+Exercises:
+
+#. At *y = 5*, add the sentence :math:`z^2 = x^2 + y^2`.
+
+#. At *y = 6*, add the sentence "It is 32° today".

--- a/doc/rst/source/tutorial/session-3_jl.rst
+++ b/doc/rst/source/tutorial/session-3_jl.rst
@@ -1,0 +1,267 @@
+Session Three
+=============
+
+Contouring gridded data sets
+----------------------------
+
+GMT comes with several utilities that can create gridded data sets; we will discuss two such modules later
+this session.  The data sets needed for this tutorial are obtained via the Internet as they are needed.
+Here, we will use :doc:`/grdcut` to obtain and extract a GMT-ready grid that we will next use for contouring::
+
+    G = grdcut("@earth_relief_05m", region=(-66,-60,30,35), verbose=true)
+
+Here we use the file extension .nc instead of the generic .grd to indicate that this is a netCDF file.
+It is good form, but not essential, to use .nc for netCDF grids. Using that extension will help other
+programs installed on your system to recognize these files and might give it an identifiable icon in
+your file browser.  Learn about other programs that read netCDF files at the
+`netCDF website <https://www.unidata.ucar.edu/software/netcdf/>`_.
+You can also obtain tut_bathy.nc from the GMT cache server as we are doing below. Feel free to open it
+in any other program and compare results with GMT.
+
+We first use the GMT module :doc:`/grdinfo` to see what's in this file::
+
+    grdinfo(G)
+
+The file contains bathymetry for the Bermuda region and has depth values from -5475 to -89 meters. We want to
+make a contour map of this data; this is a job for `grdcontour <https://www.generic-mapping-tools.org/GMT.jl/dev/grdcontour/>`_.
+As with previous plot commands we need to set up the map projection with **proj**. Here, however, we do not have
+to specify the region since that is by default assumed to be the extent of the grid file. To generate any plot we
+will in addition need to supply information about which contours to draw. Unfortunately,
+`grdcontour <https://www.generic-mapping-tools.org/GMT.jl/dev/grdcontour/>`_ is a complicated module with too
+many options. We put a positive spin on this situation by touting its flexibility. Here are the most useful options:
+
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | Option                                                          |  Purpose                                                             |
+  +=================================================================+======================================================================+
+  | **annot**\ =\ *annot\_int*                                      | Annotation interval and attributes                                   |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | **cont**\ =\ *cont\_int*                                        | Contour interval                                                     |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | **labels**\ *gap*                                               | Controls placement of contour annotations                            |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | **range**\ =\ *(low,high)*                                      | Only draw contours within the *low* to *high* range                  |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | **cut**\ =\ *cut*                                               | Do not draw contours with fewer than *cut* points                    |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | **smooth**\ =\ *factor*                                         | Resample contours *smooth* times per grid cell increment             |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | **ticks**\ =(local_high=true, local_low=true,                   | Draw tick-marks in downhill                                          |
+  |  gap=\ *gap*, closed=true, labels=lab)                          |                                                                      |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  |                                                                 | direction for innermost closed contours.  Add tick spacing           |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  |                                                                 | and length, and characters to plot at the center of closed contours  |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | **pen**\ =(annot=true, contour=true, pen=\ *pen*,               | Set contour and annotation pens                                      |
+  |  colored=true, cline=true, ctext=true)                          |                                                                      |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+  | **scale**\ =(factor=\ *factor*, shift=\ *shift*, periodic=true) | Subtract *offset* and multiply data by *factor* prior to processing  |
+  +-----------------------------------------------------------------+----------------------------------------------------------------------+
+
+We will first make a plain contour map using 1 km as annotation interval and 250 m as contour interval.
+We choose a 15-cm-wide Mercator plot and annotate the borders every 2°:
+
+   grdcontour("@earth_relief_05m", region=(-66,-60,30,35), proj=:Mercator, figsize=15, cont=250, annot=1000, show=true)
+
+Your plot should look like :ref:`our example 11 below <gmt_tut_11_jl>`
+
+.. _gmt_tut_11_jl:
+
+.. figure:: /_images/GMT_tut_11.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 11
+
+Exercises:
+
+#. Add smoothing with **smooth**\ =4.
+
+#. Try tick all highs and lows with **ticks**.
+
+#. Skip small features with **cut**\ =10.
+
+#. Override region using **region**\ =(-70,-60,25,35)
+
+#. Try another region that clips our data domain.
+
+#. Scale data to km and use the km unit in the annotations.
+
+Gridding of arbitrarily spaced data
+-----------------------------------
+
+Except in the situation above when a grid file is available, we must convert our data to the right format
+readable by GMT before we can make contour plots and color-coded images. We distinguish between two scenarios:
+
+#. The (*x, y, z*) data are available on a regular lattice grid.
+
+#. The (*x, y, z*) data are distributed unevenly in the plane.
+
+The former situation may require a simple reformatting (using :doc:`/xyz2grd`), while the latter must be
+interpolated onto a regular lattice; this process is known as gridding. GMT supports three different
+approaches to gridding; here, we will briefly discuss the two most common techniques.
+
+All GMT gridding modules have in common the requirement that the
+user must specify the grid domain and output filename:
+
+======================================= ======================================================================
+Option                                  Purpose
+======================================= ======================================================================
+**region**\ =\ *(xmin,xmax/ymin,ymax)*  The desired grid extent
+**inc**\ =\ *(xinc [,yinc])*            The grid spacing (append **m** or **s** for minutes or seconds of arc)
+**outgrid**\ =\ *gridfile*              The output grid filename
+======================================= ======================================================================
+
+Nearest neighbor gridding
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. figure:: /_images/GMT_nearneighbor.*
+   :width: 200 px
+   :align: center
+
+   Search geometry for nearneighbor.
+
+The GMT module :doc:`/nearneighbor` implements a simple "nearest neighbor" averaging operation.
+It is the preferred way to grid data when the data density is high. :doc:`/nearneighbor` is a
+local procedure which means it will only consider the control data that is close to the desired
+output grid node. Only data points inside a specified search radius will be used, and we may also
+impose the condition that each of the *n* sectors must have at least one data point in order to
+assign the nodal value. The nodal value is computed as a weighted average of the nearest data
+point per sector inside the search radius, with each point weighted according to its distance
+from the node. The most important switches are listed below.
+
+=========================== =====================================================================================
+Option                      Purpose
+=========================== =====================================================================================
+**search_radius**\ =\ *val* Sets search radius.  Append *unit* for radius in that unit [Default is *x*-units]
+**empty**\ =*val*           Assign this value to unconstrained nodes [Default is NaN]
+**sectors**\ =*n*           Sector search, indicate number of sectors [Default is 4]
+**weights**\ =true          Read relative weights from the 4th column of input data
+=========================== =====================================================================================
+
+We will grid the data in the file tut_ship.xyz which contains ship observations of bathymetry off
+Baja California. We obtain the file via the cache server as before. We desire to make a 5' by 5' grid.
+Running gmt info on @tut_ship.xyz yields::
+
+    tut_ship.xyz: N = 82970     <245/254.705>   <20/29.99131>   <-7708/-9>
+
+so we choose the region accordingly, and get a view of the contour map using
+
+   ::
+
+    G = nearneighbor("@tut_ship.xyz", region=(245,255,20,30), inc="5m", search_radius="40k");
+    grdcontour(G, proj=:Mercator, figsize=15, cont=250, annot=1000, show=true)
+
+Your plot should look like :ref:`our example 12 below <gmt_tut_12_jl>`
+
+.. _gmt_tut_12_jl:
+
+.. figure:: /_images/GMT_tut_12.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 12
+
+Since the grid ship.nc is stored in netCDF format that is supported by a host of other modules,
+you can try one of those as well on the same grid.
+
+Exercises:
+
+#. Try using a 100 km search radius and a 10 minute grid spacing.
+
+
+Gridding with Splines in Tension
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As an alternative, we may use a global procedure to grid our data. This approach, implemented in the module
+:doc:`/surface`, represents an improvement over standard minimum curvature algorithms by allowing users to
+introduce some tension into the surface. Physically, we are trying to force a thin elastic plate to go
+through all our data points; the values of this surface at the grid points become the gridded data.
+Mathematically, we want to find the function *z(x, y)* that satisfies the following equation away from data constraints:
+
+.. math::
+
+    (1-t)\nabla ^2 z -  t \nabla z = 0,
+
+where *t* is the "tension" in the 0-1 range. Basically, for zero tension we obtain the minimum curvature
+solution, while as tension goes toward unity we approach a harmonic solution (which is linear in cross-section).
+The theory behind all this is quite involved and we do not have the time to explain it all here, please see
+*Smith and Wessel* [1990] for details. Some of the most important switches for this module are indicated below.
+
+============================ =========================================================
+Option                       Purpose
+============================ =========================================================
+**aspect_ratio**\ =\ *val*   Sets aspect ratio for anisotropic grids.
+**convergence**\ =\ *limit*  Sets convergence limit.  Default is 1/1000 of data range.
+**tension**\ =\ *val*        Sets the tension [Default is 0]
+============================ =========================================================
+
+Preprocessing
+-------------
+
+The :doc:`/surface` module assumes that the data have been preprocessed to eliminate aliasing,
+hence we must ensure that this step is completed prior to gridding. GMT comes with three preprocessors, called
+`blockmean <https://www.generic-mapping-tools.org/GMT.jl/dev/blockmean/>`_,
+`blockmedian <https://www.generic-mapping-tools.org/GMT.jl/dev/blockmedian/>`_, and
+`blockmode <https://www.generic-mapping-tools.org/GMT.jl/dev/blockmode/>`_. The first averages values inside the
+grid-spacing boxes, the second returns median values, wile the latter returns modal values. As a rule of thumb,
+we use means for most smooth data (such as potential fields) and medians (or modes) for rough, non-Gaussian data
+(such as topography). In addition to the required **region** and **inc** switches, these preprocessors all take
+the same options shown below:
+
+=========================== ====================================================================
+Option                      Purpose
+=========================== ====================================================================
+**reg**\ =true              Choose pixel node registration [Default is gridline]
+=========================== ====================================================================
+
+With respect to our ship data we preprocess it using the median method::
+
+    D = blockmedian("@tut_ship.xyz", region=(245,255,20,30), inc="5m", verbose=true);
+
+The output data can now be used with surface::
+
+    G = surface(D, region=(245,255,20,30), inc="5m", verbose=true);
+
+If you rerun `grdcontour <https://www.generic-mapping-tools.org/GMT.jl/dev/grdcontour/>`_ on the new grid file
+(try it!) you will notice a big difference compared to the grid made by :doc:`/nearneighbor`: since surface is a
+global method it will evaluate the solution at all nodes, even if there are no data constraints. There are numerous
+options available to us at this point:
+
+#. We can reset all nodes too far from a data constraint to the NaN value.
+
+#. We can pour white paint over those regions where contours are unreliable.
+
+#. We can plot the landmass which will cover most (but not all) of the unconstrained areas.
+
+#. We can set up a clip path so that only the contours in the constrained region will show.
+
+Here we have only time to explore the latter approach. The :doc:`/mask` module can read the same preprocessed
+data and set up a contour mask based on the data distribution. Once the clip path is activated we can contour
+the final grid; we finally deactivate the clipping with a second call to :doc:`/mask`. Note also that since
+we are appending layers to the figure, second and on commands use the bang (**!**) form. Here's the recipe:
+
+   ::
+
+    D = blockmedian("@tut_ship.xyz", region=(245,255,20,30), inc="5m", verbose=true);
+    G = surface(D, region=(245,255,20,30), inc="5m", verbose=true);
+    mask(D, region=(245,255,20,30), inc="5m", figsize=15)
+    grdcontour!(G, cont=250, annot=1000)
+    mask!(end_clip_path=true, show=true)
+    
+
+Your plot should look like :ref:`our example 13 below <gmt_tut_13_jl>`
+
+.. _gmt_tut_13_jl:
+
+.. figure:: /_images/GMT_tut_13.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 13
+
+Exercises:
+
+#. Add the continents using any color you want.
+
+#. Color the clip path light gray (use **fill** in the first :doc:`/mask` call).

--- a/doc/rst/source/tutorial/session-4_jl.rst
+++ b/doc/rst/source/tutorial/session-4_jl.rst
@@ -1,0 +1,390 @@
+Session Four
+============
+
+In our final session we will concentrate on color images and perspective views of gridded data sets.
+Before we start that discussion we need to cover three important aspects of plotting that must be understood.
+These are
+
+#. Color tables and pseudo-colors in GMT.
+#. Artificial illumination and how it affects colors.
+#. Multi-dimensional grids.
+
+CPTs
+----
+
+The CPT is discussed in detail in the GMT Technical Reference and Cookbook. Please review the format before
+experimenting further.
+
+CPTs can be created in any number of ways. GMT provides two mechanisms:
+
+#. Create simple, linear color tables given a master color table
+   (several are built-in) and the desired *z*-values at color boundaries
+   (`makecpt <https://www.generic-mapping-tools.org/GMT.jl/dev/makecpt/>`_)
+
+#. Create color tables based on a master CPT color table and the histogram-equalized distribution of *z*-values
+   in a gridded data file (`grd2cpt <https://www.generic-mapping-tools.org/GMT.jl/dev/grd2cpt/>`_)
+
+One can also make these files manually. Here we will limit our discussion to
+`makecpt <https://www.generic-mapping-tools.org/GMT.jl/dev/makecpt/>`_.
+Its main argument is the name of the master color table (a list is
+shown if you run the module with no arguments) and the equidistant
+*z*-values to go with it.  The main options are given below.
+
+============== =============================================
+Option         Purpose
+============== =============================================
+**cmap**       Set the name of the master CPT to use
+**inverse**    Reverse the sense of the color progression
+**verbose**    Run in verbose mode
+**continuous** Make a continuous rather than discrete table
+============== =============================================
+
+To make discrete and continuous color CPTs for data that ranges
+from -20 to 60, with color changes at every 10, try these two variants:
+
+   ::
+
+    makecpt(cmap=:rainbow, range=(-20,60,10), write="disc.cpt")
+    makecpt(cmap=:rainbow, range=(-20,60,10), continuous=true, write="cont.cpt")
+
+We can plot these color tables with `colorbar <https://www.generic-mapping-tools.org/GMT.jl/dev/colorbar/>`_;
+the options worth mentioning here are listed below. The placement of the color bar is particularly important
+and we refer you to the :ref:`Plot embellishments <GMT_Embellishments>` section for all the details. In addition,
+the **frame** option can be used to set the title and unit label (and optionally to set the annotation-, tick-,
+and grid-line intervals for the color bars.).  Note that the makecpt commands above are done in classic mode.
+If you run `makecpt <https://www.generic-mapping-tools.org/GMT.jl/dev/makecpt/>`_ in modern mode then you usually
+do not specify an output file via standard output since modern mode maintains what is known as the current CPT.
+However, if you must explicitly name an output CPT then you will need to add the -H option for modern mode to
+allow output to standard output.
+
+============================================================================= ==============================================
+Option                                                                        Purpose
+============================================================================= ==============================================
+**cmap**\ =\ *cpt*                                                            The required CPT
+**position**\ =(paper=(xpos,ypos), length=(length,width) [,horizontal=true])  Sets the position and dimensions of scale bar.
+**shade**\ =\ *max\_intensity*                                                Add illumination effects
+============================================================================= ==============================================
+
+Here is an example of four different ways of presenting the color bar:
+
+   ::
+
+    C1 = makecpt(cmap=:rainbow, range=(-20,60,10));
+    C2 = makecpt(cmap=:rainbow, range=(-20,60,10), continuous=true);
+    basemap(region=(0,15,0,22), scale=1, frame=:noannot, x_offset=:c)
+    colorbar!(C1, pos=(paper=(2.5,2.5),  size=(10,1.25), horizontal=true), frame=:auto, title=:discrete)
+    colorbar!(C2, pos=(paper=(2.5,7.5),  size=(10,1.25), horizontal=true), frame=:auto, title=:continuous)
+    colorbar!(C1, pos=(paper=(2.5,12.5), size=(10,1.25), horizontal=true), frame=:auto, title=:discrete, shade=0.5)
+    colorbar!(C2, pos=(paper=(2.5,17.5), size=(10,1.25), horizontal=true), frame=:auto, title=:continuous, shade=0.5)
+    showfig()
+
+Your plot should look like :ref:`our example 14 below <gmt_tut_14_jl>`
+
+.. _gmt_tut_14_jl:
+
+.. figure:: /_images/GMT_tut_14.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 14
+
+Exercises:
+
+#. Redo the `makecpt <https://www.generic-mapping-tools.org/GMT.jl/dev/makecpt/>`_ exercise using the
+   master table *hot* and redo the bar plot.
+
+#. Try specifying **frame**\ =(annot=10, grid=5).
+
+Illumination and intensities
+----------------------------
+
+GMT allows for artificial illumination and shading. What this means is that we imagine an artificial sun
+placed at infinity in some azimuth and elevation position illuminating our surface. The parts of the surface
+that slope toward the sun should brighten while those sides facing away should become darker; no shadows are
+cast as a result of topographic undulations.
+
+While it is clear that the actual slopes of the surface and the orientation of the sun enter into these
+calculations, there is clearly an arbitrary element when the surface is not topographic relief but some
+other quantity. For instance, what does the slope toward the sun mean if we are plotting a grid of heat
+flow anomalies?  While there are many ways to accomplish what we want, GMT offers a relatively simple way:
+We may calculate the gradient of the surface in the direction of the sun and normalize these values to fall
+in the -1 to +1 range; +1 means maximum sun exposure and -1 means complete shade. Although we will not
+show it here, it should be added that GMT treats the intensities as a separate data set. Thus, while these
+values are often derived from the relief surface we want to image they could be separately observed
+quantities such as back-scatter information.
+
+Colors in GMT are specified in the RGB system used for computer screens; it mixes red, green, and blue
+light to achieve other colors.  The RGB system is a Cartesian coordinate system and produces a color cube.
+For reasons better explained in Appendix I in the Reference book it is difficult to darken and brighten a
+color based on its RGB values and an alternative coordinate system is used instead; here we use the HSV system.
+If you hold the color cube so that the black and white corners are along a vertical axis, then the other
+6 corners project onto the horizontal plane to form a hexagon; the corners of this hexagon are the primary
+colors Red, Yellow, Green, Cyan, Blue, and Magenta. The CMY colors are the complimentary colors and are used
+when paints are mixed to produce a new color (this is how printers operate; they also add pure black (K) to
+avoid making gray from CMY). In this coordinate system the angle 0-360° is the hue (H); the Saturation and
+Value are harder to explain. Suffice it to say here that we intend to darken any pure color (on the cube facets)
+by keeping H fixed and adding black and brighten it by adding white; for interior points in the cube we will
+add or remove gray. This operation is efficiently done in the HSV coordinate system; hence all GMT shading
+operations involve translating from RGB to HSV, do the illumination effect, and transform back the modified RGB values.
+
+Color images
+------------
+
+Once a CPT has been made it is relatively straightforward to generate a color image of a gridded data.
+Here, we will extract a subset of the global 30" DEM called SRTM30+:
+
+   ::
+
+    G = grdcut("@earth_relief_30s", region=(-108,-103,35,40));
+
+Using :doc:`/grdinfo` we find that the data ranges from about 1000m to
+about 4300m so we need to make a CPT with that range.
+
+Color images are made with `grdimage <https://www.generic-mapping-tools.org/GMT.jl/dev/grdimage/>`_
+which takes the usual common command options (by default the **region** is taken from the data set) and a CPT;
+the main other options are:
+
+==================== ======================================================================
+Option               Purpose
+==================== ======================================================================
+**dpi**\ =val        Sets the desired resolution of the image [Default is data resolution]
+**shade**\ =grid     Use artificial illumination using intensities from a grid or *intensfile*
+**monochrom**\ =true Force gray shade using the (television) YIQ conversion
+==================== ======================================================================
+
+We want to make a plain color map with a color bar superimposed above the plot. We try
+
+   ::
+
+    C = makecpt(cmap=:rainbow, range=(1000,5000));
+    grdimage("@earth_relief_30s", region=(-108,-103,35,40), proj=:merc, frame=(axes=:WSnE,))
+    colorbar!(pos=(outside=:TC,), shade=0.4, xaxis=(annot=:auto,), ylabel=:m, show=true)
+
+Your plot should look like :ref:`our example 15 below <gmt_tut_15_jl>`
+
+.. _gmt_tut_15_jl:
+
+.. figure:: /_images/GMT_tut_15.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 15
+
+The plain color map lacks detail and fails to reveal the topographic complexity of this Rocky Mountain region.
+What it needs is artificial illumination. We want to simulate shading by a sun source in the east, hence we
+derive the required intensities from the gradients of the topography in the N90°E direction using
+`grdgradient <https://www.generic-mapping-tools.org/GMT.jl/dev/grdgradient/>`_.
+Other than the required input and output filenames, the available options are
+
+  +----------------------------------------------+-----------------------------------------------------------------------------+
+  | Option                                       | Purpose                                                                     |
+  | **azim**\ =*azimuth*                         | Azimuthal direction for gradients                                           |
+  +----------------------------------------------+-----------------------------------------------------------------------------+
+  | **colinfo**\ =*:g*                           | Indicates that this is a geographic grid                                    |
+  +----------------------------------------------+-----------------------------------------------------------------------------+
+  | **norm**\ =*\ ([laplace=true, cauchy=true,]* | Normalize gradients by *norm/offset* [= 1/0 by default].                    |
+  | *[amp=val,] [sigma=val, offset=val])*        |                                                                             |
+  +----------------------------------------------+-----------------------------------------------------------------------------+
+  |                                              | Use **cauchy**\ =true to normalize by the inverse tangent transformation.   |
+  +----------------------------------------------+-----------------------------------------------------------------------------+
+  |                                              | Insert **laplace**\ =true normalize by the cumulative Laplace distribution. |
+  +----------------------------------------------+-----------------------------------------------------------------------------+
+
+The :ref:`GMT inverse tangent transformation <gmt_atan_jl>` shows that raw slopes from bathymetry tend to be far
+from normally distributed (left). By using the inverse tangent transformation we can ensure a more uniform
+distribution (right). The inverse tangent transform simply takes the raw slope estimate (the *x* value at the arrow)
+and returns the corresponding inverse tangent value (normalized to fall in the plus/minus 1 range; horizontal
+arrow pointing to the *y*-value).
+
+.. _gmt_atan_jl:
+
+.. figure:: /_images/GMT_atan.*
+   :width: 600 px
+   :align: center
+
+   How the inverse tangent operation works. Raw slope values (left) are processed
+   via the inverse tangent operator, turning tan(x) into x and thus compressing
+   the data range. The transformed slopes are more normally distributed (right).
+
+**cauchy**\ =true and **laplace**\ =true yield well behaved gradients. Personally, we prefer to use the
+**laplace**\ =true option; the value of *norm* is subjective and you may experiment somewhat in the 0.5-5 range.
+For our case we choose
+
+    ::
+
+     Ggrad = grdgradient(G, norm=(laplace=0.8,)), azim=100, colinfo=:g);
+
+Given the CPT and the two gridded data sets we can create the shaded relief image:
+
+   ::
+
+    C = makecpt(cmap=:rainbow, range=(1000,5000));
+    G = grdcut("@earth_relief_30s", region=(-108,-103,35,40));
+    Ggrad = grdgradient(G, norm=(laplace=0.8,), azim=100, colinfo=:g);
+    grdimage(G, shade=Ggrad, proj=:merc, frame=(axes=:WSnE,))
+    colorbar!(pos=(outside=:TC,), shade=0.4, xaxis=(annot=:auto,), ylabel=:m, show=true) 
+
+Your plot should look like :ref:`our example 16 below <gmt_tut_16_jl>`
+
+.. _gmt_tut_16_jl:
+
+.. figure:: /_images/GMT_tut_16.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 16
+
+
+Exercises:
+
+#. Force a gray-shade image.
+
+#. Rerun `grdgradient <https://www.generic-mapping-tools.org/GMT.jl/dev/grdgradient/>`_ with **norm**\ =1.
+
+Multi-dimensional maps
+----------------------
+
+Climate data, like ocean temperatures or atmospheric pressure, are often provided as multi-dimensional
+(3-D, 4-D or 5-D) grids in netCDF format. This section will demonstrate that GMT is able to plot
+"horizontal" slices (spanning latitude and longitude) of such grids without much effort.
+
+As an example we will download the Seasonal Analysed Mean Temperature from the
+`World Ocean Atlas 1998 <https://psl.noaa.gov/data/gridded/data.nodc.woa98.html>`_
+The file in question is named
+otemp.anal1deg.nc (ftp://ftp.cdc.noaa.gov/Datasets/nodc.woa98/temperat/seasonal/otemp.anal1deg.nc).
+
+You can look at the information pertained in this file using the program ncdump and
+notice that the variable that we want to plot (otemp) is a four-dimensional variable of time,
+level (i.e., depth), latitude and longitude.
+
+   ::
+
+    ncdump -h otemp.anal1deg.nc
+
+We will need to make an appropriate color scale, running from -2°C (freezing temperature of salt
+water) to 30°C (highest likely ocean temperature).
+Let us focus on the temperatures in Summer (that is the third season, July through
+September) at sea level (that is the first level). To plot these in a Mollweide projection we
+use:
+
+   ::
+
+    C = makecpt(cmap=:no_green, range=(-2,30,2));
+    grdimage("@otemp.anal1deg.nc?otemp[2,0]", region=:global360, proj=(name=:Mollweide, center=180),
+             frame=(annot=:auto, grid=:auto), show=true)
+
+The addition "?otemp[2,0]" indicates which variable to retrieve from the netCDF
+file (otemp) and that we need the third time step and first level. The numbering of the
+time steps and levels starts at zero, therefore "[2,0]".
+Your plot should look like :ref:`our example 17 below <gmt_tut_17_jl>`
+
+.. _gmt_tut_17_jl:
+
+.. figure:: /_images/GMT_tut_17.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 17
+
+
+Exercises:
+
+#. Plot the temperatures for Spring at 5000 m depth. (Hint: use ncdump -v level to figure out what level number that is).
+
+#. Include a color scale at the bottom of the plot.
+
+Perspective views
+-----------------
+
+Our final undertaking in this tutorial is to examine three-dimensional perspective views. The GMT module that
+produces perspective views of gridded data files is `grdview <https://www.generic-mapping-tools.org/GMT.jl/dev/grdview/>`_.
+It can make two kinds of plots:
+
+#. Mesh or wire-frame plot (with or without superimposed contours)
+
+#. Color-coded surface (with optional shading, contours, or draping).
+
+Regardless of plot type, some arguments must be specified; these are
+
+#. *relief\_file*; a gridded data set of the surface.
+
+#. **proj** for the desired map projection.
+
+#. **zscale**\ =\ *height* for the vertical scaling.
+
+#. **view**\ =\ *(azimuth,elevation)* for the vantage point.
+
+
+In addition, some options may be required:
+
+================================= ======================================================================================
+Option                            Purpose
+================================= ======================================================================================
+**cmap**\ =\ *cpt*                The *cpt* is required for color-coded surfaces and for contoured mesh plots
+**drape**\ =\ *drape\_file*       Assign colors using *drape\_file* instead of *relief\_file*
+**shade**\ =\ *intens\_file*      File with illumination intensities
+**surftype**\ =\ *(mesh=true,)*   Selects mesh plot
+**surftype**\ =\ *(surface=true*  Surface plot using polygons; append **+m** to show mesh.
+*[,monochrome=true])*
+**surftype**\ =\ *(image=dpi[g])* Image by scan-line conversion. Specify *dpi*; append **g** to force gray-shade image.
+**pen**\ = *pen*                  Draw contours on top of surface (except with **-Qi**)
+================================= ======================================================================================
+
+Mesh-plot
+~~~~~~~~~
+
+Mesh plots work best on smaller data sets. We again use the small subset of the ETOPO5 data over Bermuda and
+will use the ocean CPT. A simple mesh plot can therefore be obtained with
+
+Your plot should look like :ref:`our example 18 below <gmt_tut_18_jl>`
+
+   ::
+
+    grdview("@earth_relief_05m", region=(-66,-60,30,35), proj=:merc, zsize=5, figsize=13, view=(135,30), show=true)
+
+.. _gmt_tut_18_jl:
+
+.. figure:: /_images/GMT_tut_18.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 18
+
+Exercises:
+
+#. Select another vantage point and vertical height.
+
+Color-coded view
+~~~~~~~~~~~~~~~~
+
+We will make a perspective, color-coded view of the US Rockies from the southeast. This is done using
+
+   ::
+
+    C = makecpt(cmap=:dem2, range=(1000,5000));
+    G = grdcut("@earth_relief_30s", region=(-108,-103,35,40));
+    Ggrad = grdgradient(G, norm=(laplace=0.8,), azim=100, colinfo=:g);
+    grdview(G, proj=:merc, figsize=10, view=(135,35), surftype=(image=50,), shade=Ggrad, zsize=1.25, show=true)
+
+Your plot should look like :ref:`our example 19 below <gmt_tut_19_jl>`
+
+.. _gmt_tut_19_jl:
+
+.. figure:: /_images/GMT_tut_19.*
+   :width: 400 px
+   :align: center
+
+   Result of GMT Tutorial example 19
+
+This plot is pretty crude since we selected 50 dpi but it is fast to render and allows us to try alternate
+values for vantage point and scaling. When we settle on the final values we select the appropriate *dpi*
+for the final output device and let it rip.
+
+Exercises:
+
+#. Choose another vantage point and scaling.
+
+#. Redo `grdgradient <https://www.generic-mapping-tools.org/GMT.jl/dev/grdgradient/>`_ with another illumination
+   direction and plot again.
+
+#. Select a higher *dpi*, e.g., 200.

--- a/doc/rst/source/tutorial_jl.rst
+++ b/doc/rst/source/tutorial_jl.rst
@@ -1,0 +1,43 @@
+#################
+Tutorial in Julia
+#################
+
+.. set default highlighting language for this document:
+
+.. highlight:: bash
+
+**Pål (Paul) Wessel**:sup:`1`,
+**Walter H. F. Smith**:sup:`2`,
+**Remko Scharroo**:sup:`3`,
+**Joaquim F. Luis**:sup:`4`, \
+**Leonardo Uieda**:sup:`5`,
+**Florian Wobbe**:sup:`6`,
+**Dongdong Tian**:sup:`7`
+
+#. SOEST, University of Hawai'i at Manoa
+#. Laboratory for Satellite Altimetry, NOAA/NESDIS/STAR
+#. EUMETSAT, Darmstadt, Germany
+#. Universidade do Algarve, Faro, Portugal
+#. University of Liverpool, UK
+#. Sea and Sun Technology, Germany
+#. China University of Geosciences, Wuhan, China
+
+The purpose of this tutorial is to introduce users to the GMT Julia wrapper, outline the
+GMT environment, and enable you to make several forms of graphics. We will not be able to
+cover all aspects of GMT nor will we necessarily cover the selected topics in sufficient detail.
+Nevertheless, it is hoped that the exposure will prompt the users to improve their GMT skills
+after completion of this short tutorial.
+
+Also, not all GMT module manuals have been converted to the verbose Julia syntax so some links
+still redirect to the hard-core GMT man pages, whilst others direct users to Julia versions of
+the translated GMT manuals. A *lost case* is the GMT CookBook that is so big/complete that it
+will take long time to see a Julia version ot it.
+
+.. toctree::
+    :maxdepth: 1
+
+    tutorial/intro_jl
+    tutorial/session-1_jl
+    tutorial/session-2_jl
+    tutorial/session-3_jl
+    tutorial/session-4_jl

--- a/doc/rst/source/tutorial_jl.rst
+++ b/doc/rst/source/tutorial_jl.rst
@@ -6,21 +6,11 @@ Tutorial in Julia
 
 .. highlight:: bash
 
-**Pål (Paul) Wessel**:sup:`1`,
-**Walter H. F. Smith**:sup:`2`,
-**Remko Scharroo**:sup:`3`,
-**Joaquim F. Luis**:sup:`4`, \
-**Leonardo Uieda**:sup:`5`,
-**Florian Wobbe**:sup:`6`,
-**Dongdong Tian**:sup:`7`
+**Joaquim F. Luis**:sup:`1`,
+**Pål (Paul) Wessel**:sup:`2`
 
-#. SOEST, University of Hawai'i at Manoa
-#. Laboratory for Satellite Altimetry, NOAA/NESDIS/STAR
-#. EUMETSAT, Darmstadt, Germany
 #. Universidade do Algarve, Faro, Portugal
-#. University of Liverpool, UK
-#. Sea and Sun Technology, Germany
-#. China University of Geosciences, Wuhan, China
+#. SOEST, University of Hawai'i at Manoa
 
 The purpose of this tutorial is to introduce users to the GMT Julia wrapper, outline the
 GMT environment, and enable you to make several forms of graphics. We will not be able to


### PR DESCRIPTION
As it says, this PR adds a version of the Tutorial translated to Julia.

One reason to submit it here is that converting the RST to Markdown (used in the Julia docs) would be a lot of work.