### PR TITLE
Clarify vector length units and scaling

### DIFF
--- a/doc/rst/source/explain_distunits.rst_
+++ b/doc/rst/source/explain_distunits.rst_
@@ -2,7 +2,7 @@ Units
 -----
 
 For map distance unit, append *unit* **d** for arc degree, **m** for arc
-minute, and **s** for arc second, or **e** for meter [Default], **f**
+minute, and **s** for arc second, or **e** for meter [Default unless stated otherwise], **f**
 for foot, **k** for km, **M** for statute mile, **n** for nautical mile,
 and **u** for US survey foot. By default we compute such distances using
 a spherical approximation with great circles (**-jg**) using the authalic radius

--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -280,7 +280,9 @@
         vector head. Vector width is set by **-W**. See `Vector Attributes`_
         for specifying attributes. **Note**: Geovector stems are drawn as thin
         filled polygons and hence pen attributes like dashed and dotted are
-        not available. For allowable geographical units, see `Units`_.
+        not available. For allowable geographical units for the length, see `Units`_ [k].
+        If your *length* is not in distance units but in arbitrary user units (e.g., a rate in
+        mm/yr) then you can use the **-i** option to scale the corresponding column via the **+s**\ *scale* modifier.
 
     The next symbol is the programmable *custom* symbol:
 


### PR DESCRIPTION
This PR makes it clear that both **-SV** and **-S=** have lengths in certain units and if your length represents something else (say a rate) then you can scale your data via **+i.**
