### PR TITLE
Set met_uv.sh as a known failure on windows/linux

### DIFF
--- a/test/grdvector/met_uv.sh
+++ b/test/grdvector/met_uv.sh
@@ -2,6 +2,7 @@
 # testing vector head shrinking and non-plotting for plain and filled geovectors
 # Using tiny subset of data shown in https://github.com/GenericMappingTools/gmt/issues/6108
 # New behavior is skipping of heads when size exceeds length
+# GMT_KNOWN_FAILURE_WINDOWS GMT_KNOWN_FAILURE_LINUX
 gmt begin met_uv
 	gmt set MAP_FRAME_TYPE plain FONT_TAG 12p
 	gmt subplot begin 5x1 -Fs14c/4.21c -R84/96/24.75/28 -JM14c -Sct -Srl -M2p -A

--- a/test/grdvector/met_uv.sh
+++ b/test/grdvector/met_uv.sh
@@ -2,7 +2,8 @@
 # testing vector head shrinking and non-plotting for plain and filled geovectors
 # Using tiny subset of data shown in https://github.com/GenericMappingTools/gmt/issues/6108
 # New behavior is skipping of heads when size exceeds length
-# GMT_KNOWN_FAILURE_WINDOWS GMT_KNOWN_FAILURE_LINUX
+# GMT_KNOWN_FAILURE_LINUX
+# GMT_KNOWN_FAILURE_WINDOWS
 gmt begin met_uv
 	gmt set MAP_FRAME_TYPE plain FONT_TAG 12p
 	gmt subplot begin 5x1 -Fs14c/4.21c -R84/96/24.75/28 -JM14c -Sct -Srl -M2p -A


### PR DESCRIPTION
**Description of proposed changes**

As discussed in https://github.com/GenericMappingTools/gmt/pull/6161, this test fails on windows and linux due to small differences in which vector heads are drawn. This PR marks the test as a failure on those operating systems.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
