### PR TITLE
Add check for zero length vectors

### DIFF
--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -60,7 +60,8 @@ end point (**e**) of a line segment:
 
     **+o**\ [*plon*\ /\ *plat*] specifies the oblique pole for the great or
     small circles.  Only needed for great circles if **+q** is given. If no
-    pole is appended then we default to the north pole.
+    pole is appended then we default to the north pole. Input arguments are then
+    *lon *lat arclength* with the latter in map distance units; see **+q** of angular limits instead.
 
     **+p**\ [*pen*] sets the vector pen attributes. If no *pen* is appended
     then the head outline is not drawn. [Default pen is half the width of stem pen, and

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -9789,6 +9789,9 @@ unsigned int gmt_geo_vector (struct GMT_CTRL *GMT, double lon0, double lat0, dou
 		are possible. If a small-circle vector is chosen then azimuth, length may be opening angles
 		1 and 2 if PSL_VEC_ANGLES is set as well. */
 	unsigned int warn;
+
+	if (gmt_M_is_zero (length)) return (GMT_NOERROR); /* Only plot vectors with a non-zero length */
+
 	if ((S->v.status & PSL_VEC_SCALE) == 0) {	/* Must determine the best inch to degree scale for this map */
 		if (gmt_M_is_perspective (GMT)) {
 			double clon, clat;

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -4906,13 +4906,14 @@ GMT_LOCAL void gmtplot_plot_vector_head (struct GMT_CTRL *GMT, double *xp, doubl
     }
 }
 
-GMT_LOCAL unsigned int gmtplot_geo_vector_smallcircle (struct GMT_CTRL *GMT, double lon0, double lat0, double azimuth, double length, struct GMT_PEN *ppen, struct GMT_SYMBOL *S) {
-	/* Draws a small-circle vector with or without heads, etc. There are some complications to consider:
+GMT_LOCAL unsigned int gmtplot_geo_vector_smallcircle (struct GMT_CTRL *GMT, double lon0, double lat0, double angle_1, double angle_2, struct GMT_PEN *ppen, struct GMT_SYMBOL *S) {
+	/* Draws a small-circle vector around an oblique pole, with or without heads, etc. There are some complications to consider:
 	 * When there are no heads it is simple.  If +n is active we may shrink the line thickness.
 	 * With heads there are these cases:
 	 * Head length is longer than 90% of the vector length.  We then skip the head and return 1
 	 * +n<norm> is in effect.  We shrink vector pen and head length.  Still, the shrunk head
 	 * may be longer than 90% of the vector length.  We then shrink head (not pen) further and return 2
+     * Note: Angle_1|2 may be degrees or km, depending on modifier +q.
 	*/
 
 	uint64_t n1, n2, n, add;
@@ -4933,7 +4934,7 @@ GMT_LOCAL unsigned int gmtplot_geo_vector_smallcircle (struct GMT_CTRL *GMT, dou
 	justify = PSL_vec_justify (S->v.status);	/* Return justification as 0-3 */
 #endif
 
-	gmtplot_scircle_sub (GMT, lon0, lat0, azimuth, length, S, &C);
+	gmtplot_scircle_sub (GMT, lon0, lat0, angle_1, angle_2, S, &C);
 	perspective = gmt_M_is_perspective (GMT);
 
 	/* Here we have the endpoints A and B of the great (or small) circle arc */
@@ -9790,8 +9791,6 @@ unsigned int gmt_geo_vector (struct GMT_CTRL *GMT, double lon0, double lat0, dou
 		1 and 2 if PSL_VEC_ANGLES is set as well. */
 	unsigned int warn;
 
-	if (gmt_M_is_zero (length)) return (GMT_NOERROR); /* Only plot vectors with a non-zero length */
-
 	if ((S->v.status & PSL_VEC_SCALE) == 0) {	/* Must determine the best inch to degree scale for this map */
 		if (gmt_M_is_perspective (GMT)) {
 			double clon, clat;
@@ -9806,10 +9805,14 @@ unsigned int gmt_geo_vector (struct GMT_CTRL *GMT, double lon0, double lat0, dou
 		}
 	}
 
-	if (S->v.status & PSL_VEC_POLE)
+	if (S->v.status & PSL_VEC_POLE) {    /* Here, azimuth, length is actually angle_1 and angle_2 (if +q) or length_1, length_2 distance around the pole */
+		if (doubleAlmostEqualZero (azimuth, length)) return (GMT_NOERROR); /* Only plot vectors with a non-zero angular or distance extension */
 		warn = gmtplot_geo_vector_smallcircle (GMT, lon0, lat0, azimuth, length, pen, S);
-	else
+	}
+	else {
+		if (gmt_M_is_zero (length)) return (GMT_NOERROR); /* Only plot vectors with a non-zero length */
 		warn = gmtplot_geo_vector_greatcircle (GMT, lon0, lat0, azimuth, length, pen, S);
+    }
 	return (warn);
 }
 

--- a/test/psxy/smallcirvec.sh
+++ b/test/psxy/smallcirvec.sh
@@ -13,7 +13,7 @@ cat << EOF > t.txt
 EOF
 gmt psbasemap -Rg -JG0/0/4.5i -Bag -P -K -Xc > $ps
 while read lon lat length color plon plat just; do
-	echo $lon $lat $length 0 | gmt psxy -R -J -W1p,$color -S=0.4i+j${just}+o${plon}/${plat}+h1 -G$color -O -K >> $ps
+	echo $lon $lat $length | gmt psxy -R -J -W1p,$color -S=0.4i+j${just}+o${plon}/${plat}+h1 -G$color -O -K >> $ps
 	echo $lon $lat   | gmt psxy -R -J -O -K -Sc0.1i -G$color -W0.25p >> $ps
 	echo $plon $plat | gmt psxy -R -J -O -K -St0.1i -G$color -W0.25p >> $ps
 done < t.txt

--- a/test/psxy/smallcirvec.sh
+++ b/test/psxy/smallcirvec.sh
@@ -13,7 +13,7 @@ cat << EOF > t.txt
 EOF
 gmt psbasemap -Rg -JG0/0/4.5i -Bag -P -K -Xc > $ps
 while read lon lat length color plon plat just; do
-	echo $lon $lat $length | gmt psxy -R -J -W1p,$color -S=0.4i+j${just}+o${plon}/${plat}+h1 -G$color -O -K >> $ps
+	echo $lon $lat $length 0 | gmt psxy -R -J -W1p,$color -S=0.4i+j${just}+o${plon}/${plat}+h1 -G$color -O -K >> $ps
 	echo $lon $lat   | gmt psxy -R -J -O -K -Sc0.1i -G$color -W0.25p >> $ps
 	echo $plon $plat | gmt psxy -R -J -O -K -St0.1i -G$color -W0.25p >> $ps
 done < t.txt


### PR DESCRIPTION
**Description of proposed changes**

This PR adds a check for zero length vectors to prevent failures with the new tests in https://github.com/GenericMappingTools/gmt/pull/6162. 

With this change, [smallcircvec.sh](https://github.com/GenericMappingTools/gmt/blob/vector-length-check/test/psxy/smallcirvec.sh) fails with the following diff (vectors in magenta are plotted in master but not this branch):

![smallcirvec](https://user-images.githubusercontent.com/14077947/147619144-bb3fefcb-8052-4fe6-9aa5-ce0c8621c082.png)

I think the issue is that an azimuth is not given in the test script, so the length is used as the azimuth:
`echo $lon $lat $length | gmt psxy -R -J -W1p,$color -S=0.4i+j${just}+o${plon}/${plat}+h1 -G$color -O -K >> $ps`

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
