### PR TITLE
Switch to using q instead of u for user unit

### DIFF
--- a/doc/examples/ex43/ex43.bat
+++ b/doc/examples/ex43/ex43.bat
@@ -43,7 +43,7 @@ gmt begin ex43
 	echo 30	-2.5	>> lines.txt
 	echo 0	-2.5	>> lines.txt
 	gmt plot lines.txt -Gcornsilk1 -W0.25p,-
-	gawk "{print NR, $6, $7}" A.txt | gmt plot -Sb1ub0 -W0.25p -C
+	gawk "{print NR, $6, $7}" A.txt | gmt plot -Sb1q+b0 -W0.25p -C
 	gmt basemap -Bafg100 -Bx+l"Animal index number" -By+l"z-zcore" -BWSne
 	del *.txt
 gmt end show

--- a/doc/examples/ex43/ex43.sh
+++ b/doc/examples/ex43/ex43.sh
@@ -50,7 +50,7 @@ gmt begin ex43
 	0	-2.5
 
 	EOF
-	$AWK '{print NR, $6, $7}' A.txt | gmt plot -Sb1ub0 -W0.25p -C
+	$AWK '{print NR, $6, $7}' A.txt | gmt plot -Sb1q+b0 -W0.25p -C
 	gmt basemap -Bafg100 -Bx+l"Animal index number" -By+l"z-zcore" -BWSne
 	rm -f *.txt
 gmt end show

--- a/doc/examples/ex50/ex50.bat
+++ b/doc/examples/ex50/ex50.bat
@@ -9,10 +9,10 @@ gmt begin ex50
 	gmt set FONT_ANNOT_PRIMARY 10p,Helvetica,black
 	REM Binomial distribution
 	gmt math -T0/8/1 0.25 8 T BPDF = p.txt
-	gmt plot -R-0.6/8.6/0/0.35 -JX7.5c/1.25c -Glightgreen p.txt -Sb0.8u -W0.5p -BWS -Bxa1 -Byaf
+	gmt plot -R-0.6/8.6/0/0.35 -JX7.5c/1.25c -Glightgreen p.txt -Sb0.8q -W0.5p -BWS -Bxa1 -Byaf
 	REM Poisson distribution
 	gmt math -T0/8/1 T 2 PPDF = p.txt
-	gmt plot -R-0.6/8.6/0/0.3 -Glightgreen p.txt -Sb0.8u -W0.5p -BWS -Bxa1 -Byaf -Y2.25c
+	gmt plot -R-0.6/8.6/0/0.3 -Glightgreen p.txt -Sb0.8q -W0.5p -BWS -Bxa1 -Byaf -Y2.25c
 	REM Plot normal distribution
 	gmt math -T-4/4/0.1 T ZPDF = p.txt
 	gmt plot -R-4/4/0/0.4 p.txt -L+yb -Glightgreen -W1p -BWS -Bxa1 -Byaf -Y2.25c
@@ -41,10 +41,10 @@ gmt begin ex50
 	REM Right column has all the CDF
 	REM Plot binomial cumulative distribution
 	gmt math -T0/8/1 0.25 8 T BCDF = p.txt
-	gmt plot -R-0.6/8.6/0/1.02 -Glightred p.txt -Sb0.8u -W0.5p -BES -Bxa1 -Byaf -X9c -Y-8.1i
+	gmt plot -R-0.6/8.6/0/1.02 -Glightred p.txt -Sb0.8q -W0.5p -BES -Bxa1 -Byaf -X9c -Y-8.1i
 	REM Plot Poisson cumulative distribution
 	gmt math -T0/8/1 T 2 PCDF = p.txt
-	gmt plot -R-0.6/8.6/0/1.02 -Glightred p.txt -Sb0.8u -W0.5p -BES -Bxa1 -Byaf -Y2.25c
+	gmt plot -R-0.6/8.6/0/1.02 -Glightred p.txt -Sb0.8q -W0.5p -BES -Bxa1 -Byaf -Y2.25c
 	REM Plot normal cumulative distribution
 	gmt math -T-4/4/0.1 T ZCDF = p.txt
 	gmt plot -R-4/4/0/1.02 p.txt -L+yb -Glightred -W1p -BES -Bxa1 -Byaf -Y2.25c

