### PR TITLE
Must check for label content before offsetting

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3551,7 +3551,7 @@ GMT_LOCAL void gmtplot_draw_dir_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 			char *T_label = NULL;
 			if (hh) {	/* We need horizontal adjustments. Do label offset here and adjust for text size in PSL */
 				T_label = (hh == -1) ? mr->label[3] : mr->label[1];	/* Get the W or E text label */
-				if (T_label) {	/* Get width of label and use it to shift origin left or right */
+				if (T_label && T_label[0]) {	/* Get width of label and use it to shift origin left or right */
 					mr->refpoint->x -= hh * txt_offset;	/* Any horizontal shifts we know exactly */
 					PSL_deftextdim (PSL, "-w", title_size, T_label);	/* Get label width and place on PSL stack */
 					PSL_command (PSL, "%d mul 0 T\n", -hh);	/* Multiply by +1 or -1 and transform x-origin by that amount */
@@ -3559,7 +3559,7 @@ GMT_LOCAL void gmtplot_draw_dir_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 			}
 			if (vv) {	/* We need vertical adjustments. Do label offset here and adjust for text size in PSL */
 				T_label = (vv == -1) ? mr->label[0] : mr->label[2];	/* Get the S or N text label */
-				if (T_label) {	/* Get height of string and use it to shift origin up or down */
+				if (T_label && T_label[0]) {	/* Get height of string and use it to shift origin up or down */
 					mr->refpoint->y -= vv * txt_offset;	/* Any horizontal shifts we know exactly */
 					PSL_deftextdim (PSL, "-H", title_size, T_label);	/* Get label height and place on PSL stack */
 					PSL_command (PSL, "%d mul 0 exch T\n", -vv);	/* Multiply by +1 or -1 and transform y-origin by that amount */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3337,7 +3337,7 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 	GMT->current.plot.r_theta_annot = false;	/* Just in case it was turned on in gmt_map.c */
 
 	mr->refpoint->x -= hh * (font_size[1] / 72.0 + off[1] + 2.0 * tlen[2]);	/* Any horizontal shifts we know exactly */
-	mr->refpoint->y -= vv * (font_size[1] / 72.0 + off[1] + 2.0 * tlen[2]);	/* Any vectical shifts we know exactly */
+	mr->refpoint->y -= vv * (font_size[1] / 72.0 + off[1] + 2.0 * tlen[2]);	/* Any vertical shifts we know exactly */
 
 	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3345,7 +3345,7 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 
 	if (hh) {	/* We need horizontal adjustments. Do label offset here and adjust for text size in PSL */
 		T_label = (hh == -1) ? mr->label[3] : mr->label[1];	/* Get the W or E text label */
-		if (T_label) {	/* Get width of label and use it to shift origin left or right */
+		if (T_label && T_label[0]) {	/* Get width of label and use it to shift origin left or right */
 			mr->refpoint->x -= hh * txt_offset;	/* Any horizontal shifts we know exactly */
 			PSL_deftextdim (PSL, "-w", title_size, T_label);	/* Get label width and place on PSL stack */
 			PSL_command (PSL, "%d mul 0 T\n", -hh);	/* Multiply by +1 or -1 and transform x-origin by that amount */
@@ -3353,7 +3353,7 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 	}
 	if (vv) {	/* We need vertical adjustments. Do label offset here and adjust for text size in PSL */
 		T_label = (vv == -1) ? mr->label[0] : mr->label[2];	/* Get the S or N text label */
-		if (T_label) {	/* Get height of string and use it to shift origin up or down */
+		if (T_label && T_label[0]) {	/* Get height of string and use it to shift origin up or down */
 			mr->refpoint->y -= vv * txt_offset;	/* Any horizontal shifts we know exactly */
 			PSL_deftextdim (PSL, "-H", title_size, T_label);	/* Get label height and place on PSL stack */
 			PSL_command (PSL, "%d mul 0 exch T\n", -vv);	/* Multiply by +1 or -1 and transform y-origin by that amount */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3290,7 +3290,7 @@ GMT_LOCAL void gmtplot_northstar (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, do
 #define TITLE_SCL	0.125	/* Title Font size is this fraction of rose size */
 #define LBL_SCL		0.07	/* Label Font size is this fraction of rose size */
 #define TITLE_OFF	0.2		/* Title offset is this fraction of rose size */
-#define SIZE_THRESHOLD	0.984251968504	/* Compass smaller than 2.5cm gets changed annotation intervals */
+#define SIZE_THRESHOLD	0.984251968504	/* Compass smaller than 2.5 cm gets changed annotation intervals */
 
 GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, struct GMT_MAP_ROSE *mr) {
 	/* Magnetic compass rose */
@@ -3299,7 +3299,7 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 	int hh = mr->justify % 4 - 2, vv = mr->justify / 4 - 1;	/* Horizontal and vertical shift indicators */
 	double ew_angle, angle, R[2], tlen[3], L, s, c, lon, lat, x[5], y[5], xp[5], yp[5];
 	double offset, t_angle, scale[2], base, v_angle, *val = NULL, dim[PSL_MAX_DIMS];
-	double font_size[2], off[2], txt_offset, title_size, lbl_size;
+	double font_size[2], off[2], txt_offset, title_size, lbl_size, factor = (mr->do_label) ? 1.0 : 0.0;
 	char label[GMT_LEN16], *type[2] = {"inner", "outer"}, *T_label = NULL;
 
 	struct GMT_FILL f;
@@ -3336,24 +3336,24 @@ GMT_LOCAL void gmtplot_draw_mag_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 	scale[GMT_ROSE_SECONDARY] = 1.0;
 	GMT->current.plot.r_theta_annot = false;	/* Just in case it was turned on in gmt_map.c */
 
-	mr->refpoint->x -= hh * (font_size[1] / 72.0 + off[1] + 2.0 * tlen[2]);	/* Any horizontal shifts we know exactly */
-	mr->refpoint->y -= vv * (font_size[1] / 72.0 + off[1] + 2.0 * tlen[2]);	/* Any vertical shifts we know exactly */
+	mr->refpoint->x -= hh * (font_size[1] / 72.0 + off[1] + factor * tlen[2]);	/* Any horizontal shifts we know exactly */
+	mr->refpoint->y -= vv * (font_size[1] / 72.0 + off[1] + factor * tlen[2]);	/* Any vertical shifts we know exactly */
 
 	PSL_settextmode (PSL, PSL_TXTMODE_MINUS);	/* Replace hyphens with minus signs */
 
 	PSL_command (PSL, "V\n");	/* Place the rose under gsave/grestore */
 
-	if (hh) {	/* We need horizontal adjustments. Do label offset here and adjust for text size in PSL */
+	if (hh && mr->do_label) {	/* We need horizontal adjustments. Do label offset here and adjust for text size in PSL */
 		T_label = (hh == -1) ? mr->label[3] : mr->label[1];	/* Get the W or E text label */
-		if (T_label && T_label[0]) {	/* Get width of label and use it to shift origin left or right */
+		if (T_label[0]) {	/* Get width of label and use it to shift origin left or right */
 			mr->refpoint->x -= hh * txt_offset;	/* Any horizontal shifts we know exactly */
 			PSL_deftextdim (PSL, "-w", title_size, T_label);	/* Get label width and place on PSL stack */
 			PSL_command (PSL, "%d mul 0 T\n", -hh);	/* Multiply by +1 or -1 and transform x-origin by that amount */
 		}
 	}
-	if (vv) {	/* We need vertical adjustments. Do label offset here and adjust for text size in PSL */
+	if (vv && mr->do_label) {	/* We need vertical adjustments. Do label offset here and adjust for text size in PSL */
 		T_label = (vv == -1) ? mr->label[0] : mr->label[2];	/* Get the S or N text label */
-		if (T_label && T_label[0]) {	/* Get height of string and use it to shift origin up or down */
+		if (T_label[0]) {	/* Get height of string and use it to shift origin up or down */
 			mr->refpoint->y -= vv * txt_offset;	/* Any horizontal shifts we know exactly */
 			PSL_deftextdim (PSL, "-H", title_size, T_label);	/* Get label height and place on PSL stack */
 			PSL_command (PSL, "%d mul 0 exch T\n", -vv);	/* Multiply by +1 or -1 and transform y-origin by that amount */
@@ -3551,7 +3551,7 @@ GMT_LOCAL void gmtplot_draw_dir_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 			char *T_label = NULL;
 			if (hh) {	/* We need horizontal adjustments. Do label offset here and adjust for text size in PSL */
 				T_label = (hh == -1) ? mr->label[3] : mr->label[1];	/* Get the W or E text label */
-				if (T_label && T_label[0]) {	/* Get width of label and use it to shift origin left or right */
+				if (T_label[0]) {	/* Get width of label and use it to shift origin left or right */
 					mr->refpoint->x -= hh * txt_offset;	/* Any horizontal shifts we know exactly */
 					PSL_deftextdim (PSL, "-w", title_size, T_label);	/* Get label width and place on PSL stack */
 					PSL_command (PSL, "%d mul 0 T\n", -hh);	/* Multiply by +1 or -1 and transform x-origin by that amount */
@@ -3559,7 +3559,7 @@ GMT_LOCAL void gmtplot_draw_dir_rose (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL
 			}
 			if (vv) {	/* We need vertical adjustments. Do label offset here and adjust for text size in PSL */
 				T_label = (vv == -1) ? mr->label[0] : mr->label[2];	/* Get the S or N text label */
-				if (T_label && T_label[0]) {	/* Get height of string and use it to shift origin up or down */
+				if (T_label[0]) {	/* Get height of string and use it to shift origin up or down */
 					mr->refpoint->y -= vv * txt_offset;	/* Any horizontal shifts we know exactly */
 					PSL_deftextdim (PSL, "-H", title_size, T_label);	/* Get label height and place on PSL stack */
 					PSL_command (PSL, "%d mul 0 exch T\n", -vv);	/* Multiply by +1 or -1 and transform y-origin by that amount */

--- a/src/gmt_symbol.h
+++ b/src/gmt_symbol.h
@@ -203,7 +203,7 @@ struct GMT_MAP_ROSE {
 	unsigned int mode;	/* 0 for given width, 1 for percentage of map width [10%], 2 for offsets given */
 	unsigned int type;	/* 0 for plain directional rose, 1 for a fancy directional map rose, 2 for magnetic rose */
 	unsigned int kind;	/* 0 : 90 degrees, 1 : 45 degrees, 2 : 22.5 degrees between points */
-	char label[4][GMT_LEN64];	/* User-changable labels for W, E, S, N point */
+	char label[4][GMT_LEN64];	/* User-changeable labels for W, E, S, N point */
 	char dlabel[GMT_LEN256];	/* Magnetic declination label */
 	struct GMT_PEN pen[2];	/* Pens for main and secondary magrose circle outline */
 	struct GMT_MAP_PANEL *panel;	/* Everything about optional back panel */


### PR DESCRIPTION
In the magnetic map rose case, we examine if there are labels to plot (hence we need to do more offsets) but that test was flawed.  It checked if the pointer existed (it always does) instead of its content (may be empty).

This PR fixes that bug.  It is related to the issues in #6213 but probably not the last word.  That may be a mix of this bug (now fixed) and design decisions since the default offset still looks a wee bit too large?
