### PR TITLE
Must let inset process -X -Y

### DIFF
--- a/src/inset.c
+++ b/src/inset.c
@@ -36,7 +36,7 @@
 #define THIS_MODULE_PURPOSE	"Manage figure inset setup and completion"
 #define THIS_MODULE_KEYS	">X}"
 #define THIS_MODULE_NEEDS	"JR"
-#define THIS_MODULE_OPTIONS	"JRV"
+#define THIS_MODULE_OPTIONS	"JRVXY"
 
 /* Control structure for inset */
 


### PR DESCRIPTION
Because there are things happening under the hood that adds **-X -Y** to a **gmt inset** call, we need to keep **XY** among the list in **THIS_MODULE_OPTIONS**, thus reverting #6298.  I will see if I can find a way to distinguish between these GMT-imposed **-X -Y** settings and that of a user specifying them on the command line (which we would like to prevent).  For now, just reverting to avoid errors.
