### PR TITLE
Simplify testing of alternate data server via ConfigUserAdvancedTemplate.cmake

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -141,7 +141,7 @@ endif (NOT DEFINED GMT_RELEASE_PREFIX)
 
 # Default location of remote data server
 if (NOT DEFINED GMT_DATA_SERVER)
-	set (GMT_DATA_SERVER "test")
+	set (GMT_DATA_SERVER "oceania")
 endif (NOT DEFINED GMT_DATA_SERVER)
 
 # Default name of ghostscript executable

--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -141,7 +141,7 @@ endif (NOT DEFINED GMT_RELEASE_PREFIX)
 
 # Default location of remote data server
 if (NOT DEFINED GMT_DATA_SERVER)
-	set (GMT_DATA_SERVER "oceania")
+	set (GMT_DATA_SERVER "test")
 endif (NOT DEFINED GMT_DATA_SERVER)
 
 # Default name of ghostscript executable

--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -200,6 +200,11 @@
 # Uncomment the following line to enable running low-level C tests of the API
 #set (DO_API_TESTS ON)
 
+# Uncomment the following line if you need to run the full tests suite using
+# the gmtserver "test" distribution instead of the default server.
+# You may wish to rename existing cache and server dirs so you can restore afterwards
+# set (GMT_DATA_SERVER "test")
+
 # List extra sub-dirs of 'src' with a CMakeLists.txt to build custom modules
 # that link against the full gmt libs. (For building codes that only need the GMT API,
 # see the https://github.com/GenericMappingTools/custom-supplements project).


### PR DESCRIPTION
Before new remote data sets are added we place them in the test (not oceania) server section and run some tests to ensure we got everything correctly done.  For running the GMT suite using the test.generic-mapping-tools.org data server, simply uncomment the line in your ConfigUserAdvanced.cmake file (after updating via the Template):

`# set (GMT_DATA_SERVER "test")`

and rebuild.  Also, to preserve your existing cache and server files, simply do

```
mv ~/.gmt/server ~/.gmt/server_orig
mv ~/.gmt/cache ~/.gmt/cache_orig
```

so that you will only use files from the test server.  Once you have finished testing, remove the new directories and rename the old:

```
rm -f /.gmt/server  ~/.gmt/cache 
mv ~/.gmt/server_orig~/.gmt/server 
mv ~/.gmt/cache_orig ~/.gmt/cache
```

As is, this PR has no effect (unless a developers updates their settings).