### PR TITLE
Turn on ~1m margin for auto-size plots

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -88,7 +88,7 @@
 #define GMT_TOP_MODULE	1	/* func_level of top-level module being called */
 
 #define GMT_PAPER_DIM		32767	/* Upper limit on PostScript paper size under modern mode, in points (~11.6 meters) */
-#define GMT_PAPER_MARGIN_AUTO	5	/* Default paper margin under modern mode, in inches (12.7 centimeter) for auto-size mode */
+#define GMT_PAPER_MARGIN_AUTO	40	/* Default paper margin under modern mode, in inches (101.6 centimeter) for auto-size mode */
 #define GMT_PAPER_MARGIN_FIXED	1	/* Default paper margin under modern mode, in inches (2.54 centimeter) for fixed-size mode */
 
 #define GMT_JPEG_DEF_QUALITY	90	/* Default JPG quality value for psconvert -Tj */


### PR DESCRIPTION
We started with 5 inches but as some people prefer to lay out plots going down they can quickly run out of space.  This moves the starting point to (40i, 40i) which gives us about  1 meter marings for autoplots to move into.  This seems big enough (poster boards are usually < 1m tall?) but perhaps worrying about people making 5+ meter maps is misplaced and we should set it to 100 inches to be absolutely sure this issue is put to rest? Let me know.

Closes #195.