### PR TITLE
Improve detection of cubes

### DIFF
--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -224,6 +224,8 @@ struct GMTAPI_CTRL {
 #define GMTAPI_OBJECT_FAMILY_START 15U	/* Start position of the encoded actual family in the virtual filename */
 #define GMTAPI_OBJECT_ID_START 21U		/* Start position of the encoded object ID in the virtual filename */
 #define gmt_M_file_is_memory(file) (file && !strncmp (file, "@GMTAPI@-", GMTAPI_PREFIX_LEN) && strlen (file) == GMTAPI_MEMFILE_LEN)
+#define gmt_M_memfile_is_grid(file) (gmt_M_file_is_memory(file) && file[GMTAPI_OBJECT_FAMILY_START] == 'G')
+#define gmt_M_memfile_is_cube(file) (gmt_M_file_is_memory(file) && file[GMTAPI_OBJECT_FAMILY_START] == 'U')
 
 #ifdef __cplusplus
 }

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -564,18 +564,25 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 	for (opt = options; opt; opt = opt->next) {	/* Loop over arguments, skip options */
 
 		if (opt->option != '<') continue;	/* We are only processing filenames here */
-		if ((G = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, opt->arg, NULL)) == NULL) {
-			Return (API->error);
-		}
-		header = G->header;
-		if (gmtlib_is_nc_grid (GMT, header))	/* Not netCDF so must be grid */
+
+		if (gmt_M_memfile_is_grid (opt->arg))	/* Can just check file name */
 			ng++;
-		else if (gmt_nc_is_cube (API, opt->arg))	/* Determine if this netCDF file is a cube or not */
+		else if (gmt_M_memfile_is_cube (opt->arg))	/* Can just check file name */
 			nc++;
-		else
-			ng++;
-		if (GMT_Destroy_Data (API, &G) != GMT_NOERROR){
-			Return (API->error);
+		else {	/* Must read file header (as if a grid) to figure it out */
+			if ((G = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, opt->arg, NULL)) == NULL) {
+				Return (API->error);
+			}
+			header = G->header;
+			if (gmtlib_is_nc_grid (GMT, header) || header->n_bands == 1)	/* Not netCDF or a single layer so must be grid */
+				ng++;
+			else if (gmt_nc_is_cube (API, opt->arg))	/* Determine if this netCDF file is a cube or not */
+				nc++;
+			else
+				ng++;
+			if (GMT_Destroy_Data (API, &G) != GMT_NOERROR){
+				Return (API->error);
+			}
 		}
 	}
 


### PR DESCRIPTION
Add two macros working on virtual names that can detect cubes vs grids.  Also, use _n_bands_ to help detect cubes vs grids.
Now works in Julia again.  Closes #6617.
