### PR TITLE
CI: Force installing GraphicsMagick 1.3.32 on Windows to fix broken CI

### DIFF
--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -41,10 +41,10 @@ if [ "$BUILD_DOCS" = "true" ]; then
 fi
 
 if [ "$RUN_TESTS" = "true" ]; then
-    choco install graphicsmagick
+    choco install graphicsmagick --version 1.3.32
     pip install --user dvc
     # Add GraphicsMagick to PATH
-    echo 'C:\Program Files\GraphicsMagick-1.3.36-Q8' >> $GITHUB_PATH
+    echo 'C:\Program Files\GraphicsMagick-1.3.32-Q8' >> $GITHUB_PATH
     # Add dvc to PATH
     echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
 fi


### PR DESCRIPTION
**Description of proposed changes**

For unknown reason, GraphicsMagick 1.3.36 from Chocolaty doesn't work well, making all CI tests failing. This PR forces installing old GraphicsMagick v1.3.32.