### PR TITLE
Use @loader_path for building the bundle

### DIFF
--- a/cmake/dist/CMakeLists.txt
+++ b/cmake/dist/CMakeLists.txt
@@ -189,7 +189,7 @@ if (APPLE)
 			set(path \"\${\${default_embedded_path_var}}\")
 			# Embed *.dylib in the lib folder:
 			if(item MATCHES \"[.]dylib\$\")
-				set(path \"@executable_path/../lib\")
+				set(path \"@loader_path/../lib\")
 			endif()
 			set(\${default_embedded_path_var} \"\${path}\" PARENT_SCOPE)
 		endfunction(gp_item_default_embedded_path_override)


### PR DESCRIPTION
**Description of proposed changes**

As proposed in https://github.com/GenericMappingTools/gmt/issues/1930#issuecomment-698683500, this PR updates `cmake/dist/CMakeLists.txt` to use `@loader_path` rather than `@executable_path`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Relates to https://github.com/GenericMappingTools/gmt/issues/1930, https://github.com/GenericMappingTools/gmt/issues/6128, and https://github.com/GenericMappingTools/gmt/pull/4246.


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
