### PR TITLE
Let one-liners with CPTs add colorbar

### DIFF
--- a/doc/rst/source/cookbook/one-liner.rst
+++ b/doc/rst/source/cookbook/one-liner.rst
@@ -25,6 +25,9 @@ The syntax for this special mechanism involves a few simple rules:
    leading hyphen for the format option.
 #. The one-liner command cannot itself be part of a longer modern mode session.
 
+**Note**: If the single module involves a CPT (either explicitly or implicitly) then a
+color bar will be plotted above the map.
+
 Examples
 --------
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -816,7 +816,7 @@ GMT_LOCAL void gmtapi_set_object (struct GMTAPI_CTRL *API, struct GMTAPI_DATA_OB
 }
 #endif
 
-GMT_LOCAL bool gmtapi_modern_onliner (struct GMTAPI_CTRL *API, struct GMT_OPTION *head) {
+GMT_LOCAL bool gmtapi_modern_oneliner (struct GMTAPI_CTRL *API, struct GMT_OPTION *head) {
 	/* Must check if a one-liner with special graphics format settings were given, e.g., "gmt pscoast -Rg -JH0/15c -Gred -png map" */
 	bool modern = false;
 	unsigned pos;
@@ -856,7 +856,7 @@ GMT_LOCAL int gmtapi_check_for_modern_oneliner (struct GMTAPI_CTRL *API, const c
 	struct GMT_OPTION *opt, *head = NULL;
 
 	head = GMT_Create_Options (API, mode, args);	/* Get option list */
-	modern = gmtapi_modern_onliner (API, head);		/* Return true if one-liner syntax was detected */
+	modern = gmtapi_modern_oneliner (API, head);		/* Return true if one-liner syntax was detected */
 	if (API->GMT->current.setting.run_mode == GMT_MODERN) {	/* Need to check if a classic name was given or if user tried a one-liner in modern mode */
 		if (modern) {	/* Yikes, someone is using one-liner within a GMT modern mode session */
 			GMT_Report (API, GMT_MSG_ERROR, "Cannot run a one-liner modern command within an existing modern mode session\n");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15829,6 +15829,12 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 		char *setting = getenv ("GMT_END_SHOW");
 		char *show = (setting && !strcmp (setting, "off")) ? "" : "show";
 		GMT->current.ps.oneliner = false;
+		if (gmt_get_current_item (GMT, "cpt", false)) {	/* One-liner with a current CPT, place it on top */
+			if ((i = GMT_Call_Module (GMT->parent, "colorbar", GMT_MODULE_CMD, "-DJTC -Baf"))) {
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to call module colorbar for a one-liner plot.\n");
+				return;
+			}
+		}
 		if ((i = GMT_Call_Module (GMT->parent, "end", GMT_MODULE_CMD, show))) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to call module end for a one-liner plot.\n");
 			return;


### PR DESCRIPTION
Without the colorbar, a colored image has little meaning if we cannot tell what values they represent.
This PR checks if the plotting module involves a CPT, and if so we place it on top via a `colorbar -DJTC -Baf` call.

Example: `gmt grdimage @earth_relief_02m -RFR -B -png map`

![map](https://user-images.githubusercontent.com/26473567/157643347-373d0f47-7039-4f73-92dc-9ed0dfc5f983.png)

Closes #6426.