### PR TITLE
Allow gmtconvert -S +e modifier for exact search

### DIFF
--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -297,6 +297,11 @@ the string "RIDGE AXIS", try::
 
     gmt convert big_file.txt -S"RIDGE AXIS" > subset.txt
 
+To only get the segments in the file big_file.txt whose headers exactly
+matches the string "Spitsbergen", try::
+
+    gmt convert big_file.txt -SSpitsbergen+e > subset.txt
+
 To invert the selection of segments whose headers begin with "profile "
 followed by an integer number and any letter between "g" and "l", try::
 

--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-L| ]
 [ |-N|\ *col*\ [**+a**\|\ **d**] ]
 [ |-Q|\ [**~**]\ *selection*]
-[ |-S|\ [**~**]\ *"search string"* \| |-S|\ [**~**]/\ *regexp*/[**i**] ]
+[ |-S|\ [**~**]\ *"search string"*[**+e**] \| |-S|\ [**~**]/\ *regexp*/[**i**] ]
 [ |-T|\ [**h**][**d**\ [[**~**]\ *selection*]] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [**+n**] ]
@@ -175,7 +175,7 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ [**~**]\ *"search string"* or **-S**\ [**~**]/\ *regexp*/[**i**]
+**-S**\ [**~**]\ *"search string"*[**+e**] or **-S**\ [**~**]/\ *regexp*/[**i**]
     Only output those segments whose header record contains the
     specified text string. To reverse the search, i.e., to output
     segments whose headers do *not* contain the specified pattern, use
@@ -190,7 +190,9 @@ Optional Arguments
     headers against extended regular expressions enclose the expression
     in slashes. Append **i** for case-insensitive matching.
     For a list of such patterns, give **+f**\ *file* with one pattern per line.
-    To give a single pattern starting with +f, escape it with a backslash.
+    To give a single pattern starting with "+f", escape it with a backslash.
+    Finally, append **+e** at the end to request an exact match [Default will
+    match any sub-string in the target].
 
 .. _-T:
 
@@ -199,7 +201,7 @@ Optional Arguments
     suppress segment headers [Default], and/or **d** to suppress duplicate
     data records.  Use **-Thd** to suppress both types of records.  By default,
     all columns must be identical across the two records to skip the record.
-    ALternatively, append a column *selection* to only use those columns
+    Alternatively, append a column *selection* to only use those columns
     in the comparisons instead.  The *selection* syntax is
     *range*\ [,\ *range*,...] where each *range* of items is either a single
     column *number* or a range with stepped increments given via *start*\ [:*step*:]\ :*stop*

--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-L| ]
 [ |-N|\ *col*\ [**+a**\|\ **d**] ]
 [ |-Q|\ [**~**]\ *selection*]
-[ |-S|\ [**~**]\ *"search string"*[**+e**] \| |-S|\ [**~**]/\ *regexp*/[**i**] ]
+[ |-S|\ [**~**]\ *"search string"*\|\ **+f**\|\ *file*\ [**+e**] \| |-S|\ [**~**]/\ *regexp*/[**i**][**+e**] ]
 [ |-T|\ [**h**][**d**\ [[**~**]\ *selection*]] ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [**+n**] ]
@@ -175,7 +175,7 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ [**~**]\ *"search string"*[**+e**] or **-S**\ [**~**]/\ *regexp*/[**i**]
+**-S**\ [**~**]\ *"search string"*\|\ **+f**\|\ *file*\ [**+e**] \| |-S|\ [**~**]/\ *regexp*/[**i**][**+e**]
     Only output those segments whose header record contains the
     specified text string. To reverse the search, i.e., to output
     segments whose headers do *not* contain the specified pattern, use
@@ -191,7 +191,7 @@ Optional Arguments
     in slashes. Append **i** for case-insensitive matching.
     For a list of such patterns, give **+f**\ *file* with one pattern per line.
     To give a single pattern starting with "+f", escape it with a backslash.
