### PR TITLE
Add -Wo to mapproject for oblique domain in degrees

### DIFF
--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -27,7 +27,7 @@ Synopsis
 [ |-S| ]
 [ |-T|\ [**h**]\ *from*\ [/*to*] ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **r**\|\ **R**\|\ **w**\|\ **x**] ]
+[ |-W|\ [**g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**] ]
 [ |-Z|\ [*speed*][**+a**][**+i**][**+f**][**+t**\ *epoch*] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -230,7 +230,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **r**\|\ **R**\|\ **w**\|\ **x**]
+**-W**\ [**g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**]
     Prints map width and height on standard output.  No input files are read.
     To only output the width or the height, append **w** or **h**, respectively.
     To output the plot coordinates of a map point, give **g**\ *lon*/*lat*.
@@ -242,8 +242,9 @@ Optional Arguments
     covers an oblique area as defined by **-R -J**, append **r**,
     or use **R** to get the result in -Rw/e/s/n string format. Similarly, if an
     oblique domain is set via **-R**\ *xmin/xmax/ymin/ymax*\ **+u**\ *unit* then
-    use **o** to return the diagonal corner coordinates in degrees and the equivalent
-    **-R** string as trailing text [Default returns the width and height of the map].
+    use **o** to return the diagonal corner coordinates in degrees (in the order
+    *llx urx lly ury*) or use **O** to get the equivalent **-R** string as trailing
+    text [Default returns the width and height of the map].
 
 .. _-Z:
 
@@ -384,7 +385,7 @@ To determine the oblique region string (in degrees) that corresponds to a rectan
 
    ::
 
-    R=$(gmt mapproject -R-2800/2400/-570/630+uk -Joc190/25/266/68/1:1 -Fk -C -Wo -ot)
+    gmt mapproject -R-2800/2400/-570/630+uk -Joc190/25/266/68/1:1 -WO
 
 Restrictions
 ------------

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -27,7 +27,7 @@ Synopsis
 [ |-S| ]
 [ |-T|\ [**h**]\ *from*\ [/*to*] ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**g**\|\ **h**\|\ **j**\|\ **n**\|\ **r**\|\ **R**\|\ **w**\|\ **x**] ]
+[ |-W|\ [**g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **r**\|\ **R**\|\ **w**\|\ **x**] ]
 [ |-Z|\ [*speed*][**+a**][**+i**][**+f**][**+t**\ *epoch*] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -230,7 +230,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**g**\|\ **h**\|\ **j**\|\ **n**\|\ **r**\|\ **R**\|\ **w**\|\ **x**]
+**-W**\ [**g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **r**\|\ **R**\|\ **w**\|\ **x**]
     Prints map width and height on standard output.  No input files are read.
     To only output the width or the height, append **w** or **h**, respectively.
     To output the plot coordinates of a map point, give **g**\ *lon*/*lat*.
@@ -240,8 +240,10 @@ Optional Arguments
     point is given as normalized positions in the 0-1 range, or **x**\ *px*/*py*,
     where a plot point is given directly. To output the rectangular domain that
     covers an oblique area as defined by **-R -J**, append **r**,
-    or use **R** to get the result in -Rw/e/s/n string format [Default returns
-    the width and height of the map].
+    or use **R** to get the result in -Rw/e/s/n string format. Similarly, if an
+    oblique domain is set via **-R**\ *xmin/xmax/ymin/ymax*\ **+u**\ *unit* then
+    use **o** to return the diagonal corner coordinates in degrees and the equivalent
+    **-R** string as trailing text [Default returns the width and height of the map].
 
 .. _-Z:
 

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -379,6 +379,13 @@ defined by an oblique Mercator projection, try
 
     gmt mapproject -R270/20/305/25+r -JOc280/25.5/22/69/2c -WR
 
+To determine the oblique region string (in degrees) that corresponds to a rectangular
+(but oblique) region specified in projected units defined by an oblique Mercator projection, try
+
+   ::
+
+    R=$(gmt mapproject -R-2800/2400/-570/630+uk -Joc190/25/266/68/1:1 -Fk -C -Wo -ot)
+
 Restrictions
 ------------
 

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -67,7 +67,8 @@ enum GMT_mp_Wcodes {	/* Support for -W parsing */
 	GMT_MP_M_HEIGHT  = 2,	/* Return height */
 	GMT_MP_M_POINT   = 3,	/* Return user coordinates of point given in plot coordinates */
 	GMT_MP_M_REGION  = 4,	/* Return rectangular w/e/s/n for oblique -R -J setting */
-	GMT_MP_M_RSTRING = 5	/* As 4, but return string -Rw/e/s/n */
+	GMT_MP_M_RSTRING = 5,	/* As 4, but return string -Rw/e/s/n */
+	GMT_MP_M_OSTRING = 6	/* Converts -R<xmin/xmax/ymin/ymax>+u<unit> to <llx/lly/urx/ury>+r string and numbers */
 };
 
 enum GMT_mp_Zcodes {	/* Support for -Z parsing */
@@ -195,7 +196,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <table> %s %s [-Ab|B|f|F|o|O[<lon0>/<lat0>][+v]] [-C[<dx></dy>][+m]] [-D%s] "
 		"[-E[<datum>]] [-F[<%s|%s>]] [-G[<lon0>/<lat0>][+a][+i][+u<unit>][+v]] [-I] [-L<table>[+p][+u<unit>]] "
-		"[-N[a|c|g|m]] [-Q[d|e]] [-S] [-T[h]<from>[/<to>]] [%s] [-W[g|h|j|n|r|R|w|x]] [-Z[<speed>][+a][+i][+f][+t<epoch>]] "
+		"[-N[a|c|g|m]] [-Q[d|e]] [-S] [-T[h]<from>[/<to>]] [%s] [-W[g|h|j|n|o|r|R|w|x]] [-Z[<speed>][+a][+i][+f][+t<epoch>]] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_DIM_UNITS_DISPLAY, GMT_LEN_UNITS2_DISPLAY, GMT_DIM_UNITS_DISPLAY, GMT_V_OPT,
 		GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_o_OPT, GMT_p_OPT,
@@ -278,12 +279,13 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"If <from> equals - we use WGS-84.  If /<to> is not given we assume WGS-84. "
 		"Note: -T can be used as pre- or post- (-I) processing for -J -R.");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[g|h|j|n|r|R|w|x]");
+	GMT_Usage (API, 1, "\n-W[g|h|j|n|o|r|R|w|x]");
 	GMT_Usage (API, -2, "Print map width and/or height or a reference point. No input files are read. Select optional directive:");
 	GMT_Usage (API, 3, "g: Print map coordinates of reference point <gx/gy>.");
 	GMT_Usage (API, 3, "h: Print map height (See -D for plot units).");
 	GMT_Usage (API, 3, "j: Print map coordinates of justification point given as 2-char justification code (BL, MC, etc.).");
 	GMT_Usage (API, 3, "n: Print map coordinates of reference point with normalized coordinates <rx/ry> in 0-1 range.");
+	GMT_Usage (API, 3, "o: Print oblique <llx>/<lly>/<urx>/<ury>+r coordinates and -R string for an oblique input region given via <xmin/xmax/ymin/ymax>+u<unit>.");
 	GMT_Usage (API, 3, "r: Print rectangular region for an oblique -R -J selection.");
 	GMT_Usage (API, 3, "R: Same as r but prints -Rw/e/s/n string as trailing text instead.");
 	GMT_Usage (API, 3, "w: Print map width (See -D for plot units).");
@@ -706,10 +708,11 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 						}
 						Ctrl->W.mode = GMT_MP_M_POINT;
 						break;
+					case 'o': Ctrl->W.mode = GMT_MP_M_OSTRING; break;
 					case 'r': Ctrl->W.mode = GMT_MP_M_REGION; break;
 					case 'R': Ctrl->W.mode = GMT_MP_M_RSTRING; break;
 					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Expected -W[g|h|j|n|r|R|w|x]\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Expected -W[g|h|j|n|o|r|R|w|x]\n");
 						n_errors++;
 						break;
 				}
@@ -1049,6 +1052,11 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 				}
 				gmt_free_refpoint (GMT, &Ctrl->W.refpoint);
 				n_output = 2;	break;
