### PR TITLE
Fix error in determining min/max stack values in grdtrack -S

### DIFF
--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -977,14 +977,15 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 				T = Dout->table[tbl];
 				M = Stack->table[0]->segment[tbl];	/* Current stack */
 				M->n_rows = n_rows;
-				for (k = 0; k < Ctrl->G.n_grids; k++) {	/* Reset arrays and extremes */
+				for (k = 0; k < Ctrl->G.n_grids; k++)	/* Allocate arrays for stack */
 					stack[k] = gmt_M_memory (GMT, NULL, T->n_segments, double);
-					stacked_hi[k] = -DBL_MAX;
-					stacked_lo[k] = +DBL_MAX;
-				}
 				if (Ctrl->S.mode == STACK_MEDIAN || Ctrl->S.mode == STACK_MODE) dev = gmt_M_memory (GMT, NULL, Dout->table[tbl]->n_segments, double);	/* Ned temp array for these methods */
 				for (row = 0; row < n_rows; row++) {	/* For each row to stack across all segments, per data grid */
 					gmt_M_memset (stacked_n, Ctrl->G.n_grids, uint64_t);	/* Reset counts for new stack */
+					for (k = 0; k < Ctrl->G.n_grids; k++) {	/* Reset extremes upon starting new stack */
+						stacked_hi[k] = -DBL_MAX;
+						stacked_lo[k] = +DBL_MAX;
+					}
 					for (seg = 0; seg < T->n_segments; seg++) {	/* For each segment to resample */
 						for (col = 4, k = 0; k < Ctrl->G.n_grids; k++, col++) {	/* Collect sampled values across all profiles for same row into temp array */
 							if (gmt_M_is_dnan (T->segment[seg]->data[col][row])) continue;	/* Must skip any NaN entries in any profile */


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/grdtrack-error-in-min-and-max-values-calculation/2653) for background.  The resetting of min/max values needs to be done on a per-row basis, not per segment.  This PR fixes this and corrects the bug.

Here is plotting the stacked median with min/max bounds before the fix:

![a](https://user-images.githubusercontent.com/26473567/155210634-6d8ad0ca-0da4-40ca-ad19-09008a12496d.png)

Here is the same plot after the fix:

![b](https://user-images.githubusercontent.com/26473567/155210648-b35371c8-cf78-4381-9e50-e03e53219143.png)

