### PR TITLE
Support using GMT_GRAPHICS_FORMAT through view format in movie -M

### DIFF
--- a/doc/scripts/GMT_movie_progress.sh
+++ b/doc/scripts/GMT_movie_progress.sh
@@ -10,5 +10,5 @@ gmt begin
 	gmt basemap -R0/10/0/5 -JX7.6i/3.4i -Bafg -BWSrt+gbeige
 gmt end
 EOF
-gmt movie map.sh -CHD -T50 -M10,ps -NGMT_movie_progress -Pa+jTL -Pb+jTC+ap -Pc+ap -Pd+jLM+ap -Pe+ap+jRM -Pf+ap -W/tmp/junk -Z \
+gmt movie map.sh -CHD -T50 -M10,view -NGMT_movie_progress -Pa+jTL -Pb+jTC+ap -Pc+ap -Pd+jLM+ap -Pe+ap+jRM -Pf+ap -W/tmp/junk -Z \
 	-Ls"a)"+jTL+o1.7c/0.5c -Ls"b)"+jTC+o-1.1c/0.5c -Ls"c)"+jTR+o1.7c/0.5c -Ls"d)"+jML+o0.7c/0  -Ls"e)"+jMR+o0.6c/0 -Ls"f)"+jBC+o-8c/0.5c

--- a/doc/scripts/psevents_action.sh
+++ b/doc/scripts/psevents_action.sh
@@ -57,4 +57,4 @@ gmt begin
 	gmt sample1d normal.txt -T${MOVIE_COL0}, -Fl | gmt plot -Sc2p -Gblue -N
 gmt end
 EOF
-gmt movie -C22cx12cx100 main.sh -Sbpre.sh -Npsevents_action -T-0.5/1.5/0.01 -D24 -Fnone -Lc0 -Lf+jTR -Pf+jBC+o0/1.5c+ac -M150,ps -Z
+gmt movie -C22cx12cx100 main.sh -Sbpre.sh -Npsevents_action -T-0.5/1.5/0.01 -D24 -Fnone -Lc0 -Lf+jTR -Pf+jBC+o0/1.5c+ac -M150,view -Z

--- a/src/movie.c
+++ b/src/movie.c
@@ -95,6 +95,7 @@
 #ifdef WIN32
 #include <windows.h>
 #endif
+#include "gmt_gsformats.h"
 
 #define THIS_MODULE_CLASSIC_NAME	"movie"
 #define THIS_MODULE_MODERN_NAME	"movie"
@@ -1026,7 +1027,10 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 					s[0] = '\0';	/* Truncate for now */
 				}
 				if ((c = strchr (opt->arg, ',')) ) {	/* Gave frame and format */
-					Ctrl->M.format = strdup (&c[1]);
+					if (!strncmp (&c[1], "view", 4U))  /* Check for using 'view' to set with GMT_GRAPHICS_FORMAT */
+						Ctrl->M.format = strdup (gmt_session_format[API->GMT->current.setting.graphics_format]);
+					else
+						Ctrl->M.format = strdup (&c[1]);
 					c[0] = '\0';	/* Chop off format */
 					switch (opt->arg[0]) {
 						case 'f':	Ctrl->M.frame  = 0; break;
@@ -1046,7 +1050,10 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 					}
 				}
 				else if (opt->arg[0])	/* Must be format, with frame = 0 implicit */
-					Ctrl->M.format = strdup (opt->arg);
+					if (strchr ("v", opt->arg[0])) /* Check for using 'view' to set with GMT_GRAPHICS_FORMAT */
+						Ctrl->M.format = strdup (gmt_session_format[API->GMT->current.setting.graphics_format]);
+					else
+						Ctrl->M.format = strdup (opt->arg);
 				else /* Default is PDF of frame 0 */
 					Ctrl->M.format = strdup ("pdf");
 				if (s) s[0] = '+';	/* Restore */


### PR DESCRIPTION
**Description of proposed changes**

Follow up to https://github.com/GenericMappingTools/gmt/pull/6520. This PR allows using `view` as a format for movie's -M option to use GMT_GRAPHICS_FORMAT.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
