### PR TITLE
Further vector scale improvements and enhancements

### DIFF
--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -26,6 +26,9 @@ end point (**e**) of a line segment:
     Further append **l**\|\ **r** to only draw the left or right
     half-sides of this head [both sides].
 
+    **+c** selects the vector data quantity magnitude for use with CPT color look-up. Requires
+    data scaling (with unit **q** via **+v** or **+z**) and an active CPT.
+
     **+e** places a vector head at the **e**\ nd of the vector path [none].
     Optionally, append **t** for a terminal line, **c** for a circle,
     **a** for arrow [Default], **i** for tail, **A** for plain open arrow,
@@ -52,10 +55,12 @@ end point (**e**) of a line segment:
     **+n**\ [*norm*\ [/*min*]] scales down vector attributes (pen thickness, head size)
     with decreasing length, where vector plot lengths shorter than *norm* will have
     their attributes scaled by length/\ *norm* [other arrow attributes remain
-    invariant to length]. For Cartesian vectors specify a length in plot units or append
-    **u** to indicate we should use the user data units in making the decision, while
-    for geovectors specify a length in map units (see :ref:`cookbook/features:Distance units`) [k]. Optionally, append
-    /*min* for the minimum shrink factor (in the 0-1 range) that we will shrink to [0.25].
+    invariant to length]. Optionally, append /*min* for the minimum shrink factor (in the
+    0-1 range) that we will shrink to [0.25]. For Cartesian vectors, please specify a *norm*
+    in plot units, while for geovectors specify a *norm* in map units (see :ref:`cookbook/features:Distance units`) [k].
+    Alternatively, append unit **q** to indicate we should use user quantity units in making the
+    decision; this means the user also must select user quantity input via **+v** or *++z**.
+
     If no argument is given then **+n** ensures vector heads are not shrunk and always
     plotted regardless of vector length [Vector heads are not plotted if exceeding vector length].
 
@@ -95,12 +100,13 @@ into plot lengths.
     unit.  If **i** is prepended we use the inverse scale while if **l** is prepended then it is
     taken as a fixed length to override input lengths. Append unit **q** if input magnitudes are
     in user quantity units and we will scale to current plot unit (see :term:`PROJ_LENGTH_UNIT`
-    for to change the plot unit).
+    for to change the plot unit) for Cartesian vectors or to km for geovectors.
 
     **+z**\ [*scale*] expects input :math:`\Delta x, \Delta y` vector components and
     uses the *scale* [1] to convert to polar coordinates with length in given unit.
     Append unit **q** if input components are in user quantity units and we will scale to current plot unit
-    (see :term:`PROJ_LENGTH_UNIT` for how to change the plot unit).  In addition, if **-C** is
+    (see :term:`PROJ_LENGTH_UNIT` for how to change the plot unit) for Cartesian vectors or to
+    km for geovectors.  In addition, if **-C** is
     used the the vector magnitude is used for CPT-lookup and no extra data column is required.
 
 **Note**: Vectors were completely redesigned for GMT5 which separated the vector head (a polygon)

--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -87,14 +87,21 @@ In addition, all but circular vectors may take these modifiers:
     **+s** means the input *angle*, *length* are instead the :math:`x_e, y_e`
     coordinates of the vector end point.
 
-Finally, Cartesian vectors and geovectors may take these modifiers (except in :doc:`grdvector`):
+Finally, Cartesian vectors and geovectors may take these modifiers (except in :doc:`grdvector`)
+which can be used to convert vector components to polar form or magnify user quantity magnitudes
+into plot lengths.
 
     **+v**\ [**i**\|\ **l**]\ *scale* expects a *scale* to magnify the polar length in the given
     unit.  If **i** is prepended we use the inverse scale while if **l** is prepended then it is
-    taken as a fixed length to override input lengths.
+    taken as a fixed length to override input lengths. Append unit **q** if input magnitudes are
+    in user quantity units and we will scale to current plot unit (see :term:`PROJ_LENGTH_UNIT`
+    for to change the plot unit).
 
     **+z**\ [*scale*] expects input :math:`\Delta x, \Delta y` vector components and
     uses the *scale* [1] to convert to polar coordinates with length in given unit.
+    Append unit **q** if input components are in user quantity units and we will scale to current plot unit
+    (see :term:`PROJ_LENGTH_UNIT` for how to change the plot unit).  In addition, if **-C** is
+    used the the vector magnitude is used for CPT-lookup and no extra data column is required.
 
 **Note**: Vectors were completely redesigned for GMT5 which separated the vector head (a polygon)
 from the vector stem (a line).  In GMT4, the entire vector was a polygon and it could only

--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -52,7 +52,8 @@ end point (**e**) of a line segment:
     **+n**\ [*norm*\ [/*min*]] scales down vector attributes (pen thickness, head size)
     with decreasing length, where vector plot lengths shorter than *norm* will have
     their attributes scaled by length/\ *norm* [other arrow attributes remain
-    invariant to length]. For Cartesian vectors specify a length in plot units, while
+    invariant to length]. For Cartesian vectors specify a length in plot units or append
+    **u** to indicate we should use the user data units in making the decision, while
     for geovectors specify a length in map units (see `Units`_) [k]. Optionally, append
     /*min* for the minimum shrink factor (in the 0-1 range) that we will shrink to [0.25].
     If no argument is given then **+n** ensures vector heads are not shrunk and always
@@ -88,8 +89,12 @@ In addition, all but circular vectors may take these modifiers:
 
 Finally, Cartesian vectors and geovectors may take these modifiers (except in :doc:`grdvector`):
 
-    **+z**\ *scale* expects input :math:`\Delta x, \Delta y` vector components and
-    uses the *scale* to convert to polar coordinates with length in given unit.
+    **+v**\ [**i**\|\ **l**]\ *scale* expects a *scale* to magnify the polar length in the given
+    unit.  If **i** is prepended we use the inverse scale while if **l** is prepended then it is
+    taken as a fixed length to override input lengths.
+
+    **+z**\ [*scale*] expects input :math:`\Delta x, \Delta y` vector components and
+    uses the *scale* [1] to convert to polar coordinates with length in given unit.
 
 **Note**: Vectors were completely redesigned for GMT5 which separated the vector head (a polygon)
 from the vector stem (a line).  In GMT4, the entire vector was a polygon and it could only

--- a/doc/rst/source/explain_vectors.rst_
+++ b/doc/rst/source/explain_vectors.rst_
@@ -26,8 +26,9 @@ end point (**e**) of a line segment:
     Further append **l**\|\ **r** to only draw the left or right
     half-sides of this head [both sides].
 
-    **+c** selects the vector data quantity magnitude for use with CPT color look-up. Requires
-    data scaling (with unit **q** via **+v** or **+z**) and an active CPT.
+    **+c** selects the vector data quantity *magnitude* for use with CPT color look-up [Default
+    requires a separate data column following the 2 or 3 coordinates]. Requires that data
+    quantity scaling (with unit **q** via **+v** or **+z**) and a CPT have been selected.
 
     **+e** places a vector head at the **e**\ nd of the vector path [none].
     Optionally, append **t** for a terminal line, **c** for a circle,
@@ -59,7 +60,7 @@ end point (**e**) of a line segment:
     0-1 range) that we will shrink to [0.25]. For Cartesian vectors, please specify a *norm*
     in plot units, while for geovectors specify a *norm* in map units (see :ref:`cookbook/features:Distance units`) [k].
     Alternatively, append unit **q** to indicate we should use user quantity units in making the
-    decision; this means the user also must select user quantity input via **+v** or *++z**.
+    decision; this means the user also must select user quantity input via **+v** or **+z**.
 
     If no argument is given then **+n** ensures vector heads are not shrunk and always
     plotted regardless of vector length [Vector heads are not plotted if exceeding vector length].
@@ -67,7 +68,7 @@ end point (**e**) of a line segment:
     **+o**\ [*plon*\ /\ *plat*] specifies the oblique pole for the great or
     small circles.  Only needed for great circles if **+q** is given. If no
     pole is appended then we default to the north pole. Input arguments are then
-    *lon *lat arclength* with the latter in map distance units; see **+q** of angular limits instead.
+    *lon lat arclength* with the latter in map distance units; see **+q** of angular limits instead.
 
     **+p**\ [*pen*] sets the vector pen attributes. If no *pen* is appended
     then the head outline is not drawn. [Default pen is half the width of stem pen, and
@@ -92,22 +93,24 @@ In addition, all but circular vectors may take these modifiers:
     **+s** means the input *angle*, *length* are instead the :math:`x_e, y_e`
     coordinates of the vector end point.
 
-Finally, Cartesian vectors and geovectors may take these modifiers (except in :doc:`grdvector`)
+Finally, Cartesian vectors and geovectors may take these modifiers (except in :doc:`grdvector </grdvector>`)
 which can be used to convert vector components to polar form or magnify user quantity magnitudes
 into plot lengths.
 
     **+v**\ [**i**\|\ **l**]\ *scale* expects a *scale* to magnify the polar length in the given
     unit.  If **i** is prepended we use the inverse scale while if **l** is prepended then it is
     taken as a fixed length to override input lengths. Append unit **q** if input magnitudes are
-    in user quantity units and we will scale to current plot unit (see :term:`PROJ_LENGTH_UNIT`
-    for to change the plot unit) for Cartesian vectors or to km for geovectors.
+    given in user quantity units and we will scale them to current plot unit for Cartesian vectors
+    (see :term:`PROJ_LENGTH_UNIT` for how to change the plot unit) or to km for geovectors.  In addition,
+    if **+c** is selected then the vector magnitudes may be used for CPT color-lookup (and no extra data
+    column is required by **-C**).
 
     **+z**\ [*scale*] expects input :math:`\Delta x, \Delta y` vector components and
     uses the *scale* [1] to convert to polar coordinates with length in given unit.
-    Append unit **q** if input components are in user quantity units and we will scale to current plot unit
-    (see :term:`PROJ_LENGTH_UNIT` for how to change the plot unit) for Cartesian vectors or to
-    km for geovectors.  In addition, if **-C** is
-    used the the vector magnitude is used for CPT-lookup and no extra data column is required.
+    Append unit **q** if input components are given in user quantity units and we will scale to current plot unit
+    for Cartesian vectors (see :term:`PROJ_LENGTH_UNIT` for how to change the plot unit) or to
+    km for geovectors.  In addition, if **+c** is selected then the vector magnitudes may be used
+    for CPT color-lookup (and no extra data column is required by **-C**).
 
 **Note**: Vectors were completely redesigned for GMT5 which separated the vector head (a polygon)
 from the vector stem (a line).  In GMT4, the entire vector was a polygon and it could only

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15958,13 +15958,13 @@ GMT_LOCAL unsigned int gmtinit_get_length (struct GMT_CTRL *GMT, char symbol, ch
 			}
 		}
 	}
-	else if (string[len] != 'u') {	/* Got plot units in c|i|p or no unit */
+	else if (string[len] != 'q') {	/* Got plot units in c|i|p or no unit */
 		int j = gmt_get_dim_unit (GMT, string[len]);
 		if (j == GMT_NOTSET) j = GMT->current.setting.proj_length_unit;	/* No unit specified, convert value from default unit to inches */
 		/* Convert length from given c|i|p unit to inches */
 		*value *= (float)GMT->session.u2u[j][GMT_INCH];
 	}
-	/* Her, *value is either in user units, km, or plot units */
+	/* Her, *value is either in user units (q), km, or plot units */
 	return error;
 }
 
@@ -16119,7 +16119,7 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 					error += gmtinit_get_length (GMT, symbol, &p[1], &(S->v.v_norm));
 					if (symbol == '=')	/* Since norm distance is now in km we convert to spherical degrees */
 						S->v.v_norm /= (float)GMT->current.proj.DIST_KM_PR_DEG;	/* Finally, convert km to degrees */
-					else if (p[strlen (p)-1] == 'u')	/* Make shrink decision on data magnitude */
+					else if (p[strlen (p)-1] == 'q')	/* Make shrink decision on data magnitude */
 						S->v.v_norm_d = true;
 					/* Here, v_norm is either in inches (if Cartesian vector), spherical degrees (if geovector) */
 					GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Vector shrink scale v_norm = %g going down to %g %% of head size\n", S->v.v_norm, 100.0 * S->v.v_norm_limit);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16042,6 +16042,9 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 	  	  			else if (p[2] == 'r') S->v.status |= PSL_VEC_BEGIN_R;	/* Only right half of head requested */
 				}
 				break;
