### PR TITLE
Update GMT install instructions via conda-forge

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -228,7 +228,7 @@ You can use the [conda package manager](https://conda.io/) that comes with the
    This will give you access to the conda package manager. **Make sure you select to
    have conda added to your `PATH` when asked by the installer**. If you have
    the Anaconda Python distribution installed, you won't need to do this step.
-2. Install GMT and its dependencies (including ghostscript, gdal, ffmpeg and graphicsmagick)
+2. Install GMT and its dependencies (including ghostscript and gdal)
    by running the following in a terminal:
 
    ```
@@ -244,6 +244,12 @@ You can use the [conda package manager](https://conda.io/) that comes with the
 4. If you want to install the weekly snapshot of the GMT master branch, use:
    ```
    conda install gmt -c conda-forge/label/dev
+   ```
+
+5. Install other optional dependencies if you want to create animated GIFs or MP4:
+
+   ```
+   conda install ffmpeg graphicsmagick -c conda-forge
    ```
 
 ## FreeBSD


### PR DESCRIPTION
**Description of proposed changes**

After https://github.com/conda-forge/gmt-feedstock/pull/183, ffmpeg and graphicsmagick are not installed by default when installing GMT from conda-forge.

This PR updates the install instructions to reflect the change.