### PR TITLE
Return with error if libcurl fails

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1388,7 +1388,9 @@ int gmt_download_file (struct GMT_CTRL *GMT, const char *name, char *url, char *
 	if ((curl_err = curl_easy_perform (Curl))) {	/* Failed, give error message */
 		if (be_fussy || !(curl_err == CURLE_REMOTE_FILE_NOT_FOUND || curl_err == CURLE_HTTP_RETURNED_ERROR)) {	/* Unexpected failure - want to bitch about it */
 			GMT_Report (API, GMT_MSG_ERROR, "Libcurl Error: %s\n", curl_easy_strerror (curl_err));
-			GMT_Report (API, GMT_MSG_WARNING, "You can turn remote file download off by setting GMT_DATA_UPDATE_INTERVAL to \"off\"\n");
+			if (curl_err == CURLE_HTTP_RETURNED_ERROR)
+				GMT_Report (API, GMT_MSG_ERROR, "Probably means %s does not exist on the remote server\n", name);
+			error = curl_err;
 			if (urlfile.fp != NULL) {
 				fclose (urlfile.fp);
 				urlfile.fp = NULL;


### PR DESCRIPTION
If we request a remote file that does not exist we would get a long list of repeated error messages about failures and suggestions to turn off internet download, etc.  Part of the problem was the error code was not returned, so we tried again later on in the module.  Second, the message

`grdimage [WARNING]: You can turn remote file download off by setting GMT_DATA_UPDATE_INTERVAL to "off"`

is really not that helpful in this situation (it is better if there is time-outs), and third, the general HTTP error says nothing, so it is unclear what is happening.

This PR makes these changes:

1. It properly returns the error code so the module can gracefully stop
2. It no longer prints that misplaced message about **GMT_DATA_UPDATE_INTERVAL**
3. It suggests that if this error is returned that it likely means the file cannot be found.

Closes #6477.  It is not exactly what I expected but since it can be hard to tell a cache file from a remote server file, the improved error handling should be good enough.