### PR TITLE
Improved documentation of the developer KEYS

### DIFF
--- a/src/geodesy/gpsgridder.c
+++ b/src/geodesy/gpsgridder.c
@@ -24,6 +24,8 @@
  * See Sandwell and Wessel, 2016, "Interpolation of 2-D Vector Data Using Constraints
  *   from Elasticity", Geophys. Res. Lett., 43, 10,703-710,709, doi:10.1002/2016GL070340,
  *   for details.
+ *
+ * Note on KEYS: CD)=f means -C takes an optional output Dataset as argument via the +f modifier.
  */
 
 #include "gmt_dev.h"

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12874,8 +12874,28 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 	 *   2. pscoast normally plots PostSCript but pscoast -E+l only want to return a text listing of countries.  We allow for this
 	 *      switch by using the key >DE-lL so that if -E with either +l or +L are used we change primary output to D.
 	 *
+     * There can also be complications when an option either takes a file but may also accept optional modifiers, or the
+     * file in question is itself given via an optional modifier.  These cases are encoded this way:
+     *
+     *   A) If an input|output file argument to an option may be followed by optional modifiers we append "=" to that key.
+     *        Example: The dataset given to gmtselect via -C (syntax -C<ptfile>|<lon>/<lat>+d<dist>) needs means CD(=.
+     *   B) If an input|output file is given via an option's modifier +x, then we append =x to that key.
+     *        Example: The output dataset file given to grd2cpt via -E (syntax -E[<nlevels>][+c][+f<file>]) means code ED)=f.
+     *
+     * Both psxy[z] and the contour functions may specify options that may accept file arguments.  These are special cases:
+     *
+     *  A) psxy[z] lists KEY S?(=2. ? means unknown type, but this is replaced by D (dataset) only if -S requests either the
+     *     quoted or decorated lines symbols since these require crossing or fixed-point dataset files.  If any other symbol
+     *     is specified then the type is set to ! which means we skip the processing of this key.
+     *  B) The contour program has option -G to set annotation placements.  The key is G?(=1 and only if -Gf|x is given will we
+     *     need to read a dataset (so type becomes D), else type is set to ! to skip the processing of this key.
+     *
+     *  The optional integer that may follow the '=' character indicates how many characters must we skip following the option
+     *  switch before we reach the start of the filename.  Since -Gxfile or -Gffile has that initial x or f we use =1.  For the
+     *  psxy[z] command we used =2 since -Sqffile, -Sqxfile, -S~ffile, -S~xfile means file starts after 2 leading characters.
+     *  If not given the the default is 0 (i.e., the filename immediately follows the option switch, like in -Adatafile).
+     *
 	 *   After processing, all magic key sequences are set to "---" to render them inactive.
-	 *
 	 */
 
 	unsigned int n_keys, direction = 0, kind, pos = 0, n_items = 0, ku, n_out = 0, nn[2][2];

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12878,22 +12878,22 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
      * file in question is itself given via an optional modifier.  These cases are encoded this way:
      *
      *   A) If an input|output file argument to an option may be followed by optional modifiers we append "=" to that key.
