### PR TITLE
Let default remote grid registration be gridline for grdtrack

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -84,7 +84,10 @@ Required Arguments
     **-G** as many times as you have grids you wish to sample.
     Alternatively, use **-G+l**\ *list* to pass a list of file names.
     The grids are sampled and results are output in the order given.
-    (See :ref:`Grid File Formats <grd_inout_full>`).
+    (See :ref:`Grid File Formats <grd_inout_full>`). **Note**: If *gridfile*
+    is a remote global grid and no registration is specified then **grdtrack**
+    will default to gridline registration (instead of the default pixel registration)
+    to ensure all input points are inside the grid.
 
 Optional Arguments
 ------------------

--- a/src/gmt_bcr.c
+++ b/src/gmt_bcr.c
@@ -253,7 +253,9 @@ double gmt_bcr_get_z_fast (struct GMT_CTRL *GMT, struct GMT_GRID *G, double xx, 
 		for (i = 0; i < HH->bcr_n; i++) {
 			/* assure that index is inside bounds of the array G->data: */
 			node = ij + i;
-			assert (node < G->header->size);
+			/* node may be outside if xx, yy is exactly at a node and wx, wy is zero exept at that point. If so,
+			 * we just skip this node as it does not affect calculation, and calling assert is too draconian */
+			if (node >= G->header->size) continue;
 			w = wx[i] * wy[j];
 			retval += G->data[node] * w;
 			wsum += w;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15044,14 +15044,16 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	/* First handle any half-hearted naming of remote datasets where _g or _p should be appended */
 
 	if (options) {
-	  for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
-		  if (!gmtinit_might_be_remotefile (opt->arg)) continue;
-		  if (remote_first) {
-			  gmt_refresh_server (API);	/* Refresh hash and info tables as needed */
-			  remote_first = false;
-		  }
-		  gmt_set_unspecified_remote_registration (API, &(opt->arg));	/* If argument is a remote file name then this handles any missing registration _p|_g */
+		if (!strcmp (mod_name, "grdtrack")) API->use_gridline_registration = true;	/* Override API default since grdtrack is a data processor */
+		for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
+			if (!gmtinit_might_be_remotefile (opt->arg)) continue;
+			if (remote_first) {
+				gmt_refresh_server (API);	/* Refresh hash and info tables as needed */
+				remote_first = false;
+			}
+			gmt_set_unspecified_remote_registration (API, &(opt->arg));	/* If argument is a remote file name then this handles any missing registration _p|_g */
 		}
+		API->use_gridline_registration = false;	/* Reset API default setting */
 	}
 
 	/* Making -R<country-codes> globally available means it must affect history, etc.  The simplest fix here is to

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -149,6 +149,7 @@ struct GMTAPI_CTRL {
 	bool cache;					/* true if we want to read a cache file via GDAL */
 	bool no_history;					/* true if we want to disable the gmt.history mechanism */
 	bool got_remote_wesn;				/* true if we obtained w/e/sn via a remote grid/image with no resolution given */
+	bool use_gridline_registration;	/* true if default remote grid registration should be gridline, not pixel */
 	size_t n_objects_alloc;			/* Allocation counter for data objects */
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */


### PR DESCRIPTION
See #6299 for background.  This PR ensures that **grdtrack** first selects a gridline-registered version of a remote grid unless registration is specified by the user.  This ensures that sampling of arbitrary points is optimally handled.  The change is documented in the man page.  Also, since we now no longer add a grid pad for non-bicubic sampling we must allow for a node outside the range when the input point lands on the final node.  This is not an error (since the weight is zero) so we simply skip rather than cause a crash via _assert_.  Closes #6299.

A point of discussion may be this proposal which would extend the solution above:

The default resolution chosen for remote grids without specific resolution shall be:

1. All plotting modules: pixel-registration
2. All processing modules: gridline-registration

The argument here is loosely that the plotters are fine with the pixel registration and some are only pixel anyway (think images), while data processors often (but not always) need to consider resampling.

Embracing that suggestion would mean the user of @earth_relief_01d in **grdcut**, **grdsample**, **grdclip**, **grd2xyz**, etc would default to gridline registration since for calculations that is the better format (i.e., default GMT output anyway from surface, etc.).  Thoughts, @GenericMappingTools/core ?