### PR TITLE
BUILDING.md and INSTALL.md: remove OpenBSD

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,7 @@
 # Building GMT
 
 This document describes how to build GMT from source codes
-(stable release or development version) on Linux, FreeBSD, OpenBSD, macOS and Windows.
+(stable release or development version) on Linux, FreeBSD, macOS and Windows.
 
 ## Contents
 
@@ -165,7 +165,7 @@ with a focus on speed.
 In the build directory, type
 
 ```
-# Linux/macOS/FreeBSD/OpenBSD
+# Linux/macOS/FreeBSD
 cmake --build .
 
 # Windows
@@ -186,7 +186,7 @@ tool's default number is used.
 ## Installing
 
 ```
-# Linux/macOS/FreeBSD/OpenBSD
+# Linux/macOS/FreeBSD
 cmake --build . --target install
 
 # Windows

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 [![GitHub release](https://img.shields.io/github/release/GenericMappingTools/gmt)](https://github.com/GenericMappingTools/gmt/releases)
 
-GMT is available on Windows, macOS, Linux, FreeBSD and OpenBSD.
+GMT is available on Windows, macOS, Linux and FreeBSD.
 Source and binary packages are provided for the latest release,
 and can be downloaded from the [GitHub repository](https://github.com/GenericMappingTools/gmt/releases).
 
@@ -27,8 +27,6 @@ for compiling GMT source package (either stable release or development version).
   * [Install via conda](#install-via-conda)
 - [FreeBSD](#freebsd)
   * [Install via Ports](#install-via-freebsd-ports)
-- [OpenBSD](#openbsd)
-  * [Install via Ports](#install-via-openbsd-ports)
 
 ## Windows
 
@@ -269,8 +267,8 @@ $ pkg install gmt
 
 **Compile from Ports**
 
-If not done already, set up the **Ports Collection** (see
-https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/ports-using.html):
+If not done already, set up the **Ports Collection**
+See https://docs.freebsd.org/en/books/handbook/ports/#ports-using:
 
 ```
 portsnap fetch
@@ -287,22 +285,4 @@ Then change into directory `/usr/ports/graphics/gmt` and build:
 
 ```
 make install clean
-```
-
-## OpenBSD
-
-GMT may be installed on OpenBSD using Ports or from source.
-
-**NOTE:** The Ports Collection may provide old GMT versions. If you want the latest GMT release, consider [building the
-latest release from source](BUILDING.md).
-
-### Install via Ports
-For more information, please refer to relevant documentation from the OpenBSD project.
-
-**Precompiled**
-
-Install precompiled gmt binaries with
-
-```
-$ pkg_add gmt
 ```


### PR DESCRIPTION
* I did a test of compiling (bleeding edge) GMT on FreeBSD;
```
$ uname -r
13.0-RELEASE
```
which is flawless.

* OpenBSD on the other hand is more difficult. *I think* I compiled GMT on OpenBSD a year ago, without problems. But a recent attempt did not succeed. This is with release 7.0. The problem was with ``ucontext..``. In this PR I've removed references to OpenBSD. GMT *can* be installed on OpenBSD (precompiled), but that version is very old; 4.1.something (2006 I think was the year of the release).
OpenBSD is very strict on security and they have a lot of kernel-based measures. That means that the source code needs to be, in many ways, custom made to OpenBSD, which I think is not an option. Please review.