### PR TITLE
Only deny -O -K in modern mode if a PS-producing module

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15195,12 +15195,12 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		opt_J = gmtinit_find_J_option (API, *options);
 		if (GMT->hidden.func_level == GMT_CONTROLLER) {	/* The -R -J -O -K prohibition only applies to top-level module call */
 			/* 1. No -O allowed */
-			if ((opt = GMT_Find_Option (API, 'O', *options))) {
+			if (is_PS && (opt = GMT_Find_Option (API, 'O', *options))) {
 				GMT_Report (API, GMT_MSG_ERROR, "Option -O not allowed for modern GMT mode.\n");
 				n_errors++;
 			}
 			/* 2. No -K allowed */
-			if ((opt = GMT_Find_Option (API, 'K', *options))) {
+			if (is_PS && (opt = GMT_Find_Option (API, 'K', *options))) {
 				GMT_Report (API, GMT_MSG_ERROR, "Option -K not allowed for modern GMT mode.\n");
 				n_errors++;
 			}


### PR DESCRIPTION
Some non-ploting modules use **-K** and that should not be result in the message

`gmt [ERROR]: Option -K not allowed for modern GMT mode.`

This PR adds the additional check that it must be a _PostScript_-producing module.