### PR TITLE
More fixing and improvements in talwani?d

### DIFF
--- a/doc/rst/source/supplements/potential/talwani2d.rst
+++ b/doc/rst/source/supplements/potential/talwani2d.rst
@@ -52,8 +52,8 @@ Required Arguments
     One or more ASCII files describing cross-sectional polygons of one or more bodies.  Polygons
     will be automatically closed if not already closed, and repeated vertices will
     be eliminated.  The segment header for each body will be examined for a density
-    parameter in kg/m^3; see **-D** for overriding this value.  If no *table* is given then we
-    read standard input.
+    parameter in kg/m^3 or g/cm^3; see **-D** for overriding this value.  If no *table* is
+    given then we read standard input.
 
 Optional Arguments
 ------------------
@@ -66,7 +66,7 @@ Optional Arguments
 .. _-D:
 
 **-D**\ *density*
-    Sets a fixed density contrast that overrides any per-body settings in the model file, in kg/m^3.
+    Sets a fixed density contrast that overrides any per-body settings in the model file, in kg/m^3 or g/cm^3.
 
 .. _-F:
 

--- a/doc/rst/source/supplements/potential/talwani3d.rst
+++ b/doc/rst/source/supplements/potential/talwani3d.rst
@@ -57,7 +57,8 @@ Required Arguments
     The file describing the horizontal contours of the bodies.  Contours will be
     automatically closed if not already closed, and repeated vertices will be eliminated.
     The segment header for each slice will be examined for the pair *zlevel density*, i.e.,
-    the depth level of the slice and a density contrast in kg/m^3; see **-D** for overriding this value.
+    the depth level of the slice and a density contrast in kg/m^3 or g/cm^3; see **-D**
+    for overriding this value.
 
 .. _-I:
 
@@ -79,7 +80,7 @@ Optional Arguments
 .. _-D:
 
 **-D**\ *density*
-    Sets a fixed density contrast that overrides any individual slice settings in the model file, in kg/m^3.
+    Sets a fixed density contrast that overrides any individual slice settings in the model file, in kg/m^3 or g/cm^3.
 
 .. _-F:
 

--- a/doc/rst/source/supplements/potential/talwani3d.rst
+++ b/doc/rst/source/supplements/potential/talwani3d.rst
@@ -84,7 +84,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ **f**\|\ **n**\|\ **v**
+**-F**\ **f**\|\ **n**\ [*lat*]\|\ **v**
     Specify desired gravitational field component.  Choose between **f** (free-air anomaly) [Default],
     **n** (geoid; optionally append average latitude for normal gravity reference value [Default is
     mid-grid (or mid-profile if **-N**)]) or **v** (vertical gravity gradient).

