### PR TITLE
Clarify how -Z in a data header affects color

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -212,8 +212,8 @@ Optional Arguments
     Append **+xl**\|\ **r**\|\ *x0* to connect first and last point to anchor points at either *xmin*, *xmax*, or *x0*, or
     append **+yb**\|\ **t**\|\ *y0* to connect first and last point to anchor points at either *ymin*, *ymax*, or *y0*.
     Polygon may be painted (**-G**) and optionally outlined by adding **+p**\ *pen* [no outline].
-    **Note**: When options like **-G** and **-Z** are passed via segment headers you will need **-L** to ensure
-    your segments are interpreted as polygons.
+    **Note**: When option **-Z** is passed via segment headers you will need **-L** to ensure
+    your segments are interpreted as polygons, else they are seen as lines.
 
 .. _-N:
 

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -175,8 +175,8 @@ Optional Arguments
     append **+yb**\|\ **t**\|\ *y0* to connect first and last point to anchor points at either *ymin*, *ymax*, or *y0*.
     Polygon may be painted (**-G**) and optionally outlined by adding **+p**\ *pen* [no outline].
     All constructed polygons are assumed to have a constant *z* value.
-    **Note**: When options like **-G** and **-Z** are passed via segment headers you will need **-L** to ensure
-    your segments are interpreted as polygons.
+    **Note**: When option **-Z** is passed via segment headers you will need **-L** to ensure
+    your segments are interpreted as polygons, else they are seen as lines.
 
 .. _-N:
 

--- a/doc/rst/source/plot3d_notes.rst_
+++ b/doc/rst/source/plot3d_notes.rst_
@@ -19,7 +19,8 @@ Segment header records may contain one of more of the following options:
 **-W-**
     Turn outline off
 **-Z**\ *zval*
-    Obtain fill via cpt lookup using z-value *zval*
+    Obtain fill via cpt lookup using z-value *zval* (what the color is used
+    for is controlled further by **-L** or **-W**)
 **-Z**\ *NaN*
     Get the NaN color from the CPT
 **-t**\ *transparency*

--- a/doc/rst/source/plot_notes.rst_
+++ b/doc/rst/source/plot_notes.rst_
@@ -19,7 +19,8 @@ Segment header records may contain one of more of the following options:
 **-W-**
     Turn outline off
 **-Z**\ *zval*
-    Obtain fill via cpt lookup using z-value *zval*
+    Obtain fill via cpt lookup using z-value *zval* (what the color is used
+    for is controlled further by **-L** or **-W**)
 **-Z**\ *NaN*
     Get the NaN color from the CPT
 **-t**\ *transparency*


### PR DESCRIPTION
This pertains to issue #6312 and lines or polygons.  With **-G** it is not an issue - a filled polygon is secured.  However, for **-Z** we do not know if it is a color change for a polygon or a line.  By default we use the color for the line.  This can be further changed via **-L** (fill polygon instead) or **-W+c** (set the color for fill and line).  This PR improves the documentation for these situations.  Closes #6312.
