### PR TITLE
Download remote files for test scripts to the cache dir

### DIFF
--- a/doc/examples/ex43/ex43.sh
+++ b/doc/examples/ex43/ex43.sh
@@ -12,7 +12,7 @@ AWK=${AWK:-awk}
 # Data from Table 7 in Rousseeuw and Leroy, 1987.
 gmt begin ex43
 
-	file=$(gmt which -G @bb_weights.txt)
+	file=$(gmt which -Gc @bb_weights.txt)
 	gmt regress -Ey -Nw -i0:1+l $file > model.txt
 	gmt regress -Ey -Nw -i0:1+l $file -Fxmc -T-2/6/0.1 -C99 > rls_line.txt
 	gmt regress -Ey -N2 -i0:1+l $file -Fxm -T-2/6/2+n > ls_line.txt

--- a/test/geodesy/case_largeR_noW.sh
+++ b/test/geodesy/case_largeR_noW.sh
@@ -6,7 +6,7 @@
 # GRAPHICSMAGICK_RMS = 0.0435
 ps=case_largeR_noW.ps
 # Use real GPS data with uncertainties
-data=$(gmt which -G @wus_gps_final_crowell.txt)
+data=$(gmt which -Gc @wus_gps_final_crowell.txt)
 #  Large region
 R=122.5W/115W/33N/38N
 # blockmean interval

--- a/test/geodesy/case_largeR_withW.sh
+++ b/test/geodesy/case_largeR_withW.sh
@@ -6,7 +6,7 @@
 # GRAPHICSMAGICK_RMS = 0.0435
 ps=case_largeR_withW.ps
 # Use real GPS data with uncertainties
-data=$(gmt which -G @wus_gps_final_crowell.txt)
+data=$(gmt which -Gc @wus_gps_final_crowell.txt)
 #  Large region
 R=122.5W/115W/33N/38N
 # blockmean interval

--- a/test/geodesy/case_smallR_noW.sh
+++ b/test/geodesy/case_smallR_noW.sh
@@ -6,7 +6,7 @@
 # GRAPHICSMAGICK_RMS = 0.0655
 ps=case_smallR_noW.ps
 # Use real GPS data with uncertainties
-data=$(gmt which -G @wus_gps_final_crowell.txt)
+data=$(gmt which -Gc @wus_gps_final_crowell.txt)
 #  Small region
 R=118.5W/115.2W/33.0N/34.5N
 # blockmean interval

--- a/test/geodesy/case_smallR_withW.sh
+++ b/test/geodesy/case_smallR_withW.sh
@@ -6,7 +6,7 @@
 # GRAPHICSMAGICK_RMS = 0.0655
 ps=case_smallR_withW.ps
 # Use real GPS data with uncertainties
-data=$(gmt which -G @wus_gps_final_crowell.txt)
+data=$(gmt which -Gc @wus_gps_final_crowell.txt)
 #  Select small region
 R=118.5W/115.2W/33.0N/34.5N
 # blockmean interval

--- a/test/gmtregress/regress_1.sh
+++ b/test/gmtregress/regress_1.sh
@@ -15,7 +15,7 @@ function plot_one {	# 5 args are: -E -N axes -X -Y
 	gmt math tmp -i0,1 DUP DUP LOWER EQ MUL = | awk '{if (NF == 2 && $2 > 0) printf "%s %s %s 0.001\n", $1, $2, $1}' | gmt psxy -R -J -O -K -Sv0.2i+n+s+b+h1 -Gred $4 $5
 }
 # Allow outliers to be included in the analysis:
-file=$(gmt which -G @hertzsprung-russell.txt)
+file=$(gmt which -Gc @hertzsprung-russell.txt)
 sed -e s/#//g $file > data
 gmt psxy -R-90/90/0.001/100 -JX2i/2il -T -P -K -Xa1i -Ya1i > $ps
 # L1

--- a/test/gmtregress/regress_2.sh
+++ b/test/gmtregress/regress_2.sh
@@ -15,7 +15,7 @@ function plot_one {	# 5 args are: -E -N axes -X -Y
 	gmt psxy -R -J -O -K $4 $5 giants -Sc0.1i -W0.25p -N
 }
 # Allow outliers to be included in the analysis:
-file=$(gmt which -G @hertzsprung-russell.txt)
+file=$(gmt which -Gc @hertzsprung-russell.txt)
 sed -e s/#//g $file > data
 # Identify the red giants (outliers)
 grep '#' $file | sed -e s/#//g > giants

--- a/test/gmtspatial/nn.sh
+++ b/test/gmtspatial/nn.sh
@@ -7,7 +7,7 @@
 #gmt math -T0/9/1 -o1 0 100 RAND = z
 #paste x y z > points.txt
 ps=nn.ps
