### PR TITLE
movie.rst: add default -L

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -200,8 +200,7 @@ Optional Arguments
 .. _-L:
 
 **-L**\ *labelinfo*\ [*modifiers*]
-    Automatic labeling of individual frames.
-    Default is running frame number (f).
+    Automatic labeling of individual frames [Default is running frame number (f)].
     Repeatable up to 32 labels.  Places the chosen label at the frame perimeter:
     **e** selects the elapsed time in seconds as the label; append **+s**\ *scale* to set the length
     in seconds of each frame [Default is 1/*framerate*],

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -200,7 +200,9 @@ Optional Arguments
 .. _-L:
 
 **-L**\ *labelinfo*\ [*modifiers*]
-    Automatic labeling of individual frames.  Repeatable up to 32 labels.  Places the chosen label at the frame perimeter:
+    Automatic labeling of individual frames.
+    Default is running frame number (f).
+    Repeatable up to 32 labels.  Places the chosen label at the frame perimeter:
     **e** selects the elapsed time in seconds as the label; append **+s**\ *scale* to set the length
     in seconds of each frame [Default is 1/*framerate*],
     **s**\ *string* uses the fixed text *string* as the label,


### PR DESCRIPTION
I can't see that the movie man page mentions the default choice of `-L` (which is `f`). Added.