### PR TITLE
Address the warning introduced in #6390

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7331,7 +7331,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 				"<lon0>/<lat0> is the center of the projection. "
 				"The <scale> can also be given as <radius>/<lat>, where <radius> is distance "
 				"in %s to the oblique parallel <lat0>. "
-				"Several optional modifiers control the perspective:", GMT->session.unit_name[GMT->current.setting.proj_length_unit]); 
+				"Several optional modifiers control the perspective:", GMT->session.unit_name[GMT->current.setting.proj_length_unit]);
 			GMT_Usage (API, 3, "+a Append <azimuth> east of North of view [0].");
 			GMT_Usage (API, 3, "+t Append the upward <tilt> of the plane of projection; "
 				"if <tilt> < 0 then viewpoint is centered on the horizon [0].");
@@ -14693,7 +14693,7 @@ GMT_LOCAL bool gmtinit_replace_missing_with_questionmark (struct GMTAPI_CTRL *AP
 		}
 		else if (strchr ("gG", arg[0]) && (c = gmt_first_modifier (API->GMT, arg, "atvwz"))) {	/* General perspective with one or more modifiers */
 			c[0] = '\0';	/* Chop you go */
-			L = strlen (arg) - 1;	/* Recompute position of last char */			
+			L = strlen (arg) - 1;	/* Recompute position of last char */
 		}
 		if (arg[L] == '/')	/* User followed instructions and left a trailing / */
 			sprintf (newarg, "%s?", arg);	/* newarg has no trailing modifiers yet */
@@ -14896,7 +14896,7 @@ void gmtinit_complete_RJ (struct GMT_CTRL *GMT, char *codes, struct GMT_OPTION *
 		gmt_M_memset (str, 3, char);
 		str[0] = codes[j];
 		if ((id = gmt_get_option_id (0, str)) == GMT_NOTSET) continue;	/* Not an option we have history for yet */
-		if (codes[j] == 'R' && !GMT->current.ps.active || !GMT->init.history[id]) id++;		/* Examine -RG history if not a plotter or no -RP */
+		if (codes[j] == 'R' && (!GMT->current.ps.active || !GMT->init.history[id])) id++;		/* Examine -RG history if not a plotter or no -RP */
 		if (GMT->init.history[id] == NULL) continue;	/* No history for this option */
 		if (codes[j] == 'J') {	/* Must now search for actual option since -J only has the code (e.g., -JM) */
 			/* Continue looking for -J<code> */
@@ -16312,15 +16312,15 @@ int gmt_parse_vector (struct GMT_CTRL *GMT, char symbol, char *text, struct GMT_
 	}
 	if ((S->v.status & PSL_VEC_JUST_S) && (S->v.status & PSL_VEC_COMPONENTS)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot combine second point coordinates (+s) with component scaling (+z)\n");
-		error++;		
+		error++;
 	}
 	if ((S->v.status & PSL_VEC_JUST_S) && (S->v.status & PSL_VEC_MAGNIFY)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot combine second point coordinates (+s) with magnitude scaling (+v)\n");
-		error++;		
+		error++;
 	}
 	if ((S->v.status & PSL_VEC_MAGCPT) && !S->v.v_unit_d) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot select magnitude for CPT (+c) without magnitude scaling (via +v or +z)\n");
-		error++;		
+		error++;
 	}
 	if ((S->v.status & PSL_VEC_MID_FWD || S->v.status & PSL_VEC_MID_BWD) && (S->v.status & PSL_VEC_BEGIN || S->v.status & PSL_VEC_END)) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot combine mid-point vector head (+m) with end-point heads (+b | +e)\n");
@@ -19430,7 +19430,7 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 			if (S->D.fill[0]) strcat (scode, "+g"), strcat (scode, S->D.fill);
 			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 		}
-		else 
+		else
 			fprintf (fp, "S - %c %s %s %s - %s\n", symbol, size_string, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 	}
 


### PR DESCRIPTION
**Description of proposed changes**

Address the warning reported in https://github.com/GenericMappingTools/gmt/pull/6390#issuecomment-1053270501.

Some trailing whitespaces are also removed by my text editor.