### PR TITLE
More cleanup

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -1104,7 +1104,7 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				}
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S[k].active);
 				/* Got a valid f or b */
-				n_errors += gmt_get_required_file (GMT, opt->arg, opt->option, 0, GMT_IS_DATASET, GMT_IN, GMT_FILE_REMOTE, &(Ctrl->S[k].file));
+				n_errors += gmt_get_required_file (GMT, &opt->arg[1], opt->option, 0, GMT_IS_DATASET, GMT_IN, GMT_FILE_REMOTE, &(Ctrl->S[k].file));
 				if (n_errors == 0 && (Ctrl->S[k].fp = fopen (Ctrl->S[k].file, "r")) == NULL) {
 					GMT_Report (API, GMT_MSG_ERROR, "Option -S%c: Unable to open file %s\n", opt->arg[0], Ctrl->S[k].file);
 					n_errors++;

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -704,7 +704,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDFLEXURE_CTRL *Ctrl, struct GMT
 				break;
 			case 'M':	/* Viscoelastic Maxwell time [in year] */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active);
-				n_errors += gmt_get_required_double (GMT, opt->arg, opt->option, 0, &Ctrl->M.maxwell_t);
+				Ctrl->M.maxwell_t = gmt_get_modeltime (opt->arg, &Ctrl->M.unit, &Ctrl->M.scale);
 				break;
 			case 'N':	/* FFT parameters */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->N.active);


### PR DESCRIPTION
Two more errors introduced during parse updates:

1. **movie**: Parsing of **-Sb**|**f** lost the offset into &opt->arg[1] and used opt->arg instead so the leading **b** or **f** becomes part of the (wrong) file name.
2. **grdflexure**: I completely overwrote the _gmt_get_modeltime_ function and just read a double via _gmt_get_required_double_. But units matter...

All now pass.