### PR TITLE
Increase GRAPHICSMAGICK limit for GMT_grinten.sh

### DIFF
--- a/doc/scripts/GMT_grinten.sh
+++ b/doc/scripts/GMT_grinten.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+# GRAPHICSMAGICK_RMS = 0.0035
 gmt coast -Rg -JV10c -Bg -Dc -Glightgray -Scornsilk -A10000 -Wthinnest --GMT_THEME=cookbook -ps GMT_grinten


### PR DESCRIPTION
**Description of proposed changes**

This test fails with a slightly higher RMS error than allowed on Windows. This PR increases the limit by 0.0005. I tested that the comment does not appear in the docs.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
