### PR TITLE
Add revised 2014 x2sys paper via ResearchGate URL

### DIFF
--- a/doc/rst/source/supplements/x2sys/x2sys_binlist.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_binlist.rst
@@ -77,19 +77,17 @@ Examples
 --------
 
 To create a bin index file from the MGD77 file 01030061.mgd77 using the
-settings associated with the tag MGD77, do
-
-   ::
+settings associated with the tag MGD77, do::
 
     gmt x2sys_binlist 01030061.mgd77 -TMGD77 > 01030061.tbf
 
 To create a track bin index file of all MGD77+ files residing in the
 current directory using the settings associated with the tag MGD77+ and
-calculate track distances, run
-
-   ::
+calculate track distances, run::
 
     gmt x2sys_binlist *.nc -TMGD77+ -D > all.tbf
+
+.. include:: x2sys_refs.rst_
 
 See Also
 --------

--- a/doc/rst/source/supplements/x2sys/x2sys_cross.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_cross.rst
@@ -187,32 +187,22 @@ Examples
 --------
 
 To compute all internal crossovers in the gmt-formatted file c2104.gmt,
-and using the tag GMT, try
-
-   ::
+and using the tag GMT, try::
 
     gmt x2sys_cross c2104.gmt -TGMT > c2104.txt
 
 To find the crossover locations with bathymetry between the two MGD77
-files A13232.mgd77 and A99938.mgd77, using the MGD77 tag, try
-
-   ::
+files A13232.mgd77 and A99938.mgd77, using the MGD77 tag, try::
 
     gmt x2sys_cross A13232.mgd77 A99938.mgd77 -Qe -TMGD77 > crossovers.txt
 
-References
-----------
-
-Wessel, P. (2010), Tools for analyzing intersecting tracks: the x2sys
-package. *Computers and Geosciences*, **36**, 348-354, https://doi.org/10.1016/j.cageo.2009.05.009.
-
-Wessel, P. (1989), XOVER: A cross-over error detector for track data,
-*Computers and Geosciences*, **15**\ (3), 333-346, https://doi.org/10.1016/0098-3004(89)90044-7.
+.. include:: x2sys_refs.rst_
 
 See Also
 --------
 
-:doc:`gmt </gmt>`, :doc:`x2sys_binlist`,
+:doc:`gmt </gmt>`,
+:doc:`x2sys_binlist`,
 :doc:`x2sys_init`,
 :doc:`x2sys_datalist`,
 :doc:`x2sys_get`,

--- a/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
@@ -126,9 +126,7 @@ recognized by the tag GMT:
 To make lon,lat, and depth input for :doc:`blockmean </blockmean>` and :doc:`surface </surface>` using
 all the files listed in the file tracks.lis and defined by the tag TRK,
 but only the data that are inside the specified area, and make output
-binary, run
-
-   ::
+binary, run::
 
     gmt x2sys_datalist =tracks.lis -TTRK -Flon,lat,depth -R40/-30/25/35 -bo > alltopo_bin.xyz
 
@@ -180,6 +178,8 @@ ABC obs 0.5\*exp(-1e-3(lat))^1.5
 ABC weight -1
 
 ABC fuel 0.02\*((dist))
+
+.. include:: x2sys_refs.rst_
 
 See Also
 --------

--- a/doc/rst/source/supplements/x2sys/x2sys_get.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_get.rst
@@ -100,24 +100,18 @@ Examples
 
 To find all the tracks associated with the tag MGD77, restricted to
 occupy a certain region in the south Pacific, and have at least free air
-anomalies and bathymetry, try
-
-   ::
+anomalies and bathymetry, try::
 
     gmt x2sys_get -V -TMGD77 -R180/240/-60/-30 -Ffaa,depth
 
 To find all the tracks associated with the tag MGD77 that have depth but
-not twt, try
-
-   ::
+not twt, try::
 
     gmt x2sys_get -V -TMGD77 -Fdepth -Nwt
 
 To find all the pairs associated with the tag MGD77 that might intersect
 each other, but only those pairs which involves tracks in your list
-new.lis, try
-
-   ::
+new.lis, try::
 
     gmt x2sys_get -V -TMGD77 -Lnew.lis > xpairs.lis
 
@@ -128,6 +122,8 @@ The tracks that are returned all have the requested data (**-F**) within
 the specified region (**-R**). Furthermore, the columns of Y and N for
 other data types also reflect the content of the track portion within
 the selected region, unless **-G** is set.
+
+.. include:: x2sys_refs.rst_
 
 See Also
 --------

--- a/doc/rst/source/supplements/x2sys/x2sys_init.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_init.rst
@@ -362,6 +362,8 @@ The Format Definition Files used to have extension .def but since that is also u
 by GMT's symbol macro files we have deprecated that extension and now use .fmt.
 However, old .def files are still being read.
 
+.. include:: x2sys_refs.rst_
+
 See Also
 --------
 

--- a/doc/rst/source/supplements/x2sys/x2sys_list.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_list.rst
@@ -178,19 +178,17 @@ Examples
 
 To find all the magnetic crossovers associated with the tag MGD77 from
 the file COE_data.txt, restricted to occupy a certain region in the
-south Pacific, and return location, time, and crossover value, try
-
-   ::
+south Pacific, and return location, time, and crossover value, try::
 
     gmt x2sys_list COE_data.txt -V -TMGD77 -R180/240/-60/-30 -Cmag -Fxytz > mag_coe.txt
 
 To find all the faa crossovers globally that involves track 12345678 and
 output time since start of the year, using a binary double precision
