### PR TITLE
Also handle a colon-search in GMT_Encode_Options

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12981,8 +12981,8 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 		/* Found the -S option, check if we requested quoted or decorated lines via fixed or crossing lines */
 		/* If not f|x then we don't want this at all and set type = ! */
 		type = (!strchr ("~q", opt->arg[0]) || !strchr ("fx", opt->arg[1])) ? '!' : 'D';  /* Only -S[~q][fx] will yield D */
-		strip_colon = (strchr (opt->arg, ':') != NULL); /* true if optional arguments beginning with colon, otherwise false */
-		strip_colon_opt = opt->option;    /* An option with (a possible) colon argument */
+		strip_colon = (gmtlib_colon_pos (API->GMT, opt->arg) != GMT_NOTSET); /* true if optional arguments beginning with colon, otherwise false */
+		strip_colon_opt = opt->option;    /* An option with (a possible) colon argument (if strip_colon is true, of course) */
 		if (strip_colon)
 			GMT_Report (API, GMT_MSG_DEBUG, "GMT_Encode_Options: Got quoted or decorate line and must strip argument %s from colon to end\n", opt->arg);
 	}

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16398,7 +16398,7 @@ double gmtinit_get_diameter (struct GMT_CTRL *GMT, char code, char *text, bool *
 	return (d);
 }
 
-GMT_LOCAL int gmtinit_colon_pos (struct GMT_CTRL *GMT, char *text) {
+int gmtlib_colon_pos (struct GMT_CTRL *GMT, char *text) {
 	/* Quoted and decorated lines options separate directives from optional modifiers with a colon.
 	 * Because Bill uses the colon in hard paths (C:/badpath) we must be careful
 	 * in looking for the right colon. */
@@ -17144,7 +17144,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 				break;
 			}
 			/* Determine the first colon as a separator between info and specs */
-			colon = gmtinit_colon_pos (GMT, text);
+			colon = gmtlib_colon_pos (GMT, text);
 			if (colon != GMT_NOTSET) {	/* Gave :<labelinfo> */
 				text[colon] = 0;
 				gmt_contlabel_init (GMT, &p->G, 0);
@@ -17363,7 +17363,7 @@ int gmt_parse_symbol_option (struct GMT_CTRL *GMT, char *text, struct GMT_SYMBOL
 				p->fq_parse = true;	/* This will be set to false once at least one header has been parsed */
 				break;
 			}
-			colon = gmtinit_colon_pos (GMT, text);
+			colon = gmtlib_colon_pos (GMT, text);
 			if (colon != GMT_NOTSET) {	/* Gave :<symbolinfo> */
 				text[colon] = 0;
 				gmtlib_decorate_init (GMT, &p->D, 0);

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -53,6 +53,7 @@ struct GMT_XINGS {
 EXTERN_MSC char *dlerror (void);
 #endif
 
+EXTERN_MSC int gmtlib_colon_pos (struct GMT_CTRL *GMT, char *text);
 EXTERN_MSC bool gmtlib_invalid_symbolname (struct GMT_CTRL *GMT, char *name);
 EXTERN_MSC void gmtlib_terminate_session ();
 EXTERN_MSC unsigned int gmtlib_pick_in_col_number (struct GMT_CTRL *GMT, unsigned int col, unsigned int *col_pos_in);


### PR DESCRIPTION
As a follow-up to #6653, there was something similar in _gmt_api.c_ where we simply searched for a stand-alone colon.  I have now promoted the function introduced in #6658 to the lower gmt-wide library and use it in _gmt_api.c_ as well as the original cases in _gmt_init.c_