### PR TITLE
Check for angles that are either 0, -180 or 180 in gmtplot_get_outside_point_extension

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6025,7 +6025,7 @@ GMT_LOCAL void gmtplot_get_outside_point_extension (struct GMT_CTRL *GMT, double
 	/* The is_dnan catches bad cases yielding a NaN angle */
 	if (gmt_M_is_dnan (d_angle) || doubleAlmostEqualZero (fabs (d_angle), 90.0))		/* Line is orthogonal to border; no need to extend it when at a horizontal border */
 		L = 0.0;
-	else if (doubleAlmostEqualZero (d_angle, 0.0))	/* Line is parallel to border; would get infinity so truncate to width of map */
+	else if (doubleAlmostEqualZero (d_angle, 0.0) || doubleAlmostEqualZero (fabs (d_angle), 180.0))	/* Line is parallel to border; would get infinity so truncate to width of map */
 		//L = GMT->current.map.width; /* What we want but still picking up stray horizontal lines, hence L = 0 for now */
 		L = 0.0;
 	else	/* Safe to get width (but still truncate to width of map) */


### PR DESCRIPTION
This function is responsible for extending a line that intersects the rectangular box so that the width of the line is taking into consideration (Note: if we just stop drawing exactly at the intersection coordinates then the finite width of an _oblique_ line will leave a gap).  The case highlighted in this bug was when the vertical line was identified to cross the left boundary (yet the line goes through the top-left corner) but it could also be seen as crossing the top boundary (at 90 degrees).  Either case should result in no extension, but since it was seen to cross the left boundary (when in fact the line is parallel to it) we did not check for that case and ended up with a crazy value.

Closes #6366.