### PR TITLE
Add optional fraction for terminal shrinking value

### DIFF
--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -51,7 +51,7 @@ end point (**e**) of a line segment:
 
     **+n**\ *norm*\ [/*min*] scales down vector attributes (pen thickness, head size)
     with decreasing length, where vector plot lengths shorter than *norm* will have
-    their attributes scaled by length/\ *norm* [other arrow attributes remains
+    their attributes scaled by length/\ *norm* [other arrow attributes remain
     invariant to length]. For Cartesian vectors specify a length in plot units, while
     for geovectors specify a length in km. Optionally, append /*min* for the minimum
     shrink factor (in the 0-1 range) that we will shrink to [0.25].

--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -51,10 +51,10 @@ end point (**e**) of a line segment:
 
     **+n**\ *norm*\ [/*min*] scales down vector attributes (pen thickness, head size)
     with decreasing length, where vector plot lengths shorter than *norm* will have
-    their attributes scaled by length/\ *norm* [arrow attributes remains
+    their attributes scaled by length/\ *norm* [other arrow attributes remains
     invariant to length]. For Cartesian vectors specify a length in plot units, while
-    for geovectors specify a length in km. Optionally, append the minimum fraction
-    (0-1 range) of the full size we will shrink to [0].
+    for geovectors specify a length in km. Optionally, append /*min* for the minimum
+    shrink factor (in the 0-1 range) that we will shrink to [0.25].
 
     **+o**\ [*plon*\ /\ *plat*] specifies the oblique pole for the great or
     small circles.  Only needed for great circles if **+q** is given. If no

--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -49,11 +49,12 @@ end point (**e**) of a line segment:
     and **I** for plain open tail. Further append **l**\|\ **r** to only draw the left or right
     half-sides of this head [both sides].  Cannot be combined with **+b** or **+e**.
 
-    **+n**\ *norm* scales down vector attributes (pen thickness, head size)
+    **+n**\ *norm*\ [/*min*] scales down vector attributes (pen thickness, head size)
     with decreasing length, where vector plot lengths shorter than *norm* will have
     their attributes scaled by length/\ *norm* [arrow attributes remains
     invariant to length]. For Cartesian vectors specify a length in plot units, while
-    for geovectors specify a length in km.
+    for geovectors specify a length in km. Optionally, append the minimum fraction
+    (0-1 range) of the full size we will shrink to [0].
 
     **+o**\ [*plon*\ /\ *plat*] specifies the oblique pole for the great or
     small circles.  Only needed for great circles if **+q** is given. If no

--- a/src/geodesy/psvelo.c
+++ b/src/geodesy/psvelo.c
@@ -1280,6 +1280,7 @@ EXTERN_MSC int GMT_psvelo (void *V_API, int mode, void *args) {
 						n_warn++;
 					}
 					s = (length < Ctrl->A.S.v.v_norm) ? length / Ctrl->A.S.v.v_norm : 1.0;
+					if (s < Ctrl->A.S.v.v_norm_limit) s = Ctrl->A.S.v.v_norm_limit;
 					hw = s * Ctrl->A.S.v.h_width;
 					hl = s * Ctrl->A.S.v.h_length;
 					vw = s * Ctrl->A.S.v.v_width;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8474,7 +8474,7 @@ void gmt_vector_syntax (struct GMT_CTRL *GMT, unsigned int mode, int level) {
 		"Append f or r for forward|reverse direction [forward]. "
 		"Append t for terminal, c for circle, s for square, or a for arrow [Default]. "
 		"Append l|r to only draw left or right side of this head [both sides].");
-	GMT_Usage (API, level, "+n Shrink attributes if vector length < <norm> [none]; optionally, append /<terminal> shrink fraction [0]");
+	GMT_Usage (API, level, "+n Shrink attributes if vector length < <norm> [none]; optionally, append /<min> to change the minimum shrink factor [0.25]");
 	GMT_Usage (API, level, "+o Set pole <plon/plat> [Default is north pole] for great or small circles; only give length via input.");
 	if (mode & 4) GMT_Usage (API, level, "+p Set pen attributes; exclude <pen> to turn off head outlines [Default pen and outline].");
 	GMT_Usage (API, level, "+q Start and stop opening angles are given instead of (azimuth,length) on input.");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8474,7 +8474,7 @@ void gmt_vector_syntax (struct GMT_CTRL *GMT, unsigned int mode, int level) {
 		"Append f or r for forward|reverse direction [forward]. "
 		"Append t for terminal, c for circle, s for square, or a for arrow [Default]. "
 		"Append l|r to only draw left or right side of this head [both sides].");
-	GMT_Usage (API, level, "+n Shrink attributes if vector length < <norm> [none].");
+	GMT_Usage (API, level, "+n Shrink attributes if vector length < <norm> [none]; optionally, append /<terminal> shrink fraction [0]");
 	GMT_Usage (API, level, "+o Set pole <plon/plat> [Default is north pole] for great or small circles; only give length via input.");
 	if (mode & 4) GMT_Usage (API, level, "+p Set pen attributes; exclude <pen> to turn off head outlines [Default pen and outline].");
 	GMT_Usage (API, level, "+q Start and stop opening angles are given instead of (azimuth,length) on input.");
@@ -15941,7 +15941,7 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 	size_t len;
 	bool p_opt = false, g_opt = false;
 	int j;
-	char p[GMT_BUFSIZ];
+	char p[GMT_BUFSIZ], *c = NULL;
 	double value[2];
 
 	S->v.pen = GMT->current.setting.map_default_pen;
@@ -16069,6 +16069,14 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 				}
 				break;
 			case 'n':	/* Vector shrinking head */
+				if ((c = strchr (p, '/'))) {
+					S->v.v_norm_limit = atof (&c[1]);
+					c[0] = '\0';	/* Chop off after getting the value */
+					if (S->v.v_norm_limit < 0.0 || S->v.v_norm_limit > 1.0) {
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Vector shrink terminal fraction must be in 0-1 range\n");
+						error++;
+					}
+				}
 				len = strlen (p);
 				j = (symbol == 'v' || symbol == 'V') ? gmt_get_dim_unit (GMT, p[len-1]) : -1;	/* Only -Sv|V takes unit */
 				S->v.v_norm = (float)atof (&p[1]);	/* This is normalizing length in given units, not (yet) converted to inches or degrees (but see next lines) */
@@ -16084,7 +16092,7 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 				else	/* Convert length from default unit to inches */
 					S->v.v_norm *= GMT->session.u2u[GMT->current.setting.proj_length_unit][GMT_INCH];
 				/* Here, v_norm is either in inches (if Cartesian vector) or spherical degrees (if geovector) */
-				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Vector shrink scale v_norm = %g\n", S->v.v_norm);
+				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Vector shrink scale v_norm = %g going down to %g %% of head size\n", S->v.v_norm, 100.0 * S->v.v_norm_limit);
 				break;
 			case 'o':	/* Sets oblique pole for small or great circles */
 				S->v.status |= PSL_VEC_POLE;

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -4957,6 +4957,8 @@ GMT_LOCAL unsigned int gmtplot_geo_vector_smallcircle (struct GMT_CTRL *GMT, dou
 	}
 	else
 		s = s2;
+	if (s < S->v.v_norm_limit) s = S->v.v_norm_limit;
+	if (s1 < S->v.v_norm_limit) s1 = S->v.v_norm_limit;
 	head_length = s * S->size_x;
 	arc_width   = s1 * S->v.v_width;	/* Use scale s1 for pen shrinking */
 
@@ -5196,6 +5198,8 @@ GMT_LOCAL unsigned int gmtplot_geo_vector_greatcircle (struct GMT_CTRL *GMT, dou
 	}
 	else
 		s = s2;
+	if (s < S->v.v_norm_limit) s = S->v.v_norm_limit;
+	if (s1 < S->v.v_norm_limit) s1 = S->v.v_norm_limit;
 	head_length = s * S->size_x;
 	arc_width   = s1 * S->v.v_width;	/* Use scale s1 for pen shrinking */
 	gmt_M_memcpy (olon, C.lon, 2, double);	gmt_M_memcpy (olat, C.lat, 2, double);	/* Keep copy of original coordinates */

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -114,6 +114,7 @@ struct GMT_VECT_ATTR {
 	bool parsed_v4;		/* true if we parsed old-style <vectorwidth/headlength/headwidth> attribute */
 	float v_angle;		/* Head angle */
 	float v_norm;		/* shrink when lengths are smaller than this */
+	float v_norm_limit;	/* Only shrink down to this factor [0] */
 	float v_stem;		/* Min length in % of visible vector when head is large [10%] */
 	float v_width;		/* Width of vector stem in inches */
 	float v_shape;		/* Shape of vector head [MAP_VECTOR_SHAPE] */

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -757,6 +757,7 @@ EXTERN_MSC int GMT_grdvector (void *V_API, int mode, void *args) {
 				dim[PSL_VEC_HEAD_PENWIDTH] = headpen_width;	/* Possibly shrunk head pen width */
 				if (scaled_vec_length < Ctrl->Q.S.v.v_norm) {	/* Scale arrow attributes down with length */
 					f = scaled_vec_length / Ctrl->Q.S.v.v_norm;
+					if (f < Ctrl->Q.S.v.v_norm_limit) f = Ctrl->Q.S.v.v_norm_limit;
 					for (k = 2; k <= 4; k++) dim[k] *= f;
 					dim[PSL_VEC_HEAD_PENWIDTH] *= f;
 				}

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -896,6 +896,7 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 				dim[PSL_VEC_XTIP] = radius * c;
 				dim[PSL_VEC_YTIP] = radius * s;
 				f = (radius < Ctrl->M.S.v.v_norm) ? radius / Ctrl->M.S.v.v_norm : 1.0;
+				if (f < Ctrl->M.S.v.v_norm_limit) f = Ctrl->M.S.v.v_norm_limit;
 				dim[PSL_VEC_TAIL_WIDTH]  = f * Ctrl->M.S.v.v_width;
 				dim[PSL_VEC_HEAD_LENGTH] = f * Ctrl->M.S.v.h_length;
 				dim[PSL_VEC_HEAD_WIDTH]  = f * Ctrl->M.S.v.h_width;

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2060,6 +2060,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 							n_warn[1]++;
 						}
 						s = (length < S.v.v_norm) ? length / S.v.v_norm : 1.0;
+						if (s < S.v.v_norm_limit) s = S.v.v_norm_limit;
 						dim[PSL_VEC_XTIP]        = x_2;
 						dim[PSL_VEC_YTIP]        = y_2;
 						dim[PSL_VEC_TAIL_WIDTH]  = s * S.v.v_width;
@@ -2120,6 +2121,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 							continue;
 						}
 						s = (length < S.v.v_norm) ? length / S.v.v_norm : 1.0;
+						if (s < S.v.v_norm_limit) s = S.v.v_norm_limit;
 						dim[PSL_MATHARC_HEAD_LENGTH]     = s * S.v.h_length;
 						dim[PSL_MATHARC_HEAD_WIDTH]      = s * S.v.h_width;
 						dim[PSL_MATHARC_ARC_PENWIDTH]    = s * S.v.v_width;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1477,6 +1477,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 					data[n].dim[PSL_VEC_XTIP] = x_2;
 					data[n].dim[PSL_VEC_YTIP] = y_2;
 					s = (data[n].dim[1] < S.v.v_norm) ? data[n].dim[1] / S.v.v_norm : 1.0;
+					if (s < S.v.v_norm_limit) s = S.v.v_norm_limit;
 					data[n].dim[PSL_VEC_TAIL_WIDTH]  = s * S.v.v_width;
 					data[n].dim[PSL_VEC_HEAD_LENGTH] = s * S.v.h_length;
 					data[n].dim[PSL_VEC_HEAD_WIDTH]  = s * S.v.h_width;
@@ -1527,6 +1528,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 						continue;
 					}
 					s = (length < S.v.v_norm) ? length / S.v.v_norm : 1.0;
