### PR TITLE
Allow for tiny slop when computing pads in grdimage

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1153,10 +1153,10 @@ void grdimage_reset_grd_minmax (struct GMT_CTRL *GMT, struct GMT_GRID *G, double
 	gmt_M_memcpy (old_wesn, G->header->wesn, 4, double);	/* Save a copy of what we have */
 	gmt_M_memcpy (new_wesn, G->header->wesn, 4, double);	/* Save a copy of what we have */
 	old_z_min = G->header->z_min;	old_z_max = G->header->z_max;
-	pad[XLO] = (G->header->wesn[XLO] < GMT->common.R.wesn[XLO]) ? irint (floor ((GMT->common.R.wesn[XLO] - G->header->wesn[XLO]) / G->header->inc[GMT_X])) : 0;
-	pad[XHI] = (G->header->wesn[XHI] > GMT->common.R.wesn[XHI]) ? irint (floor ((G->header->wesn[XHI] - GMT->common.R.wesn[XHI]) / G->header->inc[GMT_X])) : 0;
-	pad[YLO] = (G->header->wesn[YLO] < GMT->common.R.wesn[YLO]) ? irint (floor ((GMT->common.R.wesn[YLO] - G->header->wesn[YLO]) / G->header->inc[GMT_Y])) : 0;
-	pad[YHI] = (G->header->wesn[YHI] > GMT->common.R.wesn[YHI]) ? irint (floor ((G->header->wesn[YHI] - GMT->common.R.wesn[YHI]) / G->header->inc[GMT_Y])) : 0;
+	pad[XLO] = (G->header->wesn[XLO] < GMT->common.R.wesn[XLO]) ? irint (floor ((GMT->common.R.wesn[XLO] - G->header->wesn[XLO] + GMT_CONV12_LIMIT) / G->header->inc[GMT_X])) : 0;
+	pad[XHI] = (G->header->wesn[XHI] > GMT->common.R.wesn[XHI]) ? irint (floor ((G->header->wesn[XHI] - GMT->common.R.wesn[XHI] + GMT_CONV12_LIMIT) / G->header->inc[GMT_X])) : 0;
+	pad[YLO] = (G->header->wesn[YLO] < GMT->common.R.wesn[YLO]) ? irint (floor ((GMT->common.R.wesn[YLO] - G->header->wesn[YLO] + GMT_CONV12_LIMIT) / G->header->inc[GMT_Y])) : 0;
+	pad[YHI] = (G->header->wesn[YHI] > GMT->common.R.wesn[YHI]) ? irint (floor ((G->header->wesn[YHI] - GMT->common.R.wesn[YHI] + GMT_CONV12_LIMIT) / G->header->inc[GMT_Y])) : 0;
 	for (k = 0; k < 4; k++) if (pad[k]) {
 		new_wesn[k] = GMT->common.R.wesn[k];	/* Snap back to -R */
 		n_pad++;	/* Number of nonzero pads */


### PR DESCRIPTION
Due to the need to add extra rows/cols for some projections and interpolants, we read in extra data from a file if it has it.  However, when an automatic CPT scaling is needed we do not want to include this extra pad data in determining the zmin/zmax limits so we temporarily scale back and recompute the min/max in those cases.  Unfortunately, the calculation that determined the pad was subject to round-off and did not follow what is done elsewhere in GMT (tolerate 10e-12 in such cases.  So 1.9999999 became 1 instead of 2, for instance and junk was considered and min/max changed badly.

This PR fixes this issue.  No test was affected but a figure in a paper started acting up...
