### PR TITLE
The standard -Rw/e/s/n in degrees had +u in docs

### DIFF
--- a/doc/rst/source/explain_-Rgeo.rst_
+++ b/doc/rst/source/explain_-Rgeo.rst_
@@ -4,7 +4,7 @@
 
     The region may be specified in one of several ways:
 
-    1. **-R**\ *west*/*east*/*south*/*north*\ [**+u**\ *unit*]. This is the standard way to specify geographic regions
+    1. **-R**\ *west*/*east*/*south*/*north*. This is the standard way to specify geographic regions
        when using map projections where meridians and parallels are rectilinear. The coordinates may be specified in
        decimal degrees or in [±]dd:mm[:ss.xxx][**W**\|\ **E**\|\ **S**\|\ **N**] format.
 


### PR DESCRIPTION
Since these are meridians and parallel boundaries in degrees there is no **+u** modifier for this flavor of input.
