### PR TITLE
Remove strict check for repeatable seis options

### DIFF
--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -743,7 +743,6 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 				Ctrl->A.polygon = true;
 				break;
 			case 'F':	/* Set various symbol parameters  */
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->F.active);
 				Ctrl->F.active = true;
 				switch (opt->arg[0]) {
 					case 'a':	/* plot axis */

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -401,7 +401,6 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 				}
 				break;
 			case 'F':	/* Repeatable; Controls various symbol attributes  */
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->F.active);
 				Ctrl->F.active = true;
 				switch (opt->arg[0]) {
 					case 'a':	/* plot axis */

--- a/src/seis/pspolar.c
+++ b/src/seis/pspolar.c
@@ -368,7 +368,6 @@ static int parse (struct GMT_CTRL *GMT, struct PSPOLAR_CTRL *Ctrl, struct GMT_OP
 				}
 				break;
 			case 'Q':	/* Repeatable; Controls various symbol attributes  */
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->Q.active);
 				Ctrl->Q.active = true;
 				switch (opt->arg[0]) {
 					case 'e':	/* Outline station symbol in extensive part */


### PR DESCRIPTION
The checking police got carried away here, as this [forum](https://forum.generic-mapping-tools.org/t/psmeca-in-6-3-for-windows/2704) post shows.  This PR removes that check for the repeatable options in seis modules.
