### PR TITLE
Enhance mapproject to give closed domain polygons

### DIFF
--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -258,7 +258,7 @@ Optional Arguments
    (left) Some domains are oblique (their perimeters are not following meridians and parallels).
    We can use **-Wr**\ \|\ **R** to obtain the enclosing meridian/parallel box or the |-R| string
    for that region. (right) Other domains are not oblique but their enclosing rectangular box in
-   the map projection will be  We can explore **-We**\ \|\ **E** to obtain the geographic coordinates
+   the map projection will be.  We can explore **-We**\ \|\ **E** to obtain the geographic coordinates
    of the encompassing oblique rectangle or the |-R| string for that region.
 
 .. _-Z:

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -27,7 +27,7 @@ Synopsis
 [ |-S| ]
 [ |-T|\ [**h**]\ *from*\ [/*to*] ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**e**\|\ **E**\|\ **g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**] ]
+[ |-W|\ [**e**\|\ **E**\|\ **g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**][**+n**\ [*nx*\ [/*ny*]]] ]
 [ |-Z|\ [*speed*][**+a**][**+i**][**+f**][**+t**\ *epoch*] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -230,7 +230,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**e**\|\ **E**\|\ **g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**]
+**-W**\ [**e**\|\ **E**\|\ **g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**][**+n**\ [*nx*\ [/*ny*]]]
     Prints map width and height on standard output.  No input files are read.
     To only output the width or the height, append **w** or **h**, respectively.
     To output the plot coordinates of a map point, give **g**\ *lon*/*lat*.
@@ -245,8 +245,21 @@ Optional Arguments
     use **o** to return the diagonal corner coordinates in degrees (in the order
     *llx urx lly ury*) or use **O** to get the equivalent |-R| string as trailing
     text. To return the coordinates of the rectangular area encompassing the non-rectangular
-    area defined by your **-R -J**, use **e**, or **E** for the trailing text string
+    area defined by your **-R -J**, use **e**, or **E** for the trailing text string.
+    Alternatively (for **e** or **r**), append **+n** to set how many points you want along
+    each side for a closed polygon of the oblique area instead
     [Default returns the width and height of the map].
+
+.. figure:: /_images/GMT_obl_regions.*
+   :width: 400 px
+   :align: center
+
+   Comparing oblique (red outline) and regular (just meridians and parallels; black outline) regions.
+   (left) Some domains are oblique (their perimeters are not following meridians and parallels).
+   We can use **-Wr**\ \|\ **R** to obtain the enclosing meridian/parallel box or the |R| string
+   for that region. (right) Other domains are not oblique but their enclosing rectangular box in
+   the map projection will be  We can explore **-We**\ \|\ **E** to obtain the geographic coordinates
+   of the encompassing oblique rectangle or the |R| string for that region.
 
 .. _-Z:
 
@@ -388,6 +401,12 @@ To determine the oblique region string (in degrees) that corresponds to a rectan
    ::
 
     gmt mapproject -R-2800/2400/-570/630+uk -Joc190/25/266/68/1:1 -WO
+
+To instead get a closed polygon of the oblique area in geographical coordinates, try
+
+   ::
+
+    gmt mapproject -R-2800/2400/-570/630+uk -Joc190/25/266/68/1:1 -Wr+n > polygon.txt
 
 To find the region string that corresponds to the rectangular region that encompasses
 the projected region defined by a stereographic projection, try

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -246,20 +246,20 @@ Optional Arguments
     *llx urx lly ury*) or use **O** to get the equivalent |-R| string as trailing
     text. To return the coordinates of the rectangular area encompassing the non-rectangular
     area defined by your **-R -J**, use **e**, or **E** for the trailing text string.
-    Alternatively (for **e** or **r**), append **+n** to set how many points you want along
-    each side for a closed polygon of the oblique area instead
+    Alternatively (for **e** or **r**), append **+n** to set how many points [100]
+    you want along each side for a closed polygon of the oblique area instead
     [Default returns the width and height of the map].
 
 .. figure:: /_images/GMT_obl_regions.*
-   :width: 400 px
+   :width: 600 px
    :align: center
 
    Comparing oblique (red outline) and regular (just meridians and parallels; black outline) regions.
    (left) Some domains are oblique (their perimeters are not following meridians and parallels).
-   We can use **-Wr**\ \|\ **R** to obtain the enclosing meridian/parallel box or the |R| string
+   We can use **-Wr**\ \|\ **R** to obtain the enclosing meridian/parallel box or the |-R| string
    for that region. (right) Other domains are not oblique but their enclosing rectangular box in
    the map projection will be  We can explore **-We**\ \|\ **E** to obtain the geographic coordinates
-   of the encompassing oblique rectangle or the |R| string for that region.
+   of the encompassing oblique rectangle or the |-R| string for that region.
 
 .. _-Z:
 

--- a/doc/scripts/GMT_obl_regions.sh
+++ b/doc/scripts/GMT_obl_regions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Illustrate the functions of -Wr and -We in mapproject and
-# compare the enclosed versus circumescribed oblique retions
+# compare the enclosed versus circumscribed oblique regions
 
 gmt begin GMT_obl_regions
 	gmt set MAP_FRAME_TYPE plain MAP_ANNOT_OBLIQUE lat_horizontal,tick_normal,lon_horizontal FONT_ANNOT 8p
@@ -12,8 +12,8 @@ gmt begin GMT_obl_regions
 	gmt clip geo.txt -W1p,red
 	gmt coast -Gblack
 	gmt clip -C
-	# Stereographic region defined - find enclosing mn/max oblique rectangle
-	R=$(gmt mapproject -JS36/90/5c+dh -R-15/60/68/90 -WE)
+	# Stereographic region defined - find enclosing min/max oblique rectangle
+	R=$(gmt mapproject -R-15/60/68/90 -JS36/90/5c+dh -WE)
 	cat <<- EOF > geo.txt	# Build the geographic box
 	-15	68
 	60	68

--- a/doc/scripts/GMT_obl_regions.sh
+++ b/doc/scripts/GMT_obl_regions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Illustrate the functions of -Wr and -We in mapproject and
+# compare the enclosed versus circumescribed oblique retions
+
+gmt begin GMT_obl_regions
+	gmt set MAP_FRAME_TYPE plain MAP_ANNOT_OBLIQUE lat_horizontal,tick_normal,lon_horizontal FONT_ANNOT 8p
+	# Oblique Mercator region defined - find enclosing w/e/s/n rectangle
+	R=$(gmt mapproject -R270/20/305/25+r -JOc280/25.5/22/69/5c+dh -WR)
+	gmt mapproject -Wr+n > geo.txt
+	gmt coast $R -JM5c+dh -Bafg -Glightgray
+	gmt clip geo.txt -W1p,red
+	gmt coast -Gblack
+	gmt clip -C
+	# Stereographic region defined - find enclosing mn/max oblique rectangle
+	R=$(gmt mapproject -JS36/90/5c+dh -R-15/60/68/90 -WE)
+	cat <<- EOF > geo.txt	# Build the geographic box
+	-15	68
+	60	68
+	60	90
+	-15	90
+	EOF
+	gmt coast $R -Bxa15f5g10 -Bya5f5g5 -Glightgray -X7.5c --MAP_FRAME_PEN=1p,red
+	gmt clip geo.txt -W1p -Ap
+	gmt coast -Gblack
+	gmt clip -C -Ap
+gmt end show

--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 2aa6ab9cf5dddd154f4d747bdde0b38f.dir
-  size: 32415865
-  nfiles: 197
+- md5: b6459673d7a8a0b6ba470a48598b5492.dir
+  size: 32703171
+  nfiles: 198
   path: images

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13178,7 +13178,7 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 	/* 1y. Check if this is the gravprisms module, where primary dataset input should be turned off if -C is used */
 	else if (!strncmp (module, "gravprisms", 10U) && (opt = GMT_Find_Option (API, 'C', *head))) {
 		deactivate_input = true;    /* Turn off implicit input since none is in effect */
-    }
+	}
 
 	/* 2a. Get the option key array for this module */
 	key = gmtapi_process_keys (API, keys, type, *head, n_per_family, &n_keys);	/* This is the array of keys for this module, e.g., "<D{,GG},..." */

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1027,8 +1027,8 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 		unsigned int wmode = 0, tmode = GMT_COL_FIX_NO_TEXT;
 		char key[3] = {""}, region[GMT_LEN256] = {""};
 
