### PR TITLE
Ensure that the raster has x and y increasing normally

### DIFF
--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -426,6 +426,16 @@ GMT_LOCAL int populate_metadata (struct GMT_CTRL *GMT, struct GMT_GDALREAD_OUT_C
 		anSrcWin[2] = irint ((dfLRX - dfULX) / adfGeoTransform[1]);
 		anSrcWin[3] = irint ((dfLRY - dfULY) / adfGeoTransform[5]);
 
+		/* First check if we have a compliant raster (right handed coordinates) */
+		if (anSrcWin[2] < 0) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your raster has x-coordinates increasing to the left - exiting\n");
+			return(GMT_NOTSET);
+		}
+		if (anSrcWin[3] < 0) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your raster has y-coordinates increasing down rows - exiting\n");
+			return(GMT_NOTSET);
+		}
+		/* Next check if we are outside valid y-range since that check is always Cartesian */
 		if (anSrcWin[0] < 0 || anSrcWin[1] < 0
 		    || anSrcWin[0] + anSrcWin[2] > GDALGetRasterXSize(hDataset)
 		    || anSrcWin[1] + anSrcWin[3] > GDALGetRasterYSize(hDataset)) {
@@ -982,7 +992,16 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 			anSrcWin[3] = irint (dfULY - dfLRY);
 		}
 
-		/* First check if we are outside valid y-range since that check is always Cartesian */
+		/* First check if we have a compliant raster (right handed coordinates) */
+		if (anSrcWin[2] < 0) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your raster has x-coordinates increasing to the left - exiting\n");
+			return(GMT_NOTSET);
+		}
+		if (anSrcWin[3] < 0) {
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your raster has y-coordinates increasing down rows - exiting\n");
+			return(GMT_NOTSET);
+		}
+		/* Next check if we are outside valid y-range since that check is always Cartesian */
 		if (anSrcWin[1] < 0 || (anSrcWin[1] + anSrcWin[3]) > YDim) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_gdalread: Computed -srcwin falls outside raster size of %dx%d in the y-direction.\n",
 				XDim, YDim);

--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -426,16 +426,6 @@ GMT_LOCAL int populate_metadata (struct GMT_CTRL *GMT, struct GMT_GDALREAD_OUT_C
 		anSrcWin[2] = irint ((dfLRX - dfULX) / adfGeoTransform[1]);
 		anSrcWin[3] = irint ((dfLRY - dfULY) / adfGeoTransform[5]);
 
-		/* First check if we have a compliant raster (right handed coordinates) */
-		if (anSrcWin[2] < 0) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your raster has x-coordinates increasing to the left - exiting\n");
-			return(GMT_NOTSET);
-		}
-		if (anSrcWin[3] < 0) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your raster has y-coordinates increasing down rows - exiting\n");
-			return(GMT_NOTSET);
-		}
-		/* Next check if we are outside valid y-range since that check is always Cartesian */
 		if (anSrcWin[0] < 0 || anSrcWin[1] < 0
 		    || anSrcWin[0] + anSrcWin[2] > GDALGetRasterXSize(hDataset)
 		    || anSrcWin[1] + anSrcWin[3] > GDALGetRasterYSize(hDataset)) {
@@ -694,15 +684,15 @@ GMT_LOCAL int populate_metadata (struct GMT_CTRL *GMT, struct GMT_GDALREAD_OUT_C
 		Ctrl->hdr[7] = adfGeoTransform[1];
 		Ctrl->hdr[8] = fabs(adfGeoTransform[5]);
 
+		if (got_R) {
+			Ctrl->hdr[0] = dfULX;	Ctrl->hdr[1] = dfLRX;
+			Ctrl->hdr[2] = dfLRY;	Ctrl->hdr[3] = dfULY;
+		}
+
 		if (Ctrl->hdr[2] > Ctrl->hdr[3]) {	/* Sometimes GDAL does it: y_min > y_max. If so, revert it */
 			tmpdble = Ctrl->hdr[2];
 			Ctrl->hdr[2] = Ctrl->hdr[3];
 			Ctrl->hdr[3] = tmpdble;
-		}
-
-		if (got_R) {
-			Ctrl->hdr[0] = dfULX;	Ctrl->hdr[1] = dfLRX;
-			Ctrl->hdr[2] = dfLRY;	Ctrl->hdr[3] = dfULY;
 		}
 	}
 
@@ -766,7 +756,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 	bool   pixel_reg = false;	/* GDAL decides everything is pixel reg, we make our decisions based on data type */
 	bool   fliplr, got_R = false, got_r = false;
 	bool   topdown = false, rowmajor = true;               /* arrays from GDAL have this order */
-	bool   just_copy = false, copy_flipud = false;
+	bool   just_copy = false, copy_flipud = false, UDflip_Y = false;
 	int	   *whichBands = NULL;
 	int64_t *rowVec = NULL, *colVec = NULL;
 	int64_t  off, i_x_nXYSize, startColPos = 0, indent = 0, col_indent = 0, nXSize_withPad = 0, nYSize_withPad;
@@ -954,6 +944,12 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "gmt_gdalread: Image %s does not have geographic coordinates so -R is ignored for subregion\n", gdal_filename);
 		got_R = false;
 	}
