### PR TITLE
Add option to get Git commit information through C API

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13527,7 +13527,7 @@ int GMT_Get_Default (void *V_API, const char *keyword, char *value) {
 	else if (!strncmp (keyword, "API_IMAGE_LAYOUT", 16U)) {	/* Report image/band layout */
 		gmt_M_memcpy (value, API->GMT->current.gdal_read_in.O.mem_layout, 4, char);
 	}
-	else if (!strncmp (keyword, "API_GIT_VERSION", 15U))	/* The API version */
+	else if (!strncmp (keyword, "API_GIT_COMMIT", 14U))	/* The API version */
 		sprintf (value, "%s", GMT_PACKAGE_VERSION_WITH_GIT_REVISION);
 	else if (!strncmp (keyword, "API_GRID_LAYOUT", 15U)) {	/* Report grid layout */
 		if (API->shape == GMT_IS_COL_FORMAT)

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13527,6 +13527,8 @@ int GMT_Get_Default (void *V_API, const char *keyword, char *value) {
 	else if (!strncmp (keyword, "API_IMAGE_LAYOUT", 16U)) {	/* Report image/band layout */
 		gmt_M_memcpy (value, API->GMT->current.gdal_read_in.O.mem_layout, 4, char);
 	}
+	else if (!strncmp (keyword, "API_GIT_VERSION", 15U))	/* The API version */
+		sprintf (value, "%s", GMT_PACKAGE_VERSION_WITH_GIT_REVISION);
 	else if (!strncmp (keyword, "API_GRID_LAYOUT", 15U)) {	/* Report grid layout */
 		if (API->shape == GMT_IS_COL_FORMAT)
 			strcpy (value, "columns");


### PR DESCRIPTION
**Description of proposed changes**

This PR adds `API_GIT_COMMIT` to the API keywords for `GMT_Get_Default`, so that wrappers can more easily access the commit information for the GMT library (xref https://github.com/GenericMappingTools/pygmt/pull/1838).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
