### PR TITLE
Just keep all testapi*.c with same prefix

### DIFF
--- a/src/testapi_conv.c
+++ b/src/testapi_conv.c
@@ -19,7 +19,7 @@
  * Date:	7-JUN-2016
  * Version:	6 API
  *
- * Brief synopsis: testapiconv tests GMT_Convert_Data function.
+ * Brief synopsis: testapi_conv tests GMT_Convert_Data function.
  *
  */
 

--- a/test/api/apiconv.sh
+++ b/test/api/apiconv.sh
@@ -4,7 +4,7 @@
 # Also read groups of items just to free them,
 
 # This files holds what is expected to be produced
-cat << EOF > testapiconv_answer.txt
+cat << EOF > testapi_conv_answer.txt
 1	2
 2	3
 3	4
@@ -58,8 +58,8 @@ gmt makecpt -Cgray -T0/1000/100 > last.cpt
 gmt psbasemap -R0/20/0/20 -JM6i -P -Baf > first.ps
 gmt psbasemap -R0/20/20/40 -JM6i -P -Baf > second.ps
 gmt psbasemap -R0/20/40/60 -JM6i -P -Baf > third.ps
-# testapiconv will read the groups or grids, cpts and ps but not doing anything
+# testapi_conv will read the groups or grids, cpts and ps but not doing anything
 # unless it crashes of course,  It then writes out A and B via matrix and vector to a file
-testapiconv
+testapi_conv
 cat *AB*.txt > results.txt
-diff -q --strip-trailing-cr results.txt testapiconv_answer.txt > fail
+diff -q --strip-trailing-cr results.txt testapi_conv_answer.txt > fail


### PR DESCRIPTION
testapiconv.c was the outlier, now testapi_conv.c

Does not affect anything so I will approve and merge myself.