-		if (Ctrl->W.poly) {	/* Must generate a polygon via -We|r+n */
-			uint64_t dim[4] = {1, 1, 2*(Ctrl->W.nx+Ctrl->W.ny-2), 2};
+		if (Ctrl->W.poly) {	/* Must generate a closed polygon via -We|r+n */
+			uint64_t dim[4] = {1, 1, 2*(Ctrl->W.nx+Ctrl->W.ny)-3, 2};
 			double dx, dy;
 			struct GMT_DATASEGMENT *S = NULL;
 			struct GMT_DATASET *D = NULL;
@@ -1045,6 +1045,7 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XHI]-i*dx, GMT->current.proj.rect[YHI]);
 			for (i = 1; i < Ctrl->W.ny; i++, k++)	/* max to min along left side */
 				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XLO], GMT->current.proj.rect[YHI]-i*dy);
+			S->data[GMT_X][k] = S->data[GMT_X][0];	S->data[GMT_Y][k] = S->data[GMT_Y][0];	/* Close polygon */
 			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_WRITE_SET, NULL, NULL, D) != GMT_NOERROR)
 				Return (API->error);
 			Return (GMT_NOERROR);

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1045,7 +1045,6 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XHI]-i*dx, GMT->current.proj.rect[YHI]);
 			for (i = 1; i < Ctrl->W.ny; i++, k++)	/* max to min along left side */
 				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XLO], GMT->current.proj.rect[YHI]-i*dy);