-    Finally, append **+e** at the end to request an exact match [Default will
+    Finally, append **+e** as last modifier to request an exact match [Default will
     match any sub-string in the target].
 
 .. _-T:

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -517,7 +517,7 @@ EXTERN_MSC void gmt_free_int_selection (struct GMT_CTRL *GMT, struct GMT_INT_SEL
 EXTERN_MSC struct GMT_INT_SELECTION * gmt_set_int_selection (struct GMT_CTRL *GMT, char *item);
 EXTERN_MSC bool gmt_get_int_selection (struct GMT_CTRL *GMT, struct GMT_INT_SELECTION *S, uint64_t this);
 EXTERN_MSC void gmt_free_text_selection (struct GMT_CTRL *GMT, struct GMT_TEXT_SELECTION **S);
-EXTERN_MSC bool gmt_get_segtext_selection (struct GMT_CTRL *GMT, struct GMT_TEXT_SELECTION *S, struct GMT_DATASEGMENT *T, bool last_match);
+EXTERN_MSC bool gmt_get_segtext_selection (struct GMT_CTRL *GMT, struct GMT_TEXT_SELECTION *S, struct GMT_DATASEGMENT *T, bool exact, bool last_match);
 EXTERN_MSC struct GMT_TEXT_SELECTION * gmt_set_text_selection (struct GMT_CTRL *GMT, char *arg);
 EXTERN_MSC int gmt_flip_justify (struct GMT_CTRL *GMT, unsigned int justify);
 EXTERN_MSC int gmt_get_pair (struct GMT_CTRL *GMT, char *string, unsigned int mode, double par[]);

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -365,7 +365,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTCONVERT_CTRL *Ctrl, struct GMT
 					c[0] = '\0';	/* Temporarily hide this string */
 				}
 				Ctrl->S.select = gmt_set_text_selection (GMT, opt->arg);
-				c[0] = '+';	/* Restore */
+				if (c) c[0] = '+';	/* Restore */
 				break;
 			case 'T':	/* -T[h]: Do not write segment headers, -Td: Skip duplicate records */
 				strncpy (p, opt->arg, GMT_BUFSIZ-1);
@@ -692,7 +692,8 @@ EXTERN_MSC int GMT_gmtconvert (void *V_API, int mode, void *args) {
 		if ((Ctrl->S.select->ogr_item = gmt_get_ogr_id (GMT->current.io.OGR, Ctrl->S.select->pattern[0])) != GMT_NOTSET) {
 			Ctrl->S.select->ogr_match = true;
 			p++;
-			strcpy (Ctrl->S.select->pattern[0], p);	/* Move the value over to the start */
+			gmt_M_str_free (Ctrl->S.select->pattern[0]);	/* Free the old string */
+			Ctrl->S.select->pattern[0] = strdup (p);		/* Copy over start value */
 		}
 	}
 

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -135,7 +135,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<table>] [-A] [-C[+l<min>][+u<max>][+i]] [-D[<template>[+o<orig>]]] "
-		"[-E[f|l|m|M<stride>]] [-F%s] [-I[tsr]] [-L] [-N<col>[+a|d]] [-Q[~]<selection>] [-S[~]\"search string\"] "
+		"[-E[f|l|m|M<stride>]] [-F%s] [-I[tsr]] [-L] [-N<col>[+a|d]] [-Q[~]<selection>] [-S[~]\"search string\"|+f<file>[+e] | -S[~]/<regexp>/[i][+e]]"
 		"[-T[h][d[[~]<selection>]]] [%s] [-W[+n]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_SEGMENTIZE4, GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT,
 		GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_q_OPT, GMT_s_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
@@ -187,15 +187,15 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"either a single number, start-stop (for range), start:step:stop (for stepped range), "
 		"or +f<file> for a file list with one <range> selection per line. "
 		"A leading ~ will invert the selection and write all segments but the ones listed.");
-	GMT_Usage (API, 1, "\n-S[~]\"search string\"");
-	GMT_Usage (API, -2, "Only output segments whose headers contain the pattern \"string\"[+e]. "
-		"Use -S~\"string\" to output segment that DO NOT contain this pattern. "
+	GMT_Usage (API, 1, "\n-S[~]\"search string\"|+f<file>[+e] | -S[~]/<regexp>/[i][+e]");
+	GMT_Usage (API, -2, "Only output segments whose headers contain the pattern \"search string\". "
+		"Use -S~\"search string\" to output segment that DO NOT contain this pattern. "
 		"If your pattern begins with ~, escape it with \\~. "
-		"Append +e to require an exact match [Default will match sub-strings]. "
 		"To match OGR aspatial values, use name=value, and to match headers against "
 		"extended regular expressions use -S[~]/regexp/[i] (i for case-insensitive). "
-		"Give +f<file> for a file list with such patterns, one per line. "
+		"Instead of \"search string\", give +f<file> for a file with such patterns, one per line. "
 		"To give a single pattern starting with +f, escape it with \\+f.");
+		"Any of these three forms accept an optional +e to require an exact match [Default will match sub-strings]. "
 	GMT_Usage (API, 1, "\n-T[h][d[[~]<selection>]]");
 	GMT_Usage (API, -2, "Skip certain types of records.  Append one or both of these directives:");
 	GMT_Usage (API, 3, "h: Prevent the writing of segment headers [Default].");

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -194,8 +194,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"To match OGR aspatial values, use name=value, and to match headers against "
 		"extended regular expressions use -S[~]/regexp/[i] (i for case-insensitive). "
 		"Instead of \"search string\", give +f<file> for a file with such patterns, one per line. "
-		"To give a single pattern starting with +f, escape it with \\+f.");
-		"Any of these three forms accept an optional +e to require an exact match [Default will match sub-strings]. "
+		"To give a single pattern starting with +f, escape it with \\+f. "
+		"Any of these three forms accept an optional +e to require an exact match [Default will match sub-strings]. ");
 	GMT_Usage (API, 1, "\n-T[h][d[[~]<selection>]]");
 	GMT_Usage (API, -2, "Skip certain types of records.  Append one or both of these directives:");
 	GMT_Usage (API, 3, "h: Prevent the writing of segment headers [Default].");


### PR DESCRIPTION
This PR addresses the issue in #6385 by adding a new, optional modifier **+e** for exact match.  The default will remain a pattern match.  In the example given by the post above, `-Slocation=Riga` will match two segments (Riga and West_Gulf_of_Riga) while `-Slocation=Riga+e` will only match Riga.

In addition to this new modifier I fixed a bug where we tried to overwrite a string with a longer value.  I also improved the docs.

Would be great if @evangowan could give this branch a test as well.