### PR TITLE
Fix use of data offset when grdpaste reads grids

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -1518,7 +1518,7 @@ int gmt_update_grd_info (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEADE
 	return ((*GMT->session.updateinfo[header->type]) (GMT, header));
 }
 
-int gmtlib_read_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEADER *header, gmt_grdfloat *grid, double *wesn, unsigned int *pad, int complex_mode) {
+int gmtlib_read_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEADER *header, gmt_grdfloat *pgrid, double *wesn, unsigned int *pad, int complex_mode) {
 	/* file:	- IGNORED -
 	 * header:	grid structure header
 	 * grid:	array with final grid
@@ -1533,6 +1533,7 @@ int gmtlib_read_grd (struct GMT_CTRL *GMT, char *file, struct GMT_GRID_HEADER *h
 	int err = GMT_OK;		/* Implied by gmt_M_err_trap */
 	struct GRD_PAD P;
 	struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (header);
+	gmt_grdfloat *grid = pgrid + HH->data_offset;	/* This can be nonzero when grdpaste is reading */
 
 	complex_mode &= GMT_GRID_IS_COMPLEX_MASK;	/* Remove any non-complex flags */
 	/* If we are reading a 2nd grid (e.g., real, then imag) we must update info about the file since it will be a different file */

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1651,12 +1651,12 @@ int gmt_nc_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_g
 
 	/* Read grid */
 	if (dim2[1] == 0)
-		gmtnc_io_nc_grid (GMT, header, dim, origin, HH->stride, k_get_netcdf, pgrid + HH->data_offset, false);
+		gmtnc_io_nc_grid (GMT, header, dim, origin, HH->stride, k_get_netcdf, pgrid, false);
 	else {
 		/* Read grid in two parts */
 		unsigned int stride_or_width = HH->stride != 0 ? HH->stride : width;
-		gmtnc_io_nc_grid (GMT, header, dim, origin, stride_or_width, k_get_netcdf, pgrid + HH->data_offset, false);
-		gmtnc_io_nc_grid (GMT, header, dim2, origin2, stride_or_width, k_get_netcdf, pgrid + HH->data_offset + dim[1], false);
+		gmtnc_io_nc_grid (GMT, header, dim, origin, stride_or_width, k_get_netcdf, pgrid, false);
+		gmtnc_io_nc_grid (GMT, header, dim2, origin2, stride_or_width, k_get_netcdf, pgrid + dim[1], false);
 	}
 
 	/* If we need to shift grid */
@@ -1721,7 +1721,7 @@ int gmt_nc_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_g
 
 	/* Flip grid upside down */
 	if (HH->row_order == k_nc_start_south)
-		gmt_grd_flip_vertical (pgrid + HH->data_offset, width, height, HH->stride, sizeof(grid[0]));
+		gmt_grd_flip_vertical (pgrid, width, height, HH->stride, sizeof(grid[0]));
 
 	/* Add padding with border replication */
 	gmtnc_pad_grid (pgrid, width, height, pad, sizeof(grid[0]), k_pad_fill_zero);
@@ -1731,7 +1731,7 @@ int gmt_nc_read_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_g
 		unsigned n;
 		unsigned pad_x = pad[XLO] + pad[XHI];
 		unsigned stride = HH->stride ? HH->stride : width;
-		gmt_grdfloat *p_data = pgrid + HH->data_offset;
+		gmt_grdfloat *p_data = pgrid;
 		for (n = 0; n < (stride + pad_x) * (height + pad[YLO] + pad[YHI]); n++) {
 			if (n % (stride + pad_x) == 0)
 				fprintf (stderr, "\n");


### PR DESCRIPTION
See #6487 for background and example.  Sometime during the recoding from GMT4 to GMT 5 we (meaning me) introduced a bug that only affected **grdpaste**.  The way **grdpaste** works is to set a data offset parameter in the hidden grid header section so that when we read in data we consider if the hidden data_offset is nonzero (well, we basically always offset the start of the grid by that amount, zero or not).  Thus data are read twice by **grdpaste** into the same array but at two different starting positions.  This works fine.

The trouble had to do with input grids that have scale factors or offsets that are _not_ the default (1, 0).  Turned out the code that does the unpacking was not made aware of the data offset and hence only the first part of the combined grid would have scaling applied.

This PR applies the offset immediately at the top of the highest level _gmtlib_read_grd_ function and then all subsequent function calls dealing with the grid (such as finding min/max or unpacking) do not need to consider any offsets.  The example discussed in the background now works fine.  Closes #6487.
