### PR TITLE
Improve macro checking if option given more than once

### DIFF
--- a/src/gmt_error.h
+++ b/src/gmt_error.h
@@ -92,10 +92,18 @@ EXTERN_MSC const char * GMT_strerror (int err);
 
 #define gmt_M_is_verbose(C,level) (MAX(C->parent->verbose, C->current.setting.verbose) >= level)
 
-/* Check condition and report error if true */
+/* Check condition and report error if true - passing GMT as arg */
 #define gmt_M_check_condition(C,condition,...) ((condition) ? 1+GMT_Report(C->parent,GMT_MSG_ERROR,__VA_ARGS__) : 0)
-/* Check if a module option has been called more than once (context has opt available) */
-#define gmt_M_repeated_module_option(API,active) (gmt_M_check_condition (API->GMT, active, "Option -%c: Given more than once (offending option is -%c%s)\n", opt->option, opt->option, opt->arg))
+/* Check condition and report error if true - passing API as arg */
+#define gmt_M_check_active(API,condition,...) ((condition) ? 1+GMT_Report(API,GMT_MSG_ERROR,__VA_ARGS__) : 0)
+/* Check if a module option has been called more than once (context has opt available), then sets active to true. */
+#define gmt_M_repeated_module_option(API,active) gmt_M_check_active (API, active, "Option -%c: Given more than once (offending option is -%c%s)\n", opt->option, opt->option, opt->arg); active = true
+/* Because it is called like this:
+ *		n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
+ * the macro expands to the two statements
+ *		n_errors += ((Ctrl->T.active) ? 1+GMT_Report (API,GMT_MSG_ERROR, "Option -%c: Given more than once (offending option is -%c%s)\n", opt->option, opt->option, opt->arg) : 0); Ctrl->T.active = true;
+ * which is why the macro does not have a semi-colon at the end after setting active = true
+ */
 
 /* Set __func__ identifier */
 #ifndef HAVE___FUNC__

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -835,7 +835,6 @@ static int parse (struct GMT_CTRL *GMT, struct GMTMATH_CTRL *Ctrl, struct GMT_OP
 					Ctrl->A.file = strdup (&opt->arg[k]);
 				break;
 			case 'C':	/* Processed in the main loop but not here; just skip */
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
 				break;
 			case 'E':	/* Set minimum eigenvalue cutoff */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->E.active);

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -347,11 +347,6 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct GMT
 				break;
 			case 'C':	/* Contour interval/cpt */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
-				if (Ctrl->C.active) {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -C: Given more than once\n");
-					n_errors++;
-					break;
-				}
 				Ctrl->C.active = true;
 				n_errors += gmt_contour_C_arg_parsing (GMT, opt->arg, &Ctrl->C.info);
 				break;

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -550,12 +550,12 @@ static int parse (struct GMT_CTRL *GMT, struct GREENSPLINE_CTRL *Ctrl, struct GM
 				if (Ctrl->C.value < 0.0) Ctrl->C.dryrun = true, Ctrl->C.value = 0.0;	/* Check for deprecated syntax giving negative value */
 				break;
 			case 'D':
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->D.active);
 				if (gmt_M_compat_check (API->GMT, 6) && strlen (opt->arg) == 1) {	/* Old -D<mode> option supported for backwards compatibility (now -Z) */
 					Ctrl->Z.active = true;
 					Ctrl->Z.mode = atoi (opt->arg);	/* Since I added 0 to be 1-D later so now this is mode -1 */
 				}
 				else {	/* Give grid or cube information */
+					n_errors += gmt_M_repeated_module_option (API, Ctrl->D.active);
 					Ctrl->D.active = true;
 					Ctrl->D.information = strdup (opt->arg);
 				}

--- a/src/movie.c
+++ b/src/movie.c
@@ -676,7 +676,6 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 	 * Any GMT common options will override values set previously by other commands.
 	 */
 
-	bool d_active = false;
 	unsigned int n_errors = 0, n_files = 0, k, pos, mag, T, frames;
 	int n;
 	char txt_a[GMT_LEN32] = {""}, txt_b[GMT_LEN32] = {""}, arg[GMT_LEN64] = {""}, p[GMT_LEN256] = {""};
@@ -806,8 +805,6 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				break;
 
 			case 'D':	/* ALready processed but need to have a case so we can skip */
-				n_errors += gmt_M_repeated_module_option (API, d_active);
-				d_active = true;
 				break;
 
 			case 'E':	/* Title/fade sequence  */

--- a/src/potential/gmtflexure.c
+++ b/src/potential/gmtflexure.c
@@ -201,7 +201,6 @@ static int parse (struct GMT_CTRL *GMT, struct GMTFLEXURE_CTRL *Ctrl, struct GMT
 				}
 				break;
 			case 'C':	/* Rheology constants E and nu */
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
 				switch (opt->arg[0]) {
 					case 'p':
 						n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active[0]);

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -513,11 +513,6 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct GMT_
 				break;
 			case 'C':	/* Contour arguments */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
