### PR TITLE
Address minor lapses due to parser updates

### DIFF
--- a/doc/rst/source/supplements/x2sys/x2sys_init.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_init.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt x2sys_init** *TAG* |-D|\ *fmtfile*
 [ |-E|\ *suffix* ]
 [ |-F| ]
-[ |-G|\ **d**\|\ **g** ]
+[ |-G|\ [**d**\|\ **g**] ]
 [ |-I|\ *dx*\ [/*dy*] ]
 [ |-N|\ **d**\|\ **s**\ *unit* ]
 [ |SYN_OPT-R| ]
@@ -82,7 +82,7 @@ Optional Arguments
 
 .. _-G:
 
-**-Gd**\|\ **g**
+**-G**\ [**d**\|\ **g**]
     Selects geographical coordinates. Append **d** for discontinuity at
     the Dateline (makes longitude go from -180 to + 180) or **g** for
     discontinuity at Greenwich (makes longitude go from 0 to 360

--- a/src/grdproject.c
+++ b/src/grdproject.c
@@ -77,6 +77,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 
+	C->F.unit = 'e';	/* Default projected unit is meter */
 	return (C);
 }
 
@@ -173,7 +174,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDPROJECT_CTRL *Ctrl, struct GMT
 				/* Intentionally fall through - to get -F */
 			case 'F':	/* Force specific unit */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->F.active);
-				n_errors += gmt_get_required_char (GMT, opt->arg, opt->option, 0, &Ctrl->F.unit);
+				if (opt->arg[0]) Ctrl->F.unit = opt->arg[0];
 				break;
 			case 'G':	/* Output file */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->G.active);

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -176,6 +176,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 
 	/* Initialize values whose defaults are not 0/false/NULL */
 
+	C->F.unit = 'e';	/* Default projected unit is meter */
 	C->G.unit = GMT_MAP_DIST_UNIT;	/* Default unit is meter */
 	C->G.sph = GMT_GREATCIRCLE;	/* Default is great-circle distances */
 	C->L.mode = GMT_MP_GIVE_CORD;	/* Default returns coordinates of nearest point */
@@ -546,7 +547,7 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 				break;
 			case 'F':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->F.active);
-				n_errors += gmt_get_required_char (GMT, opt->arg, opt->option, 0, &Ctrl->F.unit);
+				if (opt->arg[0]) Ctrl->F.unit = opt->arg[0];
 				will_need_RJ = true;	/* Since -F is used with projections only */
 				break;
 			case 'G':	/* Syntax. Old: -G[<lon0/lat0>][/[+|-]unit][+|-]  New: -G[<lon0/lat0>][+i][+a][+u<unit>][+v] */

--- a/src/x2sys/x2sys_init.c
+++ b/src/x2sys/x2sys_init.c
@@ -211,7 +211,7 @@ static int parse (struct GMT_CTRL *GMT, struct X2SYS_INIT_CTRL *Ctrl, struct GMT
 				break;
 			case 'G':	/* Geographical coordinates, set discontinuity */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->G.active);
-				n_errors += gmt_get_required_string (GMT, opt->arg, opt->option, 0, &Ctrl->G.string);
+				if (opt->arg[0]) Ctrl->G.string = strdup (opt->arg);
 				break;
 			case 'F':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->F.active);


### PR DESCRIPTION
A few newly created issues was noticed, and fixed:

1. The **-F** option in **mapproject** and **grdproject** has a default setting of **e** for meter.  It is clear from usage and documentation, but the code never set the default hence I got confused.  I now set initialize the default and check if an argument is given to **-F** before assigning.
2. **x2sys_init** man page said that **-G** takes a required **d** or **g**, but the code and usage messages disagree and I got confused.  Now we allow **-G** with no argument and the usual default to **g**.  Man page was fixed.
3. **pssac** had checks for valid arguments to **-E** and **-F** deep in the code, and my recent changes causes an invalid memory access.  Now I check for valid argument in the parser instead and handles any bad args.

With those we are back to passing all tests again.
