### PR TITLE
Include PS images for docs in releases

### DIFF
--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -15,6 +15,16 @@
 #-------------------------------------------------------------------------------
 
 if (SPHINX_FOUND)
+	# Copy PS sources for gmt release
+	if (GIT_FOUND AND HAVE_GIT_VERSION)
+		add_custom_target (_examples_images_release
+			COMMAND ${CMAKE_COMMAND} -E copy_directory
+			${CMAKE_CURRENT_SOURCE_DIR}/images/
+			${GMT_RELEASE_PREFIX}/doc/examples/images
+			DEPENDS git_export_release)
+		add_depend_to_target (gmt_release _examples_images_release)
+	endif (GIT_FOUND AND HAVE_GIT_VERSION)
+
 	# Convert figures to PNG
 	file (GLOB _examples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/images/*.ps")
 	set (_examples_png)

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -15,6 +15,16 @@
 #-------------------------------------------------------------------------------
 
 if (SPHINX_FOUND)
+	# Copy PS sources for gmt release
+	if (GIT_FOUND AND HAVE_GIT_VERSION)
+		add_custom_target (_scripts_images_release
+			COMMAND ${CMAKE_COMMAND} -E copy_directory
+			${CMAKE_CURRENT_SOURCE_DIR}/images/
+			${GMT_RELEASE_PREFIX}/doc/scripts/images
+			DEPENDS git_export_release)
+		add_depend_to_target (gmt_release _scripts_images_release)
+	endif (GIT_FOUND AND HAVE_GIT_VERSION)
+
 	# Convert PS to PNG
 	file (GLOB _scripts_ps2png RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/images/*.ps")
 	set (_scripts_png)


### PR DESCRIPTION
**Description of proposed changes**

In past GMT releases, users could build the documentation from the source tarballs because the .PS files were included in the `doc/examples` and `doc/scripts` directories. This PR maintains that option for future releases by copying the `doc/examples/images` and `doc/scripts/images` directories to the release directory.

Supersedes https://github.com/GenericMappingTools/gmt/pull/6473, which tried to solve the problem by generating the images directly. I think this PR is better because it is simpler and therefore easier to maintain. While https://github.com/GenericMappingTools/gmt/pull/6473 worked for me locally, it failed to work in the CI due to issues finding dcw and the supplement modules.

Whereas https://github.com/GenericMappingTools/gmt/pull/6473 would have provided an option for building the docs either from a git clone or the releases without DVC, this PR only applies to the releases. To build the docs from a git clone, users will still need to install dvc and run dvc pull first.

Relates to https://github.com/GenericMappingTools/gmt/issues/5724, https://github.com/GenericMappingTools/gmt/issues/6356