### PR TITLE
Fix gravprism issues related to vertical scaling and NaNs

### DIFF
--- a/src/potential/gravprisms.c
+++ b/src/potential/gravprisms.c
@@ -801,8 +801,8 @@ EXTERN_MSC int GMT_gravprisms (void *V_API, int mode, void *args) {
 			for (k = 0; k < n_prisms; k++)	{ /* Unscramble edges to coordinates and dimensions and possibly convert Cartesian data back to km */
 				S->data[0][k] = 0.5 * (prism[1][k] + prism[0][k]) * i_scl_xy;	/* Get x */
 				S->data[1][k] = 0.5 * (prism[3][k] + prism[2][k]) * i_scl_xy;	/* Get y */
-				S->data[2][k] = prism[4][k] * i_scl_xy;	/* Get z_low */
-				S->data[3][k] = prism[5][k] * i_scl_xy;	/* Get z_high */
+				S->data[2][k] = prism[4][k] * i_scl_z;	/* Get z_low */
+				S->data[3][k] = prism[5][k] * i_scl_z;	/* Get z_high */
 				S->data[4][k] = (prism[1][k] - prism[0][k]) * i_scl_xy;	/* Get dx */
 				S->data[5][k] = (prism[3][k] - prism[2][k]) * i_scl_xy;	/* Get dy */
 			}
@@ -989,7 +989,7 @@ EXTERN_MSC int GMT_gravprisms (void *V_API, int mode, void *args) {
 					z_level = (S->n_columns == 3 && !Ctrl->Z.active) ? S->data[GMT_Z][row] : Ctrl->Z.level;	/* Default observation z level unless provided in input file */
 					GMT->hidden.mem_coord[GMT_X][row] = eval (S->data[GMT_X][row] * scl_xy, S->data[GMT_Y][row] * scl_xy, z_level * scl_z, n_prisms, prism, G0);
 				}
-				/* This loop is not under OpenMP */
+				/* This second loop is not under OpenMP control */
 				out[GMT_Z] = Ctrl->Z.level;	/* Default observation z level unless provided in input file */
 				for (row = 0; row < (int64_t)S->n_rows; row++) {	/* Loop over output locations */
 					out[GMT_X] = S->data[GMT_X][row];

--- a/src/potential/gravprisms.c
+++ b/src/potential/gravprisms.c
@@ -682,6 +682,9 @@ EXTERN_MSC int GMT_gravprisms (void *V_API, int mode, void *args) {
 	i_scl_xy = 1.0 / scl_xy;	/* Scale use for output horizontal distances */
 	i_scl_z  = 1.0 / scl_z;		/* Scale use for output vertical distances */
 
+	GMT_Report (API, GMT_MSG_INFORMATION, "All x/y-values are assumed to be given in %s\n", uname[Ctrl->M.active[GRAVPRISMS_HOR]]);
+	GMT_Report (API, GMT_MSG_INFORMATION, "All z-values are assumed to be given in %s\n",   uname[Ctrl->M.active[GRAVPRISMS_VER]]);
+
 	if (Ctrl->C.active) {	/* Need to create prisms from two surfaces first */
 		struct GMT_GRID *B = NULL, *T = NULL, *H = NULL, *Rho = NULL;
 		double base = 0.0, top = 0.0, z1, z2, z_prev, z_next, z_mid, rs = 0.0, ws = 0.0;
@@ -723,7 +726,9 @@ EXTERN_MSC int GMT_gravprisms (void *V_API, int mode, void *args) {
 
 		gmt_M_grd_loop (GMT, H, row, col, node) {
 			z2 = (T) ? T->data[node] : top;
+			if (gmt_M_is_dnan (z2)) continue;	/* Cannot work with NaNs - probably outside the feature */
 			z1 = (B) ? B->data[node] : base;
+			if (gmt_M_is_dnan (z1)) continue;	/* Cannot work with NaNs - probably outside the feature */
 			if (z2 <= z1) continue;	/* No layer thickness detected */
 			z_prev = z1;	/* We start exactly at z = z1 */
 			do {	/* Will at least be one prism */
@@ -917,8 +922,6 @@ EXTERN_MSC int GMT_gravprisms (void *V_API, int mode, void *args) {
 	if (Ctrl->A.active) Ctrl->Z.level = -Ctrl->Z.level;
 
 	/* Read polygon information from multiple segment file */
-	GMT_Report (API, GMT_MSG_INFORMATION, "All x/y-values are assumed to be given in %s\n", uname[Ctrl->M.active[GRAVPRISMS_HOR]]);
-	GMT_Report (API, GMT_MSG_INFORMATION, "All z-values are assumed to be given in %s\n",   uname[Ctrl->M.active[GRAVPRISMS_VER]]);
 
 	/* Now we can write (if -V) to the screen the user's polygon model characteristics. */
 


### PR DESCRIPTION
**Description of proposed changes**

Most of the testing of **gravprism** was done with geographic grids, so the whole dance of converting degrees to meters has been tested well.  However, I am now working on oblique grids in km so ran into an issue with the conversion of km to meters.  And also found there was a lack of checks for NaNs.  This PR does the following

1. Fixes the bug where _i_scl_xy_ was used instead of _i_scl_z_ to convert heights back to (km) on output.
2. Now checks if the grid given via **-S** or **-T** contains NaNs, which means we are outside the volume of interest.  However, without an explicit NaN check we will not know this.
3. Move the message about what units are used head of the **-C** code since otherwise it will not be printed for some types of runs.

Tests pass plus my own work with km grids now is correct.