### PR TITLE
Remove the restriction in grdpaste on same scale/offset

### DIFF
--- a/src/grdpaste.c
+++ b/src/grdpaste.c
@@ -189,10 +189,6 @@ EXTERN_MSC int GMT_grdpaste (void *V_API, int mode, void *args) {
 
 	if (A->header->registration != B->header->registration)
 		error++;
-	if ((A->header->z_scale_factor != B->header->z_scale_factor) || (A->header->z_add_offset != B->header->z_add_offset)) {
-		GMT_Report (API, GMT_MSG_ERROR, "Scale/offset not compatible!\n");
-		Return (GMT_RUNTIME_ERROR);
-	}
 
 	if (! (fabs (A->header->inc[GMT_X] - B->header->inc[GMT_X]) < 1.0e-6 && fabs (A->header->inc[GMT_Y] - B->header->inc[GMT_Y]) < 1.0e-6)) {
 		GMT_Report (API, GMT_MSG_ERROR, "Grid intervals do not match!\n");


### PR DESCRIPTION
If you paste two grids with different internal scalings or offsets you will get the error message

`Scale/offset not compatible!
`

However, that is irrelevant as each grid is handled separately and are internally converted to a unity scale and zero offset anyway.  This works fine (after fixing the bug in #6488):

```
gmt grdmath -R0/2/0/2 -I1 -rp 10 = a.grd=ns+s0.5
gmt grdmath -R0/2/2/4 -I1 -rp 10 = b.grd=ns+s0.25
gmt grdpaste a.grd b.grd -Gc.grd
```