--- a/doc/examples/ex50/ex50.sh
+++ b/doc/examples/ex50/ex50.sh
@@ -9,10 +9,10 @@ gmt begin ex50
 	# Left column have all the PDFs
 	# Binomial distribution
 	gmt math -T0/8/1 0.25 8 T BPDF = p.txt
-	gmt plot -R-0.6/8.6/0/0.35 -JX7.5c/1.25c -Glightgreen p.txt -Sb0.8u -W0.5p -BWS -Bxa1 -Byaf
+	gmt plot -R-0.6/8.6/0/0.35 -JX7.5c/1.25c -Glightgreen p.txt -Sb0.8q -W0.5p -BWS -Bxa1 -Byaf
 	# Poisson distribution
 	gmt math -T0/8/1 T 2 PPDF = p.txt
-	gmt plot -R-0.6/8.6/0/0.3 -Glightgreen p.txt -Sb0.8u -W0.5p -BWS -Bxa1 -Byaf -Y2.25c
+	gmt plot -R-0.6/8.6/0/0.3 -Glightgreen p.txt -Sb0.8q -W0.5p -BWS -Bxa1 -Byaf -Y2.25c
 	# Plot normal distribution
 	gmt math -T-4/4/0.1 T ZPDF = p.txt
 	gmt plot -R-4/4/0/0.4 p.txt -L+yb -Glightgreen -W1p -BWS -Bxa1 -Byaf -Y2.25c
@@ -41,10 +41,10 @@ gmt begin ex50
 	# Right column has all the CDF
 	# Plot binomial cumulative distribution
 	gmt math -T0/8/1 0.25 8 T BCDF = p.txt
-	gmt plot -R-0.6/8.6/0/1.02 -Glightred p.txt -Sb0.8u -W0.5p -BES -Bxa1 -Byaf -X9c -Y-8.1i
+	gmt plot -R-0.6/8.6/0/1.02 -Glightred p.txt -Sb0.8q -W0.5p -BES -Bxa1 -Byaf -X9c -Y-8.1i
 	# Plot Poisson cumulative distribution
 	gmt math -T0/8/1 T 2 PCDF = p.txt
-	gmt plot -R-0.6/8.6/0/1.02 -Glightred p.txt -Sb0.8u -W0.5p -BES -Bxa1 -Byaf -Y2.25c
+	gmt plot -R-0.6/8.6/0/1.02 -Glightred p.txt -Sb0.8q -W0.5p -BES -Bxa1 -Byaf -Y2.25c
 	# Plot normal cumulative distribution
 	gmt math -T-4/4/0.1 T ZCDF = p.txt
 	gmt plot -R-4/4/0/1.02 p.txt -L+yb -Glightred -W1p -BES -Bxa1 -Byaf -Y2.25c

--- a/doc/rst/source/explain_3D_symbols.rst_
+++ b/doc/rst/source/explain_3D_symbols.rst_
@@ -10,9 +10,9 @@
         of uniform color (upper case **U** and **O**). The column may also
         be a multiband symbol using the **+v**\|\ **i** modifiers.
 
-    **-So**\ *size*\ [**c**\|\ **i**\|\ **p**\|\ **u**][**+b**\ \|\ **B**\ [*base*]][**+v**\|\ **i**\ *nz*]
+    **-So**\ *size*\ [**c**\|\ **i**\|\ **p**\|\ **q**][**+b**\ \|\ **B**\ [*base*]][**+v**\|\ **i**\ *nz*]
         c\ **o**\ lumn (3-D) extending from *base* to *z*.  The *size* sets base width
-        (Use *xsize/ysize* if they are not the same).  Append **u** if *size* is in the users' x-units
+        (Use *xsize/ysize* if they are not the same).  Append **q** if *size* is a quantity in the users' x-units
         [Default is plot-distance units].  If no *size* is given we expect both *xsize*
         and *ysize* as two extra data columns.  By default, *base* = 0.  Append
         **+b**\ *base* to change this value.  If *base* is not appended then we read it
