### PR TITLE
Fix regression in parsing of -W in block[mean|median|mode]

### DIFF
--- a/src/block_subs.h
+++ b/src/block_subs.h
@@ -83,7 +83,7 @@ struct BLOCK_CTRL {
 		bool active;
 		unsigned int mode;
 	} S;
-	struct W {	/* -W[i][o][+s] */
+	struct W {	/* -W[i|o][+s] */
 		bool active;
 		bool weighted[2];
 		bool sigma[2];

--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -128,7 +128,7 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEAN_CTRL *Ctrl, struct GMT_
 
 	unsigned int n_errors = 0, k;
 	bool sigma;
-	char arg[GMT_LEN16] = {""};
+	char arg[GMT_LEN16] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -223,11 +223,13 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEAN_CTRL *Ctrl, struct GMT_
 						n_errors++; break;
 				}
 				break;
-			case 'W':	/* Use in|out weights */
+			case 'W':	/* Use in|out weights -W[i|o][+s] */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);
 				Ctrl->W.active = true;
-				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "s", GMT_MSG_ERROR)) n_errors++;
-				sigma = (gmt_get_modifier (opt->arg, 's', arg)) ? true : false;
+				if ((c = strstr (opt->arg, "+s"))) {	/* Gave +s */
+					sigma = true;
+					c[0] = '\0';	/* Hide modifier */
+				}
 				switch (opt->arg[0]) {
 					case '\0':	case '+':
 						Ctrl->W.weighted[GMT_IN] = Ctrl->W.weighted[GMT_OUT] = true;
@@ -241,9 +243,11 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEAN_CTRL *Ctrl, struct GMT_
 						Ctrl->W.weighted[GMT_OUT] = true;
 						break;
 					default:
+						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Unrecognized argument %s!\n", opt->arg);
 						n_errors++;
 						break;
 				}
+				if (c) c[0] = '+';	/* Restore modifier */
 				break;
 
 			default:	/* Report bad options */

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -244,12 +244,14 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->Q.active);
 				Ctrl->Q.active = true;
 				break;
-			case 'W':	/* Use in|out weights */
+			case 'W':	/* Use in|out weights -W[i|o][+s] */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);
 				Ctrl->W.active = true;
-				if (gmt_validate_modifiers (GMT, opt->arg, 'W', "s", GMT_MSG_ERROR)) n_errors++;
-				sigma = (gmt_get_modifier (opt->arg, 's', arg)) ? true : false;
-				switch (opt->arg[0]) {
+				if ((c = strstr (opt->arg, "+s"))) {	/* Gave +s */
+					sigma = true;
+					c[0] = '\0';	/* Hide modifier */
+				}
+				switch (opt->arg[0]) {	/* Check for -Wi or -Wo as well */
 					case '\0':
 						Ctrl->W.weighted[GMT_IN] = Ctrl->W.weighted[GMT_OUT] = true;
 						Ctrl->W.sigma[GMT_IN] = Ctrl->W.sigma[GMT_OUT] = sigma;
@@ -263,9 +265,11 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_
 						Ctrl->W.sigma[GMT_OUT] = sigma;
 						break;
 					default:
+						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Unrecognized argument %s!\n", opt->arg);
 						n_errors++;
 						break;
 				}
+				if (c) c[0] = '+';	/* Restore modifier */
 				break;
 
 			default:	/* Report bad options */


### PR DESCRIPTION
See #6538 for the problem.  We had a regression in all the block modules where a **-W+s** argument would yield a parsing error but not tell anyone - just exiting.  Unfortunately there is no workaround since adding **i** or **o** turns off the opposite direction; here the user wants weights in and sigma out.

This PR does the more conventional check for a single modifier and then strips it off, simplifying the remaining checks for i or o.

Now works:

```
gmt blockmedian -R-2/2/-2/2 -I1 -r t.txt -W+s << EOF
0 0 2 1
0 0 3 2
0 0 4 1
EOF
0	0	3	0.4
```

Closes #6538.
