### PR TITLE
Let oneliner plot colorbar used default justification

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15838,7 +15838,7 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 		char *show = (setting && !strcmp (setting, "off")) ? "" : "show";
 		GMT->current.ps.oneliner = false;
 		if (gmt_get_current_item (GMT, "cpt", false)) {	/* One-liner with a current CPT, place it on top */
-			if ((i = GMT_Call_Module (GMT->parent, "colorbar", GMT_MODULE_CMD, "-DJTC -Baf"))) {
+			if ((i = GMT_Call_Module (GMT->parent, "colorbar", GMT_MODULE_CMD, "-DJBC -Baf"))) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to call module colorbar for a one-liner plot.\n");
 				return;
 			}


### PR DESCRIPTION
This PR fixes the automatic **colorbar** placement for one-liners to be BC as it is the default placement.  I had initially used TC but we shall be consistent (or try to be).
