### PR TITLE
Add option to save mean prism densities

### DIFF
--- a/doc/rst/source/supplements/potential/gravprisms.rst
+++ b/doc/rst/source/supplements/potential/gravprisms.rst
@@ -21,6 +21,7 @@ Synopsis
 [ |-G|\ *outfile* ]
 [ |-H|\ *H*/*rho_l*/*rho_h*\ [**+d**\ *densify*][**+p**\ *power*] ]
 [ |SYN_OPT-I| ]
+[ |-K|\ *outavedens* ]
 [ |-L|\ *base* ]
 [ |-M|\ [**h**]\ [**v**] ]
 [ |-N|\ *trackfile* ]
@@ -28,7 +29,7 @@ Synopsis
 [ |-S|\ *shapegrid* ]
 [ |-T|\ *top* ]
 [ |SYN_OPT-V| ]
-[ |-W|\ *avedens* ]
+[ |-W|\ *inavedens* ]
 [ |-Z|\ *level*\|\ *obsgrid* ]
 [ |SYN_OPT-bo| ]
 [ |SYN_OPT-d| ]
@@ -64,7 +65,7 @@ gravity gradient anomalies, or geoid anomalies.  Options are available to contro
 axes units and direction.
 
 .. figure:: /_images/GMT_seamount_prisms.*
-   :width: 500 px
+   :width: 600 px
    :align: center
 
    Three density models modeled by prisms for a truncated Gaussian seamount via **-C**: (left) Constant
@@ -148,6 +149,12 @@ Optional Arguments
     Requires **-S** to know the full height of the seamount.
     See :doc:`grdseamount </supplements/potential/grdseamount>` for more details.
 
+.. _-K:
+
+**-K**\ *outavedens*
+    Give name of an output grid with spatially varying, vertically-averaged prism densities created
+    by **-C** and **-H**.
+
 .. _-L:
 
 **-L**\ *base*
@@ -190,7 +197,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ *avedens*
+**-W**\ *inavedens*
     Give name of an input grid with spatially varying, vertically-averaged prism densities. Requires
     **-C** and the grid must be co-registered with the grid provided by **-S** (or **L** and **-T**).
 

--- a/src/potential/gravprisms.c
+++ b/src/potential/gravprisms.c
@@ -369,6 +369,8 @@ static int parse (struct GMT_CTRL *GMT, struct GRAVPRISMS_CTRL *Ctrl, struct GMT
 	                                 "Option -L: Requires -T (or -S)\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.quit && !Ctrl->C.dump,
 	                                 "Option -C: Modifier +q requires +w\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->C.dz > 0.0 && !Ctrl->H.active,
+	                                 "Option -C: Modifier +z set without -H is disallowed\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }

--- a/src/potential/gravprisms.c
+++ b/src/potential/gravprisms.c
@@ -781,7 +781,7 @@ EXTERN_MSC int GMT_gravprisms (void *V_API, int mode, void *args) {
 			if (Ctrl->K.active) {	/* Get vertical average density and keep track of means */
 				Rho->data[node] = gravprisms_mean_density (Ctrl, H->data[node], z1, z2);
 				rs += Rho->data[node];
-				ws += (z1 - z1);
+				ws += (z2 - z1);
 			}
 		}
 		/* Finalize allocation */

--- a/src/potential/gravprisms.c
+++ b/src/potential/gravprisms.c
@@ -758,7 +758,6 @@ EXTERN_MSC int GMT_gravprisms (void *V_API, int mode, void *args) {
 					if (z_next <= z_prev) z_next += Ctrl->C.dz;	/* Can happen if z1 is a multiple of dz */
 					else if (z_next > z2) z_next = z2;	/* At the top, clip to limit */
 					z_mid = 0.5 * (z_prev + z_next);	/* Middle of prism - used to look up density */
-					//rho = gravprisms_rho (Ctrl, z_mid, H->data[node]);
 					rho = gravprisms_mean_density (Ctrl, H->data[node], z_prev, z_next);
 				}
 				else {	/* Constant density rho (set above via -D) or by Rho (via -W), just need a single prism per location */

--- a/src/potential/gravprisms.c
+++ b/src/potential/gravprisms.c
@@ -779,9 +779,10 @@ EXTERN_MSC int GMT_gravprisms (void *V_API, int mode, void *args) {
 				z_prev = z_next;	/* The the top of this prism be the bottom of the next */
 			} while (z_prev < z2);	/* Until we run out of this stack */
 			if (Ctrl->K.active) {	/* Get vertical average density and keep track of means */
+				double dz = z2 - z1;
 				Rho->data[node] = gravprisms_mean_density (Ctrl, H->data[node], z1, z2);
-				rs += Rho->data[node];
-				ws += (z2 - z1);
+				rs += Rho->data[node] * dz;
+				ws += dz;
 			}
 		}
 		/* Finalize allocation */


### PR DESCRIPTION
While **-W** reads average vertical densities, when **-C -H** are used we actually _create_ these and hence need another option (**-K**) to write them to a grid.
Fix minor typos and inconsistent checking as well, and updated the docs.
