### PR TITLE
Fix grdfilter -Ff|o

### DIFF
--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -1338,7 +1338,7 @@ EXTERN_MSC int GMT_grdfilter (void *V_API, int mode, void *args) {
 
 	gmt_M_toc(GMT,"");		/* Print total run time, but only if -Vt was set */
 
-	gmt_M_free (GMT, weight);
+	if (!Ctrl->F.custom) gmt_M_free (GMT, weight);
 	gmt_M_free (GMT, F.x);
 	gmt_M_free (GMT, F.y);
 	if (visit_check) gmt_M_free (GMT, F.visit);
@@ -1468,7 +1468,7 @@ GMT_LOCAL void grdfilter_threaded_function (struct THREAD_STRUCT *t) {
 
 	/* We need a local copy of these because they are modified in this function */
 	visit = gmt_M_memory (GMT, NULL, Gin->header->n_columns, char);
-	if (!weight)
+	if (!t->weight)
 		weight = gmt_M_memory(GMT, NULL, F.n_columns*F.n_rows, double);	/* Allocate space for convolution grid */
 	else
 		weight = t->weight;	/* The F.custom case, where weights were obtained in main and allows NOT multi-threading */


### PR DESCRIPTION
The check to allocate a weight array was flawed so all weights were zero when **-Fo** or **-Ft** was selected, as this forum [post](https://forum.generic-mapping-tools.org/t/sum-of-subgrids/2687/4) shows.
