### PR TITLE
Ensure plot and plot3d uses rect in legend for -L

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2394,7 +2394,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 
 		if (!seq_legend && GMT->common.l.active) {
 			if (S.symbol == GMT_SYMBOL_LINE) {
-				if (polygon) {	/* Place a rectangle in the legend */
+				if (polygon || Ctrl->L.active) {	/* Place a rectangle in the legend */
 					int symbol = S.symbol;
 					S.symbol = PSL_RECT;
 					gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -2001,7 +2001,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 
 		if (!seq_legend && GMT->common.l.active) {
 			if (S.symbol == GMT_SYMBOL_LINE) {
-				if (polygon) {	/* Place a rectangle in the legend */
+				if (polygon || Ctrl->L.active) {	/* Place a rectangle in the legend */
 					int symbol = S.symbol;
 					S.symbol = PSL_RECT;
 					gmt_add_legend_item (API, &S, Ctrl->G.active, &(Ctrl->G.fill), Ctrl->W.active, &(Ctrl->W.pen), &(GMT->common.l.item));


### PR DESCRIPTION
When we build a polygon from a line with **-L** we want the auto-legend entry to be a filled polygon symbol (rect), not a line.
