### PR TITLE
Fix how variable rho abd rho = NaN is handled in gravfft

### DIFF
--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -97,7 +97,8 @@ Optional Arguments
     with the free-air anomaly to get the Bouguer anomaly. In this case
     do not use **-T**. It also implicitly sets **-N+h**.  Alternatively,
     specify a co-registered grid with density contrasts if a variable
-    density contrast is required.
+    density contrast is required.  **Note**: Any NaNs found in the density
+    grid will be replaced with the minimum density found.
 
 .. _-E:
 

--- a/src/potential/gravfft.c
+++ b/src/potential/gravfft.c
@@ -634,7 +634,7 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "Surface and density grids have different intervals\n");
 			Return (GMT_RUNTIME_ERROR);
 		}
-		for (m = 0; m < Rho->header->size; m++) if (gmt_M_is_fnan (Rho->data[m])) Rho->data[m] = 0.0;	/* Replace any NaNs with zeros */
+		for (m = 0; m < Rho->header->size; m++) if (gmt_M_is_fnan (Rho->data[m])) Rho->data[m] = Rho->header->z_min;	/* Replace any NaNs with the minimum density */
 	}
 
 	/* Grids are compatible. Initialize FFT structs, grid headers, read data, and check for NaNs */
@@ -799,6 +799,7 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
 			strcpy (Grid[0]->header->title, "Gravity anomalies");
 			strcpy (Grid[0]->header->z_units, "mGal");
 			if (Ctrl->F.slab) {	/* Do the slab adjustment */
+				if (Ctrl->D.variable) Ctrl->misc.rho = Rho->header->z_min;
 				slab_gravity = (gmt_grdfloat) (1.0e5 * 2 * M_PI * Ctrl->misc.rho * GRAVITATIONAL_CONST *
 				                        fabs (Ctrl->W.water_depth - Ctrl->misc.z_level));
 				GMT_Report (API, GMT_MSG_INFORMATION, "Add %g mGal to predicted FAA grid to account for implied slab\n", slab_gravity);


### PR DESCRIPTION
This PR only addresses issues related to variable density grids via **-D**:

1. We used to replace any rho = NaN with zero.  However, that is not so good since for variable rho, the rho(x) is multiplied by h(x) after h(x) has ben adjusted for water depth.  We now set it to the minimum density value in the grid.
2. We now use min(rho) in the slab correction (**-Ff+s**) since that is likely what is at the far field.
