### PR TITLE
Let GMT verify counters in external datasets

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -10080,6 +10080,7 @@ GMT_LOCAL void gmtapi_get_record_init (struct GMTAPI_CTRL *API) {
 		case GMT_IS_DUPLICATE:	/* Only for datasets */
 		case GMT_IS_REFERENCE:	/* Only for datasets */
 			API->current_get_D_set = gmtapi_get_dataset_data (S->resource);	/* Get the right dataset */
+			gmt_set_dataset_verify (GMT, API->current_get_D_set);    /* Basic sanity checking of incoming dataset */
 			API->current_get_n_columns = (GMT->common.i.select) ? GMT->common.i.n_cols : API->current_get_D_set->n_columns;
 			API->api_get_record = gmtapi_get_record_dataset;
 			if (!(API->current_get_D_set->type & GMT_READ_TEXT)) GMT->current.io.record.text = NULL;

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3792,6 +3792,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 				if (GMT->common.q.mode == GMT_RANGE_ROW_IN || GMT->common.q.mode == GMT_RANGE_DATA_IN)
 					GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qi is not implemented for GMT_IS_DUPLICATE with GMT_IS_DATASET external memory objects\n");
 				GMT_Report (API, GMT_MSG_INFORMATION, "Duplicating data table from GMT_DATASET memory location\n");
+                if (gmt_set_dataset_verify (GMT, S_obj->resource)) return_null (API, GMT_RUNTIME_ERROR);
 				Din_obj = gmt_duplicate_dataset (GMT, S_obj->resource, GMT_ALLOC_NORMAL|GMT_ALLOC_VIA_ICOLS, NULL);
 				if ((tbl + Din_obj->n_tables) >= n_alloc) {	/* Need more space to hold these new tables */
 					n_alloc += Din_obj->n_tables;
@@ -3809,6 +3810,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 
 			case GMT_IS_REFERENCE:	/* Just pass memory locations to tables */
 				if ((Din_obj = S_obj->resource) == NULL) return_null (API, GMT_PTR_IS_NULL);
+                if (gmt_set_dataset_verify (GMT, Din_obj)) return_null (API, GMT_RUNTIME_ERROR);
 				if (GMT->common.q.mode == GMT_RANGE_ROW_IN || GMT->common.q.mode == GMT_RANGE_DATA_IN)
 					GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qi is not implemented for GMT_IS_REFERENCE with GMT_IS_DATASET external memory objects\n");
 				GMT_Report (API, GMT_MSG_INFORMATION, "Referencing data table from GMT_DATASET memory location\n");

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3792,7 +3792,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 				if (GMT->common.q.mode == GMT_RANGE_ROW_IN || GMT->common.q.mode == GMT_RANGE_DATA_IN)
 					GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qi is not implemented for GMT_IS_DUPLICATE with GMT_IS_DATASET external memory objects\n");
 				GMT_Report (API, GMT_MSG_INFORMATION, "Duplicating data table from GMT_DATASET memory location\n");
-				if (gmt_set_dataset_verify (GMT, S_obj->resource)) return_null (API, GMT_RUNTIME_ERROR);
+				gmt_set_dataset_verify (GMT, S_obj->resource);    /* Basic sanity checking of incoming dataset */
 				Din_obj = gmt_duplicate_dataset (GMT, S_obj->resource, GMT_ALLOC_NORMAL|GMT_ALLOC_VIA_ICOLS, NULL);
 				if ((tbl + Din_obj->n_tables) >= n_alloc) {	/* Need more space to hold these new tables */
 					n_alloc += Din_obj->n_tables;
@@ -3810,7 +3810,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 
 			case GMT_IS_REFERENCE:	/* Just pass memory locations to tables */
 				if ((Din_obj = S_obj->resource) == NULL) return_null (API, GMT_PTR_IS_NULL);
-				if (gmt_set_dataset_verify (GMT, Din_obj)) return_null (API, GMT_RUNTIME_ERROR);
+				gmt_set_dataset_verify (GMT, Din_obj);   /* Basic sanity checking of incoming dataset */
 				if (GMT->common.q.mode == GMT_RANGE_ROW_IN || GMT->common.q.mode == GMT_RANGE_DATA_IN)
 					GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qi is not implemented for GMT_IS_REFERENCE with GMT_IS_DATASET external memory objects\n");
 				GMT_Report (API, GMT_MSG_INFORMATION, "Referencing data table from GMT_DATASET memory location\n");

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3792,7 +3792,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 				if (GMT->common.q.mode == GMT_RANGE_ROW_IN || GMT->common.q.mode == GMT_RANGE_DATA_IN)
 					GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qi is not implemented for GMT_IS_DUPLICATE with GMT_IS_DATASET external memory objects\n");
 				GMT_Report (API, GMT_MSG_INFORMATION, "Duplicating data table from GMT_DATASET memory location\n");
-                if (gmt_set_dataset_verify (GMT, S_obj->resource)) return_null (API, GMT_RUNTIME_ERROR);
+				if (gmt_set_dataset_verify (GMT, S_obj->resource)) return_null (API, GMT_RUNTIME_ERROR);
 				Din_obj = gmt_duplicate_dataset (GMT, S_obj->resource, GMT_ALLOC_NORMAL|GMT_ALLOC_VIA_ICOLS, NULL);
 				if ((tbl + Din_obj->n_tables) >= n_alloc) {	/* Need more space to hold these new tables */
 					n_alloc += Din_obj->n_tables;
@@ -3810,7 +3810,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 
 			case GMT_IS_REFERENCE:	/* Just pass memory locations to tables */
 				if ((Din_obj = S_obj->resource) == NULL) return_null (API, GMT_PTR_IS_NULL);
-                if (gmt_set_dataset_verify (GMT, Din_obj)) return_null (API, GMT_RUNTIME_ERROR);
+				if (gmt_set_dataset_verify (GMT, Din_obj)) return_null (API, GMT_RUNTIME_ERROR);
 				if (GMT->common.q.mode == GMT_RANGE_ROW_IN || GMT->common.q.mode == GMT_RANGE_DATA_IN)
 					GMT_Report (API, GMT_MSG_WARNING, "Row-selection via -qi is not implemented for GMT_IS_REFERENCE with GMT_IS_DATASET external memory objects\n");
 				GMT_Report (API, GMT_MSG_INFORMATION, "Referencing data table from GMT_DATASET memory location\n");

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7381,55 +7381,36 @@ void gmt_set_tbl_minmax (struct GMT_CTRL *GMT, unsigned int geometry, struct GMT
 }
 
 /*! . */
-int gmt_set_dataset_verify (struct GMT_CTRL *GMT, struct GMT_DATASET *D) {
+void gmt_set_dataset_verify (struct GMT_CTRL *GMT, struct GMT_DATASET *D) {
 	/* Function that does basic sanity checking of an externally produced GMT
 	 * data set to ensure internal counters are self-consistent */
 
 	uint64_t tbl, seg, n_records = 0, n_segments = 0;
 	struct GMT_DATATABLE *T = NULL;
 	struct GMT_DATASEGMENT *S = NULL;
-	if (!D) return GMT_NOERROR;	/* No dataset given */
+	if (!D) return;	/* No dataset given */
 	for (tbl = 0; tbl < D->n_tables; tbl++) {
 		T = D->table[tbl];
 		for (seg = 0; seg < T->n_segments; seg++) {
 			S = T->segment[seg];
 			n_records += S->n_rows;
-			if (S->n_columns > T->n_columns) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Segment %" PRIu64 " in table %" PRIu64 " has %" PRIu64 " columns but table header says it only has %" PRIu64 "\n", seg, tbl, S->n_columns, T->n_columns);
-				return GMT_DIM_TOO_SMALL;
-			}
-			else if (S->n_columns < T->n_columns) {
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Segment %" PRIu64 " in table %" PRIu64 " has %" PRIu64 " columns but table header says it has %" PRIu64 "\n", seg, tbl, S->n_columns, T->n_columns);
-				return GMT_DIM_TOO_SMALL;
+			if (S->n_columns != T->n_columns) {
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_set_dataset_verify: Segment %" PRIu64 " in table %" PRIu64 " has %" PRIu64 " columns but table header says it only has %" PRIu64 "\n", seg, tbl, S->n_columns, T->n_columns);
 			}
 		}
-		if (T->n_columns > D->n_columns) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Table %" PRIu64 " has %" PRIu64 " columns but dataset header says it only has %" PRIu64 "\n", tbl, T->n_columns, D->n_columns);
-			return GMT_DIM_TOO_SMALL;
-		}
-		else if (T->n_columns < D->n_columns) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Table %" PRIu64 " has %" PRIu64 " columns but dataset header says it has %" PRIu64 "\n", tbl, T->n_columns, D->n_columns);
-			return GMT_DIM_TOO_SMALL;
+		if (T->n_columns != D->n_columns) {
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_set_dataset_verify: Table %" PRIu64 " has %" PRIu64 " columns but dataset header says it only has %" PRIu64 "\n", tbl, T->n_columns, D->n_columns);
 		}
 		n_segments += T->n_segments;
 	}
-	if (n_segments > D->n_segments) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Data set has %" PRIu64 " segments but header says it only has %" PRIu64 "\n", n_segments, D->n_segments);
-		return GMT_DIM_TOO_SMALL;
+	if (n_segments != D->n_segments) {
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_set_dataset_verify: Data set has %" PRIu64 " segments but header says it only has %" PRIu64 "\n", n_segments, D->n_segments);
+		D->n_segments = n_segments;	/* Update total number of segments to match realilty */
 	}
-	else if (n_segments < D->n_segments) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Data set has %" PRIu64 " segments but header says it has %" PRIu64 "\n", n_segments, D->n_segments);
-		return GMT_DIM_TOO_LARGE;
+	if (n_records != D->n_records) {
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_set_dataset_verify: Data set has %" PRIu64 " data records but header says it only has %" PRIu64 "\n", n_records, D->n_records);
+		D->n_records = n_records;	/* Update total number of records to match realilty */
 	}
-	if (n_records > D->n_records) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Data set has %" PRIu64 " data records but header says it only has %" PRIu64 "\n", n_records, D->n_records);
-		return GMT_DIM_TOO_SMALL;
-	}
-	else if (n_records < D->n_records) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Data set has %" PRIu64 " data records but header says it has %" PRIu64 "\n", n_records, D->n_records);
-		return GMT_DIM_TOO_LARGE;
-	}
-	return GMT_NOERROR;
 }
 
 /*! . */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7381,6 +7381,58 @@ void gmt_set_tbl_minmax (struct GMT_CTRL *GMT, unsigned int geometry, struct GMT
 }
 
 /*! . */
+int gmt_set_dataset_verify (struct GMT_CTRL *GMT, struct GMT_DATASET *D) {
+	/* Function that does basic sanity checking of an externally produced GMT
+	 * data set to ensure internal counters are self-consistent */
+
+	uint64_t tbl, seg, n_records = 0, n_segments = 0;
+	struct GMT_DATATABLE *T = NULL;
+	struct GMT_DATASEGMENT *S = NULL;
+	if (!D) return GMT_NOERROR;	/* No dataset given */
+	for (tbl = 0; tbl < D->n_tables; tbl++) {
+		T = D->table[tbl];
+		for (seg = 0; seg < T->n_segments; seg++) {
+			S = T->segment[seg];
+			n_records += S->n_rows;
+			if (S->n_columns > T->n_columns) {
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Segment %" PRIu64 " in table %" PRIu64 " has %" PRIu64 " columns but table header says it only has %" PRIu64 "\n", seg, tbl, S->n_columns, T->n_columns);
+				return GMT_DIM_TOO_SMALL;
+			}
+			else if (S->n_columns < T->n_columns) {
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Segment %" PRIu64 " in table %" PRIu64 " has %" PRIu64 " columns but table header says it has %" PRIu64 "\n", seg, tbl, S->n_columns, T->n_columns);
+				return GMT_DIM_TOO_SMALL;
+			}
+		}
+		if (T->n_columns > D->n_columns) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Table %" PRIu64 " has %" PRIu64 " columns but dataset header says it only has %" PRIu64 "\n", tbl, T->n_columns, D->n_columns);
+			return GMT_DIM_TOO_SMALL;
+		}
+		else if (T->n_columns < D->n_columns) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Table %" PRIu64 " has %" PRIu64 " columns but dataset header says it has %" PRIu64 "\n", tbl, T->n_columns, D->n_columns);
+			return GMT_DIM_TOO_SMALL;
+		}
+		n_segments += T->n_segments;
+	}
+	if (n_segments > D->n_segments) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Data set has %" PRIu64 " segments but header says it only has %" PRIu64 "\n", n_segments, D->n_segments);
+		return GMT_DIM_TOO_SMALL;
+	}
+	else if (n_segments < D->n_segments) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Data set has %" PRIu64 " segments but header says it has %" PRIu64 "\n", n_segments, D->n_segments);
+		return GMT_DIM_TOO_LARGE;
+	}
+	if (n_records > D->n_records) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Data set has %" PRIu64 " data records but header says it only has %" PRIu64 "\n", n_records, D->n_records);
+		return GMT_DIM_TOO_SMALL;
+	}
+	else if (n_records < D->n_records) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_set_dataset_verify: Data set has %" PRIu64 " data records but header says it has %" PRIu64 "\n", n_records, D->n_records);
+		return GMT_DIM_TOO_LARGE;
+	}
+	return GMT_NOERROR;
+}
+
+/*! . */
 void gmt_set_dataset_minmax (struct GMT_CTRL *GMT, struct GMT_DATASET *D) {
 	uint64_t tbl, col;
 	struct GMT_DATATABLE *T = NULL;

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -303,6 +303,7 @@ EXTERN_MSC int gmt_set_psfilename (struct GMT_CTRL *GMT);
 
 /* gmt_io.c: */
 
+EXTERN_MSC int gmt_set_dataset_verify (struct GMT_CTRL *GMT, struct GMT_DATASET *D);
 EXTERN_MSC unsigned int gmt_realloc_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D, uint64_t dim[]);
 EXTERN_MSC void gmt_check_abstime_format (struct GMT_CTRL *GMT, struct GMT_DATASET *D, uint64_t chunk);
 EXTERN_MSC int gmt_get_precision_width (struct GMT_CTRL *GMT, double x);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -303,7 +303,7 @@ EXTERN_MSC int gmt_set_psfilename (struct GMT_CTRL *GMT);
 
 /* gmt_io.c: */
 
