### PR TITLE
Remember separate fill settings for lakes and river-lakes

### DIFF
--- a/test/pscoast/riverlake.ps
+++ b/test/pscoast/riverlake.ps
@@ -1,0 +1,1332 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 612 792
+%%HiResBoundingBox: 0 0 612.0000 792.0000
+%%Title: GMT v6.4.0_0842727_2021.12.26 Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Sun Dec 26 12:25:19 2021
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 10200 def
+/PSL_page_ysize 13200 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -JQ50/42/10c -R46/54/36/48 -Sc1c -W1p,black -Gred
+%@PROJ: eqc 46.00000000 54.00000000 36.00000000 48.00000000 -330536.110 330536.110 4003021.871 5337362.495 +proj=eqc +lat_ts=42 +lat_0=0 +lon_0=50 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+4724 0 D
+0 9536 D
+-4724 0 D
+P
+PSL_clip N
+V
+17 W
+{1 0 0 C} FS
+O1
+236 2362 4768 Sc
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt coast -Dl -Ggray -Cgray+r -R46/54/36/48 -JQ50/42/10c
+%@PROJ: eqc 46.00000000 54.00000000 36.00000000 48.00000000 -330536.110 330536.110 4003021.871 5337362.495 +proj=eqc +lat_ts=42 +lat_0=0 +lon_0=50 +x_0=0 +y_0=0 +units=m +a=6371007.181 +b=6371007.181 +units=m +no_defs
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+0 -280 72 -8 230 169 13 119 4 2047 3179 SP
+2362 7132 M
+-12 -15 D
+12 -15 D
+0 -3462 D
+-115 -13 D
+-164 78 D
+3 99 D
+-183 184 D
+-108 314 D
+-214 293 D
+-169 111 D
+-161 321 D
+-224 245 D
+-23 181 D
+-145 178 D
+79 168 D
+-59 -3 D
+-1 129 D
+125 328 D
+-94 -7 D
+-78 -285 D
+32 289 D
+-133 286 D
+-46 -19 D
+-75 121 D
+-187 56 D
+-1 178 D
+146 92 D
+19 126 D
+49 -111 D
+13 133 D
+165 185 D
+51 158 D
+-50 24 D
+66 9 D
+7 132 D
+40 -20 D
+-112 144 D
+152 -153 D
+-50 172 D
+158 -129 D
+19 88 D
+229 -6 D
+27 98 D
+72 0 D
+-25 34 D
+113 71 D
+89 -123 D
+47 19 D
+-94 197 D
+46 40 D
+68 -67 D
+-18 63 D
+49 -44 D
+-19 56 D
+60 -48 D
+56 90 D
+47 -38 D
+-36 83 D
+54 65 D
+90 -65 D
+-78 123 D
+70 -14 D
+-17 64 D
+65 -65 D
+-39 156 D
+118 -73 D
+-20 68 D
+71 -66 D
+17 64 D
+115 -35 D
+111 87 D
+P
+FO
+{0.745 A} FS
+-83 60 -8 75 -94 -7 -70 99 -101 302 -13 -136 89 -165 82 -107 96 3 29 -131 78 7 11 827 8749 SP
+FQ
+119 7 -44 70 107 45 -174 -3 -312 110 304 -226 6 380 4014 SP
+72 32 -60 21 -14 -53 3 830 7897 SP
+47 21 -80 2 30 -23 3 927 7895 SP
+52 27 -55 -25 2 931 7859 SP
+11 50 -11 -48 2 908 7954 SP
+45 12 -45 -11 2 895 7804 SP
+{0.745 A} FS
+-116 145 101 -66 18 -81 3 1489 7854 SP
+-46 104 51 -105 2 1403 7791 SP
+-26 -90 -2 -3 2 1825 8040 SP
+25 57 -22 -59 2 1721 7967 SP
+19 -41 -1 -5 2 1481 7765 SP
+-30 71 33 -75 2 1367 7753 SP
+24 34 -23 -38 2 1110 7639 SP
+-15 53 18 -56 2 1620 8018 SP
+1 49 0 -52 2 2028 8355 SP
+-30 34 35 -36 2 1731 7991 SP
+8 40 -7 -44 2 1087 7546 SP
+16 60 -13 -63 2 1782 8061 SP
+95 7 -52 -37 2 1011 6350 SP
+2047 3179 M
+13 119 D
+230 169 D
+72 -8 D
+0 181 D
+-115 -13 D
+-164 78 D
+3 99 D
+-183 184 D
+-108 314 D
+-214 293 D
+-169 111 D
+-161 321 D
+-224 245 D
+-23 181 D
+-145 178 D
+79 168 D
+-59 -3 D
+-1 129 D
+125 328 D
+-94 -7 D
+-78 -285 D
+32 289 D
+-133 286 D
+-46 -19 D
+-75 121 D
+-187 56 D
+-1 178 D
+146 92 D
+19 126 D
+49 -111 D
+13 133 D
+165 185 D
+51 158 D
+-50 24 D
+66 9 D
+7 132 D
+40 -20 D
+-112 144 D
+152 -153 D
+-50 172 D
+158 -129 D
+19 88 D
+229 -6 D
+27 98 D
+72 0 D
+-25 34 D
+113 71 D
+89 -123 D
+47 19 D
+-94 197 D
+46 40 D
+68 -67 D
+-18 63 D
+49 -44 D
+-19 56 D
+60 -48 D
+56 90 D
+47 -38 D
+-36 83 D
+54 65 D
+90 -65 D
+-78 123 D
+70 -14 D
+-17 64 D
+65 -65 D
+-39 156 D
+118 -73 D
+-20 68 D
+71 -66 D
+17 64 D
+115 -35 D
+111 87 D
+0 1080 D
+-2362 0 D
+0 -6357 D
+P
+FO
+12 -15 -12 -15 2 2362 7132 SP
+-83 60 -8 75 -94 -7 -70 99 -101 302 -13 -136 89 -165 82 -107 96 3 29 -131 78 7 11 827 8749 SP
+FQ
+119 7 -44 70 107 45 -174 -3 -312 110 304 -226 6 380 4014 SP
+72 32 -60 21 -14 -53 3 830 7897 SP
+47 21 -80 2 30 -23 3 927 7895 SP
+52 27 -55 -25 2 931 7859 SP
+11 50 -11 -48 2 908 7954 SP
+45 12 -45 -11 2 895 7804 SP
+{0.745 A} FS
+-116 145 101 -66 18 -81 3 1489 7854 SP
+-46 104 51 -105 2 1403 7791 SP
+-26 -90 -2 -3 2 1825 8040 SP
+25 57 -22 -59 2 1721 7967 SP
+19 -41 -1 -5 2 1481 7765 SP
+-30 71 33 -75 2 1367 7753 SP
+24 34 -23 -38 2 1110 7639 SP
+-15 53 18 -56 2 1620 8018 SP
+1 49 0 -52 2 2028 8355 SP
+-30 34 35 -36 2 1731 7991 SP
+8 40 -7 -44 2 1087 7546 SP
+16 60 -13 -63 2 1782 8061 SP
+95 7 -52 -37 2 1011 6350 SP
+FQ
+12 -4 6 4 2 4378 3179 SP
+37 -9 -4 9 2 4082 3179 SP
+2362 3459 M
+155 -19 D
+75 -85 D
+-18 118 D
+-179 170 D
+-33 -3 D
+0 3462 D
+80 -100 D
+31 34 D
+-64 14 D
+-38 73 D
+62 84 D
+-3 3 D
+-68 -78 D
+0 1324 D
+218 169 D
+2 -42 D
+34 80 D
+89 -15 D
+-9 -47 D
+27 86 D
+85 30 D
+2 -49 D
+52 102 D
+203 62 D
+245 -107 D
+47 57 D
+51 -114 D
+71 21 D
+31 -47 D
+41 48 D
+36 -91 D
+72 -14 D
+-10 57 D
+104 9 D
+57 87 D
+268 -27 D
+92 -59 D
+86 -191 D
+-124 -126 D
+49 16 D
+50 -152 D
+-46 -247 D
+-209 -363 D
+309 -175 D
+-211 -14 D
+-245 76 D
+-328 -34 D
+-102 68 D
+-98 -92 D
+-103 39 D
+-99 -172 D
+18 -116 D
+-56 31 D
+-125 -63 D
+-11 -95 D
+159 -107 D
+50 -107 D
+71 13 D
+85 -75 D
+-164 28 D
+-91 -56 D
+-161 119 D
+-325 24 D
+-54 -68 D
+3 -158 D
+360 -144 D
+10 -133 D
+271 -458 D
+-29 -236 D
+230 24 D
+146 -271 D
+162 33 D
+60 -79 D
+90 38 D
+181 -97 D
+-17 -103 D
+-85 132 D
+67 -175 D
+-161 -348 D
+53 -151 D
+-38 -118 D
+94 -83 D
+-20 -103 D
+122 -114 D
+56 -246 D
+-25 249 D
+60 235 D
+-89 -3 D
+106 243 D
+117 96 D
+304 39 D
+148 -70 D
+53 -256 D
+0 -838 D
+-149 -50 D
+-89 221 D
+-72 -131 D
+-57 79 D
+-35 -50 D
+-37 38 D
+-85 -36 D
+7 75 D
+-121 174 D
+-30 -322 D
+-105 -321 D
+29 -179 D
+27 -37 D
+-1645 0 D
+P
+FO
+-79 -79 95 28 -10 50 3 2965 9024 SP
+{0.745 A} FS
+-15 59 20 -61 2 4011 7521 SP
+48 13 -50 -17 2 4187 8453 SP
+45 -64 1 -4 2 4082 7487 SP
+-6 55 9 -58 2 4194 8258 SP
+12 60 -11 -64 2 3968 7559 SP
+14 59 -12 -62 2 3935 7556 SP
+6 41 -5 -46 2 2580 7010 SP
+32 47 -32 -52 2 2548 7103 SP
+24 -49 0 -5 2 2575 3551 SP
+-33 24 37 -26 2 2696 3445 SP
+-29 37 35 -38 2 4057 7455 SP
+32 105 -30 -109 2 4168 8233 SP
+4082 3179 M
+-4 9 D
+37 -9 D
+263 0 D
+6 4 D
+12 -4 D
+328 0 D
+0 6357 D
+-2362 0 D
+0 -1080 D
+218 169 D
+2 -42 D
+34 80 D
+89 -15 D
+-9 -47 D
+27 86 D
+85 30 D
+2 -49 D
+52 102 D
+203 62 D
+245 -107 D
+47 57 D
+51 -114 D
+71 21 D
+31 -47 D
+41 48 D
+36 -91 D
+72 -14 D
+-10 57 D
+104 9 D
+57 87 D
+268 -27 D
+92 -59 D
+86 -191 D
+-124 -126 D
+49 16 D
+50 -152 D
+-46 -247 D
+-209 -363 D
+309 -175 D
+-211 -14 D
+-245 76 D
+-328 -34 D
+-102 68 D
+-98 -92 D
+-103 39 D
+-99 -172 D
+18 -116 D
+-56 31 D
+-125 -63 D
+-11 -95 D
+159 -107 D
+50 -107 D
+71 13 D
+85 -75 D
+-164 28 D
+-91 -56 D
+-161 119 D
+-325 24 D
+-54 -68 D
+3 -158 D
+360 -144 D
+10 -133 D
+271 -458 D
+-29 -236 D
+230 24 D
+146 -271 D
+162 33 D
+60 -79 D
+90 38 D
+181 -97 D
+-17 -103 D
+-85 132 D
+67 -175 D
+-161 -348 D
+53 -151 D
+-38 -118 D
+94 -83 D
+-20 -103 D
+122 -114 D
+56 -246 D
+-25 249 D
+60 235 D
+-89 -3 D
+106 243 D
+117 96 D
+304 39 D
+148 -70 D
+53 -256 D
+0 -838 D
+-149 -50 D
+-89 221 D
+-72 -131 D
+-57 79 D
+-35 -50 D
+-37 38 D
+-85 -36 D
+7 75 D
+-121 174 D
+-30 -322 D
+-105 -321 D
+29 -179 D
+27 -37 D
+P
+FO
+-68 -78 -3 3 62 84 -38 73 -64 14 31 34 80 -100 7 2362 7102 SP
+-33 -3 -179 170 -18 118 75 -85 155 -19 5 2362 3459 SP
+FQ
+-79 -79 95 28 -10 50 3 2965 9024 SP
+{0.745 A} FS
+-15 59 20 -61 2 4011 7521 SP
+48 13 -50 -17 2 4187 8453 SP
+45 -64 1 -4 2 4082 7487 SP
+-6 55 9 -58 2 4194 8258 SP
+12 60 -11 -64 2 3968 7559 SP
+14 59 -12 -62 2 3935 7556 SP
+6 41 -5 -46 2 2580 7010 SP
+32 47 -32 -52 2 2548 7103 SP
+24 -49 0 -5 2 2575 3551 SP
+-33 24 37 -26 2 2696 3445 SP
+-29 37 35 -38 2 4057 7455 SP
+32 105 -30 -109 2 4168 8233 SP
+FQ
+2362 1134 M
+-464 117 D
+-159 256 D
+-68 765 D
+61 73 D
+19 181 D
+106 -65 D
+-55 -76 D
+53 -19 D
+66 265 D
+52 14 D
+39 -36 D
+4 80 D
+-78 93 D
+84 163 D
+25 234 D
+315 0 D
+P
+FO
+97 -67 -91 67 2 2012 1143 SP
+45 88 -47 -83 2 1720 2375 SP
+{0.745 A} FS
+2362 0 M
+0 1134 D
+-464 117 D
+-159 256 D
+-68 765 D
+61 73 D
+19 181 D
+106 -65 D
+-55 -76 D
+53 -19 D
+66 265 D
+52 14 D
+39 -36 D
+4 80 D
+-78 93 D
+84 163 D
+25 234 D
+-2047 0 D
+0 -3179 D
+P
+FO
+FQ
+97 -67 -91 67 2 2012 1143 SP
+45 88 -47 -83 2 1720 2375 SP
+4007 3179 M
+150 -207 D
+-75 207 D
+33 0 D
+185 -49 D
+78 49 D
+18 0 D
+78 -27 D
+-114 -160 D
+15 -79 D
+82 6 D
+110 -128 D
+-90 11 D
+-10 -51 D
+-88 60 D
+-120 -15 D
+31 109 D
+-107 -207 D
+45 -171 D
+3 133 D
+133 -35 D
+103 43 D
+-1 -130 D
+25 34 D
+46 -125 D
+24 128 D
+-11 -136 D
+165 -122 D
+-93 -297 D
+-14 -509 D
+116 -747 D
+0 -113 D
+-72 -19 D
+-159 58 D
+207 57 D
+-1231 -283 D
+-516 145 D
+-394 293 D
+-91 205 D
+-106 27 D
+0 2045 D
+P
+FO
+{0.745 A} FS
+-8 269 46 -213 -36 -59 3 4183 2458 SP
+-1 69 3 -72 2 4425 2855 SP
+18 32 -20 -36 2 4502 2852 SP
+4396 3179 M
+78 -27 D
+-114 -160 D
+15 -79 D
+82 6 D
+110 -128 D
+-90 11 D
+-10 -51 D
+-88 60 D
+-120 -15 D
+31 109 D
+-107 -207 D
+45 -171 D
+3 133 D
+133 -35 D
+103 43 D
+-1 -130 D
+25 34 D
+46 -125 D
+24 128 D
+-11 -136 D
+165 -122 D
+-93 -297 D
+-14 -509 D
+116 -747 D
+0 -113 D
+-72 -19 D
+-159 58 D
+207 57 D
+-1231 -283 D
+-516 145 D
+-394 293 D
+-91 205 D
+-106 27 D
+0 -1134 D
+2362 0 D
+0 3179 D
+P
+FO
+78 49 185 -49 2 4115 3179 SP
+-75 207 150 -207 2 4007 3179 SP
+-8 269 46 -213 -36 -59 3 4183 2458 SP
+-1 69 3 -72 2 4425 2855 SP
+18 32 -20 -36 2 4502 2852 SP
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/pscoast/riverlake.sh
+++ b/test/pscoast/riverlake.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Make sure lakes are not set if only river-lakes are filled.
+# Script used in showing the bug from https://github.com/GenericMappingTools/gmt/issues/6038
+# The red circle should be visible as lake should not be filled
+gmt begin riverlake
+    echo "50 42" | gmt plot -JQ50/42/10c -R46/54/36/48 -Sc1c -W1p,black -Gred
+    gmt coast -Dl -Ggray -Cgray+r
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

See #6038 for background.  The problem was that we considerer `Ctrl->C.active `when setting both the lake and river fills but in this case only the river fill was specified and the lake should default to **-S**, which here is no fill. We now use the array `Ctrl->C.set[]` to set them separately.

Improved readability of code by introducing named enums instead or integers 0-5 in the fill array.  Closes #6038.