### PR TITLE
Check if plotting degenerate symbols for legend

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -17157,6 +17157,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 	else if (p->symbol == GMT_SYMBOL_COLUMN)
 		p->base = (GMT->current.proj.xyz_projection[GMT_Z] == GMT_LOG10) ? 1.0 : 0.0;
 	if (add_to_base) p->base_set |= GMT_BASE_ORIGIN;	/* Means to add base value to height offset to get actual z at top */
+	p->degenerate = degenerate;
 	return (decode_error);
 }
 
@@ -19106,7 +19107,7 @@ GMT_LOCAL void gmtinit_set_symbol_size (struct GMTAPI_CTRL *API, struct GMT_SYMB
 
 void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do_fill, struct GMT_FILL *fill, bool do_line, struct GMT_PEN *pen, struct GMT_LEGEND_ITEM *item) {
 	/* Adds a new entry to the auto-legend information file hidden in the session directory */
-	char file[PATH_MAX] = {""}, label[GMT_LEN128] = {""}, size_string[GMT_LEN128] = {""};
+	char file[PATH_MAX] = {""}, label[GMT_LEN128] = {""}, size_string[GMT_LEN128] = {""}, symbol;
 	bool gap_done = false;
 	double size = 0.0;
 	FILE *fp = NULL;
@@ -19237,14 +19238,19 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 		fprintf (fp, "S - - %s - %s - %s\n", size_string, gmt_putpen (API->GMT, pen), label);
 	}
 	else {	/* Regular symbol */
+		symbol = S->symbol;	/* Selected symbol */
+		if (S->degenerate) {	/* Replace ellipses and rotated rectangles with circles and squares */
+			if (strchr ("eE", symbol)) symbol = 'c';
+			if (strchr ("jJ", symbol)) symbol = 's';
+		}
 		if (!(do_fill || do_line)) do_line = true;	/* If neither fill nor pen is selected, plot will draw line, so override do_line here */
 		if (do_line && pen == NULL) pen = &(API->GMT->current.setting.map_default_pen);	/* Must have pen to draw line */
-		if (S->symbol == 'q') {	/* Quoted line [Experimental] */
+		if (symbol == 'q') {	/* Quoted line [Experimental] */
 			char scode[GMT_LEN64] = {""};
 			sprintf (scode, "qn1:+ltext");
 			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 		}
-		else if (S->symbol == '~') {	/* Decorated line [Experimental] */
+		else if (symbol == '~') {	/* Decorated line [Experimental] */
 			char scode[GMT_LEN64] = {""};
 			sprintf (scode, "~n1:+s%s%s", S->D.symbol_code, S->D.size);
 			if (S->D.pen[0])  strcat (scode, "+p"), strcat (scode, S->D.pen);
@@ -19252,7 +19258,7 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 		}
 		else 
-			fprintf (fp, "S - %c %s %s %s - %s\n", S->symbol, size_string, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+			fprintf (fp, "S - %c %s %s %s - %s\n", symbol, size_string, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 	}
 
 	if (item->draw & GMT_LEGEND_DRAW_V && item->pen[GMT_LEGEND_PEN_V][0]) {	/* Must end with horizontal, then vertical line */

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -141,6 +141,7 @@ struct GMT_SYMBOL {
 	unsigned int read_symbol_cmd;	/* 1 when -S indicated we must read symbol type from file, 2 with -SK is used */
 	bool u_set;		/* true if u was set */
 	bool par_set;		/* true if all parameters were set for e,j */
+	bool degenerate;		/* true for E- and J- as degenerate ellipses and rectangles */
 	double factor;		/* Scaling needed to unify symbol area for circle, triangles, etc. [1] */
 	double size_x;		/* Current symbol size in x */
 	double size_y;		/* Current symbol size in y */


### PR DESCRIPTION
When plotting circles on a map with **gmt plot -SE**- we are plotting circles but doing so via the elliptical outline option to get a projected circle.  In those cases, if we use **-l** for an auto-legend we do not want to see an ellipse in the legend but a circle.  Same for **-SJ-** for degenerate rectangles as squares:

(echo 150 -20 500 | gmt plot -Rg -JG200/5/6i -Baf -B+t"Fake Earthquakes on Jan 1, 2022" -SE- -Gred -l"Nasty Quake 1" -png map

![map](https://user-images.githubusercontent.com/26473567/147892524-94f87e19-85cf-4e30-a325-ee4d615fc5f8.png)

