### PR TITLE
Update features.rst. Fix GMT_colorbar.png legend

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -2104,7 +2104,7 @@ supply suitable required and optional modifiers:
 
    Color bar placed beneath a map (here truncated).  We extended the bar to show background and foreground
    colors, and used the frame-annotation machinery to add labels.  The bar was placed with
-   **-D**\ *JBC*\ **+o**\ 0/0.35i\ **+w**\ 4.5i/0.1i\ **+h**.
+   **-D**\ *JBC*\ **+e**.
 
 .. toggle::
 


### PR DESCRIPTION
The legend ot the figure GMT_colorbar.png says: "The bar was placed with -DJBC+o0/0.35i+w4.5i/0.1i+h."

I modified it to match the script below (-DJBC+e).