### PR TITLE
Make sure key[k][K_MODIFIER] is > 0 before sending it to isdigit()

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12730,7 +12730,7 @@ GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key,
 		strcpy (argument, inarg);	/* Any colon-string will be added back in GMT_Encode_Options */
 		gmt_M_str_free (inarg);
 		/* Also return 1 or 2, depending on -G vs -S */
-		*n_pre = (k >= 0 && key[k][K_MODIFIER] && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
+		*n_pre = (k >= 0 && key[k][K_MODIFIER] > 0 && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
 		return (0);
 	}
 


### PR DESCRIPTION
When in debug mode I get crashes on this line because ``key[k][K_MODIFIER] = -3`` and an ``assert`` in VS's ``isdigit`` make it crash. This is strange because it seems there are times where ``key[k][K_MODIFIER]`` is not yet defined and we are checking it's value but in release mode it gets a value of 0 and the test passes.