### PR TITLE
Enhance legend -M scenarios

### DIFF
--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -18,7 +18,7 @@ Synopsis
 [ |-C|\ *dx*/*dy* ]
 [ |-F|\ *box* ]
 [ |-J|\ *parameters* ]
-[ |-M| ]
+[ |-M|\ [*items*] ]
 [ |SYN_OPT-R| ]
 [ |-S|\ *scale* ]
 [ |-T|\ *file* ]
@@ -73,6 +73,14 @@ Required Arguments
 Optional Arguments
 ------------------
 
+*specfile*
+    This ASCII file contains instructions for the layout of items in the
+    legend. Each legend item is described by a unique record. All
+    records begin with a unique character that is common to all records
+    of the same kind. The order of the legend items is implied by the
+    order of the records.  See **-M** for mixing legend items set by a
+    *specfile* and those set implicitly via **-l** by previous modules.
+
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_
     :start-after: **Syntax**
@@ -103,11 +111,14 @@ Optional Arguments
 
 .. _-M:
 
-**-M**
-    Modern mode only: Read both (1) the hidden auto-generated legend information file created by
-    plotting-modules' **-l** option and (2) additional information from input file(s) given on the
-    command line (or via standard input) [hidden file only].  For classic mode an input file must be
-    given or else we will read from standard input.
+**-M**\ [*items*]
+    Modern mode only and pertains the the situation where there are **h**\ idden, auto-generated legend
+    information created by prior plotting-modules' **-l** option and **e**\ xplicitly given information
+    from input file(s) given on the command line (or via standard input).  Use **-M** to set which of
+    these should be used and in what order via directives **h** and **e** [Default is **he**, meaning
+    we will first place any hidden auto-generated legend items (if any) and then we append the explicitly
+    given information (if present).  **Note**: For classic mode an input file must be given or else we
+    will attempt read from standard input.
 
 .. |Add_-R| replace:: |Add_-R_links|
 .. include:: explain_-R.rst_
@@ -151,13 +162,9 @@ Optional Arguments
 Legend Codes
 ------------
 
-*specfile*
-    This ASCII file contains instructions for the layout of items in the
-    legend. Each legend item is described by a unique record. All
-    records begin with a unique character that is common to all records
-    of the same kind. The order of the legend items is implied by the
-    order of the records. Fourteen different record types are recognized, and
-    the syntax for each of these records are presented below:
+Fourteen different record types are recognized, and
+the syntax for each of these records are presented below:
+
 **#** *comment*
     Records starting with # and blank lines are skipped.
 **A** *cptname*

--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -79,7 +79,8 @@ Optional Arguments
     records begin with a unique character that is common to all records
     of the same kind. The order of the legend items is implied by the
     order of the records.  See **-M** for mixing legend items set by a
-    *specfile* and those set implicitly via **-l** by previous modules.
+    *specfile* and those set implicitly via **-l** by previous modules
+    under modern mode.
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -151,9 +151,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_mappanel_syntax (API->GMT, 'F', "Specify a rectangular panel behind the legend", 2);
 	GMT_Option (API, "J-,K");
 	GMT_Usage (API, 1, "\n-M[<items>]");
-	GMT_Usage (API, 1, "\nControl how hidden and explicit legend information files are used (modern mode only).  Append one or both of:");
-	GMT_Usage (API, 3, "e: Select the explicit legend information given by <specfile>\n");
-	GMT_Usage (API, 3, "h: Select the hidden legend information built via -l\n");
+	GMT_Usage (API, -2, "Control how hidden and explicit legend information files are used (modern mode only).  Append one or both of:");
+	GMT_Usage (API, 3, "e: Select the explicit legend information given by <specfile>.");
+	GMT_Usage (API, 3, "h: Select the hidden legend information built via previous -l options.");
 	GMT_Usage (API, -2, "The order these are appended controls the read order [Default is he].");
 	GMT_Option (API, "O,P,R");
 	GMT_Usage (API, 1, "\n-S<scale>");

--- a/test/baseline/pslegend.dvc
+++ b/test/baseline/pslegend.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a8a6de2681d889cec0e530397cbd4daf.dir
-  size: 802484
-  nfiles: 18
+- md5: d3e313ed08e46568f46d3692d8c25f0a.dir
+  size: 855500
+  nfiles: 19
   path: pslegend

--- a/test/pslegend/mixlegend.sh
+++ b/test/pslegend/mixlegend.sh
@@ -6,7 +6,7 @@ cat << EOF > legend.txt
 S - kvolcano 0.3c red - - Plot1
 S - kvolcano 0.3c green - - Plot2
 EOF
-gmt begin mixlegend png
+gmt begin mixlegend
 	gmt subplot begin 3x2 -R0/10/0/10 -Fs8c -A+jTR
 		gmt subplot set -A"No -M"
 		echo 2 2 | gmt plot -Sc0.2c -Gblack -lLABEL1

--- a/test/pslegend/mixlegend.sh
+++ b/test/pslegend/mixlegend.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Testing gmt pslegend modern mode mixing of hidden and explicit legend info
+
+cat << EOF > legend.txt
+S - kvolcano 0.3c red - - Plot1
+S - kvolcano 0.3c green - - Plot2
+EOF
+gmt begin mixlegend png
+	gmt subplot begin 3x2 -R0/10/0/10 -Fs8c -A+jTR
+		gmt subplot set -A"No -M"
+		echo 2 2 | gmt plot -Sc0.2c -Gblack -lLABEL1
+		echo 5 5 | gmt plot -St0.2c -Gred -lLABEL2
+		gmt legend legend.txt -DjTL -F
+		gmt subplot set -A"-M"
+		echo 2 2 | gmt plot -Sc0.2c -Gblack -lLABEL1
+		echo 5 5 | gmt plot -St0.2c -Gred -lLABEL2
+		gmt legend legend.txt -DjTL -F -M
+		gmt subplot set -A"-Mh"
+		echo 2 2 | gmt plot -Sc0.2c -Gblack -lLABEL1
+		echo 5 5 | gmt plot -St0.2c -Gred -lLABEL2
+		gmt legend legend.txt -DjTL -F -Mh
+		gmt subplot set -A"-Me"
+		echo 2 2 | gmt plot -Sc0.2c -Gblack -lLABEL1
+		echo 5 5 | gmt plot -St0.2c -Gred -lLABEL2
+		gmt legend legend.txt -DjTL -F -Me
+		gmt subplot set -A"-Meh"
+		echo 2 2 | gmt plot -Sc0.2c -Gblack -lLABEL1
+		echo 5 5 | gmt plot -St0.2c -Gred -lLABEL2
+		gmt legend legend.txt -DjTL -F -Meh
+		gmt subplot set -A"-Mhe"
+		echo 2 2 | gmt plot -Sc0.2c -Gblack -lLABEL1
+		echo 5 5 | gmt plot -St0.2c -Gred -lLABEL2
+		gmt legend legend.txt -DjTL -F -Mhe
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
This PR adds optional directives to **-M** that allows us to indicate the order and selection of the two possible input sources (hidden and explicit) in modern mode.  Not used nor allowed in classic mode.