### PR TITLE
Bash scripts under macOS need set -e

### DIFF
--- a/src/gmt.c
+++ b/src/gmt.c
@@ -274,6 +274,9 @@ int main (int argc, char *argv[]) {
 					type = 1;	/* Select csh */
 				if (type < 2) {	/* Start the shell via env and pass -e to exit script upon error */
 					printf ("#!/usr/bin/env -S %s -e\n", shell[type]);
+#ifdef __APPLE__
+					if (type == 0) printf ("set -e\n");	/* Explicitly needed for bash under macOS */
+#endif
 					printf ("%s GMT modern mode %s template\n", comment[type], shell[type]);
 				}
 				printf ("%s Date:    %s\n%s User:    %s\n%s Purpose: Purpose of this script\n", comment[type], stamp, comment[type], name, comment[type]);


### PR DESCRIPTION
The shebang line

`#!/usr/bin/env -S bash -e`

does not set the exit on error feature under macOS.  We must specifically add

`set -e`

for that to work reliably.  See [StackOverflow](https://stackoverflow.com/questions/2870992/automatic-exit-from-bash-shell-script-on-error) for more information.
