### PR TITLE
New default legend symbol dimensions when no details are provided

### DIFF
--- a/doc/examples/ex07/ex07.bat
+++ b/doc/examples/ex07/ex07.bat
@@ -6,7 +6,7 @@ REM
 gmt begin ex07
 	gmt coast -R-50/0/-10/20 -JM24c -Slightblue -GP26+r300+ftan+bdarkbrown -Dl -Wthinnest -B --FORMAT_GEO_MAP=dddF
 	gmt plot @fz_07.txt -Wthinner,-
-	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.2c
+	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.5c
 	gmt plot @isochron_07.txt -Wthin,blue
 	gmt plot @ridge_07.txt -Wthicker,orange
 	gmt legend -DjTR+o0.5c -F+pthick+ithinner+gwhite --FONT_ANNOT_PRIMARY=18p,Times-Italic

--- a/doc/examples/ex07/ex07.bat
+++ b/doc/examples/ex07/ex07.bat
@@ -6,7 +6,7 @@ REM
 gmt begin ex07
 	gmt coast -R-50/0/-10/20 -JM24c -Slightblue -GP26+r300+ftan+bdarkbrown -Dl -Wthinnest -B --FORMAT_GEO_MAP=dddF
 	gmt plot @fz_07.txt -Wthinner,-
-	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.5c
+	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.4c
 	gmt plot @isochron_07.txt -Wthin,blue
 	gmt plot @ridge_07.txt -Wthicker,orange
 	gmt legend -DjTR+o0.5c -F+pthick+ithinner+gwhite --FONT_ANNOT_PRIMARY=18p,Times-Italic

--- a/doc/examples/ex07/ex07.sh
+++ b/doc/examples/ex07/ex07.sh
@@ -7,7 +7,7 @@
 gmt begin ex07
 	gmt coast -R-50/0/-10/20 -JM24c -Slightblue -GP26+r300+ftan+bdarkbrown -Dl -Wthinnest -B --FORMAT_GEO_MAP=dddF
 	gmt plot @fz_07.txt -Wthinner,-
-	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.5c
+	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.4c
 	gmt plot @isochron_07.txt -Wthin,blue
 	gmt plot @ridge_07.txt -Wthicker,orange
 	gmt legend -DjTR+o0.5c -F+pthick+ithinner+gwhite --FONT_ANNOT_PRIMARY=18p,Times-Italic

--- a/doc/examples/ex07/ex07.sh
+++ b/doc/examples/ex07/ex07.sh
@@ -7,7 +7,7 @@
 gmt begin ex07
 	gmt coast -R-50/0/-10/20 -JM24c -Slightblue -GP26+r300+ftan+bdarkbrown -Dl -Wthinnest -B --FORMAT_GEO_MAP=dddF
 	gmt plot @fz_07.txt -Wthinner,-
-	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.2c
+	gmt plot @quakes_07.txt -h1 -Scc -i0,1,2+s0.025 -Gred -Wthinnest -l"ISC Earthquakes"+S0.5c
 	gmt plot @isochron_07.txt -Wthin,blue
 	gmt plot @ridge_07.txt -Wthicker,orange
 	gmt legend -DjTR+o0.5c -F+pthick+ithinner+gwhite --FONT_ANNOT_PRIMARY=18p,Times-Italic

--- a/doc/rst/source/auto_legend_info.rst_
+++ b/doc/rst/source/auto_legend_info.rst_
@@ -2,7 +2,7 @@ Auto-legend entries
 -------------------
 
 This module allows you to use the **-l** option to specify an automatic legend entry.
-This option is available for lines or symbols only.  If there is no size specified
-(which is always true for lines) or if the symbol size is computed from other information
-(which may be true for some symbols deriving size from other input columns), then you need
-to supply a legend size (i.e., length of a line symbol) via the **+S** modifier.
+This option is available for lines or symbols only.  If the symbol size is variable
+and computed from other information (which may be true for some symbols deriving their
+size from other input columns), then you need to supply a representative legend size
+via the **+S** modifier.

--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -253,8 +253,8 @@ Legend Codes
     of the column, with the optional explanatory *text* starting *dx2*
     from the margin, printed with :term:`FONT_ANNOT_PRIMARY`. If *dx1* is given
     as **-** then it is automatically computed from half the largest symbol size.
