### PR TITLE
Enable plain geovector heads

### DIFF
--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -22,14 +22,14 @@ end point (**e**) of a line segment:
     **+b** places a vector head at the **b**\ eginning of the vector path [none].
     Optionally, append **t** for a terminal line, **c** for a circle,
     **a** for arrow [Default], **i** for tail, **A** for plain open arrow,
-    and **I** for plain open tail.
+    and **I** for plain open tail. **Note**: For geovectors only **a** and **A** are available.
     Further append **l**\|\ **r** to only draw the left or right
     half-sides of this head [both sides].
 
     **+e** places a vector head at the **e**\ nd of the vector path [none].
     Optionally, append **t** for a terminal line, **c** for a circle,
     **a** for arrow [Default], **i** for tail, **A** for plain open arrow,
-    and **I** for plain open tail.
+    and **I** for plain open tail. **Note**: For geovectors only **a** and **A** are available.
     Further append **l**\|\ **r** to only draw the left or right
     half-sides of this head [both sides].
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8453,19 +8453,19 @@ void gmt_vector_syntax (struct GMT_CTRL *GMT, unsigned int mode, int level) {
 	 * 4	= Accepts +p (not mathangle)
 	 * 8	= Accepts +g (not mathangle)
 	 * 16	= Accepts +z (not mathangle, geovector)
+	 * 32	= geovector so only a|A[l|r] available
 	 */
+	unsigned int kind = (mode & 32) ? 1 : 0;
 	struct GMTAPI_CTRL *API = GMT->parent;
+	static char *string[2] = {"Append t for terminal, c for circle, s for square, a for arrow [Default], i for tail, A for plain arrow, and I for plain tail. ",
+		"Append a for arrow [Default] or A for plain arrow. "};
 	GMT_Usage (API, -level, "Append length of vector head. Note: "
 		"Left and right sides are defined by looking from start to end of vector. Optional modifiers:");
 	GMT_Usage (API, level, "+a Set <angle> of the vector head apex [30]");
-	GMT_Usage (API, level, "+b Place a vector head at the beginning of the vector [none]. "
-		"Append t for terminal, c for circle, s for square, a for arrow [Default], "
-		"i for tail, A for plain arrow, and I for plain tail. "
-		"Append l|r to only draw left or right side of this head [both sides].");
-	GMT_Usage (API, level, "+e Place a vector head at the end of the vector [none]. "
-		"Append t for terminal, c for circle, s for square, a for arrow [Default], "
-		"i for tail, A for plain arrow, and I for plain tail. "
-		"Append l|r to only draw left or right side of this head [both sides].");
+	GMT_Usage (API, level, "+b Place a vector head at the beginning of the vector [none]. %s"
+		"Append l|r to only draw left or right side of this head [both sides].", string[kind]);
+	GMT_Usage (API, level, "+e Place a vector head at the end of the vector [none]. %s"
+		"Append l|r to only draw left or right side of this head [both sides].", string[kind]);
 	if (mode & 8) GMT_Usage (API, level, "+g Set head <fill>; exclude <fill> to turn off fill [Default fill].");
 	GMT_Usage (API, level, "+h Set vector head shape in -2/2 range [%g].", GMT->current.setting.map_vector_shape);
 	if (mode & 1) GMT_Usage (API, level, "+j Justify vector at (b)eginning [Default], (e)nd, or (c)enter.");

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -684,7 +684,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 2, "\n%s Geovector: -S=<size>[+a<angle>][+b][+e][+h<shape>][+j<just>][+l][+m][+n<norm>][+o<lon>/<lat>][+q][+r][+s][+t[b|e]<trim>][+z]", GMT_LINE_BULLET);
 	GMT_Usage (API, -3, "Azimuth and length must be in columns 3-4. "
 		"Append any of the units in %s to length [k].", GMT_LEN_UNITS_DISPLAY);
