### PR TITLE
Address mixup related to time in x2sys_datalist

### DIFF
--- a/src/gmt_memory.c
+++ b/src/gmt_memory.c
@@ -570,7 +570,7 @@ void gmt_free_func (struct GMT_CTRL *GMT, void *addr, bool align, const char *wh
 #ifdef DEBUG
 		/* Report attempt at freeing unallocated memory only in level GMT_MSG_DEBUG (-V4) */
 		gmtlib_report_func (GMT, GMT_MSG_DEBUG, where,
-				"tried to free unallocated memory\n");
+				"FYI: gmt_M_free given a NULL pointer - ignored\n");
 #endif
 		return; /* Do not free a NULL pointer, although allowed */
 	}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -6068,6 +6068,7 @@ GMT_LOCAL int gmtsupport_sort_order_ascend (const void *p_1, const void *p_2) {
 void gmt_free_list (struct GMT_CTRL *GMT, char **list, uint64_t n) {
 	/* Properly free memory allocated by gmt_read_list */
 	uint64_t i;
+	if (n == 0) return;	/* Nothing to do here */
 	for (i = 0; i < n; i++) gmt_M_str_free (list[i]);
 	gmt_M_free (GMT, list);
 }

--- a/src/x2sys/x2sys.c
+++ b/src/x2sys/x2sys.c
@@ -1093,6 +1093,7 @@ int x2sys_read_weights (struct GMT_CTRL *GMT, char *file, char ***list, double *
 void x2sys_free_list (struct GMT_CTRL *GMT, char **list, uint64_t n) {
 	/* Properly free memory allocated by x2sys_read_list */
 	uint64_t i;
+	if (n == 0) return;	/* Nothing to do */
 	for (i = 0; i < n; i++) gmt_M_str_free (list[i]);
 	gmt_M_free (GMT, list);
 }
@@ -1967,7 +1968,7 @@ int x2sys_get_tracknames (struct GMT_CTRL *GMT, struct GMT_OPTION *options, char
 	char **file = NULL, *p = NULL;
 	struct GMT_OPTION *opt = NULL, *list = NULL;
 
-	/* Backwards checking for :list in addition to the new 9as in mgd77) =list mechanism */
+	/* Backwards checking for :list in addition to the new (as in mgd77) =list mechanism */
 	for (opt = options; !list && opt; opt = opt->next)
 		if (opt->option == GMT_OPT_INFILE && (opt->arg[0] == ':' || opt->arg[0] == '=')) list = opt;
 
@@ -2029,8 +2030,14 @@ GMT_LOCAL unsigned int x2sys_separate_aux_columns2 (struct GMT_CTRL *GMT, unsign
 }
 
 int x2sys_get_corrtable (struct GMT_CTRL *GMT, struct X2SYS_INFO *S, char *ctable, uint64_t ntracks, char **trk_name, char *column, struct MGD77_AUX_INFO *aux, struct MGD77_AUXLIST *auxlist, struct MGD77_CORRTABLE ***CORR) {
-	/* Load an ephemeral correction table */
-	/* Pass aux as NULL if the auxiliary columns do not matter (only used by x2sys_datalist) */
+	/* Load an ephemeral correction table.
+	 * Pass aux as NULL if the auxiliary columns do not matter (only used by x2sys_datalist).
+	 * Note: One complication relates to the name "time".  It may appear in the info file as
+	 * atime, rtime, or ytime, possibly.  However, the correction table will use the word
+	 * "time" in all these cases. Hence, when we find "time" in the correction table we must
+	 * be careful when we use MGD77_Match_List since it checks absolutely, hence "time" != "rtime".
+	 * The solution here is to consult S->info to ensure the col_name entry uses "time" instead.
+	 */
 	unsigned int i, n_items, n_aux = 0, n_cols, missing;
 	int ks;
 	char path[PATH_MAX] = {""}, **item_names = NULL, **col_name = NULL, **aux_name = NULL;
@@ -2043,6 +2050,7 @@ int x2sys_get_corrtable (struct GMT_CTRL *GMT, struct X2SYS_INFO *S, char *ctabl
 		}
 		ctable = path;
 	}
+
 	if (column) {	/* Must build list of the 7 standard COE database column names */
 		n_cols = 7;
 		col_name = gmt_M_memory (GMT, NULL, n_cols, char *);
@@ -2057,7 +2065,12 @@ int x2sys_get_corrtable (struct GMT_CTRL *GMT, struct X2SYS_INFO *S, char *ctabl
 	else {	/* Use what is available in the data files */
 		n_cols = S->n_out_columns;
 		col_name = gmt_M_memory (GMT, NULL, n_cols, char *);
-		for (i = 0; i < n_cols; i++) col_name[i] = strdup (S->info[S->out_order[i]].name);
+		for (i = 0; i < n_cols; i++) {	/* Watch out for [a|r|y]time and replace with time */
+			if (strstr (S->info[S->out_order[i]].name, "time"))
+				col_name[i] = strdup ("time");
+			else
+				col_name[i] = strdup (S->info[S->out_order[i]].name);
+		}
 	}
 	n_items = MGD77_Scan_Corrtable (GMT, ctable, trk_name, (unsigned int)ntracks, n_cols, col_name, &item_names, 0);
 	if (aux && (n_aux = x2sys_separate_aux_columns2 (GMT, n_items, item_names, aux, auxlist)) != 0) {	/* Determine which auxiliary columns are requested (if any) */


### PR DESCRIPTION
See #6170 for background.  The key issue was a mismatch between the parameter "time" which is used in correction tables that need a temporal drift correction, and the actual time data column called "rtime".  Because time may be passed into GMT as rtime, atime or ytime, we need to check for this and only compare against "time".  With this fix the rest of the code example seems to work.  I added a long comment to explain why the extra checks.

I also spent time tracking down the scary

`x2sys_datalist (x2sys.c:1097(x2sys_free_list)): tried to free unallocated memory`

one gets under **-Vd** but those were only meant to inform developers that _gmt_M_free_ was given a NULL pointer - there is no problem here.  However, I changed the message to something more benign:

`x2sys_datalist (mgd77.c:4295(MGD77_end)): FYI: gmt_M_free given a NULL pointer - ignored`

as well as preventing two functions freeing arrays of lists not to bother if the number of entries is zero.

Hopefully @bjcoakley can give this branch a spin unless it gets merger before then,
 Closes #6170.
