### PR TITLE
Must allow colon in custom symbol paths on Windowa

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15555,11 +15555,17 @@ int gmt_flip_justify (struct GMT_CTRL *GMT, unsigned int justify) {
 
 bool gmtlib_invalid_symbolname (struct GMT_CTRL *GMT, char *name) {
 	/* Check that a symbol name only contains valid characters,
-	 * which are the alphanumerics plus /, _, @, - and . */
+	 * which are the alphanumerics plus /, _, @, - and . (and : for Windows) */
+#ifdef WIN32
+#define CUSTOM_EXTRA_CHAR "@_-/.:"
+#else
+#define CUSTOM_EXTRA_CHAR "@_-/."
+#endif
+
 	char *text = strrchr (name ,'/');	/* Only check name of symbol, not leading directory */
 	if (text == NULL) text = name;	/* No directory slash found - use entire name */
 	for (unsigned int k = 0; k < strlen (name); k++) {
-		if (!(isalnum (name[k]) || strchr ("@_-/.", name[k]))) {
+		if (!(isalnum (name[k]) || strchr (CUSTOM_EXTRA_CHAR, name[k]))) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Symbol name %s contains invalid character %c\n", name, name[k]);
 			return (true);
 		}


### PR DESCRIPTION
This checker added yesterday forgot about C:\path ...
Partly addresses #6598 for Windows I hope (please let me know @seisman).
