### PR TITLE
Consistently use https://doi.org for DOIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ GMT uses (or can access) raster data derived from these sources:
 - [Earth 15" GEBCO DEM](https://www.gebco.net/data_and_products/gridded_bathymetry_data/)
 - [Earth 1" SRTM DEM](https://lpdaac.usgs.gov/products/srtmgl3v003)
 - [Earth 15" GSHHG land/sea masks](http://www.soest.hawaii.edu/pwessel/)
-- [Earth 1' crustal age](http://dx.doi.org/10.1029/2020GC009214)
+- [Earth 1' crustal age](https://doi.org/10.1029/2020GC009214)
 - [Earth 30" Blue Marble images](https://visibleearth.nasa.gov/images/57752/blue-marble-land-surface-shallow-water-and-shaded-topography)
 - [Earth 30" Black Marble images](https://earthobservatory.nasa.gov/features/NightLights/page3.php)
 - [Earth 1' EGM2008 Geoid Anomalies](https://earth-info.nga.mil)

--- a/doc/rst/source/cookbook/introduction.rst
+++ b/doc/rst/source/cookbook/introduction.rst
@@ -169,7 +169,7 @@ References
 
 *  Treinish, L. A., and M. L. Gough, A software package for the
    data-independent management of multidimensional data, *EOS Trans.
-   AGU*, 68(28), 633–635, 1987. `doi:10.1029/EO068i028p00633 <https://dx.doi.org/10.1029/EO068i028p00633>`_.
+   AGU*, 68(28), 633–635, 1987. `doi:10.1029/EO068i028p00633 <https://doi.org/10.1029/EO068i028p00633>`_.
 
 
 Modern and Classic Mode

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -255,7 +255,7 @@ doi:10.1007/978-3-319-21578-5_2.
 
 Sandwell, D. T. and P. Wessel, 2016, Interpolation of 2-D Vector Data Using Constraints from Elasticity,
 *Geophys. Res. Lett., 43*, 10,703-10,709,
-`https://dx.doi.org/10.1002/2016GL070340 <https://dx.doi.org/10.1002/2016GL070340>`_
+`https://doi.org/10.1002/2016GL070340 <https://doi.org/10.1002/2016GL070340>`_
 
 See Also
 --------

--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -336,13 +336,13 @@ References
 Luis, J.F. and M.C. Neves. 2006, The isostatic compensation of the
 Azores Plateau: a 3D admittance and coherence analysis. J. Geothermal
 Volc. Res. Volume 156, Issues 1-2, Pages 10–22,
-`https://dx.doi.org/10.1016/j.jvolgeores.2006.03.010 <https://dx.doi.org/10.1016/j.jvolgeores.2006.03.010>`_
+`https://doi.org/10.1016/j.jvolgeores.2006.03.010 <https://doi.org/10.1016/j.jvolgeores.2006.03.010>`_
 
 Parker, R. L., 1972, The rapid calculation of potential anomalies, Geophys. J., 31, 447–455.
 
 Wessel. P., 2001, Global distribution of seamounts inferred from gridded Geosat/ERS-1 altimetry,
 J. Geophys. Res., 106(B9), 19,431–19,441,
-`https://dx.doi.org/10.1029/2000JB000083 <https://dx.doi.org/10.1029/2000JB000083>`_
+`https://doi.org/10.1029/2000JB000083 <https://doi.org/10.1029/2000JB000083>`_
 
 See Also
 --------

--- a/doc/rst/source/supplements/potential/gravprisms.rst
+++ b/doc/rst/source/supplements/potential/gravprisms.rst
@@ -281,11 +281,11 @@ Grant, F. S. and West, G. F., 1965, *Interpretation Theory in Applied Geophysics
 
 Kim, S.-S., and P. Wessel, 2016, New analytic solutions for modeling vertical
 gravity gradient anomalies, *Geochem. Geophys. Geosyst., 17*,
-`https://dx.doi.org/10.1002/2016GC006263 <https://dx.doi.org/10.1002/2016GC006263>`_.
+`https://doi.org/10.1002/2016GC006263 <https://doi.org/10.1002/2016GC006263>`_.
 
 Nagy D., Papp G., Benedek J., 2000, The gravitational potential and its derivatives
 for the prism, *J. Geod., 74*, 552–560,
-`https://dx.doi.org/10.1007/s001900000116 <https://dx.doi.org/10.1007/s001900000116>`_.
+`https://doi.org/10.1007/s001900000116 <https://doi.org/10.1007/s001900000116>`_.
 
 See Also
 --------

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -432,16 +432,16 @@ Karner, G. D., 1982, Spectral representation of isostatic models, *BMR J. Austra
 
 Nakada, M., 1986, Holocene sea levels in oceanic islands: Implications for the rheological
 structure of the Earth's mantle, *Tectonophysics, 121*, 263–276,
-`https://dx.doi.org/10.1016/0040-1951(86)90047-8 <https://dx.doi.org/10.1016/0040-1951(86)90047-8>`_.
+`https://doi.org/10.1016/0040-1951(86)90047-8 <https://doi.org/10.1016/0040-1951(86)90047-8>`_.
 
 Watts, A. B., 2001, *Isostasy and Flexure of the Lithosphere*, 458 pp., Cambridge University Press.
 
 Wessel. P., 2001, Global distribution of seamounts inferred from gridded Geosat/ERS-1 altimetry,
 J. Geophys. Res., 106(B9), 19,431-19,441,
-`https://dx.doi.org/10.1029/2000JB000083 <https://dx.doi.org/10.1029/2000JB000083>`_.
+`https://doi.org/10.1029/2000JB000083 <https://doi.org/10.1029/2000JB000083>`_.
 
 Wessel, P., 2016, Regional–residual separation of bathymetry and revised estimates of Hawaii plume flux,
-*Geophys. J. Int., 204(2)*, 932-947, `https://dx.doi.org/10.1093/gji/ggv472 <https://dx.doi.org/10.1093/gji/ggv472>`_.
+*Geophys. J. Int., 204(2)*, 932-947, `https://doi.org/10.1093/gji/ggv472 <https://doi.org/10.1093/gji/ggv472>`_.
 
 See Also
 --------

--- a/doc/rst/source/supplements/potential/talwani2d.rst
+++ b/doc/rst/source/supplements/potential/talwani2d.rst
@@ -177,7 +177,7 @@ Chapman, M. E., 1979, Techniques for interpretation of geoid anomalies,
 
 Kim, S.-S., and P. Wessel, 2016, New analytic solutions for modeling vertical
 gravity gradient anomalies, *Geochem. Geophys. Geosyst., 17*,
-`https://dx.doi.org/10.1002/2016GC006263 <https://dx.doi.org/10.1002/2016GC006263>`_.
+`https://doi.org/10.1002/2016GC006263 <https://doi.org/10.1002/2016GC006263>`_.
 
 Talwani, M., J. L. Worzel, and M. Landisman, 1959, Rapid gravity computations for
 two-dimensional bodies with application to the Mendocino submarine fracture zone,

--- a/doc/rst/source/supplements/potential/talwani3d.rst
+++ b/doc/rst/source/supplements/potential/talwani3d.rst
@@ -184,7 +184,7 @@ References
 
 Kim, S.-S., and P. Wessel, 2016, New analytic solutions for modeling vertical
 gravity gradient anomalies, *Geochem. Geophys. Geosyst., 17*,
-`https://dx.doi.org/10.1002/2016GC006263 <https://dx.doi.org/10.1002/2016GC006263>`_.
+`https://doi.org/10.1002/2016GC006263 <https://doi.org/10.1002/2016GC006263>`_.
 
 Talwani, M., and M. Ewing, 1960, Rapid computation of gravitational attraction of
 three-dimensional bodies of arbitrary shape, *Geophysics, 25*, 203-225.

--- a/src/potential/gravfft.c
+++ b/src/potential/gravfft.c
@@ -27,7 +27,7 @@
  *
  * For details, see Luis, J.F. and M.C. Neves. 2006, "The isostatic compensation of the Azores Plateau:
  * a 3D admittance and coherence analysis. J. Geotermal Vulc. Res. Volume 156, Issues 1-2 ,
- * Pages 10-22, http://dx.doi.org/10.1016/j.jvolgeores.2006.03.010
+ * Pages 10-22, https://doi.org/10.1016/j.jvolgeores.2006.03.010
  *
  * */
 


### PR DESCRIPTION
**Description of proposed changes**

As mentioned in the official documentation (https://www.doi.org/factsheets/DOIProxy.html), `https://doi.org` is the preferred proxy server.