### PR TITLE
Fix some issues related to geo vs cart

### DIFF
--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -174,6 +174,8 @@ struct GMT_COMMON {
 	} e;
 	struct f {	/* -f[i|o]<col>|<colrange>[t|T|g],.. */
 		bool active[2];	/* For GMT_IN|OUT */
+		bool is_geo[2];	/* true if -f[i|o]g was set to force a Cartesian grid to be seen as geographic */
+		bool is_cart[2];	/* true if -f[i|o]c was set to force a geographic grid to be seen as Cartesian */
 		char string[GMT_LEN64];
 	} f;
 	struct g {	/* -g[+]x|x|y|Y|d|Y<gap>[unit]  */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -1404,10 +1404,12 @@ GMT_LOCAL int gmtinit_parse_f_option (struct GMT_CTRL *GMT, char *arg) {
 		if (dir == GMT_IO) {
 			gmt_set_cartesian (GMT, GMT_IN);
 			gmt_set_cartesian (GMT, GMT_OUT);
+			GMT->common.f.is_cart[GMT_IN] = GMT->common.f.is_cart[GMT_OUT] = true;
 		}
 		else {
 			col[GMT_X] = GMT_IS_FLOAT;
 			col[GMT_Y] = GMT_IS_FLOAT;
+			GMT->common.f.is_cart[dir] = true;
 		}
 		pos = 1;
 		start = stop = 1;
@@ -1416,10 +1418,12 @@ GMT_LOCAL int gmtinit_parse_f_option (struct GMT_CTRL *GMT, char *arg) {
 		if (dir == GMT_IO) {
 			gmt_set_geographic (GMT, GMT_IN);
 			gmt_set_geographic (GMT, GMT_OUT);
+			GMT->common.f.is_geo[GMT_IN] = GMT->common.f.is_geo[GMT_OUT] = true;
 		}
 		else {
 			col[GMT_X] = GMT_IS_LON;
 			col[GMT_Y] = GMT_IS_LAT;
+			GMT->common.f.is_geo[dir] = true;
 		}
 		pos = 1;
 		start = stop = 1;

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -470,7 +470,7 @@ int grd2kml_coarsen_grid (struct GMT_CTRL *GMT, unsigned int level, char filter,
 			case 'm':	k = 3; break;
 		}
 		sprintf (filt_report, " [%s filtered with -F%c%s -I%s]", kind[k], filter, fwidth, s_int);
-		sprintf (cmd, "%s -D0 -F%c%s -I%s -rp -G%s", DataGrid, filter, fwidth, s_int, Zgrid);
+		sprintf (cmd, "%s -D0 -fc -F%c%s -I%s -rp -G%s", DataGrid, filter, fwidth, s_int, Zgrid);
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Running grdfilter : %s\n", cmd);
 		if ((error = GMT_Call_Module (GMT->parent, "grdfilter", GMT_MODULE_CMD, cmd)) != GMT_NOERROR)
 			return (GMT_RUNTIME_ERROR);


### PR DESCRIPTION
This PR started as a fix to the problem reported via #6587, which was due to a recently imposed check in **grdfilter** that one should not supply Cartesian distance computations with geographic grids.  Because in this particular module (**grd2kml**) I actually need Cartesian treatment I thought I could just add **-fc** to fix this. But no, then we had some trickle-down issues.

Basically, users have always had the option of using **-f** to override what a grid file says it is.  Typically, one may read a Cartesian grid that perhaps should be seen as geographic, and then using **-fg** makes it so (this is for modules where there is no mapping i.e., **-J** is not used).  However, the opposite turned out not to be true: If you have a geographic grid but wanted it to be treated as a Cartesian grid then **-fc** did _not_ do that since **-fc** is parsed first and then when the geographic grid is read we recognize it as such and basically **-fg** is set.

The solution is to _remember_ that we set **-fg** or **-fc** and then apply it.  This PR checks at the end of _gmtapi_import_grid_ to see if we need to impose one of them, as well as the start of _gmtapi_export_grid_ to see if a change should apply to the output.  Great, simple as that.

Now I got failures from all the **grdflexure** tests! In debugging one of them I learned that _GMT_Get_Values_, which is this clever API function that understands units, temporarily may set **-fg** but then leave it as is when it returns.  So in **grdflexure**, after parsing `-E5k`, the **k** for km triggered **-fg** (even if a 5 km plate has nothing to do with geographic data) and then the 0/600/0/600 region was seen as too big for geographic...

WIth these fixes:

1. Add memory to **-fc** and **-fg**
2. Apply that memory just before writing or just after reading grids
3. Reset col types and **-f** settings to what they were when _GMT_Get_Values_ is used
4. Pass the **-fc** flag to **grdfilter** from **grd2kml**

 all seems OK again and the original problem is fixed.