### PR TITLE
Let grdimage -Q+zvalue set the transparent pixel indirectly

### DIFF
--- a/doc/rst/source/grdimage.rst
+++ b/doc/rst/source/grdimage.rst
@@ -23,7 +23,7 @@ Synopsis
 [ |-I|\ [*intensfile*\|\ *intensity*\|\ *modifiers*] ]
 [ |-M| ]
 [ |-N| ]
-[ |-Q|\ [*color*] ]
+[ |-Q|\ [*color*][**+z**\ *value*] ]
 [ |SYN_OPT-Rz| ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
@@ -168,9 +168,10 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ [*color*]
+**-Q**\ [*color*][**+z**\ *value*]
     Make grid nodes with NaN values transparent, using the color-masking
     feature in PostScript Level 3 (the PS device must support PS Level 3).
+    Use **+z** to select another grid value than NaN.
     If input is instead an image then black pixels are set to be transparent;
     append an alternate color to select another pixel value to be transparent.
 


### PR DESCRIPTION
Instead of specifying a specific` r/g/b` color that should be transparent, or default to grid values that are NaN, this PR adds the option to specifying a specific grid value and then determine what` r/g/b` color that is via the CPT.
Also fixes some confusion related to the order of checks: If an `r/g/b `is given via **-Q** then that should be consulted first before the NaN color.

Seems to work:

```
gmt grdmath -R0/4/0/4 -I1 X Y MUL = t.grd
gmt grdimage t.grd -JX5i -Baf -Cturbo -Q+z4 -png t
```

![t](https://user-images.githubusercontent.com/26473567/149848961-b989c8ef-4e9e-4242-8eb9-4f6248d91506.png)