-			S->data[GMT_X][k] = S->data[GMT_X][0];	S->data[GMT_Y][k] = S->data[GMT_Y][0];	/* Close polygon */
 			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_WRITE_SET, NULL, NULL, D) != GMT_NOERROR)
 				Return (API->error);
 			Return (GMT_NOERROR);

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -93,6 +93,8 @@ enum GMT_mp_cols {	/* Index into the extra and ecol_type arrays */
 	MP_COL_N		/* How many extra items there are to choose from */
 };
 
+#define GMT_MP_NNODES	100	/* Default number of points on one polygon side in -We|r+n */
+
 struct MAPPROJECT_CTRL {	/* All control options for this program (except common args) */
 	/* active is true if the option has been activated */
 	bool used[8];	/* Used to keep track of which items are used by -A,G,L,Z */
@@ -157,9 +159,11 @@ struct MAPPROJECT_CTRL {	/* All control options for this program (except common 
 		struct GMT_DATUM from;	/* Contains a, f, xyz[3] */
 		struct GMT_DATUM to;	/* Contains a, f, xyz[3] */
 	} T;
-	struct MAPPROJECT_W {	/* -W[w|h|j<code>|n<rx/ry>|g<lon/lat>|x<x/y>] */
+	struct MAPPROJECT_W {	/* -W[e|E|g<lon/lat>|h|j<code>|n<rx/ry>|o|O|r|R|w|x<x/y>[+n<nx/ny>] */
 		bool active;
+		bool poly;
 		unsigned int mode;	/* See GMT_mp_Wcodes above */
+		unsigned int nx, ny;
 		struct GMT_REFPOINT *refpoint;
 	} W;
 	struct MAPPROJECT_Z {	/* -Z[<speed>][+c][+f][+i][+t<epoch>] */
@@ -200,7 +204,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <table> %s %s [-Ab|B|f|F|o|O[<lon0>/<lat0>][+v]] [-C[<dx></dy>][+m]] [-D%s] "
 		"[-E[<datum>]] [-F[<%s|%s>]] [-G[<lon0>/<lat0>][+a][+i][+u<unit>][+v]] [-I] [-L<table>[+p][+u<unit>]] "
-		"[-N[a|c|g|m]] [-Q[d|e]] [-S] [-T[h]<from>[/<to>]] [%s] [-W[e|E|g|h|j|n|o|O|r|R|w|x]] [-Z[<speed>][+a][+i][+f][+t<epoch>]] "
+		"[-N[a|c|g|m]] [-Q[d|e]] [-S] [-T[h]<from>[/<to>]] [%s] [-W[e|E|g|h|j|n|o|O|r|R|w|x]][+n[<nx>[/<ny]]] [-Z[<speed>][+a][+i][+f][+t<epoch>]] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_DIM_UNITS_DISPLAY, GMT_LEN_UNITS2_DISPLAY, GMT_DIM_UNITS_DISPLAY, GMT_V_OPT,
 		GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_o_OPT, GMT_p_OPT,
@@ -283,9 +287,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"If <from> equals - we use WGS-84.  If /<to> is not given we assume WGS-84. "
 		"Note: -T can be used as pre- or post- (-I) processing for -J -R.");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[e|E|g|h|j|n|o|O|r|R|w|x]");
+	GMT_Usage (API, 1, "\n-W[e|E|g|h|j|n|o|O|r|R|w|x][+n[<nx>[/<ny]]]");
 	GMT_Usage (API, -2, "Print map width and/or height or a reference point. No input files are read. Select optional directive:");
-	GMT_Usage (API, 3, "e: Print oblique <llx>/<lly>/<urx>/<ury>+r coordinates and -R string for rectangular region encompassing the -R -J area.");
+	GMT_Usage (API, 3, "e: Print oblique <llx>/<lly>/<urx>/<ury>+r coordinates for rectangular region encompassing the -R -J area.");
 	GMT_Usage (API, 3, "E: Same as e but prints -Rw/s/e/n+r string as trailing text instead.");
 	GMT_Usage (API, 3, "g: Print map coordinates of reference point <gx/gy>.");
 	GMT_Usage (API, 3, "h: Print map height (See -D for plot units).");
@@ -296,7 +300,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "R: Same as r but prints -Rw/e/s/n string as trailing text instead.");
 	GMT_Usage (API, 3, "w: Print map width (See -D for plot units).");
 	GMT_Usage (API, 3, "x: Print map coordinates of reference point given in plot coordinates <px/py>.");
-	GMT_Usage (API, -2, "Default prints both map width and map height.");
+	GMT_Usage (API, -2, "Note: For -We|r you can use +n[<nx>[/<ny]] to output the enclosing polygon instead "
+		"by giving the number of nodes along the two sides [100]. Default (-W with no args) prints map width and map height.");
 	GMT_Usage (API, 1, "\n-Z[<speed>][+a][+i][+f][+t<epoch>]");
 	GMT_Usage (API, -2, "Compute travel times along track using specified speed. "
 		"Note: Requires -G for setting distance calculations. "
@@ -710,9 +715,22 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 					case 'r': Ctrl->W.mode = GMT_MP_M_REGION; break;
 					case 'R': Ctrl->W.mode = GMT_MP_M_RSTRING; break;
 					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Expected -W[g|h|j|n|o|O|r|R|w|x]\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Expected -W[e|E|g|h|j|n|o|O|r|R|w|x]\n");
 						n_errors++;
 						break;
+				}
+				if ((p = strstr (opt->arg, "+n"))) {	/* Building polygon */
+					if (p[2] == '\0')	/* No args, set default nodes */
+						Ctrl->W.nx = Ctrl->W.ny = GMT_MP_NNODES;
+					else {	/* Scan and assign */
+						n = sscanf (&p[2], "%u/%u", &Ctrl->W.nx, &Ctrl->W.ny);
+						if (n == 1) Ctrl->W.ny = Ctrl->W.nx;
+					}
+					if (!(Ctrl->W.mode == GMT_MP_M_EREGION || Ctrl->W.mode == GMT_MP_M_REGION)) {
+						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Modifier +n is only allowed with directives e or r\n");
+						n_errors++;
+					}
+					Ctrl->W.poly = true;
 				}
 				will_need_RJ = true;	/* Since knowing the dimensions means region and projection */
 				break;
@@ -1002,12 +1020,36 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 
 	if (gmt_M_err_pass (GMT, gmt_proj_setup (GMT, GMT->common.R.wesn), "")) Return (GMT_PROJECTION_ERROR);
 
-	Out = gmt_new_record (GMT, NULL, NULL);
+	if (!Ctrl->W.poly) Out = gmt_new_record (GMT, NULL, NULL);
 
 	if (Ctrl->W.active) {	/* Print map dimensions or reference point and exit */
 		double w_out[4] = {0.0, 0.0, 0.0, 0.0}, x_orig, y_orig;
 		unsigned int wmode = 0, tmode = GMT_COL_FIX_NO_TEXT;
 		char key[3] = {""}, region[GMT_LEN256] = {""};
+
+		if (Ctrl->W.poly) {	/* Must generate a polygon via -We|r+n */
+			uint64_t dim[4] = {1, 1, 2*(Ctrl->W.nx+Ctrl->W.ny-2), 2};
+			double dx, dy;
+			struct GMT_DATASEGMENT *S = NULL;
+			struct GMT_DATASET *D = NULL;
+			if ((D = GMT_Create_Data (API, GMT_IS_DATASET, GMT_IS_POLY, 0, dim, NULL, NULL, 0, 0, NULL)) == NULL)
+				Return (API->error);
+			S = D->table[0]->segment[0];	/* The one and only segment */
+			dx = (GMT->current.proj.rect[XHI] - GMT->current.proj.rect[XLO]) / (Ctrl->W.nx - 1);
+			dy = (GMT->current.proj.rect[YHI] - GMT->current.proj.rect[YLO]) / (Ctrl->W.ny - 1);
+			for (i = k = 0; i < Ctrl->W.nx; i++, k++)	/* min to max along bottom */
+				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XLO]+i*dx, GMT->current.proj.rect[YLO]);
+			for (i = 1; i < Ctrl->W.ny; i++, k++)	/* min to max along right side */
+				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XHI], GMT->current.proj.rect[YLO]+i*dy);
+			for (i = 1; i < Ctrl->W.nx; i++, k++)	/* max to min along top */
+				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XHI]-i*dx, GMT->current.proj.rect[YHI]);
+			for (i = 1; i < Ctrl->W.ny; i++, k++)	/* max to min along left side */
+				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XLO], GMT->current.proj.rect[YHI]-i*dy);
+			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_WRITE_SET, NULL, NULL, D) != GMT_NOERROR)
+				Return (API->error);
+			Return (GMT_NOERROR);
+		}
+
 		switch (Ctrl->W.mode) {
 			case GMT_MP_M_WIDTH:
 				GMT_Report (API, GMT_MSG_INFORMATION, "Reporting map width in %s\n", unit_name);

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1043,8 +1043,9 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XHI], GMT->current.proj.rect[YLO]+i*dy);
 			for (i = 1; i < Ctrl->W.nx; i++, k++)	/* max to min along top */
 				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XHI]-i*dx, GMT->current.proj.rect[YHI]);
