### PR TITLE
Read dcw.conf first so it takes precedence over dcw-collections.txt

### DIFF
--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -233,12 +233,12 @@ GMT_LOCAL int gmtdcw_load_lists (struct GMT_CTRL *GMT, struct GMT_DCW_COUNTRY **
 	Collection = gmt_M_memory (GMT, NULL, n_alloc, struct GMT_DCW_COLLECTION);
 	k = 0;
 	for (collection = 0; collection < 2; collection++) {	/* Read both system and user collections */
-		if (collection == 0) {	/* Look for DCW system file (which requires 2.0.2 or higher) */
-			if (!gmtdcw_get_path (GMT, "dcw-collections", ".txt", path))
+		if (collection == 0) {	/* Look for DCW conf file first so it can override anything in the system file */
+			if (!gmtlib_getuserpath (GMT, "dcw.conf", path))
 				continue;
 		}
-		else {	/* Look for a similar user file in the user dir, if present */
-			if (!gmtlib_getuserpath (GMT, "dcw.conf", path))
+		else {	/* Look for the system DCW collection file second */
+			if (!gmtdcw_get_path (GMT, "dcw-collections", ".txt", path))
 				continue;
 		}
 		/* Here we got the requested path */


### PR DESCRIPTION
We want the user to have the ability to add their own collections and even redefine what any particular tag also present in the system file should mean.  If I want Europe to include the Bouvet Island in the S Atlantic then I am allowed to give a crazy -R setting for that name.  This requires we read the user dcw.conf _first_ since the search through the array is linear.

@Esteban82 please check if this fixes your issue in #6241.