### PR TITLE
Remove GMT_seamount_density.sh test if latex not installed

### DIFF
--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -77,7 +77,7 @@ endforeach()
 
 # Remove GMT_latex.sh if latex or dvips not found
 if (NOT LATEX OR NOT DVIPS)
-	list (REMOVE_ITEM _scripts_tests doc/scripts/GMT_latex.sh doc/scripts/GMT_slope2intensity.sh)
+	list (REMOVE_ITEM _scripts_tests doc/scripts/GMT_latex.sh doc/scripts/GMT_slope2intensity.sh doc/scripts/GMT_seamount_density.sh)
 endif (NOT LATEX OR NOT DVIPS)
 
 if (DO_TESTS AND BASH)


### PR DESCRIPTION
**Description of proposed changes**

`doc/scripts/GMT_seamount_density.sh` contains LaTeX expressions and needs to be removed from the tests if LaTeX is not installed.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
