### PR TITLE
gmt --show-library gave NULL in Xcode

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -1088,6 +1088,10 @@ GMT_LOCAL int gmtapi_init_sharedlibs (struct GMTAPI_CTRL *API) {
 #endif
 		}
 		if (!GMT->init.runtime_plugindir) GMT->init.runtime_plugindir = strdup (plugindir);
+		if (!GMT->init.runtime_library) {	/* Last call, probably in Xcode */
+			sprintf (path, "%s/%s", GMT->init.runtime_libdir, GMT_CORE_LIB_NAME);
+			GMT->init.runtime_library = strdup (path);
+		}
 		GMT_Report (API, GMT_MSG_DEBUG, "Loading GMT plugins from: %s\n", plugindir);
 		for (e = 0; e < n_extensions; e++) {	/* Handle case of more than one allowed shared library extension */
 			if ((list = gmtlib_get_dir_list (GMT, plugindir, extension[e]))) {	/* Add these files to the libs */


### PR DESCRIPTION
The library path for public consumption was never set in Xcode.  Did not seem to have any consequence except when I tried to run `gmt --show-library` inside Xcode.

This PR builds the library path if nothing is set at the end of the checks.
