### PR TITLE
Unpin docutils from v0.17

### DIFF
--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y --no-install-recommends --no-install-suggests $packages
 # Install more packages for building documentation
 if [ "$BUILD_DOCS" = "true" ]; then
     sudo snap install pngquant
-    pip3 install --user docutils==0.17 sphinx dvc
+    pip3 install --user sphinx dvc
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -41,7 +41,7 @@ fi
 brew install ${packages}
 
 if [ "$BUILD_DOCS" = "true" ]; then
-	pip3 install --user docutils==0.17 sphinx dvc
+	pip3 install --user sphinx dvc
     # Add sphinx to PATH
     echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
 fi

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -33,7 +33,7 @@ choco install ninja
 choco install ghostscript --version 9.50
 
 if [ "$BUILD_DOCS" = "true" ]; then
-    pip install --user docutils==0.17 sphinx dvc
+    pip install --user sphinx dvc
     # Add sphinx to PATH
     echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
 


### PR DESCRIPTION
**Description of proposed changes**

We pinned docutils to v0.17, because docutils v0.16 or v0.18 is not fully compatible with some sphinx and sphinx_rtd_theme versions (related to https://github.com/GenericMappingTools/gmt/issues/5282 and https://github.com/GenericMappingTools/gmt/issues/5097).

The latest sphinx versions have pinned docutils to [`docutils>=0.14,<0.18`](https://github.com/sphinx-doc/sphinx/blob/b8789b4cb6ca034ed7209b9adc91095b0b9b763c/setup.py#L25), so installing sphinx should install docutils v0.17 automatically. Thus we don't have to pin docutils in our CI scripts.

BTW, we don't pin docutils to v0.17 in the [`vercel-docs.sh`](https://github.com/GenericMappingTools/gmt/blob/master/ci/vercel-docs.sh) script, and the preview documentation looks good.