### PR TITLE
CI: graphicsmagick and ffmpeg are no longer needed for building the GMT documentation

### DIFF
--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -26,7 +26,7 @@ fi
 
 # packages for building documentation
 if [ "$BUILD_DOCS" = "true" ]; then
-    packages+=" python3-pip python3-setuptools python3-wheel graphicsmagick ffmpeg"
+    packages+=" python3-pip python3-setuptools python3-wheel"
 fi
 
 # packages for running GMT tests

--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -21,7 +21,7 @@ packages="ninja curl pcre2 netcdf gdal geos fftw ghostscript"
 
 # packages for build documentation
 if [ "$BUILD_DOCS" = "true" ]; then
-    packages+=" graphicsmagick ffmpeg pngquant"
+    packages+=" pngquant"
 fi
 # packages for running GMT tests
 if [ "$RUN_TESTS" = "true" ]; then

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -38,13 +38,6 @@ if [ "$BUILD_DOCS" = "true" ]; then
     echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
 
     choco install pngquant
-    choco install graphicsmagick
-    # Add GraphicsMagick to PATH
-    echo 'C:\Program Files\GraphicsMagick-1.3.32-Q8' >> $GITHUB_PATH
-
-    choco install ffmpeg
-    # Add ffmpeg to PATH
-    echo 'C:\ProgramData\chocolatey\lib\ffmpeg\tools' >> $GITHUB_PATH
 fi
 
 if [ "$RUN_TESTS" = "true" ]; then


### PR DESCRIPTION
**Description of proposed changes**

I think graphicsmagick and ffmpeg are no longer needed for building the GMT documentation after we upload all GMT animations to YouTube. 

This PR removes graphicsmagick and ffmpeg from the package list for building the GMT documentation.