### PR TITLE
Let coupe parse old format without error

### DIFF
--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -574,7 +574,10 @@ GMT_LOCAL unsigned int pscoupe_parse_old_A (struct GMT_CTRL *GMT, struct PSCOUPE
 		n = sscanf (&arg[1], "%lf/%lf/%lf/%lf/%lf/%lf/%lf/%lf",
 			&Ctrl->A.lon1, &Ctrl->A.lat1, &Ctrl->A.PREF.str, &Ctrl->A.p_length, &Ctrl->A.PREF.dip, &Ctrl->A.p_width, &Ctrl->A.dmin, &Ctrl->A.dmax);
 	}
-	return (n != 8) ? 1 : GMT_NOERROR;
+	if (n != 8)
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Parsing of old format %s only recovered %d items but 8 was expected - formatting/unexpected unit problem?\n", &arg[1], n);
+
+	return GMT_NOERROR;
 }
 
 static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OPTION *options) {

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -574,8 +574,10 @@ GMT_LOCAL unsigned int pscoupe_parse_old_A (struct GMT_CTRL *GMT, struct PSCOUPE
 		n = sscanf (&arg[1], "%lf/%lf/%lf/%lf/%lf/%lf/%lf/%lf",
 			&Ctrl->A.lon1, &Ctrl->A.lat1, &Ctrl->A.PREF.str, &Ctrl->A.p_length, &Ctrl->A.PREF.dip, &Ctrl->A.p_width, &Ctrl->A.dmin, &Ctrl->A.dmax);
 	}
-	if (n != 8)
-		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Parsing of old format %s only recovered %d items but 8 was expected - formatting/unexpected unit problem?\n", &arg[1], n);
+	if (n != 8) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Parsing of old format %s only recovered %d items but 8 was expected - formatting/unexpected unit problem?\n", &arg[1], n);
+		return GMT_PARSE_ERROR;
+	}
 
 	return GMT_NOERROR;
 }


### PR DESCRIPTION
See the [forum](https://forum.generic-mapping-tools.org/t/pscoupe-not-outputting-text-files-for-projected-focal-mechanisms-in-gmt-6-2-or-6-3/2523/6) post for background.  Basically, older GMT versions did not bother to check if the _sscanf_ was successful, and when we encountering 50k instead of 50 it gave up.  In GMT 6.2 we added more checking so this resulted in a parsing error but no message was given, leaving the user without any reason to believe there were problems

This PR now gives an error if scanning is unsuccessful since items following the failing item are uninitialized.