-format, try
-
-   ::
+format, try::
 
     gmt x2sys_list COE_data.txt -V -TMGD77 -Cfaa -S12345678 -FTz -bod > faa_coe.b
+
+.. include:: x2sys_refs.rst_
 
 See Also
 --------

--- a/doc/rst/source/supplements/x2sys/x2sys_merge.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_merge.rst
@@ -49,11 +49,11 @@ Examples
 --------
 
 To update the main COE_data.txt with the new COEs estimations saved in
-the smaller COE_fresh.txt, try
-
-   ::
+the smaller COE_fresh.txt, try::
 
     gmt x2sys_merge -ACOE_data.txt -MCOE_fresh.txt > COE_updated.txt
+
+.. include:: x2sys_refs.rst_
 
 See Also
 --------

--- a/doc/rst/source/supplements/x2sys/x2sys_put.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_put.rst
@@ -85,7 +85,10 @@ options passed to :doc:`x2sys_init` when the *TAG* was first initiated.
 Both data base files are stored in the **$X2SYS_HOME**/*TAG* directory.
 Do not attempt to edit these files by hand.
 
+.. include:: x2sys_refs.rst_
+
 See Also
 --------
 
-:doc:`x2sys_binlist`, :doc:`x2sys_get`
+:doc:`x2sys_binlist`,
+:doc:`x2sys_get`

--- a/doc/rst/source/supplements/x2sys/x2sys_refs.rst_
+++ b/doc/rst/source/supplements/x2sys/x2sys_refs.rst_
@@ -1,0 +1,8 @@
+References
+----------
+
+Wessel, P. (2010), Tools for analyzing intersecting tracks: the x2sys
+package. *Computers and Geosciences*, **36**, 348-354, https://www.researchgate.net/publication/220164039_Tools_for_analyzing_intersecting_tracks_The_x2sys_package.
+
+Wessel, P. (1989), XOVER: A cross-over error detector for track data,
+*Computers and Geosciences*, **15**\ (3), 333-346, https://doi.org/10.1016/0098-3004(89)90044-7.

--- a/doc/rst/source/supplements/x2sys/x2sys_report.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_report.rst
@@ -114,20 +114,15 @@ Examples
 
 To report statistics of all the external magnetic crossovers associated
 with the tag MGD77 from the file COE_data.txt, restricted to occupy a
-certain region in the south Pacific, try
-
-   ::
+certain region in the south Pacific, try::
 
     gmt x2sys_report COE_data.txt -V -TMGD77 -R180/240/-60/-30 -Cmag > mag_report.txt
 
-To report on the faa crossovers globally that involves track 12345678, try
-
-   ::
+To report on the faa crossovers globally that involves track 12345678, try::
 
     gmt x2sys_report COE_data.txt -V -TMGD77 -Cfaa -S2345678 > faa_report.txt
 
-References
-----------
+.. include:: x2sys_refs.rst_
 
 Mittal, P. K. (1984), Algorithm for error adjustment of potential field
 data along a survey network, *Geophysics*, **49**\ (4), 467-469.

--- a/doc/rst/source/supplements/x2sys/x2sys_solve.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_solve.rst
@@ -138,34 +138,28 @@ crossover tables produced by an earlier GMT version without reformatting.
 Examples
 --------
 
-To fit a simple bias offset to faa for all tracks under the MGD77 tag, try
-
-   ::
+To fit a simple bias offset to faa for all tracks under the MGD77 tag, try::
 
     gmt x2sys_list COE_data.txt -V -TMGD77 -Cfaa -Fnc > faa_coe.txt
     gmt x2sys_solve faa_coe.txt -V -TMGD77 -Cfaa -Ec > coe_table.txt
 
-To fit a faa linear drift with time instead, try
-
-   ::
+To fit a faa linear drift with time instead, try::
 
     gmt x2sys_list COE_data.txt -V -TMGD77 -Cfaa -FnTc > faa_coe.txt
     gmt x2sys_solve faa_coe.txt -V -TMGD77 -Cfaa -Et > coe_table.txt
 
 To estimate heading corrections based on magnetic crossovers associated
-with the tag MGD77 from the file COE_data.txt, try
-
-   ::
+with the tag MGD77 from the file COE_data.txt, try::
 
     gmt x2sys_list COE_data.txt -V -TMGD77 -Cmag -Fnhc > mag_coe.txt
     gmt x2sys_solve mag_coe.txt -V -TMGD77 -Cmag -Eh > coe_table.txt
 
-To estimate unit scale corrections based on bathymetry crossovers, try
-
-   ::
+To estimate unit scale corrections based on bathymetry crossovers, try::
 
     gmt x2sys_list COE_data.txt -V -TMGD77 -Cdepth -Fnz > depth_coe.txt
     gmt x2sys_solve depth_coe.txt -V -TMGD77 -Cdepth -Es > coe_table.txt
+
+.. include:: x2sys_refs.rst_
 
 See Also
 --------


### PR DESCRIPTION
The x2sys software got an update in 2014 after the major (and published paper on) revision in 2010 turned out to have a few weaknesses.  The accepted final revision Word document from 2009 was updated with the 2014 corrections and posted on ResearchGate and I have added links to this site from the documentation.  This makes it easier for people who do not have access to the journal to follow what is going on in x2sys.

I added a small rst_ include file with the refs and included it from all the x2sys man pages, plus did a few minor formatting issues.

Closes #6412.