### PR TITLE
Fix the cmake packaging issue on macOS

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@
 name: Docs
 
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@
 name: Docs
 
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master

--- a/cmake/dist/CMakeLists.txt
+++ b/cmake/dist/CMakeLists.txt
@@ -195,7 +195,11 @@ if (APPLE)
 		endfunction(gp_item_default_embedded_path_override)
 
 		include (BundleUtilities)
-		fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${GMT_BINDIR}/gmt${CMAKE_EXECUTABLE_SUFFIX}\" \"\${CMAKE_INSTALL_PREFIX}/${GMT_LIBDIR}/gmt${CMAKE_EXECUTABLE_SUFFIX}/plugins/${GMT_SUPPL_LIB_NAME}.so\" \"\")
+		# The dir /usr/local/lib is added to address the packaging issue for Homebrew
+		# as reported https://github.com/GenericMappingTools/gmt/issues/6025.
+		# The root cause is unclear, possibly a cmake issue.
+		# We should try to remove it when new cmake releases are available.
+		fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${GMT_BINDIR}/gmt${CMAKE_EXECUTABLE_SUFFIX}\" \"\${CMAKE_INSTALL_PREFIX}/${GMT_LIBDIR}/gmt${CMAKE_EXECUTABLE_SUFFIX}/plugins/${GMT_SUPPL_LIB_NAME}.so\" \"/usr/local/lib\")
 	endif ()
 	" COMPONENT Runtime)
 endif (APPLE)


### PR DESCRIPTION
**Description of proposed changes**

The workflow fails to make the macOS bundle, with the following error message:
```
/Applications/Xcode_13.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic:
  can't open file: @rpath/libgeos.3.10.1.dylib (No such file or directory)
```
It's unclear why other libraries (like gdal) have abosulte paths, but the geos library has a relative path `@rpath/libgeos.3.10.1.dylib`. So the root cause of the error is still unclear to me.

A temporary workaround is passing extra RPATH (`/usr/local/lib` for homebrew) as the last parameter of the `fixup_bundle` function. 

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #6025.