### PR TITLE
Make the RMS threshold a bit larger for oblsuite_N.sh

### DIFF
--- a/test/pscoast/oblsuite_N.sh
+++ b/test/pscoast/oblsuite_N.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Higher RMS threshold due to hairline differences in many gridlines between different OS
-# GRAPHICSMAGICK_RMS = 0.004
+# GRAPHICSMAGICK_RMS = 0.0045
 ps=oblsuite_N.ps
 gmt pscoast -R-2000/2000/-1000/1000+uk -Joa-30/60/-180/1:60000000 -Ba0fg -P -Gred -K -X1.25i -Y9i > $ps
 gmt pscoast -R-2000/2000/-1000/1000+uk -Joa-30/60/-150/1:60000000 -Ba0fg -O -K -Gred -Y-1.7i >> $ps


### PR DESCRIPTION
This script already had a **GRAPHICSMAGICK_RMS** set to 0.004 but on my new M1 Max it still failed with rms = 0.0042.  This PR increases the RMS to 0.0045 so that it passes (since this is just roundoff for lots of gridlines).

I have two other failures that require more checking, but they consistently fail on M1 chips (grdcyclic.sh and gspline_5.sh).  I will work on those separately to understand them first.