+			case 'c':	/* Use internal vector magnitude with CPT [MAP_VECTOR_SHAPE] */
+				S->v.status |= PSL_VEC_MAGCPT;
+				break;
 			case 'e':	/* Vector head at end point */
 				S->v.status |= PSL_VEC_END;
 				switch (p[1]) {
@@ -16238,6 +16241,10 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 	}
 	if ((S->v.status & PSL_VEC_JUST_S) && (S->v.status & PSL_VEC_MAGNIFY)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot combine second point coordinates (+s) with magnitude scaling (+v)\n");
+		error++;		
+	}
+	if ((S->v.status & PSL_VEC_MAGCPT) && !S->v.v_unit_d) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot select magnitude for CPT (+c) without magnitude scaling (via +v or +z)\n");
 		error++;		
 	}
 	if ((S->v.status & PSL_VEC_MID_FWD || S->v.status & PSL_VEC_MID_BWD) && (S->v.status & PSL_VEC_BEGIN || S->v.status & PSL_VEC_END)) {

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16083,7 +16083,7 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 					S->v.status |= PSL_VEC_LINE;
 				else {	/* Parse the cutoff size */
 					len = strlen (p);
-					j = (symbol == 'v' || symbol == 'V') ? gmt_get_dim_unit (GMT, p[len-1]) : -1;	/* Only -Sv|V takes dimensional unit */
+					j = (symbol == 'v' || symbol == 'V') ? gmt_get_dim_unit (GMT, p[len-1]) : -2;	/* Only -Sv|V takes dimensional unit */
 					S->v.v_norm = (float)atof (&p[1]);	/* This is normalizing length in given units, not (yet) converted to inches or degrees (but see next lines) */
 					if (symbol == '=') {	/* Since norm distance is in map units for geovectors we convert to spherical degrees */
 						if (p[len-1]) {	/* Examine if a unit was given */
@@ -16098,7 +16098,9 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 					}
 					else if (j >= GMT_CM)	/* Convert length from given unit to inches */
 						S->v.v_norm *= GMT->session.u2u[j][GMT_INCH];
-					else	/* Convert length from default unit to inches */
+					else if (j == GMT_NOTSET)	/* Make shrink decision on data magnitude */
+						S->v.v_norm_d = true;
+					else	/* No unit specified, convert length from default unit to inches */
 						S->v.v_norm *= GMT->session.u2u[GMT->current.setting.proj_length_unit][GMT_INCH];
 					/* Here, v_norm is either in inches (if Cartesian vector) or spherical degrees (if geovector) */
 					GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Vector shrink scale v_norm = %g going down to %g %% of head size\n", S->v.v_norm, 100.0 * S->v.v_norm_limit);

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -10058,9 +10058,15 @@ int gmt_circle_to_region (struct GMT_CTRL *GMT, double lon, double lat, double r
 	return (code);
 }
 
-double gmt_get_az_dist_from_components (struct GMT_CTRL *GMT, double lon, double lat, double dx, double dy, double *azim) {
+double gmt_get_az_dist_from_components (struct GMT_CTRL *GMT, double lon, double lat, double dx, double dy, bool user_unit, double *azim) {
 	/* Given a location and dx_km,dy_km of a geovector in map distance, compute equivalent length (in km) and azimuth */
 	double x2, y2, L;
+	if (user_unit) {	/* No geographic lengths given, just Cartesian user vector components */
+		*azim = 90.0 - atan2d (dy, dx);
+		L = hypot (dx, dy);
+		return (L);
+	}
+	/* Here we have geographic components */
 	if (doubleAlmostEqual (lat, -90.0) || doubleAlmostEqual (lat, 90.0))	/* No x adjustment possible */
 		x2 = lon;
 	else 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5063,6 +5063,7 @@ GMT_LOCAL unsigned int gmtplot_geo_vector_smallcircle (struct GMT_CTRL *GMT, dou
 	if (!heads) return (warn);	/* All done */
 
 	PSL_command (GMT->PSL, "V\n");
+	PSL_command (GMT->PSL, "PSL_vecheadpen\n");      /* Switch to vector head pen */
 	/* Get half-angle at head and possibly change pen */
 	da = 0.5 * S->v.v_angle;	/* Half-opening angle at arrow head */
 	if ((S->v.status & PSL_VEC_OUTLINE) == 0)
@@ -5291,6 +5292,7 @@ GMT_LOCAL unsigned int gmtplot_geo_vector_greatcircle (struct GMT_CTRL *GMT, dou
 	/* Get half-angle at head and possibly change pen */
 	da = 0.5 * S->v.v_angle;	/* Half-opening angle at arrow head */
 	PSL_command (GMT->PSL, "V\n");
+	PSL_command (GMT->PSL, "PSL_vecheadpen\n");      /* Switch to vector head pen */
 	if ((S->v.status & PSL_VEC_OUTLINE) == 0)
 		PSL_command (GMT->PSL, "O0\n");	/* Turn off outline */
 	else {

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -113,6 +113,7 @@ struct GMT_VECT_ATTR {
 	unsigned int v_kind[2];	/* Type of vector heads */
 	bool parsed_v4;		/* true if we parsed old-style <vectorwidth/headlength/headwidth> attribute */
 	bool v_norm_d;		/* true if Cartesian vector shrinking limit is in data unit not plot unit */
+	bool v_unit_d;		/* true if vector magnitude is in data unit and not plot/map unit */
 	float v_angle;		/* Head angle */
 	float v_norm;		/* shrink when lengths are smaller than this */
 	float v_norm_limit;	/* Only shrink down to this factor [0.25] */

--- a/src/gmt_plot.h
+++ b/src/gmt_plot.h
@@ -112,6 +112,7 @@ struct GMT_VECT_ATTR {
 	unsigned int status;	/* Bit flags for vector information (see GMT_enum_vecattr above) */
 	unsigned int v_kind[2];	/* Type of vector heads */
 	bool parsed_v4;		/* true if we parsed old-style <vectorwidth/headlength/headwidth> attribute */
+	bool v_norm_d;		/* true if Cartesian vector shrinking limit is in data unit not plot unit */
 	float v_angle;		/* Head angle */
 	float v_norm;		/* shrink when lengths are smaller than this */
 	float v_norm_limit;	/* Only shrink down to this factor [0.25] */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -578,7 +578,7 @@ EXTERN_MSC void gmt_gcal_from_dt (struct GMT_CTRL *GMT, double t, struct GMT_GCA
 /* gmt_map.c: */
 
 
-EXTERN_MSC double gmt_get_az_dist_from_components (struct GMT_CTRL *GMT, double lon, double lat, double dx, double dy, double *azim);
+EXTERN_MSC double gmt_get_az_dist_from_components (struct GMT_CTRL *GMT, double lon, double lat, double dx, double dy, bool user_unit, double *azim);
 EXTERN_MSC int gmt_map_perimeter_search (struct GMT_CTRL *GMT, double *wesn, bool add_pad);
 EXTERN_MSC int gmt_circle_to_region (struct GMT_CTRL *GMT, double lon, double lat, double radius, double *wesn);
 EXTERN_MSC void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat, double *back_az);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -409,6 +409,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC double gmt_get_vector_shrinking (struct GMT_CTRL *GMT, struct GMT_VECT_ATTR *v, double magitude, double length);
 EXTERN_MSC unsigned int gmt_get_limits (struct GMT_CTRL *GMT, char option, char *text, unsigned int mode, double *min, double *max);
 EXTERN_MSC unsigned int gmt_unpack_rgbcolors (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, unsigned char rgbmap[]);
 EXTERN_MSC void gmt_format_region (struct GMT_CTRL *GMT, char *record, double *wesn);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -18575,6 +18575,6 @@ double gmt_get_vector_shrinking (struct GMT_CTRL *GMT, struct GMT_VECT_ATTR *v, 
 	s = (val < v->v_norm) ? val / v->v_norm : 1.0;	/* Compute scaling */
 	/* Apply minimum scaling limit if set */
 	if (s < v->v_norm_limit) s = v->v_norm_limit;
-	GMT_Report (GMT->parent, GMT_MSG_NOTICE, "Given vector value %g and shrink limit %g, returned scale = %g\n", val, v->v_norm, s);
+	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Given vector value %g and shrink limit %g, returned scale = %g\n", val, v->v_norm, s);
 	return (s);
 }

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -18565,15 +18565,16 @@ unsigned int gmt_get_limits (struct GMT_CTRL *GMT, char option, char *text, unsi
 	return GMT_NOERROR;
 }
 
-double gmt_get_vector_shrinking (struct GMT_CTRL *GMT, struct GMT_VECT_ATTR *v, double magitude, double length) {
+double gmt_get_vector_shrinking (struct GMT_CTRL *GMT, struct GMT_VECT_ATTR *v, double magnitude, double length) {
 	/* Magnitude is in data units while length is in plot units */
-	double s;
+	double s, val;
 	gmt_M_unused (GMT);
-	if (v->v_norm_d)	/* Make decision based on data magnitude */
-		s = (magitude < v->v_norm) ? magitude / v->v_norm : 1.0;
-	else	/* Make decision based on plot length */
-		s = (length < v->v_norm) ? length / v->v_norm : 1.0;
+	if (v->v_norm < 0.0) return 1.0;	/* No shrinking selected */
+	/* Select which amplitude to use for comparison: data magnitude or plot length */
+	val = (v->v_norm_d) ? magnitude : length;
+	s = (val < v->v_norm) ? val / v->v_norm : 1.0;	/* Compute scaling */
 	/* Apply minimum scaling limit if set */
 	if (s < v->v_norm_limit) s = v->v_norm_limit;
+	GMT_Report (GMT->parent, GMT_MSG_NOTICE, "Given vector value %g and shrink limit %g, returned scale = %g\n", val, v->v_norm, s);
 	return (s);
 }

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -18564,3 +18564,16 @@ unsigned int gmt_get_limits (struct GMT_CTRL *GMT, char option, char *text, unsi
 	}
 	return GMT_NOERROR;
 }
+
+double gmt_get_vector_shrinking (struct GMT_CTRL *GMT, struct GMT_VECT_ATTR *v, double magitude, double length) {
+	/* Magnitude is in data units while length is in plot units */
+	double s;
+	gmt_M_unused (GMT);
+	if (v->v_norm_d)	/* Make decision based on data magnitude */
+		s = (magitude < v->v_norm) ? magitude / v->v_norm : 1.0;
+	else	/* Make decision based on plot length */
+		s = (length < v->v_norm) ? length / v->v_norm : 1.0;
+	/* Apply minimum scaling limit if set */
+	if (s < v->v_norm_limit) s = v->v_norm_limit;
+	return (s);
+}

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -118,7 +118,8 @@ enum PSL_enum_vecattr {
 	PSL_VEC_SCALE		= BIT(21),	/* Not yet needed in postscriptlight: If not set we determine the required inch-to-degree scale */
 	PSL_VEC_LINE		= BIT(22),	/* Flag that we are adding vector heads to a line, not a stand-alone vector */
 	PSL_VEC_MAGNIFY		= BIT(23),	/* Flag that we are adding vector heads to a line, not a stand-alone vector */
-	PSL_VEC_FIXED		= BIT(24)};	/* Flag that we were given a fixed length to override for each vector */
+	PSL_VEC_FIXED		= BIT(24),	/* Flag that we were given a fixed length to override for each vector */
+	PSL_VEC_MAGCPT		= BIT(25)};	/* Flag that says use user data magnitude as internal data for CPT lookup */
 
 enum PSL_enum_vecdim {	/* Indices into the dim[] array passed to psl_vector */
 	PSL_VEC_XTIP 			= 0,	/* x-coordinate of tip of vector in inches */

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -104,7 +104,7 @@ enum PSL_enum_vecattr {
 	PSL_VEC_JUST_E		= BIT(7),	/* Align vector end at (x,y) */
 	PSL_VEC_JUST_S		= BIT(8),	/* Align vector center at (x,y) */
 	PSL_VEC_ANGLES		= BIT(9),	/* Got start/stop angles instead of az, length */
-	PSL_VEC_POLE		= BIT(19),	/* Got pole of small/great circle */
+	PSL_VEC_POLE		= BIT(10),	/* Got pole of small/great circle */
 	PSL_VEC_OUTLINE		= BIT(11),	/* Draw vector head outline using default pen */
 	PSL_VEC_OUTLINE2	= BIT(12),	/* Draw vector head outline using supplied v_pen */
 	PSL_VEC_FILL		= BIT(13),	/* Fill vector head using default fill */

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -82,6 +82,8 @@ extern "C" {
 
 /* PSL codes for vector attributes */
 
+#define BIT(no)		((unsigned int)(1 << (no)))
+
 enum PSL_enum_vecattr {
 	PSL_VEC_ARROW		= 0,		/* Default head symbol is arrow */
 	PSL_VEC_TERMINAL	= 1,		/* Cross-bar normal to vector */
@@ -93,28 +95,30 @@ enum PSL_enum_vecattr {
 	PSL_VEC_BEGIN		= 1,		/* Place vector head at beginning of vector. Add PSL_VEC_BEGIN_L for left only, PSL_VEC_BEGIN_R for right only */
 	PSL_VEC_END			= 2,		/* Place vector head at end of vector.  Add PSL_VEC_END_L for left only, and PSL_VEC_END_R for right only */
 	PSL_VEC_HEADS		= 3,		/* Mask for either head end */
-	PSL_VEC_BEGIN_L		= 4,		/* Left-half head at beginning */
-	PSL_VEC_BEGIN_R		= 8,		/* Right-half head at beginning */
-	PSL_VEC_END_L		= 16,		/* Left-half head at end */
-	PSL_VEC_END_R		= 32,		/* Right-half head at end */
+	PSL_VEC_BEGIN_L		= BIT(2),	/* Left-half head at beginning */
+	PSL_VEC_BEGIN_R		= BIT(3),	/* Right-half head at beginning */
+	PSL_VEC_END_L		= BIT(4),	/* Left-half head at end */
+	PSL_VEC_END_R		= BIT(5),	/* Right-half head at end */
 	PSL_VEC_JUST_B		= 0,		/* Align vector beginning at (x,y) */
-	PSL_VEC_JUST_C		= 64,		/* Align vector center at (x,y) */
-	PSL_VEC_JUST_E		= 128,		/* Align vector end at (x,y) */
-	PSL_VEC_JUST_S		= 256,		/* Align vector center at (x,y) */
-	PSL_VEC_ANGLES		= 512,		/* Got start/stop angles instead of az, length */
-	PSL_VEC_POLE		= 1024,		/* Got pole of small/great circle */
-	PSL_VEC_OUTLINE		= 2048,		/* Draw vector head outline using default pen */
-	PSL_VEC_OUTLINE2	= 4096,		/* Draw vector head outline using supplied v_pen */
-	PSL_VEC_FILL		= 8192,		/* Fill vector head using default fill */
-	PSL_VEC_FILL2		= 16384,	/* Fill vector head using supplied v_fill) */
-	PSL_VEC_MARC90		= 32768,	/* Matharc only: if angles subtend 90, draw straight angle symbol */
-	PSL_VEC_OFF_BEGIN	= 65536,	/* Starting point of vector should be moved a distance along the line */
-	PSL_VEC_OFF_END		= 131072,	/* End point of vector should be moved a distance along the line */
-	PSL_VEC_MID_FWD		= 262144,	/* End point of vector should be moved a distance along the line */
-	PSL_VEC_MID_BWD		= 524288,	/* End point of vector should be moved a distance along the line */
-	PSL_VEC_COMPONENTS	= 1048576,	/* Not yet needed in postscriptlight: Got vector dx, dy Cartesian components */
-	PSL_VEC_SCALE		= 2097152,	/* Not yet needed in postscriptlight: If not set we determine the required inch-to-degree scale */
-	PSL_VEC_LINE		= 4194304};	/* Flag that we are adding vector heads to a line, not a stand-alone vector */
+	PSL_VEC_JUST_C		= BIT(6),	/* Align vector center at (x,y) */
+	PSL_VEC_JUST_E		= BIT(7),	/* Align vector end at (x,y) */
+	PSL_VEC_JUST_S		= BIT(8),	/* Align vector center at (x,y) */
+	PSL_VEC_ANGLES		= BIT(9),	/* Got start/stop angles instead of az, length */
+	PSL_VEC_POLE		= BIT(19),	/* Got pole of small/great circle */
+	PSL_VEC_OUTLINE		= BIT(11),	/* Draw vector head outline using default pen */
+	PSL_VEC_OUTLINE2	= BIT(12),	/* Draw vector head outline using supplied v_pen */
+	PSL_VEC_FILL		= BIT(13),	/* Fill vector head using default fill */
+	PSL_VEC_FILL2		= BIT(14),	/* Fill vector head using supplied v_fill) */
+	PSL_VEC_MARC90		= BIT(15),	/* Matharc only: if angles subtend 90, draw straight angle symbol */
+	PSL_VEC_OFF_BEGIN	= BIT(16),	/* Starting point of vector should be moved a distance along the line */
+	PSL_VEC_OFF_END		= BIT(17),	/* End point of vector should be moved a distance along the line */
+	PSL_VEC_MID_FWD		= BIT(18),	/* End point of vector should be moved a distance along the line */
+	PSL_VEC_MID_BWD		= BIT(19),	/* End point of vector should be moved a distance along the line */
+	PSL_VEC_COMPONENTS	= BIT(20),	/* Not yet needed in postscriptlight: Got vector dx, dy Cartesian components */
+	PSL_VEC_SCALE		= BIT(21),	/* Not yet needed in postscriptlight: If not set we determine the required inch-to-degree scale */
+	PSL_VEC_LINE		= BIT(22),	/* Flag that we are adding vector heads to a line, not a stand-alone vector */
+	PSL_VEC_MAGNIFY		= BIT(23),	/* Flag that we are adding vector heads to a line, not a stand-alone vector */
+	PSL_VEC_FIXED		= BIT(24)};	/* Flag that we were given a fixed length to override for each vector */
 
 enum PSL_enum_vecdim {	/* Indices into the dim[] array passed to psl_vector */
 	PSL_VEC_XTIP 			= 0,	/* x-coordinate of tip of vector in inches */

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1334,9 +1334,13 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		gmt_set_column_type (GMT, GMT_IN, pos2y, gmt_M_type (GMT, GMT_IN, GMT_Y));
 	}
 	if (S.v.status & PSL_VEC_COMPONENTS) {	/* Giving vector components */
-		gmt_set_column_type (GMT, GMT_IN, pos2x, (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION);	/* Just the users dx component, not azimuth */
-		gmt_set_column_type (GMT, GMT_IN, pos2y, (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION);	/* Just the users dy component, not length */
+		unsigned int type = (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION;
+		if (S.v.v_norm_d) type = GMT_IS_FLOAT;	/* Read user units */
+		gmt_set_column_type (GMT, GMT_IN, pos2x, type);	/* Just the users dx component, not azimuth */
+		gmt_set_column_type (GMT, GMT_IN, pos2y, type);	/* Just the users dy component, not length */
 	}
+	else if (S.v.status & PSL_VEC_MAGNIFY)
+		gmt_set_column_type (GMT, GMT_IN, pos2y, GMT_IS_FLOAT);	/* Read user units */
 	if (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC ) {	/* One of the vector symbols */
 		geovector = (S.symbol == GMT_SYMBOL_GEOVECTOR);
 		if ((S.v.status & PSL_VEC_FILL) == 0 && !S.v.parsed_v4) Ctrl->G.active = false;	/* Want no fill so override -G */
@@ -2006,22 +2010,27 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 						(void) gmt_setfont (GMT, &S.font);
 						PSL_plottext (PSL, xpos[item], plot_y, dim[0] * PSL_POINTS_PER_INCH, S.string, 0.0, S.justify, outline_setting);
 						break;
-					case PSL_VECTOR:
+					case PSL_VECTOR:	/* Cartesian vector symbol */
 						gmt_init_vector_param (GMT, &S, false, false, NULL, false, NULL);	/* Update vector head parameters */
-						if (S.v.status & PSL_VEC_COMPONENTS)	/* Read dx, dy in user units */
-							data_magnitude = hypot (in[ex1+S.read_size], in[ex2+S.read_size]) * S.v.comp_scale;
-						else
+						if (S.v.status & PSL_VEC_COMPONENTS) {	/* Read dx, dy in user units */
+							d = d_atan2d (in[ex2+S.read_size], in[ex1+S.read_size]);	/* Compute direction */
+							data_magnitude = hypot (in[ex1+S.read_size], in[ex2+S.read_size]);	/* Compute magnitude */
+						}
+						else {	/* Got direction and magnitude as is */
+							d = in[ex1+S.read_size];
 							data_magnitude = in[ex2+S.read_size];
+						}
+						if (S.v.status & PSL_VEC_FIXED) data_magnitude = 1.0;	/* Override with fixed vector length given by comp_scale */
 						if (gmt_M_is_dnan (data_magnitude)) {
-							GMT_Report (API, GMT_MSG_WARNING, "Vector length = NaN near line %d. Skipped\n", n_total_read);
+							GMT_Report (API, GMT_MSG_WARNING, "Vector magnitude = NaN near line %d. Skipped\n", n_total_read);
 							continue;
 						}
-						length = factor * data_magnitude;
-						if (S.v.status & PSL_VEC_COMPONENTS)	/* Read dx, dy in user units */
-							d = d_atan2d (in[ex2+S.read_size], in[ex1+S.read_size]);
-						else
-							d = in[ex1+S.read_size];
+						if (gmt_M_is_dnan (d)) {
+							GMT_Report (API, GMT_MSG_WARNING, "Vector direction = NaN near line %d. Skipped\n", n_total_read);
+							continue;
+						}
 
+						length = factor * data_magnitude * S.v.comp_scale;	/* Compute vector plot length in inches */
 						if (!S.convert_angles)	/* Use direction as given */
 							direction = d;
 						else if (gmt_M_is_cartesian (GMT, GMT_IN))	/* Cartesian angle; change to azimuth */
@@ -2029,10 +2038,6 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 						else	/* Convert geo azimuth to map direction */
 							direction = gmt_azim_to_angle (GMT, in[GMT_X], in[GMT_Y], 0.1, d);
 
-						if (gmt_M_is_dnan (direction)) {
-							GMT_Report (API, GMT_MSG_WARNING, "Vector direction = NaN near line %d. Skipped\n", n_total_read);
-							continue;
-						}
 						if (S.v.status & PSL_VEC_JUST_S) {	/* Got coordinates of tip instead of dir/length */
 							gmt_geo_to_xy (GMT, in[pos2x], in[pos2y], &x_2, &y_2);
 							if (gmt_M_is_dnan (x_2) || gmt_M_is_dnan (y_2)) {
@@ -2043,7 +2048,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 								if (x_2 < GMT->current.map.half_width)     /* Might reappear at right edge */
 									x_2 += width;	/* Outside the right edge */
 								else      /* Might reappear at left edge */
-						              		x_2 -= width;         /* Outside the left edge */
+									x_2 -= width;         /* Outside the left edge */
 							}
 							length = hypot (plot_x - x_2, plot_y - y_2);	/* Compute vector length in case of shrinking */
 						}
@@ -2093,7 +2098,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 							dim[PSL_VEC_HEAD_WIDTH] *= 0.5;	/* Since it was double in the parsing */
 							psl_vector_v4 (PSL, xpos[item], plot_y, dim, v4_rgb, v4_outline);
 						}
-						else {
+						else {	/* Current vector model */
 							dim[PSL_VEC_HEAD_SHAPE]      = S.v.v_shape;
 							dim[PSL_VEC_STATUS]          = (double)S.v.status;
 							dim[PSL_VEC_HEAD_TYPE_BEGIN] = (double)S.v.v_kind[0];
@@ -2106,25 +2111,27 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 						break;
 					case GMT_SYMBOL_GEOVECTOR:
 						gmt_init_vector_param (GMT, &S, true, Ctrl->W.active, &Ctrl->W.pen, Ctrl->G.active, &Ctrl->G.fill);	/* Update vector head parameters */
+						if (S.v.status & PSL_VEC_COMPONENTS) {	/* Read dx, dy in user units to be scaled to km then converted to polar form */
+							double dx = in[ex1+S.read_size] * S.v.comp_scale;
+							double dy = in[ex2+S.read_size] * S.v.comp_scale;
+							length = gmt_get_az_dist_from_components (GMT, in[GMT_X], in[GMT_Y], dx, dy, &d);
+						}
+						else	/* Got azimuth and length */
+							d = in[ex1+S.read_size], length = in[ex2+S.read_size];
+						if (S.v.status & PSL_VEC_FIXED) length = 1.0;	/* Override with fixed vector length given by comp_scale */
+						length *= factor * S.v.comp_scale;	/* Compute vector plot length in inches */
+						if (gmt_M_is_dnan (d)) {
+							GMT_Report (API, GMT_MSG_WARNING, "Geovector azimuth = NaN near line %d. Skipped\n", n_total_read);
+							continue;
+						}
+						if (gmt_M_is_dnan (length)) {
+							GMT_Report (API, GMT_MSG_WARNING, "Geovector length = NaN near line %d. Skipped\n", n_total_read);
+							continue;
+						}
 						if (S.v.status & PSL_VEC_OUTLINE2)
 							S.v.v_width = (float)(S.v.pen.width * GMT->session.u2u[GMT_PT][GMT_INCH]);
 						else
 							S.v.v_width = (float)(current_pen.width * GMT->session.u2u[GMT_PT][GMT_INCH]);
-						if (gmt_M_is_dnan (in[ex1+S.read_size])) {
-							GMT_Report (API, GMT_MSG_WARNING, "Geovector azimuth = NaN near line %d. Skipped\n", n_total_read);
-							continue;
-						}
-						if (gmt_M_is_dnan (in[ex2+S.read_size])) {
-							GMT_Report (API, GMT_MSG_WARNING, "Geovector length = NaN near line %d. Skipped\n", n_total_read);
-							continue;
-						}
-						if (S.v.status & PSL_VEC_COMPONENTS) {	/* Read dx, dy in user units to be scaled to km */
-							double dx = in[ex1+S.read_size] * S.v.comp_scale;
-							double dy = in[ex2+S.read_size] * S.v.comp_scale;
-							length = factor * gmt_get_az_dist_from_components (GMT, in[GMT_X], in[GMT_Y], dx, dy, &d);
-						}
-						else	/* Got azimuth and length */
-							d = in[ex1+S.read_size], length = factor * in[ex2+S.read_size];
 						warn = gmt_geo_vector (GMT, in[GMT_X], in[GMT_Y], d, length, &current_pen, &S);
 						n_warn[warn]++;
 						break;

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1726,6 +1726,8 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 						double scl = (Ctrl->H.mode == PSXY_READ_SCALE) ? in[xcol] : Ctrl->H.value;
 						gmt_scale_pen (GMT, &current_pen, scl);
 					}
+					if (geovector && Ctrl->W.active)
+						S.v.status |= PSL_VEC_OUTLINE;
 					if (can_update_headpen && !gmt_M_same_pen (current_pen, last_headpen)) {	/* Since color may have changed */
 						PSL_defpen (PSL, "PSL_vecheadpen", current_pen.width, current_pen.style, current_pen.offset, current_pen.rgb);
 						last_headpen = current_pen;

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1186,6 +1186,8 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		}
 		else if ((P->categorical & GMT_CPT_CATEGORICAL_KEY))	/* Get rgb from trailing text, so read no extra z columns */
 			rgb_from_z = false;
+		else if (S.v.v_unit_d)	/* Get rgb via user data magnitude and handle it per symbol */
+			rgb_from_z = false;
 		else {	/* Read extra z column for symbols only */
 			rgb_from_z = not_line;
 			if (rgb_from_z && (P->categorical & GMT_CPT_CATEGORICAL_KEY) == 0) n_cols_start++;
@@ -1335,7 +1337,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	}
 	if (S.v.status & PSL_VEC_COMPONENTS) {	/* Giving vector components */
 		unsigned int type = (S.symbol == GMT_SYMBOL_GEOVECTOR) ? GMT_IS_GEODIMENSION : GMT_IS_DIMENSION;
-		if (S.v.v_norm_d) type = GMT_IS_FLOAT;	/* Read user units */
+		if (S.v.v_norm_d || S.v.v_unit_d) type = GMT_IS_FLOAT;	/* Read user units */
 		gmt_set_column_type (GMT, GMT_IN, pos2x, type);	/* Just the users dx component, not azimuth */
 		gmt_set_column_type (GMT, GMT_IN, pos2y, type);	/* Just the users dy component, not length */
 	}
@@ -1372,7 +1374,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	bcol = (S.read_size) ? ex2 : ex1;
 	if (S.symbol == GMT_SYMBOL_BARX && (S.base_set & GMT_BASE_READ)) gmt_set_column_type (GMT, GMT_IN, bcol, gmt_M_type (GMT, GMT_IN, GMT_X));
 	if (S.symbol == GMT_SYMBOL_BARY && (S.base_set & GMT_BASE_READ)) gmt_set_column_type (GMT, GMT_IN, bcol, gmt_M_type (GMT, GMT_IN, GMT_Y));
-	if (S.symbol == GMT_SYMBOL_GEOVECTOR && (S.v.status & PSL_VEC_JUST_S) == 0) {	/* Input is either azim,length or just length for small circle vectors */
+	if (S.symbol == GMT_SYMBOL_GEOVECTOR && (S.v.status & PSL_VEC_JUST_S) == 0 && !(S.v.v_norm_d || S.v.v_unit_d)) {	/* Input is either azim,length or just length for small circle vectors */
 		if (S.v.status & PSL_VEC_POLE) {	/* Small circle distance is either map length or start,stop angles */
 			if ((S.v.status & PSL_VEC_ANGLES) == 0)	/* Just map length */
 				gmt_set_column_type (GMT, GMT_IN, ex1, GMT_IS_GEODIMENSION);
@@ -1609,10 +1611,19 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			}
 
 			if (get_rgb) {
+				double value;
+				if (S.v.status & PSL_VEC_MAGNIFY) {	/* Base color on vector magnitude in user units */
+					if (S.v.status & PSL_VEC_COMPONENTS)	/* Read dx, dy in user units and compute magnitude */
+						value = hypot (in[ex1+S.read_size], in[ex2+S.read_size]);
+					else	/* Just get data magnitude as given */
+						value = in[ex2+S.read_size];
+				}
+				else	/* Base color on z-vector */
+					value = in[GMT_Z];
 				if (P->categorical & GMT_CPT_CATEGORICAL_KEY)
 					gmt_get_fill_from_key (GMT, P, In->text, &current_fill);
 				else
-					gmt_get_fill_from_z (GMT, P, in[GMT_Z], &current_fill);
+					gmt_get_fill_from_z (GMT, P, value, &current_fill);
 				if (PH->skip) continue;	/* Chosen CPT indicates skip for this z */
 				if (Ctrl->I.active) {
 					if (Ctrl->I.mode == 0)
@@ -2112,14 +2123,14 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 					case GMT_SYMBOL_GEOVECTOR:
 						gmt_init_vector_param (GMT, &S, true, Ctrl->W.active, &Ctrl->W.pen, Ctrl->G.active, &Ctrl->G.fill);	/* Update vector head parameters */
 						if (S.v.status & PSL_VEC_COMPONENTS) {	/* Read dx, dy in user units to be scaled to km then converted to polar form */
-							double dx = in[ex1+S.read_size] * S.v.comp_scale;
-							double dy = in[ex2+S.read_size] * S.v.comp_scale;
-							length = gmt_get_az_dist_from_components (GMT, in[GMT_X], in[GMT_Y], dx, dy, &d);
+							double dx = in[ex1+S.read_size];
+							double dy = in[ex2+S.read_size];
+							data_magnitude = gmt_get_az_dist_from_components (GMT, in[GMT_X], in[GMT_Y], dx, dy, S.v.v_unit_d, &d);
 						}
 						else	/* Got azimuth and length */
-							d = in[ex1+S.read_size], length = in[ex2+S.read_size];
-						if (S.v.status & PSL_VEC_FIXED) length = 1.0;	/* Override with fixed vector length given by comp_scale */
-						length *= factor * S.v.comp_scale;	/* Compute vector plot length in inches */
+							d = in[ex1+S.read_size], data_magnitude = in[ex2+S.read_size];
+						if (S.v.status & PSL_VEC_FIXED) data_magnitude = 1.0;	/* Override with fixed vector length given by comp_scale */
+						length = factor * data_magnitude * S.v.comp_scale;	/* Compute vector plot length in inches */
 						if (gmt_M_is_dnan (d)) {
 							GMT_Report (API, GMT_MSG_WARNING, "Geovector azimuth = NaN near line %d. Skipped\n", n_total_read);
 							continue;

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1186,7 +1186,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		}
 		else if ((P->categorical & GMT_CPT_CATEGORICAL_KEY))	/* Get rgb from trailing text, so read no extra z columns */
 			rgb_from_z = false;
-		else if (S.v.v_unit_d)	/* Get rgb via user data magnitude and handle it per symbol */
+		else if (S.v.status & PSL_VEC_MAGCPT)	/* Get rgb via user data magnitude and handle it per symbol */
 			rgb_from_z = false;
 		else {	/* Read extra z column for symbols only */
 			rgb_from_z = not_line;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1674,9 +1674,10 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 					if (S.shade3D) gmt_illuminate (GMT, lux[j], rgb[j]);
 				}
 			}
-
-			gmt_setfill (GMT, &data[i].f, data[i].outline);
-			gmt_setpen (GMT, &data[i].p);
+			if (!geovector) {
+				gmt_setfill (GMT, &data[i].f, data[i].outline);
+				gmt_setpen (GMT, &data[i].p);
+			}
 			if (QR_symbol) {
 				if (Ctrl->G.active)	/* Change color of QR code */
 					PSL_command (PSL, "/QR_fill {%s} def\n", PSL_makecolor (PSL, data[i].f.rgb));
@@ -1879,6 +1880,8 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 					case GMT_SYMBOL_GEOVECTOR:
 						gmt_plane_perspective (GMT, GMT_Z, data[i].z);
 						S.v = data[i].v;	/* Update vector attributes from saved values */
+						if (get_rgb) S.v.fill = data[i].f;
+						PSL_defpen (PSL, "PSL_vecheadpen", data[i].h.width, data[i].h.style, data[i].h.offset, data[i].h.rgb);
 						warn = gmt_geo_vector (GMT, xpos[item], data[i].y, data[i].dim[0], data[i].dim[1], &data[i].p, &S);
 						n_warn[warn]++;
 						break;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -832,7 +832,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 		}
 		else if ((P->categorical & GMT_CPT_CATEGORICAL_KEY))	/* Get rgb from trailing text, so read no extra z columns */
 			rgb_from_z = false;
-		else if (S.v.v_unit_d)	/* Get rgb via user data magnitude and handle it per symbol */
+		else if (S.v.status & PSL_VEC_MAGCPT)	/* Get rgb via user data magnitude and handle it per symbol */
 			rgb_from_z = false;
 		else {	/* Read extra z column for symbols only */
 			rgb_from_z = not_line;

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1675,10 +1675,8 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 				}
 			}
 
-			if (!geovector) {	/* Vectors do it separately */
-				gmt_setfill (GMT, &data[i].f, data[i].outline);
-				gmt_setpen (GMT, &data[i].p);
-			}
+			gmt_setfill (GMT, &data[i].f, data[i].outline);
+			gmt_setpen (GMT, &data[i].p);
 			if (QR_symbol) {
 				if (Ctrl->G.active)	/* Change color of QR code */
 					PSL_command (PSL, "/QR_fill {%s} def\n", PSL_makecolor (PSL, data[i].f.rgb));

--- a/test/psxy/vector2d_mods.ps
+++ b/test/psxy/vector2d_mods.ps
@@ -1,0 +1,2988 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 595 842
+%%HiResBoundingBox: 0 0 595.0000 842.0000
+%%Title: GMT v6.4.0_f51bf5e_2022.01.06 Document from plot
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Thu Jan  6 18:18:11 2022
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 9917 def
+/PSL_page_ysize 14033 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot -R-0.1/3/-0.1/9 -Jx1i -Bafg -Sv20p+e -W2p -Gred
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+120 0 M
+0 10920 D
+S
+1320 0 M
+0 10920 D
+S
+2520 0 M
+0 10920 D
+S
+3720 0 M
+0 10920 D
+S
+0 120 M
+3720 0 D
+S
+0 1320 M
+3720 0 D
+S
+0 2520 M
+3720 0 D
+S
+0 3720 M
+3720 0 D
+S
+0 4920 M
+3720 0 D
+S
+0 6120 M
+3720 0 D
+S
+0 7320 M
+3720 0 D
+S
+0 8520 M
+3720 0 D
+S
+0 9720 M
+3720 0 D
+S
+0 10920 M
+3720 0 D
+S
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+{1 0 0 C} FS
+O1
+33 W
+V 120 120 T 30 R
+N 0 0 M 950 0 D S
+U
+V 1159 720 T 30 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 10920 M 0 -10920 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 0 120 M -63 0 D S
+N 0 1320 M -63 0 D S
+N 0 2520 M -63 0 D S
+N 0 3720 M -63 0 D S
+N 0 4920 M -63 0 D S
+N 0 6120 M -63 0 D S
+N 0 7320 M -63 0 D S
+N 0 8520 M -63 0 D S
+N 0 9720 M -63 0 D S
+N 0 10920 M -63 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+158 F0
+(0) sw mx
+(1) sw mx
+(2) sw mx
+(3) sw mx
+(4) sw mx
+(5) sw mx
+(6) sw mx
+(7) sw mx
+(8) sw mx
+(9) sw mx
+def
+/PSL_A0_y PSL_A0_y 47 add def
+120 PSL_A0_y MM
+(0) mr Z
+1320 PSL_A0_y MM
+(1) mr Z
+2520 PSL_A0_y MM
+(2) mr Z
+3720 PSL_A0_y MM
+(3) mr Z
+4920 PSL_A0_y MM
+(4) mr Z
+6120 PSL_A0_y MM
+(5) mr Z
+7320 PSL_A0_y MM
+(6) mr Z
+8520 PSL_A0_y MM
+(7) mr Z
+9720 PSL_A0_y MM
+(8) mr Z
+10920 PSL_A0_y MM
+(9) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 360 M -32 0 D S
+N 0 600 M -32 0 D S
+N 0 840 M -32 0 D S
+N 0 1080 M -32 0 D S
+N 0 1560 M -32 0 D S
+N 0 1800 M -32 0 D S
+N 0 2040 M -32 0 D S
+N 0 2280 M -32 0 D S
+N 0 2760 M -32 0 D S
+N 0 3000 M -32 0 D S
+N 0 3240 M -32 0 D S
+N 0 3480 M -32 0 D S
+N 0 3960 M -32 0 D S
+N 0 4200 M -32 0 D S
+N 0 4440 M -32 0 D S
+N 0 4680 M -32 0 D S
+N 0 5160 M -32 0 D S
+N 0 5400 M -32 0 D S
+N 0 5640 M -32 0 D S
+N 0 5880 M -32 0 D S
+N 0 6360 M -32 0 D S
+N 0 6600 M -32 0 D S
+N 0 6840 M -32 0 D S
+N 0 7080 M -32 0 D S
+N 0 7560 M -32 0 D S
+N 0 7800 M -32 0 D S
+N 0 8040 M -32 0 D S
+N 0 8280 M -32 0 D S
+N 0 8760 M -32 0 D S
+N 0 9000 M -32 0 D S
+N 0 9240 M -32 0 D S
+N 0 9480 M -32 0 D S
+N 0 9960 M -32 0 D S
+N 0 10200 M -32 0 D S
+N 0 10440 M -32 0 D S
+N 0 10680 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3720 0 T
+24 W
+N 0 10920 M 0 -10920 D S
+-3720 0 T
+N 0 0 M 3720 0 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 120 0 M 0 -63 D S
+N 1320 0 M 0 -63 D S
+N 2520 0 M 0 -63 D S
+N 3720 0 M 0 -63 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
+120 PSL_A0_y MM
+(0) bc Z
+1320 PSL_A0_y MM
+(1) bc Z
+2520 PSL_A0_y MM
+(2) bc Z
+3720 PSL_A0_y MM
+(3) bc Z
+N 360 0 M 0 -32 D S
+N 600 0 M 0 -32 D S
+N 840 0 M 0 -32 D S
+N 1080 0 M 0 -32 D S
+N 1560 0 M 0 -32 D S
+N 1800 0 M 0 -32 D S
+N 2040 0 M 0 -32 D S
+N 2280 0 M 0 -32 D S
+N 2760 0 M 0 -32 D S
+N 3000 0 M 0 -32 D S
+N 3240 0 M 0 -32 D S
+N 3480 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 10920 T
+24 W
+N 0 0 M 3720 0 D S
+0 -10920 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 30 2.54 Vector: -Sv20p+e) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 1153 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 1153 M (Input: 30 2.54 Vector: -Sv20p+e) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sv20p+e -W2p -Gred --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+{1 0 0 C} FS
+O1
+33 W
+V 120 1320 T 30 R
+N 0 0 M 950 0 D S
+U
+V 1159 1920 T 30 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 30 1 Vector: -Sv20p+e --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 2353 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 2353 M (Input: 30 1 Vector: -Sv20p+e --PROJ_LENGTH_UNIT=inch) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sv20p+e -W2p -Gred --PROJ_LENGTH_UNIT=cm -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+{1 0 0 C} FS
+O1
+33 W
+V 120 2520 T 30 R
+N 0 0 M 950 0 D S
+U
+V 1159 3120 T 30 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 30 1i Vector: -Sv20p+e --PROJ_LENGTH_UNIT=cm) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 3553 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 3553 M (Input: 30 1i Vector: -Sv20p+e --PROJ_LENGTH_UNIT=cm) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sv20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+{1 0 0 C} FS
+O1
+33 W
+V 120 3720 T 29.9966677697 R
+N 0 0 M 950 0 D S
+U
+V 1159 4320 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  2.20  1.27 Vector: -Sv20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 4753 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 4753 M (Input:  2.20  1.27 Vector: -Sv20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sv20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+{1 0 0 C} FS
+O1
+33 W
+V 120 4920 T 29.9966677697 R
+N 0 0 M 950 0 D S
+U
+V 1159 5520 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_10
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  2.20c  1.27c Vector: -Sv20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 5953 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 5953 M (Input:  2.20c  1.27c Vector: -Sv20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sv20p+e+z1q -W2p -Gred -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_11
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+{1 0 0 C} FS
+O1
+33 W
+V 120 6120 T 29.9966677697 R
+N 0 0 M 950 0 D S
+U
+V 1159 6720 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_12
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  2.20  1.27 Vector: -Sv20p+e+z1q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 7153 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 7153 M (Input:  2.20  1.27 Vector: -Sv20p+e+z1q) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sv20p+e+z0.394q -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_13
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+{0.252 0.253 0.639 C} FS
+O1
+33 W
+V 120 7320 T 29.9966677697 R
+N 0 0 M 951 0 D S
+U
+V 1160 7920 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_14
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 8353 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 8353 M (Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q --PROJ_LENGTH_UNIT=inch) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sv20p+e+z0.0394q -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_15
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+{0.945 0.796 0.227 C} FS
+O1
+33 W
+V 120 8520 T 29.9966677697 R
+N 0 0 M 951 0 D S
+U
+V 1160 9120 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_16
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 9553 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 9553 M (Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q --PROJ_LENGTH_UNIT=inch) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -Sv20p+e+v0.0394q -W2p+c -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_17
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+/PSL_vecheadpen {33 W 0.945 0.797 0.227 C 1 1 /Normal PSL_transp [] 0 B} def
+{0.945 0.797 0.227 C} FS
+O1
+0.945 0.797 0.227 C
+33 W
+V 120 9720 T 30 R
+N 0 0 M 951 0 D S
+U
+V 1160 10320 T 30 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_18
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 30 25.4 Vector: -Sv20p+e+v0.0394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 10753 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 10753 M (Input: 30 25.4 Vector: -Sv20p+e+v0.0394q --PROJ_LENGTH_UNIT=inch) tl Z
+%%EndObject
+0 A
+FQ
+O0
+4200 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -JM9.1i+dh -Bafg -S=20p+e -W2p -Gred -X3.5i -R-0.1/3/-0.1/9
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_19
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+120 0 M
+0 10920 D
+S
+1323 0 M
+0 10920 D
+S
+2527 0 M
+0 10920 D
+S
+3730 0 M
+0 10920 D
+S
+0 120 M
+3730 0 D
+S
+0 1315 M
+3730 0 D
+S
+0 2510 M
+3730 0 D
+S
+0 3706 M
+3730 0 D
+S
+0 4904 M
+3730 0 D
+S
+0 6102 M
+3730 0 D
+S
+0 7303 M
+3730 0 D
+S
+0 8506 M
+3730 0 D
+S
+0 9711 M
+3730 0 D
+S
+0 10920 M
+3730 0 D
+S
+8 W
+N 120 0 M 0 -63 D S
+N 1323 0 M 0 -63 D S
+N 2527 0 M 0 -63 D S
+N 3730 0 M 0 -63 D S
+N 0 120 M -63 0 D S
+N 0 1315 M -63 0 D S
+N 0 2510 M -63 0 D S
+N 0 3706 M -63 0 D S
+N 0 4904 M -63 0 D S
+N 0 6102 M -63 0 D S
+N 0 7303 M -63 0 D S
+N 0 8506 M -63 0 D S
+N 0 9711 M -63 0 D S
+N 0 10920 M -63 0 D S
+N 120 0 M 0 -32 D S
+N 421 0 M 0 -32 D S
+N 722 0 M 0 -32 D S
+N 1023 0 M 0 -32 D S
+N 1323 0 M 0 -32 D S
+N 1624 0 M 0 -32 D S
+N 1925 0 M 0 -32 D S
+N 2226 0 M 0 -32 D S
+N 2527 0 M 0 -32 D S
+N 2827 0 M 0 -32 D S
+N 3128 0 M 0 -32 D S
+N 3429 0 M 0 -32 D S
+N 3730 0 M 0 -32 D S
+N 0 120 M -32 0 D S
+N 0 418 M -32 0 D S
+N 0 717 M -32 0 D S
+N 0 1016 M -32 0 D S
+N 0 1315 M -32 0 D S
+N 0 1613 M -32 0 D S
+N 0 1912 M -32 0 D S
+N 0 2211 M -32 0 D S
+N 0 2510 M -32 0 D S
+N 0 2809 M -32 0 D S
+N 0 3108 M -32 0 D S
+N 0 3407 M -32 0 D S
+N 0 3706 M -32 0 D S
+N 0 4006 M -32 0 D S
+N 0 4305 M -32 0 D S
+N 0 4604 M -32 0 D S
+N 0 4904 M -32 0 D S
+N 0 5203 M -32 0 D S
+N 0 5503 M -32 0 D S
+N 0 5803 M -32 0 D S
+N 0 6102 M -32 0 D S
+N 0 6402 M -32 0 D S
+N 0 6703 M -32 0 D S
+N 0 7003 M -32 0 D S
+N 0 7303 M -32 0 D S
+N 0 7604 M -32 0 D S
+N 0 7904 M -32 0 D S
+N 0 8205 M -32 0 D S
+N 0 8506 M -32 0 D S
+N 0 8807 M -32 0 D S
+N 0 9108 M -32 0 D S
+N 0 9410 M -32 0 D S
+N 0 9711 M -32 0 D S
+N 0 10013 M -32 0 D S
+N 0 10315 M -32 0 D S
+N 0 10618 M -32 0 D S
+N 0 10920 M -32 0 D S
+120 -110 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+158 F0
+(0è) tc Z
+1323 -110 M (1èE) tc Z
+2527 -110 M (2èE) tc Z
+3730 -110 M (3èE) tc Z
+/PSL_AH1 0
+-110 120 M (0è) mr Z
+(0è) sw mx
+-110 1315 M (1èN) mr Z
+(1èN) sw mx
+-110 2510 M (2èN) mr Z
+(2èN) sw mx
+-110 3706 M (3èN) mr Z
+(3èN) sw mx
+-110 4904 M (4èN) mr Z
+(4èN) sw mx
+-110 6102 M (5èN) mr Z
+(5èN) sw mx
+-110 7303 M (6èN) mr Z
+(6èN) sw mx
+-110 8506 M (7èN) mr Z
+(7èN) sw mx
+-110 9711 M (8èN) mr Z
+(8èN) sw mx
+-110 10920 M (9èN) mr Z
+(9èN) sw mx
+def
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+O0
+/FO {P}!
+112 134 M
+43 24 D
+21 13 D
+54 30 D
+21 13 D
+225 128 D
+21 13 D
+54 30 D
+21 13 D
+267 153 D
+17 -29 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+735 571 M
+287 76 D
+35 10 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-53 -52 D
+19 110 D
+PSL_clip N
+735 571 M
+287 76 D
+35 10 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-53 -52 D
+19 110 D
+FO
+735 571 M
+287 76 D
+35 10 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-53 -52 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+24 W
+0 A
+0 0 M
+3730 0 D
+0 10920 D
+-933 0 D
+-932 0 D
+-933 0 D
+-932 0 D
+0 -10920 D
+P S
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_20
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 60 100 Vector: -S=20p+e) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 1148 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 1148 M (Input: 60 100 Vector: -S=20p+e) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=20p+e -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_21
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+112 1329 M
+182 104 D
+546 313 D
+16 -29 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+735 1766 M
+144 38 D
+47 13 D
+132 35 D
+-27 -26 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-9 -8 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-35 -34 D
+19 110 D
+PSL_clip N
+735 1766 M
+144 38 D
+47 13 D
+132 35 D
+-27 -26 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-9 -8 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-35 -34 D
+19 110 D
+FO
+735 1766 M
+144 38 D
+47 13 D
+132 35 D
+-27 -26 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-9 -8 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-35 -34 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_22
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 60 54n Vector: -S=20p+e) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 2343 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 2343 M (Input: 60 54n Vector: -S=20p+e) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=20p+e -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_23
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+112 2524 M
+225 129 D
+21 13 D
+54 30 D
+21 13 D
+54 30 D
+21 13 D
+332 190 D
+17 -29 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+736 2962 M
+239 63 D
+47 13 D
+36 10 D
+-17 -18 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+19 110 D
+PSL_clip N
+736 2962 M
+239 63 D
+47 13 D
+36 10 D
+-17 -18 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+19 110 D
+FO
+736 2962 M
+239 63 D
+47 13 D
+36 10 D
+-17 -18 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_24
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 60 100k Vector: -S=20p+e) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 3539 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 3539 M (Input: 60 100k Vector: -S=20p+e) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_25
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+112 3721 M
+289 165 D
+21 13 D
+54 30 D
+21 13 D
+54 30 D
+21 13 D
+268 153 D
+16 -29 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+735 4158 M
+323 86 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -61 D
+20 111 D
+PSL_clip N
+735 4158 M
+323 86 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -61 D
+20 111 D
+FO
+735 4158 M
+323 86 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -61 D
+20 111 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_26
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 86.60 50.00 Vector: -S=20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 4737 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 4737 M (Input: 86.60 50.00 Vector: -S=20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_27
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+112 4918 M
+311 178 D
+21 13 D
+54 30 D
+21 13 D
+54 30 D
+21 13 D
+54 30 D
+21 13 D
+172 98 D
+16 -29 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+736 5356 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+20 111 D
+PSL_clip N
+736 5356 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+20 111 D
+FO
+736 5356 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+20 111 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_28
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 86.60k 50.00k Vector: -S=20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 5935 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 5935 M (Input: 86.60k 50.00k Vector: -S=20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_29
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+112 6117 M
+172 98 D
+21 13 D
+376 215 D
+21 13 D
+140 80 D
+17 -29 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+737 6556 M
+180 47 D
+47 13 D
+96 26 D
+-26 -27 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-26 -27 D
+-9 -8 D
+-8 -9 D
+19 110 D
+PSL_clip N
+737 6556 M
+180 47 D
+47 13 D
+96 26 D
+-26 -27 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-26 -27 D
+-9 -8 D
+-8 -9 D
+19 110 D
+FO
+737 6556 M
+180 47 D
+47 13 D
+96 26 D
+-26 -27 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-26 -27 D
+-9 -8 D
+-8 -9 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_30
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 46.76n 27.00n Vector: -S=20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 7136 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 7136 M (Input: 46.76n 27.00n Vector: -S=20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=20p+e+z10q -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_31
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+112 7317 M
+291 167 D
+54 31 D
+54 31 D
+205 117 D
+21 13 D
+108 61 D
+17 -28 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+741 7758 M
+322 85 D
+-44 -43 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-9 -8 D
+19 110 D
+PSL_clip N
+741 7758 M
+322 85 D
+-44 -43 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-9 -8 D
+19 110 D
+FO
+741 7758 M
+322 85 D
+-44 -43 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-9 -8 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_32
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  8.66  5.00 Vector: -S=20p+e+z10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 8338 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 8338 M (Input:  8.66  5.00 Vector: -S=20p+e+z10q) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=20p+e+z10q -W2p -C -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_33
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+V
+{0 A} FS
+/FO {P}!
+112 8520 M
+670 384 D
+65 37 D
+17 -28 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{0.159 0.734 0.925 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+743 8962 M
+322 85 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+19 110 D
+PSL_clip N
+743 8962 M
+322 85 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+19 110 D
+FO
+743 8962 M
+322 85 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_34
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  8.66  5.00 Vector: -S=20p+e+z10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 9544 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 9544 M (Input:  8.66  5.00 Vector: -S=20p+e+z10q) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot -S=20p+e+v10q -W2p+c -C -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_35
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+/PSL_vecheadpen {33 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+33 W
+/PSL_vecheadpen {33 W 0.159 0.734 0.925 C 1 1 /Normal PSL_transp [] 0 B} def
+V
+0.159 0.734 0.925 C
+{0.159 0.734 0.925 C} FS
+/FO {P}!
+112 9726 M
+22 12 D
+21 13 D
+185 105 D
+21 13 D
+185 105 D
+21 13 D
+282 161 D
+17 -29 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+O1
+2 setlinecap
+O0
+clipsave
+745 10168 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-9 -8 D
+20 110 D
+PSL_clip N
+745 10168 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-9 -8 D
+20 110 D
+FO
+745 10168 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-9 -8 D
+20 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_36
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 60 10 Vector: -S=20p+e+v10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 10752 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 10752 M (Input: 60 10 Vector: -S=20p+e+v10q) tl Z
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psxy/vector2d_mods.ps
+++ b/test/psxy/vector2d_mods.ps
@@ -5,7 +5,7 @@
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jan  6 18:18:11 2022
+%%CreationDate: Thu Jan  6 19:38:24 2022
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -1260,7 +1260,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot -Sv20p+e+z0.394q -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@GMT: gmt plot -Sv20p+e+z0.394q+c -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
 %@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
 %%BeginObject PSL_Layer_13
 0 setlinecap
@@ -1310,20 +1310,20 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q+c --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 8353 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 8353 M (Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q --PROJ_LENGTH_UNIT=inch) tl Z
+47 8353 M (Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q+c --PROJ_LENGTH_UNIT=inch) tl Z
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot -Sv20p+e+z0.0394q -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@GMT: gmt plot -Sv20p+e+z0.0394q+c -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
 %@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
 %%BeginObject PSL_Layer_15
 0 setlinecap
@@ -1373,20 +1373,20 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q+c --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 9553 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 9553 M (Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q --PROJ_LENGTH_UNIT=inch) tl Z
+47 9553 M (Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q+c --PROJ_LENGTH_UNIT=inch) tl Z
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot -Sv20p+e+v0.0394q -W2p+c -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@GMT: gmt plot -Sv20p+e+v0.0394q+c -W2p+c -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
 %@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
 %%BeginObject PSL_Layer_17
 0 setlinecap
@@ -1438,13 +1438,13 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input: 30 25.4 Vector: -Sv20p+e+v0.0394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input: 30 25.4 Vector: -Sv20p+e+v0.0394q+c --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 10753 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 10753 M (Input: 30 25.4 Vector: -Sv20p+e+v0.0394q --PROJ_LENGTH_UNIT=inch) tl Z
+47 10753 M (Input: 30 25.4 Vector: -Sv20p+e+v0.0394q+c --PROJ_LENGTH_UNIT=inch) tl Z
 %%EndObject
 0 A
 FQ
@@ -2676,7 +2676,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot -S=20p+e+z10q -W2p -C -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@GMT: gmt plot -S=20p+e+z10q+c -W2p -C -R-0.1/3/-0.1/9 -JM9.1i+dh
 %@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_33
 0 setlinecap
@@ -2811,20 +2811,20 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input:  8.66  5.00 Vector: -S=20p+e+z10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input:  8.66  5.00 Vector: -S=20p+e+z10q+c) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 9544 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 9544 M (Input:  8.66  5.00 Vector: -S=20p+e+z10q) tl Z
+47 9544 M (Input:  8.66  5.00 Vector: -S=20p+e+z10q+c) tl Z
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot -S=20p+e+v10q -W2p+c -C -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@GMT: gmt plot -S=20p+e+v10q+c -W2p+c -C -R-0.1/3/-0.1/9 -JM9.1i+dh
 %@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_35
 0 setlinecap
@@ -2968,13 +2968,13 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input: 60 10 Vector: -S=20p+e+v10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input: 60 10 Vector: -S=20p+e+v10q+c) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 10752 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 10752 M (Input: 60 10 Vector: -S=20p+e+v10q) tl Z
+47 10752 M (Input: 60 10 Vector: -S=20p+e+v10q+c) tl Z
 %%EndObject
 grestore
 PSL_movie_label_completion /PSL_movie_label_completion {} def

--- a/test/psxy/vector2d_mods.sh
+++ b/test/psxy/vector2d_mods.sh
@@ -39,14 +39,14 @@ gmt begin vector2d_mods
 	echo 0 5 ${dx} ${dy} | gmt plot -Sv20p+e+z1q -W2p -Gred
 	echo "-0.1 5.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z1q" | gmt text $textopt
 	# dx, dy in specified plot units with scale, and color based on magintude
-	echo 0 6 ${dx} ${dy} | gmt plot -Sv20p+e+z${scl}q -W2p -C --PROJ_LENGTH_UNIT=inch
-	echo "-0.1 6.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z${scl}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	echo 0 6 ${dx} ${dy} | gmt plot -Sv20p+e+z${scl}q+c -W2p -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 6.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z${scl}q+c --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
 	# dx, dy in specified data units with scale, and color based on magintude
-	echo 0 7 ${dx1} ${dy1} | gmt plot -Sv20p+e+z${scl1}q -W2p -C --PROJ_LENGTH_UNIT=inch
-	echo "-0.1 7.9 Input: ${dx1} ${dy1} Vector: -Sv20p+e+z${scl1}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	echo 0 7 ${dx1} ${dy1} | gmt plot -Sv20p+e+z${scl1}q+c -W2p -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 7.9 Input: ${dx1} ${dy1} Vector: -Sv20p+e+z${scl1}q+c --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
 	# magnitude in specified data units with scale, and color based on magintude
-	echo 0 8 30 25.4 | gmt plot -Sv20p+e+v${scl1}q -W2p+c -C --PROJ_LENGTH_UNIT=inch
-	echo "-0.1 8.9 Input: 30 25.4 Vector: -Sv20p+e+v${scl1}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	echo 0 8 30 25.4 | gmt plot -Sv20p+e+v${scl1}q+c -W2p+c -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 8.9 Input: 30 25.4 Vector: -Sv20p+e+v${scl1}q+c --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
 	### GEOVECTOR
 	# Direction, length given as 100, imnplying 100k
 	echo 0 0 60 100 | gmt plot -JM9.1i+dh -Bafg -S=20p+e -W2p -Gred -X3.5i
@@ -70,9 +70,9 @@ gmt begin vector2d_mods
 	echo 0 6 ${dx2} ${dy2} | gmt plot -S=20p+e+z10q -W2p -Gred
 	echo "-0.1 6.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q" | gmt text $textopt
 	# dx, dy in specific data units with scale, and color based on magintude
-	echo 0 7 ${dx2} ${dy2} | gmt plot -S=20p+e+z10q -W2p -C
-	echo "-0.1 7.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q" | gmt text $textopt
+	echo 0 7 ${dx2} ${dy2} | gmt plot -S=20p+e+z10q+c -W2p -C
+	echo "-0.1 7.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q+c" | gmt text $textopt
 	# magnitude in specific data units with scale, and color based on magintude
-	echo 0 8 60 10 | gmt plot -S=20p+e+v10q -W2p+c -C
-	echo "-0.1 8.9 Input: 60 10 Vector: -S=20p+e+v10q" | gmt text $textopt
+	echo 0 8 60 10 | gmt plot -S=20p+e+v10q+c -W2p+c -C
+	echo "-0.1 8.9 Input: 60 10 Vector: -S=20p+e+v10q+c" | gmt text $textopt
 gmt end show

--- a/test/psxy/vector2d_mods.sh
+++ b/test/psxy/vector2d_mods.sh
@@ -2,6 +2,7 @@
 # Test various ways of plotting 2-D vectors
 
 gmt begin vector2d_mods
+	gmt set PROJ_LENGTH_UNIT cm
 	scl=$(gmt math --FORMAT_FLOAT_OUT=%.3g -Q 2.54 INV =)
 	scl1=$(gmt math --FORMAT_FLOAT_OUT=%.3g -Q 2.54 INV 10 DIV =)
 	gmt set MAP_FRAME_TYPE=plain FORMAT_FLOAT_OUT=%5.2f

--- a/test/psxy/vector2d_mods.sh
+++ b/test/psxy/vector2d_mods.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Test various ways of plotting 2-D vectors
+
+gmt begin vector2d_mods
+	scl=$(gmt math --FORMAT_FLOAT_OUT=%.3g -Q 2.54 INV =)
+	scl1=$(gmt math --FORMAT_FLOAT_OUT=%.3g -Q 2.54 INV 10 DIV =)
+	gmt set MAP_FRAME_TYPE=plain FORMAT_FLOAT_OUT=%5.2f
+	# Get vector components of a 1 inch long vector with direction of 30 degrees from horizontal
+	dx=$(gmt math -Q 2.54 30 COSD MUL =)
+	dy=$(gmt math -Q 2.54 30 SIND MUL =)
+	dx1=$(gmt math -Q $dx 10 MUL =)
+	dy1=$(gmt math -Q $dy 10 MUL =)
+	dx_km=$(gmt math -Q 100 30 COSD MUL =)
+	dy_km=$(gmt math -Q 100 30 SIND MUL =)
+	dx_n=$(gmt math -Q $dx_km 1.852 DIV =)
+	dy_n=$(gmt math -Q $dy_km 1.852 DIV =)
+	dx2=$(gmt math -Q $dx_km 0.1 MUL =)
+	dy2=$(gmt math -Q $dy_km 0.1 MUL =)
+	gmt makecpt -Cturbo -T0/40
+	textopt="-F+f6.5p+jLT -Gwhite -Dj0.1c -N"
+	### CARTESIAN
+	# Direction, length given as 2.54, implying 2.54c
+	echo 0 0 30 2.54 | gmt plot -R-0.1/3/-0.1/9 -Jx1i -Bafg -Sv20p+e -W2p -Gred
+	echo "-0.1 0.9 Input: 30 2.54 Vector: -Sv20p+e" | gmt text $textopt
+	# Direction, length given as 1, and change default unit to be inch
+	echo 0 1 30 1 | gmt plot -Sv20p+e -W2p -Gred --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 1.9 Input: 30 1 Vector: -Sv20p+e --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	# Direction, length given as 1i, yet trying to change unit
+	echo 0 2 30 1i | gmt plot -Sv20p+e -W2p -Gred --PROJ_LENGTH_UNIT=cm
+	echo "-0.1 2.9 Input: 30 1i Vector: -Sv20p+e --PROJ_LENGTH_UNIT=cm" | gmt text $textopt
+	# dx, dy in assumed plot units (cm) and unit scale
+	echo 0 3 ${dx} ${dy} | gmt plot -Sv20p+e+z -W2p -Gred
+	echo "-0.1 3.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z" | gmt text $textopt
+	# dx, dy in actual plot units (cm) and unit scale
+	echo 0 4 ${dx}c ${dy}c | gmt plot -Sv20p+e+z -W2p -Gred
+	echo "-0.1 4.9 Input: ${dx}c ${dy}c Vector: -Sv20p+e+z" | gmt text $textopt
+	# dx, dy in specified user units with scale
+	echo 0 5 ${dx} ${dy} | gmt plot -Sv20p+e+z1q -W2p -Gred
+	echo "-0.1 5.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z1q" | gmt text $textopt
+	# dx, dy in specified plot units with scale, and color based on magintude
+	echo 0 6 ${dx} ${dy} | gmt plot -Sv20p+e+z${scl}q -W2p -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 6.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z${scl}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	# dx, dy in specified data units with scale, and color based on magintude
+	echo 0 7 ${dx1} ${dy1} | gmt plot -Sv20p+e+z${scl1}q -W2p -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 7.9 Input: ${dx1} ${dy1} Vector: -Sv20p+e+z${scl1}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	# magnitude in specified data units with scale, and color based on magintude
+	echo 0 8 30 25.4 | gmt plot -Sv20p+e+v${scl1}q -W2p+c -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 8.9 Input: 30 25.4 Vector: -Sv20p+e+v${scl1}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	### GEOVECTOR
+	# Direction, length given as 100, imnplying 100k
+	echo 0 0 60 100 | gmt plot -JM9.1i+dh -Bafg -S=20p+e -W2p -Gred -X3.5i
+	echo "-0.1 0.9 Input: 60 100 Vector: -S=20p+e" | gmt text $textopt
+	# Direction, length given as 54n ~ 100k
+	echo 0 1 60 54n | gmt plot -S=20p+e -W2p -Gred
+	echo "-0.1 1.9 Input: 60 54n Vector: -S=20p+e" | gmt text $textopt
+	# Direction, length given as 100kÏ
+	echo 0 2 60 100k | gmt plot -S=20p+e -W2p -Gred
+	echo "-0.1 2.9 Input: 60 100k Vector: -S=20p+e" | gmt text $textopt
+	# dx_km, dy_km to mimick the same
+	echo 0 3 ${dx_km} ${dy_km} | gmt plot -S=20p+e+z -W2p -Gred
+	echo "-0.1 3.9 Input: ${dx_km} ${dy_km} Vector: -S=20p+e+z" | gmt text $textopt
+	# dx_km, dy_km to mimick the same but with unit
+	echo 0 4 ${dx_km}k ${dy_km}k | gmt plot -S=20p+e+z -W2p -Gred
+	echo "-0.1 4.9 Input: ${dx_km}k ${dy_km}k Vector: -S=20p+e+z" | gmt text $textopt
+	# dx_km, dy_km to mimick the same
+	echo 0 5 ${dx_n}n ${dy_n}n | gmt plot -S=20p+e+z -W2p -Gred
+	echo "-0.1 5.9 Input: ${dx_n}n ${dy_n}n Vector: -S=20p+e+z" | gmt text $textopt
+	# dx, dy in specific data units with scale
+	echo 0 6 ${dx2} ${dy2} | gmt plot -S=20p+e+z10q -W2p -Gred
+	echo "-0.1 6.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q" | gmt text $textopt
+	# dx, dy in specific data units with scale, and color based on magintude
+	echo 0 7 ${dx2} ${dy2} | gmt plot -S=20p+e+z10q -W2p -C
+	echo "-0.1 7.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q" | gmt text $textopt
+	# magnitude in specific data units with scale, and color based on magintude
+	echo 0 8 60 10 | gmt plot -S=20p+e+v10q -W2p+c -C
+	echo "-0.1 8.9 Input: 60 10 Vector: -S=20p+e+v10q" | gmt text $textopt
+gmt end show

--- a/test/psxy/vector2d_mods.sh
+++ b/test/psxy/vector2d_mods.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test various ways of plotting 2-D vectors
 
 gmt begin vector2d_mods

--- a/test/psxyz/vector3d_mods.ps
+++ b/test/psxyz/vector3d_mods.ps
@@ -1,0 +1,2986 @@
+%!PS-Adobe-3.0
+%%BoundingBox: 0 0 595 842
+%%HiResBoundingBox: 0 0 595.0000 842.0000
+%%Title: GMT v6.4.0_f51bf5e_2022.01.06 Document from plot3d
+%%Creator: GMT6
+%%For: unknown
+%%DocumentNeededResources: font Helvetica
+%%CreationDate: Thu Jan  6 18:18:11 2022
+%%LanguageLevel: 2
+%%DocumentData: Clean7Bit
+%%Orientation: Portrait
+%%Pages: 1
+%%EndComments
+%%BeginProlog
+250 dict begin
+/! {bind def} bind def
+/# {load def}!
+/A /setgray #
+/B /setdash #
+/C /setrgbcolor #
+/D /rlineto #
+/E {dup stringwidth pop}!
+/F /fill #
+/G /rmoveto #
+/H /sethsbcolor #
+/I /setpattern #
+/K /setcmykcolor #
+/L /lineto #
+/M /moveto #
+/N /newpath #
+/P /closepath #
+/R /rotate #
+/S /stroke #
+/T /translate #
+/U /grestore #
+/V /gsave #
+/W /setlinewidth #
+/Y {findfont exch scalefont setfont}!
+/Z /show #
+/FP {true charpath flattenpath}!
+/MU {matrix setmatrix}!
+/MS {/SMat matrix currentmatrix def}!
+/MR {SMat setmatrix}!
+/edef {exch def}!
+/FS {/fc edef /fs {V fc F U} def}!
+/FQ {/fs {} def}!
+/O0 {/os {N} def}!
+/O1 {/os {P S} def}!
+/FO {fs os}!
+/Sa {M MS dup 0 exch G 0.726542528 mul -72 R dup 0 D 4 {72 R dup 0 D -144 R dup 0 D} repeat pop MR FO}!
+/Sb {M dup 0 D exch 0 exch D neg 0 D FO}!
+/SB {MS T /BoxR edef /BoxW edef /BoxH edef BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Sc {N 3 -1 roll 0 360 arc FO}!
+/Sd {M 4 {dup} repeat 0 G neg dup dup D exch D D FO}!
+/Se {N MS T R scale 0 0 1 0 360 arc MR FO}!
+/Sg {M MS 22.5 R dup 0 exch G -22.5 R 0.765366865 mul dup 0 D 6 {-45 R dup 0 D} repeat pop MR FO}!
+/Sh {M MS dup 0 G -120 R dup 0 D 4 {-60 R dup 0 D} repeat pop MR FO}!
+/Si {M MS dup neg 0 exch G 60 R 1.732050808 mul dup 0 D 120 R 0 D MR FO}!
+/Sj {M MS R dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D MR FO}!
+/Sn {M MS dup 0 exch G -36 R 1.175570505 mul dup 0 D 3 {-72 R dup 0 D} repeat pop MR FO}!
+/Sp {N 3 -1 roll 0 360 arc fs N}!
+/SP {M {D} repeat FO}!
+/Sr {M dup -2 div 2 index -2 div G dup 0 D exch 0 exch D neg 0 D FO}!
+/SR {MS T /BoxR edef /BoxW edef /BoxH edef BoxR BoxW -2 div BoxH -2 div T BoxR 0 M
+  BoxW 0 BoxW BoxH BoxR arct BoxW BoxH 0 BoxH BoxR arct 0 BoxH 0 0 BoxR arct 0 0 BoxW 0 BoxR arct MR FO}!
+/Ss {M 1.414213562 mul dup dup dup -2 div dup G 0 D 0 exch D neg 0 D FO}!
+/St {M MS dup 0 exch G -60 R 1.732050808 mul dup 0 D -120 R 0 D MR FO}!
+/SV {0 exch M 0 D D D D D 0 D FO}!
+/Sv {0 0 M D D 0 D D D D D 0 D D FO}!
+/Sw {2 copy M 5 2 roll arc FO}!
+/Sx {M 1.414213562 mul 5 {dup} repeat -2 div dup G D neg 0 G neg D S}!
+/Sy {M dup 0 exch G dup -2 mul dup 0 exch D S}!
+/S+ {M dup 0 G dup -2 mul dup 0 D exch dup G 0 exch D S}!
+/S- {M dup 0 G dup -2 mul dup 0 D S}!
+/sw {stringwidth pop}!
+/sh {V MU 0 0 M FP pathbbox N 4 1 roll pop pop pop U}!
+/sd {V MU 0 0 M FP pathbbox N pop pop exch pop U}!
+/sH {V MU 0 0 M FP pathbbox N exch pop exch sub exch pop U}!
+/sb {E exch sh}!
+/bl {}!
+/bc {E -2 div 0 G}!
+/br {E neg 0 G}!
+/ml {dup 0 exch sh -2 div G}!
+/mc {dup E -2 div exch sh -2 div G}!
+/mr {dup E neg exch sh -2 div G}!
+/tl {dup 0 exch sh neg G}!
+/tc {dup E -2 div exch sh neg G}!
+/tr {dup E neg exch sh neg G}!
+/mx {2 copy lt {exch} if pop}!
+/PSL_xorig 0 def /PSL_yorig 0 def
+/TM {2 copy T PSL_yorig add /PSL_yorig edef PSL_xorig add /PSL_xorig edef}!
+/PSL_reencode {findfont dup length dict begin
+  {1 index /FID ne {def}{pop pop} ifelse} forall
+  exch /Encoding edef currentdict end definefont pop
+}!
+/PSL_eps_begin {
+  /PSL_eps_state save def
+  /PSL_dict_count countdictstack def
+  /PSL_op_count count 1 sub def
+  userdict begin
+  /showpage {} def
+  0 setgray 0 setlinecap 1 setlinewidth
+  0 setlinejoin 10 setmiterlimit [] 0 setdash newpath
+  /languagelevel where
+  {pop languagelevel 1 ne {false setstrokeadjust false setoverprint} if} if
+}!
+/PSL_eps_end {
+  count PSL_op_count sub {pop} repeat
+  countdictstack PSL_dict_count sub {end} repeat
+  PSL_eps_state restore
+}!
+/PSL_transp {
+  /PSL_BM_arg edef /PSL_S_arg edef /PSL_F_arg edef
+  /.setfillconstantalpha where
+  { pop PSL_BM_arg .setblendmode PSL_S_arg .setstrokeconstantalpha PSL_F_arg .setfillconstantalpha }
+  { /pdfmark where {pop [ /BM PSL_BM_arg /CA PSL_S_arg /ca PSL_F_arg /SetTransparency pdfmark} if }
+  ifelse
+}!
+/Standard+_Encoding [
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef	/.notdef
+/.notdef	/threequarters	/threesuperior	/trademark	/twosuperior	/yacute		/ydieresis	/zcaron
+/space		/exclam		/quotedbl	/numbersign	/dollar		/percent	/ampersand	/quoteright
+/parenleft	/parenright	/asterisk	/plus		/comma		/hyphen		/period		/slash
+/zero		/one		/two		/three		/four		/five		/six		/seven
+/eight		/nine		/colon		/semicolon	/less		/equal		/greater	/question
+/at		/A		/B		/C		/D		/E		/F		/G
+/H		/I		/J		/K		/L		/M		/N		/O
+/P		/Q		/R		/S		/T		/U		/V		/W
+/X		/Y		/Z		/bracketleft	/backslash	/bracketright	/asciicircum	/underscore
+/quoteleft	/a		/b		/c		/d		/e		/f		/g
+/h		/i		/j		/k		/l		/m		/n		/o
+/p		/q		/r		/s		/t		/u		/v		/w
+/x		/y		/z		/braceleft	/bar		/braceright	/asciitilde	/florin
+/Atilde		/Ccedilla	/Eth		/Lslash		/Ntilde		/Otilde		/Scaron		/Thorn
+/Yacute		/Ydieresis	/Zcaron		/atilde		/brokenbar	/ccedilla	/copyright	/degree
+/divide		/eth		/logicalnot	/lslash		/minus		/mu		/multiply	/ntilde
+/onehalf	/onequarter	/onesuperior	/otilde		/plusminus	/registered	/scaron		/thorn
+/.notdef	/exclamdown	/cent		/sterling	/fraction	/yen		/florin		/section
+/currency	/quotesingle	/quotedblleft	/guillemotleft	/guilsinglleft	/guilsinglright	/fi		/fl
+/Aacute		/endash		/dagger		/daggerdbl	/periodcentered	/Acircumflex	/paragraph	/bullet
+/quotesinglbase	/quotedblbase	/quotedblright	/guillemotright	/ellipsis	/perthousand	/Adieresis	/questiondown
+/Agrave		/grave		/acute		/circumflex	/tilde		/macron		/breve		/dotaccent
+/dieresis	/Eacute		/ring		/cedilla	/Ecircumflex	/hungarumlaut	/ogonek		/caron
+/emdash		/Edieresis	/Egrave		/Iacute		/Icircumflex	/Idieresis	/Igrave		/Oacute
+/Ocircumflex	/Odieresis	/Ograve		/Uacute		/Ucircumflex	/Udieresis	/Ugrave		/aacute
+/acircumflex	/AE		/adieresis	/ordfeminine	/agrave		/eacute		/ecircumflex	/edieresis
+/egrave		/Oslash		/OE		/ordmasculine	/iacute		/icircumflex	/idieresis	/igrave
+/oacute		/ae		/ocircumflex	/odieresis	/ograve		/dotlessi	/uacute		/ucircumflex
+/udieresis	/oslash		/oe		/germandbls	/ugrave		/Aring		/aring		/ydieresis
+] def
+/PSL_font_encode 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 39 array astore def
+/F0 {/Helvetica Y}!
+/F1 {/Helvetica-Bold Y}!
+/F2 {/Helvetica-Oblique Y}!
+/F3 {/Helvetica-BoldOblique Y}!
+/F4 {/Times-Roman Y}!
+/F5 {/Times-Bold Y}!
+/F6 {/Times-Italic Y}!
+/F7 {/Times-BoldItalic Y}!
+/F8 {/Courier Y}!
+/F9 {/Courier-Bold Y}!
+/F10 {/Courier-Oblique Y}!
+/F11 {/Courier-BoldOblique Y}!
+/F12 {/Symbol Y}!
+/F13 {/AvantGarde-Book Y}!
+/F14 {/AvantGarde-BookOblique Y}!
+/F15 {/AvantGarde-Demi Y}!
+/F16 {/AvantGarde-DemiOblique Y}!
+/F17 {/Bookman-Demi Y}!
+/F18 {/Bookman-DemiItalic Y}!
+/F19 {/Bookman-Light Y}!
+/F20 {/Bookman-LightItalic Y}!
+/F21 {/Helvetica-Narrow Y}!
+/F22 {/Helvetica-Narrow-Bold Y}!
+/F23 {/Helvetica-Narrow-Oblique Y}!
+/F24 {/Helvetica-Narrow-BoldOblique Y}!
+/F25 {/NewCenturySchlbk-Roman Y}!
+/F26 {/NewCenturySchlbk-Italic Y}!
+/F27 {/NewCenturySchlbk-Bold Y}!
+/F28 {/NewCenturySchlbk-BoldItalic Y}!
+/F29 {/Palatino-Roman Y}!
+/F30 {/Palatino-Italic Y}!
+/F31 {/Palatino-Bold Y}!
+/F32 {/Palatino-BoldItalic Y}!
+/F33 {/ZapfChancery-MediumItalic Y}!
+/F34 {/ZapfDingbats Y}!
+/F35 {/Ryumin-Light-EUC-H Y}!
+/F36 {/Ryumin-Light-EUC-V Y}!
+/F37 {/GothicBBB-Medium-EUC-H Y}!
+/F38 {/GothicBBB-Medium-EUC-V Y}!
+/PSL_pathtextdict 26 dict def
+/PSL_pathtext
+  {PSL_pathtextdict begin
+    /ydepth exch def
+    /textheight exch def
+    /just exch def
+    /offset exch def
+    /str exch def
+    /pathdist 0 def
+    /setdist offset def
+    /charcount 0 def
+    /justy just 4 idiv textheight mul 2 div neg ydepth sub def
+    V flattenpath
+	{movetoproc} {linetoproc}
+	{curvetoproc} {closepathproc}
+	pathforall
+    U N
+    end
+  } def
+PSL_pathtextdict begin
+/movetoproc
+  { /newy exch def /newx exch def
+    /firstx newx def /firsty newy def
+    /ovr 0 def
+    newx newy transform
+    /cpy exch def /cpx exch def
+  } def
+/linetoproc
+  { /oldx newx def /oldy newy def
+    /newy exch def /newx exch def
+    /dx newx oldx sub def
+    /dy newy oldy sub def
+    /dist dx dup mul dy dup mul add sqrt def
+    dist 0 ne
+    { /dsx dx dist div ovr mul def
+      /dsy dy dist div ovr mul def
+      oldx dsx add oldy dsy add transform
+      /cpy exch def /cpx exch def
+      /pathdist pathdist dist add def
+      {setdist pathdist le
+	  {charcount str length lt
+	      {setchar} {exit} ifelse}
+	  { /ovr setdist pathdist sub def
+	    exit}
+	  ifelse
+      } loop
+    } if
+  } def
+/curvetoproc
+  { (ERROR: No curveto's after flattenpath!)
+    print
+  } def
+/closepathproc
+  {firstx firsty linetoproc
+    firstx firsty movetoproc
+  } def
+/setchar
+  { /char str charcount 1 getinterval def
+    /charcount charcount 1 add def
+    /charwidth char stringwidth pop def
+    V cpx cpy itransform T
+      dy dx atan R
+      0 justy M
+      PSL_font_F {
+        char show}
+      if
+      PSL_font_FO {
+        currentpoint N M V char true charpath fs U V char false charpath S U char E 0 G
+      } if
+      PSL_font_OF {
+        currentpoint N M V char false charpath S U V char true charpath fs U char E 0 G
+      } if
+      0 justy neg G currentpoint transform
+      /cpy exch def /cpx exch def
+    U /setdist setdist charwidth add def
+  } def
+end
+/PSL_set_label_heights
+{
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_heights PSL_n_labels array def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    /psl_label PSL_label_str psl_k get def
+    PSL_label_font psl_k get cvx exec
+    psl_label sH /PSL_height edef
+    PSL_heights psl_k PSL_height put
+  } for
+} def
+/PSL_curved_path_labels
+{ /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_clippath psl_bits 4 and 4 eq def
+  /PSL_strokeline false def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  PSL_clippath {clipsave N clippath} if
+  /psl_k 0 def
+  /psl_p 0 def
+  0 1 PSL_n_paths1
+  { /psl_kk exch def
+    /PSL_n PSL_path_n  psl_kk get def
+    /PSL_m PSL_label_n psl_kk get def
+    /PSL_x PSL_path_x psl_k PSL_n getinterval def
+    /PSL_y PSL_path_y psl_k PSL_n getinterval def
+    /PSL_node_tmp PSL_label_node psl_p PSL_m getinterval def
+    /PSL_angle_tmp PSL_label_angle psl_p PSL_m getinterval def
+    /PSL_str_tmp PSL_label_str psl_p PSL_m getinterval def
+    /PSL_fnt_tmp PSL_label_font psl_p PSL_m getinterval def
+    PSL_curved_path_label
+    /psl_k psl_k PSL_n add def
+    /psl_p psl_p PSL_m add def
+  } for
+  PSL_clippath {PSL_eoclip} if N
+} def
+/PSL_curved_path_label
+{
+  /PSL_n1 PSL_n 1 sub def
+  /PSL_m1 PSL_m 1 sub def
+  PSL_CT_calcstringwidth
+  PSL_CT_calclinedist
+  PSL_CT_excludelabels
+  PSL_CT_addcutpoints
+  /PSL_nn1 PSL_nn 1 sub def
+  /n 0 def
+  /k 0 def
+  /j 0 def
+  /PSL_seg 0 def
+  /PSL_xp PSL_nn array def
+  /PSL_yp PSL_nn array def
+  PSL_xp 0 PSL_xx 0 get put
+  PSL_yp 0 PSL_yy 0 get put
+  1 1 PSL_nn1
+  { /i exch def
+    /node_type PSL_kind i get def
+    /j j 1 add def
+    PSL_xp j PSL_xx i get put
+    PSL_yp j PSL_yy i get put
+    node_type 1 eq
+    {n 0 eq
+      {PSL_CT_drawline}
+      {
+        PSL_CT_reversepath
+	      PSL_CT_textline}
+      ifelse
+      /j 0 def
+      PSL_xp j PSL_xx i get put
+      PSL_yp j PSL_yy i get put
+    } if
+  } for
+  n 0 eq {PSL_CT_drawline} if
+} def
+/PSL_CT_textline
+{ PSL_fnt k get cvx exec
+  /PSL_height PSL_heights k get def
+  PSL_placetext	{PSL_CT_placelabel} if
+  PSL_clippath {PSL_CT_clippath} if
+  /n 0 def /k k 1 add def
+} def
+/PSL_CT_calcstringwidth
+{ /PSL_width_tmp PSL_m array def
+  0 1 PSL_m1
+  { /i exch def
+    PSL_fnt_tmp i get cvx exec
+    PSL_width_tmp i PSL_str_tmp i get stringwidth pop put
+  } for
+} def
+/PSL_CT_calclinedist
+{ /PSL_newx PSL_x 0 get def
+  /PSL_newy PSL_y 0 get def
+  /dist 0.0 def
+  /PSL_dist PSL_n array def
+  PSL_dist 0 0.0 put
+  1 1 PSL_n1
+  { /i exch def
+    /PSL_oldx PSL_newx def
+    /PSL_oldy PSL_newy def
+    /PSL_newx PSL_x i get def
+    /PSL_newy PSL_y i get def
+    /dx PSL_newx PSL_oldx sub def
+    /dy PSL_newy PSL_oldy sub def
+    /dist dist dx dx mul dy dy mul add sqrt add def
+    PSL_dist i dist put
+  } for
+} def
+/PSL_CT_excludelabels
+{ /k 0 def
+  /PSL_width PSL_m array def
+  /PSL_angle PSL_m array def
+  /PSL_node PSL_m array def
+  /PSL_str PSL_m array def
+  /PSL_fnt PSL_m array def
+  /lastdist PSL_dist PSL_n1 get def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node_tmp i get get def
+    /halfwidth PSL_width_tmp i get 2 div PSL_gap_x add def
+    /L_dist dist halfwidth sub def
+    /R_dist dist halfwidth add def
+    L_dist 0 gt R_dist lastdist lt and
+    {
+      PSL_width k PSL_width_tmp i get put
+      PSL_node k PSL_node_tmp i get put
+      PSL_angle k PSL_angle_tmp i get put
+      PSL_str k PSL_str_tmp i get put
+      PSL_fnt k PSL_fnt_tmp i get put
+      /k k 1 add def
+    } if
+  } for
+  /PSL_m k def
+  /PSL_m1 PSL_m 1 sub def
+} def
+/PSL_CT_addcutpoints
+{ /k 0 def
+  /PSL_nc PSL_m 2 mul 1 add def
+  /PSL_cuts PSL_nc array def
+  /PSL_nc1 PSL_nc 1 sub def
+  0 1 PSL_m1
+  { /i exch def
+    /dist PSL_dist PSL_node i get get def
+    /halfwidth PSL_width i get 2 div PSL_gap_x add def
+    PSL_cuts k dist halfwidth sub put
+    /k k 1 add def
+    PSL_cuts k dist halfwidth add put
+    /k k 1 add def
+  } for
+  PSL_cuts k 100000.0 put
+  /PSL_nn PSL_n PSL_m 2 mul add def
+  /PSL_xx PSL_nn array def
+  /PSL_yy PSL_nn array def
+  /PSL_kind PSL_nn array def
+  /j 0 def
+  /k 0 def
+  /dist 0.0 def
+  0 1 PSL_n1
+  { /i exch def
+    /last_dist dist def
+    /dist PSL_dist i get def
+    k 1 PSL_nc1
+    { /kk exch def
+      /this_cut PSL_cuts kk get def
+      dist this_cut gt
+      { /ds dist last_dist sub def
+	/f ds 0.0 eq {0.0} {dist this_cut sub ds div} ifelse def
+	/i1 i 0 eq {0} {i 1 sub} ifelse def
+	PSL_xx j PSL_x i get dup PSL_x i1 get sub f mul sub put
+	PSL_yy j PSL_y i get dup PSL_y i1 get sub f mul sub put
+	PSL_kind j 1 put
+	/j j 1 add def
+	/k k 1 add def
+      } if
+    } for
+    dist PSL_cuts k get le
+    {PSL_xx j PSL_x i get put PSL_yy j PSL_y i get put
+      PSL_kind j 0 put
+      /j j 1 add def
+    } if
+  } for
+} def
+/PSL_CT_reversepath
+{PSL_xp j get PSL_xp 0 get lt
+  {0 1 j 2 idiv
+    { /left exch def
+      /right j left sub def
+      /tmp PSL_xp left get def
+      PSL_xp left PSL_xp right get put
+      PSL_xp right tmp put
+      /tmp PSL_yp left get def
+      PSL_yp left PSL_yp right get put
+      PSL_yp right tmp put
+    } for
+  } if
+} def
+/PSL_CT_placelabel
+{
+  /PSL_just PSL_label_justify k get def
+  /PSL_height PSL_heights k get def
+  /psl_label PSL_str k get def
+  /psl_depth psl_label sd def
+  PSL_usebox
+  {PSL_CT_clippath
+    PSL_fillbox
+    {V PSL_setboxrgb fill U} if
+    PSL_drawbox
+    {V PSL_setboxpen S U} if N
+  } if
+  PSL_CT_placeline psl_label PSL_gap_x PSL_just PSL_height psl_depth PSL_pathtext
+} def
+/PSL_CT_clippath
+{
+  /H PSL_height 2 div PSL_gap_y add def
+  /xoff j 1 add array def
+  /yoff j 1 add array def
+  /angle 0 def
+  0 1 j {
+    /ii exch def
+    /x PSL_xp ii get def
+    /y PSL_yp ii get def
+    ii 0 eq {
+      /x1 PSL_xp 1 get def
+      /y1 PSL_yp 1 get def
+      /dx x1 x sub def
+      /dy y1 y sub def
+    }
+    { /i1 ii 1 sub def
+      /x1 PSL_xp i1 get def
+      /y1 PSL_yp i1 get def
+      /dx x x1 sub def
+      /dy y y1 sub def
+    } ifelse
+    dx 0.0 eq dy 0.0 eq and not
+    { /angle dy dx atan 90 add def} if
+    /sina angle sin def
+    /cosa angle cos def
+    xoff ii H cosa mul put
+    yoff ii H sina mul put
+  } for
+  PSL_xp 0 get xoff 0 get add PSL_yp 0 get yoff 0 get add M
+  1 1 j {
+    /ii exch def
+    PSL_xp ii get xoff ii get add PSL_yp ii get yoff ii get add L
+  } for
+  j -1 0 {
+    /ii exch def
+    PSL_xp ii get xoff ii get sub PSL_yp ii get yoff ii get sub L
+  } for P
+} def
+/PSL_CT_drawline
+{
+  /str 20 string def
+  PSL_strokeline
+  {PSL_CT_placeline S} if
+  /PSL_seg PSL_seg 1 add def
+  /n 1 def
+} def
+/PSL_CT_placeline
+{PSL_xp 0 get PSL_yp 0 get M
+  1 1 j { /ii exch def PSL_xp ii get PSL_yp ii get L} for
+} def
+/PSL_draw_path_lines
+{
+  /PSL_n_paths1 PSL_n_paths 1 sub def
+  V
+  /psl_start 0 def
+  0 1 PSL_n_paths1
+  { /psl_k exch def
+    /PSL_n PSL_path_n psl_k get def
+    /PSL_n1 PSL_n 1 sub def
+    PSL_path_pen psl_k get cvx exec
+    N
+    PSL_path_x psl_start get PSL_path_y psl_start get M
+    1 1 PSL_n1
+    { /psl_i exch def
+      /psl_kk psl_i psl_start add def
+      PSL_path_x psl_kk get PSL_path_y psl_kk get L
+    } for
+    /psl_xclose PSL_path_x psl_kk get PSL_path_x psl_start get sub def
+    /psl_yclose PSL_path_y psl_kk get PSL_path_y psl_start get sub def
+    psl_xclose 0 eq psl_yclose 0 eq and { P } if
+    S
+    /psl_start psl_start PSL_n add def
+  } for
+  U
+} def
+/PSL_straight_path_labels
+{
+  /psl_bits exch def
+  /PSL_placetext psl_bits 2 and 2 eq def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_fillbox psl_bits 128 and 128 eq def
+  /PSL_drawbox psl_bits 256 and 256 eq def
+  /PSL_font_F  psl_bits 1536 and 0 eq def
+  /PSL_font_FO psl_bits 512 and 512 eq def
+  /PSL_font_OF psl_bits 1024 and 1024 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  /PSL_usebox PSL_fillbox PSL_drawbox or def
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_usebox
+    {  PSL_rounded
+        {PSL_ST_textbox_round}
+        {PSL_ST_textbox_rect}
+      ifelse
+      PSL_fillbox {V PSL_setboxrgb fill U} if
+      PSL_drawbox {V PSL_setboxpen S U} if
+      N
+    } if
+    PSL_font_F {
+      PSL_placetext {PSL_ST_place_label} if
+    } if
+    PSL_font_FO {
+      PSL_placetext {PSL_ST_place_label_FO} if
+    } if
+    PSL_font_OF {
+      PSL_placetext {PSL_ST_place_label_OF} if
+    } if
+  } for
+} def
+/PSL_straight_path_clip
+{
+  /psl_bits exch def
+  /PSL_rounded psl_bits 32 and 32 eq def
+  /PSL_n_labels_minus_1 PSL_n_labels 1 sub def
+  N clipsave clippath
+  0 1 PSL_n_labels_minus_1
+  { /psl_k exch def
+    PSL_ST_prepare_text
+    PSL_rounded
+      {PSL_ST_textbox_round}
+      {PSL_ST_textbox_rect}
+    ifelse
+  } for
+  PSL_eoclip N
+} def
+/PSL_ST_prepare_text
+{
+  /psl_xp PSL_txt_x psl_k get def
+  /psl_yp PSL_txt_y psl_k get def
+  /psl_label PSL_label_str psl_k get def
+  PSL_label_font psl_k get cvx exec
+  /PSL_height PSL_heights psl_k get def
+  /psl_boxH PSL_height PSL_gap_y 2 mul add def
+  /PSL_just PSL_label_justify psl_k get def
+  /PSL_justx PSL_just 4 mod 1 sub 2 div neg def
+  /PSL_justy PSL_just 4 idiv 2 div neg def
+  /psl_SW psl_label stringwidth pop def
+  /psl_boxW psl_SW PSL_gap_x 2 mul add def
+  /psl_x0 psl_SW PSL_justx mul def
+  /psl_y0 PSL_justy PSL_height mul def
+  /psl_angle PSL_label_angle psl_k get def
+} def
+/PSL_ST_textbox_rect
+{
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  PSL_gap_x neg PSL_gap_y neg M
+  0 psl_boxH D psl_boxW 0 D 0 psl_boxH neg D P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_textbox_round
+{
+  /psl_BoxR PSL_gap_x PSL_gap_y lt {PSL_gap_x} {PSL_gap_y} ifelse def
+  /psl_xd PSL_gap_x psl_BoxR sub def
+  /psl_yd PSL_gap_y psl_BoxR sub def
+  /psl_xL PSL_gap_x neg def
+  /psl_yB PSL_gap_y neg def
+  /psl_yT psl_boxH psl_yB add def
+  /psl_H2 PSL_height psl_yd 2 mul add def
+  /psl_W2 psl_SW psl_xd 2 mul add def
+  /psl_xR psl_xL psl_boxW add def
+  /psl_x0 psl_SW PSL_justx mul def
+  psl_xp psl_yp T psl_angle R psl_x0 psl_y0 T
+  psl_xL psl_yd M
+  psl_xL psl_yT psl_xR psl_yT psl_BoxR arct psl_W2 0 D
+  psl_xR psl_yT psl_xR psl_yB psl_BoxR arct 0 psl_H2 neg D
+  psl_xR psl_yB psl_xL psl_yB psl_BoxR arct psl_W2 neg 0 D
+  psl_xL psl_yB psl_xL psl_yd psl_BoxR arct P
+  psl_x0 neg psl_y0 neg T psl_angle neg R psl_xp neg psl_yp neg T
+} def
+/PSL_ST_place_label
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G show
+    U
+} def
+/PSL_ST_place_label_FO
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V fs U S N
+    U
+} def
+/PSL_ST_place_label_OF
+{
+    V psl_xp psl_yp T psl_angle R
+    psl_SW PSL_justx mul psl_y0 M
+    psl_label dup sd neg 0 exch G false charpath V S U fs N
+    U
+} def
+/PSL_nclip 0 def
+/PSL_clip {clip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_eoclip {eoclip /PSL_nclip PSL_nclip 1 add def} def
+/PSL_cliprestore {cliprestore /PSL_nclip PSL_nclip 1 sub def} def
+%%EndProlog
+%%BeginSetup
+/PSLevel /languagelevel where {pop languagelevel} {1} ifelse def
+%%EndSetup
+%%Page: 1 1
+%%BeginPageSetup
+V 0.06 0.06 scale
+%%EndPageSetup
+/PSL_page_xsize 9917 def
+/PSL_page_ysize 14033 def
+/PSL_plot_completion {} def
+/PSL_movie_label_completion {} def
+/PSL_movie_prog_indicator_completion {} def
+%PSL_End_Header
+gsave
+0 A
+FQ
+O0
+1200 1200 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -R-0.1/3/-0.1/9 -Jx1i -Bafg -Sv20p+e -W2p -Gred
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_1
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+120 0 M
+0 10920 D
+S
+1320 0 M
+0 10920 D
+S
+2520 0 M
+0 10920 D
+S
+3720 0 M
+0 10920 D
+S
+0 120 M
+3720 0 D
+S
+0 1320 M
+3720 0 D
+S
+0 2520 M
+3720 0 D
+S
+0 3720 M
+3720 0 D
+S
+0 4920 M
+3720 0 D
+S
+0 6120 M
+3720 0 D
+S
+0 7320 M
+3720 0 D
+S
+0 8520 M
+3720 0 D
+S
+0 9720 M
+3720 0 D
+S
+0 10920 M
+3720 0 D
+S
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{1 0 0 C} FS
+O1
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 120 T 30 R
+N 0 0 M 950 0 D S
+U
+V 1159 720 T 30 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+24 W
+0 A
+/PSL_slant_y 0 def /PSL_slant_x 0 def
+2 setlinecap
+N 0 10920 M 0 -10920 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 0 120 M -63 0 D S
+N 0 1320 M -63 0 D S
+N 0 2520 M -63 0 D S
+N 0 3720 M -63 0 D S
+N 0 4920 M -63 0 D S
+N 0 6120 M -63 0 D S
+N 0 7320 M -63 0 D S
+N 0 8520 M -63 0 D S
+N 0 9720 M -63 0 D S
+N 0 10920 M -63 0 D S
+/MM {neg exch M} def
+/PSL_AH0 0
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+158 F0
+(0) sw mx
+(1) sw mx
+(2) sw mx
+(3) sw mx
+(4) sw mx
+(5) sw mx
+(6) sw mx
+(7) sw mx
+(8) sw mx
+(9) sw mx
+def
+/PSL_A0_y PSL_A0_y 47 add def
+120 PSL_A0_y MM
+(0) mr Z
+1320 PSL_A0_y MM
+(1) mr Z
+2520 PSL_A0_y MM
+(2) mr Z
+3720 PSL_A0_y MM
+(3) mr Z
+4920 PSL_A0_y MM
+(4) mr Z
+6120 PSL_A0_y MM
+(5) mr Z
+7320 PSL_A0_y MM
+(6) mr Z
+8520 PSL_A0_y MM
+(7) mr Z
+9720 PSL_A0_y MM
+(8) mr Z
+10920 PSL_A0_y MM
+(9) mr Z
+/PSL_A0_y PSL_A0_y PSL_AH0 add def
+N 0 360 M -32 0 D S
+N 0 600 M -32 0 D S
+N 0 840 M -32 0 D S
+N 0 1080 M -32 0 D S
+N 0 1560 M -32 0 D S
+N 0 1800 M -32 0 D S
+N 0 2040 M -32 0 D S
+N 0 2280 M -32 0 D S
+N 0 2760 M -32 0 D S
+N 0 3000 M -32 0 D S
+N 0 3240 M -32 0 D S
+N 0 3480 M -32 0 D S
+N 0 3960 M -32 0 D S
+N 0 4200 M -32 0 D S
+N 0 4440 M -32 0 D S
+N 0 4680 M -32 0 D S
+N 0 5160 M -32 0 D S
+N 0 5400 M -32 0 D S
+N 0 5640 M -32 0 D S
+N 0 5880 M -32 0 D S
+N 0 6360 M -32 0 D S
+N 0 6600 M -32 0 D S
+N 0 6840 M -32 0 D S
+N 0 7080 M -32 0 D S
+N 0 7560 M -32 0 D S
+N 0 7800 M -32 0 D S
+N 0 8040 M -32 0 D S
+N 0 8280 M -32 0 D S
+N 0 8760 M -32 0 D S
+N 0 9000 M -32 0 D S
+N 0 9240 M -32 0 D S
+N 0 9480 M -32 0 D S
+N 0 9960 M -32 0 D S
+N 0 10200 M -32 0 D S
+N 0 10440 M -32 0 D S
+N 0 10680 M -32 0 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+3720 0 T
+24 W
+N 0 10920 M 0 -10920 D S
+-3720 0 T
+N 0 0 M 3720 0 D S
+/PSL_A0_y 63 def
+/PSL_A1_y 0 def
+8 W
+N 120 0 M 0 -63 D S
+N 1320 0 M 0 -63 D S
+N 2520 0 M 0 -63 D S
+N 3720 0 M 0 -63 D S
+/MM {neg M} def
+/PSL_AH0 0
+(0) sh mx
+(1) sh mx
+(2) sh mx
+(3) sh mx
+def
+/PSL_A0_y PSL_A0_y 47 add PSL_AH0 add def
+120 PSL_A0_y MM
+(0) bc Z
+1320 PSL_A0_y MM
+(1) bc Z
+2520 PSL_A0_y MM
+(2) bc Z
+3720 PSL_A0_y MM
+(3) bc Z
+N 360 0 M 0 -32 D S
+N 600 0 M 0 -32 D S
+N 840 0 M 0 -32 D S
+N 1080 0 M 0 -32 D S
+N 1560 0 M 0 -32 D S
+N 1800 0 M 0 -32 D S
+N 2040 0 M 0 -32 D S
+N 2280 0 M 0 -32 D S
+N 2760 0 M 0 -32 D S
+N 3000 0 M 0 -32 D S
+N 3240 0 M 0 -32 D S
+N 3480 0 M 0 -32 D S
+/PSL_LH 0 def /PSL_L_y PSL_A0_y PSL_A1_y mx def
+0 10920 T
+24 W
+N 0 0 M 3720 0 D S
+0 -10920 T
+0 setlinecap
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_2
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 30 2.54 Vector: -Sv20p+e) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 1153 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 1153 M (Input: 30 2.54 Vector: -Sv20p+e) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -Sv20p+e -W2p -Gred --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_3
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{1 0 0 C} FS
+O1
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 1320 T 30 R
+N 0 0 M 950 0 D S
+U
+V 1159 1920 T 30 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_4
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 30 1 Vector: -Sv20p+e --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 2353 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 2353 M (Input: 30 1 Vector: -Sv20p+e --PROJ_LENGTH_UNIT=inch) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -Sv20p+e -W2p -Gred --PROJ_LENGTH_UNIT=cm -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_5
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{1 0 0 C} FS
+O1
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 2520 T 30 R
+N 0 0 M 950 0 D S
+U
+V 1159 3120 T 30 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_6
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 30 1i Vector: -Sv20p+e --PROJ_LENGTH_UNIT=cm) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 3553 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 3553 M (Input: 30 1i Vector: -Sv20p+e --PROJ_LENGTH_UNIT=cm) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -Sv20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_7
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{1 0 0 C} FS
+O1
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 3720 T 29.9966677697 R
+N 0 0 M 950 0 D S
+U
+V 1159 4320 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_8
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  2.20  1.27 Vector: -Sv20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 4753 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 4753 M (Input:  2.20  1.27 Vector: -Sv20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -Sv20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_9
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{1 0 0 C} FS
+O1
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 4920 T 29.9966677697 R
+N 0 0 M 950 0 D S
+U
+V 1159 5520 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_10
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  2.20c  1.27c Vector: -Sv20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 5953 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 5953 M (Input:  2.20c  1.27c Vector: -Sv20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -Sv20p+e+z1q -W2p -Gred -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_11
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{1 0 0 C} FS
+O1
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 6120 T 29.9966677697 R
+N 0 0 M 950 0 D S
+U
+V 1159 6720 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_12
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  2.20  1.27 Vector: -Sv20p+e+z1q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 7153 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 7153 M (Input:  2.20  1.27 Vector: -Sv20p+e+z1q) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -Sv20p+e+z0.394q -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_13
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{0.252 0.253 0.639 C} FS
+O1
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 7320 T 29.9966677697 R
+N 0 0 M 951 0 D S
+U
+V 1160 7920 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_14
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 8353 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 8353 M (Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q --PROJ_LENGTH_UNIT=inch) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -Sv20p+e+z0.0394q -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_15
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{0.945 0.796 0.227 C} FS
+O1
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 8520 T 29.9966677697 R
+N 0 0 M 951 0 D S
+U
+V 1160 9120 T 29.9966677697 R
+PSL_vecheadpen
+33 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_16
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 9553 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 9553 M (Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q --PROJ_LENGTH_UNIT=inch) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -Sv20p+e+v0.0394q -W2p+c -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_17
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3720 0 D
+0 10920 D
+-3720 0 D
+P
+PSL_clip N
+V
+33 W
+{0.945 0.797 0.227 C} FS
+O1
+0.945 0.797 0.227 C
+/PSL_vecheadpen {33 W 0.945 0.797 0.227 C 1 1 /Normal PSL_transp [] 0 B} def
+33 W
+V 120 9720 T 30 R
+N 0 0 M 951 0 D S
+U
+V 1160 10320 T 30 R
+PSL_vecheadpen
+67 W
+0 0 M
+-333 89 D
+83 -89 D
+-83 -89 D
+P clip fs P S 
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -Jx1i
+%@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
+%%BeginObject PSL_Layer_18
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 30 25.4 Vector: -Sv20p+e+v0.0394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 10753 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 10753 M (Input: 30 25.4 Vector: -Sv20p+e+v0.0394q --PROJ_LENGTH_UNIT=inch) tl Z
+%%EndObject
+0 A
+FQ
+O0
+4200 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -JM9.1i+dh -Bafg -S=20p+e -W2p -Gred -X3.5i -R-0.1/3/-0.1/9
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_19
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+0 A
+120 0 M
+0 10920 D
+S
+1323 0 M
+0 10920 D
+S
+2527 0 M
+0 10920 D
+S
+3730 0 M
+0 10920 D
+S
+0 120 M
+3730 0 D
+S
+0 1315 M
+3730 0 D
+S
+0 2510 M
+3730 0 D
+S
+0 3706 M
+3730 0 D
+S
+0 4904 M
+3730 0 D
+S
+0 6102 M
+3730 0 D
+S
+0 7303 M
+3730 0 D
+S
+0 8506 M
+3730 0 D
+S
+0 9711 M
+3730 0 D
+S
+0 10920 M
+3730 0 D
+S
+8 W
+N 120 0 M 0 -63 D S
+N 1323 0 M 0 -63 D S
+N 2527 0 M 0 -63 D S
+N 3730 0 M 0 -63 D S
+N 0 120 M -63 0 D S
+N 0 1315 M -63 0 D S
+N 0 2510 M -63 0 D S
+N 0 3706 M -63 0 D S
+N 0 4904 M -63 0 D S
+N 0 6102 M -63 0 D S
+N 0 7303 M -63 0 D S
+N 0 8506 M -63 0 D S
+N 0 9711 M -63 0 D S
+N 0 10920 M -63 0 D S
+N 120 0 M 0 -32 D S
+N 421 0 M 0 -32 D S
+N 722 0 M 0 -32 D S
+N 1023 0 M 0 -32 D S
+N 1323 0 M 0 -32 D S
+N 1624 0 M 0 -32 D S
+N 1925 0 M 0 -32 D S
+N 2226 0 M 0 -32 D S
+N 2527 0 M 0 -32 D S
+N 2827 0 M 0 -32 D S
+N 3128 0 M 0 -32 D S
+N 3429 0 M 0 -32 D S
+N 3730 0 M 0 -32 D S
+N 0 120 M -32 0 D S
+N 0 418 M -32 0 D S
+N 0 717 M -32 0 D S
+N 0 1016 M -32 0 D S
+N 0 1315 M -32 0 D S
+N 0 1613 M -32 0 D S
+N 0 1912 M -32 0 D S
+N 0 2211 M -32 0 D S
+N 0 2510 M -32 0 D S
+N 0 2809 M -32 0 D S
+N 0 3108 M -32 0 D S
+N 0 3407 M -32 0 D S
+N 0 3706 M -32 0 D S
+N 0 4006 M -32 0 D S
+N 0 4305 M -32 0 D S
+N 0 4604 M -32 0 D S
+N 0 4904 M -32 0 D S
+N 0 5203 M -32 0 D S
+N 0 5503 M -32 0 D S
+N 0 5803 M -32 0 D S
+N 0 6102 M -32 0 D S
+N 0 6402 M -32 0 D S
+N 0 6703 M -32 0 D S
+N 0 7003 M -32 0 D S
+N 0 7303 M -32 0 D S
+N 0 7604 M -32 0 D S
+N 0 7904 M -32 0 D S
+N 0 8205 M -32 0 D S
+N 0 8506 M -32 0 D S
+N 0 8807 M -32 0 D S
+N 0 9108 M -32 0 D S
+N 0 9410 M -32 0 D S
+N 0 9711 M -32 0 D S
+N 0 10013 M -32 0 D S
+N 0 10315 M -32 0 D S
+N 0 10618 M -32 0 D S
+N 0 10920 M -32 0 D S
+120 -110 M PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+158 F0
+(0è) tc Z
+1323 -110 M (1èE) tc Z
+2527 -110 M (2èE) tc Z
+3730 -110 M (3èE) tc Z
+/PSL_AH1 0
+-110 120 M (0è) mr Z
+(0è) sw mx
+-110 1315 M (1èN) mr Z
+(1èN) sw mx
+-110 2510 M (2èN) mr Z
+(2èN) sw mx
+-110 3706 M (3èN) mr Z
+(3èN) sw mx
+-110 4904 M (4èN) mr Z
+(4èN) sw mx
+-110 6102 M (5èN) mr Z
+(5èN) sw mx
+-110 7303 M (6èN) mr Z
+(6èN) sw mx
+-110 8506 M (7èN) mr Z
+(7èN) sw mx
+-110 9711 M (8èN) mr Z
+(8èN) sw mx
+-110 10920 M (9èN) mr Z
+(9èN) sw mx
+def
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+{0 A} FS
+O0
+/FO {P}!
+112 134 M
+43 24 D
+21 13 D
+54 30 D
+21 13 D
+225 128 D
+21 13 D
+54 30 D
+21 13 D
+267 153 D
+17 -29 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+735 571 M
+287 76 D
+35 10 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-53 -52 D
+19 110 D
+PSL_clip N
+735 571 M
+287 76 D
+35 10 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-53 -52 D
+19 110 D
+FO
+735 571 M
+287 76 D
+35 10 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-53 -52 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+24 W
+0 A
+0 0 M
+3730 0 D
+0 10920 D
+-933 0 D
+-932 0 D
+-933 0 D
+-932 0 D
+0 -10920 D
+P S
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_20
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 60 100 Vector: -S=20p+e) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 1148 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 1148 M (Input: 60 100 Vector: -S=20p+e) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -S=20p+e -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_21
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+{0 A} FS
+/FO {P}!
+112 1329 M
+182 104 D
+546 313 D
+16 -29 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+735 1766 M
+144 38 D
+47 13 D
+132 35 D
+-27 -26 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-9 -8 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-35 -34 D
+19 110 D
+PSL_clip N
+735 1766 M
+144 38 D
+47 13 D
+132 35 D
+-27 -26 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-9 -8 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-35 -34 D
+19 110 D
+FO
+735 1766 M
+144 38 D
+47 13 D
+132 35 D
+-27 -26 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-9 -8 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-35 -34 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_22
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 60 54n Vector: -S=20p+e) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 2343 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 2343 M (Input: 60 54n Vector: -S=20p+e) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -S=20p+e -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_23
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+{0 A} FS
+/FO {P}!
+112 2524 M
+225 129 D
+21 13 D
+54 30 D
+21 13 D
+54 30 D
+21 13 D
+332 190 D
+17 -29 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+736 2962 M
+239 63 D
+47 13 D
+36 10 D
+-17 -18 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+19 110 D
+PSL_clip N
+736 2962 M
+239 63 D
+47 13 D
+36 10 D
+-17 -18 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+19 110 D
+FO
+736 2962 M
+239 63 D
+47 13 D
+36 10 D
+-17 -18 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_24
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 60 100k Vector: -S=20p+e) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 3539 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 3539 M (Input: 60 100k Vector: -S=20p+e) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -S=20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_25
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+{0 A} FS
+/FO {P}!
+112 3721 M
+289 165 D
+21 13 D
+54 30 D
+21 13 D
+54 30 D
+21 13 D
+268 153 D
+16 -29 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+735 4158 M
+323 86 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -61 D
+20 111 D
+PSL_clip N
+735 4158 M
+323 86 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -61 D
+20 111 D
+FO
+735 4158 M
+323 86 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -61 D
+20 111 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_26
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 86.60 50.00 Vector: -S=20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 4737 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 4737 M (Input: 86.60 50.00 Vector: -S=20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -S=20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_27
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+{0 A} FS
+/FO {P}!
+112 4918 M
+311 178 D
+21 13 D
+54 30 D
+21 13 D
+54 30 D
+21 13 D
+54 30 D
+21 13 D
+172 98 D
+16 -29 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+736 5356 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+20 111 D
+PSL_clip N
+736 5356 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+20 111 D
+FO
+736 5356 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-27 -26 D
+20 111 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_28
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 86.60k 50.00k Vector: -S=20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 5935 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 5935 M (Input: 86.60k 50.00k Vector: -S=20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -S=20p+e+z -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_29
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+{0 A} FS
+/FO {P}!
+112 6117 M
+172 98 D
+21 13 D
+376 215 D
+21 13 D
+140 80 D
+17 -29 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+737 6556 M
+180 47 D
+47 13 D
+96 26 D
+-26 -27 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-26 -27 D
+-9 -8 D
+-8 -9 D
+19 110 D
+PSL_clip N
+737 6556 M
+180 47 D
+47 13 D
+96 26 D
+-26 -27 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-26 -27 D
+-9 -8 D
+-8 -9 D
+19 110 D
+FO
+737 6556 M
+180 47 D
+47 13 D
+96 26 D
+-26 -27 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-26 -27 D
+-9 -8 D
+-8 -9 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_30
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 46.76n 27.00n Vector: -S=20p+e+z) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 7136 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 7136 M (Input: 46.76n 27.00n Vector: -S=20p+e+z) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -S=20p+e+z10q -W2p -Gred -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_31
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+{0 A} FS
+/FO {P}!
+112 7317 M
+291 167 D
+54 31 D
+54 31 D
+205 117 D
+21 13 D
+108 61 D
+17 -28 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{1 0 0 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+741 7758 M
+322 85 D
+-44 -43 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-9 -8 D
+19 110 D
+PSL_clip N
+741 7758 M
+322 85 D
+-44 -43 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-9 -8 D
+19 110 D
+FO
+741 7758 M
+322 85 D
+-44 -43 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-27 -26 D
+-8 -9 D
+-9 -8 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_32
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  8.66  5.00 Vector: -S=20p+e+z10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 8338 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 8338 M (Input:  8.66  5.00 Vector: -S=20p+e+z10q) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -S=20p+e+z10q -W2p -C -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_33
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {17 W 0 A 1 1 /Normal PSL_transp [] 0 B} def
+V
+{0 A} FS
+/FO {P}!
+112 8520 M
+670 384 D
+65 37 D
+17 -28 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+{0.159 0.734 0.925 C} FS
+O1
+2 setlinecap
+O0
+clipsave
+743 8962 M
+322 85 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+19 110 D
+PSL_clip N
+743 8962 M
+322 85 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+19 110 D
+FO
+743 8962 M
+322 85 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-97 -95 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-9 -8 D
+19 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_34
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input:  8.66  5.00 Vector: -S=20p+e+z10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 9544 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 9544 M (Input:  8.66  5.00 Vector: -S=20p+e+z10q) tl Z
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt plot3d -S=20p+e+v10q -W2p+c -C -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_35
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+clipsave
+0 0 M
+3730 0 D
+0 10920 D
+-3730 0 D
+P
+PSL_clip N
+V
+33 W
+/PSL_vecheadpen {33 W 0.159 0.734 0.925 C 1 1 /Normal PSL_transp [] 0 B} def
+V
+0.159 0.734 0.925 C
+{0.159 0.734 0.925 C} FS
+/FO {P}!
+112 9726 M
+22 12 D
+21 13 D
+185 105 D
+21 13 D
+185 105 D
+21 13 D
+282 161 D
+17 -29 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-22 -13 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -12 D
+-22 -13 D
+-22 -12 D
+-21 -13 D
+-22 -12 D
+-22 -12 D
+-21 -13 D
+P
+FO
+/FO {fs os}!
+FO
+U
+V
+PSL_vecheadpen
+33 W
+O1
+2 setlinecap
+O0
+clipsave
+745 10168 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-9 -8 D
+20 110 D
+PSL_clip N
+745 10168 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-9 -8 D
+20 110 D
+FO
+745 10168 M
+323 86 D
+-27 -26 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-36 -34 D
+-17 -18 D
+-18 -17 D
+-8 -9 D
+-62 -60 D
+-17 -18 D
+-9 -8 D
+20 110 D
+P S
+PSL_cliprestore
+0 setlinecap
+O1
+U
+U
+PSL_cliprestore
+%%EndObject
+0 A
+FQ
+O0
+0 0 TM
+% PostScript produced by:
+%@GMT: gmt text -F+f6.5p+jLT -Gwhite -Dj0.1c -N -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
+%%BeginObject PSL_Layer_36
+0 setlinecap
+0 setlinejoin
+3.32550952342 setmiterlimit
+4 W
+{1 A} FS
+PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
+108 F0
+V
+(Input: 60 10 Vector: -S=20p+e+v10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+/PSL_dx 16 def
+/PSL_dy 16 def
+47 10752 T 0 PSL_dim_h neg T
+PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
+U
+47 10752 M (Input: 60 10 Vector: -S=20p+e+v10q) tl Z
+%%EndObject
+grestore
+PSL_movie_label_completion /PSL_movie_label_completion {} def
+PSL_movie_prog_indicator_completion /PSL_movie_prog_indicator_completion {} def
+%PSL_Begin_Trailer
+%%PageTrailer
+U
+showpage
+%%Trailer
+end
+%%EOF

--- a/test/psxyz/vector3d_mods.ps
+++ b/test/psxyz/vector3d_mods.ps
@@ -5,7 +5,7 @@
 %%Creator: GMT6
 %%For: unknown
 %%DocumentNeededResources: font Helvetica
-%%CreationDate: Thu Jan  6 18:18:11 2022
+%%CreationDate: Thu Jan  6 19:36:16 2022
 %%LanguageLevel: 2
 %%DocumentData: Clean7Bit
 %%Orientation: Portrait
@@ -1260,7 +1260,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot3d -Sv20p+e+z0.394q -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@GMT: gmt plot3d -Sv20p+e+z0.394q+c -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
 %@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
 %%BeginObject PSL_Layer_13
 0 setlinecap
@@ -1310,20 +1310,20 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q+c --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 8353 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 8353 M (Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q --PROJ_LENGTH_UNIT=inch) tl Z
+47 8353 M (Input:  2.20  1.27 Vector: -Sv20p+e+z0.394q+c --PROJ_LENGTH_UNIT=inch) tl Z
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot3d -Sv20p+e+z0.0394q -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@GMT: gmt plot3d -Sv20p+e+z0.0394q+c -W2p -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
 %@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
 %%BeginObject PSL_Layer_15
 0 setlinecap
@@ -1373,20 +1373,20 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q+c --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 9553 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 9553 M (Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q --PROJ_LENGTH_UNIT=inch) tl Z
+47 9553 M (Input: 22.00 12.70 Vector: -Sv20p+e+z0.0394q+c --PROJ_LENGTH_UNIT=inch) tl Z
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot3d -Sv20p+e+v0.0394q -W2p+c -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
+%@GMT: gmt plot3d -Sv20p+e+v0.0394q+c -W2p+c -C --PROJ_LENGTH_UNIT=inch -R-0.1/3/-0.1/9 -Jx1i
 %@PROJ: xy -0.10000000 3.00000000 -0.10000000 9.00000000 -0.100 3.000 -0.100 9.000 +xy
 %%BeginObject PSL_Layer_17
 0 setlinecap
@@ -1437,13 +1437,13 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input: 30 25.4 Vector: -Sv20p+e+v0.0394q --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input: 30 25.4 Vector: -Sv20p+e+v0.0394q+c --PROJ_LENGTH_UNIT=inch) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 10753 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 10753 M (Input: 30 25.4 Vector: -Sv20p+e+v0.0394q --PROJ_LENGTH_UNIT=inch) tl Z
+47 10753 M (Input: 30 25.4 Vector: -Sv20p+e+v0.0394q+c --PROJ_LENGTH_UNIT=inch) tl Z
 %%EndObject
 0 A
 FQ
@@ -2675,7 +2675,7 @@ FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot3d -S=20p+e+z10q -W2p -C -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@GMT: gmt plot3d -S=20p+e+z10q+c -W2p -C -R-0.1/3/-0.1/9 -JM9.1i+dh
 %@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_33
 0 setlinecap
@@ -2810,20 +2810,20 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input:  8.66  5.00 Vector: -S=20p+e+z10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input:  8.66  5.00 Vector: -S=20p+e+z10q+c) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 9544 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 9544 M (Input:  8.66  5.00 Vector: -S=20p+e+z10q) tl Z
+47 9544 M (Input:  8.66  5.00 Vector: -S=20p+e+z10q+c) tl Z
 %%EndObject
 0 A
 FQ
 O0
 0 0 TM
 % PostScript produced by:
-%@GMT: gmt plot3d -S=20p+e+v10q -W2p+c -C -R-0.1/3/-0.1/9 -JM9.1i+dh
+%@GMT: gmt plot3d -S=20p+e+v10q+c -W2p+c -C -R-0.1/3/-0.1/9 -JM9.1i+dh
 %@PROJ: merc -0.10000000 3.00000000 -0.10000000 9.00000000 -172545.211 172545.211 -11057.433 999341.310 +proj=merc +lon_0=1.45 +k=1 +x_0=0 +y_0=0 +units=m +a=6378137.000 +b=6356752.314 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
 %%BeginObject PSL_Layer_35
 0 setlinecap
@@ -2966,13 +2966,13 @@ O0
 PSL_font_encode 0 get 0 eq {Standard+_Encoding /Helvetica /Helvetica PSL_reencode PSL_font_encode 0 1 put} if
 108 F0
 V
-(Input: 60 10 Vector: -S=20p+e+v10q) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
+(Input: 60 10 Vector: -S=20p+e+v10q+c) V MU 0 0 M E /PSL_dim_w edef FP pathbbox N /PSL_dim_h edef /PSL_dim_x1 edef /PSL_dim_d edef /PSL_dim_x0 edef U
 /PSL_dx 16 def
 /PSL_dy 16 def
 47 10752 T 0 PSL_dim_h neg T
 PSL_dim_h PSL_dim_d sub PSL_dy 2 mul add PSL_dim_x1 PSL_dim_x0 sub PSL_dx 2 mul add PSL_dim_x0 PSL_dx sub PSL_dim_d PSL_dy sub Sb
 U
-47 10752 M (Input: 60 10 Vector: -S=20p+e+v10q) tl Z
+47 10752 M (Input: 60 10 Vector: -S=20p+e+v10q+c) tl Z
 %%EndObject
 grestore
 PSL_movie_label_completion /PSL_movie_label_completion {} def

--- a/test/psxyz/vector3d_mods.sh
+++ b/test/psxyz/vector3d_mods.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Test various ways of plotting vectors via psxyz
+
+gmt begin vector3d_mods
+	scl=$(gmt math --FORMAT_FLOAT_OUT=%.3g -Q 2.54 INV =)
+	scl1=$(gmt math --FORMAT_FLOAT_OUT=%.3g -Q 2.54 INV 10 DIV =)
+	gmt set MAP_FRAME_TYPE=plain FORMAT_FLOAT_OUT=%5.2f
+	# Get vector components of a 1 inch long vector with direction of 30 degrees from horizontal
+	dx=$(gmt math -Q 2.54 30 COSD MUL =)
+	dy=$(gmt math -Q 2.54 30 SIND MUL =)
+	dx1=$(gmt math -Q $dx 10 MUL =)
+	dy1=$(gmt math -Q $dy 10 MUL =)
+	dx_km=$(gmt math -Q 100 30 COSD MUL =)
+	dy_km=$(gmt math -Q 100 30 SIND MUL =)
+	dx_n=$(gmt math -Q $dx_km 1.852 DIV =)
+	dy_n=$(gmt math -Q $dy_km 1.852 DIV =)
+	dx2=$(gmt math -Q $dx_km 0.1 MUL =)
+	dy2=$(gmt math -Q $dy_km 0.1 MUL =)
+	gmt makecpt -Cturbo -T0/40
+	textopt="-F+f6.5p+jLT -Gwhite -Dj0.1c -N"
+	### CARTESIAN
+	# Direction, length given as 2.54, implying 2.54c
+	echo 0 0 0 30 2.54 | gmt plot3d -R-0.1/3/-0.1/9 -Jx1i -Bafg -Sv20p+e -W2p -Gred
+	echo "-0.1 0.9 Input: 30 2.54 Vector: -Sv20p+e" | gmt text $textopt
+	# Direction, length given as 1, and change default unit to be inch
+	echo 0 1 0 30 1 | gmt plot3d -Sv20p+e -W2p -Gred --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 1.9 Input: 30 1 Vector: -Sv20p+e --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	# Direction, length given as 1i, yet trying to change unit
+	echo 0 2 0 30 1i | gmt plot3d -Sv20p+e -W2p -Gred --PROJ_LENGTH_UNIT=cm
+	echo "-0.1 2.9 Input: 30 1i Vector: -Sv20p+e --PROJ_LENGTH_UNIT=cm" | gmt text $textopt
+	# dx, dy in assumed plot units (cm) and unit scale
+	echo 0 3 0 ${dx} ${dy} | gmt plot3d -Sv20p+e+z -W2p -Gred
+	echo "-0.1 3.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z" | gmt text $textopt
+	# dx, dy in actual plot units (cm) and unit scale
+	echo 0 4 0 ${dx}c ${dy}c | gmt plot3d -Sv20p+e+z -W2p -Gred
+	echo "-0.1 4.9 Input: ${dx}c ${dy}c Vector: -Sv20p+e+z" | gmt text $textopt
+	# dx, dy in specified user units with scale
+	echo 0 5 0 ${dx} ${dy} | gmt plot3d -Sv20p+e+z1q -W2p -Gred
+	echo "-0.1 5.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z1q" | gmt text $textopt
+	# dx, dy in specified plot units with scale, and color based on magintude
+	echo 0 6 0 ${dx} ${dy} | gmt plot3d -Sv20p+e+z${scl}q -W2p -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 6.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z${scl}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	# dx, dy in specified data units with scale, and color based on magintude
+	echo 0 7 0 ${dx1} ${dy1} | gmt plot3d -Sv20p+e+z${scl1}q -W2p -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 7.9 Input: ${dx1} ${dy1} Vector: -Sv20p+e+z${scl1}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	# magnitude in specified data units with scale, and color based on magintude
+	echo 0 8 0 30 25.4 | gmt plot3d -Sv20p+e+v${scl1}q -W2p+c -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 8.9 Input: 30 25.4 Vector: -Sv20p+e+v${scl1}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	### GEOVECTOR
+	# Direction, length given as 100, imnplying 100k
+	echo 0 0 0 60 100 | gmt plot3d -JM9.1i+dh -Bafg -S=20p+e -W2p -Gred -X3.5i
+	echo "-0.1 0.9 Input: 60 100 Vector: -S=20p+e" | gmt text $textopt
+	# Direction, length given as 54n ~ 100k
+	echo 0 1 0 60 54n | gmt plot3d -S=20p+e -W2p -Gred
+	echo "-0.1 1.9 Input: 60 54n Vector: -S=20p+e" | gmt text $textopt
+	# Direction, length given as 100kÏ
+	echo 0 2 0 60 100k | gmt plot3d -S=20p+e -W2p -Gred
+	echo "-0.1 2.9 Input: 60 100k Vector: -S=20p+e" | gmt text $textopt
+	# dx_km, dy_km to mimick the same
+	echo 0 3 0 ${dx_km} ${dy_km} | gmt plot3d -S=20p+e+z -W2p -Gred
+	echo "-0.1 3.9 Input: ${dx_km} ${dy_km} Vector: -S=20p+e+z" | gmt text $textopt
+	# dx_km, dy_km to mimick the same but with unit
+	echo 0 4 0 ${dx_km}k ${dy_km}k | gmt plot3d -S=20p+e+z -W2p -Gred
+	echo "-0.1 4.9 Input: ${dx_km}k ${dy_km}k Vector: -S=20p+e+z" | gmt text $textopt
+	# dx_km, dy_km to mimick the same
+	echo 0 5 0 ${dx_n}n ${dy_n}n | gmt plot3d -S=20p+e+z -W2p -Gred
+	echo "-0.1 5.9 Input: ${dx_n}n ${dy_n}n Vector: -S=20p+e+z" | gmt text $textopt
+	# dx, dy in specific data units with scale
+	echo 0 6 0 ${dx2} ${dy2} | gmt plot3d -S=20p+e+z10q -W2p -Gred
+	echo "-0.1 6.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q" | gmt text $textopt
+	# dx, dy in specific data units with scale, and color based on magintude
+	echo 0 7 0 ${dx2} ${dy2} | gmt plot3d -S=20p+e+z10q -W2p -C
+	echo "-0.1 7.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q" | gmt text $textopt
+	# magnitude in specific data units with scale, and color based on magintude
+	echo 0 8 0 60 10 | gmt plot3d -S=20p+e+v10q -W2p+c -C
+	echo "-0.1 8.9 Input: 60 10 Vector: -S=20p+e+v10q" | gmt text $textopt
+gmt end show

--- a/test/psxyz/vector3d_mods.sh
+++ b/test/psxyz/vector3d_mods.sh
@@ -39,14 +39,14 @@ gmt begin vector3d_mods
 	echo 0 5 0 ${dx} ${dy} | gmt plot3d -Sv20p+e+z1q -W2p -Gred
 	echo "-0.1 5.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z1q" | gmt text $textopt
 	# dx, dy in specified plot units with scale, and color based on magintude
-	echo 0 6 0 ${dx} ${dy} | gmt plot3d -Sv20p+e+z${scl}q -W2p -C --PROJ_LENGTH_UNIT=inch
-	echo "-0.1 6.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z${scl}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	echo 0 6 0 ${dx} ${dy} | gmt plot3d -Sv20p+e+z${scl}q+c -W2p -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 6.9 Input: ${dx} ${dy} Vector: -Sv20p+e+z${scl}q+c --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
 	# dx, dy in specified data units with scale, and color based on magintude
-	echo 0 7 0 ${dx1} ${dy1} | gmt plot3d -Sv20p+e+z${scl1}q -W2p -C --PROJ_LENGTH_UNIT=inch
-	echo "-0.1 7.9 Input: ${dx1} ${dy1} Vector: -Sv20p+e+z${scl1}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	echo 0 7 0 ${dx1} ${dy1} | gmt plot3d -Sv20p+e+z${scl1}q+c -W2p -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 7.9 Input: ${dx1} ${dy1} Vector: -Sv20p+e+z${scl1}q+c --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
 	# magnitude in specified data units with scale, and color based on magintude
-	echo 0 8 0 30 25.4 | gmt plot3d -Sv20p+e+v${scl1}q -W2p+c -C --PROJ_LENGTH_UNIT=inch
-	echo "-0.1 8.9 Input: 30 25.4 Vector: -Sv20p+e+v${scl1}q --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
+	echo 0 8 0 30 25.4 | gmt plot3d -Sv20p+e+v${scl1}q+c -W2p+c -C --PROJ_LENGTH_UNIT=inch
+	echo "-0.1 8.9 Input: 30 25.4 Vector: -Sv20p+e+v${scl1}q+c --PROJ_LENGTH_UNIT=inch" | gmt text $textopt
 	### GEOVECTOR
 	# Direction, length given as 100, imnplying 100k
 	echo 0 0 0 60 100 | gmt plot3d -JM9.1i+dh -Bafg -S=20p+e -W2p -Gred -X3.5i
@@ -70,9 +70,9 @@ gmt begin vector3d_mods
 	echo 0 6 0 ${dx2} ${dy2} | gmt plot3d -S=20p+e+z10q -W2p -Gred
 	echo "-0.1 6.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q" | gmt text $textopt
 	# dx, dy in specific data units with scale, and color based on magintude
-	echo 0 7 0 ${dx2} ${dy2} | gmt plot3d -S=20p+e+z10q -W2p -C
-	echo "-0.1 7.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q" | gmt text $textopt
+	echo 0 7 0 ${dx2} ${dy2} | gmt plot3d -S=20p+e+z10q+c -W2p -C
+	echo "-0.1 7.9 Input: ${dx2} ${dy2} Vector: -S=20p+e+z10q+c" | gmt text $textopt
 	# magnitude in specific data units with scale, and color based on magintude
-	echo 0 8 0 60 10 | gmt plot3d -S=20p+e+v10q -W2p+c -C
-	echo "-0.1 8.9 Input: 60 10 Vector: -S=20p+e+v10q" | gmt text $textopt
+	echo 0 8 0 60 10 | gmt plot3d -S=20p+e+v10q+c -W2p+c -C
+	echo "-0.1 8.9 Input: 60 10 Vector: -S=20p+e+v10q+c" | gmt text $textopt
 gmt end show

--- a/test/psxyz/vector3d_mods.sh
+++ b/test/psxyz/vector3d_mods.sh
@@ -2,6 +2,7 @@
 # Test various ways of plotting vectors via psxyz
 
 gmt begin vector3d_mods
+	gmt set PROJ_LENGTH_UNIT cm
 	scl=$(gmt math --FORMAT_FLOAT_OUT=%.3g -Q 2.54 INV =)
 	scl1=$(gmt math --FORMAT_FLOAT_OUT=%.3g -Q 2.54 INV 10 DIV =)
 	gmt set MAP_FRAME_TYPE=plain FORMAT_FLOAT_OUT=%5.2f

--- a/test/psxyz/vector3d_mods.sh
+++ b/test/psxyz/vector3d_mods.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test various ways of plotting vectors via psxyz
 
 gmt begin vector3d_mods


### PR DESCRIPTION
See #6190 for background.  This PR addresses the sub-tasks 1 , 2 and 6 (last task 5 will be handled after this PR is merged):

(**Task 1)**: Offer a way, like **+z**_scale_, to accept polar form direction, length input, with length in data units to be scaled to plot units. I chose **+v**_scale_ for "scale vector data length to plot length". Append a unit from c|i|p to indicate the unit of the product.
(**Task 2**): Allow the shrinking limit to be given in data units or plot units. Follow the lead of **plot** **-Sb** and use unit **q** to indicate data units (since no unit would mean cm and hence a plot unit for Cartesian vectors and km as map unit for geovectors).
(**Task 6**): Ensure that any use of vector modifiers that cannot apply in a particular module result in errors.

Along the way, a few other things had to happen:

1. I selected **q** (for user quantity) to use as a unit signifying the user's data unit.  We used **u** in plot **-Sb**, **-So**, and **-Su** but these have now been changed to **q** as well (backwards compatible of course).  This prevents the conflict with unit **u** (survey foot).
2. Both **+v** and **+z** can take unit **q** as well to indicate that input data are given in user quantities and the scale results in either plot units (Cartesian vector) or map units (geovector).
3. New vector attribute modifier **+c** was introduced to let us use the data magnitude instead of a separate input column with **-C** to look up vector head colors.
4. Fixed a bug for plotting vectors with fill and pen color taken from a CPT. The bug prevented the head outline pen from being changed.  We had no such test example so no failure, but I found this when plotting the top two rows.
5. Documentation updates and clarifications.

Here is one of two new tests (for **psxy**, the **psxyz** is identical since I did not use any perspective view point):

![vector2d_mods](https://user-images.githubusercontent.com/26473567/148508300-fc299c1e-240b-4ed6-8d2b-601c2f7a572e.png)

This test (psxy/vector2_mods.sh) plots a bunch of 1 inch = 2.54 cm vectors (left) or 100 km geovectors (right) but it does so using a wide range of input, units and vector attributes; these are plotted as text.  Top two row use the new **+c** modifier with a CPT and **-W+c** modifications. Left column is Cartesian, right column are geovectors.  View them from the bottom to the top to see what is going on with the input.  We test combination of unit-less and unit input points, vector components in plot or map units, and magnitudes and components in quantity units (**q**) scaled to suitable plot and map lengths. Note result for left side y = 3: Input length is given as 1i (with unit) so specifying **PROJ_LENGHT_UNIT** as cm has no effect since the data unit takes precedence. We experiment with the new **+v** and the improved **+z** modifier.