### PR TITLE
Let inset take -C instead of -M

### DIFF
--- a/doc/examples/anim14/anim14.sh
+++ b/doc/examples/anim14/anim14.sh
@@ -59,7 +59,7 @@ gmt begin
 	gmt makecpt -T0/$DepthMax -Chot -I -H > q.cpt
 	# 1c. Draw profile
 	gmt basemap -R0/$KM/0/$DepthMax -JX$W/-$H -Bg25 -BwESn -Bxaf+l"Distance (km)" -Byaf+l"Depth (km)" -X$X -Y$Y
-	gmt inset begin -DjLB+w$Wa/$Ha+o0.1c/0.2c -F+p+gwhite+s+r -M0.15c
+	gmt inset begin -DjLB+w$Wa/$Ha+o0.1c/0.2c -F+p+gwhite+s+r -C0.15c
 		gmt plot angles.txt -Wthinnest,red -Bnw -Bg -R0/1/0/1 -JX?/-? --MAP_FRAME_TYPE=graph -Fr0/0 -i0-1+s0.9
 		gmt text angles.txt -F+f6 -N
 	gmt inset end

--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -20,8 +20,8 @@ Synopsis (begin mode)
 
 **gmt inset begin**
 |-D|\ *inset-box*
+[ |-C|\ [*side*]\ *clearance* ]
 [ |-F|\ *box* ]
-[ |-M|\ *margins* ]
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |-J|\ *parameters* ]
@@ -67,6 +67,16 @@ Required Arguments (begin mode)
 Optional Arguments (begin mode)
 -------------------------------
 
+.. _-C:
+
+**-C**\ [*side*]\ *clearance*
+    Reserve a space of dimension *clearance* between the inner set plot area and the given inset box on the specified
+    side, using *side* values from **w**, **e**, **s**, or **n**, or **x** for both **w** and **e**
+    or **y** for both **s** and **n**.  No *side* means all sides. The option is repeatable to set aside space
+    on more than one side.  Alternatively, if all sides are to be set you can also give a pair of values separated by slashes
+    (for setting separate horizontal and vertical margins), or the full set of four separate margins. Such space
+    will be left untouched by the inset map plotting.  Append units as desired [Default is set by :term:`PROJ_LENGTH_UNIT`].
+
 .. _-F:
 
 **-F**\ [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]][**+p**\ [*pen*]][**+r**\ [*radius*]]\
@@ -82,15 +92,6 @@ Optional Arguments (begin mode)
 .. include:: explain_-J.rst_
     :start-after: **Syntax**
     :end-before: **Description**
-
-.. _-M:
-
-**-M**\ *margins*
-    This is clearance that is added around the inside of the inset.  Plotting will take place
-    within the inner region only. The margins can be a single value, a pair of values separated by slashes
-    (for setting separate horizontal and vertical margins), or the full set of four margins (for setting
-    separate left, right, bottom, and top margins) [no margins]. Append units as desired [Default is set
-    by :term:`PROJ_LENGTH_UNIT`].
 
 .. _-N:
 
@@ -139,7 +140,7 @@ To make a simple basemap plot called inset.pdf that demonstrates the inset modul
 
     gmt begin inset pdf
       gmt basemap -R0/40/20/60 -JM6.5i -Bafg -B+glightgreen
-      gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -M0.25i
+      gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -C0.25i
         gmt basemap -Rg -JA20/20/ -Bafg
         gmt text -F+f18p+cTR+tINSET -Dj-0.15i -N
       gmt inset end

--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -70,7 +70,7 @@ Optional Arguments (begin mode)
 .. _-C:
 
 **-C**\ [*side*]\ *clearance*
-    Reserve a space of dimension *clearance* between the inner set plot area and the given inset box on the specified
+    Reserve a space of dimension *clearance* between the actual inset plot area and the given inset box on the specified
     side, using *side* values from **w**, **e**, **s**, or **n**, or **x** for both **w** and **e**
     or **y** for both **s** and **n**.  No *side* means all sides. The option is repeatable to set aside space
     on more than one side.  Alternatively, if all sides are to be set you can also give a pair of values separated by slashes

--- a/doc/scripts/GMT_inset.sh
+++ b/doc/scripts/GMT_inset.sh
@@ -6,7 +6,7 @@ gmt begin GMT_inset
 # Bottom map of Australia
 	gmt set GMT_THEME cookbook
 	gmt coast -R110E/170E/44S/9S -JM6i -B -BWSne -Wfaint -N2/1p  -EAU+gbisque -Gbrown -Sazure1 -Da -Xc --FORMAT_GEO_MAP=dddF
-	gmt inset begin -DjTR+w1.5i+o0.15i -F+gwhite+p1p+s -M0.05i
+	gmt inset begin -DjTR+w1.5i+o0.15i -F+gwhite+p1p+s -C0.05i
 	gmt coast -Rg -JG120/30S/ -Da -Gbrown -A5000 -Bg -Wfaint -EAU+gbisque
 	gmt inset end
 gmt end show

--- a/test/modern/inset.sh
+++ b/test/modern/inset.sh
@@ -2,7 +2,7 @@
 # DVC_TEST
 gmt begin inset ps
 	gmt basemap -R0/40/20/60 -JM6.5i -Bafg -B+glightgreen
-	gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -M0.1i
+	gmt inset begin -DjTR+w2.5i+o0.2i -F+gpink+p0.5p -C0.1i
 		gmt basemap -Rg -JA20/20/2.3i -Bafg
 		gmt text -F+f12p+cTR+tINSET
 	gmt inset end

--- a/test/modern/insetlegend.sh
+++ b/test/modern/insetlegend.sh
@@ -3,7 +3,7 @@
 # DVC_TEST
 gmt begin insetlegend ps
   gmt psbasemap -R0/7/3/7 -Jx1i -B0 -B+t"Inset with plot and legend" -Xc
-  gmt inset begin -DjTR+w3.8i/2.5i+o0.1i -M1c -F+p1p,red
+  gmt inset begin -DjTR+w3.8i/2.5i+o0.1i -C1c -F+p1p,red
     gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL+s0.5+glightblue+p2p+o0.3c
     gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"
     gmt plot @Table_5_11.txt -St0.15i -Gorange -lOranges


### PR DESCRIPTION
**Description of proposed changes**

As discussed in #6288, I unfortunately selected **-M** as the option for adding interior margins for a map inset, even though **-C** as used in **subplot** is the most comparable situation.  This PR rectifies this by switching **inset** to use **-C** but of course retaining backwards compatibility with any **-M** use.  Some related points:

1. I ran all tests as they were first to ensure the **-M** options were correctly processed
2. I then switched the 4 scripts that used **-M** to **-C** and ran the tests again
3. Since the new **-C** has to also handle the syntax of **-M** it can now handle the old **-C** syntax plus **-C**_xmargin_/_ymargin_ and **-C**_wmargin/emargin/smargin/nmargin_  which is even more flexible than either previous option.
4. It also turned out that inset had been left out of the synopsis reformatting (to use terminal width) so I fixed that in the process.

All tests still pass as before, the documentation has been updated.  Once this PR is approved and merged I will enhance the **-C** option in **subplot** to be equally flexible.
