### PR TITLE
Make sure both grd2xyz and xyz2grd handles -Z and -d

### DIFF
--- a/src/grd2xyz.c
+++ b/src/grd2xyz.c
@@ -538,10 +538,13 @@ EXTERN_MSC int GMT_grd2xyz (void *V_API, int mode, void *args) {
 
 		if (Ctrl->Z.active) {	/* Write z-values only to stdout */
 			bool previous = GMT->common.b.active[GMT_OUT], rst = false;
+			unsigned int was;
 			int (*save) (struct GMT_CTRL *, FILE *, uint64_t, double *, char *);
 			save = GMT->current.io.output;
 			Out = gmt_new_record (GMT, &d_value, NULL);	/* Since we only need to worry about numerics in this module */
-
+			was = GMT->common.d.first_col[GMT_IN];
+			if (GMT->common.d.active[GMT_IN])	/* Change the default to the only column available */
+				GMT->common.d.first_col[GMT_IN] = GMT_X;
 			if (Ctrl->Z.swab) GMT_Report (API, GMT_MSG_INFORMATION, "Binary output data will be byte swapped\n");
 			GMT->current.io.output = gmt_z_output;		/* Override and use chosen output mode */
 			GMT->common.b.active[GMT_OUT] = io.binary;	/* May have to set binary as well */
@@ -563,6 +566,7 @@ EXTERN_MSC int GMT_grd2xyz (void *V_API, int mode, void *args) {
 			GMT->current.io.output = save;			/* Reset pointer */
 			GMT->common.b.active[GMT_OUT] = previous;	/* Reset binary */
 			if (rst) GMT->current.io.io_nan_col[0] = GMT_Z;	/* Reset to what it was */
+			if (GMT->common.d.active[GMT_IN]) GMT->common.d.first_col[GMT_IN] = was;	/* Reset to what it was */
 		}
 		else if (Ctrl->E.active) {	/* ESRI format */
 			double slop;

--- a/src/xyz2grd.c
+++ b/src/xyz2grd.c
@@ -318,7 +318,7 @@ GMT_LOCAL void xyz2grd_protect_J(struct GMTAPI_CTRL *API, struct GMT_OPTION *opt
 EXTERN_MSC int GMT_xyz2grd (void *V_API, int mode, void *args) {
 	bool previous_bin_i = false, previous_bin_o = false;
 	int error = 0, scol, srow;
-	unsigned int zcol, row, col, i, *flag = NULL, n_min = 1;
+	unsigned int zcol, row, col, i, *flag = NULL, n_min = 1, was;
 	uint64_t n_empty = 0, n_confused = 0;
 	uint64_t ij, ij_gmt, n_read, n_filled = 0, n_used = 0, n_req;
 
@@ -573,6 +573,7 @@ EXTERN_MSC int GMT_xyz2grd (void *V_API, int mode, void *args) {
 
 	gmt_set_xy_domain (GMT, wesn, Grid->header);	/* May include some padding if gridline-registered */
 	if (Ctrl->Z.active && GMT->common.d.active[GMT_IN]) {
+		was = GMT->common.d.first_col[GMT_IN];
 		if (gmt_M_is_fnan (no_data_f))	/* No point testing since nan_proxy is NaN... */
 			GMT->common.d.active[GMT_IN] = false;
 		else if (GMT->common.d.first_col[GMT_IN] == GMT_Z)	/* Change the default to the only column available */
@@ -727,6 +728,8 @@ EXTERN_MSC int GMT_xyz2grd (void *V_API, int mode, void *args) {
 	if (Ctrl->Z.active) {
 		GMT->current.io.input = save_i;	/* Reset pointer */
 		GMT->common.b.active[GMT_IN] = previous_bin_i;	/* Reset binary */
+		if (GMT->common.d.active[GMT_IN])	/* Reset column */
+			GMT->common.d.first_col[GMT_IN] = was;
 		if (ij != io.n_expected) {	/* Input amount does not match expectations */
 			GMT_Report (API, GMT_MSG_ERROR, "Found %" PRIu64 " records, but %" PRIu64 " was expected (aborting)!\n", ij, io.n_expected);
 				GMT_Report (API, GMT_MSG_ERROR, "(You are probably misterpreting xyz2grd with an interpolator; see 'surface' man page)\n");


### PR DESCRIPTION
This PR follows up on the eariler #6242.  Both of these modules have **-Z** and when used the z-value is in fact in the x position and the default +c2 is not appropriate.  Also, we only want to change that default temporarily since we do not know if this call is part of an external function.
