### PR TITLE
Add test for passing text dataset to legend

### DIFF
--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -2016,7 +2016,7 @@ EXTERN_MSC int GMT_pslegend (void *V_API, int mode, void *args) {
 			D[PAR]->table[0]->n_segments = D[PAR]->n_segments = n_para;
 			D[PAR]->table[0]->n_records += S[PAR]->n_rows;
 			D[PAR]->n_records = D[PAR]->table[0]->n_records;
-			S[PAR] = D[PAR]->table[0]->segment[n_para] = GMT_Alloc_Segment (GMT->parent, GMT_WITH_STRINGS, krow[PAR], 0U, NULL, S[PAR]);
+			S[PAR] = D[PAR]->table[0]->segment[n_para-1] = GMT_Alloc_Segment (GMT->parent, GMT_WITH_STRINGS, krow[PAR], 0U, NULL, S[PAR]);
 		}
 
 		/* Create option list, register D[PAR] as input source */

--- a/src/testapi_text_legend.c
+++ b/src/testapi_text_legend.c
@@ -1,0 +1,33 @@
+/* Testing the case of passing a virtual dataset for paragraph text to pslegend */
+
+#include "gmt.h"
+#include <string.h>
+
+int main () {
+	void *API = NULL;                 /* The API control structure */
+	struct GMT_DATASET *D = NULL;	  /* Structure to hold input dataset as vectors */
+	struct GMT_DATASEGMENT *S = NULL;	  /* Structure to hold input dataset as vectors */
+	char input[GMT_VF_LEN] = {""};     			/* String to hold virtual input filename */
+	char args[128] = {""};            			/* String to hold module command arguments */
+
+	uint64_t dim[4] = {1, 1, 2, 0};
+
+	/* Initialize the GMT session */
+	API = GMT_Create_Session ("test", 2U, GMT_SESSION_EXTERNAL, NULL);
+	/* Create a dataset */
+	if ((D = GMT_Create_Data (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_WITH_STRINGS, dim, NULL, NULL, 0, 0, NULL)) == NULL) return (EXIT_FAILURE);
+	/**/
+	S = D->table[0]->segment[0];
+	S->text[0] = strdup ("P");
+	S->text[1] = strdup ("T d = [0 0; 1 1; 2 1; 3 0.5; 2 0.25]");
+	/* Associate our data table with a virtual file */
+	GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_IN|GMT_IS_REFERENCE, D, input);
+	/* Prepare the module arguments */
+	sprintf (args, "%s -R-3/3/-3/3 -JX12 -Baf -BWSen -F+p+ggray -Dg-1.8/2.6+w12c+jTL -P > t.ps\n", input);
+
+	/* Call the pslegend module */
+	GMT_Call_Module (API, "pslegend", GMT_MODULE_CMD, args);
+	GMT_Close_VirtualFile (API, input);
+	/* Destroy the GMT session */
+	if (GMT_Destroy_Session (API)) return EXIT_FAILURE;
+};

--- a/src/testapi_text_legend.c
+++ b/src/testapi_text_legend.c
@@ -10,20 +10,20 @@ int main () {
 	char input[GMT_VF_LEN] = {""};     			/* String to hold virtual input filename */
 	char args[128] = {""};            			/* String to hold module command arguments */
 
-	uint64_t dim[4] = {1, 1, 2, 0};
+	uint64_t dim[4] = {1, 1, 2, 0};	/* one table with one segment with two rows and no columns (just trailing text) */
 
 	/* Initialize the GMT session */
 	API = GMT_Create_Session ("test", 2U, GMT_SESSION_EXTERNAL, NULL);
 	/* Create a dataset */
 	if ((D = GMT_Create_Data (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_WITH_STRINGS, dim, NULL, NULL, 0, 0, NULL)) == NULL) return (EXIT_FAILURE);
 	/**/
-	S = D->table[0]->segment[0];
+	S = D->table[0]->segment[0];	/* Get the pointer to the only segment and add specific strings */
 	S->text[0] = strdup ("P");
 	S->text[1] = strdup ("T d = [0 0; 1 1; 2 1; 3 0.5; 2 0.25]");
 	/* Associate our data table with a virtual file */
 	GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_TEXT, GMT_IN|GMT_IS_REFERENCE, D, input);
 	/* Prepare the module arguments */
-	sprintf (args, "%s -R-3/3/-3/3 -JX12 -Baf -BWSen -F+p+ggray -Dg-1.8/2.6+w12c+jTL -P > t.ps\n", input);
+	sprintf (args, "%s -R-3/3/-3/3 -JX12 -Baf -BWSen -F+p+ggray -Dg-1.8/2.6+w12c+jTL -P\n", input);
 
 	/* Call the pslegend module */
 	GMT_Call_Module (API, "pslegend", GMT_MODULE_CMD, args);


### PR DESCRIPTION
Basically replicates the situation in #6336.

@joa-quim, might you be able to try this branch and build all and then run the` testapi_text_legend > junk.ps `command? It should crash as well since it is basically doing your case - but perhaps things are easier to see.