### PR TITLE
Avoid race conditions when we can

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -322,12 +322,9 @@ GMT_LOCAL unsigned char * gmtplot_latex_eps (struct GMT_CTRL *GMT, struct GMT_FO
 
 	/* Create unique directory for outputs, stored in tmpdir */
 
-	if (gmt_get_tempname (API, "gmt_latex", NULL, tmpdir))
-		return NULL;
-	if (gmt_mkdir (tmpdir)) {
-		GMT_Report (API, GMT_MSG_ERROR, "Unable to create directory %s - exiting.\n", tmpdir);
-		return NULL;
-	}
+    if (gmt_create_tempdir (API, "gmt_latex", tmpdir))
+        return NULL;
+
 	/* Remember where we are */
 	if (getcwd (here, PATH_MAX) == NULL) {
 		GMT_Report (API, GMT_MSG_ERROR, "Unable to determine current working directory - exiting.\n");

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -414,7 +414,8 @@ EXTERN_MSC double gmt_get_vector_shrinking (struct GMT_CTRL *GMT, struct GMT_VEC
 EXTERN_MSC unsigned int gmt_get_limits (struct GMT_CTRL *GMT, char option, char *text, unsigned int mode, double *min, double *max);
 EXTERN_MSC unsigned int gmt_unpack_rgbcolors (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, unsigned char rgbmap[]);
 EXTERN_MSC void gmt_format_region (struct GMT_CTRL *GMT, char *record, double *wesn);
-EXTERN_MSC FILE *gmt_create_tempfile (struct GMTAPI_CTRL *API, char *stem, char *extension, char path[]);
+EXTERN_MSC int gmt_create_tempdir (struct GMTAPI_CTRL *API, char *name, char *path);
+EXTERN_MSC FILE *gmt_create_tempfile (struct GMTAPI_CTRL *API, char *name, char *extension, char path[]);
 EXTERN_MSC int gmt_get_tempname (struct GMTAPI_CTRL *API, char *stem, char *extension, char path[]);
 EXTERN_MSC bool gmt_found_modifier (struct GMT_CTRL *GMT, char *string, char *mods);
 EXTERN_MSC bool gmt_is_fill (struct GMT_CTRL *GMT, char *word);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4908,6 +4908,28 @@ GMT_LOCAL void gmtsupport_make_template (struct GMTAPI_CTRL *API, char *stem, ch
 		snprintf (path, PATH_MAX, "%s_XXXXXX", stem ? stem : "gmttemp");
 }
 
+int gmt_create_tempdir (struct GMTAPI_CTRL *API, char *name, char path[]) {
+	/* Get unique directory name template and create directory in one go */
+
+	gmtsupport_make_template (API, name, path);	/* Readying the directory name template */
+
+#ifdef _WIN32
+	if (gmt_get_tempname (API, name, NULL, path))
+		return GMT_RUNTIME_ERROR;
+	if (gmt_mkdir (path)) {
+		GMT_Report (API, GMT_MSG_ERROR, "Unable to create directory %s - exiting.\n", path);
+		return GMT_RUNTIME_ERROR;
+	}
+#else
+	/* Create final temp dir name and create it at the same time to avoid race condition */
+	if (mkdtemp (path) == NULL) {
+		GMT_Report (API, GMT_MSG_ERROR, "Could not create temporary directory %s.\n", path);
+		return (GMT_RUNTIME_ERROR);
+	}
+#endif
+	return (GMT_NOERROR);
+}
+
 int gmt_get_tempname (struct GMTAPI_CTRL *API, char *stem, char *extension, char path[]) {
 	/* Create a unique temporary file or directory name on the system;
 	 * If stem is NULL we use "gmttemp" as file prefix.  If extension is not NULL we append it.


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/building-gmt-mktemp-is-dangerous/2541) for some background.  The _mktemp_ function is generally not recommended since it only creates a unique filename template, but by the time we use it to create a file it may no longer be unique (another user could have created that file, somehow).  However, when creating a directory there is _mkdtemp_ which sets the template and opens the file at the same time, avoiding this race condition.  This PR adds _gmt_create_tempdir_  (which calls _mkdtemp_) which we use (for now) in one place that previously relied on _mktemp_.  Unfortunately, not available on Windows (?) so keeping the old scheme for WIN32.

The final place we use _mktemp_ to create a unique file name is in **grdblend** but here we do _not_ want to open the file since it is an output gridfile name passed to another GMT module.  We will simply have to tolerate intolerant rants from the compilers.
