### PR TITLE
say 2 sigma not 95%

### DIFF
--- a/doc/examples/ex33/ex33.sh
+++ b/doc/examples/ex33/ex33.sh
@@ -22,7 +22,7 @@ gmt begin ex33
 	# and stack these using the median, write stacked profile
 	gmt grdtrack ridge.txt -Gspac_33.nc -C400k/2k/10k+v -Sm+sstack.txt > table.txt
 	gmt plot -W0.5p table.txt
-	# Show upper/lower 95% confidence bounds encountered as an envelope
+	# Show upper/lower 2-sigma confidence bounds encountered as an envelope
 	gmt plot -R-200/200/-3500/-2000 -JX15c/7.5c -W3p stack.txt -i0,1,5,6 -L+b -Glightgray -Yh+3c
 	gmt basemap  -Bxafg1000+l"Distance from ridge (km)" -Byaf+l"Depth (m)" -BWSne
 	echo "0 -2000 MEDIAN STACKED PROFILE" | gmt text -Gwhite -F+jTC+f14p -Dj8p

--- a/doc/rst/source/gallery/ex33.rst
+++ b/doc/rst/source/gallery/ex33.rst
@@ -9,7 +9,7 @@ used to automatically create a suite of crossing profiles of uniform
 spacing and length and then sample one or more grids along these
 profiles; we also use the median stacking option to create a stacked
 profile, showed above the map, with the gray area representing the
-95% confidence bounds on the stacked median profile.
+:math:`2\sigma` confidence bounds on the stacked median profile.
 
 
 .. literalinclude:: /_verbatim/ex33.txt


### PR DESCRIPTION
Since the default -S+c factor is 2, not 1.96 I updated the example and docs to state 2-sigma confidence band rather than 95%.
