### PR TITLE
Fix incorrect check in line shortening

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -804,7 +804,7 @@ static int psl_convert_path_new (struct PSL_CTRL *PSL, double *x, double *y, int
 				if (by < 0 || by > dy) break;
 			}
 			else {
-				if (by > 0 || bx < dy) break;
+				if (by > 0 || by < dy) break;
 			}
 			/* Generic case where the intermediate point is within the x- and y-range */
 			db = abs((int)(dx * by) - (int)(bx * dy));

--- a/test/psxy/line_shortening.sh
+++ b/test/psxy/line_shortening.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Ensure the bug reported by https://github.com/GenericMappingTools/gmt/issues/6217 is gone
 # Black dots are input points to be connected by blue line
-gmt begin line_shortening
-	cat <<- EOF > t.txt
+gmt begin line_shortening png
+	cat <<- EOF > v.txt
 	2 4
 	2 1
 	2 3.5
 	EOF
-	gmt plot -R0/5/0/5 -JX8c -Ba1g1 -W1p,blue t.txt
-	gmt plot -Sc3p -Gblack t.txt
+	cat <<- EOF > h.txt
+	1	0.5
+	4	0.5
+	3.5	0.5
+	EOF
+	gmt plot -R0/5/0/5 -JX8c -Ba1g1 -W1p,blue v.txt h.txt
+	gmt plot -Sc3p -Gblack v.txt h.txt
 gmt end show

--- a/test/psxy/line_shortening.sh
+++ b/test/psxy/line_shortening.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ensure the bug reported by https://github.com/GenericMappingTools/gmt/issues/6217 is gone
+# Black dots are input points to be connected by blue line
+gmt begin line_shortening
+	cat <<- EOF > t.txt
+	2 4
+	2 1
+	2 3.5
+	EOF
+	gmt plot -R0/5/0/5 -JX8c -Ba1g1 -W1p,blue t.txt
+	gmt plot -Sc3p -Gblack t.txt
+gmt end show


### PR DESCRIPTION
The PSL library had a minor error in the line-shortening section that mostly went unnoticed but was caught by #6217.  I added a simple test based on $6217 but also added a check on horizontal lines (they were not affected). Note that ~30 other tests now fail with tiny changes to lines.  Once this PR is merged we will need to update the _PostScript_ originals in DVC.

Here is the result in master:

![was](https://user-images.githubusercontent.com/26473567/149862298-59ae04ff-310e-405b-99ab-9bbdb58152db.png)

Here is the result after the fix:

![now](https://user-images.githubusercontent.com/26473567/149862320-3dbac573-9fc7-4a00-93f6-e442acf735ea.png)
