### PR TITLE
Ensure small circle vector lengths can use map units

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1366,8 +1366,14 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	bcol = (S.read_size) ? ex2 : ex1;
 	if (S.symbol == GMT_SYMBOL_BARX && (S.base_set & GMT_BASE_READ)) gmt_set_column_type (GMT, GMT_IN, bcol, gmt_M_type (GMT, GMT_IN, GMT_X));
 	if (S.symbol == GMT_SYMBOL_BARY && (S.base_set & GMT_BASE_READ)) gmt_set_column_type (GMT, GMT_IN, bcol, gmt_M_type (GMT, GMT_IN, GMT_Y));
-	if (S.symbol == GMT_SYMBOL_GEOVECTOR && (S.v.status & PSL_VEC_JUST_S) == 0)
-		gmt_set_column_type (GMT, GMT_IN, ex2, GMT_IS_GEODIMENSION);
+	if (S.symbol == GMT_SYMBOL_GEOVECTOR && (S.v.status & PSL_VEC_JUST_S) == 0) {	/* Input is either azim,length or just length for small circle vectors */
+		if (S.v.status & PSL_VEC_POLE) {	/* Small circle distance is either map length or start,stop angles */
+			if ((S.v.status & PSL_VEC_ANGLES) == 0)	/* Just map length */
+				gmt_set_column_type (GMT, GMT_IN, ex1, GMT_IS_GEODIMENSION);
+		}
+		else	/* Great circle map length */
+			gmt_set_column_type (GMT, GMT_IN, ex2, GMT_IS_GEODIMENSION);
+	}
 	else if ((S.symbol == PSL_ELLIPSE || S.symbol == PSL_ROTRECT) && S.convert_angles && !S.par_set) {
 		if (S.n_required == 1)
 			gmt_set_column_type (GMT, GMT_IN, ex1, GMT_IS_GEODIMENSION);

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1044,8 +1044,14 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 		}
 		gmt_set_meminc (GMT, GMT_BIG_CHUNK);	/* Only a sizeable amount of PSXZY_DATA structures when we initially allocate */
 		GMT->current.map.is_world = !(S.symbol == PSL_ELLIPSE && S.convert_angles);
-		if (S.symbol == GMT_SYMBOL_GEOVECTOR && (S.v.status & PSL_VEC_JUST_S) == 0)
-			gmt_set_column_type (GMT, GMT_IN, ex2, GMT_IS_GEODIMENSION);
+		if (S.symbol == GMT_SYMBOL_GEOVECTOR && (S.v.status & PSL_VEC_JUST_S) == 0) {	/* Input is either azim,length or just length for small circle vectors */
+			if (S.v.status & PSL_VEC_POLE) {	/* Small circle distance is either map length or start,stop angles */
+				if ((S.v.status & PSL_VEC_ANGLES) == 0)	/* Just map length */
+					gmt_set_column_type (GMT, GMT_IN, ex1, GMT_IS_GEODIMENSION);
+			}
+			else	/* Great circle map length */
+				gmt_set_column_type (GMT, GMT_IN, ex2, GMT_IS_GEODIMENSION);
+		}
 		else if ((S.symbol == PSL_ELLIPSE || S.symbol == PSL_ROTRECT) && S.convert_angles && !S.par_set) {
 			if (S.n_required == 1)  {
 				gmt_set_column_type (GMT, GMT_IN, ex1, GMT_IS_GEODIMENSION);

--- a/test/psxy/smallcirvec.sh
+++ b/test/psxy/smallcirvec.sh
@@ -6,10 +6,10 @@ ps=smallcirvec.ps
 gmt set PROJ_ELLIPSOID Sphere
 # Vector from point with head at end
 cat << EOF > t.txt
-0 0 8000	red	0	45	b+e+b
--30 0 6000	green	-30	-30	e+e+b
-30 30 6000	blue	10	10	c+e+b
--10 0 6671.7	yellow	80	0	c+e+b
+0 0 8000k	red	0	45	b+e+b
+-30 0 6000k	green	-30	-30	e+e+b
+30 30 6000000e	blue	10	10	c+e+b
+-10 0 6671.7k	yellow	80	0	c+e+b
 EOF
 gmt psbasemap -Rg -JG0/0/4.5i -Bag -P -K -Xc > $ps
 while read lon lat length color plon plat just; do


### PR DESCRIPTION
See #6166 for background.  This PR fixes mistakes in both **plot** and **plot3** where the case for small circle and map length was not considered.

Instead of adding a new test I simply added **k** to the values in _smallcirclevec.sh_ and changed one entry to be in meters.  All tests work as before plus the problem was fixed.  Closes #6166.
