### PR TITLE
Avoid setting enums to unrecognized values

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2988,7 +2988,7 @@ GMT_LOCAL int gmtapi_get_object (struct GMTAPI_CTRL *API, int sfamily, void *ptr
 	 * Unless family is GMT_NOTSET the object must be of the specified family.
 	 */
 	unsigned int item;
-	enum GMT_enum_family family = GMT_NOTSET;
+	enum GMT_enum_family family;
 	int object_ID = GMT_NOTSET;	/* Not found yet */
 	struct GMTAPI_DATA_OBJECT *S_obj = NULL;
 


### PR DESCRIPTION
We do not want to set the _family_ enum to **GMT_NOTSET** (-1) since no such value was declared for that enum.  There is no reason to initialize since we used the incoming _sfamily_ to check if we have assigned it.

I can merge this myself but added @joa-quim since he mentioned the warning.