### PR TITLE
Fix error in setting max half-width in node search

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15626,7 +15626,7 @@ openmp_int * gmt_prep_nodesearch (struct GMT_CTRL *GMT, struct GMT_GRID *G, doub
 
 	dist_y = gmt_distance (GMT, G->header->wesn[XLO], G->header->wesn[YLO], G->header->wesn[XLO], G->header->wesn[YLO] + G->header->inc[GMT_Y]);
 	if (mode) {	/* Input data is geographical, so circle widens with latitude due to cos(lat) effect */
-		max_d_col = urint (ceil (G->header->n_columns / 2.0) + 0.1);	/* Upper limit on +- halfwidth */
+		max_d_col = G->header->n_columns;	/* Upper limit on +- halfwidth */
 		*actual_max_d_col = 0;
 		for (row = 0; row < (openmp_int)G->header->n_rows; row++) {
 			lat = gmt_M_grd_row_to_y (GMT, row, G->header);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15628,19 +15628,20 @@ openmp_int * gmt_prep_nodesearch (struct GMT_CTRL *GMT, struct GMT_GRID *G, doub
 		*actual_max_d_col = 0;
 		for (row = 0; row < (openmp_int)G->header->n_rows; row++) {
 			lat = gmt_M_grd_row_to_y (GMT, row, G->header);
-			/* Determine longitudinal width of one grid ell at this latitude */
+			/* Determine longitudinal width of one grid cell at this latitude */
 			dist_x = gmt_distance (GMT, G->header->wesn[XLO], lat, lon, lat);
 			d_col[row] = (fabs (lat) == 90.0) ? G->header->n_columns : urint (ceil (radius / dist_x) + 0.1);
-			if (d_col[row] > G->header->n_columns) d_col[row] = G->header->n_columns;	/* No point exceed the upper limit */
-			if (d_col[row] > (*actual_max_d_col)) *actual_max_d_col = d_col[row];
+			if (d_col[row] > G->header->n_columns) d_col[row] = G->header->n_columns;	/* No point exceeding the upper limit */
+			if (d_col[row] > (*actual_max_d_col)) *actual_max_d_col = d_col[row];	/* Update the max range so far */
 		}
 	}
-	else {	/* Plain Cartesian data with rectangular box */
+	else {	/* Plain Cartesian data with rectangular box and no latitude variation */
 		dist_x = gmt_distance (GMT, G->header->wesn[XLO], G->header->wesn[YLO], lon, G->header->wesn[YLO]);
 		*actual_max_d_col = urint (ceil (radius / dist_x) + 0.1);
-		if (*actual_max_d_col > G->header->n_columns) *actual_max_d_col = G->header->n_columns;	/* No point exceed the upper limit */
-		for (row = 0; row < (openmp_int)G->header->n_rows; row++) d_col[row] = *actual_max_d_col;
+		if (*actual_max_d_col > G->header->n_columns) *actual_max_d_col = G->header->n_columns;	/* No point exceeding the upper limit */
+		for (row = 0; row < (openmp_int)G->header->n_rows; row++) d_col[row] = *actual_max_d_col;	/* Constant array */
 	}
+
 	/* Set fixed limit on +/- delta rows */
 	dist_y = gmt_distance (GMT, G->header->wesn[XLO], G->header->wesn[YLO], G->header->wesn[XLO], G->header->wesn[YLO] + G->header->inc[GMT_Y]);
 	*d_row = urint (ceil (radius / dist_y) + 0.1);	/* The constant half-width of nodes in y-direction */


### PR DESCRIPTION
When we need to access all nodes inside a given _search radius_ (as we do in **grdfilter**, **nearneighbor**, **grdmask** etc), we first determine limits on the number of rows and columns away from the search center.  For geographic data this also means we consider the change in longitudinal distance with latitude.  All this works fine.  However, because for high latitudes (even ±90) we may divide by cos(lat) and hence we had a "safety valve" that clipped the upper limit of how many columns we may want to search to either side of a node to `n_columns/2`.  This is an error: If you are at the far left column and have a search radius that equals or exceeds the longitude range then you want _all_ the columns to be inside, hence the upper limit must be `n_columns`.

No tests affected but I ran into this with a **grdseamount**  research case where I only used a small region to view a portion of a seamount whose radius exceeded half the width and things got oddly clipped in longitude but not in latitude...

![uff](https://user-images.githubusercontent.com/26473567/162619441-f5099b0a-bf11-4057-9b79-96ce97ab4d38.png)
