### PR TITLE
Improve clip path for images in -Qi

### DIFF
--- a/src/grdview.c
+++ b/src/grdview.c
@@ -1566,11 +1566,11 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 
 			for (ip_l = 0, ip_r = nx_i - 1; ip_l < nx_i; ip_l++, ip_r--) {
 				if (go_right && top_jp[ip_l] < bottom_jp[ip_l])	/* No pixels yet in this column, we can move to the right */
-					first_ip = ip_l;
+					first_ip = ip_l + 1;
 				else	/* First non-empty sliver */
 					go_right = false;
 				if (go_left && top_jp[ip_r] < bottom_jp[ip_r])	/* No pixels yet in this column, we can move to the left */
-					last_ip = ip_r;
+					last_ip = ip_r - 1;
 				else	/* First non-empty sliver */
 					go_left = false;
 			}

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -1592,7 +1592,7 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 					y_imask[nk-k] = y_imask[nk-k1] = GMT->current.proj.z_project.ymin + bottom_jp[ip] * y_pixel_size;
 				}
 			}
-#if 1
+#if 0
 			{	/* For debugging the clip path - set the if# to 1 */
 				FILE *fp = fopen ("image_mask.txt", "w");
 				for (k = 0; k < n4; k++)


### PR DESCRIPTION
The algorithm used for building the staircase clip path for the image in **grdview -Qi** was somewhat smart but not smart _enough_, leaving a path when there is no valid image to the far left or right.  While the clipping worked fine, the fact that the path extends too far means **ghostscript** senses these excursions and hence the bounding box is too large.

This PR eliminates that problem.  I also added more comments to explain the otherwise cryptic section.  The plot below show an actual 3-D image clip path.  The BB of the full projected image is 0/8.37/0/3. The heavy line was the previous version and the new version is the thin red line.

No tests were affected.

![mask](https://user-images.githubusercontent.com/26473567/161812523-16130048-5241-4ae6-aea4-239a27d4b6db.png)

