### PR TITLE
Let gmtspatial -W extend segments from one of both ends

### DIFF
--- a/doc/rst/source/gmtspatial.rst
+++ b/doc/rst/source/gmtspatial.rst
@@ -26,6 +26,7 @@ Synopsis
 [ |-S|\ **b**\ *width*\|\ **h**\|\ **i**\|\ **u**\|\ **s**\|\ **j** ]
 [ |-T|\ [*clippolygon*] ]
 [ |SYN_OPT-V| ]
+[ |-W|\ *dist*\[*unit*][**+f**\|\ **l**] ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -215,6 +216,15 @@ Optional Arguments
     :start-after: **Syntax**
     :end-before: **Description**
 
+.. --W:
+
+**-W**\ *dist*\[*unit*][**+f**\|\ **l**]
+    Extend all segments with a new first and last point such that these points are *dist* away
+    from their neighbor point in the direction implied by the two points at each end of the
+    segment.  For geographic data you may append a *unit* (see `Units`_). To give separate
+    distances for the two ends, give distf*\[*unit*]/distl*\[*unit*] instead.  Optionally,
+    append either **+f** or **+l** to only extend the first or last point this way [both].
+
 .. include:: explain_-aspatial.rst_
 
 .. |Add_-bi| replace:: [Default is 2 input columns].
@@ -267,51 +277,37 @@ as well as the land area in km squared, try::
     gmt spatial @GSHHS_h_Australia.txt -fg -Qk
 
 To turn all lines in the multisegment file lines.txt into closed polygons,
-run
-
-   ::
+run::
 
     gmt spatial lines.txt -F > polygons.txt
 
 To compute the area of all geographic polygons in the multisegment file
-polygons.txt, run
-
-   ::
+polygons.txt, run::
 
     gmt spatial polygons.txt -Q > areas.txt
 
 Same data, but now orient all polygons to go counter-clockwise and write
-their areas to the segment headers, run
-
-   ::
+their areas to the segment headers, run::
 
     gmt spatial polygons.txt -Q+h -E+p > areas.txt
 
 To determine the areas of all the polygon segments in the file janmayen_land_full.txt,
 add this information to the segment headers, sort the segments from largest
-to smallest in area but only keep polygons with area larger than 1000 sq. meters, run
-
-   ::
+to smallest in area but only keep polygons with area larger than 1000 sq. meters, run::
 
     gmt spatial -Qe+h+p+c1000+sd -V janmayen_land_full.txt > largest_pols.txt
 
-To determine the intersections between the polygons A.txt and B.txt, run
-
-   ::
+To determine the intersections between the polygons A.txt and B.txt, run::
 
     gmt spatial A.txt B.txt -Ie > crossovers.txt
 
-To truncate polygons A.txt against polygon B.txt, resulting in an open line segment, run
-
-   ::
+To truncate polygons A.txt against polygon B.txt, resulting in an open line segment, run::
 
     gmt spatial A.txt -TB.txt > line.txt
 
 If you want to plot a polygon with holes (donut polygon) from a multiple segment file
 which contains both perimeters and holes, it could be necessary first to reorganize the file
-so it can plotted with plot. To do this, run
-
-   ::
+so it can plotted with plot. To do this, run::
 
     gmt spatial file.txt -Sh > organized_file.txt
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -5635,14 +5635,14 @@ GMT_LOCAL bool gmtinit_parse_J_option (struct GMT_CTRL *GMT, char *args_in) {
 			}
 			GMT->current.proj.N_hemi = (strchr ("AB", GMT->common.J.string[1]) == NULL) ? true : false;	/* Upper case -JoA, -JoB allows S pole views */
 			if (n_slashes == 3) {
-				double distance = 10.0;	/* Default spherical length for gmt_translate_point */
+				double distance = 10.0;	/* Default spherical length for gmtlib_translate_point */
 				n = sscanf (args, "%[^/]/%[^/]/%lf/%s", txt_a, txt_b, &az, txt_e);
 				error += gmt_verify_expectations (GMT, GMT_IS_LON, gmt_scanf (GMT, txt_a, GMT_IS_LON, &GMT->current.proj.pars[0]), txt_a);
 				error += gmt_verify_expectations (GMT, GMT_IS_LAT, gmt_scanf (GMT, txt_b, GMT_IS_LAT, &GMT->current.proj.pars[1]), txt_b);
 				if ((90.0 - fabs (GMT->current.proj.pars[1])) < distance)
 					distance = 90.0 - fabs (GMT->current.proj.pars[1]) - GMT_CONV4_LIMIT;
 				/* compute point <distance> degrees from origin along azimuth */
-				gmt_translate_point (GMT, GMT->current.proj.pars[0], GMT->current.proj.pars[1], az, distance, &GMT->current.proj.pars[2], &GMT->current.proj.pars[3], NULL);
+				gmtlib_translate_point (GMT, GMT->current.proj.pars[0], GMT->current.proj.pars[1], az, distance, &GMT->current.proj.pars[2], &GMT->current.proj.pars[3], NULL);
 			}
 			else if (n_slashes == 4) {
 				n = sscanf (args, "%[^/]/%[^/]/%[^/]/%[^/]/%s", txt_a, txt_b, txt_c, txt_d, txt_e);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -580,10 +580,11 @@ EXTERN_MSC void gmt_gcal_from_dt (struct GMT_CTRL *GMT, double t, struct GMT_GCA
 /* gmt_map.c: */
 
 
+EXTERN_MSC void gmt_translate_point (struct GMT_CTRL *GMT, double A[3], double B[3], double a_d[], bool geo);
 EXTERN_MSC double gmt_get_az_dist_from_components (struct GMT_CTRL *GMT, double lon, double lat, double dx, double dy, bool user_unit, double *azim);
 EXTERN_MSC int gmt_map_perimeter_search (struct GMT_CTRL *GMT, double *wesn, bool add_pad);
 EXTERN_MSC int gmt_circle_to_region (struct GMT_CTRL *GMT, double lon, double lat, double radius, double *wesn);
-EXTERN_MSC void gmt_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat, double *back_az);
+EXTERN_MSC void gmtlib_translate_point (struct GMT_CTRL *GMT, double lon, double lat, double azimuth, double distance, double *tlon, double *tlat, double *back_az);
 EXTERN_MSC bool gmt_segment_BB_outside_map_BB (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S);
 EXTERN_MSC struct GMT_DATASEGMENT * gmt_get_geo_ellipse (struct GMT_CTRL *GMT, double lon, double lat, double major, double minor, double azimuth, uint64_t m);
 EXTERN_MSC double gmt_half_map_width (struct GMT_CTRL *GMT, double y);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -5716,7 +5716,7 @@ GMT_LOCAL struct GMT_DATASET * gmtsupport_crosstracks_spherical (struct GMT_CTRL
 				gmt_geo_to_cart (GMT, y, x, P, true);		/* 3-D vector of current point P */
 				if (set_fixed_azim) {	/* Need 2nd point in azim direction to cross with P */
 					double b_x, b_y;
-					gmt_translate_point (GMT, x, y, fixed_azim, dist_to_end, &b_x, &b_y, NULL);
+					gmtlib_translate_point (GMT, x, y, fixed_azim, dist_to_end, &b_x, &b_y, NULL);
 					gmt_geo_to_cart (GMT, b_y, b_x, R, true);		/* 3-D vector of end point R */
 					gmt_cross3v (GMT, P, R, E);			/* Get pole E to plane trough P and R */
 				}

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -150,6 +150,13 @@ struct GMTSPATIAL_CTRL {
 		bool active;
 		char *file;
 	} T;
+	struct GMTSPATIAL_W {	/* -W<length>[unit][+f|l] */
+		bool active;
+		bool extend[2];
+		unsigned int smode[2];
+		double length[2];
+		char unit[2];
+	} W;
 };
 
 struct GMTSPATIAL_PAIR {
@@ -762,7 +769,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<table>] [-A[a<min_dist>]] [-C] [-D[+a<amax>][+c|C<cmax>][+d<dmax>][+f<file>][+p][+s<sfact>]] [-E+n|p] "
 		"[-F[l]] [-I[i|e]] [-L%s/<noise>/<offset>] [-N<pfile>[+a][+p<ID>][+r][+z]] [-Q[<unit>][+c<min>[/<max>]][+h][+l][+p][+s[a|d]]] [%s] "
-		"[-Sb<width>|h|i|j|s|u] [-T[<cpol>]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n", name, GMT_DIST_OPT, GMT_Rgeo_OPT,
+		"[-Sb<width>|h|i|j|s|u] [-T[<cpol>]] [-W<dist>[<unit>][+f|l]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n", name, GMT_DIST_OPT, GMT_Rgeo_OPT,
 		GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_o_OPT, GMT_q_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -842,7 +849,15 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-T[<cpol>]");
 	GMT_Usage (API, -2, "Truncate polygons against the clip polygon <cpol>; if <cpol> is not given we require -R "
 		"and clip against a polygon derived from the region border.");
-	GMT_Option (API, "V,a,bi2,bo,d,e,f,g,h,i,j,o,q,s,:,.");
+	GMT_Option (API, "V");
+	GMT_Usage (API, 1, "\n-W<dist>[<unit>][+f|l]");
+	GMT_Usage (API, -2, "Extend all segments with extra first and last points that are <dist> units away from the "
+		"original end points in the directions implied by the line ends.  For geographic data append a unit from %s [k]. "
+		" To extend the two ends by different amounts, give <distf>[<unit>]/<distl>[<unit>] instead. "
+		"By default we extend both ends of the segments.  Choose one modifier to change this:", GMT_LEN_UNITS_DISPLAY);
+	GMT_Usage (API, 3, "+f Only extend the start of the segments.");
+	GMT_Usage (API, 3, "+l Only extend the end of the segments.");
+	GMT_Option (API, "a,bi2,bo,d,e,f,g,h,i,j,o,q,s,:,.");
 
 	return (GMT_MODULE_USAGE);
 }
@@ -857,7 +872,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTSPATIAL_CTRL *Ctrl, struct GMT
 
 	unsigned int n_files[2] = {0, 0}, pos, n_errors = 0;
 	int n;
-	char txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, txt_c[GMT_LEN64] = {""}, p[GMT_LEN256] = {""}, *s = NULL;
+	char txt_a[GMT_LEN64] = {""}, txt_b[GMT_LEN64] = {""}, txt_c[GMT_LEN64] = {""}, p[GMT_LEN256] = {""}, *s = NULL, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -1108,6 +1123,30 @@ static int parse (struct GMT_CTRL *GMT, struct GMTSPATIAL_CTRL *Ctrl, struct GMT
 				Ctrl->S.mode = POL_CLIP;
 				if (opt->arg[0]) Ctrl->T.file = strdup (opt->arg);
 				break;
+			case 'W':	/* Widen the line */
+				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);
+				Ctrl->W.active = true;
+				if ((s = strstr (opt->arg, "+f")))
+					Ctrl->W.extend[0] = true;	/* Only first point */
+				else if ((s = strstr (opt->arg, "+l")))
+					Ctrl->W.extend[1] = true;	/* Only last point */
+				else
+					Ctrl->W.extend[0] = Ctrl->W.extend[1] = true;	/* Both points */
+				if (s) s[0] = '\0';	/* Temporarily chop off modifier */
+				if ((c = strchr (opt->arg, '/')))
+					c[0] = '\0';	/* Hide the second distance */
+				Ctrl->W.smode[0] = gmt_get_distance (GMT, opt->arg, &(Ctrl->W.length[0]), &(Ctrl->W.unit[0]));
+				if (c) {	/* Got two separate distances possibly in different units too */
+					Ctrl->W.smode[1] = gmt_get_distance (GMT, &c[1], &(Ctrl->W.length[1]), &(Ctrl->W.unit[1]));
+					c[0] = '/';	/* Restore slash */
+				}
+				else {	/* Same distance (and mode and unit for geographic) */
+					Ctrl->W.smode[1]  = Ctrl->W.smode[0];
+					Ctrl->W.length[1] = Ctrl->W.length[0];
+					Ctrl->W.unit[1]   = Ctrl->W.unit[0];
+				}
+				if (s) s[0] = '+';	/* Restore modifier */
+				break;
 			default:	/* Report bad options */
 				n_errors += gmt_default_error (GMT, opt->option);
 				break;
@@ -1127,6 +1166,20 @@ static int parse (struct GMT_CTRL *GMT, struct GMTSPATIAL_CTRL *Ctrl, struct GMT
 	n_errors += gmt_M_check_condition (GMT, n_files[GMT_OUT] > 1, "Only one output destination can be specified\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
+}
+
+GMT_LOCAL double gmtspatial_dist_to_degree (struct GMT_CTRL *GMT, double d_in) {
+	double d_out = d_in / GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in degrees or meters */
+	if (!GMT->current.map.dist[GMT_MAP_DIST].arc)	/* Got unit distance measure */
+		d_out /= GMT->current.proj.DIST_M_PR_DEG;	/* Now in degrees */
+	return (d_out);
+}
+
+GMT_LOCAL double gmtspatial_dist_to_meter (struct GMT_CTRL *GMT, double d_in) {
+	double d_out = d_in / GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in degrees or meters */
+	if (GMT->current.map.dist[GMT_MAP_DIST].arc)	/* Got arc measure */
+		d_out *= GMT->current.proj.DIST_M_PR_DEG;	/* Now in degrees */
+	return (d_out);
 }
 
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
@@ -1192,6 +1245,7 @@ EXTERN_MSC int GMT_gmtspatial (void *V_API, int mode, void *args) {
 	else if (Ctrl->A.active) geometry = GMT_IS_POINT;	/* NN analysis involves points */
 	else if (Ctrl->F.active) geometry = Ctrl->F.geometry;	/* Forcing polygon or line mode */
 	else if (Ctrl->S.active) geometry = GMT_IS_POLY;	/* Forcing polygon mode */
+	else if (Ctrl->W.active) geometry = GMT_IS_LINE;	/* Forcing polygon mode */
 	if (GMT_Init_IO (API, GMT_IS_DATASET, geometry, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {	/* Registers default input sources, unless already set */
 		Return (API->error);
 	}
@@ -2223,6 +2277,85 @@ EXTERN_MSC int GMT_gmtspatial (void *V_API, int mode, void *args) {
 			Return (error);
 	}
 #endif
+
+	if (Ctrl->W.active) {	/* Calculate centroid and polygon areas or line lengths and place in segment headers */
+		bool geo;
+		uint64_t seg, tbl, col, n_new = 0, n_old;
+		double par[2], in[2], out[2], dist[2];
+
+		if (gmt_M_is_cartesian (GMT, GMT_IN) && ((Ctrl->W.unit[0] && strchr (GMT_LEN_UNITS, Ctrl->W.unit[0])) || (Ctrl->W.unit[1] && strchr (GMT_LEN_UNITS, Ctrl->W.unit[1])))) {
+			gmt_parse_common_options (GMT, "f", 'f', "g"); /* Set -fg if -W uses unit */
+		}
+		geo = gmt_M_is_geographic (GMT, GMT_IN);
+		if (Ctrl->W.extend[0]) n_new++;	/* Count number of new points in this segment */
+		if (Ctrl->W.extend[1]) n_new++;
+
+		if (geo) {
+			int def_mode = (GMT->common.j.active) ? GMT->common.j.mode : GMT_GREATCIRCLE;
+			if (GMT->common.j.active) Ctrl->W.smode[0] = Ctrl->W.smode[1] = def_mode;	/* Override any setting in -W */
+			if (Ctrl->W.unit[0] == '\0' && Ctrl->W.unit[0] == '\0') Ctrl->W.unit[0] = Ctrl->W.unit[1] = 'k';	/* Default for geographic distance is km */
+			else if (Ctrl->W.unit[0] == '\0')	/* Use same unit as for end extension */
+				Ctrl->W.unit[0] = Ctrl->W.unit[1];
+			else if (Ctrl->W.unit[1] == '\0')	/* Use same unit as for start extension */
+				Ctrl->W.unit[1] = Ctrl->W.unit[0];
+		}
+		else {	/* Just get Cartesian length(s) */
+			dist[0] = Ctrl->W.length[0];
+			dist[1] = Ctrl->W.length[1];
+		}
+
+		for (tbl = 0; tbl < D->n_tables; tbl++) {
+			for (seg = 0; seg < D->table[tbl]->n_segments; seg++) {
+				S = D->table[tbl]->segment[seg];
+				if (S->n_rows < 2) continue;	/* Need at least 2 points to extend line */
+				n_old = S->n_rows;
+				S->n_rows += n_new;
+				if (gmt_alloc_segment (GMT, S, S->n_rows, S->n_columns, (S->text) ? GMT_WITH_STRINGS : 0, false)) continue;
+				if (Ctrl->W.extend[0]) {
+					if (geo) {
+						error = gmt_init_distaz (GMT, Ctrl->W.unit[0], Ctrl->W.smode[0], GMT_MAP_DIST);
+						if (Ctrl->W.smode[0] == GMT_GREATCIRCLE)
+							dist[0] = gmtspatial_dist_to_degree (GMT, Ctrl->W.length[0]);	/* Make sure we have degrees from whatever -W set */
+						else	/* Get meters */
+							dist[0] = gmtspatial_dist_to_meter (GMT, Ctrl->W.length[0]);	/* Make sure we have degrees from whatever -W set */
+					}
+					/* Get outward azimuth at first point and widen profile */
+					for (col = 0; col < S->n_columns; col++) {	/* First move all rows one down */
+						memmove (&S->data[col][1], S->data[col], n_old * sizeof (double));
+						S->data[col][0] = 0;	/* Wipe all row 0 entries */
+					}
+					if (S->text) {
+						memmove (&S->text[1], S->text, n_old * sizeof (char *));
+						S->text[0] = strdup ("");
+					}
+					par[0] = gmt_az_backaz (GMT, S->data[GMT_X][1], S->data[GMT_Y][1], S->data[GMT_X][2], S->data[GMT_Y][2], true);
+					par[1] = dist[0];
+					in[GMT_X] = S->data[GMT_X][1];	in[GMT_Y] = S->data[GMT_Y][1];
+					gmt_translate_point (GMT, in, out, par, geo);
+					S->data[GMT_X][0] = out[GMT_X];	S->data[GMT_Y][0] = out[GMT_Y];
+				}
+				if (Ctrl->W.extend[1]) {
+					if (geo) {
+						error = gmt_init_distaz (GMT, Ctrl->W.unit[1], Ctrl->W.smode[1], GMT_MAP_DIST);
+						if (Ctrl->W.smode[1] == GMT_GREATCIRCLE)
+							dist[1] = gmtspatial_dist_to_degree (GMT, Ctrl->W.length[1]);	/* Make sure we have degrees from whatever -W set */
+						else	/* Get meters */
+							dist[1] = gmtspatial_dist_to_meter (GMT, Ctrl->W.length[1]);	/* Make sure we have degrees from whatever -W set */
+					}
+					if (S->text) S->text[S->n_rows-1] = strdup ("");
+					/* Get outward azimuth at last point and widen profile */
+					par[0] = gmt_az_backaz (GMT, S->data[GMT_X][S->n_rows-3], S->data[GMT_Y][S->n_rows-3], S->data[GMT_X][S->n_rows-2], S->data[GMT_Y][S->n_rows-2], false);
+					par[1] = dist[1];
+					in[GMT_X] = S->data[GMT_X][S->n_rows-2];	in[GMT_Y] = S->data[GMT_Y][S->n_rows-2];
+					gmt_translate_point (GMT, in, out, par, geo);
+					S->data[GMT_X][S->n_rows-1] = out[GMT_X];	S->data[GMT_Y][S->n_rows-1] = out[GMT_Y];
+				}
+			}
+		}
+		if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_WRITE_SET, NULL, Ctrl->Out.file, D) != GMT_NOERROR) {
+			Return (API->error);
+		}
+	}
 
 	if (Ctrl->F.active) {	/* We read as polygons to force closure, now write out revised data */
 		if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_WRITE_SET, NULL, Ctrl->Out.file, D) != GMT_NOERROR) {

--- a/src/gmtvector.c
+++ b/src/gmtvector.c
@@ -390,19 +390,6 @@ GMT_LOCAL void gmtvector_get_azpole (struct GMT_CTRL *GMT, double A[3], double P
 	gmt_matrix_vect_mult (GMT, 3U, R, tmp, P);
 }
 
-GMT_LOCAL void gmtvector_translate_point (struct GMT_CTRL *GMT, double A[3], double B[3], double a_d[], bool geo) {
-	/* Given point in A, azimuth az and distance d, return the point P away from A */
-	if (geo)
-		GMT->current.map.second_point (GMT, A[GMT_X], A[GMT_Y], a_d[0], a_d[1], &B[GMT_X], &B[GMT_Y], NULL);
-		// gmt_translate_point (GMT, A[GMT_X], A[GMT_Y], a_d[0], a_d[1], &B[GMT_X], &B[GMT_Y]);
-	else {	/* Cartesian translation */
-		double s, c;
-		sincosd (90.0 - a_d[0], &s, &c);
-		B[GMT_X] = A[GMT_X] + a_d[1] * c;
-		B[GMT_Y] = A[GMT_Y] + a_d[1] * s;
-	}
-}
-
 GMT_LOCAL void gmtvector_mean_vector (struct GMT_CTRL *GMT, struct GMT_DATASET *D, bool cartesian, double conf, bool geocentric, double *M, double *E) {
 	/* Determines the mean vector M and the covariance matrix C */
 
@@ -731,7 +718,7 @@ EXTERN_MSC int GMT_gmtvector (void *V_API, int mode, void *args) {
 							else
 								Ctrl->T.par[1] = Sin->data[3][row];	/* Pass as is */
 						}
-						gmtvector_translate_point (GMT, vector_1, vector_3, Ctrl->T.par, geo);
+						gmt_translate_point (GMT, vector_1, vector_3, Ctrl->T.par, geo);
 						break;
 					case DO_NOTHING:	/* Probably just want the effect of -C, -E, -N */
 						gmt_M_memcpy (vector_3, vector_1, n_components, double);

--- a/test/gmtspatial/extend.sh
+++ b/test/gmtspatial/extend.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Testing gmt spatial segment extensions via -W
+cat << EOF > t.txt
+-0.5	1.5
+0.25	2.0
+0.75	2.0
+1.25	3.0
+EOF
+
+gmt begin extend
+	# Geographic
+	gmt subplot begin 2x2 -Fs8c -A+gwhite+p0.25p+o5p -R-2/2/0/4 -M10p
+		gmt subplot set 0 -A"Geographic: 60n/100k"
+		gmt spatial t.txt -W60n/100k > new.txt
+		gmt plot -JM? -W4p,gray new.txt -Bafg
+		gmt plot t.txt -W1p
+		gmt plot new.txt -Sc8p -Ggreen
+		gmt plot t.txt -Sc8p -Gred
+		gmt subplot set 1 -A"Geographic: 1d at start"
+		gmt spatial t.txt -W1d+f > new.txt
+		gmt plot -JM? -W4p,gray new.txt -Bafg
+		gmt plot t.txt -W1p
+		gmt plot new.txt -Sc8p -Ggreen
+		gmt plot t.txt -Sc8p -Gred
+		gmt subplot set 2 -A"Cartesian: 1/0.5"
+		gmt spatial t.txt -W1.5/0.5 > new.txt
+		gmt plot -JX? -W4p,gray new.txt -Bafg
+		gmt plot t.txt -W1p
+		gmt plot new.txt -Sc8p -Ggreen
+		gmt plot t.txt -Sc8p -Gred
+		gmt subplot set 3 -A"Cartesian: 0.5 at end"
+		gmt spatial t.txt -W0.5+l > new.txt
+		gmt plot -JX? -W4p,gray new.txt -Bafg
+		gmt plot t.txt -W1p
+		gmt plot new.txt -Sc8p -Ggreen
+		gmt plot t.txt -Sc8p -Gred
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
This PR follows the comments on the forum [post](https://forum.generic-mapping-tools.org/t/how-extend-profile/2544/4) and adds a new **-W** option that is used to extend existing lines in one or both directions by a given amount(s).  A test has been added to show how it works for geographic and Cartesian settings, and the documentation has been updated. Here is the test output:

![extend](https://user-images.githubusercontent.com/26473567/150663380-5f43bed5-9977-4256-b91d-aca6be7b3fb5.png)

