### PR TITLE
Use static instead of GMT_LOCAL

### DIFF
--- a/src/block_subs.h
+++ b/src/block_subs.h
@@ -204,7 +204,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct  BLOCK_CTRL *C) {
 	gmt_M_free (GMT, C);
 }
 
-GMT_LOCAL void BLK_strip_commas (const char *in, char out[]) {
+static void BLK_strip_commas (const char *in, char out[]) {
 	/* Remove the commas in the input and return the remaining characters via out */
 	size_t i, o = 0;
 	for (i = 0; in[i]; i++)
@@ -212,7 +212,7 @@ GMT_LOCAL void BLK_strip_commas (const char *in, char out[]) {
 	out[o] = '\0';	/* Terminate string */
 }
 
-GMT_LOCAL unsigned int BLK_parse_weight_opt (struct GMTAPI_CTRL *API, char *arg, bool weighted[], bool sigma[]) {
+static unsigned int BLK_parse_weight_opt (struct GMTAPI_CTRL *API, char *arg, bool weighted[], bool sigma[]) {
 	/* Common parser for the -W option in the three modules */
 	bool def_sigma = false;
 	char *c = NULL;

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -148,7 +148,7 @@ struct PSEVENTS_CTRL {
 };
 
 /* The names of the three external modules.  We skip first 2 letters if in modern mode */
-GMT_LOCAL char *coupe = "pscoupe", *meca = "psmeca", *velo = "psvelo";
+static char *coupe = "pscoupe", *meca = "psmeca", *velo = "psvelo";
 
 static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
 	struct PSEVENTS_CTRL *C;


### PR DESCRIPTION
In some places we must use static to avoid linker troubles.