+			case GMT_MP_M_OSTRING:
+				tmode = GMT_COL_FIX;
+				n_output = 4;
+				gmt_M_memcpy (w_out, GMT->common.R.wesn, 4, double);
+				break;
 			case GMT_MP_M_RSTRING:
 				tmode = GMT_COL_FIX;	/* Fall through on purpose here */
 			case GMT_MP_M_REGION:
@@ -1079,6 +1087,10 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 		if (GMT_Set_Geometry (API, GMT_OUT, GMT_IS_NONE) != GMT_NOERROR) {	/* Sets output geometry */
 			gmt_M_free (GMT, Out);
 			Return (API->error);
+		}
+		if (Ctrl->W.mode == GMT_MP_M_OSTRING) {
+			sprintf (region, "-R%.16lg/%.16lg/%.16lg/%.16lg+r", w_out[XLO], w_out[YLO], w_out[XHI], w_out[YHI]);
+			Out->text = region;
 		}
 		if (Ctrl->W.mode == GMT_MP_M_RSTRING) {
 			sprintf (region, "-R%.16lg/%.16lg/%.16lg/%.16lg", w_out[XLO], w_out[XHI], w_out[YLO], w_out[YHI]);

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -68,7 +68,8 @@ enum GMT_mp_Wcodes {	/* Support for -W parsing */
 	GMT_MP_M_POINT   = 3,	/* Return user coordinates of point given in plot coordinates */
 	GMT_MP_M_REGION  = 4,	/* Return rectangular w/e/s/n for oblique -R -J setting */
 	GMT_MP_M_RSTRING = 5,	/* As 4, but return string -Rw/e/s/n */
-	GMT_MP_M_OSTRING = 6	/* Converts -R<xmin/xmax/ymin/ymax>+u<unit> to <llx/lly/urx/ury>+r string and numbers */
+	GMT_MP_M_OREGION = 6,	/* Converts -R<xmin/xmax/ymin/ymax>+u<unit> to <llx/lly/urx/ury> returned as llx urx lly ury */
+	GMT_MP_M_OSTRING = 7	/* As 6, but return string -Rw/e/s/n */
 };
 
 enum GMT_mp_Zcodes {	/* Support for -Z parsing */
@@ -196,7 +197,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <table> %s %s [-Ab|B|f|F|o|O[<lon0>/<lat0>][+v]] [-C[<dx></dy>][+m]] [-D%s] "
 		"[-E[<datum>]] [-F[<%s|%s>]] [-G[<lon0>/<lat0>][+a][+i][+u<unit>][+v]] [-I] [-L<table>[+p][+u<unit>]] "
-		"[-N[a|c|g|m]] [-Q[d|e]] [-S] [-T[h]<from>[/<to>]] [%s] [-W[g|h|j|n|o|r|R|w|x]] [-Z[<speed>][+a][+i][+f][+t<epoch>]] "
+		"[-N[a|c|g|m]] [-Q[d|e]] [-S] [-T[h]<from>[/<to>]] [%s] [-W[g|h|j|n|o|O|r|R|w|x]] [-Z[<speed>][+a][+i][+f][+t<epoch>]] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_DIM_UNITS_DISPLAY, GMT_LEN_UNITS2_DISPLAY, GMT_DIM_UNITS_DISPLAY, GMT_V_OPT,
 		GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_o_OPT, GMT_p_OPT,
@@ -279,7 +280,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"If <from> equals - we use WGS-84.  If /<to> is not given we assume WGS-84. "
 		"Note: -T can be used as pre- or post- (-I) processing for -J -R.");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[g|h|j|n|o|r|R|w|x]");
+	GMT_Usage (API, 1, "\n-W[g|h|j|n|o|O|r|R|w|x]");
 	GMT_Usage (API, -2, "Print map width and/or height or a reference point. No input files are read. Select optional directive:");
 	GMT_Usage (API, 3, "g: Print map coordinates of reference point <gx/gy>.");
 	GMT_Usage (API, 3, "h: Print map height (See -D for plot units).");
@@ -708,11 +709,12 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 						}
 						Ctrl->W.mode = GMT_MP_M_POINT;
 						break;
