### PR TITLE
Fix the do_animations.sh script

### DIFF
--- a/doc/examples/do_animations.sh
+++ b/doc/examples/do_animations.sh
@@ -17,7 +17,7 @@ fi
 for i in anim??; do
     echo "Running animation ${i}"
     cd $i
-    bash $i.sh animate
+    bash $i.sh
     cd ..
 done
 


### PR DESCRIPTION
**Description of proposed changes**

All animation scripts can be run directly. The `animate` parameter is no longer needed.
