### PR TITLE
Check if mode is suitable for grid in grdfilter

### DIFF
--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -975,13 +975,13 @@ EXTERN_MSC int GMT_grdfilter (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 	/* Check that -D option is compatible with the type of grid */
-	if (gmt_M_is_geographic (GMT, GMT_IN)) {
+	if (gmt_M_is_geographic (GMT, GMT_IN)) {	/*  Make sure we selected a geographic distance mode */
 		if (Ctrl->D.mode < GRDFILTER_GEO_CARTESIAN || Ctrl->D.mode > GRDFILTER_GEO_SPHERICAL) {
 			GMT_Report (API, GMT_MSG_ERROR, "Option -D: Input grid is geographic but your distance mode is Cartesian\n");
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
-	else if (Ctrl->D.mode > GRDFILTER_XY_CARTESIAN) {
+	else if (Ctrl->D.mode > GRDFILTER_XY_CARTESIAN) {	/*  Make sure we selected a Cartesian distance mode */
 		GMT_Report (API, GMT_MSG_ERROR, "Option -D: Input grid is Cartesian but your distance mode is set for geographic distances\n");
 		Return (GMT_RUNTIME_ERROR);
 	}

--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -971,7 +971,22 @@ EXTERN_MSC int GMT_grdfilter (void *V_API, int mode, void *args) {
 	/*---------------------------- This is the grdfilter main code ----------------------------*/
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input grid\n");
-	if ((Gin = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, Ctrl->In.file, NULL)) == NULL) {	/* Get entire grid */
+	if ((Gin = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, Ctrl->In.file, NULL)) == NULL) {	/* Get header first */
+		Return (API->error);
+	}
+	/* Check that -D option is compatible with the type of grid */
+	if (gmt_M_is_geographic (GMT, GMT_IN)) {
+		if (Ctrl->D.mode < GRDFILTER_GEO_CARTESIAN || Ctrl->D.mode > GRDFILTER_GEO_SPHERICAL) {
+			GMT_Report (API, GMT_MSG_ERROR, "Option -D: Input grid is geographic but your distance mode is Cartesian\n");
+			Return (GMT_RUNTIME_ERROR);
+		}
+	}
+	else if (Ctrl->D.mode > GRDFILTER_XY_CARTESIAN) {
+		GMT_Report (API, GMT_MSG_ERROR, "Option -D: Input grid is Cartesian but your distance mode is set for geographic distances\n");
+		Return (GMT_RUNTIME_ERROR);
+	}
+	/* Safe to read the adta */
+	if ((Gin = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY, NULL, Ctrl->In.file, Gin)) == NULL) {	/* Get entire grid */
 		Return (API->error);
 	}
 	if (GMT->common.R.active[GSET])	/* Explicitly set the output registration */


### PR DESCRIPTION
We have a set of distance modes in **grdfilter**.  Some are for Cartesian grids and some are for geographic grids (including complete spherical distances between nodes).  However, there were absolutely no checks that the user selected a sensible mode with their grid.  I was trying to filter a Cartesian grid and from memory thought `-D1` was the thing (but it should be `-D0`).  So I was a bit surprised seeing this on output and was about to file a bug report about strange repeating 360-ghosts:

![shit](https://user-images.githubusercontent.com/26473567/160236301-fce23f75-9ced-443f-88ce-caccfd3a4be7.png)

But of course, I cannot select `-D1 `with a Cartesian grid:

`       1: grid x,y in degrees, <width> in km, Cartesian distances.`

Thus, this PR checks and gives an error if you select a bad distance mode given the type of your grid.

While there might be special cases where the user want to treat their grid as something different that what it is, they can always use **-fg** or **-fc** to pretend otherwise.
