### PR TITLE
Fix event -E parsing and add animation to documentation

### DIFF
--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -52,17 +52,19 @@ Synopsis
 
 .. module_common_begins
 
-.. figure:: /_images/psevents_action.gif
+.. figure:: /_images/psevents_action.*
    :width: 600 px
    :align: center
 
-   Animation of two events from time -0.5 to 1.5. Both events are only active from
-   0 to 1. One symbol (blue) is only plotted while active, while the other (red)
-   is highlighted when it first arrives by adding a rise, plateau, decay, and fade
-   interval, and finally then let to fade to a persistent but smaller, darker
-   and partly transparent symbol after it is no longer active.  in contrast, the
-   blue symbol just turns on and off.  We also delay the red symbol label by 0.25.
-   Red event used -Es+r0.25+p0.25+d0.25+f0.25 -Et+o0.25 while blue used the default.
+   Animation of two events over the time window -0.5 to 1.5. The events are only active during times
+   0 to 1. One symbol (blue) is plotted normally only while active (size follows the light-blue time-curve,
+   while the other (red) is highlighted when it first arrives by adding a rise, plateau, decay, and fade
+   interval, and finally then let to fade to a persistent but smaller, darker and partly transparent
+   symbol after it is no longer active; its size follows the red time-curve. In contrast, the
+   blue symbol just turns on and off.  We also delay the red symbol's label by 0.25 time units.
+   Red event was plotted using -Es+r0.25+p0.25+d0.25+f0.25 -Et+o0.25 while the blue event used the
+   default settings (i.e., the lightblue time curve). **Note**: The time curves are plotted here just
+   to illustrate what is happening under the hood. The movie we make is really about the two events only.
 
 Description
 -----------
@@ -160,7 +162,7 @@ Optional Arguments
 .. _-E:
 
 **-E**\ [**s**\|\ **t**\ ][**+o**\|\ **O**\ *dt*][**+r**\ *dt*][**+p**\ *dt*][**+d**\ *dt*][**+f**\ *dt*][**+l**\ *dt*]
-    Set the time knots for the **s**\ ymbol or **t**\ ext time-functions (see `The four time-functions`_).  Append
+    Set the relative time knots for the **s**\ ymbol or **t**\ ext time-functions (see `The four time-functions`_).  Append
     **+o** to shift the event start and end times by a constant offset (basically shifting
     the event in time by *dt*\ ; or use **+O** to only shift the start time, effectively shortening
     the duration of the event), **+r** to indicate the

--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -52,19 +52,18 @@ Synopsis
 
 .. module_common_begins
 
-.. figure:: /_images/psevents_action.*
-   :width: 600 px
-   :align: center
+..  youtube:: iWt0yZICKlM
+    :width: 100%
 
-   Animation of two events over the time window -0.5 to 1.5. The events are only active during times
-   0 to 1. One symbol (blue) is plotted normally only while active (size follows the light-blue time-curve,
-   while the other (red) is highlighted when it first arrives by adding a rise, plateau, decay, and fade
-   interval, and finally then let to fade to a persistent but smaller, darker and partly transparent
-   symbol after it is no longer active; its size follows the red time-curve. In contrast, the
-   blue symbol just turns on and off.  We also delay the red symbol's label by 0.25 time units.
-   Red event was plotted using -Es+r0.25+p0.25+d0.25+f0.25 -Et+o0.25 while the blue event used the
-   default settings (i.e., the lightblue time curve). **Note**: The time curves are plotted here just
-   to illustrate what is happening under the hood. The movie we make is really about the two events only.
+Animation of two events over the time window -0.5 to 1.5. The events are only active during times
+0 to 1. One symbol (blue) is plotted normally only while active (size follows the light-blue time-curve,
+while the other (red) is highlighted when it first arrives by adding a rise, plateau, decay, and fade
+interval, and finally then let to fade to a persistent but smaller, darker and partly transparent
+symbol after it is no longer active; its size follows the red time-curve. In contrast, the
+blue symbol just turns on and off.  We also delay the red symbol's label by 0.25 time units.
+Red event was plotted using -Es+r0.25+p0.25+d0.25+f0.25 -Et+o0.25 while the blue event used the
+default settings (i.e., the lightblue time curve). **Note**: The time curves are plotted here just
+to illustrate what is happening under the hood. The movie we make is really about the two events only.
 
 Description
 -----------

--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -52,19 +52,6 @@ Synopsis
 
 .. module_common_begins
 
-..  youtube:: iWt0yZICKlM
-    :width: 100%
-
-Animation of two events over the time window -0.5 to 1.5. The events are only active during times
-0 to 1. One symbol (blue) is plotted normally only while active (size follows the light-blue time-curve,
-while the other (red) is highlighted when it first arrives by adding a rise, plateau, decay, and fade
-interval, and finally then let to fade to a persistent but smaller, darker and partly transparent
-symbol after it is no longer active; its size follows the red time-curve. In contrast, the
-blue symbol just turns on and off.  We also delay the red symbol's label by 0.25 time units.
-Red event was plotted using -Es+r0.25+p0.25+d0.25+f0.25 -Et+o0.25 while the blue event used the
-default settings (i.e., the lightblue time curve). **Note**: The time curves are plotted here just
-to illustrate what is happening under the hood. The movie we make is really about the two events only.
-
 Description
 -----------
 
@@ -79,6 +66,19 @@ Optionally, each symbol may have a label that can be displayed for a prescribed 
 same time as the symbol or delayed a bit. This module is typically used in conjunction with :doc:`movie`
 where the implicit loop over time is used to call **events** over a time-sequence and
 thus plot symbols as the events unfold.
+
+..  youtube:: iWt0yZICKlM
+    :width: 100%
+
+Animation of two events over the time window -0.5 to 1.5. The events are only active during times
+0 to 1. One symbol (blue) is plotted normally only while active (size follows the light-blue time-curve,
+while the other (red) is highlighted when it first arrives by adding a rise, plateau, decay, and fade
+interval, and finally then let to fade to a persistent but smaller, darker and partly transparent
+symbol after it is no longer active; its size follows the red time-curve. In contrast, the
+blue symbol just turns on and off.  We also delay the red symbol's label by 0.25 time units.
+Red event was plotted using -Es+r0.25+p0.25+d0.25+f0.25 -Et+o0.25 while the blue event used the
+default settings (i.e., the light-blue time curve). **Note**: The time curves are plotted here just
+to illustrate what is happening under the hood. The movie we make is really about the two events only.
 
 Required Arguments
 ------------------

--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -52,6 +52,18 @@ Synopsis
 
 .. module_common_begins
 
+.. figure:: /_images/psevents_action.gif
+   :width: 600 px
+   :align: center
+
+   Animation of two events from time -0.5 to 1.5. Both events are only active from
+   0 to 1. One symbol (blue) is only plotted while active, while the other (red)
+   is highlighted when it first arrives by adding a rise, plateau, decay, and fade
+   interval, and finally then let to fade to a persistent but smaller, darker
+   and partly transparent symbol after it is no longer active.  in contrast, the
+   blue symbol just turns on and off.  We also delay the red symbol label by 0.25.
+   Red event used -Es+r0.25+p0.25+d0.25+f0.25 -Et+o0.25 while blue used the default.
+
 Description
 -----------
 

--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 303627d0b39fd010f6abb6b922aecca3.dir
-  size: 31115870
-  nfiles: 194
+- md5: 557ce21d9bfb0f6b77c60483791aedbd.dir
+  size: 31148135
+  nfiles: 195
   path: images

--- a/doc/scripts/psevents_action.sh
+++ b/doc/scripts/psevents_action.sh
@@ -57,4 +57,4 @@ gmt begin
 	gmt sample1d normal.txt -T${MOVIE_COL0}, -Fl | gmt plot -Sc2p -Gblue -N
 gmt end
 EOF
-gmt movie -C22cx12cx100 main.sh -Sbpre.sh -Npsevents_action -T-0.5/1.5/0.01 -D24 -Fmp4 -Lc0 -Lf+jTR -Pf+jBC+o0/1.5c+ac -M150,png -Z
+gmt movie -C22cx12cx100 main.sh -Sbpre.sh -Npsevents_action -T-0.5/1.5/0.01 -D24 -Fnone -Lc0 -Lf+jTR -Pf+jBC+o0/1.5c+ac -M150,ps -Z

--- a/doc/scripts/psevents_action.sh
+++ b/doc/scripts/psevents_action.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Create a short MP4 showing the life of two simple events
+# By default, this script only generated the master frame
+# Modify -Fnone to -Fmp4 in L58 to generate the MP4
 # Both events starts at 0 and ends at 1, but we add rise
 # and fade and coda to one of them (red) and let the other be plain (blue).
 echo 20 6 0 1 Red Label > red.txt

--- a/doc/scripts/psevents_action.sh
+++ b/doc/scripts/psevents_action.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Create a short animated GIF showing the life of two simple events
+# Both events starts at 0 and ends at 1, but we add rise
+# and fade and coda to one of them (red) and let the other be plain (blue).
+echo 20 6 0 1 Red Label > red.txt
+echo  0 6 0 1 Blue Label > blue.txt
+cat <<- EOF > labels.txt
+-0.125 2 RISE
+0.125 2 PLATEAU
+0.375 2 DECAY
+1.125 2 FADE
+1.375 2 CODA
+EOF
+cat <<- EOF > normal.txt
+-0.5	0
+-0.001	0
+0	1
+0.999	1
+1	0
+1.5	0
+EOF
+cat <<- EOF > stepfunction.txt
+-0.5	0
+0	0
+0	1
+1	1
+1	0
+1.5	0
+EOF
+cat <<- EOF > pre.sh
+gmt begin
+	echo "-0.5 0" > size_vs_time.txt
+	# Rise (t = -0.25 to 0 symbol size goes from 0 to 2x)
+	gmt math -T-0.25/0/0.01 T 0.25 ADD 0.25 DIV 2 POW 2 MUL = >> size_vs_time.txt
+	# plateau (t = 0 to 0.25 symbol size stays at 2x)
+	#gmt math -T0/0.25/0.01 2 = >> size_vs_time.txt
+	# Decay (t = 0.25 to 0.5 symbol size decays from 2x to 1x)
+	gmt math -T0.25/0.5/0.01 1 T 0.25 SUB 0.25 DIV 2 POW SUB 1 ADD = >> size_vs_time.txt
+	# active (t = 0.5 to 1 symbol size stays at 1x)
+	gmt math -T0.6/1/0.1 1 = >> size_vs_time.txt
+	# Fade (t = 1 to 1.25 symbol size linearly drops to 0.25 during fading)
+	gmt math -T1.1/1.25/0.05 1 T 1 SUB 0.25 DIV SUB 0.75 MUL 0.25 ADD = >> size_vs_time.txt
+	# Code (t = 1.25 to 1.5 symbol size stays at 0.25 during code)
+	gmt math -T1.3/1.5/0.1 0.25 = >> size_vs_time.txt
+	gmt plot -R-0.5/1.5/-0.1/2.1 -JX13.2c/2c -X4.4c -Y2.25c stepfunction.txt -W5p,lightblue@50
+	gmt plot size_vs_time.txt -W1p,red -BW -Bafg0.25+l"Size scale"
+	gmt text -F+f8p+jBC -Dj6p -N labels.txt
+gmt end
+EOF
+cat << 'EOF' > main.sh
+gmt begin
+	gmt events red.txt -T${MOVIE_COL0} -R-20/40/1/9 -JX20c/10c -B -Es+r0.25+p0.25+d0.25+f0.25 -Et+o0.25 -Sc2c -Gred -W1p -Ms2+c0.25 -Mi1+c-0.5 -Mt100+c50 -F+f18p+jBC -Dj3c -L -X1c -Y1c
+	gmt events blue.txt -T${MOVIE_COL0} -Sc2c -Gblue -W1p -F+f18p+jBC -Dj3c -L -E
+	gmt sample1d size_vs_time.txt -T${MOVIE_COL0}, -Fl | gmt plot -Sc4p -Gred -R-0.5/1.5/-0.1/2.1 -JX13.2c/2c -N -X3.4c -Y1.25c
+	gmt sample1d normal.txt -T${MOVIE_COL0}, -Fl | gmt plot -Sc2p -Gblue -N
+gmt end
+EOF
+gmt movie -C22cx12cx50 main.sh -Sbpre.sh -Npsevents_action -T-0.5/1.5/0.01 -D24 -Fgif+l -Lc0 -Lf+jTR -Pf+jBC+o0/1.5c+ac -M150,png -Z

--- a/doc/scripts/psevents_action.sh
+++ b/doc/scripts/psevents_action.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Create a short animated GIF showing the life of two simple events
+# Create a short MP4 showing the life of two simple events
 # Both events starts at 0 and ends at 1, but we add rise
 # and fade and coda to one of them (red) and let the other be plain (blue).
 echo 20 6 0 1 Red Label > red.txt
@@ -55,4 +55,4 @@ gmt begin
 	gmt sample1d normal.txt -T${MOVIE_COL0}, -Fl | gmt plot -Sc2p -Gblue -N
 gmt end
 EOF
-gmt movie -C22cx12cx50 main.sh -Sbpre.sh -Npsevents_action -T-0.5/1.5/0.01 -D24 -Fgif+l -Lc0 -Lf+jTR -Pf+jBC+o0/1.5c+ac -M150,png -Z
+gmt movie -C22cx12cx100 main.sh -Sbpre.sh -Npsevents_action -T-0.5/1.5/0.01 -D24 -Fmp4 -Lc0 -Lf+jTR -Pf+jBC+o0/1.5c+ac -M150,png -Z


### PR DESCRIPTION
This PR fixes some issues in **psevents** and adds a simple animated GIF to the man page:

1. If a symbol is selected with **-S** but no **-E** is set then we turn on **-Es** as default.
2. For readability I use the named constants in the parsing of **-M** instead of 0-3.
3. Fixed a bug where **-E** would not set **-Et** unless it had arguments.
4. Add _psevents_action.sh_ which makes an animated GIF.

The animation can be seen here and shows the difference between just plotting symbols during their lifetime (blue) versus enhancing it to have an arrival as well as a code (red).

![one_event](https://user-images.githubusercontent.com/26473567/160414207-16c1615e-90fa-4206-ac2c-37e219b961ba.gif)

@meghanrjones, I am not sure what to do with dvc here. The script above makes an animated gif so there is no PS file....
The gif is 2.8 Mb which is not bad for an animation.