### PR TITLE
Document default Delaunay Triangulation algorithm as Shewchuk

### DIFF
--- a/doc/rst/source/contour.rst
+++ b/doc/rst/source/contour.rst
@@ -56,9 +56,9 @@ Description
 Reads an ASCII [or binary] *table* and produces a raw
 contour plot by triangulation. By default, the optimal Delaunay
 triangulation is performed (using either Shewchuk's [1996] or Watson's
-[1982] method as selected during GMT installation; run the module with argument
-**-** to see which method is selected), but the user may optionally
-provide a second file with network information, such as a triangular
+[1982] method as selected during GMT installation; run
+**gmt get GMT_TRIANGULATE** to see which method is selected), but the user may
+optionally provide a second file with network information, such as a triangular
 mesh used for finite element modeling. In addition to contours, the area
 between contours may be painted according to the CPT.
 Alternatively, the *x, y, z* positions of the contour lines may be saved to

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -507,7 +507,7 @@ GMT Miscellaneous Parameters
         Determines if we use the **Watson** or **Shewchuk**
         algorithm (if configured during installation) for triangulation.
         Note that Shewchuk is required for operations involving Voronoi
-        constructions [default is **Watson**].
+        constructions [default is **Shewchuk**].
 
     **GMT_VERBOSE**
         (**-V**) Determines the level of verbosity used by GMT

--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -57,8 +57,8 @@ input file. As an option, you may choose to create a multiple segment
 file that can be piped through :doc:`plot` to draw the triangulation
 network. If **-G** **-I** are set a grid will be calculated based on the
 surface defined by the planar triangles. The actual algorithm used in
-the triangulations is either that of Watson [1982] [Default] or Shewchuk
-[1996] (if installed; type **triangulate -** to see which method is
+the triangulations is either that of Watson [1982] or Shewchuk [1996] [Default]
+(if installed; type **gmt get GMT_TRIANGULATE** to see which method is
 selected). This choice is made during the GMT installation.  Furthermore,
 if the Shewchuk algorithm is installed then you can also perform the
 calculation of Voronoi polygons and optionally grid your data via the

--- a/src/TRIANGLE.HOWTO
+++ b/src/TRIANGLE.HOWTO
@@ -1,9 +1,9 @@
 
 GMT contains two programs (triangulate and pscontour) that
 directly or indirectly will do a Delaunay optimal triangulation
-of arbitrarily spaced (x,y,z) data.  By default, GMT uses
+of arbitrarily spaced (x,y,z) data.  In the early days, GMT used
 a public domain (published) algorithm by Dave Watson [1982] to
-to this.  Now, a new and much faster algorithm has been released
+to this.  The default now though, is a new and much faster algorithm
 by Jonathan Shewchuk [1996].  Because Shewchuk holds the copyright
 (i.e., it is not in the public domain nor distributed under the GNU
 Public License or the equivalent) you are advised to read it (see
@@ -15,12 +15,12 @@ If you later need to change the behavior w.r.t. triangulation,
 follow these guidelines:
 
 In makegmt.macro there are two parameters that can be defined:
-TRIANGLE_D and TRIANGLE_O.  By default they are commented out.
+TRIANGLE_D and TRIANGLE_O.  By default these lines are commented out.
 To use Shewchuk's [1996] routine, remove the # from the
 beginning of the lines and then 'make clean' and 'make install'.
-To revert to the default GMT usage of Watson's [1982] algorithm,
+To revert to using Watson's [1982] algorithm,
 simply place a # in the first column at these two lines.
-Then, say 'make clean' and 'make install' again.
+Then, run 'make clean' and 'make install' again.
 
 Paul Wessel, 16-AUG-1999
 


### PR DESCRIPTION
**Description of proposed changes**

Current default should be the Shewchuk [1996] algorithm, and not Watson [1982]. Modified documentation in contour.rst, triangulate.rst, gmt.conf.rst and TRIANGLE.HOWTO to be clear on this. Also mentioned using `gmt get GMT_TRIANGULATE` as the way to know which one is being used.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #6436


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