@@ -26,8 +26,8 @@
         *z* values must equal the band number (0, 1, ..., *nz*\ -1) to assign the band color.
         Thus, input records are either (*x y z1 z2 ... zn*) or (*x y dz1 dz2 ... dzn*).
 
-    **-Su**\ *size*\ [**c**\|\ **i**\|\ **p**\|\ **u**]
+    **-Su**\ *size*\ [**c**\|\ **i**\|\ **p**\|\ **q**]
         c\ **u**\ be (3-D).  The *size* sets length of all sides. Append
-        **u** if *size* is in x-units [Default is plot-distance units].
+        **q** if *size* is a quantity in x-units [Default is plot-distance units].
         The facet colors will be modified to simulate shading.
         Use **-SU** to disable 3-D illumination.

--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -198,9 +198,9 @@
         Using modifiers **+v** or **+i** you can also plot multi-band bars with colors set via **-C**,
         and **+s** can represent those as groups of individual bars instead.
 
-    **-Sb**\ [*size*\ [**c**\|\ **i**\|\ **p**\|\ **u**]][**+b**\ \|\ **B**\ [*base*]][**+v**\|\ **i**\ *ny*][**+s**\ [*gap*]]
+    **-Sb**\ [*size*\ [**c**\|\ **i**\|\ **p**\|\ **q**]][**+b**\ \|\ **B**\ [*base*]][**+v**\|\ **i**\ *ny*][**+s**\ [*gap*]]
         Vertical **b**\ ar extending from *base* to y. The *size* is bar width.
-        Append **u** if *size* is in x-units [Default is plot-distance units].
+        Append **q** if *size* is a quantity in x-units [Default is plot-distance units].
         By default, *base* = 0. Append **+b**\ [*base*] to change this
         value. If *base* is not appended then we read it from the last input
         data column.  Use **+B**\ [*base*] if the bar height is measured relative
@@ -215,9 +215,9 @@
         Multiband bars requires **-C** with one color per band (CPT z-values must be 0, 1, ..., *ny* - 1).
         Thus, input records are either (*x y1 y2 ... yn*) or (*x dy1 dy2 ... dyn*).
 
-    **-SB**\ [*size*\ [**c**\|\ **i**\|\ **p**\|\ **u**]][**+b**\ \|\ **B**\ [*base*]][**+v**\|\ **i**\ *nx*][**+s**\ [*gap*]]
+    **-SB**\ [*size*\ [**c**\|\ **i**\|\ **p**\|\ **q**]][**+b**\ \|\ **B**\ [*base*]][**+v**\|\ **i**\ *nx*][**+s**\ [*gap*]]
         Horizontal **b**\ ar extending from *base* to x. The *size* is bar width.
