### PR TITLE
Ensure consistent use of table, t, +t when discussing tables

### DIFF
--- a/doc/rst/source/explain_-q.rst_
+++ b/doc/rst/source/explain_-q.rst_
@@ -1,2 +1,2 @@
-**-q**\ [**i**\|\ **o**][~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-q_full>`
+**-q**\ [**i**\|\ **o**][~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **t**\|\ **s**] :ref:`(more ...) <-q_full>`
     Select input or output rows or data limit(s) [all].

--- a/doc/rst/source/explain_-q_full.rst_
+++ b/doc/rst/source/explain_-q_full.rst_
@@ -3,7 +3,7 @@ The **-q** option
 
 **Syntax**
 
-**-q**\ [**i**\|\ **o**][~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**]
+**-q**\ [**i**\|\ **o**][~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **t**\|\ **s**]
     Select specific data rows to be read and/or written.
 
 **Description**
@@ -16,7 +16,7 @@ rows *not* specified by the given ranges, prepend the selected rows with a leadi
 modifiers to control how the rows are counted [Default is **+a**]:
 
 - **+a** to count all rows in the data set.
-- **+f** to reset the count at the start of each file.
+- **+t** to reset the count at the start of each table.
 - **+s** to reset the count at the start of each segment.
 
 Alternatively, use **+c**\ *col* to indicate that the arguments instead are min/max *data limits* for the values in

--- a/doc/rst/source/explain_-qi.rst_
+++ b/doc/rst/source/explain_-qi.rst_
@@ -1,2 +1,2 @@
-**-qi**\ [~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-qi_full>`
+**-qi**\ [~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **t**\|\ **s**] :ref:`(more ...) <-qi_full>`
     Select input rows or data limit(s) [default is all rows].

--- a/doc/rst/source/explain_-qo.rst_
+++ b/doc/rst/source/explain_-qo.rst_
@@ -1,2 +1,2 @@
-**-qo**\ [~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **f**\|\ **s**] :ref:`(more ...) <-qo_full>`
+**-qo**\ [~]\ *rows*\|\ *limits*\ [**+c**\ *col*][**+a**\|\ **t**\|\ **s**] :ref:`(more ...) <-qo_full>`
     Select output rows or data limit(s) [default is all rows].

--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ [**+l**\ *min*][**+u**\ *max*][**+i**]]
 [ |-D|\ [*template*\ [**+o**\ *orig*]] ]
 [ |-E|\ [**f**\|\ **l**\|\ **m**\|\ **M**\ *stride*] ]
-[ |-F|\ [**c**\|\ **n**\|\ **p**\|\ **v**][**a**\|\ **f**\|\ **s**\|\ **r**\|\ *refpoint*] ]
+[ |-F|\ [**c**\|\ **n**\|\ **p**\|\ **v**][**a**\|\ **t**\|\ **s**\|\ **r**\|\ *refpoint*] ]
 [ |-I|\ [**tsr**] ]
 [ |-L| ]
 [ |-N|\ *col*\ [**+a**\|\ **d**] ]
@@ -116,7 +116,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**c**\|\ **n**\|\ **p**\|\ **v**][**a**\|\ **f**\|\ **s**\|\ **r**\|\ *refpoint*]
+**-F**\ [**c**\|\ **n**\|\ **p**\|\ **v**][**a**\|\ **t**\|\ **s**\|\ **r**\|\ *refpoint*]
     Alter the way points are connected (by specifying a *scheme*) and data are grouped (by specifying a *method*).
     Append one of four line connection schemes:
     **c**\ : Form continuous line segments for each group [Default].
@@ -126,7 +126,7 @@ Optional Arguments
     Optionally, append the one of four segmentation methods to define the group:
     **a**\ : Ignore all segment headers, i.e., let all points belong to a single group,
     and set group reference point to the very first point of the first file.
-    **f**\ : Consider all data in each file to be a single separate group and
+    **t**\ : Consider all data in each table to be a single separate group and
     reset the group reference point to the first point of each group.
     **s**\ : Segment headers are honored so each segment is a group; the group
     reference point is reset to the first point of each incoming segment [Default].

--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -236,7 +236,7 @@ struct GMT_COMMON {
 		bool do_z_rotation;	/* true if rotating plot about a vertical axis */
 		double z_rotation;	/* Rotation of <angle> about vertical axis */
 	} p;
