### PR TITLE
Handle the combination -E -Sn in blockmean

### DIFF
--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -341,7 +341,7 @@ EXTERN_MSC int GMT_blockmean (void *V_API, int mode, void *args) {
 	if (Ctrl->W.weighted[GMT_IN] && ((Ctrl->W.sigma[GMT_IN] && use_xy) || Ctrl->E.active)) np = gmt_M_memory (GMT, NULL, Grid->header->size, uint64_t);
 
 	/* Specify input and output expected columns */
-	n_input = (Ctrl->S.mode == BLK_OUT_COUNT) ? 2 : 3;
+	n_input = (Ctrl->S.mode == BLK_OUT_COUNT && !Ctrl->E.active) ? 2 : 3;	/* Only need 2 for counts unless -E is set */
 	if ((error = GMT_Set_Columns (API, GMT_IN, n_input + Ctrl->W.weighted[GMT_IN], GMT_COL_FIX_NO_TEXT)) != GMT_NOERROR) {
 		Return (error);
 	}


### PR DESCRIPTION
See this [forum](https://forum.generic-mapping-tools.org/t/blockmean-option-e-et-sn/2849) post for background.

At some point I must have decided that **-Sn** only needs to read _x,y_ and not _z_, but if **-E** is also selected then we do need _z_.  This PR fixes that glitch.
