### PR TITLE
Fix the lack of precision in -Ib

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3851,37 +3851,37 @@ unsigned int gmt_grid_perimeter (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h
 	if (h->registration == GMT_GRID_PIXEL_REG) {	/* Must add the LL corner for pixel grids */
 		xx[k] = h->wesn[XLO];	yy[k] = h->wesn[YLO];	k++;
 	}
-	gmt_M_memcpy (&xx[k], gx, h->n_columns, double);
+	gmt_M_memcpy (&xx[k], gx, h->n_columns, double);	/* Can always use the x-coordinates along south or north */
 	for (col = 0; col < h->n_columns; col++, k++)
-		yy[k] = h->wesn[YLO];
+		yy[k] = h->wesn[YLO];	/* But must set y from header */
 	if (h->registration == GMT_GRID_PIXEL_REG) {	/* Must add the LR corner for pixel grids */
 		xx[k] = h->wesn[XHI];	yy[k] = h->wesn[YLO];	k++;
-		start = 1;
+		start = 1;	/* Need all points from the gy array */
 	}
 	else
-		start = 2;
-	for (row = start; row <= h->n_rows; row++, k++) {
-		xx[k] = h->wesn[XHI];	yy[k] = gy[h->n_rows - row];
+		start = 2;	/* Skip duplicate first point from gy array */
+	for (row = start; row <= h->n_rows; row++, k++) {	/* Can always use the y-coordinates along east or west */
+		xx[k] = h->wesn[XHI];	yy[k] = gy[h->n_rows - row];	/* But must set x from header */
 	}
-	if (h->registration == GMT_GRID_PIXEL_REG) {
+	if (h->registration == GMT_GRID_PIXEL_REG) {	/* Must add the TR corner for pixel grids */
 		xx[k] = h->wesn[XHI];	yy[k] = h->wesn[YHI];	k++;
-		start = 1;
+		start = 1;	/* Need all points from the gx array */
 	}
 	else
-		start = 2;
-	for (col = start; col <= h->n_columns; col++, k++) {
-		xx[k] = gx[h->n_columns-col];	yy[k] = h->wesn[YHI];
+		start = 2;	/* Skip duplicate last point from gx array */
+	for (col = start; col <= h->n_columns; col++, k++) {	/* Can always use the x-coordinates along south or north */
+		xx[k] = gx[h->n_columns-col];	yy[k] = h->wesn[YHI];	/* But must set y from header */
 	}
-	if (h->registration == GMT_GRID_PIXEL_REG) {
+	if (h->registration == GMT_GRID_PIXEL_REG) {	/* Must add the TL corner for pixel grids */
 		xx[k] = h->wesn[XLO];	yy[k] = h->wesn[YHI];	k++;
-		start = 0;
+		start = 0;	/* Need all points from the gy array */
 	}
 	else
-		start = 1;
-	gmt_M_memcpy (&yy[k], &gy[start], h->n_rows-start, double);
+		start = 1;	/* SKip first duplicate point from the gy array */
+	gmt_M_memcpy (&yy[k], &gy[start], h->n_rows-start, double);	/* Can always use the y-coordinates along east or west */
 	for (row = start; row < h->n_rows; row++, k++)
-		xx[k] = h->wesn[XLO];
-	if (h->registration == GMT_GRID_PIXEL_REG) {
+		xx[k] = h->wesn[XLO];	/* But must set x from header */
+	if (h->registration == GMT_GRID_PIXEL_REG) {	/* Must add the BL corner for pixel grids to close the polygon */
 		xx[k] = h->wesn[XLO];	yy[k] = h->wesn[YLO];	k++;
 	}
 	gmt_M_free (GMT, gx);	gmt_M_free (GMT, gy);

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3837,3 +3837,55 @@ int gmtlib_read_image (struct GMT_CTRL *GMT, char *file, struct GMT_IMAGE *I, do
 
 	return (GMT_NOERROR);
 }
+
+unsigned int gmt_grid_perimeter (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, double **x, double **y) {
+	/* Return arrays that outlines the grid perimeter */
+	unsigned int k = 0, start, col, row, n = 2 * (h->n_columns + h->n_rows) - 3;	/* Number of points for gridline-registered grids */
+	double *xx = NULL, *yy = NULL, *gx = NULL, *gy = NULL;
+	gx = gmt_grd_coord (GMT, h, GMT_X);	/* Get array of x coordinates */
+	gy = gmt_grd_coord (GMT, h, GMT_Y);	/* Get array of y coordinates */
+	if (h->registration == GMT_GRID_PIXEL_REG) n += 8;	/* Since we will add the corners */
+	xx = gmt_M_memory (GMT, NULL, n, double);
+	yy = gmt_M_memory (GMT, NULL, n, double);
+
+	if (h->registration == GMT_GRID_PIXEL_REG) {	/* Must add the LL corner for pixel grids */
+		xx[k] = h->wesn[XLO];	yy[k] = h->wesn[YLO];	k++;
+	}
+	gmt_M_memcpy (&xx[k], gx, h->n_columns, double);
+	for (col = 0; col < h->n_columns; col++, k++)
+		yy[k] = h->wesn[YLO];
+	if (h->registration == GMT_GRID_PIXEL_REG) {	/* Must add the LR corner for pixel grids */
+		xx[k] = h->wesn[XHI];	yy[k] = h->wesn[YLO];	k++;
+		start = 1;
+	}
+	else
+		start = 2;
+	for (row = start; row <= h->n_rows; row++, k++) {
+		xx[k] = h->wesn[XHI];	yy[k] = gy[h->n_rows - row];
+	}
+	if (h->registration == GMT_GRID_PIXEL_REG) {
+		xx[k] = h->wesn[XHI];	yy[k] = h->wesn[YHI];	k++;
+		start = 1;
+	}
+	else
+		start = 2;
+	for (col = start; col <= h->n_columns; col++, k++) {
+		xx[k] = gx[h->n_columns-col];	yy[k] = h->wesn[YHI];
+	}
+	if (h->registration == GMT_GRID_PIXEL_REG) {
+		xx[k] = h->wesn[XLO];	yy[k] = h->wesn[YHI];	k++;
+		start = 0;
+	}
+	else
+		start = 1;
+	gmt_M_memcpy (&yy[k], &gy[start], h->n_rows-start, double);
+	for (row = start; row < h->n_rows; row++, k++)
+		xx[k] = h->wesn[XLO];
+	if (h->registration == GMT_GRID_PIXEL_REG) {
+		xx[k] = h->wesn[XLO];	yy[k] = h->wesn[YLO];	k++;
+	}
+	gmt_M_free (GMT, gx);	gmt_M_free (GMT, gy);
+
+	*x = xx;	*y = yy;
+	return (n);
+}

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -204,6 +204,7 @@ EXTERN_MSC bool gmt_file_is_cache (struct GMTAPI_CTRL *API, const char *file);
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC unsigned int gmt_grid_perimeter (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, double **x, double **y);
 EXTERN_MSC void gmt_change_grid_history (struct GMTAPI_CTRL *API, unsigned int mode, struct GMT_GRID_HEADER *h, char *command);
 EXTERN_MSC char *gmt_get_grd_title (struct GMT_GRID_HEADER *h);
 EXTERN_MSC char *gmt_get_grd_remark (struct GMT_GRID_HEADER *h);

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -535,7 +535,7 @@ GMT_LOCAL void grdinfo_smart_increments (struct GMT_CTRL *GMT, double inc[], uns
 
 EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 	int error = 0, k_data, k_tile_id;
-	unsigned int n_grds = 0, n_cols = 0, col, level, i_status, gtype, cmode = GMT_COL_FIX, geometry = GMT_IS_TEXT;
+	unsigned int n_grds = 0, n_cols = 0, col, row, level, i_status, gtype, cmode = GMT_COL_FIX, geometry = GMT_IS_TEXT;
 	unsigned int x_col_min, x_col_max, y_col_min, y_col_max, z_col_min, z_col_max, GMT_W = GMT_Z;
 	bool subset, delay, num_report, is_cube;
 
@@ -881,23 +881,31 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 		}
 		else if (Ctrl->I.active && i_status == GRDINFO_GIVE_BOUNDBOX) {
+			double *xx = GMT_Get_Coord (API, GMT_IS_GRID, GMT_X, G);
+			double *yy = GMT_Get_Coord (API, GMT_IS_GRID, GMT_Y, G);
+
 			sprintf (record, "Bounding box for %s", HH->name);
 			GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, record);
-			/* LL */
-			out[GMT_X] = header->wesn[XLO];	out[GMT_Y] = header->wesn[YLO];
-			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
-			/* LR */
-			out[GMT_X] = header->wesn[XHI];
-			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
-			/* UR */
-			out[GMT_Y] = header->wesn[YHI];
-			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
-			/* UL */
-			out[GMT_X] = header->wesn[XLO];
-			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
-			/* LL (repeat to close polygon) */
-			out[GMT_X] = header->wesn[XLO];	out[GMT_Y] = header->wesn[YLO];
-			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			/* Loop around perimeter building a closed polygon */
+			out[GMT_Y] = header->wesn[YLO];	/* Set south latitude */
+			for (col = 0; col < header->n_columns; col++) {	/* South going east */
+				out[GMT_X] = xx[col];
+				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			}
+			for (row = 2; row <= header->n_rows; row++) {	/* East going north */
+				out[GMT_Y] = yy[header->n_rows-row];
+				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			}
+			for (col = 1; col <= header->n_columns; col++) {	/* North going west */
+				out[GMT_X] = xx[header->n_columns-col];
+				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			}
+			for (row = 1; row < header->n_rows; row++) {	/* West going south */
+				out[GMT_Y] = yy[row];
+				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+			}
+			GMT_Destroy_Data (API, &xx);
+			GMT_Destroy_Data (API, &yy);
 		}
 		else if (Ctrl->C.active && !Ctrl->I.active) {
 			if (num_report) {	/* External interface, return as data with no leading text {...} is for 3-D cubes only */

--- a/test/grdinfo/perimeters.sh
+++ b/test/grdinfo/perimeters.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Test grdinfo -Ib for both pixel and gridline-registered grids.
+
+cat << EOF > p_answer.txt
+0	0
+0.5	0
+1.5	0
+2	0
+2	0.5
+2	1.5
+2	2
+1.5	2
+0.5	2
+0	2
+0	1.5
+0	0.5
+0	0
+EOF
+cat << EOF > g_answer.txt
+0	0
+1	0
+2	0
+2	1
+2	2
+1	2
+0	2
+0	1
+0	0
+EOF
+gmt grdmath -R0/2/0/2 -I1 -rg 0 = g.grd
+gmt grdmath -R0/2/0/2 -I1 -rp 0 = p.grd
+gmt grdinfo -Ib g.grd > g_result.txt
+gmt grdinfo -Ib p.grd > p_result.txt
+
+diff g_result.txt g_answer.txt --strip-trailing-cr > fail
+diff p_result.txt p_answer.txt --strip-trailing-cr >> fail


### PR DESCRIPTION
The **-Ib** option outputs the bounding box of the grid.  But it failed to do so at the increment resolution and instead only output the 5 corner points.  That meant that projecting this polygon would fail to outline the polygon in an oblique projection. This PR corrects this bug by sampling the perimeter at the grid spacing.  Because pixel and gridline-registered grids have the save w/e/s/n but different node coordinates we make sure both types give the correct outer box and that the polygon is closed.