### PR TITLE
Fix documentation and parsing of -W (again) for block modules

### DIFF
--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -123,15 +123,15 @@ Optional Arguments
 .. _-W:
 
 **-W**\ [**i**\|\ **o**][**+s**\|\ **w**]
-    Weighted modifier[s]. Unweighted input and output have 3 columns
-    *x*,\ *y*,\ *z*; Weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
+    Compute weighted results. Unweighted input and output have 3 columns
+    *x*,\ *y*,\ *z*; weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
     Weights can be used in input to construct weighted mean values for
-    each block. Weight sums can be reported in output for later combining
+    each block. Weight sums can be reported to output for later combining
     several runs, etc. Use **-W** for weighted i/o, **-Wi** for weighted
-    input only, and **-Wo** for weighted output only. [Default uses
+    input only, and **-Wo** for weighted output only [Default uses
     unweighted i/o]. If your weights are actually uncertainties (one sigma)
-    then append **+s** and we compute weight = 1/sigma.  Otherwise (or via **+w**
-    we use the weights directly).
+    then append **+s** and we compute weight = 1/sigma^2.  Otherwise (or
+    via **+w**) we use the weights directly.
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -147,15 +147,15 @@ Optional Arguments
 .. _-W:
 
 **-W**\ [**i**\|\ **o**][**+s**\|\ **w**]
-    Weighted modifier[s]. Unweighted input and output have 3 columns
-    *x*,\ *y*,\ *z*; Weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
+    Compute weighted results. Unweighted input and output have 3 columns
+    *x*,\ *y*,\ *z*; weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
     Weights can be used in input to construct weighted median values for each
-    block. Weight sums can be reported in output for later combining
+    block. Weight sums can be reported to output for later combining
     several runs, etc. Use **-W** for weighted i/o, **-Wi** for weighted
-    input only, and **-Wo** for weighted output only. [Default uses
+    input only, and **-Wo** for weighted output only [Default uses
     unweighted i/o]. If your weights are actually uncertainties (one sigma)
-    then append **+s** and we compute weight = 1/sigma.  Otherwise (or via **+w**
-    we use the weights directly).
+    then append **+s** and we compute weight = 1/sigma.  Otherwise (or via
+    **+w**) we use the weights directly.
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -148,15 +148,15 @@ Optional Arguments
 .. _-W:
 
 **-W**\ [**i**\|\ **o**][**+s**\|\ **w**]
-    Weighted modifier[s]. Unweighted input and output have 3 columns
-    *x*,\ *y*,\ *z*; Weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
+    Compute weighted results. Unweighted input and output have 3 columns
+    *x*,\ *y*,\ *z*; weighted i/o has 4 columns *x*,\ *y*,\ *z*,\ *w*.
     Weights can be used in input to construct weighted modal values for each
-    block. Weight sums can be reported in output for later combining
+    block. Weight sums can be reported to output for later combining
     several runs, etc. Use **-W** for weighted i/o, **-Wi** for weighted
-    input only, and **-Wo** for weighted output only. [Default uses unweighted i/o].
-    If your weights are actually uncertainties (one sigma)
-    then append **+s** and we compute weight = 1/sigma.  Otherwise (or via **+w**
-    we use the weights directly).
+    input only, and **-Wo** for weighted output only [Default uses
+    unweighted i/o]. If your weights are actually uncertainties (one sigma)
+    then append **+s** and we compute weight = 1/sigma.  Otherwise (or via
+    **+w**) we use the weights directly.
 
 .. include:: explain_-aspatial.rst_
 

--- a/src/block_subs.h
+++ b/src/block_subs.h
@@ -163,13 +163,15 @@ struct BLK_SLHG {
 #define BLK_DO_INDEX_HI	8
 #define BLK_DO_SRC_ID	16
 
-enum GMT_enum_blks {BLK_Z	= 2,
-		BLK_W		= 3};
+enum GMT_enum_blks {
+	BLK_Z	= 2,
+	BLK_W	= 3
+};
 
 struct BLK_DATA {
 	double a[4];		/* < a[0] = x, a[1] = y, a[2] = z, a[3] = w  */
 	uint64_t ij;		/* < Grid index for data value */
-#if !defined(BLOCKMEAN)		/* Only blockmedian & blockmode has a -Q option */
+#if !defined(BLOCKMEAN)		/* Only blockmedian & blockmode has the -Q option */
 	uint64_t src_id;	/* < Source id [Data record] on input */
 #endif
 };
@@ -202,12 +204,48 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct  BLOCK_CTRL *C) {
 	gmt_M_free (GMT, C);
 }
 
-static void strip_commas (const char *in, char out[]) {
+GMT_LOCAL void BLK_strip_commas (const char *in, char out[]) {
 	/* Remove the commas in the input and return the remaining characters via out */
 	size_t i, o = 0;
 	for (i = 0; in[i]; i++)
 		if (in[i] != ',') out[o++] = in[i];
 	out[o] = '\0';	/* Terminate string */
+}
+
+GMT_LOCAL unsigned int BLK_parse_weight_opt (struct GMTAPI_CTRL *API, char *arg, bool weighted[], bool sigma[]) {
+	/* Common parser for the -W option in the three modules */
+	bool def_sigma = false;
+	char *c = NULL;
+	unsigned int n_errors = 0;
+
+	if ((c = strstr (arg, "+s"))) {	/* Gave +s */
+		def_sigma = true;
+		c[0] = '\0';	/* Hide modifier */
+	}
+	else if ((c = strstr (arg, "+w"))) {	/* Gave +w explicitly [which is the default] */
+		def_sigma = false;
+		c[0] = '\0';	/* Hide modifier */
+	}
+	switch (arg[0]) {	/* Check for -Wi or -Wo as well after hiding the modifier */
+		case '\0':
+			weighted[GMT_IN] = weighted[GMT_OUT] = true;
+			sigma[GMT_IN] = sigma[GMT_OUT] = def_sigma;
+			break;
+		case 'i': case 'I':
+			weighted[GMT_IN] = true;
+			sigma[GMT_IN] = def_sigma;
+			break;
+		case 'o': case 'O':
+			weighted[GMT_OUT] = true;
+			sigma[GMT_OUT] = def_sigma;
+			break;
+		default:
+			GMT_Report (API, GMT_MSG_ERROR, "Option -W: Unrecognized argument %s!\n", arg);
+			n_errors++;
+			break;
+	}
+	if (c) c[0] = '+';	/* Restore modifier */
+	return (n_errors);	/* Return any parsing error counts */
 }
 
 #if !defined(BLOCKMEAN)	/* Not used by blockmean */

--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -98,8 +98,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Perform weighted calculations [no weights]. Optionally set weight directive:");
 	GMT_Usage (API, 3, "i: Read 4 cols (x,y,z,w) but skip w on output.");
 	GMT_Usage (API, 3, "o: Read 3 cols (x,y,z) but include weight sum (i.e., counts) on output.");
-	GMT_Usage (API, -2, "Default selects both weighted input and output. "
-		"Append +s read/write standard deviations instead, with w = 1/s. Default (or +w) reads weights directly");
+	GMT_Usage (API, -2, "Default selects both weighted input and output. Optionally, append one modifier:");
+	GMT_Usage (API, 3, "+s Read/write standard deviations instead, using conversion w = 1/s.");
+	GMT_Usage (API, 3, "+w Read/write weights as is [Default].");
 	GMT_Option (API, "a,bi");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 3 columns (or 4 if -W is set).");
 	GMT_Option (API, "bo,d,e,f,h,i,o,q,r,w,:,.");
@@ -115,8 +116,7 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEDIAN_CTRL *Ctrl, struct GM
 	 */
 
 	unsigned int n_errors = 0, k;
-	bool sigma;
-	char arg[GMT_LEN16] = {""}, *c = NULL;
+	char arg[GMT_LEN16] = {""};
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -132,7 +132,7 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEDIAN_CTRL *Ctrl, struct GM
 			case 'A':	/* Requires -G and selects which fields should be written as grids */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->A.active);
 				Ctrl->A.active = true;
-				strip_commas (opt->arg, arg);
+				BLK_strip_commas (opt->arg, arg);	/* Make local copy with any commas removed */
 				for (k = 0; arg[k] && Ctrl->A.n_selected < BLK_N_FIELDS; k++) {
 					switch (arg[k]) {	/* z,s,l,q25,q75,h,w */
 						case 'z':	Ctrl->A.selected[0] = true;	break;
@@ -227,37 +227,10 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMEDIAN_CTRL *Ctrl, struct GM
 				Ctrl->T.active = true;
 				Ctrl->T.quantile = atof (opt->arg);
 				break;
-			case 'W':	/* Use in|out weights -W[i|o][+s] */
+			case 'W':	/* Use in|out weights -W[i|o][+s|w] */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);
 				Ctrl->W.active = true;
-				if ((c = strstr (opt->arg, "+s"))) {	/* Gave +s */
-					sigma = true;
-					c[0] = '\0';	/* Hide modifier */
-				}
-				switch (opt->arg[0]) {
-					case '\0':
-						Ctrl->W.weighted[GMT_IN] = Ctrl->W.weighted[GMT_OUT] = true;
-						Ctrl->W.sigma[GMT_IN] = Ctrl->W.sigma[GMT_OUT] = sigma;
-						break;
-					case 'i': case 'I':
-						Ctrl->W.weighted[GMT_IN] = true;
-						Ctrl->W.sigma[GMT_IN] = sigma;
-						break;
-					case 'o': case 'O':
-						Ctrl->W.weighted[GMT_OUT] = true;
-						Ctrl->W.sigma[GMT_OUT] = sigma;
-						break;
-					case '+':	/* The modifier only */
-						if (!sigma) {
-							n_errors++;
-						}
-						break;
-					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Unrecognized argument %s!\n", opt->arg);
-						n_errors++;
-						break;
-				}
-				if (c) c[0] = '+';	/* Restore modifier */
+				n_errors += BLK_parse_weight_opt (API, opt->arg, Ctrl->W.weighted, Ctrl->W.sigma);
 				break;
 
 			default:	/* Report bad options */

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -113,8 +113,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Perform weighted calculations [no weights]. Optionally set weight directive:");
 	GMT_Usage (API, 3, "i: Read 4 cols (x,y,z,w) but skip w on output.");
 	GMT_Usage (API, 3, "o: Read 3 cols (x,y,z) but include weight sum (i.e., counts) on output.");
-	GMT_Usage (API, -2, "Default selects both weighted input and output. "
-		"Append +s read/write standard deviations instead, with w = 1/s. Default (or +w) reads weights directly.");
+	GMT_Usage (API, -2, "Default selects both weighted input and output. Optionally, append one modifier:");
+	GMT_Usage (API, 3, "+s Read/write standard deviations instead, using conversion w = 1/s.");
+	GMT_Usage (API, 3, "+w Read/write weights as is [Default].");
 
 	GMT_Option (API, "a,bi");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 3 columns (or 4 if -W is set).");
@@ -131,7 +132,6 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_
 	 */
 
 	unsigned int n_errors = 0, pos = 0, k;
-	bool sigma;
 	char arg[GMT_LEN16] = {""}, p[GMT_BUFSIZ] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
@@ -147,7 +147,7 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_
 
 				case 'A':	/* Requires -G and selects which fields should be written as grids */
 				Ctrl->A.active = true;
-				strip_commas (opt->arg, arg);
+				BLK_strip_commas (opt->arg, arg);	/* Make local copy with any commas removed */
 				for (k = 0; arg[k] && Ctrl->A.n_selected < BLK_N_FIELDS; k++) {
 					switch (arg[k]) {	/* z,s,l,h,w */
 						case 'z':	Ctrl->A.selected[0] = true;	break;
@@ -247,29 +247,7 @@ static int parse (struct GMT_CTRL *GMT, struct BLOCKMODE_CTRL *Ctrl, struct GMT_
 			case 'W':	/* Use in|out weights -W[i|o][+s] */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);
 				Ctrl->W.active = true;
-				if ((c = strstr (opt->arg, "+s"))) {	/* Gave +s */
-					sigma = true;
-					c[0] = '\0';	/* Hide modifier */
-				}
-				switch (opt->arg[0]) {	/* Check for -Wi or -Wo as well */
-					case '\0':
-						Ctrl->W.weighted[GMT_IN] = Ctrl->W.weighted[GMT_OUT] = true;
-						Ctrl->W.sigma[GMT_IN] = Ctrl->W.sigma[GMT_OUT] = sigma;
-						break;
-					case 'i': case 'I':
-						Ctrl->W.weighted[GMT_IN] = true;
-						Ctrl->W.sigma[GMT_IN] = sigma;
-						break;
-					case 'o': case 'O':
-						Ctrl->W.weighted[GMT_OUT] = true;
-						Ctrl->W.sigma[GMT_OUT] = sigma;
-						break;
-					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Unrecognized argument %s!\n", opt->arg);
-						n_errors++;
-						break;
-				}
-				if (c) c[0] = '+';	/* Restore modifier */
+				n_errors += BLK_parse_weight_opt (API, opt->arg, Ctrl->W.weighted, Ctrl->W.sigma);
 				break;
 
 			default:	/* Report bad options */


### PR DESCRIPTION
Despite the earlier fix (#6539) there was still more to do.  This PR does the following:

1. Standardizes the **-W** parsing via a common _BLK_parse_weight_opt_ that also looks for **+w** (which was not done).
2. Fixes glitches in the **blockmean** documentation (it stated `1/s` instead of `1/s^2`)
3. Updates the language syntax for **-W** in the documentation
4. Properly presents both the directives and modifiers for **-W** in the usage
5. Like **blockmode** and **blockmedian**, lets **-W+s** reverse the internal weight (`w = sqrt(1/s)`) back to sigma on output.
