### PR TITLE
Check as early as possible if a grid has NaNs when FFTs will be used

### DIFF
--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -179,9 +179,9 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *zm*\ [*zl*]
+**-Z**\ *zm*\ [/*zl*]
     Moho [and swell] average compensation depths (in meters positive down – the depth). For the "load from
-    top" model you only have to provide *zm*, but for the "loading from below" don't forget *zl*.
+    top" model you only have to provide *zm*, but for the "loading from below" don't forget to supply *zl*.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: /explain_-V.rst_

--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -49,12 +49,7 @@ sub-surface load (appropriate for hot spot modeling - if you believe
 them). In both cases, the model parameters are set with **-T** and
 **-Z** options. Mode 3: compute the admittance or coherence between
 two grids. The output is the average in the radial direction.
-Optionally, the model admittance may also be calculated. The horizontal
-dimensions of the grids are assumed to be in meters. Geographical
-grids may be used by specifying the |SYN_OPT-f| option that scales degrees
-to meters. If you have grids with dimensions in km, you could change
-this to meters using :doc:`grdedit </grdedit>` or scale the output with
-:doc:`grdmath </grdmath>`.
+Optionally, the model admittance may also be calculated.
 Given the number of choices this program offers, is difficult to state
 what are options and what are required arguments. It depends on what you
 are doing; see the examples for further guidance.

--- a/src/potential/gravfft.c
+++ b/src/potential/gravfft.c
@@ -608,11 +608,6 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
 	if (Ctrl->D.variable) {	/* Read density contrast grid */
 		if ((Rho = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA | GMT_GRID_IS_COMPLEX_REAL, NULL, Ctrl->D.file, NULL)) == NULL)
 			Return (API->error);
-		HH = gmt_get_H_hidden (Rho->header);
-		if (HH->has_NaNs) {
-			GMT_Report (API, GMT_MSG_ERROR, "Density grid %s has NaNs, cannot be used with FFTs\n", Ctrl->D.file);
-			Return (GMT_RUNTIME_ERROR);
-		}
 		if(Orig[0]->header->registration != Rho->header->registration) {
 			GMT_Report (API, GMT_MSG_ERROR, "Surface and density grids have different registrations!\n");
 			Return (GMT_RUNTIME_ERROR);
@@ -640,7 +635,7 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
                                       GMT_GRID_IS_COMPLEX_REAL, NULL, Ctrl->In.file[k], Orig[k])) == NULL)	/* Get data only */
 			Return (API->error);
 		HH = gmt_get_H_hidden (Orig[k]->header);
-		if (HH->has_NaNs) {
+		if (HH->has_NaNs == GMT_GRID_HAS_NANS) {
 			GMT_Report (API, GMT_MSG_ERROR, "Input grid %s has NaNs, cannot be used with FFTs\n", Ctrl->In.file[k]);
 			Return (GMT_RUNTIME_ERROR);
 		}

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -848,6 +848,7 @@ GMT_LOCAL struct GRDFLEXURE_GRID *grdflexure_prepare_load (struct GMT_CTRL *GMT,
 	double boost, mean_rho_l;
 	struct GMT_GRID *Grid = NULL, *Orig = NULL, *Rho = NULL;
 	struct GRDFLEXURE_GRID *G = NULL;
+	struct GMT_GRID_HEADER_HIDDEN *HH = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
 	if (this_time)
@@ -869,6 +870,11 @@ GMT_LOCAL struct GRDFLEXURE_GRID *grdflexure_prepare_load (struct GMT_CTRL *GMT,
 	if ((Orig = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY |
  		GMT_GRID_IS_COMPLEX_REAL, NULL, file, Orig)) == NULL) {	/* Get data only */
 		GMT_Report (API, GMT_MSG_ERROR, "Failure while reading the data of file %s - file skipped\n", file);
+		return NULL;
+	}
+	HH = gmt_get_H_hidden (Orig->header);
+	if (HH->has_NaNs) {
+		GMT_Report (API, GMT_MSG_ERROR, "Load grid %s has NaNs, cannot be used with FFTs - file skipped\n", file);
 		return NULL;
 	}
 	/* Note: If input grid is read-only then we must duplicate it; otherwise Grid points to Orig */
@@ -902,6 +908,7 @@ GMT_LOCAL struct GRDFLEXURE_GRID *grdflexure_prepare_load (struct GMT_CTRL *GMT,
 			GMT_Report (API, GMT_MSG_ERROR, "Failure to extract mean load density from %s - file skipped\n", rho);
 			return NULL;
 		}
+		/* Note: Density grid may have NaNs outside the feature since we are not taking FFT of the density grid */
 		if ((Rho = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY |
 	 		GMT_GRID_IS_COMPLEX_REAL, NULL, rho, Rho)) == NULL) {	/* Get header and data */
 			GMT_Report (API, GMT_MSG_ERROR, "Failure while reading the data of file %s - file skipped\n", rho);

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -873,7 +873,7 @@ GMT_LOCAL struct GRDFLEXURE_GRID *grdflexure_prepare_load (struct GMT_CTRL *GMT,
 		return NULL;
 	}
 	HH = gmt_get_H_hidden (Orig->header);
-	if (HH->has_NaNs) {
+	if (HH->has_NaNs == GMT_GRID_HAS_NANS) {
 		GMT_Report (API, GMT_MSG_ERROR, "Load grid %s has NaNs, cannot be used with FFTs - file skipped\n", file);
 		return NULL;
 	}


### PR DESCRIPTION
**Description of proposed changes**

FFTs requires a grid without NaNs.  While _GMT_Create_FFT_ checks for this, it often is called late in the module's life and may even crash at that point.  Better to check once we have read a grid since there are hidden variables that can be used to do the check.  While **grdfft** does its own thing, neither **gravfft** nor **grdflexure** checked for this.

This PR adds simple checks to those to modules and fixes a typo on **gravfft** man page.
