### PR TITLE
Improve sample1d docs for spatial resampling

### DIFF
--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -111,7 +111,11 @@ Optional Arguments
 
 **-T**\ [*min/max*\ /]\ *inc*\ [**+a**][**+i**\|\ **n**][**+u**]
     Make evenly spaced time-steps from *min* to *max* by *inc* [Default uses input times].
-    For details on array creation, see `Generate 1D Array`_.
+    For details on array creation, see `Generate 1D Array`_.  **Note**: For resampling of spatial
+    (*x,y* or *lon,lat*) series you must give an increment with a valid distance unit;
+    see `Units`_ for map units or use **c** if plain Cartesian coordinates.  The first two
+    columns must contain the spatial coordinates.  From these we calculate distances in the
+    chosen units and interpolate using this parametric series.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: explain_-V.rst_


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/plot-a-and-output/2591/13) for background. There was no discussion in the sample1d documentation of using **-T**_inc_ to perform spatial resampling of geographic or Cartesian paths.
