### PR TITLE
Update old -R...r syntax to the new -R...+r syntax

### DIFF
--- a/doc/rst/source/basemap.rst
+++ b/doc/rst/source/basemap.rst
@@ -257,7 +257,7 @@ the central meridian. A UTM basemap for Indo-China can be plotted as
 
    ::
 
-    gmt basemap -R95/5/108/20r -Ju46/1:10000000 -Bafg -B+tUTM -pdf utm
+    gmt basemap -R95/5/108/20+r -Ju46/1:10000000 -Bafg -B+tUTM -pdf utm
 
 Cylindrical Equal-Area
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -390,7 +390,7 @@ define our rectangle. We choose a pole at 130/-30 and use 100/-45 and
 
    ::
 
-    gmt basemap -R100/-45/160/-5r -JS130/-30/12c -Bafg -B+t"General Stereographic View" -pdf stereo2
+    gmt basemap -R100/-45/160/-5+r -JS130/-30/12c -Bafg -B+t"General Stereographic View" -pdf stereo2
 
 Miscellaneous Map Projections
 -----------------------------

--- a/doc/rst/source/psbasemap.rst
+++ b/doc/rst/source/psbasemap.rst
@@ -189,7 +189,7 @@ the central meridian. A UTM basemap for Indo-China can be plotted as
 
    ::
 
-    gmt psbasemap -R95/5/108/20r -Ju46/1:10000000 -Bafg -B+tUTM -P > utm.ps
+    gmt psbasemap -R95/5/108/20+r -Ju46/1:10000000 -Bafg -B+tUTM -P > utm.ps
 
 Cylindrical Equal-Area
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -322,7 +322,7 @@ define our rectangle. We choose a pole at 130/-30 and use 100/-45 and
 
    ::
 
-    gmt psbasemap -R100/-45/160/-5r -JS130/-30/12c -Bafg -B+t"General Stereographic View" -P > stereo2.ps
+    gmt psbasemap -R100/-45/160/-5+r -JS130/-30/12c -Bafg -B+t"General Stereographic View" -P > stereo2.ps
 
 Miscellaneous Map Projections
 -----------------------------

--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -392,7 +392,7 @@ produce a true geotiff file::
 
 To create a Polar Stereographic geotiff file of Patagonia::
 
-    gmt coast -JS-55/-60/15c -R-77/-55/-57.5/-48r -Di -Gred -Bg2 --MAP_FRAME_TYPE=inside -ps patagonia
+    gmt coast -JS-55/-60/15c -R-77/-55/-57.5/-48+r -Di -Gred -Bg2 --MAP_FRAME_TYPE=inside -ps patagonia
     gmt psconvert patagonia.ps -Tt -W+g -V
 
 To create a simple KML file for use in Google Earth, try::

--- a/doc/scripts/GMT_Defaults_1b.sh
+++ b/doc/scripts/GMT_Defaults_1b.sh
@@ -3,7 +3,7 @@ gmt begin GMT_Defaults_1b
 	gmt set GMT_THEME cookbook
 	gmt set MAP_FRAME_TYPE plain FORMAT_GEO_MAP ddd:mm:ssF MAP_GRID_CROSS_SIZE_PRIMARY 0i \
 		FONT_ANNOT_PRIMARY +8p MAP_ANNOT_OBLIQUE anywhere MAP_FRAME_AXES=WESN
-	gmt basemap -X1.5i -R-90/20/-55/25r -JOc-80/25.5/2/69/2.25i -Ba10f5g5
+	gmt basemap -X1.5i -R-90/20/-55/25+r -JOc-80/25.5/2/69/2.25i -Ba10f5g5
 	gmt text -R0/2.25/0/2 -Jx1i -N -F+f7p,Helvetica-Bold,blue+j << EOF
 -0.15 0.15  RB MAP_ORIGIN_X
 0.28  -0.2  LM MAP_ORIGIN_Y


### PR DESCRIPTION
**Description of proposed changes**

These old syntax are detected using the following command:
```
grep '\-R\S*[0-9]r' **/*.sh **/*.rst
```

Some scripts in the `test` directory are also using the old `-R...r` syntax, but I think it's OK to leave them to test if the old syntax works. 