+					if (s < S.v.v_norm_limit) s = S.v.v_norm_limit;
 					data[n].dim[PSL_MATHARC_HEAD_LENGTH]     = s * S.v.h_length;	/* Length of (shrunk) vector head */
 					data[n].dim[PSL_MATHARC_HEAD_WIDTH]      = s * S.v.h_width;	/* Width of (shrunk) vector head */
 					data[n].dim[PSL_MATHARC_ARC_PENWIDTH]    = s * S.v.v_width;	/* Thickness of (shrunk) vector */

--- a/test/geodesy/geodesy_06.sh
+++ b/test/geodesy/geodesy_06.sh
@@ -29,5 +29,5 @@ cat << EOF > test.csv
 EOF
 gmt begin geodesy_06 ps
   gmt velo -JX6.5i/9i -R0/2100/0/2700 -B test.csv -A+ea -Se600c/0+f8p -Gblack -Wthicker,black
-  gmt velo test.csv -A+ea+n1c -Se600c/0+f8p -Gorange -Wthicker,orange
+  gmt velo test.csv -A+ea+n1c/0 -Se600c/0+f8p -Gorange -Wthicker,orange
 gmt end show

--- a/test/geodesy/geodesy_07.sh
+++ b/test/geodesy/geodesy_07.sh
@@ -31,15 +31,15 @@ gmt begin -C geodesy_07 ps
 	gmt makecpt -Cturbo -T0/5
 	gmt set MAP_FRAME_TYPE plain
 	gmt subplot begin 4x2 -Fs5c -JM5c -R-124.6/-123.3/40/41 -A+jTR+gwhite -Scb -Srl+p -BWSrt -M6p/10p -Ba1
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5   -Se0.50/0+f0 -Gorange -W1.5p -c
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5   -Se0.50/0+f0 -Gorange -W1.5p,orange -c
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5   -Se0.50/0+f0 -C -W1.5p -c
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5   -Se0.50/0+f0 -C -W1.5p+c -c
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5+p -Se0.50/0+f0 -C -W1.5p+c -c
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5+p -Se0.50/0.95+f0 -D10 -C -W1.5p+c -c
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5+p -Se0.50/0.95+f0 -D10 -C -W1.5p+c -L0.25p -Elightgray -c
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5   -Se0.50/0+f0 -Gorange -W1.5p -c
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5   -Se0.50/0+f0 -Gorange -W1.5p,orange -c
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5   -Se0.50/0+f0 -C -W1.5p -c
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5   -Se0.50/0+f0 -C -W1.5p+c -c
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5+p -Se0.50/0+f0 -C -W1.5p+c -c
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5+p -Se0.50/0.95+f0 -D10 -C -W1.5p+c -c
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5+p -Se0.50/0.95+f0 -D10 -C -W1.5p+c -L0.25p -Elightgray -c
 		# Plot vectors a 2nd time so they all overlay all the ellipses
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5+p -Se0.50/0.0+f0 -D10 -C -W1.5p+c
-		gmt velo GPS_test.txt -A10p+e+a40+n6k+h0.5+p -Se0.50/0.95+f0 -D10 -C -W1.5p+c -L0.25p+c -c -Zn
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5+p -Se0.50/0.0+f0 -D10 -C -W1.5p+c
+		gmt velo GPS_test.txt -A10p+e+a40+n6k/0+h0.5+p -Se0.50/0.95+f0 -D10 -C -W1.5p+c -L0.25p+c -c -Zn
 	gmt subplot end
 gmt end show

--- a/test/geodesy/geodesy_08.sh
+++ b/test/geodesy/geodesy_08.sh
@@ -39,7 +39,7 @@ cat << EOF > main.sh
 gmt begin
 	gmt basemap -R-124.6/-123.3/40/41 -JM5i -B -BWSne -Y0.5i -X0.75i --MAP_FRAME_TYPE=plain
 	gmt events labels.txt -L1 -Et -T\${MOVIE_COL0} -F+f12p,Helvetica-Bold,red+jBL -Dj0.1c --TIME_UNIT=d
-	gmt events -Z"velo -A18p+e+a40+n6k+h0.5 -Se0.50/0" -Ct.cpt -W1.5 -N data.txt -T\${MOVIE_COL0} -Es+r1+p1+d1+f1 -Mi1+c-0.5 -Ms2+c0.5 -Mt+c0 -L3 --TIME_UNIT=d
+	gmt events -Z"velo -A18p+e+a40+n6k/0+h0.5 -Se0.50/0" -Ct.cpt -W1.5 -N data.txt -T\${MOVIE_COL0} -Es+r1+p1+d1+f1 -Mi1+c-0.5 -Ms2+c0.5 -Mt+c0 -L3 --TIME_UNIT=d
 gmt end
 EOF
 #gmt movie main.sh -C6ix6ix100 -Ngeodesy_08 -Fmp4 -Mm,ps -Lc0+jTR+o1c/1.5c -Lf+o2c/1.5c -Ttime.txt -Z --FORMAT_CLOCK_MAP=hh

--- a/test/geodesy/gpsgridder1.sh
+++ b/test/geodesy/gpsgridder1.sh
@@ -46,7 +46,7 @@ gmt pscoast $R -JM7i -P -Glightgray -Ba1f30m -BWSne -K -Df -X1i -Wfaint > $ps
 gmt psxy @CA_fault_data.txt -J -R -W0.5p -O -K >> $ps
 gmt psvelo data.lluvenct -J -R -Se.008i/0.95+f8p -A9p -W0.2p,red -O -K >> $ps
 # Shrink down heads of vectors shorter than 10 km
-gmt grdvector GPS_u.nc GPS_v.nc -Ix${DEC}/${DEC} -J -R -O -K -Q0.06i+e+n10 -Gblue -W0.2p,blue -S100i --MAP_VECTOR_SHAPE=0.2 >> $ps
+gmt grdvector GPS_u.nc GPS_v.nc -Ix${DEC}/${DEC} -J -R -O -K -Q0.06i+e+n10/0 -Gblue -W0.2p,blue -S100i --MAP_VECTOR_SHAPE=0.2 >> $ps
 #
 # Place the scale using a geovector of length RATE
 #

--- a/test/geodesy/gpsgridder2.sh
+++ b/test/geodesy/gpsgridder2.sh
@@ -46,7 +46,7 @@ gmt pscoast $R -JM7i -P -Glightgray -Ba1f30m -BWSne -K -Df -X1i -Wfaint > $ps
 gmt psxy @CA_fault_data.txt -J -R -W0.5p -O -K >> $ps
 gmt psvelo data.lluvenct -J -R -Se.008i/0.95+f8p -A9p -W0.2p,red -O -K >> $ps
 # Shrink down heads of vectors shorter than 10 km
-gmt grdvector GPS_u.nc GPS_v.nc -Ix${DEC}/${DEC} -J -R -O -K -Q0.06i+e+n10 -Gblue -W0.2p,blue -S100i --MAP_VECTOR_SHAPE=0.2 >> $ps
+gmt grdvector GPS_u.nc GPS_v.nc -Ix${DEC}/${DEC} -J -R -O -K -Q0.06i+e+n10/0 -Gblue -W0.2p,blue -S100i --MAP_VECTOR_SHAPE=0.2 >> $ps
 #
 # Place the scale using a geovector of length RATE
 #

--- a/test/grdvector/plate.sh
+++ b/test/grdvector/plate.sh
@@ -10,6 +10,6 @@ ps=plate.ps
 echo "80	60	10	10" > E.txt
 gmt grdpmodeler -Rg -I10 -r -EE.txt -Gplate_%s.nc -Sar -T10
 gmt psbasemap -A -R-30/80/-5/70 -JM3.5i > tmp