-	struct q {	/* -q[i|o]<rows>,...[+c<col>][+a|f|s] */
+	struct q {	/* -q[i|o]<rows>,...[+c<col>][+a|t|s] */
 		bool active[2];
 		bool inverse[2];
 		char string[2][GMT_LEN64];

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -227,7 +227,7 @@ GMT_LOCAL unsigned int gmtio_is_segment_header (struct GMT_CTRL *GMT, char *line
 
 /*! . */
 static inline bool gmtio_outside_in_row_range (struct GMT_CTRL *GMT, int64_t row) {
-	/* Returns true of this row should be skipped according to -qi[~]<rows>,...[+a|f|s] */
+	/* Returns true of this row should be skipped according to -qi[~]<rows>,...[+a|t|s] */
 	bool pass;
 	if (GMT->common.q.mode != GMT_RANGE_ROW_IN) return false;	/* -qi<rows> not active */
 	pass = GMT->common.q.inverse[GMT_IN];

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15825,7 +15825,7 @@ struct GMT_DATASET * gmt_segmentize_data (struct GMT_CTRL *GMT, struct GMT_DATAS
 	 *   given as a, f, s and if so we pick the first point in the dataset, or first point in each
 	 *   file, or the first point in each segment to update the actual reference point.
 	 * 4) -Fv: Vectorize.  Here, consecutive points are turned into vector segments such as used
-	 *   by psxy -Sv|=<size>+s or external applications.  Again, appending a|f|s controls if we should
+	 *   by psxy -Sv|=<size>+s or external applications.  Again, appending a|t|s controls if we should
 	 *   honor the segment headers [Default is -Fvs if -Fv is given].
 	 */
 	uint64_t dim[GMT_DIM_SIZE] = {1, 0, 2, 0};	/* Put everything in one table, each segment has 2 points */

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -52,8 +52,8 @@
 #define GMT_di_OPT	"-di<nodata>[+c<col>]"
 #define GMT_do_OPT	"-do<nodata>[+c<col>]"
 #define GMT_ho_OPT	"-ho[<nrecs>][+c][+d][+m<segheader>][+r<remark>][+t<title>]"
-#define GMT_qi_OPT	"-qi[~]<rows>|<limits>[,...][+c<col>][+a|f|s]"
-#define GMT_qo_OPT	"-qo[~]<rows>|<limits>[,...][+c<col>][+a|f|s]"
+#define GMT_qi_OPT	"-qi[~]<rows>|<limits>[,...][+c<col>][+a|t|s]"
+#define GMT_qo_OPT	"-qo[~]<rows>|<limits>[,...][+c<col>][+a|t|s]"
 #define GMT_PAR_OPT	"--PAR=<value>"
 
 #ifdef GMT_MP_ENABLED
@@ -88,8 +88,8 @@
 
 /* Argument for segmentation option */
 
-#define GMT_SEGMENTIZE3	"[c|n|p][a|f|s|r|<refpoint>]"
-#define GMT_SEGMENTIZE4	"[c|n|p|v][a|f|s|r|<refpoint>]"
+#define GMT_SEGMENTIZE3	"[c|n|p][a|t|s|r|<refpoint>]"
+#define GMT_SEGMENTIZE4	"[c|n|p|v][a|t|s|r|<refpoint>]"
 
 /* Argument to *contour programs */
 
@@ -135,7 +135,7 @@
 #define GMT_n_OPT	"-n[b|c|l|n][+a][+b<BC>][+c][+t<threshold>]"
 #endif
 #define GMT_o_OPT	"-o<cols>[,...][,t[<word>]]"
-#define GMT_q_OPT	"-q[i|o][~]<rows>[,...][+c<col>][+a|f|s]"
+#define GMT_q_OPT	"-q[i|o][~]<rows>[,...][+c<col>][+a|t|s]"
 #define GMT_p_OPT	"-p[x|y|z]<azim>[/<elev>[/<zlevel>]][+w<lon0>/<lat0>[/<z0>]][+v<x0>/<y0>]"
 #define GMT_r_OPT	"-r[g|p]"
 #define GMT_s_OPT	"-s[<cols>][+a][+r]"

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -223,7 +223,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTINFO_CTRL *Ctrl, struct GMT_OP
 						break;
 					default:
 						n_errors++;
-						GMT_Report (API, GMT_MSG_ERROR, "Option -A: Flags are a|f|s.\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -A: Flags are a|t|s.\n");
 						break;
 				}
 				break;


### PR DESCRIPTION
See #6236 for background.  This PR ensures we use directives **t** or modifier **+t** when referring to tables instead of **f** and **+f** for files in some places.  Because of the mixup we will honor **f** and **+f**  under the hood for backwards compatibility but have updated the usage message and docs.  Closes #6236.
