### PR TITLE
Address items 3, 4, 7 in vector proposal

### DIFF
--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -86,7 +86,7 @@ In addition, all but circular vectors may take these modifiers:
     **+s** means the input *angle*, *length* are instead the :math:`x_e, y_e`
     coordinates of the vector end point.
 
-Finally, Cartesian vectors may take these modifiers:
+Finally, Cartesian vectors and geovectors may take these modifiers (except in :doc:`grdvector`):
 
     **+z**\ *scale* expects input :math:`\Delta x, \Delta y` vector components and
     uses the *scale* to convert to polar coordinates with length in given unit.

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8452,8 +8452,8 @@ void gmt_vector_syntax (struct GMT_CTRL *GMT, unsigned int mode, int level) {
 	 * 2	= Accepts +s (not mathangle)
 	 * 4	= Accepts +p (not mathangle)
 	 * 8	= Accepts +g (not mathangle)
-	 * 16	= Accepts +z (not mathangle, geovector)
-	 * 32	= geovector so only a|A[l|r] available
+	 * 16	= Accepts +z (not mathangle, grdvector)
+	 * 32	= geovector so only a|A[l|r] available for head types
 	 */
 	unsigned int kind = (mode & 32) ? 1 : 0;
 	struct GMTAPI_CTRL *API = GMT->parent;
@@ -16169,7 +16169,20 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 				break;
 			case 'z':	/* Input (angle,length) are vector components (dx,dy) instead */
 				S->v.status |= PSL_VEC_COMPONENTS;
-				S->v.comp_scale = (float)gmt_convert_units (GMT, &p[1], GMT->current.setting.proj_length_unit, GMT_INCH);
+				if (symbol == '=') {	/* Scale is set to convert to km, eventually */
+					len = strlen (p);
+					S->v.comp_scale = (p[1]) ? (float)atof (&p[1]) : 1.0;	/* This is scale in given units, not (yet) converted to km */
+					if (p[len-1]) {	/* Examine if a unit was given */
+						if (strchr (GMT_DIM_UNITS, p[len-1])) {	/* Confused user gave geovector scale in c|i|p, this is an error */
+							GMT_Report (GMT->parent, GMT_MSG_ERROR, "Vector component scaling for geovectors must be given in units of %s [k]!\n", GMT_LEN_UNITS);
+							error++;
+						}
+						else if (strchr (GMT_LEN_UNITS, p[len-1]))	/* Got length with valid unit, otherwise we assume it was given in km */
+							S->v.comp_scale = gmtlib_conv_distance (GMT, S->v.comp_scale, p[len-1], 'k');	/* Convert to km first */
+					}
+				}
+				else	/* Cartesian components scaled to plot units */
+					S->v.comp_scale = (p[1]) ? (float)gmt_convert_units (GMT, &p[1], GMT->current.setting.proj_length_unit, GMT_INCH) : 1.0;
 				break;
 			default:
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad modifier +%c\n", p[0]);

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -10057,3 +10057,21 @@ int gmt_circle_to_region (struct GMT_CTRL *GMT, double lon, double lat, double r
 	}
 	return (code);
 }
+
+double gmt_get_az_dist_from_components (struct GMT_CTRL *GMT, double lon, double lat, double dx, double dy, double *azim) {
+	/* Given a location and dx_km,dy_km of a geovector in map distance, compute equivalent length (in km) and azimuth */
+	double x2, y2, L;
+	if (doubleAlmostEqual (lat, -90.0) || doubleAlmostEqual (lat, 90.0))	/* No x adjustment possible */
+		x2 = lon;
+	else 
+		x2 = lon + dx / (cosd (lat) * GMT->current.proj.DIST_KM_PR_DEG);
+	y2 = lat + dy / GMT->current.proj.DIST_KM_PR_DEG;
+	if (fabs (y2) > 90.0) {	/* Across the pole we go */
+		x2 += 180.0;
+		y2 = copysign (180 - fabs (y2), lat);
+	}
+	L = 0.001 * gmt_great_circle_dist_meter (GMT, lon, lat, x2, y2);
+	*azim = gmt_az_backaz (GMT, lon, lat, x2, y2, false);
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Geovector components (%g, %g) converted to azim = %g and length = %g km\n", dx, dy, *azim, L);
+	return (L);
+}

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -577,6 +577,7 @@ EXTERN_MSC void gmt_gcal_from_dt (struct GMT_CTRL *GMT, double t, struct GMT_GCA
 /* gmt_map.c: */
 
 
+EXTERN_MSC double gmt_get_az_dist_from_components (struct GMT_CTRL *GMT, double lon, double lat, double dx, double dy, double *azim);
 EXTERN_MSC int gmt_map_perimeter_search (struct GMT_CTRL *GMT, double *wesn, bool add_pad);
 EXTERN_MSC int gmt_circle_to_region (struct GMT_CTRL *GMT, double lon, double lat, double radius, double *wesn);
 EXTERN_MSC void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat, double *back_az);

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -279,6 +279,10 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVECTOR_CTRL *Ctrl, struct GMT_
 						Ctrl->Q.S.v.v_norm *= GMT->session.u2u[Ctrl->Q.S.u][GMT_INCH];	/* Since we are not reading this again we change to inches */
 						Ctrl->Q.S.u = GMT_INCH;
 					}