-gmt grdvector plate_vel.nc plate_az.nc -A -R-30/80/-5/70 -JM3.5i -P -Baf -BWSnE -Q0.1i+e+n50 -W0.25p -Gblack -S200i -K -Xc -Y0.75i > $ps
-gmt grdvector plate_vel.nc plate_az.nc -A -JG30/0/6i -O -K -Baf -Q0.1i+e+n50 -W0.25p -Gblack -S200i -X-1.25i -Y3.6i >> $ps
+gmt grdvector plate_vel.nc plate_az.nc -A -R-30/80/-5/70 -JM3.5i -P -Baf -BWSnE -Q0.1i+e+n50/0 -W0.25p -Gblack -S200i -K -Xc -Y0.75i > $ps
+gmt grdvector plate_vel.nc plate_az.nc -A -JG30/0/6i -O -K -Baf -Q0.1i+e+n50/0 -W0.25p -Gblack -S200i -X-1.25i -Y3.6i >> $ps
 gmt psxy -R -J -O -W0.25p,blue tmp >> $ps

--- a/test/grdvector/shrink.sh
+++ b/test/grdvector/shrink.sh
@@ -7,11 +7,11 @@ cat << EOF > line
 180	-30
 180	60
 EOF
-gmt grdvector x.nc y.nc -JM6i -Si1k -Q0.1i+n1260 -W1.5p -Gred -Ba -BWSne -P -K -Xc > $ps
+gmt grdvector x.nc y.nc -JM6i -Si1k -Q0.1i+n1260/0 -W1.5p -Gred -Ba -BWSne -P -K -Xc > $ps
 gmt psxy -R -J -O -K -W0.5p,blue line >> $ps
-gmt grdvector x.nc y.nc -R -J -Si1k -Q0.1i+b+e+n1260+jc -W0.5p -Gred -Ba -BWSne -O -K -Y2.3i >> $ps
+gmt grdvector x.nc y.nc -R -J -Si1k -Q0.1i+b+e+n1260/0+jc -W0.5p -Gred -Ba -BWSne -O -K -Y2.3i >> $ps
 gmt psxy -R -J -O -K -W0.5p,blue line >> $ps
 gmt grdvector x.nc y.nc -R -J -Si1k -Q0.1i+e -W1p -Gred -Ba -BWSne -O -K -Y2.3i >> $ps
 #psxy -R -J -O -K -W0.5p,blue line >> $ps
-gmt grdvector x.nc y.nc -R -J -Si1k -Q0.1i+e+n1260 -W1p -Gred -Ba -BWSne+t"Shrink <----> Constant" -O -K -Y2.3i >> $ps
+gmt grdvector x.nc y.nc -R -J -Si1k -Q0.1i+e+n1260/0 -W1p -Gred -Ba -BWSne+t"Shrink <----> Constant" -O -K -Y2.3i >> $ps
 gmt psxy -R -J -O -W0.5p,blue line >> $ps

--- a/test/grdvector/wrapped.sh
+++ b/test/grdvector/wrapped.sh
@@ -5,9 +5,9 @@ L=6000
 echo 345	15	60 3000 > t.txt
 echo 185	15	45	3000 >> t.txt
 # +n used but L is too small, hence only the head test apply
-gmt psxy -R0/360/0/30 -JM6i -P -K -Ba -Gred -S=1i+e+n$L -W3p t.txt -Xc > $ps
-gmt psxy -R0/360/0/30 -JM6i -O -K -Ba -S=0.5i+e+n$L+pfaint,blue -W3p t.txt -Y1.5i >> $ps
-gmt psxy -R0/360/0/30 -JM6i -O -K -Ba -S=1i+n$L -W3p t.txt -Y1.5i >> $ps
+gmt psxy -R0/360/0/30 -JM6i -P -K -Ba -Gred -S=1i+e+n$L/0 -W3p t.txt -Xc > $ps
+gmt psxy -R0/360/0/30 -JM6i -O -K -Ba -S=0.5i+e+n$L/0+pfaint,blue -W3p t.txt -Y1.5i >> $ps
+gmt psxy -R0/360/0/30 -JM6i -O -K -Ba -S=1i+n$L/0 -W3p t.txt -Y1.5i >> $ps
 gmt psxy -R0/360/0/30 -JM6i -O -K -Ba -Gred -S=0.25i+e -W3p t.txt -Y1.5i >> $ps
 gmt psxy -R0/360/0/30 -JM6i -O -K -Ba -S=0.25i+e+pfaint,blue -W3p t.txt -Y1.5i >> $ps
 gmt psxy -R0/360/0/30 -JM6i -O -Ba -S=1i -W3p t.txt -Y1.5i >> $ps

--- a/test/modern/shrinkvec1.sh
+++ b/test/modern/shrinkvec1.sh
@@ -3,8 +3,8 @@
 # Fill and pen etc. set on command line
 gmt begin shrinkvec1 ps
 	gmt math -T0/2/0.1 -o1,0 0 = | awk '{printf "%s\t%s\t0\t%si\t%s\n", $1, $2, $2, $2}' > data.txt
-	gmt plot data.txt -R0/1/0/2.1 -JX2i/9i -Sv0.5i+ea+h0.4+jb+n2i -W3p -B -BWStr
-	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i -W3p -Gred -B -Blstr -X2.25i
-	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i+p- -W3p -Gred -B -Blstr -X2.25i
+	gmt plot data.txt -R0/1/0/2.1 -JX2i/9i -Sv0.5i+ea+h0.4+jb+n2i/0 -W3p -B -BWStr
+	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i/0 -W3p -Gred -B -Blstr -X2.25i
+	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i/0+p- -W3p -Gred -B -Blstr -X2.25i
 	rm -f data.txt
 gmt end show

--- a/test/modern/shrinkvec2.sh
+++ b/test/modern/shrinkvec2.sh
@@ -5,10 +5,10 @@ gmt begin shrinkvec2 ps
 	gmt math -T0/2/0.1 -o1,0 0 = | awk '{printf "%s\t%s\t%s\t0\t%si\n", $1, $2, $2, $2}' > data.txt
 	gmt makecpt -Cjet -T0/2
 	# Use z and CPT for painting the head only
-	gmt plot data.txt -R0/1/0/2.1 -JX2i/9i -Sv0.5i+ea+h0.4+jb+n2i -W3p+cf -C -B -BWStr
+	gmt plot data.txt -R0/1/0/2.1 -JX2i/9i -Sv0.5i+ea+h0.4+jb+n2i/0 -W3p+cf -C -B -BWStr
 	# Use z and CPT for painting the head and turn off head outline
-	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i+p- -W3p+cf -C -B -Blstr -X2.25i
+	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i/0+p- -W3p+cf -C -B -Blstr -X2.25i
 	# Use z and CPT for painting the head and stem
-	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i -W3p+c -C -B -Blstr -X2.25i
+	gmt plot data.txt -Sv0.5i+ea+h0.4+jb+n2i/0 -W3p+c -C -B -Blstr -X2.25i
 	rm -f data.txt t.cpt
 gmt end show

--- a/test/psrose/vectors.sh
+++ b/test/psrose/vectors.sh
@@ -22,13 +22,13 @@ gmt psrose $common0n -Y7.5c >> $ps
 gmt psrose $common1n -Y5c >> $ps
 #  col 2: vector plot
 #  Row 1: Default plot
-gmt psrose $commonu -M0.5c+e+gorange+n1i+h0.5 -Y-20c -X9c >> $ps
+gmt psrose $commonu -M0.5c+e+gorange+n1i/0+h0.5 -Y-20c -X9c >> $ps
 #  Row 2: Apply -T
-gmt psrose $commonu -T -Y7.5c -M0.5c+b+e+gorange+n1i+h0.5 >> $ps
+gmt psrose $commonu -T -Y7.5c -M0.5c+b+e+gorange+n1i/0+h0.5 >> $ps
 #  Row 3: Apply -R-90/90...
-gmt psrose $common0n -Y7.5c -M0.5c+e+gorange+n1i+h0.5 >> $ps
+gmt psrose $common0n -Y7.5c -M0.5c+e+gorange+n1i/0+h0.5 >> $ps
 #  Row 4: Apply -R0/180...
-#gmt psrose $common1n -Y5c -M0.5c+e+gorange+n1i >> $ps
+#gmt psrose $common1n -Y5c -M0.5c+e+gorange+n1i/0 >> $ps
 gmt psrose $common1n -Y5c -M+ >> $ps
 # Finalize
 gmt psxy -R -J -O -T >> $ps

--- a/test/psxy/arrowline.sh
+++ b/test/psxy/arrowline.sh
@@ -14,12 +14,12 @@ gmt pstext -R -J -O -K -F+f18p+cTL+tCM -Dj0.1i >> $ps
 gmt psxy -J -R -SV1c+e+h0 -W0.5p,black -O -K p.txt -Bx0 -Byg0.1 -X8.5c --PROJ_LENGTH_UNIT=inch >> $ps
 gmt pstext -R -J -O -K -F+f18p+cTL+tINCH -Dj0.1i >> $ps
 # Middle row
-gmt psxy -J -R -SV1c+e+h0+n1c -W0.5p,black -O -K -X-8.5c -Y8.5c p.txt -Bx0 -Byg0.1 --PROJ_LENGTH_UNIT=cm >> $ps
+gmt psxy -J -R -SV1c+e+h0+n1c/0 -W0.5p,black -O -K -X-8.5c -Y8.5c p.txt -Bx0 -Byg0.1 --PROJ_LENGTH_UNIT=cm >> $ps
 gmt pstext -R -J -O -K -F+f18p+cTL+tCM -Dj0.1i >> $ps
-gmt psxy -J -R -SV1c+e+h0+n2c -W0.5p,black -O -K p.txt -Bx0 -Byg0.1 -X8.5c --PROJ_LENGTH_UNIT=inch >> $ps
+gmt psxy -J -R -SV1c+e+h0+n2c/0 -W0.5p,black -O -K p.txt -Bx0 -Byg0.1 -X8.5c --PROJ_LENGTH_UNIT=inch >> $ps
 gmt pstext -R -J -O -K -F+f18p+cTL+tINCH -Dj0.1i >> $ps
 # Top row
