### PR TITLE
Let gmtinfo handle pure text files

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3409,7 +3409,7 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 		*tpos = pos;
 	}
 	if (found_text && col == 0 && !GMT->common.i.select && phys_col_type != GMT_IS_STRING) {	/* Has to be a non-GMT header with just text starting in the first column - treat as header */
-		if (strncmp (GMT->init.module_name, "batch", 5U) && strncmp (GMT->init.module_name, "movie", 5U)) {	/* Make exception for these modules what often will just read text lines */
+		if (strncmp (GMT->init.module_name, "gmtinfo", 7U) && strncmp (GMT->init.module_name, "batch", 5U) && strncmp (GMT->init.module_name, "movie", 5U)) {	/* Make exception for these modules what often will just read text lines */
 			gmt_M_free (GMT, type);
 			return GMT_NOT_OUTPUT_OBJECT;
 		}


### PR DESCRIPTION
See #6105 for background. Like **movie** and **batch**, **gmtinfo** is a module that may legitimately be given a pure text file and we should read it as such (no numerical data, just trailing text).  Closes #6105.
