### PR TITLE
Ensure we properly terminate a string

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -344,10 +344,12 @@ int gmt_remote_no_resolution_given (struct GMTAPI_CTRL *API, const char *rfile, 
 		file[L-2] = '\0';
 	}
 	for (int k = 0; ID == GMT_NOTSET && k < API->n_remote_info; k++) {
-		strncpy (dir, API->remote_info[k].dir, strlen (API->remote_info[k].dir)-1);	/* Make a copy without the trailing slash */
+		L = strlen (API->remote_info[k].dir);	/* Length of directory */
+		strncpy (dir, API->remote_info[k].dir, L-1);	/* Make a copy without the trailing slash */
+		dir[L] = '\0';	/* Terminate string */
 		p = strrchr (dir, '/');	/* Start of final subdirectory */
 		p++;	/* Skip past the slash */
-		if (!strcmp (p, file)) ID = k;
+		if (!strcmp (p, file)) ID = k;	/* Found it */
 	}
 	if (ID != GMT_NOTSET && registration)
 		*registration = reg;	/* Pass back desired [or any] registration */
@@ -383,7 +385,9 @@ struct GMT_RESOLUTION *gmt_remote_resolutions (struct GMTAPI_CTRL *API, const ch
 		return NULL;	/* No memory */
 
 	for (int k = 0; k < API->n_remote_info; k++) {
-		strncpy (dir, API->remote_info[k].dir, strlen (API->remote_info[k].dir)-1);	/* Make a copy without the trailing slash */
+		L = strlen (API->remote_info[k].dir);	/* Length of directory */
+		strncpy (dir, API->remote_info[k].dir, L-1);	/* Make a copy without the trailing slash */
+		dir[L] = '\0';	/* Terminate string */
 		p = strrchr (dir, '/');	/* Start of final subdirectory */
 		p++;	/* Skip past the slash */
 		if (!strcmp (p, file) && (reg == GMT_NOTSET || registration[reg] == API->remote_info[k].reg)) {	/* Got one to keep */


### PR DESCRIPTION
As I was testing new remote data sets, the updated gmt_data_server.txt happens to have directory names that at first were long, then got shorter. This change allowed me to find this bug: We are copying over a string except for the last character (the slash), but we never terminated the string, so that a longer name would still be present at the end of a shorter one.  This made a string compare fail that previously had worked.

No affect on any tests since this only applies to the future.  The future is coming soon.