### PR TITLE
Speed up psmask -S

### DIFF
--- a/src/psmask.c
+++ b/src/psmask.c
@@ -779,10 +779,10 @@ EXTERN_MSC int GMT_psmask (void *V_API, int mode, void *args) {
 				if (gmt_M_rec_is_eof (GMT)) 		/* Reached end of file */
 					break;
 			}
-		if (In->data == NULL) {
-			gmt_quit_bad_record (API, In);
-			Return (API->error);
-		}
+			if (In->data == NULL) {
+				gmt_quit_bad_record (API, In);
+				Return (API->error);
+			}
 
 			in = In->data;	/* Only need to process numerical part here */
 
@@ -838,9 +838,10 @@ EXTERN_MSC int GMT_psmask (void *V_API, int mode, void *args) {
 					i_start = (col > d_col[jj]) ? col - d_col[jj] : 0;
 					for (ii = i_start; ii <= col + d_col[jj]; ii++) {
 						if (ii >= Grid->header->n_columns) continue;
+						ij = gmt_M_ijp (Grid->header, jj, ii);
+						if (grd[ij]) continue;	/* Already set */
 						distance = gmt_distance (GMT, x0, y0, grd_x0[ii], grd_y0[jj]);
 						if (distance > Ctrl->S.radius) continue;
-						ij = gmt_M_ijp (Grid->header, jj, ii);
 						grd[ij] = 1;
 					}
 				}


### PR DESCRIPTION
Similar to **grdmask -S** improvement in #6253: When we loop over all the nodes within a radius from a point we check if we have been here before prior to calling the distance calculator.  This will speed up execution for dense points or larger radii.
