### PR TITLE
Ignore doc directory for build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ name: Build
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
   push:
     branches:
       - master

--- a/doc/rst/source/devdocs/maintenance.rst
+++ b/doc/rst/source/devdocs/maintenance.rst
@@ -44,10 +44,11 @@ There are 11 configuration files located in ``.github/workflows/``:
 
 2. ``build.yml`` (Build GMT and run a few simple tests)
 
-   This workflow is run on every commit to the *master* branch and Pull Request branches. The workflow configures
-   and builds GMT on Linux, macOS, and Windows and runs some simple tests. The workflow uses the scripts in the ``ci/``
-   directory for downloading/installing dependencies (``ci/download-coastlines.sh`` and ``ci/install-dependencies-*.sh``),
-   configuring GMT (``ci/config-gmt-*.sh``), building GMT, and running some simple tests (``ci/simple-gmt-tests.*``).
+   This workflow is run on every commit to the *master* branch and Pull Request branches, unless the pull request only
+   involves changes in the ``doc/`` directory. The workflow configures and builds GMT on Linux, macOS, and Windows and
+   runs some simple tests. The workflow uses the scripts in the ``ci/`` directory for downloading/installing
+   dependencies (``ci/download-coastlines.sh`` and ``ci/install-dependencies-*.sh``), configuring
+   GMT (``ci/config-gmt-*.sh``), building GMT, and running some simple tests (``ci/simple-gmt-tests.*``).
 
 3. ``check-links.yml`` (Check links in the repository and website)
 


### PR DESCRIPTION
**Description of proposed changes**

This PR configures the build workflow to ignore the `doc` directory to conserve CI resources on PRs that only update the documentation.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