-				if (Ctrl->C.active) {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -C: Given more than once\n");
-					n_errors++;
-					break;
-				}
 				Ctrl->C.active = true;
 				n_errors += gmt_contour_C_arg_parsing (GMT, opt->arg, &Ctrl->C.info);
 				break;

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -252,7 +252,7 @@ GMT_LOCAL void psconvert_pclose2 (struct popen2 **Faddr, int dir) {
 GMT_LOCAL int psconvert_parse_new_A_settings (struct GMT_CTRL *GMT, char *arg, struct PSCONVERT_CTRL *Ctrl) {
 	/* Syntax: -A[+r][+u] */
 	gmt_M_unused (GMT);
-	Ctrl->A.active = Ctrl->A.crop = true;
+	Ctrl->A.crop = true;
 
 	if (strstr (arg, "r"))
 		Ctrl->A.round = true;
@@ -284,7 +284,6 @@ GMT_LOCAL int psconvert_parse_new_I_settings (struct GMT_CTRL *GMT, char *arg, s
 		return (error);
 	}
 
-	Ctrl->I.active = true;
 	while (gmt_getmodopt (GMT, 'N', arg, "msS", &pos, p, &error) && error == 0) {
 		switch (p[0]) {
 			case 'm':	/* Margins */
@@ -352,8 +351,6 @@ GMT_LOCAL int psconvert_parse_new_N_settings (struct GMT_CTRL *GMT, char *arg, s
 	char p[GMT_LEN128] = {""};
 
 	if (gmt_validate_modifiers (GMT, arg, 'N', "fgip", GMT_MSG_ERROR)) return (1);	/* Bail right away */
-
-	Ctrl->N.active = true;
 
 	while (gmt_getmodopt (GMT, 'N', arg, "fgip", &pos, p, &error) && error == 0) {
 		switch (p[0]) {
@@ -482,10 +479,14 @@ GMT_LOCAL int psconvert_parse_A_settings (struct GMT_CTRL *GMT, char *arg, struc
 	}
 	/* Now parse -A and possibly -I -N via backwards compatibility conversions */
 	n_errors += psconvert_parse_new_A_settings (GMT, A_option, Ctrl);
-	if (I_option[0])
+	if (I_option[0]) {
 		n_errors += psconvert_parse_new_I_settings (GMT, I_option, Ctrl);
-	if (N_option[0])
+		Ctrl->I.active = true;
+	}
+	if (N_option[0]) {
 		n_errors += psconvert_parse_new_N_settings (GMT, N_option, Ctrl);
+		Ctrl->N.active = true;
+	}
 	return (n_errors);
 }
 
@@ -496,7 +497,6 @@ GMT_LOCAL int psconvert_parse_GE_settings (struct GMT_CTRL *GMT, char *arg, stru
 	char p[GMT_LEN256] = {""};
 	gmt_M_unused(GMT);
 
-	C->W.active = true;
 	while (gmt_getmodopt (GMT, 'W', arg, "acfgklnotu", &pos, p, &error) && error == 0) {	/* Looking for +a, etc */
 		switch (p[0]) {
 			case 'a':	/* Altitude setting */
@@ -857,9 +857,8 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 						break;
 				}
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->M[j].active);
-				if (!n_errors && !Ctrl->M[j].active) {	/* Got -Mb<file> or -Mf<file> */
+				if (!n_errors && Ctrl->M[j].active) {	/* Got -Mb<file> or -Mf<file> */
 					if (!gmt_access (GMT, &opt->arg[1], R_OK)) {	/* The plot file exists */
-						Ctrl->M[j].active = true;
 						Ctrl->M[j].file = strdup (&opt->arg[1]);
 					}
 					else {

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -779,11 +779,9 @@ static int parse (struct GMT_CTRL *GMT, struct PSHISTOGRAM_CTRL *Ctrl, struct GM
 				Ctrl->S.active = true;
 				break;
 			case 'T':
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
 				t_arg = opt->arg;
 				break;
 			case 'W':
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);
 				w_arg = opt->arg;
 				break;
 			case 'Z':

--- a/src/psrose.c
+++ b/src/psrose.c
@@ -270,7 +270,6 @@ static int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_OPT
 				if (c) c[0] = '+';	/* Restore modifier */
 				break;
 			case 'C':
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
 				if (gmt_M_compat_check (GMT, 5)) {	/* Need to check for deprecated -Cm|[+w]<modefile> option */
 					if (((c = strstr (opt->arg, "+w")) || (opt->arg[0] == 'm' && opt->arg[1] == '\0') || opt->arg[0] == '\0') && strstr (opt->arg, GMT_CPT_EXTENSION) == NULL) {
 						GMT_Report (API, GMT_MSG_COMPAT, "Option -C for mode-vector(s) is deprecated; use -E instead.\n");
@@ -290,7 +289,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSROSE_CTRL *Ctrl, struct GMT_OPT
 						break;
 					}
 				}
-				Ctrl->C.active = true;
+				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
 				gmt_M_str_free (Ctrl->C.file);
 				if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				break;

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -610,9 +610,9 @@ static int parse (struct GMT_CTRL *GMT, struct PSTEXT_CTRL *Ctrl, struct GMT_OPT
 				Ctrl->N.active = true;
 				break;
 			case 'S':
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
 				if (opt->arg[0] == '\0' || (k = gmt_count_char (GMT, opt->arg, '/')) > 0 || gmt_is_fill (GMT, opt->arg)) {
 					/* -S[<dx>/<dy>/][>shade>]; requires -G */
+					n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
 					Ctrl->S.active = true;
 					if (opt->arg[0]) {
 						k = sscanf (opt->arg, "%[^/]/%[^/]/%s", txt_a, txt_b, txt_c);
@@ -665,15 +665,16 @@ static int parse (struct GMT_CTRL *GMT, struct PSTEXT_CTRL *Ctrl, struct GMT_OPT
 				}
 				break;
 			case 'Z':
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->Z.active);
 				/* For backward compatibility we will see -Z+ as the current -Z
 				 * and -Z<level> as an alternative to -p<az>/<el>/<level> */
-				if (opt->arg[0] == '+' && !opt->arg[1])	/* Deprecated -Z+ option */
-					Ctrl->Z.active = true;
+				if (opt->arg[0] == '+' && !opt->arg[1])	{	/* Deprecated -Z+ option */
+					n_errors += gmt_M_repeated_module_option (API, Ctrl->Z.active);
+				}
 				else if (opt->arg[0])	/* Deprecated -Z<level> option */
 					GMT->current.proj.z_level = atof(opt->arg);
-				else	/* Normal -Z only */
-					Ctrl->Z.active = true;
+				else {	/* Normal -Z only */
+					n_errors += gmt_M_repeated_module_option (API, Ctrl->Z.active);
+				}
 				break;
 
 			case 'i':	/* Local -i option for pstext to select a specific word in the text */

--- a/src/segy/pssegyz.c
+++ b/src/segy/pssegyz.c
@@ -295,11 +295,6 @@ static int parse (struct GMT_CTRL *GMT, struct PSSEGYZ_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'S':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
-				if (Ctrl->S.active) {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -S: Can't specify more than one trace location key\n");
-					n_errors++;
-					continue;
-				}
 				Ctrl->S.active = true;
 				if (sscanf (opt->arg, "%[^/]/%s", txt_a, txt_b) == 2) {
 					txt[0] = txt_a;	txt[1] = txt_b;

--- a/src/segy/segy2grd.c
+++ b/src/segy/segy2grd.c
@@ -247,11 +247,6 @@ static int parse (struct GMT_CTRL *GMT, struct SEGY2GRD_CTRL *Ctrl, struct GMT_O
 			/* variable spacing */
 			case 'S':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
-				if (Ctrl->S.active) {
-					GMT_Report (API, GMT_MSG_ERROR, "Option -S: Can only be set once\n");
-					n_errors++;
-				}
-				Ctrl->S.active = true;
 				switch (opt->arg[0]) {
 					case 'o':
 						Ctrl->S.mode = PLOT_OFFSET;

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -376,13 +376,13 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 				n_errors += psmeca_A_parse (GMT, Ctrl, opt->arg);
 				break;
 			case 'C':	/* Either modern -Ccpt option or a deprecated -C now served by -A */
-				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
 				/* Change position [set line attributes] */
 				if (psmeca_is_old_C_option (GMT, opt->arg)) {	/* Need the -A parser for obsolete -C syntax */
 					Ctrl->A.active = true;
 					n_errors += psmeca_A_parse (GMT, Ctrl, opt->arg);
 				}
 				else {	/* Here we have the modern -C<cpt> parsing */
+					n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
 					Ctrl->C.active = true;
 					if (opt->arg[0]) Ctrl->C.file = strdup (opt->arg);
 				}


### PR DESCRIPTION
We currently have this check for all options that can only be set once:

```
case 'A':
	n_errors += gmt_M_repeated_module_option (API, Ctrl->A.active);
	Ctrl->A.active = true;
	break;
```

However, it is easy to forget to set that variable to true when we add new module options. This PR combines those statements so that only

```
case 'A':
	n_errors += gmt_M_repeated_module_option (API, Ctrl->A.active);
	break;
```

will be needed, allowing us to

1. Remove a few hundred lines no longer needed, and
2. Be sure that _active_ will always be set to true in each case.

This PR updates the macro but does not yet remove the (now) superfluous `Ctrl->?.active = true` lines in the modules - that will come next.

Oh, and testing this found a bug in gmtflexure.c that I am fixing here as well.