### PR TITLE
file-formats.rst: minor formatting

### DIFF
--- a/doc/rst/source/cookbook/file-formats.rst
+++ b/doc/rst/source/cookbook/file-formats.rst
@@ -9,7 +9,7 @@ Table data
 These files have *N* records which have *M* fields each. All programs
 that handle tables can read multicolumn files. GMT can read both
 ASCII, native binary, netCDF table data, and ESRI shapefiles (which
-we convert to GMT/OGR format via GDAL's ogr2ogr tool under the hood).
+we convert to GMT/OGR format via GDAL's **ogr2ogr** tool under the hood).
 
 ASCII tables
 ~~~~~~~~~~~~


### PR DESCRIPTION
Do the man pages/cookbook etc. have a convention about formatting of utility names (e.g. `ogr2ogr`)?
There are some inconsistent ways of formatting them.

This would be a nice addition to the reStructuredText Cheatsheet (https://docs.generic-mapping-tools.org/dev/devdocs/rst-cheatsheet.html).