### PR TITLE
Better check when a column is used for both coordinates and dimension

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3815,7 +3815,7 @@ void gmt_set_column_types (struct GMT_CTRL *GMT, unsigned int n_cols_start, bool
 	 * to affect. */
 	unsigned int j;
 
-	if (GMT->common.i.active) {	/* Must figure out correct pre-shuffle columns for the non-dimensional ones */
+	if (GMT->common.i.select) {	/* Must figure out correct pre-shuffle columns for the non-dimensional ones */
 		unsigned int i_col, pre_col;
 		/* First set them all to be dimensional */
 		for (j = n_cols_start; j < GMT->common.i.n_cols; j++) {	/* All columns beyond x,y and possibly z */
@@ -3823,7 +3823,7 @@ void gmt_set_column_types (struct GMT_CTRL *GMT, unsigned int n_cols_start, bool
 			gmt_set_column_type (GMT, GMT_IN, pre_col, GMT_IS_DIMENSION);
 		}
 		for (j = 0; j < S->n_nondim; j++) {	/* This is how many columns with non-dimensional data such as angles */
-			i_col = S->nondim_col[j] + rgb_from_z;	/* Column we expect to reset if -i were not used */
+			i_col = S->nondim_col[j] + rgb_from_z;	/* Column we expect to reset */
 			gmt_set_column_type (GMT, GMT_IN, i_col, GMT_IS_FLOAT);
 		}
 	}

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3514,6 +3514,7 @@ GMT_LOCAL inline int gmtio_reached_EOF (struct GMT_CTRL *GMT) {
 /*! This is the lowest-most input function in GMT.  All ASCII table data are read via
  * gmt_ascii_input.  Changes here affect all programs that read such data. */
 GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, int *status) {
+	unsigned int decode_type, decode_type2;
 	uint64_t pos, col_no = 0, col_pos, n_convert, n_ok = 0, kind, add, n_use = 0;
 	uint64_t n_cols_this_record = GMT_MAX_COLUMNS;
 	int64_t in_col;
@@ -3702,7 +3703,8 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 			}
 			else				/* Default column order */
 				col_pos = col_no;
-			n_convert = gmt_scanf (GMT, token, gmt_M_type (GMT, GMT_IN, col_pos), &val);
+			decode_type = gmt_M_type (GMT, GMT_IN, col_pos);
+			n_convert = gmt_scanf (GMT, token, decode_type, &val);
 			if (n_convert != GMT_IS_NAN && gmt_input_col_is_nan_proxy (GMT, val, col_pos))	/* Input matched no-data setting, so change to NaN */
 				n_convert = GMT_IS_NAN;
 			if (n_convert == GMT_IS_NAN) {	/* Got a NaN or it failed to decode the string */
@@ -3727,6 +3729,10 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 					/* This input column is requested more than once */
 					col_pos = GMT->current.io.col[GMT_IN][col_no].order;	/* The data column that will receive this value */
 					GMT->current.io.curr_rec[col_pos] = gmt_M_convert_col (GMT->current.io.col[GMT_IN][col_no], val);
+					decode_type2 = gmt_M_type (GMT, GMT_IN, col_pos);
+					if (decode_type2 == GMT_IS_DIMENSION && decode_type != GMT_IS_DIMENSION) {	/* Must apply the dimensional scaling after already sscanf as non-dimensional */
+						GMT->current.io.curr_rec[col_pos] *= GMT->session.u2u[GMT->current.setting.proj_length_unit][GMT_INCH];
+					}
 					col_no++;
 					n_ok++;
 				}

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3796,6 +3796,44 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 	return ((GMT->current.io.status) ? NULL : &GMT->current.io.record);	/* Pass back pointer to data array */
 }
 
+GMT_LOCAL unsigned int gmtio_pre_column (struct GMT_CTRL *GMT, unsigned int i_col) {
+	/* Return the pre-i column that matches the post-i column i_col */
+	for (unsigned int k = 0; k < GMT->common.i.n_cols; k++) {	/* Look for the one whose order matches i_col */
+		if (GMT->current.io.col[GMT_IN][k].order == i_col)	/* Found it, return the column number */
+			return (GMT->current.io.col[GMT_IN][k].col);
+	}
+	GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmtio_pre_column: Should never get here - returning %u\n", i_col);
+	return (i_col);
+}
+
+void gmt_set_column_types (struct GMT_CTRL *GMT, unsigned int n_cols_start, bool rgb_from_z, unsigned int max, struct GMT_SYMBOL *S) {
+	/* In psxy[z], all columns beyond x,y and possibly z (for -C) are assumed to be dimensions.  However,
+	 * some are flagged as nondimensional and need to be reset to FLOAT before se start reading.
+	 * This is further complicated if -i is in effect since the columns we want to change back
+	 * to float (e.g., say column 3) are not necessarily column 3 in the input file but will become
+	 * column 3 thanks to -i.  Hence we must check if -i was set and then determine the right column
+	 * to affect. */
+	unsigned int j;
+
+	if (GMT->common.i.active) {	/* Must figure out correct pre-shuffle columns for the non-dimensional ones */
+		unsigned int i_col, pre_col;
+		/* First set them all to be dimensional */
+		for (j = n_cols_start; j < GMT->common.i.n_cols; j++) {	/* All columns beyond x,y and possibly z */
+			pre_col = gmtio_pre_column (GMT, j);
+			gmt_set_column_type (GMT, GMT_IN, pre_col, GMT_IS_DIMENSION);
+		}
+		for (j = 0; j < S->n_nondim; j++) {	/* This is how many columns with non-dimensional data such as angles */
+			i_col = S->nondim_col[j] + rgb_from_z;	/* Column we expect to reset if -i were not used */
+			gmt_set_column_type (GMT, GMT_IN, i_col, GMT_IS_FLOAT);
+		}
+	}
+	else {	/* No -i in effect so safe to do the basic loop */
+		for (j = n_cols_start; j < max; j++) gmt_set_column_type (GMT, GMT_IN, j, GMT_IS_DIMENSION);
+		for (j = 0; j < S->n_nondim; j++)	/* Since these are angles, not dimensions */
+			gmt_set_column_type (GMT, GMT_IN, S->nondim_col[j]+rgb_from_z, GMT_IS_FLOAT);
+	}
+}
+
 /*! . */
 GMT_LOCAL int gmtio_write_table (struct GMT_CTRL *GMT, void *dest, unsigned int dest_type, struct GMT_DATATABLE *table, bool use_GMT_io, unsigned int io_mode, unsigned int n_seg) {
 	/* Writes an entire segment data set to file or wherever.

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -304,6 +304,7 @@ EXTERN_MSC int gmt_set_psfilename (struct GMT_CTRL *GMT);
 
 /* gmt_io.c: */
 
+EXTERN_MSC void gmt_set_column_types (struct GMT_CTRL *GMT, unsigned int n_cols_start, bool rgb_from_z, unsigned int max, struct GMT_SYMBOL *S);
 EXTERN_MSC void gmt_set_dataset_verify (struct GMT_CTRL *GMT, struct GMT_DATASET *D);
 EXTERN_MSC unsigned int gmt_realloc_dataset (struct GMT_CTRL *GMT, struct GMT_DATASET *D, uint64_t dim[]);
 EXTERN_MSC void gmt_check_abstime_format (struct GMT_CTRL *GMT, struct GMT_DATASET *D, uint64_t chunk);

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1040,47 +1040,6 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
 
-GMT_LOCAL unsigned int psxy_pre_column (struct GMT_CTRL *GMT, unsigned int i_col) {
-	/* Return the pre-i column that matches the post-i column i_col */
-	for (unsigned int k = 0; k < GMT->common.i.n_cols; k++) {	/* Look for the one whose order matches i_col */
-		if (GMT->current.io.col[GMT_IN][k].order == i_col)	/* Found it, return the column number */
-			return (GMT->current.io.col[GMT_IN][k].col);
-	}
-	GMT_Report (GMT->parent, GMT_MSG_ERROR, "psxy_pre_column: Should never get here - returning %u\n", i_col);
-	return (i_col);
-}
-
-GMT_LOCAL void psxy_set_col_scales (struct GMT_CTRL *GMT, unsigned int n_cols_start, bool rgb_from_z, struct GMT_SYMBOL *S) {
-	/* ALl columns beyond x,y and possibly z (for -C) are assumed to be dimensions.  However,
-	 * some are flagged as nondimension and need to be reset to FLOAT before se start reading.
-	 * THis is further complicated if -i is in effect since the columns we want to change back
-	 * to float (e.g., say column 3) are not necessarily column 3 in the input file but will become
-	 * column 3 thanks to -i.  Hence we must check if -i was set and then determine the right column
-	 * to affect. */
-	unsigned int j;
-	/* First set all the columns from start and up to 6 to be dimensional */
-
-	if (GMT->common.i.active) {	/* Must figure out correct pre-shuffle columns for the non-dimensional ones */
-		unsigned int i_col, pre_col;
-		/* First set them all to dimensional */
-		for (j = n_cols_start; j < GMT->common.i.n_cols; j++) {	/* All columns beyond x,y and possibly z */
-			pre_col = psxy_pre_column (GMT, j);
-			gmt_set_column_type (GMT, GMT_IN, pre_col, GMT_IS_DIMENSION);
-		}
-		for (j = 0; j < S->n_nondim; j++) {	/* This is how many columns with non-dimensional data such as angles */
-			i_col = S->nondim_col[j] + rgb_from_z;	/* Column we expect to reset if -i were not used */
-			//pre_col = psxy_pre_column (GMT, i_col);
-			pre_col = i_col;
-			gmt_set_column_type (GMT, GMT_IN, pre_col, GMT_IS_FLOAT);
-		}
-	}
-	else {	/* No -i in effect so safe to do the basic loop */
-		for (j = n_cols_start; j < GMT->common.i.n_cols; j++) gmt_set_column_type (GMT, GMT_IN, j, GMT_IS_DIMENSION);
-		for (j = 0; j < S->n_nondim; j++)	/* Since these are angles, not dimensions */
-			gmt_set_column_type (GMT, GMT_IN, S->nondim_col[j]+rgb_from_z, GMT_IS_FLOAT);
-	}
-}
-
 #define bailout(code) {gmt_M_free_options (mode); return (code);}
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
@@ -1268,9 +1227,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		xy_errors[GMT_Y] += (S.read_size + rgb_from_z);
 	}
 	else if (not_line)	/* Here we have the usual x y [z] [size] [other args] [symbol] record */
-		psxy_set_col_scales (GMT, n_cols_start, rgb_from_z, &S);
-		//for (j = n_cols_start; j < 6; j++) gmt_set_column_type (GMT, GMT_IN, j, GMT_IS_DIMENSION);		/* Since these may have units appended */
-	//for (j = 0; j < S.n_nondim; j++) gmt_set_column_type (GMT, GMT_IN, S.nondim_col[j]+rgb_from_z, GMT_IS_FLOAT);	/* Since these are angles, not dimensions */
+		gmt_set_column_types (GMT, n_cols_start, rgb_from_z, 6, &S);	/* Handle the dimensional vs non-dimensional column types including if -i is used */
 
 	if (gmt_is_barcolumn (GMT, &S)) {
 		n_z = gmt_get_columbar_bands (GMT, &S);	/* > 0 for multiband, else 0 */

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -859,10 +859,8 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 	}
 	else
 		n_needed = n_cols_start + S.n_required;
-	if (not_line) {
-		for (j = n_cols_start; j < 7; j++) gmt_set_column_type (GMT, GMT_IN, j, GMT_IS_DIMENSION);	/* Since these may have units appended */
-		for (j = 0; j < S.n_nondim; j++) gmt_set_column_type (GMT, GMT_IN, S.nondim_col[j]+rgb_from_z, GMT_IS_FLOAT);	/* Since these are angles or km, not dimensions */
-	}
+	if (not_line)
+		gmt_set_column_types (GMT, n_cols_start, rgb_from_z, 7, &S);	/* Handle the dimensional vs non-dimensional column types including if -i is used */
 	if (Ctrl->H.active && Ctrl->H.mode == PSXYZ_READ_SCALE) {
 		xcol = n_needed;
 		n_needed++;	/* Read scaling from data file */

--- a/test/baseline/psxy.dvc
+++ b/test/baseline/psxy.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: ec8fe69e4d0901cab25ede27b5fa76cc.dir
-  size: 9293975
-  nfiles: 141
+- md5: bac31d281e71fbcedcf6ae7166ba2e5e.dir
+  size: 9331268
+  nfiles: 142
   path: psxy

--- a/test/psxy/use_x_and_symbol_col.sh
+++ b/test/psxy/use_x_and_symbol_col.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Test that GMT can handle repeated input columns via -i where the
+# columns is both an x-coordinate and another column (e.g., for color
+# or symbol properties).
+# See https://github.com/GenericMappingTools/gmt/pull/6616 for details
+
+gmt begin use_x_and_symbol_col
+	gmt set FONT_TITLE 12p
+	gmt makecpt -Croma -T0/10/1
+	gmt subplot begin 3x2 -Fs5c -R0/5/0/5 -Ba1f1g1 -Sc -Sr -M18p
+		for i in 0 1 2 3 4 5; do
+			echo 2 2.5 1 0 1.5 0.5 | gmt plot -Sj -C -W0.5p -i${i},1,2,3,4,5 -B+t"-i${i},1,2,3,4,5" -c
+		done
+	gmt subplot end
+gmt end


### PR DESCRIPTION
See https://github.com/GenericMappingTools/pygmt/issues/1892#issuecomment-1107375548 fro background.

The issues was that a physical column was used both for an x-coordinates and a dimension via repetition in **-i.**  Because x came first this prevented the text from being converted to internal inches and hence the rectangles major axis was not converted from cm to inches and was too long.

This PR recognizes this situation and keeps track if the initial decode was not in the context of dimension and then adjust the result when the same column is used in other context where dimension is expected.

Seems to work, and other tests pass.
