### PR TITLE
Use prepend instead of add in instructions

### DIFF
--- a/cmake/dist/startup_macosx.sh.in
+++ b/cmake/dist/startup_macosx.sh.in
@@ -23,7 +23,7 @@ EOF
   export -f gmt
   unset DYLD_LIBRARY_PATH
   gmt
-  echo -e "Note 1: If you want to use GMT outside of this terminal or in scripts, then follow these steps:\n        a) export GMTHOME=${BUNDLE_RESOURCES}\n        b) add \$GMTHOME/bin to your path\n        c) export PROJ_LIB=\$GMTHOME/share/proj\n        d) export GS_LIB=\$GMTHOME/share/ghostscript/Resource/Init\n        e) export MAGICK_CONFIGURE_PATH=\$GMTHOME/lib/GraphicsMagick/config"
+  echo -e "Note 1: If you want to use GMT outside of this terminal or in scripts, then follow these steps:\n        a) export GMTHOME=${BUNDLE_RESOURCES}\n        b) prepend \$GMTHOME/bin to your path\n        c) export PROJ_LIB=\$GMTHOME/share/proj\n        d) export GS_LIB=\$GMTHOME/share/ghostscript/Resource/Init\n        e) export MAGICK_CONFIGURE_PATH=\$GMTHOME/lib/GraphicsMagick/config"
   echo -e "Note 2: GMT may use Ghostscript, GraphicsMagick, FFmpeg, and GDAL executables; see\n        ${BUNDLE_RESOURCES}/share/Licenses for details.\n"
 
   _usershell=$(dscl . -read "/Users/$USER" UserShell)


### PR DESCRIPTION
See forum [post](https://forum.generic-mapping-tools.org/t/macos-gmt-6-3-0-bundle-alias-mystery/2498/3) for problem (now fixed by user).  This PR now states one should prepend the bundle path in order to avoid clashes with other versions on the user's system.