+					if (Ctrl->Q.S.v.status & PSL_VEC_COMPONENTS) {
+						GMT_Report (API, GMT_MSG_ERROR, "Option -Q: Cannot use modifier +z; see -A for Cartesian [Default] versus polar component grids\n");
+						n_errors++;
+					}
 				}
 				break;
 			case 'S':	/* Scale -S[l|i]<length|scale>[<unit>] */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1333,8 +1333,8 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		gmt_set_column_type (GMT, GMT_IN, pos2x, gmt_M_type (GMT, GMT_IN, GMT_X));
 		gmt_set_column_type (GMT, GMT_IN, pos2y, gmt_M_type (GMT, GMT_IN, GMT_Y));
 	}
-	if (S.symbol == PSL_VECTOR && S.v.status & PSL_VEC_COMPONENTS)
-		gmt_set_column_type (GMT, GMT_IN, pos2y, GMT_IS_FLOAT);	/* Just the users dy component, not length */
+	if (S.v.status & PSL_VEC_COMPONENTS)	/* Giving vector components */
+		gmt_set_column_type (GMT, GMT_IN, pos2y, (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION);	/* Just the users dy component, not length */
 	if (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC ) {	/* One of the vector symbols */
 		geovector = (S.symbol == GMT_SYMBOL_GEOVECTOR);
 		if ((S.v.status & PSL_VEC_FILL) == 0 && !S.v.parsed_v4) Ctrl->G.active = false;	/* Want no fill so override -G */
@@ -2116,7 +2116,14 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 							GMT_Report (API, GMT_MSG_WARNING, "Geovector length = NaN near line %d. Skipped\n", n_total_read);
 							continue;
 						}
-						warn = gmt_geo_vector (GMT, in[GMT_X], in[GMT_Y], in[ex1+S.read_size], in[ex2+S.read_size], &current_pen, &S);
+						if (S.v.status & PSL_VEC_COMPONENTS) {	/* Read dx, dy in user units to be scaled to km */
+							double dx = in[ex1+S.read_size] * S.v.comp_scale;
+							double dy = in[ex2+S.read_size] * S.v.comp_scale;
+							length = factor * gmt_get_az_dist_from_components (GMT, in[GMT_X], in[GMT_Y], dx, dy, &d);
+						}
+						else	/* Got azimuth and length */
+							d = in[ex1+S.read_size], length = factor * in[ex2+S.read_size];
+						warn = gmt_geo_vector (GMT, in[GMT_X], in[GMT_Y], d, length, &current_pen, &S);
 						n_warn[warn]++;
 						break;
 					case PSL_MARC:

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1333,8 +1333,10 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		gmt_set_column_type (GMT, GMT_IN, pos2x, gmt_M_type (GMT, GMT_IN, GMT_X));
 		gmt_set_column_type (GMT, GMT_IN, pos2y, gmt_M_type (GMT, GMT_IN, GMT_Y));
 	}
