### PR TITLE
Allow deprecated -Q in grdsample

### DIFF
--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -94,6 +94,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
+EXTERN_MSC int gmtinit_parse_n_option (struct GMT_CTRL *GMT, char *item);	/* Because of deprecated -Q */
+
 static int parse (struct GMT_CTRL *GMT, struct GRDSAMPLE_CTRL *Ctrl, struct GMT_OPTION *options) {
 
 	/* This parses the options provided to grdsample and sets parameters in CTRL.
@@ -157,6 +159,13 @@ static int parse (struct GMT_CTRL *GMT, struct GRDSAMPLE_CTRL *Ctrl, struct GMT_
 				else
 					n_errors += gmt_default_option_error (GMT, opt);
 				break;
+			case 'Q':	/* Deprecated option, use -n instead */
+				if (gmt_M_compat_check (GMT, 4)) {
+					GMT_Report (API, GMT_MSG_COMPAT, "Option -Q is deprecated; -n%s was set instead, use this in the future.\n", opt->arg);
+					n_errors += gmtinit_parse_n_option (GMT, opt->arg);
+				}
+				else
+					n_errors += gmt_default_option_error (GMT, opt);
 			case 'T':	/* Convert from pixel file <-> gridfile */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
 				Ctrl->T.active = true;


### PR DESCRIPTION
See Thorsten's shopping list from the [forum](https://forum.generic-mapping-tools.org/t/adjusting-gmt-version-4-compatible-scripts-so-they-can-run-in-version-6/2607).  In GMT 4 the **-n** option was instead handled by separate **-Q** and **-L** options.  We added support for **-L** as a deprecated option in GMT 5 but I assume orgot about **-Q**.  Ths PR adds this under compatibility level 4.
