### PR TITLE
Add script for documentation figure for grdblend

### DIFF
--- a/doc/rst/source/grdblend.rst
+++ b/doc/rst/source/grdblend.rst
@@ -71,6 +71,17 @@ Required Arguments
     first be resampled via :doc:`grdsample`. Also, grids that are not in
     netCDF or native binary format will first be reformatted via :doc:`grdconvert`.
 
+.. figure:: /_images/GMT_blend.*
+   :width: 500 px
+   :align: center
+
+   Each input grid has its full region (heavy line) and optionally an inner
+   region (dashed line). The area between these bounds are subject to cosine
+   tapering, where the weight will go from 0 to 1 (or the specified relative
+   weight per grid).  Any output grid node is then a weighted sum of the grids
+   that overlap the node.  Blue line shows a crossection of how the blending
+   and tapering works.
+
 .. _-G:
 
 **-G**\ *outgrid*

--- a/doc/scripts/GMT_blend.sh
+++ b/doc/scripts/GMT_blend.sh
@@ -34,7 +34,7 @@ gmt begin GMT_blend
 	EOF
 	printf "0	22\n100	22\n" | gmt plot -W1p,blue
 	gmt text -F+f12p,Times-Italic+j -Dj4p <<- EOF
-	100 50 TL z = 1, w = 1
+	0	45 TL z = 1, w = 1
 	60  40 TR z = 2, w = 2
 	75  35 TR z = 3, w = 4
 	EOF

--- a/doc/scripts/GMT_blend.sh
+++ b/doc/scripts/GMT_blend.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Demonstrate blending and weights
+# Large grid has no inner boundary
+# Crossection shows output values are correct
+gmt begin GMT_blend
+	gmt set GMT_THEME cookbook
+	gmt grdmath -R0/100/0/45  -I0.2 1 = 1.grd
+	gmt grdmath -R10/60/15/40 -I0.2 2 = 2.grd
+	gmt grdmath -R45/75/5/35  -I0.2 3 = 3.grd
+	cat <<- EOF > blend.lis
+	1.grd	1
+	2.grd	25/55/20/33	2
+	3.grd	48/70/7/25	4
+	EOF
+	gmt grdblend blend.lis -R1.grd -Gblend.grd
+	cat <<- EOF > t.cpt
+	1	lightyellow	2	lightorange
+	2	lightorange	3	lightred
+	EOF
+	gmt grdimage blend.grd -Jx0.2c -B -Ct.cpt
+	gmt grdinfo -Ib 2.grd | gmt plot -W2p
+	gmt grdinfo -Ib 3.grd | gmt plot -W2p
+	gmt plot -W0.5,- -L <<- EOF
+	> Inner region for grid 2
+	25	20
+	55	20
+	55	35
+	25	35
+	> Inner region for grid 3
+	48	7
+	70	7
+	70	25
+	48	25
+	EOF
+	printf "0	22\n100	22\n" | gmt plot -W1p,blue
+	gmt text -F+f12p,Times-Italic+j -Dj4p <<- EOF
+	100 50 TL z = 1, w = 1
+	60  40 TR z = 2, w = 2
+	75  35 TR z = 3, w = 4
+	EOF
+	gmt colorbar -DjRM -F+gwhite+p0.25p -Bx -By+lz
+	gmt grdtrack -Gblend.grd -E0/22/100/22 -o0,2 | gmt plot -R0/100/0.8/2.8 -Jx0.2c/1c -Bya1g1 -BWbrt -Y9.2c -W1p,blue
+gmt end show

--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: ad2a5dfef1fb6197fb8a929fb80a587c.dir
-  size: 18609653
-  nfiles: 193
+- md5: e8807d3a5c89bb3bd50b875e9c97b56b.dir
+  size: 18640837
+  nfiles: 194
   path: images

--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: e8807d3a5c89bb3bd50b875e9c97b56b.dir
-  size: 18640837
+- md5: ecd07d09a8f312bd880c8d3848fd7cc9.dir
+  size: 18648748
   nfiles: 194
   path: images


### PR DESCRIPTION
The figure produced by this script will be added to the **grdblend** man page.  But first it needs to be added to _dvc_ before referencing it in _grdblend.rst_.  Maybe some guidance by @meghanrjones will be needed.

![GMT_blend](https://user-images.githubusercontent.com/26473567/153679229-0afeafb5-c683-4acf-ac0d-e06edcb952e4.png)