-	if (S.v.status & PSL_VEC_COMPONENTS)	/* Giving vector components */
+	if (S.v.status & PSL_VEC_COMPONENTS) {	/* Giving vector components */
+		gmt_set_column_type (GMT, GMT_IN, pos2x, (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION);	/* Just the users dx component, not azimuth */
 		gmt_set_column_type (GMT, GMT_IN, pos2y, (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION);	/* Just the users dy component, not length */
+	}
 	if (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC ) {	/* One of the vector symbols */
 		geovector = (S.symbol == GMT_SYMBOL_GEOVECTOR);
 		if ((S.v.status & PSL_VEC_FILL) == 0 && !S.v.parsed_v4) Ctrl->G.active = false;	/* Want no fill so override -G */

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -967,8 +967,8 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 		gmt_set_column_type (GMT, GMT_IN, pos2x, gmt_M_type (GMT, GMT_IN, GMT_X));
 		gmt_set_column_type (GMT, GMT_IN, pos2y, gmt_M_type (GMT, GMT_IN, GMT_Y));
 	}
-	if (S.symbol == PSL_VECTOR && S.v.status & PSL_VEC_COMPONENTS)
-		gmt_set_column_type (GMT, GMT_IN, pos2y, GMT_IS_FLOAT);	/* Just the users dy component, not length */
+	if (S.v.status & PSL_VEC_COMPONENTS)	/* Giving vector components */
+		gmt_set_column_type (GMT, GMT_IN, pos2y, (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION);	/* Just the users dy component, not length */
 	if (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC ) {	/* One of the vector symbols */
 		geovector = (S.symbol == GMT_SYMBOL_GEOVECTOR);
 		if (S.v.status & PSL_VEC_FILL2) {	/* Gave +g<fill> to set head fill; odd, but overrides -G (and sets -G true) */
@@ -1519,8 +1519,15 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 						GMT_Report (API, GMT_MSG_WARNING, "Geovector length = NaN near line %d. Skipped\n", n_total_read);
 						continue;
 					}
-					data[n].dim[0] = in[ex1+S.read_size];	/* direction */
-					data[n].dim[1] = in[ex2+S.read_size];	/* length */
+					if (S.v.status & PSL_VEC_COMPONENTS) {	/* Read dx, dy in user units to be scaled to km */
+						double dx = in[ex1+S.read_size] * S.v.comp_scale;
+						double dy = in[ex2+S.read_size] * S.v.comp_scale;
+						data[n].dim[1] = gmt_get_az_dist_from_components (GMT, in[GMT_X], in[GMT_Y], dx, dy, &data[n].dim[0]);
+					}
+					else {	/* Got azimuth and length */
+						data[n].dim[0] = in[ex1+S.read_size];
+						data[n].dim[1] = in[ex2+S.read_size];
+					}
 					data[n].x = in[GMT_X];			/* Revert to longitude and latitude */
 					data[n].y = in[GMT_Y];
 					data[n].v = S.v;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -967,8 +967,10 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 		gmt_set_column_type (GMT, GMT_IN, pos2x, gmt_M_type (GMT, GMT_IN, GMT_X));
 		gmt_set_column_type (GMT, GMT_IN, pos2y, gmt_M_type (GMT, GMT_IN, GMT_Y));
 	}
-	if (S.v.status & PSL_VEC_COMPONENTS)	/* Giving vector components */
+	if (S.v.status & PSL_VEC_COMPONENTS) {	/* Giving vector components */
+		gmt_set_column_type (GMT, GMT_IN, pos2x, (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION);	/* Just the users dx component, not azimuth */
 		gmt_set_column_type (GMT, GMT_IN, pos2y, (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION);	/* Just the users dy component, not length */
+	}
 	if (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC ) {	/* One of the vector symbols */
 		geovector = (S.symbol == GMT_SYMBOL_GEOVECTOR);
 		if (S.v.status & PSL_VEC_FILL2) {	/* Gave +g<fill> to set head fill; odd, but overrides -G (and sets -G true) */


### PR DESCRIPTION
This PR addresses these three items in #6190:

(3) Allow **+z** in **plot** and **plot3** to accept components for a geovector and have them scaled to map distances. Properly compute what azimuth and length this corresponds to and plot the geovector accordingly.
(4) Disable (or give error) **+z** in grdvector since here we control polar vs component via **-A**.
(7) Accept a default scale of 1 if +z has no argument (currently this would give junk).

No tests are affected.

Some examples of geovector components calls:

```
echo 0 60 100 100 | gmt plot -R-2/3/59/62 -JM10c -B -S=12p+e+z -W1p -Gred -pdf map
echo 0 60 100k 100M | gmt plot -R-2/3/59/62 -JM10c -B -S=12p+e+z -W1p -Gred -pdf map
echo 0 60 1 2 | gmt plot -R-2/3/59/62 -JM10c -B -S=12p+e+z100k -W1p -Gred -pdf map

```