### PR TITLE
Fix surface -L bug

### DIFF
--- a/test/baseline/surface.dvc
+++ b/test/baseline/surface.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: f7f8435ccb533748675c23d6549b514b.dir
-  size: 322532
-  nfiles: 2
+- md5: c4aaa5128a0e932270e64a02aee21995.dir
+  size: 451677
+  nfiles: 3
   path: surface

--- a/test/surface/limits.sh
+++ b/test/surface/limits.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Test the -L option in surface for both constants and grids
+#
+gmt begin limits
+	gmt subplot begin 3x2 -R0/6.3/0/6.3 -Fs7c -A+gwhite -Sct -Srl
+	gmt subplot set -A"data"
+	gmt plot @Table_5_11.txt -Sc2p -Gblack
+	gmt surface @Table_5_11.txt -R0/6.3/0/6.3 -I0.1 -Gno_limits.grd
+	gmt subplot set -A"no limit"
+	gmt grdcontour no_limits.grd -C10 -A50 -GlTC/BC
+	gmt plot @Table_5_11.txt -Sc2p -Gblack
+	gmt subplot set -A"low = 749"
+	gmt surface @Table_5_11.txt -R0/6.3/0/6.3 -I0.1 -GLl_limits.grd -Ll749
+	gmt plot @Table_5_11.txt -Sc2p -Gblack
+	gmt grdcontour Ll_limits.grd -C10 -A50 -GlTC/BC
+	gmt subplot set -A"high = 901"
+	gmt surface @Table_5_11.txt -R0/6.3/0/6.3 -I0.1 -GLu_limits.grd -Lu901
+	gmt grdcontour Lu_limits.grd -C10 -A50 -GlTC/BC
+	gmt plot @Table_5_11.txt -Sc2p -Gblack
+	gmt subplot set -A"low = grid"
+	gmt grdmath -R0/6.3/0/6.3 -I0.1 749 = L.grd
+	gmt surface @Table_5_11.txt -R0/6.3/0/6.3 -I0.1 -GLl_grid.grd -LlL.grd
+	gmt grdcontour Ll_grid.grd -C10 -A50 -GlTC/BC
+	gmt plot @Table_5_11.txt -Sc2p -Gblack
+	gmt subplot set -A"high = grid"
+	gmt grdmath -R0/6.3/0/6.3 -I0.1 901 = H.grd
+	gmt surface @Table_5_11.txt -R0/6.3/0/6.3 -I0.1 -GLu_grid.grd -LuH.grd
+	gmt grdcontour Lu_grid.grd -C10 -A50 -GlTC/BC
+	gmt plot @Table_5_11.txt -Sc2p -Gblack
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
**Description of proposed changes**

See #6639 for background.  The issue had to do with some of the trickiness of the porting from GMT 4 to 5.  **surface** v4 was unusual in that its innards were so old the the internal grid was column based, like in fortran (which the ancestor to surface was coded in), whereas all other modules plus grid files are scanline oriented.  The section that checks if we need to impose a limit (upper or lower) had to deal with this mess as the limit grids were row-oriented while the internal surface grid was column based.  So we had a fun little node-number calculation to transpose from the data node to the limit node.  When I ported that to GMT 5 I rewrote **surface** to internally use row-orientation and thus I must have assumed I did not need to do this gymnastics anymore.  But I forgot there were two reasons for the node calculation.  One was the transpose (which no longer is needed).  However, the other is that we are doing multi-grid so early on we are stepping in increments larger than 1 over a smaller virtual grid.  Yet, the lower and upper bound grids only exist in final dimensional form, so we just scale up the row and column indices by the increment spacing to get the equivalent node for those grids.  That was the part that got lost, and hence we looked up the wrong nodes, and in this case some of those nodes were outside the grid and not set, and drove the surface crazy (and me, a bit).

The fix was simple once the brain understood the problem.  I have added a new test (_limits.sh_) that exercises the upper and lower constraint for both a constant and a grid and all looks fine.
