### PR TITLE
Put back ifdefs for gdal version in nearneighbor

### DIFF
--- a/src/nearneighbor.c
+++ b/src/nearneighbor.c
@@ -329,6 +329,7 @@ EXTERN_MSC int GMT_nearneighbor (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the nearneighbor main code ----------------------------*/
 
+#if ((GDAL_VERSION_MAJOR >= 2) && (GDAL_VERSION_MINOR >= 1)) || (GDAL_VERSION_MAJOR >= 3)
 	if (Ctrl->N.mode) {	/* Pass over to GDAL */
 		char buf[GMT_LEN128] = {""};
 		struct GMT_OPTION *opt = NULL;
@@ -347,6 +348,9 @@ EXTERN_MSC int GMT_nearneighbor (void *V_API, int mode, void *args) {
 		gmt_M_free (GMT, st);
 		Return (error);
 	}
+#else
+	GMT_Report (API, GMT_MSG_ERROR, "Option -Nn: Requires GDAL 2.1 or later\n");
+#endif
 
 	/* Regular nearest neighbor moving average operation */
 


### PR DESCRIPTION
Got cropped to harshly here.
