### PR TITLE
Better handling for 2-D colorbar for 3-D plot

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15450,16 +15450,16 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		if (is_D_module && !got_R && !got_J && P)	/* Module call with -Dx in a subplot, turn on JR since we know both must exist */
 			required = "JR";
 		if (got_R == false && (strchr (required, 'R') || strchr (required, 'g') || strchr (required, 'd'))) {	/* Need a region but no -R was set */
-			/* Check if previous plot was 3-D and this is a 2-D overlay for a colorbar, which requires a Cartesian -R -J setup */
+			/* Check if previous plot was 3-D and this is a 2-D overlay for a colorbar, which requires a Cartesian -R -J setup instead */
 			if (GMT->current.map.last_dim == 3 && (opt = GMT_Find_Option (API, 'p', *options)) == NULL && !got_J && !strncmp (mod_name, "psscale", 7U)) {
 				char region[GMT_LEN128] = {""};
-				fprintf (stderr, "Our case exactly\n");
 				sprintf (region, "0/%.16lg/0/%.16lg", GMT->current.map.last_width, GMT->current.map.last_height);
 				if ((opt = GMT_Make_Option (API, 'R', region)) == NULL) return NULL;	/* Failure to make option */
 				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 				if ((opt = GMT_Make_Option (API, 'J', "x1i")) == NULL) return NULL;	/* Failure to make option */
 				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
 				got_J = got_R = true;
+				GMT_Report (API, GMT_MSG_DEBUG, "2-D colorbar beneath 3-D plot requested: Switching to bounding box -R%s -Jx1i.\n", region);
 			}
 			else {
 				/* First consult the history */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14661,7 +14661,7 @@ GMT_LOCAL int gmtinit_get_last_dimensions (struct GMTAPI_CTRL *API, int fig) {
 		GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_last_dimensions: Could not open file %s for figure %d\n", file, fig);
 		return GMT_ERROR_ON_FOPEN;
 	}
-	if (fscanf (fp, "%lg %lg", &API->GMT->current.map.last_width, &API->GMT->current.map.last_height) != 2) {
+	if (fscanf (fp, "%lg %lg %d", &API->GMT->current.map.last_width, &API->GMT->current.map.last_height, &API->GMT->current.map.last_dim) != 3) {
 		GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_last_dimensions: Could not read dimensions from file %s for figure %d\n", file, fig);
 		fclose (fp);
 		return GMT_DATA_READ_ERROR;
@@ -14688,7 +14688,10 @@ GMT_LOCAL int gmtinit_set_last_dimensions (struct GMTAPI_CTRL *API) {
 		GMT_Report (API, GMT_MSG_ERROR, "gmtinit_set_last_dimensions: Could not create file %s for figure %d\n", file, fig);
 		return GMT_ERROR_ON_FOPEN;
 	}
-	fprintf (fp, "%lg %lg\n", API->GMT->current.map.width, API->GMT->current.map.height);
+	if (API->GMT->current.proj.three_D)
+		fprintf (fp, "%lg %lg 3\n", API->GMT->current.proj.z_project.xmax - API->GMT->current.proj.z_project.xmin, API->GMT->current.proj.z_project.ymax - API->GMT->current.proj.z_project.ymin);
+	else
+		fprintf (fp, "%lg %lg 2\n", API->GMT->current.map.width, API->GMT->current.map.height);
 	fclose (fp);
 	return (GMT_NOERROR);
 }
@@ -15364,7 +15367,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 								c += 2;
 								if (c[0] == '\0') strcat (arg, P->Bxlabel);	/* Yes, +l was empty so add preset label */
 							}
-							else {	/* No panel-speicific label override, use the preset label */
+							else {	/* No panel-specific label override, use the preset label */
 								strcat (arg, "+l");
 								strcat (arg, P->Bxlabel);
 							}
@@ -15447,21 +15450,34 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 		if (is_D_module && !got_R && !got_J && P)	/* Module call with -Dx in a subplot, turn on JR since we know both must exist */
 			required = "JR";
 		if (got_R == false && (strchr (required, 'R') || strchr (required, 'g') || strchr (required, 'd'))) {	/* Need a region but no -R was set */
-			/* First consult the history */
-			id = gmt_get_option_id (0, "R");	/* The -RP history item */
-			if (gmtlib_module_may_get_R_from_RP (API->GMT, mod_name)) {	/* First check -RP history */
-				if (!GMT->init.history[id]) id++;	/* No history for -RP, increment to -RG as fall-back */
-			}
-			else id++;	/* Only examine -RG history if not a plotter */
-			if (GMT->init.history[id]) {	/* There is history for -R */
-				if ((opt = GMT_Make_Option (API, 'R', "")) == NULL) return NULL;	/* Failure to make option */
+			/* Check if previous plot was 3-D and this is a 2-D overlay for a colorbar, which requires a Cartesian -R -J setup */
+			if (GMT->current.map.last_dim == 3 && (opt = GMT_Find_Option (API, 'p', *options)) == NULL && !got_J && !strncmp (mod_name, "psscale", 7U)) {
+				char region[GMT_LEN128] = {""};
+				fprintf (stderr, "Our case exactly\n");
+				sprintf (region, "0/%.16lg/0/%.16lg", GMT->current.map.last_width, GMT->current.map.last_height);
+				if ((opt = GMT_Make_Option (API, 'R', region)) == NULL) return NULL;	/* Failure to make option */
 				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
-				n_slashes = gmt_count_char (GMT, GMT->init.history[id], '/');	/* May need to know if it is 3 (2-D) or 5 (3-D) later regarding -p -JZ */
-				GMT_Report (API, GMT_MSG_DEBUG, "Modern mode: Added -R to options since history is available [%s].\n", GMT->init.history[id]);
+				if ((opt = GMT_Make_Option (API, 'J', "x1i")) == NULL) return NULL;	/* Failure to make option */
+				if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
+				got_J = got_R = true;
 			}
-			else if (strchr (required, 'g') || strchr (required, 'd')) {	/* No history but can examine input data sets */
-				if (gmtinit_determine_R_option_from_data (API, required, false, options)) {
-					GMT_Report (API, GMT_MSG_DEBUG, "Modern mode: Failure while determining the region from input data.\n");
+			else {
+				/* First consult the history */
+				id = gmt_get_option_id (0, "R");	/* The -RP history item */
+				if (gmtlib_module_may_get_R_from_RP (API->GMT, mod_name)) {	/* First check -RP history */
+					if (!GMT->init.history[id]) id++;	/* No history for -RP, increment to -RG as fall-back */
+				}
+				else id++;	/* Only examine -RG history if not a plotter */
+				if (GMT->init.history[id]) {	/* There is history for -R */
+					if ((opt = GMT_Make_Option (API, 'R', "")) == NULL) return NULL;	/* Failure to make option */
+					if ((*options = GMT_Append_Option (API, opt, *options)) == NULL) return NULL;	/* Failure to append option */
+					n_slashes = gmt_count_char (GMT, GMT->init.history[id], '/');	/* May need to know if it is 3 (2-D) or 5 (3-D) later regarding -p -JZ */
+					GMT_Report (API, GMT_MSG_DEBUG, "Modern mode: Added -R to options since history is available [%s].\n", GMT->init.history[id]);
+				}
+				else if (strchr (required, 'g') || strchr (required, 'd')) {	/* No history but can examine input data sets */
+					if (gmtinit_determine_R_option_from_data (API, required, false, options)) {
+						GMT_Report (API, GMT_MSG_DEBUG, "Modern mode: Failure while determining the region from input data.\n");
+					}
 				}
 			}
 		}

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -260,6 +260,7 @@ struct GMT_MAP {		/* Holds all map-related parameters */
 	unsigned int n_lon_nodes;		/* Somewhat arbitrary # of nodes for lines in longitude (may be reset in gmt_map.c) */
 	unsigned int n_lat_nodes;		/* Somewhat arbitrary # of nodes for lines in latitude (may be reset in gmt_map.c) */
 	unsigned int path_mode;		/* 0 if we should call gmt_fix_up_path to resample across gaps > path_step, 1 to leave alone */
+	unsigned int last_dim;		/* 2 for 2-D or 3 for 3-D as previous plot */
 	double last_width;			/* Full width in inches of previous plot */
 	double last_height;			/* Full height in inches of previous plot */
 	double width;				/* Full width in inches of this world map */


### PR DESCRIPTION
When a one-liner wishes to place a color bar beneath a plot it uses the previous **-R -J** to correctly find the mid point of the bottom boundary.  However, if the previous plot was a 3-D **grdview** then the **-R -J** is misleading since there is a **-p** in the mix.  For a full GMT script you can choose to set a 3-D color bar (flat in the projected 3-D plane) by just adding **-p**.  However, if you wish for a properly aligned but 2-D **colorbar** then we actually need to replace the **-R -J** with the bounding box containing the 3-D plot.  This PR does that.  Here is what it looked like before:

![image](https://user-images.githubusercontent.com/26473567/161541334-2587adcf-b58c-41f4-aa40-7fbd796d5d5f.png)

As you can see, the width of the bar is wrong since it is basing that off **-R -J** in the 2-D plane. After the fix, we get this:

![t](https://user-images.githubusercontent.com/26473567/161541561-b4d780ce-7226-4b15-bb1b-8a16c46517d6.png)

In a regular script you could choose to use **-DJTC** and then you would _really_ be upset by the 3-4 extra inches of white space above the 3-D figure since it thinks the plot is 6x6 inches...

For completeness, in a regular script you can set the 3-D **colorbar** with **-p** and it looks fine:

![image](https://user-images.githubusercontent.com/26473567/161541800-af4fa885-b4b2-4fa1-af09-698f13bc2bd3.png)

So the fix is required no matter what, but I am open to suggestions if you think a one-liner with a 3-D plot should set a 2-D or a 3-D **colorbar** beneath it since that is an automatic thing without user selection.