-DATA=$(gmt which -G @nn_points.txt)
+DATA=$(gmt which -Gc @nn_points.txt)
 # NN analysis
 gmt spatial -Aa0k -fg $DATA > results.txt
 gmt set MAP_FRAME_TYPE plain

--- a/test/gmtspatial/poldecimate.sh
+++ b/test/gmtspatial/poldecimate.sh
@@ -7,7 +7,7 @@
 #gmt math -T0/2000/1 -o1 0 100 RAND = z
 #paste x y z > polar.txt
 ps=poldecimate.ps
-DATA=$(gmt which -G @nn_polar.txt)
+DATA=$(gmt which -Gc @nn_polar.txt)
 # NN averaging
 gmt spatial -Aa100k -fg $DATA > results.txt
 gmt psxy -R0/360/60/90 -JA0/90/4.5i -P -K -Bafg -BWsne $DATA -Sc0.05i -Ggreen -X1.5i -Y0.75i > $ps

--- a/test/grdmask/maskmode.sh
+++ b/test/grdmask/maskmode.sh
@@ -11,8 +11,8 @@ cat << EOF > mask.cpt
 4	black	5	- ;K
 EOF
 # Instead of add another file I just swap the ID values for polygons 1 and 2 so we can test all modes
-gmt which @multihole.gmt -Gl
-awk '{ if (NR == 10) {print "# @D2|\"polygon #1\""} else if (NR == 40) {print "# @D1|\"polygon #2\""} else {print $0}}' multihole.gmt  > modes.gmt
+data=$(gmt which -Gc @multihole.gmt)
+awk '{ if (NR == 10) {print "# @D2|\"polygon #1\""} else if (NR == 40) {print "# @D1|\"polygon #2\""} else {print $0}}' ${data}  > modes.gmt
 gmt grdmask -R-3/8/-4/7 -I0.1 -r modes.gmt -aZ=ID -Nz -Gf.nc -fg -Cf
 gmt grdmask -R-3/8/-4/7 -I0.1 -r modes.gmt -aZ=ID -Nz -Go.nc -fg -Co
 gmt grdmask -R-3/8/-4/7 -I0.1 -r modes.gmt -aZ=ID -Nz -Gl.nc -fg -Cl

--- a/test/greenspline/gspline_5.sh
+++ b/test/greenspline/gspline_5.sh
@@ -9,7 +9,7 @@ ps=gspline_5.ps
 # Generalized Green's Function for a Spherical Surface Spline in Tension,
 # Geophys. J. Int., 174, 21-28.
 
-data=$(gmt which -G @mag_obs_1990.txt)
+data=$(gmt which -Gc @mag_obs_1990.txt)
 # First find Parker's solution for no tension:
 gmt greenspline -Rg -I1 $data -Sp -GFig_2_p0.nc
 # Then repeat but use the wrong Oslo longitude to recreate Parker's original figure in his book

--- a/test/mapproject/waypoints.sh
+++ b/test/mapproject/waypoints.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test mapproject's distance and time calculations
 ps=waypoints.ps
-data=$(gmt which -G @waypoints.txt)
+data=$(gmt which -Gc @waypoints.txt)
 gmt mapproject -G+un+i+a -Af -Z20+i+a+t2017-01-01T --TIME_UNIT=h $data -: -o2:4,7 --FORMAT_FLOAT_OUT=%.1f > tmp
 gmt psxy -R181/185/-7:30/-2 -JM6.5i -P -Baf -BWSne -W0.25p $data -: -K > $ps
 gmt psxy -R -J -O -K -Sc0.2c -Gblue $data -: >> $ps

--- a/test/mgd77/cm4.sh
+++ b/test/mgd77/cm4.sh
@@ -40,7 +40,7 @@
 ps=cm4.ps
 
 gmt set FORMAT_DATE_MAP "o dd" FORMAT_CLOCK_MAP hh:mm FONT_ANNOT_PRIMARY +9p
-dia=$(gmt which -G @clf20010501d.min)
+dia=$(gmt which -Gc @clf20010501d.min)
 
 # Get Station location
 lon=$(sed -n 6p $dia   | $AWK '{print $3}')

--- a/test/potential/cyltest.sh
+++ b/test/potential/cyltest.sh
@@ -8,7 +8,7 @@ ps=cyltest.ps
 #cylinder 25 10 10 1333 5084
 # Make a 1st order correction for the fact that the cubes extend 12.5 meter outside given limits.
 # This works out to a factor of 0.992386602589:
