### PR TITLE
gmt inset shall not accept -X -Y

### DIFF
--- a/src/inset.c
+++ b/src/inset.c
@@ -36,7 +36,7 @@
 #define THIS_MODULE_PURPOSE	"Manage figure inset setup and completion"
 #define THIS_MODULE_KEYS	">X}"
 #define THIS_MODULE_NEEDS	"JR"
-#define THIS_MODULE_OPTIONS	"JRVXY"
+#define THIS_MODULE_OPTIONS	"JRV"
 
 /* Control structure for inset */
 


### PR DESCRIPTION
While the **-X** and **-Y** options serve no purpose in a **gmt inset begin** call and are in fact not listed as allowable options, neither in the synopsis nor documentation, we did in fact not _prohibit_ them, leading to troubles internally (#6288).

This PR slams that door shot.  No examples nor tests used **-X -Y** since that was never the plan.
