### PR TITLE
Check that decorated line symbol is valid

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -626,7 +626,8 @@
             **+s**\ <symbol><size> or **+sk**\ *customsymbol*/*size*
                 Specify the code and size of the decorative symbol.
                 Custom symbols need to be simple, i.e., not require data columns,
-                or give a single EPS file.
+                or be a single EPS file.  Hence, valid symbols are limited to the
+                plain geometric one-parameter symbols and the custom symbol (**k**).
 
             **+w**
                 Specify how many (*x*,\ *y*) points will be used to estimate

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -345,6 +345,9 @@ enum GMT_time_period {
 /* Valid axis setting modifiers */
 #define GMT_AXIS_MODIFIERS "aefLlpsSu"
 
+/* Valid decoraded line symbols */
+#define GMT_DECORATE_SYMBOLS "-+AaBbCcDdGgHhIikNnpSsTtxy"
+
 /* Settings for usage message indents and break/continue characters */
 
 #define GMT_LINE_BREAK	"\xe2\x8f\x8e"	/* Glyph for return symbol in UTF-8 */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -10479,14 +10479,18 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 
 			case 's':	/* Symbol to place */
 				if (p[1]) {
-					if (p[1] == 'k') {	/* Custom symbol - separate file from size */
+					if (strchr (GMT_DECORATE_SYMBOLS, p[1]) == NULL) {
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -S~: Symbol +%s not allowed!\n", &p[1]);
+						bad++;
+					}
+					else if (p[1] == 'k') {	/* Custom symbol - separate file from size */
 						char *s = strrchr (p, '/');
 						strncpy (G->size, &s[1], GMT_LEN64-1);
 						s[0] = '\0';	/* Truncate size */
 						strncpy (G->symbol_code, &p[1], GMT_LEN64-1);
 						s[0] = '/';	/* Restore size */
 					}
-					else {	/* Regular symbol */
+					else {	/* Regular geometric symbol */
 						strncpy (G->size, &p[2], GMT_LEN64-1);
 						G->symbol_code[0] = p[1];
 					}


### PR DESCRIPTION
We _say_ in the docs that the symbol must be a simple one that does not need data columns, but we never _check_.  This PR adds a check and improves the docs a git.