-        Append **u** if *size* is in y-units [Default is plot-distance units].
+        Append **q** if *size* is a quantity in y-units [Default is plot-distance units].
         By default, *base* = 0. Append **+b**\ [*base*] to change this
         value. If *base* is not appended then we read it from the last input
         data column.  Use **+B**\ [*base*] if the bar length is measured relative

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16393,9 +16393,11 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 	}
 	else if (strchr (bar_symbols[mode], (int) text[0])) {	/* Bar, column, cube with size */
 
-		/* Bar:		-Sb|B[<size_x|size_y>[c|i|p|u]][+b|B[<base>]][+v|i<nz>][+s[<gap>]]				*/
-		/* Column:	-So|O[<size_x>[c|i|p|u][/<ysize>[c|i|p|u]]][+b|B[<base>]][+v|i<nz>]	*/
-		/* Cube:	-Su|U[<size_x>[c|i|p|u]]	*/
+		/* Bar:		-Sb|B[<size_x|size_y>[c|i|p|q]][+b|B[<base>]][+v|i<nz>][+s[<gap>]]
+		 * Column:	-So|O[<size_x>[c|i|p|q][/<ysize>[c|i|p|u]]][+b|B[<base>]][+v|i<nz>]
+		 * Cube:	-Su|U[<size_x>[c|i|p|q]]
+		 * Note: 1/5/2022 PW: To avoid confusion with unit u for survey foot, we do a backwards compatible change
+		 * and now use 'q' for quantity instead, but we will of course continue to honor 'u' going forward. */
 
 		/* Also worry about backwards handling of +z|Z, now +v|i */
 		if ((c = strstr (text, "+v")) || (c = strstr (text, "+i"))|| (c = strstr (text, "+z")) || (c = strstr (text, "+Z"))) {	/* Got +z|Z<nz> */
@@ -16449,22 +16451,22 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		if (slash) {	/* Separate x/y sizes */
 			n = sscanf (text_cp, "%c%[^/]/%s", &symbol_type, txt_a, txt_b);
 			decode_error += (n != 3);
-			if (((len = (int)strlen (txt_a)) > 0) && txt_a[len-1] == 'u') {
+			if (((len = (int)strlen (txt_a)) > 0) && (txt_a[len-1] == 'q' || txt_a[len-1] == 'u')) {	/* 'u' for backwards compatibility */
 				p->user_unit[GMT_X] = true;	/* Specified xwidth in user units */
-				txt_a[len-1] = '\0';	/* Chop off the 'u' */
+				txt_a[len-1] = '\0';	/* Chop off the 'q' */
 			}
-			if (((len = (int)strlen (txt_b)) > 0) && txt_b[len-1] == 'u') {
+			if (((len = (int)strlen (txt_b)) > 0) && (txt_b[len-1] == 'q' || txt_b[len-1] == 'u')) {	/* 'u' for backwards compatibility */
 				p->user_unit[GMT_Y] = true;	/* Specified ywidth in user units */
-				txt_b[len-1] = '\0';	/* Chop off the 'u' */
+				txt_b[len-1] = '\0';	/* Chop off the 'q' */
 			}
 			if (p->user_unit[GMT_X]) {
-				if (gmtinit_get_uservalue (GMT, txt_a, gmt_M_type (GMT, GMT_IN, GMT_X), &p->given_size_x, "-Sb|B|o|O|u|u x-size value")) return GMT_PARSE_ERROR;
+				if (gmtinit_get_uservalue (GMT, txt_a, gmt_M_type (GMT, GMT_IN, GMT_X), &p->given_size_x, "-Sb|B|o|O|u|U x-size value")) return GMT_PARSE_ERROR;
 				p->size_x = p->given_size_x;
 			}
 			else
 				p->size_x = p->given_size_x = gmt_M_to_inch (GMT, txt_a);
 			if (p->user_unit[GMT_Y]) {
-				if (gmtinit_get_uservalue (GMT, txt_b, gmt_M_type (GMT, GMT_IN, GMT_Y), &p->given_size_y, "-Sb|B|o|O|u|u y-size value")) return GMT_PARSE_ERROR;
+				if (gmtinit_get_uservalue (GMT, txt_b, gmt_M_type (GMT, GMT_IN, GMT_Y), &p->given_size_y, "-Sb|B|o|O|u|U y-size value")) return GMT_PARSE_ERROR;
 				p->size_y = p->given_size_y;
 			}
 			else
@@ -16472,13 +16474,13 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 		}
 		else {	/* Only a single x = y size */
 			n = sscanf (text_cp, "%c%s", &symbol_type, txt_a);
-			if ((len = (int)strlen (txt_a)) && txt_a[len-1] == 'u') {
+			if ((len = (int)strlen (txt_a)) && (txt_a[len-1] == 'q' || txt_a[len-1] == 'u')) {	/* 'u' for backwards compatibility */
 				p->user_unit[GMT_X] = p->user_unit[GMT_Y] = true;	/* Specified xwidth [=ywidth] in user units */
-				txt_a[len-1] = '\0';	/* Chop off the 'u' */
+				txt_a[len-1] = '\0';	/* Chop off the 'q' */
 			}
 			if (n == 2) {	/* Gave size */
 				if (p->user_unit[GMT_X]) {
-					if (gmtinit_get_uservalue (GMT, txt_a, gmt_M_type (GMT, GMT_IN, GMT_X), &p->given_size_x, "-Sb|B|o|O|u|u x-size value")) return GMT_PARSE_ERROR;
+					if (gmtinit_get_uservalue (GMT, txt_a, gmt_M_type (GMT, GMT_IN, GMT_X), &p->given_size_x, "-Sb|B|o|O|u|U x-size value")) return GMT_PARSE_ERROR;
 					p->size_x = p->size_y = p->given_size_y = p->given_size_x;
 				}
 				else

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -586,10 +586,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Symbols A, C, D, G, H, I, N, S, T are adjusted to have same area "
 		"as a circle of the specified diameter.");
 
-	GMT_Usage (API, 2, "\n%s Bar: -Sb|B[<size_x|size_y>[c|i|p|u]][+b|B[<base>]][+v|i<nz>][+s[<gap>]]", GMT_LINE_BULLET);
+	GMT_Usage (API, 2, "\n%s Bar: -Sb|B[<size_x|size_y>[c|i|p|q]][+b|B[<base>]][+v|i<nz>][+s[<gap>]]", GMT_LINE_BULLET);
 	GMT_Usage (API, -3, "Place horizontal or vertical bars. Use upper case -SB for horizontal bars "
 		"(<base> then refers to x and width may be in y-units) [Default is vertical]. Append size "
-		"and use unit u if size is given in x-input units [Default is %s]. Available modifiers:",
+		"and use unit q if size is quantity given in x-input units [Default is %s]. Available modifiers:",
 			API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
 	GMT_Usage (API, 3, "+B Heights are measured relative to <base> [relative to origin].");
 	GMT_Usage (API, 3, "+b Set <base>. Alternatively, leave <base> off to read it from file.");

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -261,6 +261,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+i Increments dz are given instead or values for multiband bars.");
 	GMT_Usage (API, -3, "Multiband columns requires -C with one color per band (values 0, 1, ...).");
 
+	GMT_Usage (API, 2, "\n%s 3-D Cube: Give <size> as the length of all sides; append q if <size> "
+		"is a quantity in x-units.", GMT_LINE_BULLET);
+
 	GMT_Usage (API, 2, "\n%s Ellipse: If not given, we read direction, major, and minor axis from columns 4-6. "
 		"If -SE rather than -Se is selected, %s will expect azimuth, and "
 		"axes [in km], and convert azimuths based on map projection. "

--- a/test/gmtmath/cdfs1.sh
+++ b/test/gmtmath/cdfs1.sh
@@ -16,7 +16,7 @@ cat << EOF > ML.txt
 7	0.999984741210938
 8	1.000000000000000
 EOF
-gmt psxy -R-0.6/8.6/0/1.2 -JX6i/1.2i -P -K -Glightgreen p.d -Sb0.8u -W0.5p -BWS -Bxa1 -Byaf -Xc -Y0.75i --MAP_FRAME_TYPE=graph > $ps
+gmt psxy -R-0.6/8.6/0/1.2 -JX6i/1.2i -P -K -Glightgreen p.d -Sb0.8q -W0.5p -BWS -Bxa1 -Byaf -Xc -Y0.75i --MAP_FRAME_TYPE=graph > $ps
 gmt psxy -R -J -O -K ML.txt -Sc0.2c -Gred -N >> $ps
 gmt pstext -R -J -O -K -F+f12p,Times-Italic+cTL+jTL+t"Binomial C@-8,0.25@-" -Dj0.1i/0 >> $ps
 # Plot Poisson cumulative distribution
@@ -32,7 +32,7 @@ cat << EOF > ML.txt
 8	0.999762552671739
 EOF
 gmt math -T0/8/1 T 2 PCDF = p.d
-gmt psxy -R-0.6/8.6/0/1.2 -J -O -K -Glightgreen p.d -Sb0.8u -W0.5p -BWS -Bxa1 -Byaf -Y1.65i --MAP_FRAME_TYPE=graph >> $ps
+gmt psxy -R-0.6/8.6/0/1.2 -J -O -K -Glightgreen p.d -Sb0.8q -W0.5p -BWS -Bxa1 -Byaf -Y1.65i --MAP_FRAME_TYPE=graph >> $ps
 gmt psxy -R -J -O -K ML.txt -Sc0.2c -Gred -N >> $ps
 gmt pstext -R -J -O -K -F+f12p,Times-Italic+cTL+jTL+t"Poisson C(@~l=2@~)" -Dj0.1i/0 >> $ps
 # Plot normal cumulative distribution

--- a/test/gmtmath/pdfs1.sh
+++ b/test/gmtmath/pdfs1.sh
@@ -16,7 +16,7 @@ cat << EOF > ML.txt
 7	0.000366210937500
 8	0.000015258789063
 EOF
-gmt psxy -R-0.6/8.6/0/0.35 -JX6i/1.2i -P -K -Glightgreen p.d -Sb0.8u -W0.5p -BWS -Bxa1 -Byaf -Xc -Y0.75i --MAP_FRAME_TYPE=graph > $ps
+gmt psxy -R-0.6/8.6/0/0.35 -JX6i/1.2i -P -K -Glightgreen p.d -Sb0.8q -W0.5p -BWS -Bxa1 -Byaf -Xc -Y0.75i --MAP_FRAME_TYPE=graph > $ps
 gmt psxy -R -J -O -K ML.txt -Sc0.2c -Gred -N >> $ps
 gmt pstext -R -J -O -K -F+f12p,Times-Italic+cTR+jTR+t"Binomial P@-8,0.25@-" >> $ps
 # Plot POISSON distribution
@@ -32,7 +32,7 @@ cat << EOF > ML.txt
 8	0.000859271639598
 EOF
 gmt math -T0/8/1 T 2 PPDF = p.d
-gmt psxy -R-0.6/8.6/0/0.3 -J -O -K -Glightgreen p.d -Sb0.8u -W0.5p -BWS -Bxa1 -Byaf -Y1.65i --MAP_FRAME_TYPE=graph >> $ps
+gmt psxy -R-0.6/8.6/0/0.3 -J -O -K -Glightgreen p.d -Sb0.8q -W0.5p -BWS -Bxa1 -Byaf -Y1.65i --MAP_FRAME_TYPE=graph >> $ps
 gmt psxy -R -J -O -K ML.txt -Sc0.2c -Gred -N >> $ps
 gmt pstext -R -J -O -K -F+f12p,Times-Italic+cTR+jTR+t"Poisson P(@~l=2@~)" >> $ps
 # Plot normal distribution

--- a/test/psxy/error_bars.sh
+++ b/test/psxy/error_bars.sh
@@ -3,4 +3,4 @@
 # Show error bars on top of a bar plot
 ps=error_bars.ps
 
-printf "1 20 2\n2 35 3\n3 30 4\n4 35 1\n5 27 2\n" | gmt psxy -R0.5/5.5/0/40 -JX16c/10c -Ey+p1p -Gred -Sb0.35u+b0 -Ba -P > $ps
+printf "1 20 2\n2 35 3\n3 30 4\n4 35 1\n5 27 2\n" | gmt psxy -R0.5/5.5/0/40 -JX16c/10c -Ey+p1p -Gred -Sb0.35q+b0 -Ba -P > $ps


### PR DESCRIPTION
This change is driven by the fact **u** is already one of the recognized map distance units (survey foot) and hence we want a unique letter to indicate 'user unit'.  Such units are used in a few places, for instance the width of a vertical bar may be specified in x-units and for columns it may separately be specified as x and/or y-units.  With coming improvements to geovector where a user quantity is needed and **u** is already a valid unit we need to change.  Of course, the **u** is still handled via backwards compatibility.  The new and improved unit is called **q** for quantity.

I also fixed missing usage message for the 3-D cube symbol in **psxyz** and made sure all tests worked with the old 'u' before changing them to 'q' and rechecking the tests.  Also, ex43 had an outdated syntax for the bar base.
