### PR TITLE
Simplify GMT_RGBchart.sh by only producing tabloid size in modern mode

### DIFF
--- a/doc/rst/source/gmtcolors.rst
+++ b/doc/rst/source/gmtcolors.rst
@@ -50,9 +50,7 @@ List Of Colors
 The chart below lists the 663 unique color names that can be used in GMT.
 
 **Download PDF versions:**
-:download:`A4 size </_images/GMT_RGBchart_a4.pdf>`,
-:download:`US letter size </_images/GMT_RGBchart_letter.pdf>`,
-:download:`Tabloid size </_images/GMT_RGBchart_tabloid.pdf>`
+:download:`US tabloid size </_images/GMT_RGBchart.pdf>`
 
 .. _RGBchart:
 

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -33,7 +33,7 @@ if (SPHINX_FOUND)
 	endforeach (_fig ${_scripts_ps2png})
 
 	# Convert PS to PDF
-	set (_scripts_ps2pdf images/GMT_RGBchart_a4.ps images/GMT_RGBchart_letter.ps images/GMT_RGBchart_tabloid.ps images/GMT_App_F_stand+_iso+.ps images/GMT_App_F_symbol_dingbats.ps)
+	set (_scripts_ps2pdf images/GMT_RGBchart.ps images/GMT_App_F_stand+_iso+.ps images/GMT_App_F_symbol_dingbats.ps)
 	set (_scripts_pdf)
 	foreach (_fig ${_scripts_ps2pdf})
 		string (REPLACE ".ps" ".pdf" _pdf_fig ${_fig})

--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1402b2febdf291b6ad7565930bb11078.dir
-  size: 31158451
-  nfiles: 195
+- md5: f5855571690284f25bb0108cc392580e.dir
+  size: 30530547
+  nfiles: 192
   path: images


### PR DESCRIPTION
**Description of proposed changes**

This PR simplifies the script for GMT colors to only produce a single size using modern mode (tabloid). Although there is  now only a single button to download the tabloid output, users can download/modify the modern mode script to produce a figure of any size.

Prerequisite of https://github.com/GenericMappingTools/gmt/issues/6356.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
