### PR TITLE
Add kustom symbol name check

### DIFF
--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -53,6 +53,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC bool gmtlib_invalid_symbolname (struct GMT_CTRL *GMT, char *name);
 EXTERN_MSC void gmtlib_terminate_session ();
 EXTERN_MSC unsigned int gmtlib_pick_in_col_number (struct GMT_CTRL *GMT, unsigned int col, unsigned int *col_pos_in);
 EXTERN_MSC bool gmtlib_set_do_seconds (struct GMT_CTRL *GMT, double inc);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15550,6 +15550,8 @@ int gmt_flip_justify (struct GMT_CTRL *GMT, unsigned int justify) {
 bool gmtlib_invalid_symbolname (struct GMT_CTRL *GMT, char *name) {
 	/* Check that a symbol name only contains valid characters,
 	 * which are the alphanumerics plus /, _, @, - and . */
+	char *text = strrchr (name ,'/');	/* Only check name of symbol, not leading directory */
+	if (text == NULL) text = name;	/* No directory slash found - use entire name */
 	for (unsigned int k = 0; k < strlen (name); k++) {
 		if (!(isalnum (name[k]) || strchr ("@_-/.", name[k]))) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Symbol name %s contains invalid character %c\n", name, name[k]);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -10491,11 +10491,17 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 						}
 						else {
 							strncpy (G->size, &s[1], GMT_LEN64-1);
-							s[0] = '\0';	/* Truncate size */
-							strncpy (G->symbol_code, &p[1], GMT_LEN64-1);
-							s[0] = '/';	/* Restore size */
-							if (gmtlib_invalid_symbolname (GMT, G->symbol_code))
+							if (gmt_not_numeric (GMT, G->size)) {
+								GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -S~: Custom symbol %s not given a valid size\n", &p[2]);
 								bad++;
+							}
+							else {	/* Size seems OK */
+								s[0] = '\0';	/* Truncate size */
+								strncpy (G->symbol_code, &p[1], GMT_LEN64-1);
+								s[0] = '/';	/* Restore size */
+								if (gmtlib_invalid_symbolname (GMT, G->symbol_code))
+									bad++;
+							}
 						}
 					}
 					else {	/* Regular geometric symbol */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15549,9 +15549,9 @@ int gmt_flip_justify (struct GMT_CTRL *GMT, unsigned int justify) {
 
 bool gmtlib_invalid_symbolname (struct GMT_CTRL *GMT, char *name) {
 	/* Check that a symbol name only contains valid characters,
-	 * which are the alphanumerics plus / and . */
+	 * which are the alphanumerics plus /, _, @ and . */
 	for (unsigned int k = 0; k < strlen (name); k++) {
-		if (!(isalnum (name[k]) || strchr ("/.", name[k]))) {
+		if (!(isalnum (name[k]) || strchr ("@_/.", name[k]))) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Symbol name %s contains invalid character %c\n", name, name[k]);
 			return (true);
 		}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15549,9 +15549,9 @@ int gmt_flip_justify (struct GMT_CTRL *GMT, unsigned int justify) {
 
 bool gmtlib_invalid_symbolname (struct GMT_CTRL *GMT, char *name) {
 	/* Check that a symbol name only contains valid characters,
-	 * which are the alphanumerics plus /, _, @ and . */
+	 * which are the alphanumerics plus /, _, @, - and . */
 	for (unsigned int k = 0; k < strlen (name); k++) {
-		if (!(isalnum (name[k]) || strchr ("@_/.", name[k]))) {
+		if (!(isalnum (name[k]) || strchr ("@_-/.", name[k]))) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Symbol name %s contains invalid character %c\n", name, name[k]);
 			return (true);
 		}


### PR DESCRIPTION
Two new checks have been added:

1. When a custom symbol is used with decorated lines we require a symbol size to be present.
2. Custom symbol names need to have names that follow standard variable names (alphanumerical characters plus underscore) plus period (symbol file extension) and @ (remote file). For backwards compatibility we also allow -.

Closes #6594 (I hope - please check).