### PR TITLE
Get correct relative time for progress bars

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -2069,7 +2069,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				/* Note: All dimensions are written in inches and read as inches in gmt_plotinit */
 
 				for (T = 0; T < Ctrl->n_items[k]; T++) {
-					t = (frame + 1.0) / n_frames;
+					t = frame / (n_frames - 1.0);
 					I = &Ctrl->item[k][T];	/* Shorthand for this item */
 					/* Set selected font: Prepend + if user specified a font, else just give current default font */
 					if (I->font.size > 0.0)	/* Users selected font */


### PR DESCRIPTION
Fixing a dumb bug in computing the relative time (0-1) from frame number so that it actually starts at 0 and ends at 1...

@meghanrjones, this affects on doc plot and the tests with progress bars:

```
doc/scripts/GMT_movie_progress.sh
test/movie/movie_indicator_de.sh (Failed)
test/movie/movie_indicator_f_hor.sh (Failed)
test/movie/movie_indicator_f_ver.sh (Failed)
```

Could you please update those in dvc?