-EXTERN_MSC int gmt_set_dataset_verify (struct GMT_CTRL *GMT, struct GMT_DATASET *D);
+EXTERN_MSC void gmt_set_dataset_verify (struct GMT_CTRL *GMT, struct GMT_DATASET *D);
 EXTERN_MSC unsigned int gmt_realloc_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D, uint64_t dim[]);
 EXTERN_MSC void gmt_check_abstime_format (struct GMT_CTRL *GMT, struct GMT_DATASET *D, uint64_t chunk);
 EXTERN_MSC int gmt_get_precision_width (struct GMT_CTRL *GMT, double x);

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -389,7 +389,7 @@ GMT_LOCAL struct GMT_DATASET *pslegend_get_dataset_pointer (struct GMTAPI_CTRL *
 		return (NULL);
 	}
 	/* Initialize counters to zero */
-	D->n_records = D->table[0]->n_records = 0;
+	D->n_records = D->n_segments = D->table[0]->n_records = 0;
 	for (seg = 0; seg < n_segments; seg++)
 		D->table[0]->segment[seg]->n_rows = 0;
 	return (D);


### PR DESCRIPTION
As a sanity check, this PR lets GMT validate the counters found in a dataset passed to a module via reference or duplicate.  Mismatches between stated and actual records, segments and columns will be noted and an error is returned.

In the process of testing I found **pslegend** did not initialize _n_segments_ to zero in the dataset and thus got caught by the verifier, so I guess it works.
