### PR TITLE
Allow grdinterpolate to default to all layers if -T is not given

### DIFF
--- a/doc/rst/source/grdinterpolate.rst
+++ b/doc/rst/source/grdinterpolate.rst
@@ -144,7 +144,8 @@ Optional Arguments
     and no output times are set with **-T** we simply rewrite the grid-produced cube as
     a 3-D data cube file and exit. Also, for **-E** and **-S** you may also just give
     a range via -T**\ *min/max* to limit the layers considered, with no interpolation
-    between the selected layers.
+    between the selected layers.  If **-T** is not given and neither **-E** nor **-S** are
+    set, then we simply extract all layers within the bounds set by **-R**.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: explain_-V.rst_

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -516,7 +516,7 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 	int error = 0, k_data, k_tile_id;
 	unsigned int n_grds = 0, n_cols = 0, col, level, i_status, gtype, cmode = GMT_COL_FIX, geometry = GMT_IS_TEXT;
 	unsigned int x_col_min, x_col_max, y_col_min, y_col_max, z_col_min, z_col_max, GMT_W = GMT_Z, nc = 0, ng = 0;
-	bool subset, delay, num_report, is_cube;
+	bool subset, delay, num_report, is_cube = false;
 
 	uint64_t ij, n_nan = 0, n = 0;
 


### PR DESCRIPTION
This PR allows **-T** not to be set if **-E -S** also are not given.  This means we select all input layers and, depending on **-R**, only output the layers inside the selected bounds . If there is no **-R** then we essentially duplicate the cube on output.

Also initializes _is_cube_ to false in grdinfo.c which I forgot to do earlier.

Closes #6589.