### PR TITLE
Clean up files generated by examples

### DIFF
--- a/doc/examples/ex32/ex32.sh
+++ b/doc/examples/ex32/ex32.sh
@@ -51,5 +51,5 @@ gmt begin ex32
 	gmt text -JZ -p -F+f12p,Helvetica-Bold,red+jRM -Dj0.1i/0 cities.txt
 
 	# cleanup
-	rm -f cities.txt
+	rm -f cities.txt topo_32.nc mask_32.nc
 gmt end show

--- a/doc/examples/ex38/ex38.sh
+++ b/doc/examples/ex38/ex38.sh
@@ -34,5 +34,5 @@ gmt begin ex38
 	gmt colorbar -DJTC+w12c/0.4c+jTC+o0c/6c+h+e+n -Ct.cpt -Bxa500 -By+lm
 	gmt colorbar -DJBC+w12c/0.4c+h+e+n -Cn.cpt -Bx1 -By+l"z@-n@-"
 	gmt colorbar -DJBC+w12c/0.4c+h+e+n+o0c/2.5c -Cq.cpt -Bx1 -By+l"z@-q@-"
-	rm -f out.nc ?.cpt
+	rm -f out.nc topo_38.nc ?.cpt
 gmt end show

--- a/doc/examples/ex53/ex53.sh
+++ b/doc/examples/ex53/ex53.sh
@@ -6,7 +6,7 @@
 # GMT modules:  makecpt, subplot, set, plot, grdimage, clip, coast
 #
 
-gmt begin ex53 png
+gmt begin ex53
 	gmt set PROJ_ELLIPSOID Sphere MAP_ANNOT_OBLIQUE lon_horizontal,lat_parallel,tick_normal FONT_TAG 10p
 	gmt makecpt -Cterra
 	data=$(gmt which -G @Top12Cities.txt)
@@ -21,4 +21,5 @@ gmt begin ex53 png
 			echo ${lon} ${lat} | gmt plot -Skcity/0.25c -Gred -W0.5p -B0
 		done < $data
 	gmt subplot end
+	rm -f Top12Cities.txt
 gmt end show


### PR DESCRIPTION
**Description of proposed changes**

This PR adds more files generated by the examples to the cleanup commands. It also removes the specification of "png" output from ex53 for consistency with the other examples.

Necessary for https://github.com/GenericMappingTools/gmt/issues/6356.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
