### PR TITLE
Simplify how multiple remote DEMs can share the same SRTM tiles

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -186,6 +186,7 @@ EXTERN_MSC double gmt_fft_any_wave (uint64_t k, unsigned int mode, struct GMT_FF
 
 /* gmt_remote.c: */
 
+EXTERN_MSC bool gmt_use_srtm_coverage (struct GMTAPI_CTRL *API, char **file, int *k, unsigned int *res);
 EXTERN_MSC struct GMT_RESOLUTION *gmt_remote_resolutions (struct GMTAPI_CTRL *API, const char *rfile, unsigned int *n);
 EXTERN_MSC int gmt_remote_no_resolution_given (struct GMTAPI_CTRL *API, const char *rfile, int *registration);
 EXTERN_MSC char *gmt_dataserver_url (struct GMTAPI_CTRL *API);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -987,23 +987,24 @@ void gmt_refresh_server (struct GMTAPI_CTRL *API) {
 	}
 }
 
-GMT_LOCAL char * gmtremote_switch_to_srtm (char *file, char *res) {
+GMT_LOCAL char * gmtremote_switch_to_srtm (char *file, char *res, bool srtm) {
 	/* There may be more than one remote Earth DEM product that needs to share the
 	 * same 1x1 degree SRTM tiles.  This function handles this overlap; add more cases if needed. */
-	char *c = NULL;
-	if ((c = strstr (file, ".earth_relief_01s_g")) || (c = strstr (file, ".earth_synbath_01s_g")))
-		*res = '1';
-	else if ((c = strstr (file, ".earth_relief_03s_g")) || (c = strstr (file, ".earth_synbath_03s_g")))
-		*res = '3';
+	char *c;
+	if (!srtm) return NULL;	/* Not using SRTM tiles at all */
+	if ((c = strstr (file, "_01s_g")) || (c = strstr (file, "_03s_g"))) {
+		*res = c[2];	/* Get the '1' or '3' */
+		c = strchr (file, '.');	/* Start of "extension" */
+	}
 	return (c);	/* Returns pointer to this "extension" or NULL */
 }
 
-GMT_LOCAL char * gmtremote_get_jp2_tilename (char *file) {
+GMT_LOCAL char * gmtremote_get_jp2_tilename (char *file, bool srtm) {
 	/* Must do special legacy checks for SRTMGL1|3 tag names for SRTM tiles.
 	 * We also strip off the leading @ since we are building an URL for curl  */
 	char res, *c = NULL, *new_file = NULL;
 	
-	if ((c = gmtremote_switch_to_srtm (file, &res))) {
+	if ((c = gmtremote_switch_to_srtm (file, &res, srtm))) {
 		/* Found one of the SRTM tile families, now replace the tag with SRTMGL1|3 */
 		char remote_name[GMT_LEN64] = {""};
 		c[0] = '\0';	/* Temporarily chop off tag and beyond */
@@ -1066,7 +1067,7 @@ int gmt_set_remote_and_local_filenames (struct GMT_CTRL *GMT, const char * file,
 
 	int k_data = GMT_NOTSET, t_data = GMT_NOTSET;
 	unsigned int pos;
-	bool is_url = false, is_query = false, is_tile = false;
+	bool is_url = false, is_query = false, is_tile = false, srtm_switch = false;
 	char was, *c = NULL, *jp2_file = NULL, *clean_file = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -1128,6 +1129,7 @@ int gmt_set_remote_and_local_filenames (struct GMT_CTRL *GMT, const char * file,
 			strcat (local_path, GMT->parent->remote_info[t_data].file);	/* Append the tiledir to get full path to dir for this type of tiles */
 			strcat (local_path, &file[1]);	/* Append filename */
 			is_tile = true;
+			srtm_switch = !strcmp (GMT->parent->remote_info[t_data].coverage, "srtm_tiles.nc");	/* true if this dataset switches to SRTM tiles for this resolutions */
 			if (access (local_path, R_OK)) {	/* A local tile in netCDF format was not found.  See if it exists as compressed JP2000 */
 				char *local_jp2 = gmt_strrep (local_path, GMT_TILE_EXTENSION_LOCAL, GMT_TILE_EXTENSION_REMOTE);
  				if (access (local_jp2, R_OK))
@@ -1161,7 +1163,7 @@ int gmt_set_remote_and_local_filenames (struct GMT_CTRL *GMT, const char * file,
 not_local:	/* Get here if we failed to find a remote file already on disk */
 		/* Set remote path */
 		if (is_tile) {	/* Tile not yet downloaded, but must switch to .jp2 format on the server (and deal with legacy SRTM tile tags) */
-			jp2_file = gmtremote_get_jp2_tilename ((char *)file);
+			jp2_file = gmtremote_get_jp2_tilename ((char *)file, srtm_switch);
 			snprintf (remote_path, PATH_MAX, "%s%s%s%s", gmt_dataserver_url (API), GMT->parent->remote_info[t_data].dir, GMT->parent->remote_info[t_data].file, jp2_file);
 		}
 		else if (k_data == GMT_NOTSET) {	/* Cache file not yet downloaded */

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -344,8 +344,8 @@ int gmt_remote_no_resolution_given (struct GMTAPI_CTRL *API, const char *rfile, 
 		file[L-2] = '\0';
 	}
 	for (int k = 0; ID == GMT_NOTSET && k < API->n_remote_info; k++) {
-		L = strlen (API->remote_info[k].dir);	/* Length of directory */
-		strncpy (dir, API->remote_info[k].dir, L-1);	/* Make a copy without the trailing slash */
+		L = strlen (API->remote_info[k].dir) - 1;	/* Length of directory without the trailing slash */
+		strncpy (dir, API->remote_info[k].dir, L);	/* Make a copy without the trailing slash */
 		dir[L] = '\0';	/* Terminate string */
 		p = strrchr (dir, '/');	/* Start of final subdirectory */
 		p++;	/* Skip past the slash */
@@ -385,8 +385,8 @@ struct GMT_RESOLUTION *gmt_remote_resolutions (struct GMTAPI_CTRL *API, const ch
 		return NULL;	/* No memory */
 
 	for (int k = 0; k < API->n_remote_info; k++) {
-		L = strlen (API->remote_info[k].dir);	/* Length of directory */
-		strncpy (dir, API->remote_info[k].dir, L-1);	/* Make a copy without the trailing slash */
+		L = strlen (API->remote_info[k].dir) - 1;	/* Length of directory without the trailing slash */
+		strncpy (dir, API->remote_info[k].dir, L);	/* Make a copy without the trailing slash */
 		dir[L] = '\0';	/* Terminate string */
 		p = strrchr (dir, '/');	/* Start of final subdirectory */
 		p++;	/* Skip past the slash */

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1017,6 +1017,22 @@ GMT_LOCAL char * gmtremote_get_jp2_tilename (char *file, bool srtm) {
 	return (new_file);
 }
 
+bool gmt_use_srtm_coverage (struct GMTAPI_CTRL *API, char **file, int *k, unsigned int *res) {
+	char newfile[GMT_LEN128] = {""}, c_res = '\0', *c = NULL;
+
+	if (strcmp (API->remote_info[*k].coverage, "srtm_tiles.nc")) return false;	/* This tile does not use SRTM at this resolution */
+	/* Here, *file is something like @N33E044.earth_gebco_03s_g.nc, but we need to change it to @N33E044.earth_relief_03s_g.nc */
+	c = gmtremote_switch_to_srtm (*file, &c_res, true);	/* Set the resolution */
+	*res = c_res - '0';	/* Convert character digit to number */
+	c[0] = '\0';	/* Chop off the rest */
+	sprintf (newfile, "%s.earth_relief_0%cs_g.nc", *file, c_res);
+	c[0] = '.';	/* Restore the original file name */
+	gmt_M_str_free (*file);	/* Free the original name */
+	*file = strdup (newfile);	/* Replace with the new name */
+	*k = gmt_file_is_a_tile (API, newfile, GMT_LOCAL_DIR);	/* Update tile ID */
+	return (true);
+}
+
 GMT_LOCAL int gmtremote_convert_jp2_to_nc (struct GMTAPI_CTRL *API, char *localfile) {
 	static char *args = " -fg -Vq --IO_NC4_DEFLATION_LEVEL=9 --GMT_HISTORY=readonly";
 	char cmd[GMT_LEN512] = {""},  *ncfile = NULL;

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -275,11 +275,13 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			if (n_scanned == 2 && !(r_in[0] == '-' && (r_in[1] == '\0' || r_in[1] == 'R'))) weight = atof (r_in);	/* Got "file weight" record */
 			L[n].weight = (n_scanned == 1 || (n == 2 && r_in[0] == '-')) ? 1.0 : weight;	/* Default weight is 1 if none were given */
 			if ((t_data = gmt_file_is_a_tile (GMT->parent, L[n].file, GMT_LOCAL_DIR)) != GMT_NOTSET) {
-				if (strstr (L[n].file, ".earth_relief_01s_g.")) {	/* A 1s SRTM tile */
-					srtm_res = 1;	srtm_job = true;
-				}
-				else if (strstr (L[n].file, ".earth_relief_03s_g.")) {	/* A 3s SRTM tile */
-					srtm_res = 3;	srtm_job = true;
+				if (!strcmp (GMT->parent->remote_info[t_data].coverage, "srtm_tiles.nc")) {	/* true if this dataset uses SRTM for 1s and 3s resolutions */
+					if (strstr (L[n].file, "_01s_g.")) {	/* A 1s SRTM tile */
+						srtm_res = 1;	srtm_job = true;
+					}
+					else if (strstr (L[n].file, "_03s_g.")) {	/* A 3s SRTM tile */
+						srtm_res = 3;	srtm_job = true;
+					}
 				}
 				if (gmt_access (GMT, &L[n].file[1], F_OK)) {	/* Tile must be downloaded */
 					L[n].download = true;

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -275,14 +275,7 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			if (n_scanned == 2 && !(r_in[0] == '-' && (r_in[1] == '\0' || r_in[1] == 'R'))) weight = atof (r_in);	/* Got "file weight" record */
 			L[n].weight = (n_scanned == 1 || (n == 2 && r_in[0] == '-')) ? 1.0 : weight;	/* Default weight is 1 if none were given */
 			if ((t_data = gmt_file_is_a_tile (GMT->parent, L[n].file, GMT_LOCAL_DIR)) != GMT_NOTSET) {
-				if (!strcmp (GMT->parent->remote_info[t_data].coverage, "srtm_tiles.nc")) {	/* true if this dataset uses SRTM for 1s and 3s resolutions */
-					if (strstr (L[n].file, "_01s_g.")) {	/* A 1s SRTM tile */
-						srtm_res = 1;	srtm_job = true;
-					}
-					else if (strstr (L[n].file, "_03s_g.")) {	/* A 3s SRTM tile */
-						srtm_res = 3;	srtm_job = true;
-					}
-				}
+				srtm_job = gmt_use_srtm_coverage (GMT->parent, &(L[n].file), &t_data, &srtm_res);	/* true if this dataset uses SRTM for 1s and 3s resolutions */
 				if (gmt_access (GMT, &L[n].file[1], F_OK)) {	/* Tile must be downloaded */
 					L[n].download = true;
 					n_download++;


### PR DESCRIPTION
**Description of proposed changes**

Initially, only `@earth_relief `used the 1s and 3s SRTM tiles but with _synbath_, _gebco_ and _gebcosi_ all using then a better sharing setup had to be implemented.   A few changes to local functions and the introduction of shared _gmt_use_srtm_coverage_ function that will detect the need to switch to SRTM and update the name of the tile from, say `@N33E044.earth_gebco_03s_g.nc` to `@N33E044.earth_relief_03s_g.nc`. This is needed because **grdblend** needed to d this.

Tests still pass when using the test server, and command like 

`gmt grdimage @earth_gebco -JM15c -Bg0 -png gebco -R44/50/33/40`

now gets the right tiles.