-	gmt_vector_syntax (API->GMT, 3, 3);
+	gmt_vector_syntax (API->GMT, 3+32, 3);
 	if (API->GMT->current.setting.run_mode == GMT_CLASSIC)	/* -T has no purpose in modern mode */
 		GMT_Usage (API, 1, "\n-T Ignore all input files.");
 	GMT_Option (API, "U,V");

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -338,7 +338,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 2, "\n%s Geovector: -S=<size>[+a<angle>][+b][+e][+h<shape>][+j<just>][+l][+m][+n<norm>][+o<lon>/<lat>][+q][+r][+s][+t[b|e]<trim>][+z]", GMT_LINE_BULLET);
 	GMT_Usage (API, -3, "Azimuth and length must be in columns 4-5. "
 		"Append any of the units in %s to length [k].", GMT_LEN_UNITS_DISPLAY);
-	gmt_vector_syntax (API->GMT, 3, 3);
+	gmt_vector_syntax (API->GMT, 3+32, 3);
 
 	if (API->GMT->current.setting.run_mode == GMT_CLASSIC)	/* -T has no purpose in modern mode */
 		GMT_Usage (API, 1, "\n-T Ignore all input files.");

--- a/test/psxy/geovecplain.ps
+++ b/test/psxy/geovecplain.ps
@@ -1,0 +1,2124 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.4.0_22f90e3_2021.12.12 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec 12 06:58:14 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R-0.25/1/-0.25/1 -JM15c -S=32p+eA+bA -W2p -B --MAP_FRAME_TYPE=plain
+%@PROJ: merc -0.25000000 1.00000000 -0.25000000 1.00000000 -69574.682 69574.682 -27643.658 110579.965 +proj=merc +lon_0=0.375 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+8 W
+0 A
+N 0 0 M 0 -64 D S
+N 1417 0 M 0 -64 D S
+N 2835 0 M 0 -64 D S
+N 4252 0 M 0 -64 D S
+N 5669 0 M 0 -64 D S
+N 7087 0 M 0 -64 D S
+N 0 0 M -64 0 D S
+N 0 1408 M -64 0 D S
+N 0 2816 M -64 0 D S
+N 0 4224 M -64 0 D S
+N 0 5631 M -64 0 D S
+N 0 7039 M -64 0 D S
+N 0 0 M 0 -32 D S
+N 472 0 M 0 -32 D S
+N 945 0 M 0 -32 D S
+N 1417 0 M 0 -32 D S
+N 1890 0 M 0 -32 D S
+N 2362 0 M 0 -32 D S
+N 2835 0 M 0 -32 D S
+N 3307 0 M 0 -32 D S
+N 3780 0 M 0 -32 D S
+N 4252 0 M 0 -32 D S
+N 4724 0 M 0 -32 D S
+N 5197 0 M 0 -32 D S
+N 5669 0 M 0 -32 D S
+N 6142 0 M 0 -32 D S
+N 6614 0 M 0 -32 D S
+N 7087 0 M 0 -32 D S
+N 0 0 M -32 0 D S
+N 0 469 M -32 0 D S
+N 0 939 M -32 0 D S
+N 0 1408 M -32 0 D S
+N 0 1877 M -32 0 D S
+N 0 2346 M -32 0 D S
+N 0 2816 M -32 0 D S
+N 0 3285 M -32 0 D S
+N 0 3754 M -32 0 D S
+N 0 4224 M -32 0 D S
+N 0 4693 M -32 0 D S
+N 0 5162 M -32 0 D S
+N 0 5631 M -32 0 D S
+N 0 6101 M -32 0 D S
+N 0 6570 M -32 0 D S
+N 0 7039 M -32 0 D S
+0 -113 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+161 F0
+(0è15©W) tc Z
+1417 -113 M (0è00©) tc Z
+2835 -113 M (0è15©E) tc Z
+4252 -113 M (0è30©E) tc Z
+5669 -113 M (0è45©E) tc Z
+7087 -113 M (1è00©E) tc Z
+/PSL_AH1 0
+-113 0 M (0è15©S) mr Z
+(0è15©S) sw mx
+-113 1408 M (0è00©) mr Z
+(0è00©) sw mx
+-113 2816 M (0è15©N) mr Z
+(0è15©N) sw mx
+-113 4224 M (0è30©N) mr Z
+(0è30©N) sw mx
+-113 5631 M (0è45©N) mr Z
+(0è45©N) sw mx
+-113 7039 M (1è00©N) mr Z
+(1è00©N) sw mx
+def
+clipsave
+0 0 M
+7087 0 D
+0 7039 D
+-7087 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+O0
+/FO {P}!
+272 2827 M
+35 36 D
+18 17 D
+17 18 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+54 52 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+54 52 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+45 43 D
+35 36 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+98 96 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+54 52 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+107 105 D
+17 18 D
+24 -24 D
+-36 -35 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-54 -52 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-98 -96 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-98 -96 D
+-26 -27 D
+-18 -17 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+FQ
+O1
+747 3081 M
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-11 -6 D
+13 21 D
+155 268 D
+13 21 D
+12 22 D
+13 21 D
+62 107 D
+S
+3426 6131 M
+140 80 D
+21 13 D
+302 173 D
+-12 -22 D
+-13 -21 D
+-155 -268 D
+-13 -21 D
+-75 -129 D
+S
+U
+U
+PSL_cliprestore
+24 W
+0 A
+0 0 M
+7087 0 D
+0 7039 D
+-1772 0 D
+-1772 0 D
+-1771 0 D
+-1772 0 D
+0 -7039 D
+P S
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=32p+eAl+bAr -W2p -R-0.25/1/-0.25/1 -JM15c
+%@PROJ: merc -0.25000000 1.00000000 -0.25000000 1.00000000 -69574.682 69574.682 -27643.658 110579.965 +proj=merc +lon_0=0.375 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 7039 D
+-7087 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+1405 2827 M
+54 53 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+54 52 D
+26 27 D
+27 26 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+107 105 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+98 96 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+54 52 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+98 96 D
+26 27 D
+24 -24 D
+-36 -35 D
+-17 -18 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-54 -52 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-107 -105 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-98 -96 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-98 -96 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-54 -52 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-107 -105 D
+-17 -18 D
+-18 -17 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+FQ
+O1
+1865 3072 M
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+98 96 D
+26 27 D
+27 26 D
+17 18 D
+98 96 D
+8 9 D
+S
+4575 6140 M
+22 12 D
+21 13 D
+192 110 D
+213 122 D
+-89 -88 D
+-17 -18 D
+-89 -87 D
+-35 -36 D
+-27 -26 D
+-8 -9 D
+-9 -8 D
+S
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=32p+eal+bar -Gred -W2p -R-0.25/1/-0.25/1 -JM15c
+%@PROJ: merc -0.25000000 1.00000000 -0.25000000 1.00000000 -69574.682 69574.682 -27643.658 110579.965 +proj=merc +lon_0=0.375 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 7039 D
+-7087 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+1670 556 M
+45 44 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+54 52 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+107 105 D
+17 18 D
+89 87 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+107 105 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+54 52 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+18 17 D
+23 -23 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-54 -52 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-98 -96 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-107 -105 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-54 -52 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+1895 556 M
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-22 -12 D
+-22 -12 D
+-21 -11 D
+-22 -12 D
+-22 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-22 -11 D
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-22 -12 D
+-22 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-22 -11 D
+-22 -12 D
+-11 -6 D
+18 17 D
+8 9 D
+9 8 D
+17 18 D
+9 8 D
+8 9 D
+9 8 D
+8 9 D
+104 102 D
+8 9 D
+9 8 D
+8 9 D
+35 34 D
+8 9 D
+26 25 D
+PSL_clip N
+1895 556 M
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-22 -12 D
+-22 -12 D
+-21 -11 D
+-22 -12 D
+-22 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-22 -11 D
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-22 -12 D
+-22 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-22 -11 D
+-22 -12 D
+-11 -6 D
+18 17 D
+8 9 D
+9 8 D
+17 18 D
+9 8 D
+8 9 D
+9 8 D
+8 9 D
+104 102 D
+8 9 D
+9 8 D
+8 9 D
+35 34 D
+8 9 D
+26 25 D
+FO
+1895 556 M
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-22 -12 D
+-22 -12 D
+-21 -11 D
+-22 -12 D
+-22 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-22 -11 D
+-22 -12 D
+-21 -12 D
+-22 -11 D
+-22 -12 D
+-22 -12 D
+-22 -11 D
+-21 -12 D
+-22 -12 D
+-22 -11 D
+-22 -12 D
+-11 -6 D
+18 17 D
+8 9 D
+9 8 D
+17 18 D
+9 8 D
+8 9 D
+9 8 D
+8 9 D
+104 102 D
+8 9 D
+9 8 D
+8 9 D
+35 34 D
+8 9 D
+26 25 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+2 setlinecap
+O0
+clipsave
+4545 3589 M
+304 163 D
+185 99 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-104 -102 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-61 -59 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+PSL_clip N
+4545 3589 M
+304 163 D
+185 99 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-104 -102 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-61 -59 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+FO
+4545 3589 M
+304 163 D
+185 99 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-104 -102 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+-61 -59 D
+-8 -9 D
+-9 -8 D
+-8 -9 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=32p+ea+ba -Gred -W2p -R-0.25/1/-0.25/1 -JM15c
+%@PROJ: merc -0.25000000 1.00000000 -0.25000000 1.00000000 -69574.682 69574.682 -27643.658 110579.965 +proj=merc +lon_0=0.375 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+7087 0 D
+0 7039 D
+-7087 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+2814 566 M
+62 61 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+17 18 D
+89 87 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+89 87 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+26 27 D
+27 26 D
+8 9 D
+98 96 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+36 35 D
+8 9 D
+45 43 D
+35 36 D
+18 17 D
+17 18 D
+89 87 D
+17 18 D
+24 -24 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-27 -26 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-89 -87 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-98 -96 D
+-26 -27 D
+-27 -26 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-35 -36 D
+-18 -17 D
+-17 -18 D
+-36 -35 D
+-8 -9 D
+-45 -43 D
+-26 -27 D
+-27 -26 D
+-17 -18 D
+-36 -35 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+3015 547 M
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-11 -6 D
+62 107 D
+13 21 D
+68 118 D
+13 21 D
+74 129 D
+13 21 D
+25 43 D
+16 -179 D
+PSL_clip N
+3015 547 M
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-11 -6 D
+62 107 D
+13 21 D
+68 118 D
+13 21 D
+74 129 D
+13 21 D
+25 43 D
+16 -179 D
+FO
+3015 547 M
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-11 -6 D
+62 107 D
+13 21 D
+68 118 D
+13 21 D
+74 129 D
+13 21 D
+25 43 D
+16 -179 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+2 setlinecap
+O0
+clipsave
+5693 3597 M
+205 117 D
+237 136 D
+21 13 D
+-80 -140 D
+-13 -21 D
+-68 -118 D
+-13 -21 D
+-74 -129 D
+-13 -21 D
+-6 -11 D
+-16 179 D
+PSL_clip N
+5693 3597 M
+205 117 D
+237 136 D
+21 13 D
+-80 -140 D
+-13 -21 D
+-68 -118 D
+-13 -21 D
+-74 -129 D
+-13 -21 D
+-6 -11 D
+-16 179 D
+FO
+5693 3597 M
+205 117 D
+237 136 D
+21 13 D
+-80 -140 D
+-13 -21 D
+-68 -118 D
+-13 -21 D
+-74 -129 D
+-13 -21 D
+-6 -11 D
+-16 179 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psxy/geovecplain.sh
+++ b/test/psxy/geovecplain.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Test that plain-headed geovectors work
+
+gmt begin geovecplain
+	echo -0.2 0.25 45 100 | gmt plot -R-0.25/1/-0.25/1 -JM15c -S=32p+eA+bA -W2p -B --MAP_FRAME_TYPE=plain
+	echo 0 0.25 45 100 | gmt plot -S=32p+eAl+bAr -W2p
+	echo 0 -0.2 45 100 | gmt plot -S=32p+eal+bar -Gred -W2p
+	echo 0.2 -0.2 45 100 | gmt plot -S=32p+ea+ba -Gred -W2p
+gmt end show


### PR DESCRIPTION
Closes #6111.  This PR adds plain vector heads to the geovector plot code and updates the documentation to only list **a** (filled) and **A** (plain) as available head types for geovectors.  New test example _geovecplain.sh_ added:

![geovecplain](https://user-images.githubusercontent.com/26473567/145722020-d70ed810-18b1-4713-b702-66c71b938f41.jpg)
