### PR TITLE
Fix regression in gmtsplit

### DIFF
--- a/doc/rst/source/gmtsplit.rst
+++ b/doc/rst/source/gmtsplit.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *course_change*]
 [ |-D|\ *minimum_distance* ]
 [ |-F|\ *xy\_filter*/*z\_filter* ]
-[ |-N|\ *template* ]
+[ |-N|\ [*template*] ]
 [ |-Q|\ *flags* ]
 [ |-S| ]
 [ |SYN_OPT-V| ]
@@ -103,9 +103,9 @@ Optional Arguments
 
 .. _-N:
 
-**-N**\ *template*
+**-N**\ [*template*]
     Write each segment to a separate output file [Default writes a
-    multiple segment file to standard output]. Append a format template for the
+    multiple segment file to standard output]. Optionally append a format template for the
     individual file names; this template **must** contain a C format
     specifier that can format an integer argument (the running segment
     number across all tables); this is usually %d but could be %08d


### PR DESCRIPTION
The **-N** option can optionally take a filename template but it is optional and if not given we state a default name.  Yet that part got lost in the code.  This PR does a few things:

1. Allows **-N** _template_ to be optional and supplies the stated default if needed
2. Moves the check on how many format statements are present in the template to the parser instead of at the end of the module, and thus checks if it is 1 or 2 up front
3. UPdates the usage message and documentation to show _template_ as optional.

I tested this for both ascii and binary output on the data in `test/gmtsplit `and it worked.