-					case 'o': Ctrl->W.mode = GMT_MP_M_OSTRING; break;
+					case 'o': Ctrl->W.mode = GMT_MP_M_OREGION; break;
+					case 'O': Ctrl->W.mode = GMT_MP_M_OSTRING; break;
 					case 'r': Ctrl->W.mode = GMT_MP_M_REGION; break;
 					case 'R': Ctrl->W.mode = GMT_MP_M_RSTRING; break;
 					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Expected -W[g|h|j|n|o|r|R|w|x]\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Expected -W[g|h|j|n|o|O|r|R|w|x]\n");
 						n_errors++;
 						break;
 				}
@@ -1053,10 +1055,11 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 				gmt_free_refpoint (GMT, &Ctrl->W.refpoint);
 				n_output = 2;	break;
 			case GMT_MP_M_OSTRING:
-				tmode = GMT_COL_FIX;
-				n_output = 4;
+				tmode = GMT_COL_FIX;	/* Fall through on purpose here */
+			case GMT_MP_M_OREGION:
 				gmt_M_memcpy (w_out, GMT->common.R.wesn, 4, double);
 				if (w_out[XHI] < w_out[XLO]) w_out[XHI] += 360.0;
+				n_output = 4;
 				break;
 			case GMT_MP_M_RSTRING:
 				tmode = GMT_COL_FIX;	/* Fall through on purpose here */