-gmt psxy -J -R -SV1c+e+h0+n1c -W0.5p,black -Gblack -O -K -X-8.5c -Y8.5c p.txt -Bx0 -Byg0.1 --PROJ_LENGTH_UNIT=cm >> $ps
+gmt psxy -J -R -SV1c+e+h0+n1c/0 -W0.5p,black -Gblack -O -K -X-8.5c -Y8.5c p.txt -Bx0 -Byg0.1 --PROJ_LENGTH_UNIT=cm >> $ps
 gmt pstext -R -J -O -K -F+f18p+cTL+tCM -Dj0.1i >> $ps
-gmt psxy -J -R -SV1c+e+h0+n1i -W0.5p,black -Gblack -O -K p.txt -Bx0 -Byg0.1 -X8.5c --PROJ_LENGTH_UNIT=inch >> $ps
+gmt psxy -J -R -SV1c+e+h0+n1i/0 -W0.5p,black -Gblack -O -K p.txt -Bx0 -Byg0.1 -X8.5c --PROJ_LENGTH_UNIT=inch >> $ps
 gmt pstext -R -J -O -F+f18p+cTL+tINCH -Dj0.1i >> $ps

--- a/test/psxy/flowvectors.sh
+++ b/test/psxy/flowvectors.sh
@@ -3,4 +3,4 @@ ps=flowvectors.ps
 gmt makecpt -Cseis -T0/2000 > t.cpt
 
 gmt convert vel.horiz.xyazlen -o0,1,3,2,3 | gmt psxy -Rg -JG-10/30/6i -i0:1,2+s5000,3,4+s5000 -P -Bafg \
-  -Ct.cpt -S=0.15i+jc+e+n300+p0.25p+h0.5 -W1.5p --PS_COMMENTS=true > $ps
+  -Ct.cpt -S=0.15i+jc+e+n300/0+p0.25p+h0.5 -W1.5p --PS_COMMENTS=true > $ps

--- a/test/psxy/matharc.sh
+++ b/test/psxy/matharc.sh
@@ -35,7 +35,7 @@ gmt psxy -R -J -O -K -W1p -S << EOF >> $ps
 EOF
 # Normalized by angle below
 gmt psbasemap -R0/4/0/4 -J -O -B1g1 -BWSne -K -X1i -Y4i >> $ps
-gmt psxy -R -J -O -W1p -Gblack -Sm0.3i+b+e+n90 << EOF >> $ps
+gmt psxy -R -J -O -W1p -Gblack -Sm0.3i+b+e+n90/0 << EOF >> $ps
 0	0	4.0i	0	90
 0	0	3.6i	0	80
 0	0	3.2i	0	70

