### PR TITLE
Do not skip segments in wiggle based on x,y coordinates

### DIFF
--- a/src/pswiggle.c
+++ b/src/pswiggle.c
@@ -561,7 +561,7 @@ EXTERN_MSC int GMT_pswiggle (void *V_API, int mode, void *args) {
 
 		for (seg = 0; seg < D->table[tbl]->n_segments; seg++) {	/* For each segment in the table */
 
-			if (gmt_segment_BB_outside_map_BB (GMT, T->segment[seg])) continue;
+			/* Cannot exclude segments whose x,y are all outside since we do not yet know the coordinates of the amplitude curve */
 
 			PSL_comment (PSL, "%s\n", T->segment[seg]->header);
 

--- a/test/pswiggle/wiggle_outside.ps
+++ b/test/pswiggle/wiggle_outside.ps
@@ -1,0 +1,2253 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.4.0_b08cf03_2021.12.22 Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Wed Dec 22 16:29:46 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R0/3.93701/0/8.76172 -Jx1i -T -Xr1i -Yr1i --GMT_HISTORY=readonly
+%@PROJ: xy 0.00000000 3.93701000 0.00000000 8.76172000 0.000 3.937 0.000 8.762 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+%%EndObject
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 7207 TM
+% PostScript produced by:
+%@GMT: gmt wiggle test.txt -R-4/4/-3/3 -Z25i -Tfaint -W1p -i1,0,2 -BWrtS -Bxaf -Byaf -Xa0i -Ya6.0058i -JX15c/15c
+%@PROJ: xy -4.00000000 4.00000000 -3.00000000 3.00000000 -4.000 4.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+clipsave
+0 0 M
+4724 0 D
+0 3307 D
+-4724 0 D
+P
+PSL_clip N
+17 W
+2360 -2756 M
+2 136 D
+S
+0 W
+2362 -2756 M
+0 136 D
+S
+17 W
+2362 -2620 M
+5 140 D
+0 55 D
+-5 80 D
+S
+0 W
+2362 -2620 M
+0 275 D
+S
+17 W
+2362 -2345 M
+-10 140 D
+0 55 D
+10 81 D
+S
+0 W
+2362 -2345 M
+0 276 D
+S
+17 W
+2362 -2069 M
+16 85 D
+6 55 D
+-1 55 D
+-12 55 D
+-9 26 D
+S
+0 W
+2362 -2069 M
+0 276 D
+S
+17 W
+2362 -1793 M
+-31 84 D
+-13 55 D
+4 56 D
+23 55 D
+17 25 D
+S
+0 W
+2362 -1793 M
+0 275 D
+S
+17 W
+2362 -1518 M
+20 30 D
+40 55 D
+23 55 D
+-7 55 D
+-43 55 D
+-33 26 D
+S
+0 W
+2362 -1518 M
+0 276 D
+S
+17 W
+2362 -1242 M
+-108 85 D
+-41 55 D
+14 55 D
+78 55 D
+57 26 D
+S
+0 W
+2362 -1242 M
+0 276 D
+S
+17 W
+2362 -966 M
+185 84 D
+68 55 D
+-27 55 D
+-131 55 D
+-95 27 D
+S
+0 W
+2362 -966 M
+0 276 D
+S
+17 W
+2362 -690 M
+-300 84 D
+-105 55 D
+47 55 D
+209 55 D
+149 26 D
+S
+0 W
+2362 -690 M
+0 275 D
+S
+17 W
+2362 -415 M
+460 84 D
+156 55 D
+-78 56 D
+-317 55 D
+-221 26 D
+S
+0 W
+2362 -415 M
+0 276 D
+S
+17 W
+2362 -139 M
+-667 84 D
+-216 55 D
+121 55 D
+452 55 D
+310 27 D
+S
+0 W
+2362 -139 M
+0 276 D
+S
+17 W
+2362 137 M
+330 28 D
+586 55 D
+283 56 D
+-175 55 D
+-612 55 D
+-412 27 D
+S
+0 W
+2362 137 M
+0 276 D
+S
+17 W
+2362 413 M
+-433 28 D
+-756 55 D
+-350 55 D
+239 55 D
+783 55 D
+517 27 D
+S
+0 W
+2362 413 M
+0 275 D
+S
+17 W
+2362 688 M
+538 29 D
+923 55 D
+408 55 D
+-307 55 D
+-947 55 D
+-615 27 D
+S
+0 W
+2362 688 M
+0 276 D
+S
+17 W
+2362 964 M
+-632 28 D
+-1065 55 D
+-450 55 D
+373 55 D
+1083 56 D
+691 27 D
+S
+0 W
+2362 964 M
+0 276 D
+S
+17 W
+2362 1240 M
+703 28 D
+1163 55 D
+468 55 D
+-426 55 D
+-1174 55 D
+-734 28 D
+S
+0 W
+2362 1240 M
+0 276 D
+S
+17 W
+2362 1516 M
+-738 27 D
+-1201 55 D
+-461 56 D
+461 55 D
+1201 55 D
+738 27 D
+S
+0 W
+2362 1516 M
+0 275 D
+S
+17 W
+2362 1791 M
+734 28 D
+1174 55 D
+426 55 D
+-468 55 D
+-1163 55 D
+-703 28 D
+S
+0 W
+2362 1791 M
+0 276 D
+S
+17 W
+2362 2067 M
+-691 27 D
+-1083 56 D
+-373 55 D
+450 55 D
+1065 55 D
+632 28 D
+S
+0 W
+2362 2067 M
+0 276 D
+S
+17 W
+2362 2343 M
+615 27 D
+947 55 D
+307 55 D
+-408 55 D
+-923 56 D
+-538 28 D
+S
+0 W
+2362 2343 M
+0 276 D
+S
+17 W
+2362 2619 M
+-517 27 D
+-783 55 D
+-239 55 D
+350 55 D
+756 55 D
+433 28 D
+S
+0 W
+2362 2619 M
+0 275 D
+S
+17 W
+2362 2894 M
+412 27 D
+612 55 D
+175 55 D
+-283 56 D
+-586 55 D
+-330 28 D
+S
+0 W
+2362 2894 M
+0 276 D
+S
+17 W
+2362 3170 M
+-310 27 D
+-452 55 D
+-121 55 D
+216 55 D
+667 84 D
+S
+0 W
+2362 3170 M
+0 276 D
+S
+17 W
+2362 3446 M
+221 26 D
+317 56 D
+78 55 D
+-156 55 D
+-460 84 D
+S
+0 W
+2362 3446 M
+0 276 D
+S
+17 W
+2362 3722 M
+-149 26 D
+-209 55 D
+-47 55 D
+105 55 D
+300 84 D
+S
+0 W
+2362 3722 M
+0 275 D
+S
+17 W
+2362 3997 M
+95 27 D
+131 55 D
+27 55 D
+-68 55 D
+-185 84 D
+S
+0 W
+2362 3997 M
+0 276 D
+S
+17 W
+2362 4273 M
+-57 26 D
+-78 55 D
+-14 55 D
+41 56 D
+108 84 D
+S
+0 W
+2362 4273 M
+0 276 D
+S
+17 W
+2362 4549 M
+33 26 D
+43 55 D
+7 55 D
+-23 55 D
+-40 55 D
+-20 30 D
+S
+0 W
+2362 4549 M
+0 276 D
+S
+17 W
+2362 4825 M
+-17 25 D
+-23 56 D
+-4 55 D
+S
+0 W
+2362 4825 M
+0 136 D
+S
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 551 M -64 0 D S
+N 0 1654 M -64 0 D S
+N 0 2756 M -64 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+160 F0
+(”2) sw mx
+(0) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 48 add def
+551 PSL_A0_y MM
+(”2) mr Z
+1654 PSL_A0_y MM
+(0) mr Z
+2756 PSL_A0_y MM
+(2) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 1102 M -32 0 D S
+N 0 2205 M -32 0 D S
+N 0 3307 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4724 0 T
+24 W
+N 0 3307 M 0 -3307 D S
+-4724 0 T
+N 0 0 M 4724 0 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 0 M 0 -64 D S
+N 1181 0 M 0 -64 D S
+N 2362 0 M 0 -64 D S
+N 3543 0 M 0 -64 D S
+N 4724 0 M 0 -64 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”4) sh mx
+(”2) sh mx
+(0) sh mx
+(2) sh mx
+(4) sh mx
+def
+/PSL_A0_y PSL_A0_y 48 add PSL_AH0 add def
+0 PSL_A0_y MM
+(”4) bc Z
+1181 PSL_A0_y MM
+(”2) bc Z
+2362 PSL_A0_y MM
+(0) bc Z
+3543 PSL_A0_y MM
+(2) bc Z
+4724 PSL_A0_y MM
+(4) bc Z
+N 591 0 M 0 -32 D S
+N 1772 0 M 0 -32 D S
+N 2953 0 M 0 -32 D S
+N 4134 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+24 W
+N 0 0 M 4724 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 -7207 TM
+0 A
+FQ
+O0
+0 7207 TM
+% PostScript produced by:
+%@GMT: gmt plot test.txt -i1,0 -Sc2p -Gred -Xa0i -Ya6.0058i -R-4/4/-3/3 -JX15c/15c
+%@PROJ: xy -4.00000000 4.00000000 -3.00000000 3.00000000 -4.000 4.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+4724 0 D
+0 3307 D
+-4724 0 D
+P
+PSL_clip N
+V
+4 W
+{1 0 0 C} FS
+17 2362 0 Sc
+17 2362 55 Sc
+17 2362 110 Sc
+17 2362 165 Sc
+17 2362 220 Sc
+17 2362 276 Sc
+17 2362 331 Sc
+17 2362 386 Sc
+17 2362 441 Sc
+17 2362 496 Sc
+17 2362 551 Sc
+17 2362 606 Sc
+17 2362 661 Sc
+17 2362 717 Sc
+17 2362 772 Sc
+17 2362 827 Sc
+17 2362 882 Sc
+17 2362 937 Sc
+17 2362 992 Sc
+17 2362 1047 Sc
+17 2362 1102 Sc
+17 2362 1157 Sc
+17 2362 1213 Sc
+17 2362 1268 Sc
+17 2362 1323 Sc
+17 2362 1378 Sc
+17 2362 1433 Sc
+17 2362 1488 Sc
+17 2362 1543 Sc
+17 2362 1598 Sc
+17 2362 1654 Sc
+17 2362 1709 Sc
+17 2362 1764 Sc
+17 2362 1819 Sc
+17 2362 1874 Sc
+17 2362 1929 Sc
+17 2362 1984 Sc
+17 2362 2039 Sc
+17 2362 2094 Sc
+17 2362 2150 Sc
+17 2362 2205 Sc
+17 2362 2260 Sc
+17 2362 2315 Sc
+17 2362 2370 Sc
+17 2362 2425 Sc
+17 2362 2480 Sc
+17 2362 2535 Sc
+17 2362 2591 Sc
+17 2362 2646 Sc
+17 2362 2701 Sc
+17 2362 2756 Sc
+17 2362 2811 Sc
+17 2362 2866 Sc
+17 2362 2921 Sc
+17 2362 2976 Sc
+17 2362 3031 Sc
+17 2362 3087 Sc
+17 2362 3142 Sc
+17 2362 3197 Sc
+17 2362 3252 Sc
+17 2362 3307 Sc
+U
+PSL_cliprestore
+%%EndObject
+0 -7207 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 3603 TM
+% PostScript produced by:
+%@GMT: gmt wiggle test.txt -R-7/1/-3/3 -Z25i -Tfaint -W1p -i1,0,2 -BWrtS -Bxaf -Byaf -Xa0i -Ya3.0029i -JX15c/15c
+%@PROJ: xy -7.00000000 1.00000000 -3.00000000 3.00000000 -7.000 1.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+clipsave
+0 0 M
+4724 0 D
+0 3307 D
+-4724 0 D
+P
+PSL_clip N
+17 W
+4132 -2756 M
+2 136 D
+S
+0 W
+4134 -2756 M
+0 136 D
+S
+17 W
+4134 -2620 M
+4 140 D
+0 55 D
+-4 80 D
+S
+0 W
+4134 -2620 M
+0 275 D
+S
+17 W
+4134 -2345 M
+-11 140 D
+1 55 D
+5 56 D
+5 25 D
+S
+0 W
+4134 -2345 M
+0 276 D
+S
+17 W
+4134 -2069 M
+15 85 D
+7 55 D
+-2 55 D
+-11 55 D
+-9 26 D
+S
+0 W
+4134 -2069 M
+0 276 D
+S
+17 W
+4134 -1793 M
+-31 84 D
+-13 55 D
+3 56 D
+23 55 D
+18 25 D
+S
+0 W
+4134 -1793 M
+0 275 D
+S
+17 W
+4134 -1518 M
+59 85 D
+24 55 D
+-7 55 D
+-43 55 D
+-33 26 D
+S
+0 W
+4134 -1518 M
+0 276 D
+S
+17 W
+4134 -1242 M
+-108 85 D
+-41 55 D
+14 55 D
+78 55 D
+57 26 D
+S
+0 W
+4134 -1242 M
+0 276 D
+S
+17 W
+4134 -966 M
+185 84 D
+68 55 D
+-27 55 D
+-131 55 D
+-95 27 D
+S
+0 W
+4134 -966 M
+0 276 D
+S
+17 W
+4134 -690 M
+-300 84 D
+-106 55 D
+48 55 D
+209 55 D
+149 26 D
+S
+0 W
+4134 -690 M
+0 275 D
+S
+17 W
+4134 -415 M
+460 84 D
+155 55 D
+-78 56 D
+-316 55 D
+-221 26 D
+S
+0 W
+4134 -415 M
+0 276 D
+S
+17 W
+4134 -139 M
+-668 84 D
+-215 55 D
+120 55 D
+452 55 D
+311 27 D
+S
+0 W
+4134 -139 M
+0 276 D
+S
+17 W
+4134 137 M
+330 28 D
+586 55 D
+282 56 D
+-174 55 D
+-612 55 D
+-412 27 D
+S
+0 W
+4134 137 M
+0 276 D
+S
+17 W
+4134 413 M
+-433 28 D
+-757 55 D
+-349 55 D
+239 55 D
+782 55 D
+518 27 D
+S
+0 W
+4134 413 M
+0 275 D
+S
+17 W
+4134 688 M
+538 29 D
+923 55 D
+408 55 D
+-307 55 D
+-947 55 D
+-615 27 D
+S
+0 W
+4134 688 M
+0 276 D
+S
+17 W
+4134 964 M
+-632 28 D
+-1066 55 D
+-450 55 D
+373 55 D
+1084 56 D
+691 27 D
+S
+0 W
+4134 964 M
+0 276 D
+S
+17 W
+4134 1240 M
+702 28 D
+1163 55 D
+469 55 D
+-427 55 D
+-1173 55 D
+-734 28 D
+S
+0 W
+4134 1240 M
+0 276 D
+S
+17 W
+4134 1516 M
+-739 27 D
+-1201 55 D
+-460 56 D
+460 55 D
+1201 55 D
+739 27 D
+S
+0 W
+4134 1516 M
+0 275 D
+S
+17 W
+4134 1791 M
+734 28 D
+1173 55 D
+427 55 D
+-469 55 D
+-1163 55 D
+-702 28 D
+S
+0 W
+4134 1791 M
+0 276 D
+S
+17 W
+4134 2067 M
+-691 27 D
+-1084 56 D
+-373 55 D
+450 55 D
+1066 55 D
+632 28 D
+S
+0 W
+4134 2067 M
+0 276 D
+S
+17 W
+4134 2343 M
+615 27 D
+947 55 D
+307 55 D
+-408 55 D
+-923 56 D
+-538 28 D
+S
+0 W
+4134 2343 M
+0 276 D
+S
+17 W
+4134 2619 M
+-518 27 D
+-782 55 D
+-239 55 D
+349 55 D
+757 55 D
+433 28 D
+S
+0 W
+4134 2619 M
+0 275 D
+S
+17 W
+4134 2894 M
+412 27 D
+612 55 D
+174 55 D
+-282 56 D
+-586 55 D
+-330 28 D
+S
+0 W
+4134 2894 M
+0 276 D
+S
+17 W
+4134 3170 M
+-311 27 D
+-452 55 D
+-120 55 D
+215 55 D
+668 84 D
+S
+0 W
+4134 3170 M
+0 276 D
+S
+17 W
+4134 3446 M
+221 26 D
+316 56 D
+78 55 D
+-155 55 D
+-460 84 D
+S
+0 W
+4134 3446 M
+0 276 D
+S
+17 W
+4134 3722 M
+-149 26 D
+-209 55 D
+-48 55 D
+106 55 D
+300 84 D
+S
+0 W
+4134 3722 M
+0 275 D
+S
+17 W
+4134 3997 M
+95 27 D
+131 55 D
+27 55 D
+-68 55 D
+-185 84 D
+S
+0 W
+4134 3997 M
+0 276 D
+S
+17 W
+4134 4273 M
+-57 26 D
+-78 55 D
+-14 55 D
+41 56 D
+108 84 D
+S
+0 W
+4134 4273 M
+0 276 D
+S
+17 W
+4134 4549 M
+33 26 D
+43 55 D
+7 55 D
+-24 55 D
+-59 85 D
+S
+0 W
+4134 4549 M
+0 276 D
+S
+17 W
+4134 4825 M
+-18 25 D
+-23 56 D
+-3 55 D
+S
+0 W
+4134 4825 M
+0 136 D
+S
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 551 M -64 0 D S
+N 0 1654 M -64 0 D S
+N 0 2756 M -64 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+160 F0
+(”2) sw mx
+(0) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 48 add def
+551 PSL_A0_y MM
+(”2) mr Z
+1654 PSL_A0_y MM
+(0) mr Z
+2756 PSL_A0_y MM
+(2) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 1102 M -32 0 D S
+N 0 2205 M -32 0 D S
+N 0 3307 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4724 0 T
+24 W
+N 0 3307 M 0 -3307 D S
+-4724 0 T
+N 0 0 M 4724 0 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 591 0 M 0 -64 D S
+N 1772 0 M 0 -64 D S
+N 2953 0 M 0 -64 D S
+N 4134 0 M 0 -64 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”6) sh mx
+(”4) sh mx
+(”2) sh mx
+(0) sh mx
+def
+/PSL_A0_y PSL_A0_y 48 add PSL_AH0 add def
+591 PSL_A0_y MM
+(”6) bc Z
+1772 PSL_A0_y MM
+(”4) bc Z
+2953 PSL_A0_y MM
+(”2) bc Z
+4134 PSL_A0_y MM
+(0) bc Z
+N 0 0 M 0 -32 D S
+N 1181 0 M 0 -32 D S
+N 2362 0 M 0 -32 D S
+N 3543 0 M 0 -32 D S
+N 4724 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+24 W
+N 0 0 M 4724 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 -3603 TM
+0 A
+FQ
+O0
+0 3603 TM
+% PostScript produced by:
+%@GMT: gmt plot test.txt -i1,0 -Sc2p -Gred -Xa0i -Ya3.0029i -R-7/1/-3/3 -JX15c/15c
+%@PROJ: xy -7.00000000 1.00000000 -3.00000000 3.00000000 -7.000 1.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+4724 0 D
+0 3307 D
+-4724 0 D
+P
+PSL_clip N
+V
+4 W
+{1 0 0 C} FS
+17 4134 0 Sc
+17 4134 55 Sc
+17 4134 110 Sc
+17 4134 165 Sc
+17 4134 220 Sc
+17 4134 276 Sc
+17 4134 331 Sc
+17 4134 386 Sc
+17 4134 441 Sc
+17 4134 496 Sc
+17 4134 551 Sc
+17 4134 606 Sc
+17 4134 661 Sc
+17 4134 717 Sc
+17 4134 772 Sc
+17 4134 827 Sc
+17 4134 882 Sc
+17 4134 937 Sc
+17 4134 992 Sc
+17 4134 1047 Sc
+17 4134 1102 Sc
+17 4134 1157 Sc
+17 4134 1213 Sc
+17 4134 1268 Sc
+17 4134 1323 Sc
+17 4134 1378 Sc
+17 4134 1433 Sc
+17 4134 1488 Sc
+17 4134 1543 Sc
+17 4134 1598 Sc
+17 4134 1654 Sc
+17 4134 1709 Sc
+17 4134 1764 Sc
+17 4134 1819 Sc
+17 4134 1874 Sc
+17 4134 1929 Sc
+17 4134 1984 Sc
+17 4134 2039 Sc
+17 4134 2094 Sc
+17 4134 2150 Sc
+17 4134 2205 Sc
+17 4134 2260 Sc
+17 4134 2315 Sc
+17 4134 2370 Sc
+17 4134 2425 Sc
+17 4134 2480 Sc
+17 4134 2535 Sc
+17 4134 2591 Sc
+17 4134 2646 Sc
+17 4134 2701 Sc
+17 4134 2756 Sc
+17 4134 2811 Sc
+17 4134 2866 Sc
+17 4134 2921 Sc
+17 4134 2976 Sc
+17 4134 3031 Sc
+17 4134 3087 Sc
+17 4134 3142 Sc
+17 4134 3197 Sc
+17 4134 3252 Sc
+17 4134 3307 Sc
+U
+PSL_cliprestore
+%%EndObject
+0 -3603 TM
+PSL_plot_completion /PSL_plot_completion {} def
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt wiggle test.txt -R-9/-1/-3/3 -Z25i -Tfaint -W1p -i1,0,2 -BWrtS -Bxaf -Byaf -Xa0i -Ya0i -JX15c/15c
+%@PROJ: xy -9.00000000 -1.00000000 -3.00000000 3.00000000 -9.000 -1.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 A
+clipsave
+0 0 M
+4724 0 D
+0 3307 D
+-4724 0 D
+P
+PSL_clip N
+17 W
+5313 -2756 M
+2 136 D
+S
+0 W
+5315 -2756 M
+0 136 D
+S
+17 W
+5315 -2620 M
+5 140 D
+-3 110 D
+-2 25 D
+S
+0 W
+5315 -2620 M
+0 275 D
+S
+17 W
+5315 -2345 M
+-10 140 D
+0 55 D
+10 81 D
+S
+0 W
+5315 -2345 M
+0 276 D
+S
+17 W
+5315 -2069 M
+15 85 D
+7 55 D
+-2 55 D
+-11 55 D
+-9 26 D
+S
+0 W
+5315 -2069 M
+0 276 D
+S
+17 W
+5315 -1793 M
+-31 84 D
+-13 55 D
+3 56 D
+23 55 D
+18 25 D
+S
+0 W
+5315 -1793 M
+0 275 D
+S
+17 W
+5315 -1518 M
+20 30 D
+40 55 D
+23 55 D
+-7 55 D
+-43 55 D
+-33 26 D
+S
+0 W
+5315 -1518 M
+0 276 D
+S
+17 W
+5315 -1242 M
+-108 85 D
+-41 55 D
+14 55 D
+78 55 D
+57 26 D
+S
+0 W
+5315 -1242 M
+0 276 D
+S
+17 W
+5315 -966 M
+185 84 D
+68 55 D
+-27 55 D
+-131 55 D
+-95 27 D
+S
+0 W
+5315 -966 M
+0 276 D
+S
+17 W
+5315 -690 M
+-300 84 D
+-106 55 D
+48 55 D
+209 55 D
+149 26 D
+S
+0 W
+5315 -690 M
+0 275 D
+S
+17 W
+5315 -415 M
+460 84 D
+155 55 D
+-78 56 D
+-316 55 D
+-221 26 D
+S
+0 W
+5315 -415 M
+0 276 D
+S
+17 W
+5315 -139 M
+-668 84 D
+-215 55 D
+120 55 D
+453 55 D
+310 27 D
+S
+0 W
+5315 -139 M
+0 276 D
+S
+17 W
+5315 137 M
+330 28 D
+586 55 D
+282 56 D
+-174 55 D
+-612 55 D
+-412 27 D
+S
+0 W
+5315 137 M
+0 276 D
+S
+17 W
+5315 413 M
+-433 28 D
+-757 55 D
+-349 55 D
+239 55 D
+783 55 D
+517 27 D
+S
+0 W
+5315 413 M
+0 275 D
+S
+17 W
+5315 688 M
+538 29 D
+923 55 D
+408 55 D
+-307 55 D
+-947 55 D
+-615 27 D
+S
+0 W
+5315 688 M
+0 276 D
+S
+17 W
+5315 964 M
+-632 28 D
+-1065 55 D
+-451 55 D
+373 55 D
+1084 56 D
+691 27 D
+S
+0 W
+5315 964 M
+0 276 D
+S
+17 W
+5315 1240 M
+702 28 D
+1163 55 D
+469 55 D
+-427 55 D
+-1173 55 D
+-734 28 D
+S
+0 W
+5315 1240 M
+0 276 D
+S
+17 W
+5315 1516 M
+-738 27 D
+-1202 55 D
+-460 56 D
+460 55 D
+1202 55 D
+738 27 D
+S
+0 W
+5315 1516 M
+0 275 D
+S
+17 W
+5315 1791 M
+734 28 D
+1173 55 D
+427 55 D
+-469 55 D
+-1163 55 D
+-702 28 D
+S
+0 W
+5315 1791 M
+0 276 D
+S
+17 W
+5315 2067 M
+-691 27 D
+-1084 56 D
+-373 55 D
+451 55 D
+1065 55 D
+632 28 D
+S
+0 W
+5315 2067 M
+0 276 D
+S
+17 W
+5315 2343 M
+615 27 D
+947 55 D
+307 55 D
+-408 55 D
+-923 56 D
+-538 28 D
+S
+0 W
+5315 2343 M
+0 276 D
+S
+17 W
+5315 2619 M
+-517 27 D
+-783 55 D
+-239 55 D
+349 55 D
+757 55 D
+433 28 D
+S
+0 W
+5315 2619 M
+0 275 D
+S
+17 W
+5315 2894 M
+412 27 D
+612 55 D
+174 55 D
+-282 56 D
+-586 55 D
+-330 28 D
+S
+0 W
+5315 2894 M
+0 276 D
+S
+17 W
+5315 3170 M
+-310 27 D
+-453 55 D
+-120 55 D
+215 55 D
+668 84 D
+S
+0 W
+5315 3170 M
+0 276 D
+S
+17 W
+5315 3446 M
+221 26 D
+316 56 D
+78 55 D
+-155 55 D
+-460 84 D
+S
+0 W
+5315 3446 M
+0 276 D
+S
+17 W
+5315 3722 M
+-149 26 D
+-209 55 D
+-48 55 D
+106 55 D
+300 84 D
+S
+0 W
+5315 3722 M
+0 275 D
+S
+17 W
+5315 3997 M
+95 27 D
+131 55 D
+27 55 D
+-68 55 D
+-185 84 D
+S
+0 W
+5315 3997 M
+0 276 D
+S
+17 W
+5315 4273 M
+-57 26 D
+-78 55 D
+-14 55 D
+41 56 D
+108 84 D
+S
+0 W
+5315 4273 M
+0 276 D
+S
+17 W
+5315 4549 M
+33 26 D
+43 55 D
+7 55 D
+-23 55 D
+-40 55 D
+-20 30 D
+S
+0 W
+5315 4549 M
+0 276 D
+S
+17 W
+5315 4825 M
+-18 25 D
+-23 56 D
+-3 55 D
+S
+0 W
+5315 4825 M
+0 136 D
+S
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 3307 M 0 -3307 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 0 551 M -64 0 D S
+N 0 1654 M -64 0 D S
+N 0 2756 M -64 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+160 F0
+(”2) sw mx
+(0) sw mx
+(2) sw mx
+def
+/PSL_A0_y PSL_A0_y 48 add def
+551 PSL_A0_y MM
+(”2) mr Z
+1654 PSL_A0_y MM
+(0) mr Z
+2756 PSL_A0_y MM
+(2) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 0 M -32 0 D S
+N 0 1102 M -32 0 D S
+N 0 2205 M -32 0 D S
+N 0 3307 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+4724 0 T
+24 W
+N 0 3307 M 0 -3307 D S
+-4724 0 T
+N 0 0 M 4724 0 D S
+/PSL_A0_y 64 def
+/PSL_A1_y 0 def
+8 W
+N 591 0 M 0 -64 D S
+N 1772 0 M 0 -64 D S
+N 2953 0 M 0 -64 D S
+N 4134 0 M 0 -64 D S
+/MM {neg M} def
+/PSL_AH0 0
+(”8) sh mx
+(”6) sh mx
+(”4) sh mx
+(”2) sh mx
+def
+/PSL_A0_y PSL_A0_y 48 add PSL_AH0 add def
+591 PSL_A0_y MM
+(”8) bc Z
+1772 PSL_A0_y MM
+(”6) bc Z
+2953 PSL_A0_y MM
+(”4) bc Z
+4134 PSL_A0_y MM
+(”2) bc Z
+N 0 0 M 0 -32 D S
+N 1181 0 M 0 -32 D S
+N 2362 0 M 0 -32 D S
+N 3543 0 M 0 -32 D S
+N 4724 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 3307 T
+24 W
+N 0 0 M 4724 0 D S
+0 -3307 T
+0 setlinecap
+%%EndObject
+0 0 TM
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot test.txt -i1,0 -Sc2p -Gred -Xa0i -Ya0i -R-9/-1/-3/3 -JX15c/15c
+%@PROJ: xy -9.00000000 -1.00000000 -3.00000000 3.00000000 -9.000 -1.000 -3.000 3.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+4724 0 D
+0 3307 D
+-4724 0 D
+P
+PSL_clip N
+V
+4 W
+U
+PSL_cliprestore
+%%EndObject
+0 0 TM
+PSL_plot_completion /PSL_plot_completion {} def
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/pswiggle/wiggle_outside.sh
+++ b/test/pswiggle/wiggle_outside.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Test that wiggle is not clipped off if all x,y (red dots) are outside map
+# See https://forum.generic-mapping-tools.org/t/problem-with-wiggle-at-plot-boundary/2414/5
+gmt begin wiggle_outside
+	gmt math -T-8/6/0.1 -N3/0 -C2 T 3 DIV 2 POW NEG EXP T PI 2 MUL MUL COS MUL 50 MUL = test.txt
+	gmt subplot begin 3x1 -Fs10c/7c -Baf -M2p
+		gmt wiggle test.txt -R-4/4/-3/3 -Z25i -Tfaint -W1p -i1,0,2 -c
+		gmt plot test.txt -i1,0 -Sc2p -Gred
+		gmt wiggle test.txt -R-7/1/-3/3 -Z25i -Tfaint -W1p -i1,0,2 -c
+		gmt plot test.txt -i1,0 -Sc2p -Gred
+		gmt wiggle test.txt -R-9/-1/-3/3 -Z25i -Tfaint -W1p -i1,0,2 -c
+		gmt plot test.txt -i1,0 -Sc2p -Gred
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
We used _gmt_segment_BB_outside_map_BB_ to skip segments outside the map bounding box but that only works well in **plot** and **plot3** but for **wiggle** we do not know the plot coordinates of the line which may well be inside the domain even though the x,y coordinates are outside.  The solution is to remove that call.  Here is a test derived from the report in the [forum](https://forum.generic-mapping-tools.org/t/problem-with-wiggle-at-plot-boundary/2414/5), where the red dots are the coordinates of the input line.  In the bottom frame all points are outside yet the wiggle persists, as it should:

![wiggle_outside](https://user-images.githubusercontent.com/26473567/147179351-ff6a443e-0046-42f1-a912-7f1beb0d67f2.jpg)

