### PR TITLE
Retire old -W -K and let -D handle inputs and -W output

### DIFF
--- a/doc/rst/source/supplements/potential/gravprisms.rst
+++ b/doc/rst/source/supplements/potential/gravprisms.rst
@@ -21,7 +21,6 @@ Synopsis
 [ |-G|\ *outfile* ]
 [ |-H|\ *H*/*rho_l*/*rho_h*\ [**+d**\ *densify*][**+p**\ *power*] ]
 [ |SYN_OPT-I| ]
-[ |-K|\ *outavedens* ]
 [ |-L|\ *base* ]
 [ |-M|\ [**h**]\ [**v**] ]
 [ |-N|\ *trackfile* ]
@@ -29,7 +28,7 @@ Synopsis
 [ |-S|\ *shapegrid* ]
 [ |-T|\ *top* ]
 [ |SYN_OPT-V| ]
-[ |-W|\ *inavedens* ]
+[ |-W|\ *avedens* ]
 [ |-Z|\ *level*\|\ *obsgrid* ]
 [ |SYN_OPT-bo| ]
 [ |SYN_OPT-d| ]
@@ -56,8 +55,7 @@ if given via **-D**).  Alternatively, we can use **-C** to create the prisms nee
 the entire feature (**-S**) or just the volume between two surfaces (one of which may be a constant)
 that define a layer (set via **-L** and **-T**).  If a variable density model (**-H**) is selected
 then each vertical prism will be broken into constant-density, stacked sub-prisms using a prescribed
-vertical increment *dz*, otherwise single tall prisms are created with constant (**-D**) or spatially
-varying (**-W**) densities.
+vertical increment *dz*, otherwise single tall prisms are created with constant or spatially variable densities (**-D**).
 We can compute anomalies on an equidistant grid (by specifying a new grid with
 **-R** and **-I** or provide an observation grid with desired elevations) or at arbitrary
 output points specified via **-N**.  Choose between free-air anomalies, vertical
@@ -113,7 +111,9 @@ Optional Arguments
 .. _-D:
 
 **-D**\ *density*
-    Sets a fixed density contrast that overrides any individual prism settings in the prisms file, in kg/m^3 of g/cm^3.
+    Sets a fixed density contrast that overrides any individual prism settings in the prisms file, in kg/m^3 of g/cm^3. Alternatively, give name of an input grid with spatially varying, vertically-averaged
+    prism densities. Requires **-C** and the grid must be co-registered with the grid provided by **-S**
+    (or **L** and **-T**).
 
 .. _-E:
 
@@ -148,12 +148,6 @@ Optional Arguments
     full reference height [0] and the variable density profile exponent *power* [1, i.e., a linear change].
     Requires **-S** to know the full height of the seamount.
     See :doc:`grdseamount </supplements/potential/grdseamount>` for more details.
-
-.. _-K:
-
-**-K**\ *outavedens*
-    Give name of an output grid with spatially varying, vertically-averaged prism densities created
-    by **-C** and **-H**.
 
 .. _-L:
 
@@ -197,9 +191,9 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ *inavedens*
-    Give name of an input grid with spatially varying, vertically-averaged prism densities. Requires
-    **-C** and the grid must be co-registered with the grid provided by **-S** (or **L** and **-T**).
+**-W**\ *avedens*
+    Give name of an output grid with spatially varying, vertically-averaged prism densities created
+    by **-C** and **-H**.
 
 .. _-Z:
 

--- a/doc/scripts/GMT_seamount_prisms.sh
+++ b/doc/scripts/GMT_seamount_prisms.sh
@@ -11,7 +11,7 @@ rho_l=$(gmt grdinfo gaussaverho.grd | grep Remark | awk '{print $NF}')
 # 2. Make the constant density prisms
 gmt gravprisms -Sgausssmt.grd -D${rho_l} -C+wgaussprisms1.txt+q
 # 3. Make variable constant prism densities
-gmt gravprisms -Sgausssmt.grd -Wgaussaverho.grd -C+wgaussprisms2.txt+q
+gmt gravprisms -Sgausssmt.grd -Dgaussaverho.grd -C+wgaussprisms2.txt+q
 # 4. Make variable prism densities
 gmt gravprisms -Sgausssmt.grd -H7/2400/3030+p0.8 -C+wgaussprisms3.txt+q+z0.2
 # Make plots


### PR DESCRIPTION
Following suggestion from @joa-quim, restructure **gravprisms** to use **-D** for either constant density or a grid of densities (like **gravfft**, for instance) and then let the output average density grid be set via **-W** (like in **grdseamount**) and retire the day-old **-K** option.
