### PR TITLE
Let -X -Y also handle multipliers and not just divisors

### DIFF
--- a/doc/rst/source/explain_-XY.rst_
+++ b/doc/rst/source/explain_-XY.rst_
@@ -28,8 +28,8 @@ previous plot unless the origin is shifted using these options. The following mo
 
 When **-X** or **-Y** are used without any further arguments, the values from the last use of that option in a previous
 GMT command will be used. In modern mode, **-X** and **-Y** can also access the previous plot bounding box dimensions *w* and
-*h* and construct offsets that involve them.  Thus, *xshift* can in general be [±][[*f*]*w[/*d*]±]*xoff*, where optional signs, factor *f*
-and divisor *d* can be used to compute an offset that may further be adjusted by ±*off*.  Similarly, *yshift* can in general be
-[±][[*f*]*h[/*d*]±]*yoff*.  For instance, to move the origin up 2 cm beyond the height of the previous plot, use **-Y**\ *h*\ +2c.
+*h* and construct offsets that involve them.  Thus, *xshift* can in general be [[±][*f*]\ *w*\ [/\ *d*\ ]±]\ *xoff*, where optional signs, factor *f*
+and divisor *d* can be used to compute an offset that may be adjusted further by ±\ *off*.  Similarly, *yshift* can in general be
+[[±][*f*]\ *h*\ [/\ *d*\ ]±]\ *yoff*.  For instance, to move the origin up 2 cm beyond the height of the previous plot, use **-Y**\ *h*\ +2c.
 To move the origin half the width to the right, use **-X**\ *w*\ /2. **Note**: the previous plot bounding box refers to the last
 object plotted, which may be an image, logo, legend, colorbar, etc.

--- a/doc/rst/source/explain_-XY.rst_
+++ b/doc/rst/source/explain_-XY.rst_
@@ -27,7 +27,9 @@ previous plot unless the origin is shifted using these options. The following mo
 - Prepend **r** to move the origin relative to its current location.
 
 When **-X** or **-Y** are used without any further arguments, the values from the last use of that option in a previous
-GMT command will be used. Note that **-X** and **-Y** can also access the previous plot bounding box dimensions *w* and
-*h* and construct offsets that involves them.  For instance, to move the origin up 2 cm beyond the height of the
-previous plot, use **-Y**\ *h*\ +2c. To move the origin half the width to the right, use **-X**\ *w*\ /2. **Note**:
-the previous plot bounding box refers to the last object plotted, which may be an image, logo, legend, colorbar, etc.
+GMT command will be used. In modern mode, **-X** and **-Y** can also access the previous plot bounding box dimensions *w* and
+*h* and construct offsets that involve them.  Thus, *xshift* can in general be [±][[*f*]*w[/*d*]±]*xoff*, where optional signs, factor *f*
+and divisor *d* can be used to compute an offset that may further be adjusted by ±*off*.  Similarly, *yshift* can in general be
+[±][[*f*]*h[/*d*]±]*yoff*.  For instance, to move the origin up 2 cm beyond the height of the previous plot, use **-Y**\ *h*\ +2c.
+To move the origin half the width to the right, use **-X**\ *w*\ /2. **Note**: the previous plot bounding box refers to the last
+object plotted, which may be an image, logo, legend, colorbar, etc.

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -995,7 +995,7 @@ GMT_LOCAL int gmtinit_rectR_to_geoR (struct GMT_CTRL *GMT, char unit, double rec
 
 /*! . */
 GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
-	/* Syntax: -Xa|r|f|c<off>, -X[-|+][m]w[/<n>][-|+]<off>, where
+	/* Syntax: -Xa|r|f|c<off>, -X[-|+][<f>]w[/<d>][-|+]<off>, where
 	 * w is the width of the previous plot command. */
 	int i = 0, j;
 	if (!text || !text[0]) {	/* Default is -Xr0 */
@@ -1018,17 +1018,20 @@ GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
 			}
 			else if (text[i] == '+')	/* In case the user explicitly gave a + */
 				i++;	/* Skip the plus sign */
-			if (text[i] != 'w') {	/* Must assume it is the scale m */
+			if (text[i] != 'w') {	/* Must assume it is the scale f */
 				j = i + 1;	while (text[j] != 'w') j++;	text[j] = '\0';	/* Hide w */
-				GMT->current.setting.map_origin[GMT_X] *= atof (&text[i]);
+				GMT->current.setting.map_origin[GMT_X] *= atof (&text[i]);	/* Scale by f */
 				text[j] = 'w';
-				i = j + 1;	/* Skip past m */
+				i = j;	/* Skip past f */
 			}
 			i++;	/* Skip past the w */
 			if (text[i] == '/') {	/* Wanted a fraction of the width */
-				i++;	/* Skip the slash */
-				GMT->current.setting.map_origin[GMT_X] /= atof (&text[i]);
-				while (isdigit (text[i]) || text[i] == '.') i++;	/* Wind past the denominator */
+				int was;
+				i++;	/* Skip past the slash */
+				j = i;	while (text[j] && strchr ("-+", text[j]) == NULL) j++;	was = text[j];	text[j] = '\0';	/* Temporarily hide any trailing +/-<offset> */
+				GMT->current.setting.map_origin[GMT_X] /= atof (&text[i]);	/* Do the division */
+				text[j] = was;	/* Restore the optional offset */
+				i = j;	/* Skip past d */
 			}
 			/* Now add the offset the user added, if given */
 			if (text[i]) GMT->current.setting.map_origin[GMT_X] += gmt_M_to_inch (GMT, &text[i]);
@@ -1044,7 +1047,7 @@ GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
 
 /*! . */
 GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
-	/* Syntax: -Ya|r|f|c<off>, -Y[-|+][m]h[/<n>][-|+]<off>, where
+	/* Syntax: -Ya|r|f|c<off>, -Y[-|+][<f>]h[/<d>][-|+]<off>, where
 	 * h is the height of the previous plot command. */
 	int i = 0, j;
 	if (!text || !text[0]) {	/* Default is -Yr0 */
@@ -1071,13 +1074,16 @@ GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
 				j = i + 1;	while (text[j] != 'h') j++;	text[j] = '\0';	/* Hide h */
 				GMT->current.setting.map_origin[GMT_Y] *= atof (&text[i]);
 				text[j] = 'h';
-				i = j + 1;	/* Skip past m */
+				i = j;	/* Skip past f */
 			}
 			i++;	/* Skip past the h */
 			if (text[i] == '/') {	/* Wanted a fraction of the height */
-				i++;	/* Skip the slash */
-				GMT->current.setting.map_origin[GMT_Y] /= atof (&text[i]);
-				while (isdigit (text[i]) || text[i] == '.') i++;	/* Wind past the denominator */
+				int was;
+				i++;	/* Skip past the slash */
+				j = i;	while (text[j] && strchr ("-+", text[j]) == NULL) j++;	was = text[j];	text[j] = '\0';	/* Temporarily hide any trailing +/-<offset> */
+				GMT->current.setting.map_origin[GMT_Y] /= atof (&text[i]);	/* Do the division */
+				text[j] = was;	/* Restore the optional offset */
+				i = j;	/* Skip past d */
 			}
 			/* Now add the offset the user added, if given */
 			if (text[i]) GMT->current.setting.map_origin[GMT_Y] += gmt_M_to_inch (GMT, &text[i]);

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -995,9 +995,9 @@ GMT_LOCAL int gmtinit_rectR_to_geoR (struct GMT_CTRL *GMT, char unit, double rec
 
 /*! . */
 GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
-	/* Syntax: -Xa|r|f|c<off>, -X[-|+]w[/<n>][-|+]<off>, where
+	/* Syntax: -Xa|r|f|c<off>, -X[-|+][m]w[/<n>][-|+]<off>, where
 	 * w is the width of the previous plot command. */
-	int i = 0;
+	int i = 0, j;
 	if (!text || !text[0]) {	/* Default is -Xr0 */
 		GMT->current.ps.origin[GMT_X] = GMT->common.X.mode = 'r';
 		GMT->common.X.off = GMT->current.setting.map_origin[GMT_X] = 0.0;
@@ -1018,6 +1018,12 @@ GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
 			}
 			else if (text[i] == '+')	/* In case the user explicitly gave a + */
 				i++;	/* Skip the plus sign */
+			if (text[i] != 'w') {	/* Must assume it is the scale m */
+				j = i + 1;	while (text[j] != 'w') j++;	text[j] = '\0';	/* Hide w */
+				GMT->current.setting.map_origin[GMT_X] *= atof (&text[i]);
+				text[j] = 'w';
+				i = j + 1;	/* Skip past m */
+			}
 			i++;	/* Skip past the w */
 			if (text[i] == '/') {	/* Wanted a fraction of the width */
 				i++;	/* Skip the slash */
@@ -1038,9 +1044,9 @@ GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
 
 /*! . */
 GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
-	/* Syntax: -Ya|r|f|c<off>, -Y[-|+]h[/<n>][-|+]<off>, where
+	/* Syntax: -Ya|r|f|c<off>, -Y[-|+][m]h[/<n>][-|+]<off>, where
 	 * h is the height of the previous plot command. */
-	int i = 0;
+	int i = 0, j;
 	if (!text || !text[0]) {	/* Default is -Yr0 */
 		GMT->current.ps.origin[GMT_Y] = GMT->common.Y.mode = 'r';
 		GMT->common.Y.off = GMT->current.setting.map_origin[GMT_Y] = 0.0;
@@ -1061,6 +1067,12 @@ GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
 			}
 			else if (text[i] == '+')	/* In case the user explicitly gave a + */
 				i++;	/* Skip the plus sign */
+			if (text[i] != 'h') {	/* Must assume it is the scale m */
+				j = i + 1;	while (text[j] != 'h') j++;	text[j] = '\0';	/* Hide h */
+				GMT->current.setting.map_origin[GMT_Y] *= atof (&text[i]);
+				text[j] = 'h';
+				i = j + 1;	/* Skip past m */
+			}
 			i++;	/* Skip past the h */
 			if (text[i] == '/') {	/* Wanted a fraction of the height */
 				i++;	/* Skip the slash */


### PR DESCRIPTION
This PR extends the modern form of **-X -Y** to allow not just fractions of previous plot dimensions _w_ and _h_ to be used but also arbitrary factors.  The new full form of these arguments are

[[±][_f_]w[/_d_]±]_xoff_
[[±][_f_]h[/_d_]±]_yoff_

where the new _f_ is an optional scale [1] that compliments the optional divisor _d_ [1].  A simple example shows the parsing works:

```
gmt begin t png
	gmt psbasemap -R0/10/0/5 -Jx1c -Bafg1
	gmt psbasemap -Bafg1 -X2w/2+1 -Y2h/2+1
gmt end show
```

![t](https://user-images.githubusercontent.com/26473567/152655955-87901678-c562-4775-b6cf-97554e998d4d.png)

Here, the processing of _f_ and _d_ cancels out to give one _w_ and one _h_, plus 1 cm.
