### PR TITLE
Refresh ex33 and clarify bounds

### DIFF
--- a/doc/examples/ex33/ex33.sh
+++ b/doc/examples/ex33/ex33.sh
@@ -22,12 +22,10 @@ gmt begin ex33
 	# and stack these using the median, write stacked profile
 	gmt grdtrack ridge.txt -Gspac_33.nc -C400k/2k/10k+v -Sm+sstack.txt > table.txt
 	gmt plot -W0.5p table.txt
-	# Show upper/lower values encountered as an envelope
-	gmt convert stack.txt -o0,5 > env.txt
-	gmt convert stack.txt -o0,6 -I -T >> env.txt
-	gmt plot -R-200/200/-3500/-2000 -JX15c/7.5c -Glightgray env.txt -Yh+3c
-	gmt plot -W3p stack.txt -Bxafg1000+l"Distance from ridge (km)" -Byaf+l"Depth (m)" -BWSne
+	# Show upper/lower 95% confidence bounds encountered as an envelope
+	gmt plot -R-200/200/-3500/-2000 -JX15c/7.5c -W3p stack.txt -i0,1,5,6 -L+b -Glightgray -Yh+3c
+	gmt basemap  -Bxafg1000+l"Distance from ridge (km)" -Byaf+l"Depth (m)" -BWSne
 	echo "0 -2000 MEDIAN STACKED PROFILE" | gmt text -Gwhite -F+jTC+f14p -Dj8p
 	# cleanup
-	rm -f ridge.txt table.txt env.txt stack.txt spac_33.nc
+	rm -f ridge.txt table.txt stack.txt spac_33.nc
 gmt end show

--- a/doc/rst/source/gallery/ex33.rst
+++ b/doc/rst/source/gallery/ex33.rst
@@ -9,7 +9,7 @@ used to automatically create a suite of crossing profiles of uniform
 spacing and length and then sample one or more grids along these
 profiles; we also use the median stacking option to create a stacked
 profile, showed above the map, with the gray area representing the
-variations about the stacked median profile.
+95% confidence bounds on the stacked median profile.
 
 
 .. literalinclude:: /_verbatim/ex33.txt


### PR DESCRIPTION
A follow-up on #6369.  The ex33.sh script was developed before **plot -L+b** came around.  I have shortened the script using **-L+b** and improved the comment that says what the bounds are.

The gallery docs is updated to say the variations are the 95% confidence bounds.
