### PR TITLE
Improve histogram handling of time units via -T

### DIFF
--- a/doc/rst/source/explain_array.rst_
+++ b/doc/rst/source/explain_array.rst_
@@ -82,7 +82,7 @@ then you must append a comma to distinguish the list from the setting of an incr
 
 If the module allows you to set up an absolute time series, append a valid time unit from the list
 **y**\ ear, m\ **o**\ nth, **d**\ ay, **h**\ our, **m**\ inute, and **s**\ econd
-to the given increment; add **+t** to ensure time column (or use **-f**).  **Note**: The internal time
+to the given increment; add **+t** to ensure time column (or use **-f**). **Note**: The internal time
 unit is still controlled independently by :term:`TIME_UNIT`.  The first 7 days of March 2020::
 
     gmt math -o0 -T2020-03-01T/2020-03-07T/1d T =

--- a/doc/rst/source/explain_array.rst_
+++ b/doc/rst/source/explain_array.rst_
@@ -82,8 +82,8 @@ then you must append a comma to distinguish the list from the setting of an incr
 
 If the module allows you to set up an absolute time series, append a valid time unit from the list
 **y**\ ear, m\ **o**\ nth, **d**\ ay, **h**\ our, **m**\ inute, and **s**\ econd
-to the given increment; add **+t** to ensure time column (or use **-f**). **Note**: The internal time
-unit is still controlled independently by :term:`TIME_UNIT`.  The first 7 days of March 2020::
+to the given increment; add **+t** to ensure time column (or use **-f**). **Note**: When a unit is
+used we temporarily override the default setting of :term:`TIME_UNIT`.  The first 7 days of March 2020::
 
     gmt math -o0 -T2020-03-01T/2020-03-07T/1d T =
     2020-03-01T00:00:00

--- a/doc/rst/source/explain_array.rst_
+++ b/doc/rst/source/explain_array.rst_
@@ -82,8 +82,8 @@ then you must append a comma to distinguish the list from the setting of an incr
 
 If the module allows you to set up an absolute time series, append a valid time unit from the list
 **y**\ ear, m\ **o**\ nth, **d**\ ay, **h**\ our, **m**\ inute, and **s**\ econd
-to the given increment; add **+t** to ensure time column (or use **-f**). **Note**: When a unit is
-used we temporarily override the default setting of :term:`TIME_UNIT`.  The first 7 days of March 2020::
+to the given increment; add **+t** to ensure time column (or use **-f**).  **Note**: The internal time
+unit is still controlled independently by :term:`TIME_UNIT`.  The first 7 days of March 2020::
 
     gmt math -o0 -T2020-03-01T/2020-03-07T/1d T =
     2020-03-01T00:00:00

--- a/doc/rst/source/histogram.rst
+++ b/doc/rst/source/histogram.rst
@@ -76,7 +76,10 @@ Required Arguments
 **-T**\ [*min/max*\ /]\ *inc*\ [**+n**] \|\ **-T**\ *file*\|\ *list*
     Make evenly spaced array of bin boundaries from *min* to *max* by *inc*.
     If *min/max* are not given then we default to the range in **-R**.
-    For details on array creation, see `Generate 1D Array`_.
+    For details on array creation, see `Generate 1D Array`_. **Note**: If
+    *inc* is given with a trailing time unit then it takes precedence over
+    the current setting of :term:`TIME_UNIT`; otherwise that setting determines
+    the units used for the bin widths.
 
 Optional Arguments
 ------------------

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -409,6 +409,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC void gmt_reset_array_time (struct GMT_CTRL *GMT, struct GMT_ARRAY *T);
 EXTERN_MSC double gmt_get_vector_shrinking (struct GMT_CTRL *GMT, struct GMT_VECT_ATTR *v, double magitude, double length);
 EXTERN_MSC unsigned int gmt_get_limits (struct GMT_CTRL *GMT, char option, char *text, unsigned int mode, double *min, double *max);
 EXTERN_MSC unsigned int gmt_unpack_rgbcolors (struct GMT_CTRL *GMT, struct GMT_IMAGE *I, unsigned char rgbmap[]);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -17613,6 +17613,18 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 	if (m) m[0] = '+';	/* Restore the modifiers */
 	T->col = tcol;
 
+	if (T->temporal && T->unit && T->unit != GMT->current.setting.time_system.unit) {	/* Check that TIME_UNIT is set to same as given unit in -T */
+		double conv_scale = GMT->current.setting.time_system.scale;
+		GMT->current.setting.time_system.unit = T->unit;	/* Override and recompute scales */
+		(void) gmt_init_time_system_structure (GMT, &GMT->current.setting.time_system);
+		conv_scale *= GMT->current.setting.time_system.i_scale;	/* Scale from whatever it was to new unit */
+		T->min *= conv_scale;
+		T->max *= conv_scale;
+		if (GMT->common.R.active[RSET]) {	/* Since -R was already been parsed as initial units [s] */
+			GMT->common.R.wesn[XLO] *= conv_scale;
+			GMT->common.R.wesn[XHI] *= conv_scale;
+		}
+	}
 	return GMT_NOERROR;
 }
 

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -817,6 +817,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSHISTOGRAM_CTRL *Ctrl, struct GM
 		/* Process -T<width> [-Lb|h|l] [-W<pen>] */
 		Ctrl->T.active = true;
 		n_errors += gmt_parse_array (GMT, 'T', t_arg, &(Ctrl->T.T), GMT_ARRAY_TIME | GMT_ARRAY_DIST | GMT_ARRAY_UNIQUE, 0);
+		gmt_reset_array_time (GMT, &(Ctrl->T.T));	/* Correct any conflicts between T unit and TIME_UNIT */
 		if (l_arg) {	/* Gave -Lb|h|l */
 			Ctrl->L.active = true;
 			if (l_arg[0] == 'l') Ctrl->L.mode = PSHISTOGRAM_LEFT;


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/problem-with-plotting-time-histograms/2754) for background.

The **-T** array option allows specification of time units (e.g., 1o, 7d).  Internally, system default units are controlled by **TIME_UNIT** but it is pretty awkward (and hard to remember) to also set **TIME_UNIT** to the same as the **-T** unit.
This PR adds a check during the parsing of **-T** to detect the presence of a time unit and then re-scales the min/max values found from whatever initial units GMT used (typically seconds) to the chosen unit.  If **-R** has already been parsed it also scales those values to the new units which are now used internally for this process.

With this PR, the users can specify -T1o or -T7d or -T12h etc without having to remember to also set **TIME_UNIT**, and if they do set **TIME_UNIT** then that is still OK: If **-T** has unit then we give that one precedence, else we honor **TIME_UNIT** as before.