### PR TITLE
Simplify colonoscopy on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@
 name: Tests
 
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16409,7 +16409,7 @@ int gmtlib_colon_pos (struct GMT_CTRL *GMT, char *text) {
 		bool got_slash;
 		if (text[j] != ':') continue;	/* Not a colon, moving on */
 		if (text[j+1] == '\0') continue;	/* End of argument, moving on */
-		got_slash = !strchr ("/\\", text[j+1]);	/* True if next letter is a slash */
+		got_slash = (strchr ("/\\", text[j+1]) != NULL); /* True if next letter is a slash */
 		if (!got_slash || (got_slash && !(isupper (text[j-1]) || islower (text[j-1])))) colon = j;
 #else
 		if (text[j] == ':') colon = j;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -16404,12 +16404,17 @@ int gmtlib_colon_pos (struct GMT_CTRL *GMT, char *text) {
 	 * in looking for the right colon. */
 	int j, colon = GMT_NOTSET;
 	gmt_M_unused (GMT);
-	for (j = 1; colon == GMT_NOTSET && text[j]; j++)
+	for (j = 1; colon == GMT_NOTSET && text[j]; j++) {
 #ifdef WIN32
-		if (text[j] == ':' && text[j+1] && !strchr ("/\\", text[j+1]) && !(isupper (text[j-1]) || islower (text[j-1]))) colon = j;
+		bool got_slash;
+		if (text[j] != ':') continue;	/* Not a colon, moving on */
+		if (text[j+1] == '\0') continue;	/* End of argument, moving on */
+		got_slash = !strchr ("/\\", text[j+1]);	/* True if next letter is a slash */
+		if (!got_slash || (got_slash && !(isupper (text[j-1]) || islower (text[j-1])))) colon = j;
 #else
 		if (text[j] == ':') colon = j;
 #endif
+	}
 	return (colon);
 }
 


### PR DESCRIPTION
The solution implemented in #6658 was not correct and too obtuse.  This PR breaks down the checks to dispense with the easy checks up front and save the more involved one for when it is needed.
Hopefully fixes the issue - let the CI begin.

Note: I have only compiled this in Windows in my head...

Also, the second reference to got_slash is not needed (since we only get past the || if got_slash is true anyway) but I left it there for clarity.