-     *        Example: The dataset given to gmtselect via -C (syntax -C<ptfile>|<lon>/<lat>+d<dist>) needs means CD(=.
+     *        Example: The dataset given to gmtselect via -C (syntax -C<ptfile>|<lon>/<lat>+d<dist>) needs CD(=.
      *   B) If an input|output file is given via an option's modifier +x, then we append =x to that key.
-     *        Example: The output dataset file given to grd2cpt via -E (syntax -E[<nlevels>][+c][+f<file>]) means code ED)=f.
+     *        Example: The output dataset file given to grd2cpt via -E (syntax -E[<nlevels>][+c][+f<file>]) needs code ED)=f.
      *
      * Both psxy[z] and the contour functions may specify options that may accept file arguments.  These are special cases:
      *
      *  A) psxy[z] lists KEY S?(=2. ? means unknown type, but this is replaced by D (dataset) only if -S requests either the
      *     quoted or decorated lines symbols since these require crossing or fixed-point dataset files.  If any other symbol
      *     is specified then the type is set to ! which means we skip the processing of this key.
-     *  B) The contour program has option -G to set annotation placements.  The key is G?(=1 and only if -Gf|x is given will we
+     *  B) The contour modules have option -G to set annotation placements.  The key is G?(=1 and only if -Gf|x is given will we
      *     need to read a dataset (so type becomes D), else type is set to ! to skip the processing of this key.
      *
      *  The optional integer that may follow the '=' character indicates how many characters must we skip following the option
      *  switch before we reach the start of the filename.  Since -Gxfile or -Gffile has that initial x or f we use =1.  For the
-     *  psxy[z] command we used =2 since -Sqffile, -Sqxfile, -S~ffile, -S~xfile means file starts after 2 leading characters.
-     *  If not given the the default is 0 (i.e., the filename immediately follows the option switch, like in -Adatafile).
+     *  psxy[z] command we used =2 since -Sqffile, -Sqxfile, -S~ffile, -S~xfile all imply file starts after 2 leading characters.
+     *  If not given then the default is 0 (i.e., the filename immediately follows the option switch, like in -Adatafile).
      *
 	 *   After processing, all magic key sequences are set to "---" to render them inactive.
 	 */

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -26,6 +26,7 @@
  * on them like add, multiply, etc.
  * Some operators only work on one operand (e.g., log, exp)
  *
+ * Note on KEYS: AD(= means -A takes an input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/gmtselect.c
+++ b/src/gmtselect.c
@@ -39,6 +39,8 @@
  *
  * Any one of these conditions may be negated for the opposite result
  * Both binary and ASCII data files are accommodated
+ *
+ * Note on KEYS: CD(= and LD(= mean -C and -L take input Datasets as arguments which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -21,6 +21,9 @@
  * Author:	Paul Wessel
  * Date:	10-Jun-2009
  * Version:	6 API
+ *
+ * Note on KEYS: DD(=f mean -D takes an optional input Dataset as argument via the +f modifier.
+ *               ND(= means -N takes a input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -30,6 +30,7 @@
  * Date:	1-JAN-2010
  * Version:	6 API
  *
+ * Note on KEYS: ED)=f mean -E takes an optional Dataset as argument via the +f modifier.
  */
 
 #include "gmt_dev.h"

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -22,6 +22,9 @@
  * Brief synopsis: grdcontour reads a 2-D grid file and contours it,
  * controlled by a variety of options.
  *
+ * Note on KEYS: AD)=t mean -A takes an optional output Dataset as argument via the +t modifier.
+ *               G?(=1 means if -Gf|x is given then we may read an input Dataset, else we set type to ! to skip it.
+ *               The "1" means we must skip the single char (f or x) before finding the file name
  */
 
 #include "gmt_dev.h"

--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -23,6 +23,8 @@
  *
  * Brief synopsis: Reads a grid file and writes a portion within it
  * to a new file.
+ *
+ * Note on KEYS: FD(= means -F takes an optional input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -23,6 +23,8 @@
  * Author:	Paul Wessel
  * Date:	1-JAN-2010
  * Version:	6 API
+ *
+ * Note on KEYS: =G} is special and says the = option will write an output grid (repeatable).
  */
 
 /* Notes: To add a new operator:

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -22,6 +22,8 @@
  * Author:	Paul Wessel and Walter H F Smith
  * Date:	1-JAN-2010
  * Version:	6 API
+ *
+ * Note on KEYS: SD)=s means -S takes an optional output Dataset as argument via the +s modifier.
  */
 
 #include "gmt_dev.h"

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -43,6 +43,9 @@
  *
  * PW Update July 2015. With help from Dong Ju Choi, San Diego Supercomputing Center, we have added Open MP
  * support in greenspline and the matrix solvers in gmt_vector.c.  Requires open MP support and use of -x.
+ *
+ * Note on KEYS: CD)=f means -C takes an optional output Dataset as argument via the +f modifier.
+ *               AD(= means -A takes an optional input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -34,6 +34,8 @@
  * Author:	Paul Wessel
  * Date:	1-JAN-2010
  * Version:	6 API
+ *
+ * Note on KEYS: LD(= means -L takes an optional input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -22,6 +22,10 @@
  * Author:	Paul Wessel
  * Date:	1-JAN-2010
  * Version:	6 API
+ *
+ * Note on KEYS: AD)=t means -A takes an optional output Dataset as argument via the +t modifier.
+ *               G?(=1 means if -Gf|x is given then we may read an input Dataset, else we set type to ! to skip it
+ *               The "1" means we must skip the single char (f or x) before finding the file name
  */
 
 #include "gmt_dev.h"

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -21,6 +21,9 @@
  *
  * Brief synopsis: psxy will read <x,y> points and plot symbols, lines,
  * or polygons on maps.
+ *
+ * Note on KEYS: S?(=2 means if -S~|q then we may possibly take optional crossing line file, else the ? is set to ! for skipping it.
+ *               The "2" means we must skip two characters (q|~ and f|x) before finding the dataset file name
  */
 
 #include "gmt_dev.h"

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -21,6 +21,9 @@
  *
  * Brief synopsis: psxyz will read <x,y,z> triplets and plot symbols, lines,
  * or polygons in a 3-D perspective view.
+ *
+ * Note on KEYS: S?(=2 means if -S~|q then we may possibly take optional crossing line file, else the ? is set to ! for skipping it.
+ *               The "2" means we must skip two characters (q|~ and f|x) before finding the dataset file name
  */
 
 #include "gmt_dev.h"

--- a/src/spotter/originater.c
+++ b/src/spotter/originater.c
@@ -101,6 +101,8 @@
  * 254		-27	SLG	Sala y Gomez
  * 192		-15	SAM	Samoa
  * 212		-18	SOC	Society
+ *
+ * Note on KEYS: FD(= means -F takes an optional input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/surface.c
+++ b/src/surface.c
@@ -39,6 +39,8 @@
  *    active nodes.  That spacing is now always 1 and we expand the grid as we
  *    go to larger grids (i.e., adding more nodes).
  * 3. It relies more on functions and macros from GMT to handle rows/cols/node calculations.
+ *
+ * Note on KEYS: DD(= means -D takes an optional input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/surface_experimental.c
+++ b/src/surface_experimental.c
@@ -40,6 +40,8 @@
  *    go to larger grids (i.e., adding more nodes).
  * 3. It relies more on functions and macros from GMT to handle rows/cols/node calculations.
  * 4. TESTING: It enables multiple threads via OpenMP [if compiled that way].
+ *
+ * Note on KEYS: DD(= means -D takes an optional input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"

--- a/src/surface_old.c
+++ b/src/surface_old.c
@@ -36,6 +36,8 @@
  * Tech Note:	1. surface uses old grid-structure (transpose of current GMT grid)
  *		   and must therefore waste time transposing grid before writing.
  *		   However, this is a tiny fraction of total run time.
+ *
+ * Note on KEYS: DD(= means -D takes an optional input Dataset as argument which may be followed by optional modifiers.
  */
 
 #include "gmt_dev.h"


### PR DESCRIPTION
ThisPR adds specific comments to each module with a non-standard **THIS_MODULE_KEYS** items and a fuller description of these sequences in the longer documentation already in _GMT_Encode_Options_. Closes #6135.