-data=$(gmt which -G @cylinder25.txt)
+data=$(gmt which -Gc @cylinder25.txt)
 corr=$(gmt math -Q 25000 2 POW 5084 1333 SUB MUL 25000 25 2 DIV ADD 2 POW 5084 1333 SUB 25 ADD MUL DIV =)
 gmt math -T-100/100/1 0 = trk
 gmt talwani3d @cylinder_mod.txt -D1670 -Mh -Ntrk -o0,3 -Z0 > faa.txt

--- a/test/pshistogram/mmm.sh
+++ b/test/pshistogram/mmm.sh
@@ -2,7 +2,7 @@
 # Test all the ways of labeling the bars with -D
 ps=mmm.ps
 # Use blockmean to compute the mean
-data=`gmt which -G @Pacific_Depths.txt`
+data=`gmt which -Gc @Pacific_Depths.txt`
 mean=`awk '{print 0,0,$1}' $data | gmt blockmean -R-1/1/-1/1 -I2 -r -o2`
 # Use blockmedian to compute the median
 median=`awk '{print 0,0,$1}' $data | gmt blockmedian -R-1/1/-1/1 -I2 -r -o2`

--- a/test/psrose/vectors.sh
+++ b/test/psrose/vectors.sh
@@ -2,7 +2,7 @@
 # Test gmt psrose windrose with or without vector heads
 
 ps=vectors.ps
-data=`gmt which -G @azimuth_lengths.txt`
+data=`gmt which -Gc @azimuth_lengths.txt`
 awk '{if ((NR%50) == 0) print $0}' $data > subset.txt
 common0n="subset.txt -: -JX7c -F -L -Ggray -R0/3/-90/90 -Bxg1 -Byg90 -BWESN -O -K"
 common1n="subset.txt -: -JX7c -F -L -Ggray -R0/3/0/180 -Bxg1 -Byg90 -BWESN -O -K"

--- a/test/psxy/categorical.sh
+++ b/test/psxy/categorical.sh
@@ -3,15 +3,15 @@
 # the aspatial field NAME via the CPT to yield pen color
 ps=categorical.ps
 # get shapefile from cache
-test_data=`gmt which -Gl @RidgeTest.shp`
-gmt which -Gl @RidgeTest.shx @RidgeTest.dbf @RidgeTest.prj
+test_data=`gmt which -Gc @RidgeTest.shp`
+gmt which -Gc @RidgeTest.shx @RidgeTest.dbf @RidgeTest.prj
 # Make a text-based categorical cpt file
 cat << EOF > ridge.cpt
 Reykjanes	red
 Klitgord	green
 Dietmar		blue
 EOF
-gmt psxy -R-40/-25/30/45 -JM6i -P -Baf RidgeTest.shp -aZ=NAME -Cridge.cpt -K -Xc > $ps
+gmt psxy -R-40/-25/30/45 -JM6i -P -Baf ${test_data} -aZ=NAME -Cridge.cpt -K -Xc > $ps
 gmt psxy -R -J -O -Sc0.2i -Cridge.cpt << EOF >> $ps
 -37	33	Dietmar
 -32	38	Klitgord

--- a/test/psxy/gallo.sh
+++ b/test/psxy/gallo.sh
@@ -3,7 +3,7 @@
 ps=gallo.ps
 
 # Get the height of EPS file symbol relative to width
-epsfile=`gmt which -Gl @gallo.eps`
+epsfile=`gmt which -Gc @gallo.eps`
 
 scale=`grep "%%HiResBoundingBox" $epsfile | awk '{print ($5-$3)/($4-$2)}'`
 cat << EOF > chicks.txt

--- a/test/sph/sph_5.sh
+++ b/test/sph/sph_5.sh
@@ -4,7 +4,7 @@
 
 ps=sph_5.ps
 
-data=`gmt which -G @hotspots.txt`
+data=`gmt which -Gc @hotspots.txt`
 # Use the locations of a global hotspot file and fake z values
 gmt sphtriangulate @hotspots.txt -Qv -T > tt.arcs
 gmt makecpt -Ccategorical -T0/55/1 > t.cpt

--- a/test/spotter/spotter_03.sh
+++ b/test/spotter/spotter_03.sh
@@ -9,7 +9,7 @@ ps=spotter_03.ps
 # for the seamounts in the seamounts.txt file, given a plate motion model
 # and a list of possible hotspots.
 
-pac_ps=`gmt which -G @pac_hs.txt`
+pac_ps=`gmt which -Gc @pac_hs.txt`
 
 grep -v '^#' ${pac_ps} > tmp
 $AWK '{printf "s/%s/%d/g\n", $3, NR}' tmp > t.sed


### PR DESCRIPTION
**Description of proposed changes**

Rather than downloading the remote file to the temporary directory used for running tests, this PR modifies the gmt which command to download the file to the cache dir (if not already present). This should speed up tests and reduce the bandwidth required for running tests.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
