### PR TITLE
Disallow grdhisteq -C -N

### DIFF
--- a/doc/rst/source/grdhisteq.rst
+++ b/doc/rst/source/grdhisteq.rst
@@ -90,7 +90,7 @@ Optional Arguments
 **-N**\ [*norm*]
     Gaussian output. Use with **-G** to make an output grid with
     standard normal scores. Append *norm* to force the scores to fall in
-    the ±*norm* range [Default is standard normal scores].
+    the ±\ *norm* range [Default is standard normal scores].
 
 .. _-Q:
 

--- a/src/grdhisteq.c
+++ b/src/grdhisteq.c
@@ -178,6 +178,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDHISTEQ_CTRL *Ctrl, struct GMT_
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->In.file, "Must specify input grid file\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && !Ctrl->G.active, "Option -N: Must also specify output grid file with -G\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && Ctrl->Q.active, "Option -N: Cannot be combined with -Q\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && Ctrl->C.active, "Option -N: Cannot be combined with -C\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->C.value <= 0, "Option -C: n_cells must be positive\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->D.active && !Ctrl->G.active, "Either -D or -G is required for output\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->In.file && !strcmp (Ctrl->In.file, "="), "Piping of input grid file not supported!\n");


### PR DESCRIPTION
**Description of proposed changes**

The -C option does not impact the result for grdhisteq when -N is used because the output data are continuous. I think it is better to explicitly disallow this combination.

This PR also includes a small docs fix for grdhisteq.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
