### PR TITLE
grdcontour.rst: reorder description and change order of default value…

### DIFF
--- a/doc/rst/source/grdcontour.rst
+++ b/doc/rst/source/grdcontour.rst
@@ -243,7 +243,7 @@ Optional Arguments
 
 **-Z**\ [**+o**\ *shift*][**+p**][**+s**\ *factor*]
     Use to subtract *shift* from the data and multiply the results by
-    *factor* before contouring starts [1/0]. (Numbers in **-A**, **-C**,
+    *factor* before contouring starts [+o0+s1]. (Numbers in **-A**, **-C**,
     **-L** refer to values after this scaling has occurred.) Append
     **+p** to indicate that this grid file contains z-values that are
     periodic in 360 degrees (e.g., phase data, angular distributions)


### PR DESCRIPTION
Not sure about this. Please review.

*Shift* is mentioned before *factor*, but the default values are indicated with *[1/0]*. Should it not be *[0/1]*; i.e. shift = 0 and factor = 1?