+	if ((dfLRY < dfULY) && adfGeoTransform[5] > 0) {
+		/* Case when y-axes comes positive up from GDAL (that normally has it positive down) */
+		double t;
+		t = dfLRY;	dfLRY = dfULY;	dfULY = t;
+		UDflip_Y = true;
+	}
 
 	if (got_R || got_r) {
 		/* -------------------------------------------------------------------- */
@@ -992,16 +988,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 			anSrcWin[3] = irint (dfULY - dfLRY);
 		}
 
-		/* First check if we have a compliant raster (right handed coordinates) */
-		if (anSrcWin[2] < 0) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your raster has x-coordinates increasing to the left - exiting\n");
-			return(GMT_NOTSET);
-		}
-		if (anSrcWin[3] < 0) {
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Your raster has y-coordinates increasing down rows - exiting\n");
-			return(GMT_NOTSET);
-		}
-		/* Next check if we are outside valid y-range since that check is always Cartesian */
+		/* First check if we are outside valid y-range since that check is always Cartesian */
 		if (anSrcWin[1] < 0 || (anSrcWin[1] + anSrcWin[3]) > YDim) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_gdalread: Computed -srcwin falls outside raster size of %dx%d in the y-direction.\n",
 				XDim, YDim);
@@ -1166,7 +1153,6 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 
 		/* Can't find why but have to multiply by nRGBA otherwise it crashes in win32 builds */
 		rowVec = gmt_M_memory(GMT, NULL, (nRowsPerBlock * nRGBA) * nBlocks, size_t);
-		for (m = 0; m < nY; m++) rowVec[m] = m * nX[piece];	/* Steps in pixels as we go down rows */
 		colVec = gmt_M_memory(GMT, NULL, (nX[piece]+pad_w[piece]+pad_e[piece]) * nRGBA, size_t);	/* For now this will be used only to select BIP ordering */
 		for (i = 0; i < nBands; i++) {
 			if (!nReqBands)		/* No band selection, read them sequentially */
@@ -1201,7 +1187,12 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 				row_i = k * nRowsPerBlock;
 				row_e = (k + 1) * nRowsPerBlock;
 				buffy = nRowsPerBlock;
-				for (m = 0; m < nRowsPerBlock; m++) rowVec[m+k*nRowsPerBlock] = m * nX[piece];
+				if (UDflip_Y) {		/* Case when y-axes comes positive up from GDAL (that normally has it positive down) */
+					size_t n = ((nRowsPerBlock-1) + (nBlocks-1) * nRowsPerBlock);
+					for (m = nRowsPerBlock-1; m >= 0 ; m--) rowVec[n - (m + k * nRowsPerBlock)] = m * nX[piece];
+				}
+				else
+					for (m = 0; m < nRowsPerBlock; m++) rowVec[m + k * nRowsPerBlock] = m * nX[piece];
 				if (k == nBlocks-1) {					/* Last block only by chance is not smaller than the others */
 					buffy = nBufYSize - k * nRowsPerBlock;
 					row_e = nYSize;


### PR DESCRIPTION
See discussion on the [forum](https://forum.generic-mapping-tools.org/t/malloc-error-with-grdview-using-a-draped-tiff-image/2644/10) for background.  Unless we put in efforts to handle odd cases, we now return with error if x or y are not increasing in the expected directions (left to right, bottom to top),
