### PR TITLE
Improve the formatting of grdinfo documentation

### DIFF
--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -60,8 +60,11 @@ Optional Arguments
 
 **-C**\ [**n**\|\ **t**\]
     Formats the report using tab-separated fields on a single line. The
-    output is *name w e s n {b t} v0 v1 dx dy {dz} nx ny {nz}*\ [ *x0 y0 {z0} x1 y1 {z1}* ] [ *med
-    scale* ] [*mean std rms*] [*n\_nan*] *registration gtype*. The data in brackets are
+    output is:
+
+    *name w e s n {b t} v0 v1 dx dy {dz} nx ny {nz}* [*x0 y0 {z0} x1 y1 {z1}*] [*med scale*] [*mean std rms*] [*n\_nan*] *registration gtype*
+
+    The data in brackets are
     output only if the corresponding options **-M**, **-L1**, **-L2**,
     and **-M** are used, respectively, while the data in braces only apply if
     used with 3-D data cubes. Use **-Ct** to place file *name*


### PR DESCRIPTION
**Description of proposed changes**

The output format of `grdinfo -C` is not easy to read. This PR fixes the problem.

**Old**
<img width="901" alt="image" src="https://user-images.githubusercontent.com/3974108/164976699-2df0e622-4fe0-4941-8698-cf1ae30d0820.png">

**New**
<img width="892" alt="image" src="https://user-images.githubusercontent.com/3974108/164976688-d414ffd5-9684-4e41-9e75-25e678fc78a6.png">


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
