### PR TITLE
Let grdedit -D+c allow setting/removing default CPT for grid

### DIFF
--- a/doc/rst/source/explain_-D_cap.rst_
+++ b/doc/rst/source/explain_-D_cap.rst_
@@ -1,7 +1,8 @@
-**-D**\ [**+x**\ *xname*][**+y**\ *yname*][**+z**\ *zname*][**+d**\ *vname*][**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*][**+t**\ *title*][**+r**\ *remark*][**+v**\ *varname*]
+**-D**\ [**+x**\ *xname*][**+y**\ *yname*][**+z**\ *zname*][**+c**\ [-|*cpt*]][**+d**\ *vname*][**+s**\ *scale*][**+o**\ *offset*][**+n**\ *invalid*][**+t**\ *title*][**+r**\ *remark*][**+v**\ *varname*]
     Give one or more combinations for values *xname*, *yname*, *zname* (3rd dimension in cube),
     and *dname* (data value name) and give the names of those variables
-    and in square bracket their units, e.g., "distance [km]"), *scale* (to multiply data values after
+    and in square bracket their units, e.g., "distance [km]"), *cpt* to set a default CPT for
+    this grid [turbo] or give - to remove any default CPT already set, *scale* (to multiply data values after
     read [normally 1]), *offset* (to add to data after scaling [normally 0]),
     *invalid* (a value to represent missing data [NaN]), *title* (anything you
     like), and *remark* (anything you like). Items not listed will remain untouched.

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1034,10 +1034,8 @@ L100:
 
 		/* Define z variable. Attempt to remove "scale_factor" or "add_offset" when no longer needed */
 		gmtnc_put_units (ncid, z_id, header->z_units);
-		if (GMT->parent->remote_info && GMT->parent->remote_id != GMT_NOTSET && GMT->parent->remote_info[GMT->parent->remote_id].CPT[0] != '-') {	/* Subset of remote grid with default CPT, save name as an attribute */
+		if (GMT->parent->remote_info && GMT->parent->remote_id != GMT_NOTSET && GMT->parent->remote_info[GMT->parent->remote_id].CPT[0] != '-')	/* Subset of remote grid with default CPT, save name as an attribute */
 			HH->cpt = strdup (GMT->parent->remote_info[GMT->parent->remote_id].CPT);
-			gmt_M_err_trap (nc_put_att_text (ncid, z_id, "cpt", strlen (HH->cpt), HH->cpt));
-		}
 
 		if (header->z_scale_factor != 1.0) {
 			gmt_M_err_trap (nc_put_att_double (ncid, z_id, "scale_factor", NC_DOUBLE, 1U, &header->z_scale_factor));
@@ -1050,6 +1048,12 @@ L100:
 		}
 		else if (job == 'u')
 			nc_del_att (ncid, z_id, "add_offset");
+
+		if (HH->cpt) {
+			gmt_M_err_trap (nc_put_att_text (ncid, z_id, "cpt", strlen (HH->cpt), HH->cpt));
+		}
+		else if (job == 'u')	/* Remove any previous if updating the header */
+			nc_del_att (ncid, z_id, "cpt");
 
 		if (z_type != NC_FLOAT && z_type != NC_DOUBLE)
 			header->nan_value = rintf (header->nan_value); /* round to integer */

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -104,8 +104,8 @@
 
 /* Used in tools that sets grdheader information via a -D option */
 
-#define GMT_GRDEDIT2D	"-D[+x<xname>][+y<yname>][+d<dname>][+s<scale>][+o<offset>][+n<invalid>][+t<title>][+r<remark>][+v<name>]"
-#define GMT_GRDEDIT3D	"-D[+x<xname>][+y<yname>][+z<zname>][+d<dname>][+s<scale>][+o<offset>][+n<invalid>][+t<title>][+r<remark>][+v<name>]"
+#define GMT_GRDEDIT2D	"-D[+x<xname>][+y<yname>][+c[-|<cpt>]][+d<dname>][+s<scale>][+o<offset>][+n<invalid>][+t<title>][+r<remark>][+v<name>]"
+#define GMT_GRDEDIT3D	"-D[+x<xname>][+y<yname>][+z<zname>][+c[-|<cpt>]][+d<dname>][+s<scale>][+o<offset>][+n<invalid>][+t<title>][+r<remark>][+v<name>]"
 
 /*! Macros for the common GMT options used in a program's usage synopsis */
 

--- a/src/grdedit.c
+++ b/src/grdedit.c
@@ -356,6 +356,7 @@ EXTERN_MSC int GMT_grdedit (void *V_API, int mode, void *args) {
 		G->header->ProjRefPROJ4 = projstring;
 
 	if (Ctrl->D.active) {
+		bool was_NaN, is_NaN;
 		double scale_factor, add_offset;
 		gmt_grdfloat nan_value;
 		GMT_Report (API, GMT_MSG_INFORMATION, "Decode and change attributes in file %s\n", out_file);
@@ -365,7 +366,9 @@ EXTERN_MSC int GMT_grdedit (void *V_API, int mode, void *args) {
 		if (gmt_decode_grd_h_info (GMT, Ctrl->D.information, G->header))
 			Return (GMT_PARSE_ERROR);
 
-		if (nan_value != G->header->nan_value) {
+		was_NaN = gmt_M_is_dnan (nan_value);
+		is_NaN  = gmt_M_is_dnan (G->header->nan_value);
+		if (was_NaN != is_NaN || (was_NaN == false && is_NaN == false && nan_value != G->header->nan_value)) {
 			/* Must read data */
 			if (!grid_was_read && GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY, NULL, Ctrl->In.file, G) == NULL)
 				Return (API->error);


### PR DESCRIPTION
Given the cpt is now one of the attributes, we need a way to add, remove, or change it via **grdedit**.  This PR adds **+c**[-|**cpt**] to the **-D** option.  If no argument is used then we add the default CPT (turbo), if argument is - we remove any default CPT from the grid, else we add the specified CPT.  The PR also fixed a bug that failed to consider NaNs as the NaN values and thus lead to unnecessary reading.
