### PR TITLE
Allow contour files to only list contour level

### DIFF
--- a/doc/rst/source/contour.rst
+++ b/doc/rst/source/contour.rst
@@ -126,6 +126,7 @@ Optional Arguments
         specific *pen* may be present and will override the pen set by **-W**
         for this contour level only. **Note**: Please specify *pen* in proper
         format so it can be distinguished from a plain number like *angle*.
+        If only *cont-level* columns are present then we set type to **C**.
 
     (3) If *contours* is a string with comma-separated values it is interpreted
         as those specific contours only.  To indicate a single specific contour

--- a/doc/rst/source/grdcontour.rst
+++ b/doc/rst/source/grdcontour.rst
@@ -98,7 +98,7 @@ Optional Arguments
 
     (2) If *contours* is a file but not a CPT, it is expected to contain
         one record per contour, with information given in the order
-        *contour-level* [*angle*] **C**\|\ **c**\|\ **A**\|\ **a** [*pen*],
+        *contour-level* [[*angle*] **C**\|\ **c**\|\ **A**\|\ **a** [*pen*]],
         where items in brackets are optional.  The levels marked **C** (or **c**)
         are contoured, while the levels marked **A** (or **a**) are both contoured
         and annotated. If the annotation *angle* is present we will plot the label
@@ -106,6 +106,7 @@ Optional Arguments
         specific *pen* may be present and will override the pen set by **-W**
         for this contour level only. **Note**: Please specify *pen* in proper
         format so it can be distinguished from a plain number like *angle*.
+        If only *cont-level* columns are present then we set type to **C**.
 
     (3) If *contours* is a string with comma-separated values it is interpreted
         as those specific contours only.  To indicate a single specific contour

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -197,9 +197,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "%s Fixed contour interval.", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s Comma-separated contours (for single contour append comma to be seen as list).", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s File with contour levels, types, and optional fixed annotation angle and/or pen: "
-		"<contlevel> [<angle>] C|c|A|a [<pen>]. "
+		"<contlevel> [[<angle>] C|c|A|a [<pen>]]. "
 		"Use A|a for annotated contours or C|c for plain contours. If -T is used, "
-		"only inner-most contours with upper case C or A will be ticked.", GMT_LINE_BULLET);
+		"only inner-most contours with upper case C or A will be ticked. "
+		"If file only contains <contlevel> then we default to type C for plain contours only.", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s Name of a CPT. "
 		"[CPT contours are set to C unless the CPT flags are set; "
 		"Use -A to force all to become A].", GMT_LINE_BULLET);

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -413,8 +413,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "%s Fixed contour interval.", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s Comma-separated contours (for single contour append comma to be seen as list).", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s File with contour levels, types, and optional fixed annotation angle and/or pen: "
-		"<contlevel> [<angle>] C|c|A|a [<pen>]. Use A|a for annotated contours and C|c for plain contours. If -T is used, "
-		"only inner-most contours with upper case C or A will be ticked", GMT_LINE_BULLET);
+		"<contlevel> [[<angle>] C|c|A|a [<pen>]]. Use A|a for annotated contours and C|c for plain contours. If -T is used, "
+		"only inner-most contours with upper case C or A will be ticked. "
+		"If file only contains <contlevel> then we default to type C for plain contours only.", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s Name of a CPT. [CPT contours are set to C unless the CPT flags are set; "
 		"Use -A to force all to become A].", GMT_LINE_BULLET);
 	GMT_Usage (API, -2, "Note: If neither -A nor -C are set then we auto-select the intervals.");


### PR DESCRIPTION
Since it is **awk**ward to create a list of desired contours and add the character C to the end, this PR allows a plain single-column file of contour levels to be accepted in **-C** by **grdcontour** and **pscontour** and the type defaults to plain contour (C) only. Currently we just get an ugly read error. This is useful if you have some custom contours, e.g., want to contour close to zero but not exactly, then every 1:

```
echo 0.001 > cont.txt
gmt math -T1/10/1 -o0 T = >> cont.txt
```

This avoids having to awk to add C or to suffer a crash,