### PR TITLE
Use same bold rst format for Notes

### DIFF
--- a/doc/rst/source/explain_help.rst_
+++ b/doc/rst/source/explain_help.rst_
@@ -1,5 +1,5 @@
 **-^** or just **-**
-    Print a short message about the syntax of the command, then exit (NOTE: on Windows just use **-**).
+    Print a short message about the syntax of the command, then exit (**Note**: on Windows just use **-**).
 **-+** or just **+**
     Print an extensive usage (help) message, including the explanation of
     any module-specific option (but not the GMT common options), then exit.

--- a/doc/rst/source/explain_help_nopar.rst_
+++ b/doc/rst/source/explain_help_nopar.rst_
@@ -1,5 +1,5 @@
 **-^** or just **-**
-    Print a short message about the syntax of the command, then exits (NOTE: on Windows just use **-**).
+    Print a short message about the syntax of the command, then exits (**Note**: on Windows just use **-**).
 **-+** or just **+**
     Print an extensive usage (help) message, including the explanation of
     any module-specific option (but not the GMT common options), then exits.


### PR DESCRIPTION
Most Notes are set like this:

**Note**: Some note

but the documentation for -^ (or just -) said

NOTE: some note