@@ -1077,7 +1080,7 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 			gmt_M_free (GMT, Out);
 			Return (API->error);
 		}
-		if ((error = GMT_Set_Columns (API, GMT_OUT, (unsigned int)(Ctrl->W.mode == GMT_MP_M_RSTRING ? 0 : n_output), tmode)) != GMT_NOERROR) {
+		if ((error = GMT_Set_Columns (API, GMT_OUT, (unsigned int)(Ctrl->W.mode == GMT_MP_M_OSTRING || Ctrl->W.mode == GMT_MP_M_RSTRING ? 0 : n_output), tmode)) != GMT_NOERROR) {
 			gmt_M_free (GMT, Out);
 			Return (error);
 		}
@@ -1093,7 +1096,7 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 			sprintf (region, "-R%.16lg/%.16lg/%.16lg/%.16lg+r", w_out[XLO], w_out[YLO], w_out[XHI], w_out[YHI]);
 			Out->text = region;
 		}
-		if (Ctrl->W.mode == GMT_MP_M_RSTRING) {
+		else if (Ctrl->W.mode == GMT_MP_M_RSTRING) {
 			sprintf (region, "-R%.16lg/%.16lg/%.16lg/%.16lg", w_out[XLO], w_out[XHI], w_out[YLO], w_out[YHI]);
 			Out->text = region;
 		}

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1056,6 +1056,7 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 				tmode = GMT_COL_FIX;
 				n_output = 4;
 				gmt_M_memcpy (w_out, GMT->common.R.wesn, 4, double);
+				if (w_out[XHI] < w_out[XLO]) w_out[XHI] += 360.0;
 				break;
 			case GMT_MP_M_RSTRING:
 				tmode = GMT_COL_FIX;	/* Fall through on purpose here */


### PR DESCRIPTION
It is useful to scripters to learn what the equivalent **-R** setting in degrees might be if one specifies an oblique region via **-R**_xmin/xmax/ymin/ymax_**+u**_unit_.  This PR adds that capability via **-Wo** which will write the w e s n numbers plus **-Rstring** as trailing text.  Example:

```
gmt mapproject -R-2800/2400/-570/630+uk -Joc190/25/266/68/1:1 -Fk -C -Wo
164.589993465	210.6746652	30.1588817953	22.1514604447	-R164.589993465318/30.15888179527597/210.674665200366/22.15146044466763+r
```

or

`Rstring=$(gmt mapproject -R-2800/2400/-570/630+uk -Joc190/25/266/68/1:1 -Fk -C -Wo -ot)`

No tests are affected.  Man page updated to show such an example.