--- a/src/potential/talwani3d.c
+++ b/src/potential/talwani3d.c
@@ -760,10 +760,6 @@ EXTERN_MSC int GMT_talwani3d (void *V_API, int mode, void *args) {
 	/*---------------------------- This is the talwani3d main code ----------------------------*/
 
 	gmt_enable_threads (GMT);	/* Set number of active threads, if supported */
-	/* Specify input expected columns to be at least 2 */
-	if ((error = GMT_Set_Columns (API, GMT_IN, 2, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {
-		Return (error);
-	}
 	/* Register likely model files unless the caller has already done so */
 	if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_POLYGON, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {	/* Registers default input sources, unless already set */
 		Return (API->error);
@@ -793,8 +789,8 @@ EXTERN_MSC int GMT_talwani3d (void *V_API, int mode, void *args) {
 		}
 		if ((D = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POINT, GMT_READ_NORMAL, NULL, Ctrl->N.file, NULL)) == NULL)
 			Return (API->error);
-		if (D->n_columns < n_expected) {
-			GMT_Report (API, GMT_MSG_ERROR, "Input file %s has %d column(s) but %d are needed\n", Ctrl->N.file, (int)D->n_columns, n_expected);
+		if (D->n_columns < 2) {
+			GMT_Report (API, GMT_MSG_ERROR, "Input file %s has %d column(s) but at least 2 are needed\n", Ctrl->N.file, (int)D->n_columns);
 			Return (GMT_DIM_TOO_SMALL);
 		}
 		gmt_reenable_bghio_opts (GMT);	/* Recover settings provided by user (if -b -g -h -i were used at all) */
@@ -819,7 +815,10 @@ EXTERN_MSC int GMT_talwani3d (void *V_API, int mode, void *args) {
 	n_alloc1 = GMT_CHUNK;
 	cake = gmt_M_memory (GMT, NULL, n_alloc1, struct TALWANI3D_CAKE);
 
-	/* Read the sliced model */
+	/* Read the sliced model; expecting 2 coordinates per record */
+	if ((error = GMT_Set_Columns (API, GMT_IN, 2, GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {
+		Return (API->error);
+	}
 	do {	/* Keep returning records until we reach EOF */
 		if ((In = GMT_Get_Record (API, GMT_READ_DATA, NULL)) == NULL) {	/* Read next record, get NULL if special case */
 			if (gmt_M_rec_is_error (GMT)) { 		/* Bail if there are any read errors */

--- a/test/potential/cyltest.sh
+++ b/test/potential/cyltest.sh
@@ -11,8 +11,8 @@ ps=cyltest.ps
 data=$(gmt which -G @cylinder25.txt)
 corr=$(gmt math -Q 25000 2 POW 5084 1333 SUB MUL 25000 25 2 DIV ADD 2 POW 5084 1333 SUB 25 ADD MUL DIV =)
 gmt math -T-100/100/1 0 = trk
-gmt talwani3d @cylinder_mod.txt -D1670 -Mh -Ntrk -o0,3 > faa.txt
-gmt talwani3d @cylinder_mod.txt -D1670 -Mh -Ntrk -o0,3 -Fv > vgg.txt
+gmt talwani3d @cylinder_mod.txt -D1670 -Mh -Ntrk -o0,3 -Z0 > faa.txt
+gmt talwani3d @cylinder_mod.txt -D1670 -Mh -Ntrk -o0,3 -Z0 -Fv > vgg.txt
 gmt math -T-100/250/350 -25 = > tmp
 gmt math -T-100/250/350 -I 25  = >> tmp
 gmt psxy -R-100/100/-100/250 -JX6i/6i -P -Glightgray tmp -i1,0 -K -Xc -Y4i > $ps

--- a/test/potential/sphtest.sh
+++ b/test/potential/sphtest.sh
@@ -9,9 +9,9 @@ ps=sphtest.ps
 R=2000
 z0=4000
 gmt math -T-25/25/0.2 0 = trk
-gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -o0,3 > faa.txt
-gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -o0,3 -Fv > vgg.txt
-gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -o0,3 -Fn > n.txt
+gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -Z0 -o0,3 > faa.txt
+gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -Z0 -o0,3 -Fv > vgg.txt
+gmt talwani3d @sphere_mod.txt -D1670 -Mh -Ntrk -Z0 -o0,3 -Fn > n.txt
 gmt psbasemap -R-25/25/-5/120 -JX6i/6i -P -K -Xc -Y4i -Bxafg1000 -Byafg1000+l"mGal or Eotvos" -BWsn+t"Testing FAA, VGG and Geoid over sphere" > $ps
 cg=$(gmt math -Q 1.0e5 4.0 MUL PI MUL 6.673e-11 MUL $R 3 POW MUL $z0 MUL 1670.0 MUL 3.0 DIV =)
 cv=$(gmt math -Q 1.0e9 4.0 MUL PI MUL 6.673e-11 MUL $R 3 POW MUL 1670.0 MUL 3.0 DIV =)


### PR DESCRIPTION
This PR improves the two talwani modules in a few ways:

1. It allows densities to be given either in g/cm^3 or kg/m^3
2. **talwani3d** now checks if its input is plain **grdcontour -D** slices and then properly reads the _depth_ from the segment header [no density will be available so needs to set it via **-D**].
3. **talwani3d** failed to scale the supplied z-level to km as done for other vertical distances.
4. Both modules now properly checks the **-F** option and defaults to gravity if no argument, else checks if **f** (one of them wrongly checked for **g** instead)

