### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,15 @@ defaults:
     # default to use bash shell
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -15,8 +15,13 @@ on:
   schedule:
     - cron: '0 12 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   data_cache:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     name: Cache GMT data
     # We have to use macOS, because Linux/Windows agents may fail to download
     runs-on: macOS-latest
@@ -75,6 +80,9 @@ jobs:
             ~/.gmt/server
 
   vcpkg_cache:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     name: Cache vcpkg libraries
     runs-on: windows-latest
 

--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -9,6 +9,9 @@ on:
 
 name: Code Validator
 
+permissions:
+  contents: read
+
 jobs:
   code-validator:
     name: Code Validator

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,8 +15,15 @@ defaults:
     # default to use bash shell
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   docker:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: ${{ matrix.image }}
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,15 @@ defaults:
     # default to use bash shell
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   docs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -15,8 +15,13 @@ on:
 
 name: Create a Draft Release
 
+permissions:
+  contents: read
+
 jobs:
   draft-release:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     name: Create a Draft Release
     runs-on: macos-latest # Have to use macos because linux sometimes timeouts
     steps:

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -9,6 +9,9 @@ on:
 
 name: Lint Checker
 
+permissions:
+  contents: read
+
 jobs:
   lint-checker:
     name: Lint Checker

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,8 +6,14 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,15 @@ defaults:
     # default to use bash shell
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
