### PR TITLE
Fix foolishness in gmtconvert

### DIFF
--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -692,8 +692,7 @@ EXTERN_MSC int GMT_gmtconvert (void *V_API, int mode, void *args) {
 		if ((Ctrl->S.select->ogr_item = gmt_get_ogr_id (GMT->current.io.OGR, Ctrl->S.select->pattern[0])) != GMT_NOTSET) {
 			Ctrl->S.select->ogr_match = true;
 			p++;
-			gmt_M_str_free (Ctrl->S.select->pattern[0]);	/* Free the old string */
-			Ctrl->S.select->pattern[0] = strdup (p);		/* Copy over start value */
+			strcpy (Ctrl->S.select->pattern[0], p);	/* Shift over the string after skipping name= */
 		}
 	}
 


### PR DESCRIPTION
See #6385 for background.  Caffeine-deprivation and general foolishness related to travel preparations lead to an unwanted change related to stripping off the leading name= from the search string. Yet it somehow worked in Xcode when testing, hence the initial PR... (pls try again, @evangowan)

This PR should fix this problem.  I can confirm the output now is correct:

pattern matching:

```
gmt convert temp.gmt -Slocation=Riga
>
22.1120169091	57.7710424993
23.2040767173	57.9283770234
23.4930241573	57.6291001832
23.4606231249	57.3312000796
23.1172608995	56.8525065168
22.077814351	57.4635298952
22.1120169091	57.7710424993
>
23.4606231249	57.3312000778
24.8006762845	57.4253968551
24.6700673861	57.0026169512
24.0829844674	56.7662371812
23.3597174711	56.7601754062
23.1172608995	56.852506515
23.4606231249	57.3312000778
```

Exit match:

```
 gmt convert temp.gmt -Slocation=Riga+e
>
23.4606231249	57.3312000778
24.8006762845	57.4253968551
24.6700673861	57.0026169512
24.0829844674	56.7662371812
23.3597174711	56.7601754062
23.1172608995	56.852506515
23.4606231249	57.3312000778
```

