### PR TITLE
Always save current CPT for use by modern session

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8489,6 +8489,7 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 
 	if (mode == GMT_CPT_REQUIRED) {	/* The calling function requires the CPT to be present; GMT_Read_Data will work or fail accordingly */
 		P = GMT_Read_Data (GMT->parent, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL|continuous, NULL, file, NULL);
+		gmt_save_current_cpt (GMT, P, 0);	/* Save for use by session, if modern */
 		return (P);
 	}
 
@@ -8544,7 +8545,6 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 		PH = gmt_get_C_hidden (P);
 		PH->auto_scale = 1;	/* Flag for colorbar to supply -Baf if not given */
 		gmt_stretch_cpt (GMT, P, zmin, zmax);
-		gmt_save_current_cpt (GMT, P, 0);	/* Save for use by session, if modern */
 	}
 	else if (file) {	/* Gave a CPT file */
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "CPT argument %s understood to be a regular CPT table\n", file);
@@ -8553,6 +8553,7 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 	else
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No CPT file or master given?\n");
 
+	gmt_save_current_cpt (GMT, P, 0);	/* Save for use by session, if modern */
 	return (P);
 }
 


### PR DESCRIPTION
For unclear reasons, we only saved the current CPT when the requested CPT was a master table.  That worked for making maps using `@earth_relief` since its default CPT is _geo_, but if you tried` @earth_age` then its default cached CPT (correctly used for the image) would not be available for a **colorbar** which would hang upon trying to read _stdin_.  This PR ensures any CPT used is available as the current session CPT.