-    If *dx2* is given as **-** then it is automatically computed as 1.5
-    times the largest symbol size.  Use **-** if
+    If *dx2* is given as **-** then it is automatically computed as the largest
+    symbol size plus one character width at current annotation size.  Use **-** if
     no *fill* or outline (*pen*) is required. Alternatively, the *fill*
     may be specified indirectly via z=\ *value* and the color is assigned
     via the CPT look-up (requires a prior **A** code).  When plotting just a
@@ -270,10 +270,12 @@ Legend Codes
     ellipse, wedge, mathangle) may take more than a single argument size.
     Note that for a line segment you should use the horizontal dash symbol (**-**).
     If just a single size if given then we will provide reasonable
-    arguments to plot the symbol  (See `Defaults`_).
-    Alternatively, combine the required
-    arguments into a single, comma-separated string and use that as the
-    symbol size (again, see :doc:`plot` for details on the arguments needed).
+    arguments to plot the symbol  (See `Defaults`_). **Note**: If *size* is given
+    as **-** then we default to the character height at current annotation size
+    for geometric symbols and 2.5 times the character width for line-type symbols.
+    Alternatively, combine the required arguments into a single, comma-separated
+    string and use that as the symbol size (again, see :doc:`plot` for details on
+    the arguments needed).
 **T** *paragraph-text*
     One or more of these **T** records with *paragraph-text* printed
     with :term:`FONT_ANNOT_PRIMARY`. To specify special positioning and

--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -254,8 +254,8 @@ Legend Codes
     from the margin, printed with :term:`FONT_ANNOT_PRIMARY`. If *dx1* is given
     as **-** then it is automatically computed from half the largest symbol size.
     If *dx2* is given as **-** then it is automatically computed as the largest
-    symbol size plus one character width at current annotation size.  Use **-** if
-    no *fill* or outline (*pen*) is required. Alternatively, the *fill*
+    symbol size plus one character width at the current annotation font size.
+    Use **-** if no *fill* or outline (*pen*) is required. Alternatively, the *fill*
     may be specified indirectly via z=\ *value* and the color is assigned
     via the CPT look-up (requires a prior **A** code).  When plotting just a
     symbol, without text, *dx2* and *text* can be omitted.  The *dx1* value
@@ -270,9 +270,7 @@ Legend Codes
     ellipse, wedge, mathangle) may take more than a single argument size.
     Note that for a line segment you should use the horizontal dash symbol (**-**).
     If just a single size if given then we will provide reasonable
-    arguments to plot the symbol  (See `Defaults`_). **Note**: If *size* is given
-    as **-** then we default to the character height at current annotation size
-    for geometric symbols and 2.5 times the character width for line-type symbols.
+    arguments to plot the symbol  (See `Defaults`_).
     Alternatively, combine the required arguments into a single, comma-separated
     string and use that as the symbol size (again, see :doc:`plot` for details on
     the arguments needed).
@@ -296,6 +294,10 @@ Defaults
 
 When attributes are not provided, or extended symbol information (for symbols taking more than just an overall size) are
 not given as comma-separated quantities, we will provide the following defaults:
