### PR TITLE
Attempt to improve error catching for junk input

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3416,8 +3416,7 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 		gmtlib_reparse_i_option (GMT, col);
 
 	if (found_text) {	/* Determine record type */
-		if (GMT->current.io.trailing_text[GMT_IN]) ret_val = (*n_columns) ? GMT_READ_MIXED : GMT_READ_TEXT;	/* Possibly update record type */
-		else ret_val = GMT_READ_TEXT;
+		ret_val = (*n_columns) ? GMT_READ_MIXED : GMT_READ_TEXT;	/* Possibly update record type */
 	}
 	else	/* No trailing text found, reset tpos */
 		*tpos = 0;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3417,6 +3417,7 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 
 	if (found_text) {	/* Determine record type */
 		if (GMT->current.io.trailing_text[GMT_IN]) ret_val = (*n_columns) ? GMT_READ_MIXED : GMT_READ_TEXT;	/* Possibly update record type */
+		else ret_val = GMT_READ_TEXT;
 	}
 	else	/* No trailing text found, reset tpos */
 		*tpos = 0;


### PR DESCRIPTION
See #6530 for background.  This is not specific to **gmt vector** but to most/all table readers.
This PR fixes a likely bug in that a string record was said to be a mixed (numerical plus trailing text) format, when it is not, and hence we wrongly expected numerical columns.

Closes #6530.
