### PR TITLE
Let grdimage detect if no data

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8534,8 +8534,8 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "CPT argument %s understood to be a master table\n", file);
 		if (gmt_M_is_dnan (zmin) || gmt_M_is_dnan (zmax)) {	/* Safety valve 1 */
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Passing zmax or zmin == NaN prevents automatic CPT generation!\n");
-			return (NULL);
+			GMT_Report (GMT->parent, GMT_MSG_WARNING, "All data points are NaNs so cannot do meaningful automatic CPT generation\n");
+			zmin = 0.0;	zmax = 1.0;	/* Does not matter since only NaN color will be used */
 		}
 		if (zmax <= zmin) {	/* Safety valve 2 */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Passing zmax <= zmin prevents automatic CPT generation!\n");

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1154,8 +1154,12 @@ void grdimage_reset_grd_minmax (struct GMT_CTRL *GMT, struct GMT_GRID *G, double
 	gmt_M_memcpy (G->header->wesn, new_wesn, 4, double);	/* Temporarily update the header */
 	for (k = 0; k < 4; k++) G->header->pad[k] += pad[k];	/* Temporarily change the pad */
 	gmt_set_grddim (GMT, G->header);	/* Change header items */
-	gmt_grd_zminmax (GMT, G->header, G->data);		/* Recompute the min/max */
-	*zmin = G->header->z_min;	*zmax = G->header->z_max;	/* These are then passed out */
+	if (G->header->nm) {	/* Still a grid left to examine after moving to actual -R */
+		gmt_grd_zminmax (GMT, G->header, G->data);		/* Recompute the min/max */
+		*zmin = G->header->z_min;	*zmax = G->header->z_max;	/* These are then passed out */
+	}
+	else	/* No nodes actually inside the chosen region */
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "No grid nodes inside selected region\n");
 	gmt_M_memcpy (G->header->wesn, old_wesn, 4, double);	/* Reset the header */
 	for (k = 0; k < 4; k++) G->header->pad[k] -= pad[k];	/* Reset the pad */
 	gmt_set_grddim (GMT, G->header);	/* Reset header items */


### PR DESCRIPTION
When selecting a too small area with nothing inside the plot window we should warn the user that nothing good will happen rather than crash.  Also related to this is how we handle the case where there are only NaN nodes by not stretching the CPT then and just return CPT for z  = 0/1 since only the NaN color will be used anyway.  Hence this PR improves on two rare situations:

1. The user's grid only has NaNs.  This will now give a NaN-colored plot plus the warning `[WARNING]: All data points are NaNs so cannot do meaningful automatic CPT generation`
2. The users region is such that there are no data nodes inside the region.  This now gives an empty plot (may be colored based on the nodes that are just outside) and yields the warning` [WARNING]: No grid nodes inside selected region`

Closes #6655.