--- a/test/psxy/shrink_lim.ps
+++ b/test/psxy/shrink_lim.ps
@@ -1,0 +1,3253 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.4.0_178298a-dirty_2021.12.11 [64-bit] Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec 12 08:29:01 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/4.72114/0/7.24227 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 4.72114000 0.00000000 7.24227000 0.000 4.721 0.000 7.242 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 6051 TM
+% PostScript produced by:
+%@GMT: gmt plot t.txt -Sv12p+e+h0 -Gblack -W1p -BWrtS -Bxafg1 -Byafg1 -Xa0i -Ya5.0423i -R-0.1/2.1/-0.1/2.1 -JX15c/15c
+%@PROJ: xy -0.10000000 2.10000000 -0.10000000 2.10000000 -0.100 2.100 -0.100 2.100 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 6051 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+253 F0
+V
+(original) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 38 def
+/PSL_dy 38 def
+51 2589 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+51 2589 M (original) tl Z
+U
+}!
+4 W
+0 A
+120 0 M
+0 2640 D
+S
+1320 0 M
+0 2640 D
+S
+2520 0 M
+0 2640 D
+S
+0 120 M
+2640 0 D
+S
+0 1320 M
+2640 0 D
+S
+0 2520 M
+2640 0 D
+S
+clipsave
+0 0 M
+2640 0 D
+0 2640 D
+-2640 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+17 W
+{0 A} FS
+O1
+17 W
+V 240 120 T 90 R
+U
+V 240 240 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 360 120 T 90 R
+N 0 0 M 40 0 D S
+U
+V 360 360 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 480 120 T 90 R
+N 0 0 M 160 0 D S
+U
+V 480 480 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 600 120 T 90 R
+N 0 0 M 280 0 D S
+U
+V 600 600 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 720 120 T 90 R
+N 0 0 M 400 0 D S
+U
+V 720 720 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 840 120 T 90 R
+N 0 0 M 520 0 D S
+U
+V 840 840 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 960 120 T 90 R
+N 0 0 M 640 0 D S
+U
+V 960 960 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1080 120 T 90 R
+N 0 0 M 760 0 D S
+U
+V 1080 1080 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1200 120 T 90 R
+N 0 0 M 880 0 D S
+U
+V 1200 1200 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1320 120 T 90 R
+N 0 0 M 1000 0 D S
+U
+V 1320 1320 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1440 120 T 90 R
+N 0 0 M 1120 0 D S
+U
+V 1440 1440 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1560 120 T 90 R
+N 0 0 M 1240 0 D S
+U
+V 1560 1560 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1680 120 T 90 R
+N 0 0 M 1360 0 D S
+U
+V 1680 1680 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1800 120 T 90 R
+N 0 0 M 1480 0 D S
+U
+V 1800 1800 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1920 120 T 90 R
+N 0 0 M 1600 0 D S
+U
+V 1920 1920 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2040 120 T 90 R
+N 0 0 M 1720 0 D S
+U
+V 2040 2040 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2160 120 T 90 R
+N 0 0 M 1840 0 D S
+U
+V 2160 2160 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2280 120 T 90 R
+N 0 0 M 1960 0 D S
+U
+V 2280 2280 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2400 120 T 90 R
+N 0 0 M 2080 0 D S
+U
+V 2400 2400 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2520 120 T 90 R
+N 0 0 M 2200 0 D S
+U
+V 2520 2520 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2640 M 0 -2640 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 0 120 M -63 0 D S
+N 0 720 M -63 0 D S
+N 0 1320 M -63 0 D S
+N 0 1920 M -63 0 D S
+N 0 2520 M -63 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+158 F0
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+(2.0) sw mx
+def
+/PSL_A0_y PSL_A0_y 47 add def
+120 PSL_A0_y MM
+(0.0) mr Z
+720 PSL_A0_y MM
+(0.5) mr Z
+1320 PSL_A0_y MM
+(1.0) mr Z
+1920 PSL_A0_y MM
+(1.5) mr Z
+2520 PSL_A0_y MM
+(2.0) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 240 M -32 0 D S
+N 0 360 M -32 0 D S
+N 0 480 M -32 0 D S
+N 0 600 M -32 0 D S
+N 0 840 M -32 0 D S
+N 0 960 M -32 0 D S
+N 0 1080 M -32 0 D S
+N 0 1200 M -32 0 D S
+N 0 1440 M -32 0 D S
+N 0 1560 M -32 0 D S
+N 0 1680 M -32 0 D S
+N 0 1800 M -32 0 D S
+N 0 2040 M -32 0 D S
+N 0 2160 M -32 0 D S
+N 0 2280 M -32 0 D S
+N 0 2400 M -32 0 D S
+N 0 2640 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2640 0 T
+24 W
+N 0 2640 M 0 -2640 D S
+-2640 0 T
+N 0 0 M 2640 0 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 120 0 M 0 -63 D S
+N 720 0 M 0 -63 D S
+N 1320 0 M 0 -63 D S
+N 1920 0 M 0 -63 D S
+N 2520 0 M 0 -63 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0.0) sh mx
+(0.5) sh mx
+(1.0) sh mx
+(1.5) sh mx
+(2.0) sh mx
+def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
+120 PSL_A0_y MM
+(0.0) bc Z
+720 PSL_A0_y MM
+(0.5) bc Z
+1320 PSL_A0_y MM
+(1.0) bc Z
+1920 PSL_A0_y MM
+(1.5) bc Z
+2520 PSL_A0_y MM
+(2.0) bc Z
+N 0 0 M 0 -32 D S
+N 240 0 M 0 -32 D S
+N 360 0 M 0 -32 D S
+N 480 0 M 0 -32 D S
+N 600 0 M 0 -32 D S
+N 840 0 M 0 -32 D S
+N 960 0 M 0 -32 D S
+N 1080 0 M 0 -32 D S
+N 1200 0 M 0 -32 D S
+N 1440 0 M 0 -32 D S
+N 1560 0 M 0 -32 D S
+N 1680 0 M 0 -32 D S
+N 1800 0 M 0 -32 D S
+N 2040 0 M 0 -32 D S
+N 2160 0 M 0 -32 D S
+N 2280 0 M 0 -32 D S
+N 2400 0 M 0 -32 D S
+N 2640 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2640 T
+24 W
+N 0 0 M 2640 0 D S
+0 -2640 T
+0 setlinecap
+%%EndObject
+0 -6051 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3025 6051 TM
+% PostScript produced by:
+%@GMT: gmt plot t.txt -Sv12p+e+n1+h0 -Gblack -W1p -BWrtS -Bxafg1 -Byafg1 -Xa2.5211i -Ya5.0423i -R-0.1/2.1/-0.1/2.1 -JX15c/15c
+%@PROJ: xy -0.10000000 2.10000000 -0.10000000 2.10000000 -0.100 2.100 -0.100 2.100 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+3025 6051 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+253 F0
+V
+(norm = +n1) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 38 def
+/PSL_dy 38 def
+51 2589 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+51 2589 M (norm = +n1) tl Z
+U
+}!
+4 W
+0 A
+120 0 M
+0 2640 D
+S
+1320 0 M
+0 2640 D
+S
+2520 0 M
+0 2640 D
+S
+0 120 M
+2640 0 D
+S
+0 1320 M
+2640 0 D
+S
+0 2520 M
+2640 0 D
+S
+clipsave
+0 0 M
+2640 0 D
+0 2640 D
+-2640 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+17 W
+{0 A} FS
+O1
+2 W
+V 240 120 T 90 R
+N 0 0 M 100 0 D S
+U
+V 240 240 T 90 R
+PSL_vecheadpen
+2 W
+0 0 M
+-20 5 D
+0 -10 D
+P clip fs P S 
+U
+17 W
+3 W
+V 360 120 T 90 R
+N 0 0 M 200 0 D S
+U
+V 360 360 T 90 R
+PSL_vecheadpen
+3 W
+0 0 M
+-40 11 D
+0 -22 D
+P clip fs P S 
+U
+17 W
+5 W
+V 480 120 T 90 R
+N 0 0 M 300 0 D S
+U
+V 480 480 T 90 R
+PSL_vecheadpen
+5 W
+0 0 M
+-60 16 D
+0 -32 D
+P clip fs P S 
+U
+17 W
+7 W
+V 600 120 T 90 R
+N 0 0 M 400 0 D S
+U
+V 600 600 T 90 R
+PSL_vecheadpen
+7 W
+0 0 M
+-80 21 D
+0 -42 D
+P clip fs P S 
+U
+17 W
+8 W
+V 720 120 T 90 R
+N 0 0 M 500 0 D S
+U
+V 720 720 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+10 W
+V 840 120 T 90 R
+N 0 0 M 600 0 D S
+U
+V 840 840 T 90 R
+PSL_vecheadpen
+10 W
+0 0 M
+-120 32 D
+0 -64 D
+P clip fs P S 
+U
+17 W
+12 W
+V 960 120 T 90 R
+N 0 0 M 700 0 D S
+U
+V 960 960 T 90 R
+PSL_vecheadpen
+12 W
+0 0 M
+-140 38 D
+0 -76 D
+P clip fs P S 
+U
+17 W
+13 W
+V 1080 120 T 90 R
+N 0 0 M 800 0 D S
+U
+V 1080 1080 T 90 R
+PSL_vecheadpen
+13 W
+0 0 M
+-160 43 D
+0 -86 D
+P clip fs P S 
+U
+17 W
+15 W
+V 1200 120 T 90 R
+N 0 0 M 900 0 D S
+U
+V 1200 1200 T 90 R
+PSL_vecheadpen
+15 W
+0 0 M
+-180 48 D
+0 -96 D
+P clip fs P S 
+U
+17 W
+17 W
+V 1320 120 T 90 R
+N 0 0 M 1000 0 D S
+U
+V 1320 1320 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1440 120 T 90 R
+N 0 0 M 1120 0 D S
+U
+V 1440 1440 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1560 120 T 90 R
+N 0 0 M 1240 0 D S
+U
+V 1560 1560 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1680 120 T 90 R
+N 0 0 M 1360 0 D S
+U
+V 1680 1680 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1800 120 T 90 R
+N 0 0 M 1480 0 D S
+U
+V 1800 1800 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1920 120 T 90 R
+N 0 0 M 1600 0 D S
+U
+V 1920 1920 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2040 120 T 90 R
+N 0 0 M 1720 0 D S
+U
+V 2040 2040 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2160 120 T 90 R
+N 0 0 M 1840 0 D S
+U
+V 2160 2160 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2280 120 T 90 R
+N 0 0 M 1960 0 D S
+U
+V 2280 2280 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2400 120 T 90 R
+N 0 0 M 2080 0 D S
+U
+V 2400 2400 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2520 120 T 90 R
+N 0 0 M 2200 0 D S
+U
+V 2520 2520 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2640 M 0 -2640 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 0 120 M -63 0 D S
+N 0 720 M -63 0 D S
+N 0 1320 M -63 0 D S
+N 0 1920 M -63 0 D S
+N 0 2520 M -63 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+158 F0
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+(2.0) sw mx
+def
+/PSL_A0_y PSL_A0_y 47 add def
+120 PSL_A0_y MM
+(0.0) mr Z
+720 PSL_A0_y MM
+(0.5) mr Z
+1320 PSL_A0_y MM
+(1.0) mr Z
+1920 PSL_A0_y MM
+(1.5) mr Z
+2520 PSL_A0_y MM
+(2.0) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 240 M -32 0 D S
+N 0 360 M -32 0 D S
+N 0 480 M -32 0 D S
+N 0 600 M -32 0 D S
+N 0 840 M -32 0 D S
+N 0 960 M -32 0 D S
+N 0 1080 M -32 0 D S
+N 0 1200 M -32 0 D S
+N 0 1440 M -32 0 D S
+N 0 1560 M -32 0 D S
+N 0 1680 M -32 0 D S
+N 0 1800 M -32 0 D S
+N 0 2040 M -32 0 D S
+N 0 2160 M -32 0 D S
+N 0 2280 M -32 0 D S
+N 0 2400 M -32 0 D S
+N 0 2640 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2640 0 T
+24 W
+N 0 2640 M 0 -2640 D S
+-2640 0 T
+N 0 0 M 2640 0 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 120 0 M 0 -63 D S
+N 720 0 M 0 -63 D S
+N 1320 0 M 0 -63 D S
+N 1920 0 M 0 -63 D S
+N 2520 0 M 0 -63 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0.0) sh mx
+(0.5) sh mx
+(1.0) sh mx
+(1.5) sh mx
+(2.0) sh mx
+def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
+120 PSL_A0_y MM
+(0.0) bc Z
+720 PSL_A0_y MM
+(0.5) bc Z
+1320 PSL_A0_y MM
+(1.0) bc Z
+1920 PSL_A0_y MM
+(1.5) bc Z
+2520 PSL_A0_y MM
+(2.0) bc Z
+N 0 0 M 0 -32 D S
+N 240 0 M 0 -32 D S
+N 360 0 M 0 -32 D S
+N 480 0 M 0 -32 D S
+N 600 0 M 0 -32 D S
+N 840 0 M 0 -32 D S
+N 960 0 M 0 -32 D S
+N 1080 0 M 0 -32 D S
+N 1200 0 M 0 -32 D S
+N 1440 0 M 0 -32 D S
+N 1560 0 M 0 -32 D S
+N 1680 0 M 0 -32 D S
+N 1800 0 M 0 -32 D S
+N 2040 0 M 0 -32 D S
+N 2160 0 M 0 -32 D S
+N 2280 0 M 0 -32 D S
+N 2400 0 M 0 -32 D S
+N 2640 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2640 T
+24 W
+N 0 0 M 2640 0 D S
+0 -2640 T
+0 setlinecap
+%%EndObject
+-3025 -6051 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 3025 TM
+% PostScript produced by:
+%@GMT: gmt plot t.txt -Sv12p+e+n1/0.5+h0 -Gblack -W1p -BWrtS -Bxafg1 -Byafg1 -Xa0i -Ya2.5211i -R-0.1/2.1/-0.1/2.1 -JX15c/15c
+%@PROJ: xy -0.10000000 2.10000000 -0.10000000 2.10000000 -0.100 2.100 -0.100 2.100 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 3025 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+253 F0
+V
+(norm = +n1/0.5) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 38 def
+/PSL_dy 38 def
+51 2589 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+51 2589 M (norm = +n1/0.5) tl Z
+U
+}!
+4 W
+0 A
+120 0 M
+0 2640 D
+S
+1320 0 M
+0 2640 D
+S
+2520 0 M
+0 2640 D
+S
+0 120 M
+2640 0 D
+S
+0 1320 M
+2640 0 D
+S
+0 2520 M
+2640 0 D
+S
+clipsave
+0 0 M
+2640 0 D
+0 2640 D
+-2640 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+17 W
+{0 A} FS
+O1
+8 W
+V 240 120 T 90 R
+N 0 0 M 20 0 D S
+U
+V 240 240 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+8 W
+V 360 120 T 90 R
+N 0 0 M 140 0 D S
+U
+V 360 360 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+8 W
+V 480 120 T 90 R
+N 0 0 M 260 0 D S
+U
+V 480 480 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+8 W
+V 600 120 T 90 R
+N 0 0 M 380 0 D S
+U
+V 600 600 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+8 W
+V 720 120 T 90 R
+N 0 0 M 500 0 D S
+U
+V 720 720 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+10 W
+V 840 120 T 90 R
+N 0 0 M 600 0 D S
+U
+V 840 840 T 90 R
+PSL_vecheadpen
+10 W
+0 0 M
+-120 32 D
+0 -64 D
+P clip fs P S 
+U
+17 W
+12 W
+V 960 120 T 90 R
+N 0 0 M 700 0 D S
+U
+V 960 960 T 90 R
+PSL_vecheadpen
+12 W
+0 0 M
+-140 38 D
+0 -76 D
+P clip fs P S 
+U
+17 W
+13 W
+V 1080 120 T 90 R
+N 0 0 M 800 0 D S
+U
+V 1080 1080 T 90 R
+PSL_vecheadpen
+13 W
+0 0 M
+-160 43 D
+0 -86 D
+P clip fs P S 
+U
+17 W
+15 W
+V 1200 120 T 90 R
+N 0 0 M 900 0 D S
+U
+V 1200 1200 T 90 R
+PSL_vecheadpen
+15 W
+0 0 M
+-180 48 D
+0 -96 D
+P clip fs P S 
+U
+17 W
+17 W
+V 1320 120 T 90 R
+N 0 0 M 1000 0 D S
+U
+V 1320 1320 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1440 120 T 90 R
+N 0 0 M 1120 0 D S
+U
+V 1440 1440 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1560 120 T 90 R
+N 0 0 M 1240 0 D S
+U
+V 1560 1560 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1680 120 T 90 R
+N 0 0 M 1360 0 D S
+U
+V 1680 1680 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1800 120 T 90 R
+N 0 0 M 1480 0 D S
+U
+V 1800 1800 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1920 120 T 90 R
+N 0 0 M 1600 0 D S
+U
+V 1920 1920 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2040 120 T 90 R
+N 0 0 M 1720 0 D S
+U
+V 2040 2040 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2160 120 T 90 R
+N 0 0 M 1840 0 D S
+U
+V 2160 2160 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2280 120 T 90 R
+N 0 0 M 1960 0 D S
+U
+V 2280 2280 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2400 120 T 90 R
+N 0 0 M 2080 0 D S
+U
+V 2400 2400 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2520 120 T 90 R
+N 0 0 M 2200 0 D S
+U
+V 2520 2520 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2640 M 0 -2640 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 0 120 M -63 0 D S
+N 0 720 M -63 0 D S
+N 0 1320 M -63 0 D S
+N 0 1920 M -63 0 D S
+N 0 2520 M -63 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+158 F0
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+(2.0) sw mx
+def
+/PSL_A0_y PSL_A0_y 47 add def
+120 PSL_A0_y MM
+(0.0) mr Z
+720 PSL_A0_y MM
+(0.5) mr Z
+1320 PSL_A0_y MM
+(1.0) mr Z
+1920 PSL_A0_y MM
+(1.5) mr Z
+2520 PSL_A0_y MM
+(2.0) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 240 M -32 0 D S
+N 0 360 M -32 0 D S
+N 0 480 M -32 0 D S
+N 0 600 M -32 0 D S
+N 0 840 M -32 0 D S
+N 0 960 M -32 0 D S
+N 0 1080 M -32 0 D S
+N 0 1200 M -32 0 D S
+N 0 1440 M -32 0 D S
+N 0 1560 M -32 0 D S
+N 0 1680 M -32 0 D S
+N 0 1800 M -32 0 D S
+N 0 2040 M -32 0 D S
+N 0 2160 M -32 0 D S
+N 0 2280 M -32 0 D S
+N 0 2400 M -32 0 D S
+N 0 2640 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2640 0 T
+24 W
+N 0 2640 M 0 -2640 D S
+-2640 0 T
+N 0 0 M 2640 0 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 120 0 M 0 -63 D S
+N 720 0 M 0 -63 D S
+N 1320 0 M 0 -63 D S
+N 1920 0 M 0 -63 D S
+N 2520 0 M 0 -63 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0.0) sh mx
+(0.5) sh mx
+(1.0) sh mx
+(1.5) sh mx
+(2.0) sh mx
+def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
+120 PSL_A0_y MM
+(0.0) bc Z
+720 PSL_A0_y MM
+(0.5) bc Z
+1320 PSL_A0_y MM
+(1.0) bc Z
+1920 PSL_A0_y MM
+(1.5) bc Z
+2520 PSL_A0_y MM
+(2.0) bc Z
+N 0 0 M 0 -32 D S
+N 240 0 M 0 -32 D S
+N 360 0 M 0 -32 D S
+N 480 0 M 0 -32 D S
+N 600 0 M 0 -32 D S
+N 840 0 M 0 -32 D S
+N 960 0 M 0 -32 D S
+N 1080 0 M 0 -32 D S
+N 1200 0 M 0 -32 D S
+N 1440 0 M 0 -32 D S
+N 1560 0 M 0 -32 D S
+N 1680 0 M 0 -32 D S
+N 1800 0 M 0 -32 D S
+N 2040 0 M 0 -32 D S
+N 2160 0 M 0 -32 D S
+N 2280 0 M 0 -32 D S
+N 2400 0 M 0 -32 D S
+N 2640 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2640 T
+24 W
+N 0 0 M 2640 0 D S
+0 -2640 T
+0 setlinecap
+%%EndObject
+0 -3025 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3025 3025 TM
+% PostScript produced by:
+%@GMT: gmt plot t.txt -Sv12p+e+n1/0.3+h0 -Gblack -W1p -BWrtS -Bxafg1 -Byafg1 -Xa2.5211i -Ya2.5211i -R-0.1/2.1/-0.1/2.1 -JX15c/15c
+%@PROJ: xy -0.10000000 2.10000000 -0.10000000 2.10000000 -0.100 2.100 -0.100 2.100 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+3025 3025 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+253 F0
+V
+(norm = +n1/0.3) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 38 def
+/PSL_dy 38 def
+51 2589 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+51 2589 M (norm = +n1/0.3) tl Z
+U
+}!
+4 W
+0 A
+120 0 M
+0 2640 D
+S
+1320 0 M
+0 2640 D
+S
+2520 0 M
+0 2640 D
+S
+0 120 M
+2640 0 D
+S
+0 1320 M
+2640 0 D
+S
+0 2520 M
+2640 0 D
+S
+clipsave
+0 0 M
+2640 0 D
+0 2640 D
+-2640 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+17 W
+{0 A} FS
+O1
+5 W
+V 240 120 T 90 R
+N 0 0 M 60 0 D S
+U
+V 240 240 T 90 R
+PSL_vecheadpen
+5 W
+0 0 M
+-60 16 D
+0 -32 D
+P clip fs P S 
+U
+17 W
+5 W
+V 360 120 T 90 R
+N 0 0 M 180 0 D S
+U
+V 360 360 T 90 R
+PSL_vecheadpen
+5 W
+0 0 M
+-60 16 D
+0 -32 D
+P clip fs P S 
+U
+17 W
+5 W
+V 480 120 T 90 R
+N 0 0 M 300 0 D S
+U
+V 480 480 T 90 R
+PSL_vecheadpen
+5 W
+0 0 M
+-60 16 D
+0 -32 D
+P clip fs P S 
+U
+17 W
+7 W
+V 600 120 T 90 R
+N 0 0 M 400 0 D S
+U
+V 600 600 T 90 R
+PSL_vecheadpen
+7 W
+0 0 M
+-80 21 D
+0 -42 D
+P clip fs P S 
+U
+17 W
+8 W
+V 720 120 T 90 R
+N 0 0 M 500 0 D S
+U
+V 720 720 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+10 W
+V 840 120 T 90 R
+N 0 0 M 600 0 D S
+U
+V 840 840 T 90 R
+PSL_vecheadpen
+10 W
+0 0 M
+-120 32 D
+0 -64 D
+P clip fs P S 
+U
+17 W
+12 W
+V 960 120 T 90 R
+N 0 0 M 700 0 D S
+U
+V 960 960 T 90 R
+PSL_vecheadpen
+12 W
+0 0 M
+-140 38 D
+0 -76 D
+P clip fs P S 
+U
+17 W
+13 W
+V 1080 120 T 90 R
+N 0 0 M 800 0 D S
+U
+V 1080 1080 T 90 R
+PSL_vecheadpen
+13 W
+0 0 M
+-160 43 D
+0 -86 D
+P clip fs P S 
+U
+17 W
+15 W
+V 1200 120 T 90 R
+N 0 0 M 900 0 D S
+U
+V 1200 1200 T 90 R
+PSL_vecheadpen
+15 W
+0 0 M
+-180 48 D
+0 -96 D
+P clip fs P S 
+U
+17 W
+17 W
+V 1320 120 T 90 R
+N 0 0 M 1000 0 D S
+U
+V 1320 1320 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1440 120 T 90 R
+N 0 0 M 1120 0 D S
+U
+V 1440 1440 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1560 120 T 90 R
+N 0 0 M 1240 0 D S
+U
+V 1560 1560 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1680 120 T 90 R
+N 0 0 M 1360 0 D S
+U
+V 1680 1680 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1800 120 T 90 R
+N 0 0 M 1480 0 D S
+U
+V 1800 1800 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1920 120 T 90 R
+N 0 0 M 1600 0 D S
+U
+V 1920 1920 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2040 120 T 90 R
+N 0 0 M 1720 0 D S
+U
+V 2040 2040 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2160 120 T 90 R
+N 0 0 M 1840 0 D S
+U
+V 2160 2160 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2280 120 T 90 R
+N 0 0 M 1960 0 D S
+U
+V 2280 2280 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2400 120 T 90 R
+N 0 0 M 2080 0 D S
+U
+V 2400 2400 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2520 120 T 90 R
+N 0 0 M 2200 0 D S
+U
+V 2520 2520 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2640 M 0 -2640 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 0 120 M -63 0 D S
+N 0 720 M -63 0 D S
+N 0 1320 M -63 0 D S
+N 0 1920 M -63 0 D S
+N 0 2520 M -63 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+158 F0
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+(2.0) sw mx
+def
+/PSL_A0_y PSL_A0_y 47 add def
+120 PSL_A0_y MM
+(0.0) mr Z
+720 PSL_A0_y MM
+(0.5) mr Z
+1320 PSL_A0_y MM
+(1.0) mr Z
+1920 PSL_A0_y MM
+(1.5) mr Z
+2520 PSL_A0_y MM
+(2.0) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 240 M -32 0 D S
+N 0 360 M -32 0 D S
+N 0 480 M -32 0 D S
+N 0 600 M -32 0 D S
+N 0 840 M -32 0 D S
+N 0 960 M -32 0 D S
+N 0 1080 M -32 0 D S
+N 0 1200 M -32 0 D S
+N 0 1440 M -32 0 D S
+N 0 1560 M -32 0 D S
+N 0 1680 M -32 0 D S
+N 0 1800 M -32 0 D S
+N 0 2040 M -32 0 D S
+N 0 2160 M -32 0 D S
+N 0 2280 M -32 0 D S
+N 0 2400 M -32 0 D S
+N 0 2640 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2640 0 T
+24 W
+N 0 2640 M 0 -2640 D S
+-2640 0 T
+N 0 0 M 2640 0 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 120 0 M 0 -63 D S
+N 720 0 M 0 -63 D S
+N 1320 0 M 0 -63 D S
+N 1920 0 M 0 -63 D S
+N 2520 0 M 0 -63 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0.0) sh mx
+(0.5) sh mx
+(1.0) sh mx
+(1.5) sh mx
+(2.0) sh mx
+def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
+120 PSL_A0_y MM
+(0.0) bc Z
+720 PSL_A0_y MM
+(0.5) bc Z
+1320 PSL_A0_y MM
+(1.0) bc Z
+1920 PSL_A0_y MM
+(1.5) bc Z
+2520 PSL_A0_y MM
+(2.0) bc Z
+N 0 0 M 0 -32 D S
+N 240 0 M 0 -32 D S
+N 360 0 M 0 -32 D S
+N 480 0 M 0 -32 D S
+N 600 0 M 0 -32 D S
+N 840 0 M 0 -32 D S
+N 960 0 M 0 -32 D S
+N 1080 0 M 0 -32 D S
+N 1200 0 M 0 -32 D S
+N 1440 0 M 0 -32 D S
+N 1560 0 M 0 -32 D S
+N 1680 0 M 0 -32 D S
+N 1800 0 M 0 -32 D S
+N 2040 0 M 0 -32 D S
+N 2160 0 M 0 -32 D S
+N 2280 0 M 0 -32 D S
+N 2400 0 M 0 -32 D S
+N 2640 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2640 T
+24 W
+N 0 0 M 2640 0 D S
+0 -2640 T
+0 setlinecap
+%%EndObject
+-3025 -3025 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot t.txt -Sv12p+e+n1/0.2+h0 -Gblack -W1p -BWrtS -Bxafg1 -Byafg1 -Xa0i -Ya0i -R-0.1/2.1/-0.1/2.1 -JX15c/15c
+%@PROJ: xy -0.10000000 2.10000000 -0.10000000 2.10000000 -0.100 2.100 -0.100 2.100 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+253 F0
+V
+(norm = +n1/0.2) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 38 def
+/PSL_dy 38 def
+51 2589 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+51 2589 M (norm = +n1/0.2) tl Z
+U
+}!
+4 W
+0 A
+120 0 M
+0 2640 D
+S
+1320 0 M
+0 2640 D
+S
+2520 0 M
+0 2640 D
+S
+0 120 M
+2640 0 D
+S
+0 1320 M
+2640 0 D
+S
+0 2520 M
+2640 0 D
+S
+clipsave
+0 0 M
+2640 0 D
+0 2640 D
+-2640 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+17 W
+{0 A} FS
+O1
+3 W
+V 240 120 T 90 R
+N 0 0 M 80 0 D S
+U
+V 240 240 T 90 R
+PSL_vecheadpen
+3 W
+0 0 M
+-40 11 D
+0 -22 D
+P clip fs P S 
+U
+17 W
+3 W
+V 360 120 T 90 R
+N 0 0 M 200 0 D S
+U
+V 360 360 T 90 R
+PSL_vecheadpen
+3 W
+0 0 M
+-40 11 D
+0 -22 D
+P clip fs P S 
+U
+17 W
+5 W
+V 480 120 T 90 R
+N 0 0 M 300 0 D S
+U
+V 480 480 T 90 R
+PSL_vecheadpen
+5 W
+0 0 M
+-60 16 D
+0 -32 D
+P clip fs P S 
+U
+17 W
+7 W
+V 600 120 T 90 R
+N 0 0 M 400 0 D S
+U
+V 600 600 T 90 R
+PSL_vecheadpen
+7 W
+0 0 M
+-80 21 D
+0 -42 D
+P clip fs P S 
+U
+17 W
+8 W
+V 720 120 T 90 R
+N 0 0 M 500 0 D S
+U
+V 720 720 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+10 W
+V 840 120 T 90 R
+N 0 0 M 600 0 D S
+U
+V 840 840 T 90 R
+PSL_vecheadpen
+10 W
+0 0 M
+-120 32 D
+0 -64 D
+P clip fs P S 
+U
+17 W
+12 W
+V 960 120 T 90 R
+N 0 0 M 700 0 D S
+U
+V 960 960 T 90 R
+PSL_vecheadpen
+12 W
+0 0 M
+-140 38 D
+0 -76 D
+P clip fs P S 
+U
+17 W
+13 W
+V 1080 120 T 90 R
+N 0 0 M 800 0 D S
+U
+V 1080 1080 T 90 R
+PSL_vecheadpen
+13 W
+0 0 M
+-160 43 D
+0 -86 D
+P clip fs P S 
+U
+17 W
+15 W
+V 1200 120 T 90 R
+N 0 0 M 900 0 D S
+U
+V 1200 1200 T 90 R
+PSL_vecheadpen
+15 W
+0 0 M
+-180 48 D
+0 -96 D
+P clip fs P S 
+U
+17 W
+17 W
+V 1320 120 T 90 R
+N 0 0 M 1000 0 D S
+U
+V 1320 1320 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1440 120 T 90 R
+N 0 0 M 1120 0 D S
+U
+V 1440 1440 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1560 120 T 90 R
+N 0 0 M 1240 0 D S
+U
+V 1560 1560 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1680 120 T 90 R
+N 0 0 M 1360 0 D S
+U
+V 1680 1680 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1800 120 T 90 R
+N 0 0 M 1480 0 D S
+U
+V 1800 1800 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1920 120 T 90 R
+N 0 0 M 1600 0 D S
+U
+V 1920 1920 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2040 120 T 90 R
+N 0 0 M 1720 0 D S
+U
+V 2040 2040 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2160 120 T 90 R
+N 0 0 M 1840 0 D S
+U
+V 2160 2160 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2280 120 T 90 R
+N 0 0 M 1960 0 D S
+U
+V 2280 2280 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2400 120 T 90 R
+N 0 0 M 2080 0 D S
+U
+V 2400 2400 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2520 120 T 90 R
+N 0 0 M 2200 0 D S
+U
+V 2520 2520 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2640 M 0 -2640 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 0 120 M -63 0 D S
+N 0 720 M -63 0 D S
+N 0 1320 M -63 0 D S
+N 0 1920 M -63 0 D S
+N 0 2520 M -63 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+158 F0
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+(2.0) sw mx
+def
+/PSL_A0_y PSL_A0_y 47 add def
+120 PSL_A0_y MM
+(0.0) mr Z
+720 PSL_A0_y MM
+(0.5) mr Z
+1320 PSL_A0_y MM
+(1.0) mr Z
+1920 PSL_A0_y MM
+(1.5) mr Z
+2520 PSL_A0_y MM
+(2.0) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 240 M -32 0 D S
+N 0 360 M -32 0 D S
+N 0 480 M -32 0 D S
+N 0 600 M -32 0 D S
+N 0 840 M -32 0 D S
+N 0 960 M -32 0 D S
+N 0 1080 M -32 0 D S
+N 0 1200 M -32 0 D S
+N 0 1440 M -32 0 D S
+N 0 1560 M -32 0 D S
+N 0 1680 M -32 0 D S
+N 0 1800 M -32 0 D S
+N 0 2040 M -32 0 D S
+N 0 2160 M -32 0 D S
+N 0 2280 M -32 0 D S
+N 0 2400 M -32 0 D S
+N 0 2640 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2640 0 T
+24 W
+N 0 2640 M 0 -2640 D S
+-2640 0 T
+N 0 0 M 2640 0 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 120 0 M 0 -63 D S
+N 720 0 M 0 -63 D S
+N 1320 0 M 0 -63 D S
+N 1920 0 M 0 -63 D S
+N 2520 0 M 0 -63 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0.0) sh mx
+(0.5) sh mx
+(1.0) sh mx
+(1.5) sh mx
+(2.0) sh mx
+def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
+120 PSL_A0_y MM
+(0.0) bc Z
+720 PSL_A0_y MM
+(0.5) bc Z
+1320 PSL_A0_y MM
+(1.0) bc Z
+1920 PSL_A0_y MM
+(1.5) bc Z
+2520 PSL_A0_y MM
+(2.0) bc Z
+N 0 0 M 0 -32 D S
+N 240 0 M 0 -32 D S
+N 360 0 M 0 -32 D S
+N 480 0 M 0 -32 D S
+N 600 0 M 0 -32 D S
+N 840 0 M 0 -32 D S
+N 960 0 M 0 -32 D S
+N 1080 0 M 0 -32 D S
+N 1200 0 M 0 -32 D S
+N 1440 0 M 0 -32 D S
+N 1560 0 M 0 -32 D S
+N 1680 0 M 0 -32 D S
+N 1800 0 M 0 -32 D S
+N 2040 0 M 0 -32 D S
+N 2160 0 M 0 -32 D S
+N 2280 0 M 0 -32 D S
+N 2400 0 M 0 -32 D S
+N 2640 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2640 T
+24 W
+N 0 0 M 2640 0 D S
+0 -2640 T
+0 setlinecap
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+3025 0 TM
+% PostScript produced by:
+%@GMT: gmt plot t.txt -Sv12p+e+n1/0.1+h0 -Gblack -W1p -BWrtS -Bxafg1 -Byafg1 -Xa2.5211i -Ya0i -R-0.1/2.1/-0.1/2.1 -JX15c/15c
+%@PROJ: xy -0.10000000 2.10000000 -0.10000000 2.10000000 -0.100 2.100 -0.100 2.100 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+/PSL_plot_completion {
+V
+3025 0 T
+0 A FQ O0
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+253 F0
+V
+(norm = +n1/0.1) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 38 def
+/PSL_dy 38 def
+51 2589 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+51 2589 M (norm = +n1/0.1) tl Z
+U
+}!
+4 W
+0 A
+120 0 M
+0 2640 D
+S
+1320 0 M
+0 2640 D
+S
+2520 0 M
+0 2640 D
+S
+0 120 M
+2640 0 D
+S
+0 1320 M
+2640 0 D
+S
+0 2520 M
+2640 0 D
+S
+clipsave
+0 0 M
+2640 0 D
+0 2640 D
+-2640 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+17 W
+{0 A} FS
+O1
+2 W
+V 240 120 T 90 R
+N 0 0 M 100 0 D S
+U
+V 240 240 T 90 R
+PSL_vecheadpen
+2 W
+0 0 M
+-20 5 D
+0 -10 D
+P clip fs P S 
+U
+17 W
+3 W
+V 360 120 T 90 R
+N 0 0 M 200 0 D S
+U
+V 360 360 T 90 R
+PSL_vecheadpen
+3 W
+0 0 M
+-40 11 D
+0 -22 D
+P clip fs P S 
+U
+17 W
+5 W
+V 480 120 T 90 R
+N 0 0 M 300 0 D S
+U
+V 480 480 T 90 R
+PSL_vecheadpen
+5 W
+0 0 M
+-60 16 D
+0 -32 D
+P clip fs P S 
+U
+17 W
+7 W
+V 600 120 T 90 R
+N 0 0 M 400 0 D S
+U
+V 600 600 T 90 R
+PSL_vecheadpen
+7 W
+0 0 M
+-80 21 D
+0 -42 D
+P clip fs P S 
+U
+17 W
+8 W
+V 720 120 T 90 R
+N 0 0 M 500 0 D S
+U
+V 720 720 T 90 R
+PSL_vecheadpen
+8 W
+0 0 M
+-100 27 D
+0 -54 D
+P clip fs P S 
+U
+17 W
+10 W
+V 840 120 T 90 R
+N 0 0 M 600 0 D S
+U
+V 840 840 T 90 R
+PSL_vecheadpen
+10 W
+0 0 M
+-120 32 D
+0 -64 D
+P clip fs P S 
+U
+17 W
+12 W
+V 960 120 T 90 R
+N 0 0 M 700 0 D S
+U
+V 960 960 T 90 R
+PSL_vecheadpen
+12 W
+0 0 M
+-140 38 D
+0 -76 D
+P clip fs P S 
+U
+17 W
+13 W
+V 1080 120 T 90 R
+N 0 0 M 800 0 D S
+U
+V 1080 1080 T 90 R
+PSL_vecheadpen
+13 W
+0 0 M
+-160 43 D
+0 -86 D
+P clip fs P S 
+U
+17 W
+15 W
+V 1200 120 T 90 R
+N 0 0 M 900 0 D S
+U
+V 1200 1200 T 90 R
+PSL_vecheadpen
+15 W
+0 0 M
+-180 48 D
+0 -96 D
+P clip fs P S 
+U
+17 W
+17 W
+V 1320 120 T 90 R
+N 0 0 M 1000 0 D S
+U
+V 1320 1320 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1440 120 T 90 R
+N 0 0 M 1120 0 D S
+U
+V 1440 1440 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1560 120 T 90 R
+N 0 0 M 1240 0 D S
+U
+V 1560 1560 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1680 120 T 90 R
+N 0 0 M 1360 0 D S
+U
+V 1680 1680 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1800 120 T 90 R
+N 0 0 M 1480 0 D S
+U
+V 1800 1800 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 1920 120 T 90 R
+N 0 0 M 1600 0 D S
+U
+V 1920 1920 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2040 120 T 90 R
+N 0 0 M 1720 0 D S
+U
+V 2040 2040 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2160 120 T 90 R
+N 0 0 M 1840 0 D S
+U
+V 2160 2160 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2280 120 T 90 R
+N 0 0 M 1960 0 D S
+U
+V 2280 2280 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2400 120 T 90 R
+N 0 0 M 2080 0 D S
+U
+V 2400 2400 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+17 W
+V 2520 120 T 90 R
+N 0 0 M 2200 0 D S
+U
+V 2520 2520 T 90 R
+PSL_vecheadpen
+17 W
+0 0 M
+-200 54 D
+0 -108 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 2640 M 0 -2640 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 0 120 M -63 0 D S
+N 0 720 M -63 0 D S
+N 0 1320 M -63 0 D S
+N 0 1920 M -63 0 D S
+N 0 2520 M -63 0 D S
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+/MM {neg exch M} def
+/PSL_AH0 0
+158 F0
+(0.0) sw mx
+(0.5) sw mx
+(1.0) sw mx
+(1.5) sw mx
+(2.0) sw mx
+def
+/PSL_A0_y PSL_A0_y 47 add def
+120 PSL_A0_y MM
+(0.0) mr Z
+720 PSL_A0_y MM
+(0.5) mr Z
+1320 PSL_A0_y MM
+(1.0) mr Z
+1920 PSL_A0_y MM
+(1.5) mr Z
+2520 PSL_A0_y MM
+(2.0) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 240 M -32 0 D S
+N 0 360 M -32 0 D S
+N 0 480 M -32 0 D S
+N 0 600 M -32 0 D S
+N 0 840 M -32 0 D S
+N 0 960 M -32 0 D S
+N 0 1080 M -32 0 D S
+N 0 1200 M -32 0 D S
+N 0 1440 M -32 0 D S
+N 0 1560 M -32 0 D S
+N 0 1680 M -32 0 D S
+N 0 1800 M -32 0 D S
+N 0 2040 M -32 0 D S
+N 0 2160 M -32 0 D S
+N 0 2280 M -32 0 D S
+N 0 2400 M -32 0 D S
+N 0 2640 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+2640 0 T
+24 W
+N 0 2640 M 0 -2640 D S
+-2640 0 T
+N 0 0 M 2640 0 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 120 0 M 0 -63 D S
+N 720 0 M 0 -63 D S
+N 1320 0 M 0 -63 D S
+N 1920 0 M 0 -63 D S
+N 2520 0 M 0 -63 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0.0) sh mx
+(0.5) sh mx
+(1.0) sh mx
+(1.5) sh mx
+(2.0) sh mx
+def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
+120 PSL_A0_y MM
+(0.0) bc Z
+720 PSL_A0_y MM
+(0.5) bc Z
+1320 PSL_A0_y MM
+(1.0) bc Z
+1920 PSL_A0_y MM
+(1.5) bc Z
+2520 PSL_A0_y MM
+(2.0) bc Z
+N 0 0 M 0 -32 D S
+N 240 0 M 0 -32 D S
+N 360 0 M 0 -32 D S
+N 480 0 M 0 -32 D S
+N 600 0 M 0 -32 D S
+N 840 0 M 0 -32 D S
+N 960 0 M 0 -32 D S
+N 1080 0 M 0 -32 D S
+N 1200 0 M 0 -32 D S
+N 1440 0 M 0 -32 D S
+N 1560 0 M 0 -32 D S
+N 1680 0 M 0 -32 D S
+N 1800 0 M 0 -32 D S
+N 2040 0 M 0 -32 D S
+N 2160 0 M 0 -32 D S
+N 2280 0 M 0 -32 D S
+N 2400 0 M 0 -32 D S
+N 2640 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 2640 T
+24 W
+N 0 0 M 2640 0 D S
+0 -2640 T
+0 setlinecap
+%%EndObject
+-3025 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psxy/shrink_lim.sh
+++ b/test/psxy/shrink_lim.sh
@@ -8,7 +8,7 @@ gmt begin shrink_lim
         gmt subplot set -Aoriginal
         gmt plot t.txt -Sv12p+e+h0 -Gblack -W1p
         gmt subplot set -A"norm = +n1"