+
+Geographic symbols: If *size* is given as **-** then we default to the character height at the current annotation font size.
+
+Line/vector: If *size* is given as **-** then we default to a length of 2.5 times the character width at the current annotation font size.
 
 Front: The *size* argument is *length*\ [/*gap*\ [*ticklength*]]. Front symbol is left-side (here, that means upper side) box,
 with *ticklength* set 30% of the given symbol *length* (if not specified separately), and *gap* defaulting to -1 (one

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -434,10 +434,9 @@ enum GMT_enum_customsymb {
 	GMT_CUSTOM_DEF  = 1,
 	GMT_CUSTOM_EPS  = 2};
 
-//#define GMT_LEGEND_DX1_MUL 1.0	/* Default offset from margin to center of symbol if given as '-' times max symbol size */
-//#define GMT_LEGEND_DX2_MUL 2.0	/* Default offset from margin to start of label if given as '-' times max symbol size */
 #define GMT_LEGEND_DX1_MUL 0.5	/* Default offset from margin to center of symbol if given as '-' times max symbol size */
 #define GMT_LEGEND_DX2_MUL 1.5	/* Default offset from margin to start of label if given as '-' times max symbol size */
+#define GMT_LEGEND_DXL_MUL 1.25	/* Same as GMT_LEGEND_DX2_MUL but for line or vector symbols that typically are longer tgat circles etc */
 
 /*! Various mode for axes */
 enum GMT_enum_oblique {

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -19064,9 +19064,49 @@ GMT_LOCAL void gmtinit_draw_legend_line (struct GMTAPI_CTRL *API, FILE *fp, stru
 	}
 }
 
+GMT_LOCAL void gmtinit_set_symbol_size (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, double size, char *string) {
+	/* Format the size argument for this symbol in a string form, or set to "-"" if size is 0 */
+	gmt_M_unused (API);
+
+	if (gmt_M_is_zero (size)) {	/* Accept default symbol size and other parameters in legend */
+		strcpy (string, "-");
+		return;
+	}
+
+	switch (S->symbol) {	/* A few symbols have special needs */
+		case 'e':	case 'E':	case 'j':	case 'J':	/* Ellipse or rotated rectangle */
+			if (gmt_M_is_zero (S->size_y))	/* Did only get a single size, accept defaults for ratio and azimuth */
+				sprintf (string, "%gi", size);
+			else
+				sprintf (string, "%g,%gi,%gi", S->factor, S->size_x, S->size_y);
+			break;
+		case 'r':	/* Rectangle */
+			if (gmt_M_is_zero (S->size_y))	/* Did only get a single size, accept defaults for ratio */
+				sprintf (string, "%gi", size);
+			else
+				sprintf (string, "%gi,%gi", S->size_x, S->size_y);
+			break;
+		case 'R':	/* Rounded rectangle */
+			if (gmt_M_is_zero (S->size_y))	/* Did only get a single size, accept defaults for ratio */
+				sprintf (string, "%gi", size);
+			else
+				sprintf (string, "%gi,%gi,%gi", S->size_x, S->size_y, S->factor);
+			break;
+		case 'w':	case 'W':	/* Wedges */
+			if (gmt_M_is_zero (S->size_y))	/* Did only get a single size, accept defaults for ratio */
+				sprintf (string, "%gi", size);
+			else
+				sprintf (string, "%gi,%g,%g", S->w_radius, S->size_x, S->size_y);
+			break;
+		default:	/* Regular isotropic symbol */
+			sprintf (string, "%gi", size);
+			break;
+	}
+}
+
 void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do_fill, struct GMT_FILL *fill, bool do_line, struct GMT_PEN *pen, struct GMT_LEGEND_ITEM *item) {
 	/* Adds a new entry to the auto-legend information file hidden in the session directory */
-	char file[PATH_MAX] = {""}, label[GMT_LEN128] = {""};
+	char file[PATH_MAX] = {""}, label[GMT_LEN128] = {""}, size_string[GMT_LEN128] = {""};
 	bool gap_done = false;
 	double size = 0.0;
 	FILE *fp = NULL;
@@ -19171,12 +19211,12 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 	if (((item->draw & GMT_LEGEND_DRAW_V) && item->pen[GMT_LEGEND_PEN_V][0] == '\0'))	/* Initialize the vertical line setting */
 		gmtinit_draw_legend_line (API, fp, item, GMT_LEGEND_DRAW_V);
 	/* Get the symbol size */
-	if (item->size > 0.0)	/* Hard-wired symbol size given */
+	if (item->size > 0.0)	/* Hard-wired symbol size given via -l */
 		size = item->size;
 	else if (S)
 		size = S->size_x;	/* Use the symbol size given */
 	else
-		GMT_Report (API, GMT_MSG_INFORMATION, "No size or length given and no symbol present - default to line length of 0.5 cm.\n");
+		GMT_Report (API, GMT_MSG_DEBUG, "No size or length given and no symbol present - default to line length of 2.5 annotation character width.\n");
 
 	/* Finalize label */
 	if (item->label_type == GMT_LEGEND_LABEL_FORMAT)	/* Integer format string */
@@ -19190,20 +19230,16 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 	}
 	else	/* Got a fixed label */
 		strncpy (label, item->label, GMT_LEN128-1);
