### PR TITLE
Pass -N to grdtrack from within grdinterpolate

### DIFF
--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -609,7 +609,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 				Return (API->error);
 			}
 
-			sprintf (cmd, "%s -G%s ->%s", i_file, grid, o_file);
+			sprintf (cmd, "%s -G%s -N ->%s", i_file, grid, o_file);	/* Pass -N since points may be outside and we want NaNs returned then */
 			if (GMT->common.R.active[RSET]) {	/* Gave a subregion, so pass -R along */
 				strcat (cmd, " -R");
 				strcat (cmd, GMT->common.R.string);


### PR DESCRIPTION
See this [forum post](https://forum.generic-mapping-tools.org/t/grdinterpolate-e-fails-for-profiles-that-extend-beyond-the-data-domain/2821) for background. Since we are creating fixed data tables we do now want sampling outside a grid to skip a record but instead return a NaN - hence we must pass **-N** when calling **grdtrack**.
