### PR TITLE
Ensure we check if centroid pointer is passed

### DIFF
--- a/src/gmt_sph.c
+++ b/src/gmt_sph.c
@@ -417,10 +417,12 @@ double gmtlib_geo_centroid_area (struct GMT_CTRL *GMT, double *lon, double *lat,
 			kind = (sgn == -1) ? 0 : 1;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Spherical triangle %.4lg/%.4lg via %.4lg/%.4lg to %.4lg/%.4lg : Unit area %7.5lg oriented %3s\n", lon[0], lat[1], lon[1], lat[1], lon[2], lat[2], pol_area, way[kind]);
 		}
-		for (k = 0; k < 3; k++) C[k] = N[k] + P0[k] + P1[k];
-		gmt_normalize3v (GMT, C);
-		gmt_cart_to_geo (GMT, &clat, &centroid[GMT_X], C, true);
-		centroid[GMT_Y] = gmt_lat_swap (GMT, clat, GMT_LATSWAP_G2O+1);	/* Get geodetic latitude */
+		if (centroid) {
+			for (k = 0; k < 3; k++) C[k] = N[k] + P0[k] + P1[k];
+			gmt_normalize3v (GMT, C);
+			gmt_cart_to_geo (GMT, &clat, &centroid[GMT_X], C, true);
+			centroid[GMT_Y] = gmt_lat_swap (GMT, clat, GMT_LATSWAP_G2O+1);	/* Get geodetic latitude */
+		}
 		return (sgn * pol_area * R2);	/* Signed area in selected unit squared [km^2] */
 	}
 
@@ -447,18 +449,21 @@ double gmtlib_geo_centroid_area (struct GMT_CTRL *GMT, double *lon, double *lat,
 			kind = (sgn == -1) ? 0 : 1;
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Spherical triangle %.4lg/%.4lg via %.4lg/%.4lg to %.4lg/%.4lg : Unit area %7.5lg oriented %3s\n", center[0], center[1], lon[p-1], lat[p-1], lon[p], lat[p], tri_area, way[kind]);
 		}
-		/* Compute centroid of this spherical triangle */
-		for (k = 0; k < 3; k++) M[k] = N[k] + P0[k] + P1[k];
-		gmt_normalize3v (GMT, M);
 		/* Add up weighted contribution to polygon centroid */
 		tri_area *= sgn;
-		for (k = 0; k < 3; k++) C[k] += M[k] * tri_area;
 		pol_area += tri_area;
+		if (centroid) {	/* Compute centroid of this spherical triangle */
+			for (k = 0; k < 3; k++) M[k] = N[k] + P0[k] + P1[k];
+			gmt_normalize3v (GMT, M);
+			for (k = 0; k < 3; k++) C[k] += M[k] * tri_area;
+		}
 		if (p < n) gmt_M_memcpy (P0, P1, 3, double);	/* Make P1 the next P0 except at end */
 	}
-	for (k = 0; k < 3; k++) C[k] /= pol_area;	/* Get raw centroid */
-	gmt_normalize3v (GMT, C);
-	gmt_cart_to_geo (GMT, &clat, &centroid[GMT_X], C, true);
-	centroid[GMT_Y] = gmt_lat_swap (GMT, clat, GMT_LATSWAP_G2O+1);	/* Get geodetic latitude */
+	if (centroid) {
+		for (k = 0; k < 3; k++) C[k] /= pol_area;	/* Get raw centroid */
+		gmt_normalize3v (GMT, C);
+		gmt_cart_to_geo (GMT, &clat, &centroid[GMT_X], C, true);
+		centroid[GMT_Y] = gmt_lat_swap (GMT, clat, GMT_LATSWAP_G2O+1);	/* Get geodetic latitude */
+	}
 	return (pol_area * R2);	/* Signed area in selected unit squared [km^2] */
 }


### PR DESCRIPTION
Since a module or user may not care about the centroid but only needs the area, we only do the centroid calculation when the centroid pointer is not NULL.  This is a maintenance issue only and originated in a long-lived branch not yet ready for merging.