### PR TITLE
Passed wrong family in testapi_matrix.c

### DIFF
--- a/src/testapi_matrix.c
+++ b/src/testapi_matrix.c
@@ -15,7 +15,7 @@ int main () {
 	/* Associate our data table with a virtual file */
 	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_MATRIX, GMT_IS_PLP, GMT_IN, M[GMT_IN], input);
 	/* Open a virtual file to hold the sampled points */
-	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_IS_MATRIX, GMT_IS_PLP, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
+	GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_MATRIX, GMT_IS_PLP, GMT_OUT|GMT_IS_REFERENCE, NULL, output);
 	/* Prepare the module arguments */
 	sprintf (args, "-sa %s -Gtopo.nc ->%s", input, output);
 	/* Call the grdtrack module */


### PR DESCRIPTION
The output Open Virtual file call had two families passed instead of one and a via format.  Log showed error but test still passed...