-        gmt plot t.txt -Sv12p+e+n1+h0 -Gblack -W1p
+        gmt plot t.txt -Sv12p+e+n1/0+h0 -Gblack -W1p
         gmt subplot set -A"norm = +n1/0.5"
         gmt plot t.txt -Sv12p+e+n1/0.5+h0 -Gblack -W1p
         gmt subplot set -A"norm = +n1/0.3"

--- a/test/psxy/shrink_lim.sh
+++ b/test/psxy/shrink_lim.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Exploring the terminal limit on vector shrinking
+#
+gmt begin shrink_lim
+    gmt set PROJ_LENGTH_UNIT inch
+    gmt math -N4/3 -T0/2/0.1 0 -C2 90 ADD = t.txt
+    gmt subplot begin 3x2 -R-0.1/2.1/-0.1/2.1 -Fs2.2i -Bafg1 -A+gwhite
+        gmt subplot set -Aoriginal
+        gmt plot t.txt -Sv12p+e+h0 -Gblack -W1p
+        gmt subplot set -A"norm = +n1"
+        gmt plot t.txt -Sv12p+e+n1+h0 -Gblack -W1p
+        gmt subplot set -A"norm = +n1/0.5"
+        gmt plot t.txt -Sv12p+e+n1/0.5+h0 -Gblack -W1p
+        gmt subplot set -A"norm = +n1/0.3"
+        gmt plot t.txt -Sv12p+e+n1/0.3+h0 -Gblack -W1p
+        gmt subplot set -A"norm = +n1/0.2"
+        gmt plot t.txt -Sv12p+e+n1/0.2+h0 -Gblack -W1p
+        gmt subplot set -A"norm = +n1/0.1"
+        gmt plot t.txt -Sv12p+e+n1/0.1+h0 -Gblack -W1p
+    gmt subplot end
+gmt end show