+	gmtinit_set_symbol_size (API, S, size, size_string);	/* Format the size-string based on the size */
 	/* Place the symbol command */
 	if (S == NULL || S->symbol == GMT_SYMBOL_LINE) {	/* Line for legend entry */
 		if (pen == NULL) pen = &(API->GMT->current.setting.map_default_pen);	/* Must have pen to draw line */
-		if (size > 0.0)	/* Got a line length in inches */
-			fprintf (fp, "S - - %gi - %s - %s\n", size, gmt_putpen (API->GMT, pen), label);
-		else	/* Let the legend module supply a default length */
-			fprintf (fp, "S - - - - %s - %s\n", gmt_putpen (API->GMT, pen), label);
+		fprintf (fp, "S - - %s - %s - %s\n", size_string, gmt_putpen (API->GMT, pen), label);
 	}
 	else {	/* Regular symbol */
 		if (!(do_fill || do_line)) do_line = true;	/* If neither fill nor pen is selected, plot will draw line, so override do_line here */
 		if (do_line && pen == NULL) pen = &(API->GMT->current.setting.map_default_pen);	/* Must have pen to draw line */
-		if (S->size_x > 0.0 && S->size_y > 0.0 && S->symbol == PSL_RECT)
-			fprintf (fp, "S - %c %gi,%gi %s %s - %s\n", S->symbol, size, S->size_y, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
-		else if (S->symbol == 'q') {	/* Quoted line [Experimental] */
+		if (S->symbol == 'q') {	/* Quoted line [Experimental] */
 			char scode[GMT_LEN64] = {""};
 			sprintf (scode, "qn1:+ltext");
 			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
@@ -19215,12 +19251,8 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 			if (S->D.fill[0]) strcat (scode, "+g"), strcat (scode, S->D.fill);
 			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 		}
-		else {
-			if (size > 0.0)	/* Got a size in inches */
-				fprintf (fp, "S - %c %gi %s %s - %s\n", S->symbol, size, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
-			else
-				fprintf (fp, "S - %c - %s %s - %s\n", S->symbol, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
-		}
+		else 
+			fprintf (fp, "S - %c %s %s %s - %s\n", S->symbol, size_string, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 	}
 
 	if (item->draw & GMT_LEGEND_DRAW_V && item->pen[GMT_LEGEND_PEN_V][0]) {	/* Must end with horizontal, then vertical line */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -19215,8 +19215,12 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 			if (S->D.fill[0]) strcat (scode, "+g"), strcat (scode, S->D.fill);
 			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 		}
-		else
-			fprintf (fp, "S - %c %gi %s %s - %s\n", S->symbol, size, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+		else {
+			if (size > 0.0)	/* Got a size in inches */
+				fprintf (fp, "S - %c %gi %s %s - %s\n", S->symbol, size, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+			else
+				fprintf (fp, "S - %c - %s %s - %s\n", S->symbol, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+		}
 	}
 
 	if (item->draw & GMT_LEGEND_DRAW_V && item->pen[GMT_LEGEND_PEN_V][0]) {	/* Must end with horizontal, then vertical line */

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -32,7 +32,7 @@
 
 #include "gmt_dev.h"
 
-#define THIS_MODULE_OPTIONS "->BJKOPRUVXYfptxy" GMT_OPT("c")
+#define THIS_MODULE_OPTIONS "->BJKOPRUVXYflptxy" GMT_OPT("c")
 
 struct GRDVECTOR_CTRL {
 	struct GRDVECTOR_In {
@@ -62,12 +62,13 @@ struct GRDVECTOR_CTRL {
 		bool active;
 		struct GMT_SYMBOL S;
 	} Q;
-	struct GRDVECTOR_S {	/* -S[l|i]<length|scale>[<unit>] */
+	struct GRDVECTOR_S {	/* -S[l|i]<length|scale>[<unit>][+r<reference>] */
 		bool active;
 		bool constant;
 		bool invert;
 		char unit;
 		double factor;
+		double reference;
 	} S;
 	struct GRDVECTOR_T {	/* -T */
 		bool active;
@@ -110,8 +111,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <gridx> <gridy> %s [-A] [%s] [-C[<cpt>]] [-G<fill>] [-I[x]<dx>/<dy>] "
 		"%s[-N] %s%s[-Q<params>] [%s] [-S[i|l]<length>|<scale>] [-T] [%s] [%s] [-W<pen>] [%s] [%s] [-Z] "
-		"%s [%s] [%s] [%s] [%s]\n", name, GMT_J_OPT, GMT_B_OPT, API->K_OPT, API->O_OPT, API->P_OPT,
-		GMT_Rgeo_OPT, GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_f_OPT, GMT_p_OPT, GMT_t_OPT, GMT_PAR_OPT);
+		"%s [%s] [%s] [%s] [%s] [%s]\n", name, GMT_J_OPT, GMT_B_OPT, API->K_OPT, API->O_OPT, API->P_OPT,
+		GMT_Rgeo_OPT, GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_f_OPT, GMT_l_OPT, GMT_p_OPT, GMT_t_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -158,7 +159,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Default pen attributes [%s].", gmt_putpen(API->GMT, &API->GMT->current.setting.map_default_pen));
 	GMT_Option (API, "X");
 	GMT_Usage (API, 1, "\n-Z The theta grid provided has azimuths rather than directions (implies -A).");
-	GMT_Option (API, "c,f,p,t,.");
+	GMT_Option (API, "c,f,l,p,t,.");
 
 	return (GMT_MODULE_USAGE);
 }
@@ -174,7 +175,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct GMT_
 	unsigned int n_errors = 0, n_files = 0;
 	int j;
 	size_t len;
-	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, symbol;
+	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, symbol, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -284,6 +285,10 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct GMT_
 			case 'S':	/* Scale -S[l|i]<length|scale>[<unit>] */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
 				Ctrl->S.active = true;
+				if ((c = strstr (opt->arg, "+r"))) {	/* Gave reference value for legend */
+					Ctrl->S.reference = atof (&c[2]);
+					c[0] = '\0';	/* Chop off modifier */
+				}
 				len = strlen (opt->arg) - 1;	/* Location of expected unit */
 				j = (opt->arg[0] == 'i') ? 1 : 0;	/* j = 1 if -Si was selected */
 				if (strchr (GMT_DIM_UNITS GMT_LEN_UNITS, (int)opt->arg[len]))	/* Recognized plot length or map distance unit character */
@@ -299,6 +304,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct GMT_
 				else	/* Get the length or scale */
 					Ctrl->S.factor = atof (&opt->arg[j]);
 				if (j == 1) Ctrl->S.invert = true;
+				if (c) c[0] = '+';	/* Restore modifier */
 				break;
 			case 'T':	/* Rescale Cartesian angles */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
@@ -473,6 +479,7 @@ EXTERN_MSC int GMT_grdvector (void *V_API, int mode, void *args) {
 		Ctrl->S.factor = 1.0 / Ctrl->S.factor;	/* Turn length into a scale */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Vector scale of %g <data-unit>/%c converts to %g %c/<data-unit>.\n", was, Ctrl->S.unit, Ctrl->S.factor, Ctrl->S.unit);
 	}
+	if (Ctrl->S.reference == 0.0) Ctrl->S.reference = 1.0 / Ctrl->S.factor;	/* Default reference */
 
 	switch (Ctrl->S.unit) {	/* Adjust for possible unit selection */
 		/* First three choices will give straight vectors scaled from user length to plot lengths */
@@ -523,6 +530,10 @@ EXTERN_MSC int GMT_grdvector (void *V_API, int mode, void *args) {
 	}
 
 	if (Geographic) {	/* Now that we know this we make sure -T is disabled if given */
+		if (GMT->common.l.active) {
+			GMT_Report (API, GMT_MSG_WARNING, "Auto-legend requires Cartesian vectors; -l ignored\n");
+			GMT->common.l.active = false;
+		}
 		if (Ctrl->T.active) {	/* This is a mistake */
 			Ctrl->T.active = false;
 			GMT_Report (API, GMT_MSG_ERROR, "-T does not apply to geographic grids - ignored\n");
@@ -662,6 +673,13 @@ EXTERN_MSC int GMT_grdvector (void *V_API, int mode, void *args) {
 	}
 
 	PSL_command (GMT->PSL, "V\n");
+
+	if (GMT->common.l.active) {	/* Can we do auto-legend? */
+		scaled_vec_length = Ctrl->S.reference * Ctrl->S.factor;
+		GMT->common.l.item.size = scaled_vec_length;
+		gmt_add_legend_item (API, &Ctrl->Q.S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));
+	}
+
 	for (row = row_0; row < Grid[1]->header->n_rows; row += d_row) {
 		y = gmt_M_grd_row_to_y (GMT, row, Grid[0]->header);	/* Latitude OR y OR radius */
 		for (col = col_0; col < Grid[1]->header->n_columns; col += d_col) {

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -39,7 +39,8 @@
 #define PSLEGEND_MAJOR_SCL		1.5			/* Ratio of major axis to normal isotropic symbol size */
 #define PSLEGEND_MINOR_SCL		0.55		/* Ratio of minor axis to normal isotropic symbol size */
 #define PSLEGEND_ROUND_SCL		0.1			/* Fraction of corner rounding for round rectangles */
-#define PSLEGEND_MAJOR_ANGLE	25			/* Angle of major axis for rotated symbols */
+#define PSLEGEND_MAJOR_ANGLE	0			/* Angle of major axis for rotated ellipses */
+#define PSLEGEND_RECT_ANGLE		25			/* Angle of rotated rectangles */
 #define PSLEGEND_ANGLE_START	120			/* Start angle for wedge or math angle */
 #define PSLEGEND_ANGLE_STOP		420			/* Stop angle for wedge or math angle */
 #define PSLEGEND_MATH_SCL		0.6			/* Ratio of math angle radius to isotropic symbol size */
@@ -1638,7 +1639,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 									else {	/* Rotated rectangle needs more arguments; we use height = 0.55*width, az = 25 */
 										x = Ctrl->S.scale * get_the_size (GMT, size, def_size, PSLEGEND_MAJOR_SCL);	/* The width of the rectangle */
 										y = PSLEGEND_MINOR_SCL * x;
-										az1 = PSLEGEND_MAJOR_ANGLE;
+										az1 = PSLEGEND_RECT_ANGLE;
 									}
 									S[SYM]->data[2][0] = az1;
 									S[SYM]->data[3][0] = x;

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -799,7 +799,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 								else
 									x = 0.0;
 							}
-							if (symbol[0] == '-') {	/* Line symbol */
+							if (strchr ("v-", symbol[0])) {	/* Line symbol or vector */
 								got_line = true;
 								if (x > 0.0) line_size = x;
 							}
@@ -852,7 +852,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 	else if (def_size == 0.0)	/* No sizes specified in input file; default to 0.5 cm */
 		def_size = 0.5 / 2.54;	/* In inches */
 	if (def_dx2 == 0.0)	/* No dist to text label given; default to 2x default symbol size */
-		def_dx2 = Ctrl->S.scale * GMT_LEGEND_DX2_MUL * def_size;	/* In inches */
+		def_dx2 = Ctrl->S.scale * def_size * (got_line ? GMT_LEGEND_DXL_MUL : GMT_LEGEND_DX2_MUL);	/* In inches */
 	GMT_Report (API, GMT_MSG_DEBUG, "Default symbol size = %g and default distance to text label is %g\n", def_size, def_dx2);
 
 	if (n_char) {	/* Typesetting paragraphs, make a guesstimate of number of typeset lines */
@@ -1473,7 +1473,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 								x_off = col_left_x + x_off_col[column_number];
 							}
 							if (!strcmp (txt_b, "-"))	/* Automatic label offset */
-								off_tt = GMT_LEGEND_DX2_MUL * Ctrl->S.scale * def_size;
+								off_tt = (def_dx2 > 0.0) ? def_dx2 : GMT_LEGEND_DX2_MUL * Ctrl->S.scale * def_size;
 							else	/* Gave a specific offset */
 								off_tt = gmt_M_to_inch (GMT, txt_b);
 							d_off = 0.5 * (Ctrl->D.spacing - FONT_HEIGHT_PRIMARY) * GMT->current.setting.font_annot[GMT_PRIMARY].size / PSL_POINTS_PER_INCH;	/* To center the text */

--- a/test/modern/insetlegend.sh
+++ b/test/modern/insetlegend.sh
@@ -4,7 +4,7 @@ gmt begin insetlegend ps
   gmt psbasemap -R0/7/3/7 -Jx1i -B0 -B+t"Inset with plot and legend" -Xc
   gmt inset begin -DjTR+w3.8i/2.5i+o0.1i -M1c -F+p1p,red
     gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL+s0.5+glightblue+p2p+o0.3c
-    gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"+S1c
+    gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"
     gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges
   gmt inset end
 gmt end show

--- a/test/pslegend/autosize.sh
+++ b/test/pslegend/autosize.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Testing gmt pslegend autosizing of symbols when nothing is specified
+# other than the primary annotation font size.
+
+gmt begin autosize
+	gmt set FONT_ANNOT_PRIMARY 18p
+
+	cat > leg.txt <<- EOF
+	# S dx1 symbol size fill pen [ dx2 text ]
+	H 16p,Times-Roman Auto-sized at 18p
+	D 3p 1p
+	S - A - red 0.5p - Star
+	S - C - red 0.5p - Circle
+	S - D - red 0.5p - Diamond
+	S - G - red 0.5p - Octagon
+	S - H - red 0.5p - Hexagon
+	S - I - red 0.5p - Inv triangle
+	S - N - red 0.5p - Pentagon
+	S - S - red 0.5p - Square
+	S - T - red 0.5p - Triangle
+	S - e - red 0.5p - Ellipse
+	S - r - red 0.5p - Rectangle
+	S - R - red 0.5p - Roundtangle
+	S - j - red 0.5p - Rotangle
+	S - w - red 0.5p - Wedge
+	S - - - -   0.5p - Line
+	S - f - red 0.5p - Front
+	S - v - red 0.5p - Vector
+	S - m - red 0.5p - Math angle
+	S - k@sunglasses - - - - EPS
+	S - k@volcano - red 0.5p - Macro
+	EOF
+	# Plot colored and outlined on left and just outline or right.
+	gmt pslegend -R0/5/0/7.5 -JM12c -DjTL+l1.2+w5.5c+o0.3c -C0.2c -F+p+d -Baf leg.txt
+	sed -e 's/red/-/g' leg.txt | gmt pslegend -DjTR+l1.2+w5.5c+o0.3c -C0.2c -F+p+d -Baf
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

While **legend** will plot exactly what you tell it to, when we now start to rely on the auto legend feature in **-l** there were several shortcomings.  Once was the lack of a sense of the annotation font in placing the text (#6163) but also the lack of default parameters for most symbol when none is provided.  And the few defaults that were there needed some adjustments as well.  Before we accept these changes as is we should make sure they are adequate.  Here is a plot of all the symbols that have auto-settings (historically, we had one for front but there really is no good way to know what kind of front (here squares) so it should probably be removed as auto, just like we cannot guess what quoted and decorated lines might look like:

![autosize](https://user-images.githubusercontent.com/26473567/147623375-82c9dad5-7d95-498d-8a20-66e0947918a5.jpg)

What I mean by "no details" is simulated here by passing record like this (for circle):

`S - A - red 0.5p - Star`

[In **-l,** pen, colors, symbol type and label comes from the calling module, while _size, dz1,_ and _dx2_ may be unset]

Here are issues to tackle or make decisions on:

1. For ellipse, the rectangles, the wedge and vector sthere are named parameters at the top of _pslegend.c_ that can be tinkered with (and recompiled).  Are these the finalized settings, you think?
2. Given the new equation for _dx2 = size + W_ (symbol size plus letter width), most tests using **-l** will have slight failures
3. Two old examples (03 and 07) had very small symbols relative to the label so they have been updated (and then fail)
4. Any legend-related test script showing many types of symbols will fail due to the adjustments of parameters.

I think the proposed PR is vastly superior to what is in master, but some tinkering can happen, and I think for consistency we should remove the auto-square setting from front so it is like the other line-embellishment symbols that need more than "-" to do anything useful.

Once this PR can be merged I can start tackling the job of adding **-l** to **grdvector** and maybe **velo**.

**Note**: No _PostScript_ updates are presented here so you can run the tests and compare the results to see the changes.