### PR TITLE
Fix incorrect auto-offset for centered roses

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7262,7 +7262,8 @@ void gmt_draw_map_rose (struct GMT_CTRL *GMT, struct GMT_MAP_ROSE *mr) {
 	}
 	if (GMT->current.setting.map_embellishment_mode && ((mr->mode & GMT_ROSE_OFF_SET) == 0)) {   /* Now compute reasonable offsets */
 		int psize = irint (mr->size * 0.01 * GMT_EMBELLISHMENT_OFFSET * 72.0);	/* 10% of size in points rounded to nearest point */
-		mr->off[GMT_X] = mr->off[GMT_Y] = psize / 72.0;	/* Back to inches */
+        mr->off[GMT_X] = abs (mr->justify%4 - 2) * (psize / 72.0); /* Back to inches - and zero if centered in x */
+        mr->off[GMT_Y] = abs (mr->justify/4 - 1) * (psize / 72.0); /* Back to inches - and zero if centered in y */
 		mr->mode -= GMT_ROSE_OFF_SET;
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Map rose margin default to %d pt\n", psize);
 	}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7262,8 +7262,8 @@ void gmt_draw_map_rose (struct GMT_CTRL *GMT, struct GMT_MAP_ROSE *mr) {
 	}
 	if (GMT->current.setting.map_embellishment_mode && ((mr->mode & GMT_ROSE_OFF_SET) == 0)) {   /* Now compute reasonable offsets */
 		int psize = irint (mr->size * 0.01 * GMT_EMBELLISHMENT_OFFSET * 72.0);	/* 10% of size in points rounded to nearest point */
-        mr->off[GMT_X] = abs (mr->justify%4 - 2) * (psize / 72.0); /* Back to inches - and zero if centered in x */
-        mr->off[GMT_Y] = abs (mr->justify/4 - 1) * (psize / 72.0); /* Back to inches - and zero if centered in y */
+		mr->off[GMT_X] = abs (mr->justify%4 - 2) * (psize / 72.0); /* Back to inches - and zero if centered in x */
+		mr->off[GMT_Y] = abs (mr->justify/4 - 1) * (psize / 72.0); /* Back to inches - and zero if centered in y */
 		mr->mode -= GMT_ROSE_OFF_SET;
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Map rose margin default to %d pt\n", psize);
 	}

--- a/test/baseline/psbasemap.dvc
+++ b/test/baseline/psbasemap.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a6152c636bd39f9141552c70f3473052.dir
-  size: 2860756
+- md5: 7a8dbdfb49e66e691483d8f2d29e3396.dir
+  size: 2859270
   nfiles: 55
   path: psbasemap


### PR DESCRIPTION
See #6213 for background.  The trouble was that the auto-offset added in modern mode should of course be zero if the horizontal or vertical justification is centered - but it was not.  Then, due to apparent premature blindness I committed the wrong plots to dvc so that these errors passed.

This PR fixes the offset calculation and updates the three PS files that were just wrong.
