### PR TITLE
grdsample aliasing message failed to account for numerical noise

### DIFF
--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -347,9 +347,9 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 
-	if (Gout->header->inc[GMT_X] > Gin->header->inc[GMT_X])
+	if ((Gout->header->inc[GMT_X]/ Gin->header->inc[GMT_X]) > (1.0 + GMT_CONV8_LIMIT))
 		GMT_Report (API, GMT_MSG_WARNING, "Output sampling interval in x exceeds input interval and may lead to aliasing.\n");
-	if (Gout->header->inc[GMT_Y] > Gin->header->inc[GMT_Y])
+	if ((Gout->header->inc[GMT_Y] / Gin->header->inc[GMT_Y]) > (1.0 + GMT_CONV8_LIMIT))
 		GMT_Report (API, GMT_MSG_WARNING, "Output sampling interval in y exceeds input interval and may lead to aliasing.\n");
 
 	/* Precalculate longitudes from the output grid layout */


### PR DESCRIPTION
Do to internal rounding, when input increment is 0.0166666666666 ( 1 arc min) and output is increment was 0.0166666666667 (also 1 arc min) we would get the unexpected message

`grdsample [WARNING]: Output sampling interval in x exceeds input interval and may lead to aliasing.`

This PR fixes so there is allowed 1e-8 slop in the comparison.