-			for (i = 1; i < Ctrl->W.ny; i++, k++)	/* max to min along left side */
+			for (i = 1; i < (Ctrl->W.ny - 1); i++, k++)	/* max to min along left side */
 				gmt_xy_to_geo (GMT, &S->data[GMT_X][k], &S->data[GMT_Y][k], GMT->current.proj.rect[XLO], GMT->current.proj.rect[YHI]-i*dy);
+			S->data[GMT_X][k] = S->data[GMT_X][0];	S->data[GMT_Y][k] = S->data[GMT_Y][0];
 			if (GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_POLY, GMT_WRITE_SET, NULL, NULL, D) != GMT_NOERROR)
 				Return (API->error);
 			Return (GMT_NOERROR);


### PR DESCRIPTION
This PR follows up a bit on the one earlier today (#6669) by adding an optional modifier **+n** to **-We** or **-Wr**.  This combination will build a closed polygon outline of the oblique regions (red lines).  For **-W**r that is the _interior_ oblique region (left) while for **-We** it is the _encompassing_ oblique region (right).  I have then added a documentation figure to **mapproject -W** to explain the purpose of these and why they are different:

![GMT_obl_regions](https://user-images.githubusercontent.com/26473567/166953593-2dcb5abc-f167-4c11-bdcc-306a2fd71667.png)

Note the solid outlines in the figures are simple geographic polygons made of just meridians and parallels so these are never created since GMT can plot these as is (e.g., **plot -Ap**)

Oblique polygon for an oblique projection:

`gmt mapproject -R270/20/305/25+r -JOc280/25.5/22/69/5c -Wr+n > geo.txt`
 
Polygon for a non-oblique projections encompassing polygon:

`gmt mapproject -R-15/60/68/90 -JS36/90/5c -We+n > geo.txt`