--- a/test/psxyz/matharc.sh
+++ b/test/psxyz/matharc.sh
@@ -35,7 +35,7 @@ gmt psxyz -R -J -O -K -W1p -S -p155/35 << EOF >> $ps
 EOF
 # Normalized by angle below
 gmt psbasemap -R0/4/0/4 -J -O -B1g1 -BWSne -K -X1i -Y4i -p155/35 >> $ps
-gmt psxyz -R -J -O -W1p -Gblack -Sm0.3i+b+e+n90 << EOF -p155/35 >> $ps
+gmt psxyz -R -J -O -W1p -Gblack -Sm0.3i+b+e+n90/0 << EOF -p155/35 >> $ps
 0	0	0	4.0i	0	90
 0	0	0	3.6i	0	80
 0	0	0	3.2i	0	70


### PR DESCRIPTION
The **+n**_norm_ modifier that shrinks down vector attributes for shorter vectors would shrink to 0 by default.  This PR adds an optional terminal shrink value [0] that can be set by appending _/frac_.  The shrink_lim.sh test explores how this works. The +n is used to shrink attributes when the vector length is less than 1 inch (**-R** values are in inches and the gridlines indicates the cutoff):

![shrink_lim](https://user-images.githubusercontent.com/26473567/145724923-ce4e1555-dd43-40c3-a7fa-7d2540b48d11.png)

Comments:

1. For very short vectors and relatively large heads, we seem to plot a head that implies a starting point below the vector start (y = 0).  See top-left plot for length = 0.1" = 7.2p is less that head length of 12 p
2. @joa-quim suggested that perhaps default _frac_ should be nonzero and we would claim this is a bug fix.  The argument is that when _frac_ goes to zero we can no longer tell the azimuth of the vector as it approaches a point.  Perhaps 0.25?

Thoughts?
