### PR TITLE
Treat tile reading the same for data and intensity in grd2kml

### DIFF
--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -509,7 +509,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 	struct GMT_DATASET *C = NULL;
 	struct GMT_QUADTREE **Q = NULL;
 	struct GRD2KML_CTRL *Ctrl = NULL;
-	struct GMT_GRID *G = NULL, *T = NULL;
+	struct GMT_GRID *G = NULL, *T = NULL, *I = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
 	struct GMT_OPTION *options = NULL;
 	struct GMTAPI_CTRL *API = gmt_get_api_ptr (V_API);	/* Cast from void to GMTAPI_CTRL pointer */
@@ -657,8 +657,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 		sprintf (cmd, "%s -R%.16g/%.16g/%.16g/%.16g -N -G%s", Ctrl->In.file, ext_wesn[XLO], ext_wesn[XHI], ext_wesn[YLO], ext_wesn[YHI], DataGrid);
 		GMT_Report (API, GMT_MSG_INFORMATION, "Extend original data grid to multiple of largest grid spacing\n");
 		if ((error = GMT_Call_Module (API, "grdcut", GMT_MODULE_CMD, cmd)) != GMT_NOERROR) {
-			gmt_M_free (GMT, Q);
-			Return (GMT_RUNTIME_ERROR);
+			error = GMT_RUNTIME_ERROR;	goto end_times;
 		}
 		z_extend = true;	/* We made a temp file we need to zap later */
 		if (Ctrl->I.active) {	/* Also extend the intensity grid */
@@ -666,8 +665,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 			sprintf (cmd, "%s -R%.16g/%.16g/%.16g/%.16g -N -G%s", Ctrl->I.file, ext_wesn[XLO], ext_wesn[XHI], ext_wesn[YLO], ext_wesn[YHI], IntensGrid);
 			GMT_Report (API, GMT_MSG_INFORMATION, "Extend intensity grid to multiple of largest grid spacing\n");
 			if ((error = GMT_Call_Module (API, "grdcut", GMT_MODULE_CMD, cmd)) != GMT_NOERROR) {
-				gmt_M_free (GMT, Q);
-				Return (GMT_RUNTIME_ERROR);
+			error = GMT_RUNTIME_ERROR;	goto end_times;
 			}
 			i_extend = true;	/* We made a temp file we need to zap later */
 		}
@@ -685,12 +683,12 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 		struct GMT_PALETTE *P = NULL;
 		if ((P = gmt_get_palette (GMT, cpt, GMT_CPT_OPTIONAL, G->header->z_min, G->header->z_max, Ctrl->C.dz)) == NULL) {
 			GMT_Report (API, GMT_MSG_ERROR, "Failed to create a CPT\n");
-			Return (API->error);	/* Well, that did not go well... */
+			error = API->error;	goto end_times;	/* Well, that did not go well... */
 		}
 		if (cpt) gmt_M_str_free (cpt);
 		sprintf (cptfile, "%s/grd2kml_%d.cpt", API->tmp_dir, uniq);
 		if (GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, cptfile, P) != GMT_NOERROR) {
-			Return (API->error);
+			error = API->error;	goto end_times;	/* Well, that did not go well... */
 		}
 		Ctrl->C.active = tmp_cpt = true;
 		Ctrl->C.file = strdup (cptfile);
@@ -706,24 +704,20 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 			gmt_set_cartesian (GMT, GMT_IN);
 			if ((error = GMT_Set_Columns (API, GMT_IN, 1, GMT_COL_FIX)) != GMT_NOERROR) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to specify number of columns (1) to read\n");
-				gmt_M_free (GMT, Q);
-				Return (GMT_RUNTIME_ERROR);
+				error = GMT_RUNTIME_ERROR;	goto end_times;
 			}
 			if ((C = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, Ctrl->W.file, NULL)) == NULL) {
-				gmt_M_free (GMT, Q);
-				Return (GMT_RUNTIME_ERROR);
+				error = GMT_RUNTIME_ERROR;	goto end_times;
 			}
 			if (C->n_segments > 1 || C->n_records == 0 || C->table[0]->segment[0]->text == NULL) {
 				GMT_Report (API, GMT_MSG_ERROR, "Contour file has more than one segment, no records at all, or no text\n");
-				gmt_M_free (GMT, Q);
-				Return (GMT_RUNTIME_ERROR);
+				error = GMT_RUNTIME_ERROR;	goto end_times;
 			}
 			S = C->table[0]->segment[0];
 			for (c = 0; c < C->n_records; c++) {	/* Must reformat the records to fit grdcontour requirements */
 				if (S->text[c] == NULL) {
 					GMT_Report (API, GMT_MSG_ERROR, "No text record found\n");
-					gmt_M_free (GMT, Q);
-					Return (GMT_RUNTIME_ERROR);
+					error = GMT_RUNTIME_ERROR;	goto end_times;
 				}
 				sprintf (line, "C %s", S->text[c]);	/* Build the required record format for grdcontour */
 				gmt_M_str_free (S->text[c]);	/* Free previous string */
@@ -739,8 +733,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 			}
 			dim_c[GMT_ROW] = P->n_colors + 1;	/* Number of contours implied by CPT */
 			if ((C = GMT_Create_Data (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_WITH_STRINGS, dim_c, NULL, NULL, 0, 0, NULL)) == NULL) {
-				gmt_M_free (GMT, Q);
-				Return (GMT_RUNTIME_ERROR);
+				error = GMT_RUNTIME_ERROR;	goto end_times;
 			}
 			S = C->table[0]->segment[0];
 			sprintf (line, "C %s", Ctrl->W.file);	/* Build the required record format for grdcontour */
@@ -755,9 +748,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 		}
 		if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_IN|GMT_IS_REFERENCE, C, contour_file) != GMT_NOERROR) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to create virtual file for contours\n");
-			gmt_M_free (GMT, Q);
-			GMT_Destroy_Data (API, &C);
-			Return (GMT_RUNTIME_ERROR);
+			error = GMT_RUNTIME_ERROR;	goto end_times;
 		}
 		strcpy (K, " -K");	/* Since now we must do a contour overlay */
 	}
@@ -790,16 +781,12 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 		if (level < max_level || registration == GMT_GRID_NODE_REG || !doubleAlmostEqual (inc, G->header->inc[GMT_X])) {	/* Filter the data to match level resolution */
 			sprintf (Zgrid, "%s/grd2kml_Z_L%d_tmp_%6.6d.grd", API->tmp_dir, level, uniq);
 			if (grd2kml_coarsen_grid (GMT, level, Ctrl->F.filter, registration, G->header->inc[GMT_X], inc, DataGrid, Zgrid, filt_report)) {
-				gmt_M_free (GMT, Q);
-				if (Ctrl->W.active) GMT_Destroy_Data (API, &C);
-				Return (GMT_RUNTIME_ERROR);
+				error = GMT_RUNTIME_ERROR;	goto end_times;
 			}
 			if (Ctrl->I.active) {	/* Also filter the intensity grid */
 				sprintf (Igrid, "%s/grd2kml_I_L%d_tmp_%6.6d.grd", API->tmp_dir, level, uniq);
 				if (grd2kml_coarsen_grid (GMT, level, Ctrl->F.filter, registration, G->header->inc[GMT_X], inc, IntensGrid, Igrid, filt_report)) {
-					gmt_M_free (GMT, Q);
-					if (Ctrl->W.active) GMT_Destroy_Data (API, &C);
-					Return (GMT_RUNTIME_ERROR);
+					error = GMT_RUNTIME_ERROR;	goto end_times;
 				}
 			}
 		}
@@ -846,9 +833,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 				/* Now we have the current tile region */
 				if ((T = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, wesn, Zgrid, NULL)) == NULL) {
 					GMT_Report (API, GMT_MSG_ERROR, "Unable to read in grid tile!\n");
-					gmt_M_free (GMT, Q);
-					if (Ctrl->W.active) GMT_Destroy_Data (API, &C);
-					Return (API->error);
+					error = GMT_RUNTIME_ERROR;	goto end_times;
 				}
 				/* Determine if we have any non-NaN data points inside this grid */
 				for (trow = n_NaN = 0; trow < T->header->n_rows; trow++) {
@@ -860,13 +845,22 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 				use_tile = (n_NaN < n_NM);
 				im_type = (n_NaN) ? 1 : 0;
 				if (use_tile) {	/* Found data inside this tile, make plot and rasterize (if PostScript) */
-					char z_data[GMT_VF_LEN] = {""}, psfile[PATH_MAX] = {""};
+					char z_data[GMT_VF_LEN] = {""}, i_data[GMT_VF_LEN] = {""}, psfile[PATH_MAX] = {""};
+					if (Ctrl->I.active) {	/* Also get the intensity tile */
+						if ((I = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, wesn, Igrid, NULL)) == NULL) {
+							GMT_Report (API, GMT_MSG_ERROR, "Unable to read in intensity tile!\n");
+							error = GMT_RUNTIME_ERROR;	goto end_times;
+						}
+						/* Open the intensity subset as a virtual file we can pass to grdimage */
+						if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, I, i_data) == GMT_NOTSET) {
+							GMT_Report (API, GMT_MSG_ERROR, "Unable to open intensity tile as virtual file!\n");
+							error = GMT_RUNTIME_ERROR;	goto end_times;
+						}
+					}
 					/* Open the grid subset as a virtual file we can pass to grdimage */
 					if (GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN|GMT_IS_REFERENCE, T, z_data) == GMT_NOTSET) {
 						GMT_Report (API, GMT_MSG_ERROR, "Unable to open grid tile as virtual file!\n");
-						gmt_M_free (GMT, Q);
-						if (Ctrl->W.active) GMT_Destroy_Data (API, &C);
-						Return (API->error);
+						error = GMT_RUNTIME_ERROR;	goto end_times;
 					}
 					/* Will pass -W so grdimage will notify us if there was no valid image data imaged */
 					if (!Ctrl->W.active) {
@@ -877,22 +871,21 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 						else
 							sprintf (imagefile, "%s/R%3.3dC%3.3d.%s", level_dir, row, col, ext[im_type]);
 						if (Ctrl->I.active)	/* Must pass two grids */
-							sprintf (cmd, "%s %s -I%s -R%s/%s/%s/%s -A%s", grdimage, z_data, Igrid, W, E, S, N, imagefile);
+							sprintf (cmd, "%s %s -I%s -R%s/%s/%s/%s -A%s", grdimage, z_data, i_data, W, E, S, N, imagefile);
 						else
 							sprintf (cmd, "%s %s -R%s/%s/%s/%s -A%s", grdimage, z_data, W, E, S, N, imagefile);
 						if (im_type) strcat (cmd, transp);
 						error = GMT_Call_Module (API, "grdimage", GMT_MODULE_CMD, cmd);
 						if (!(error == GMT_NOERROR || error == GMT_IMAGE_NO_DATA)) {
 							GMT_Report (API, GMT_MSG_ERROR, "Unable to create a direct PNG from grid\n");
-							gmt_M_free (GMT, Q);
-							Return (API->error);
+							error = GMT_RUNTIME_ERROR;	goto end_times;
 						}
 					}
 					else {
 						/* Build the grdimage command to make the PostScript plot */
 						sprintf (psfile, "%s/grd2kml_tile_tmp_%6.6d.ps", API->tmp_dir, uniq);
 						if (Ctrl->I.active)	/* Must pass two grids */
-							sprintf (cmd, "%s %s -I%s -R%s/%s/%s/%s ->%s", grdimage, z_data, Igrid, W, E, S, N, psfile);
+							sprintf (cmd, "%s %s -I%s -R%s/%s/%s/%s ->%s", grdimage, z_data, i_data, W, E, S, N, psfile);
 						else
 							sprintf (cmd, "%s %s -R%s/%s/%s/%s ->%s", grdimage, z_data, W, E, S, N, psfile);
 						if (im_type) strcat (cmd, transp);
@@ -903,17 +896,22 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 							GMT_Init_VirtualFile (API, 0, contour_file);	/* Read the same contours again */
 							if ((error = GMT_Call_Module (API, "grdcontour", GMT_MODULE_CMD, cmd))) {
 								GMT_Report (API, GMT_MSG_ERROR, "Unable to overlay contours!\n");
-								gmt_M_free (GMT, Q);
-								GMT_Destroy_Data (API, &C);
-								Return (API->error);
+								error = GMT_RUNTIME_ERROR;	goto end_times;
 							}
 						}
 					}
+					/* Relinquish the tile memory */
 					GMT_Close_VirtualFile (API, z_data);
 					if (GMT_Destroy_Data (API, &T) != GMT_NOERROR) {
 						GMT_Report (API, GMT_MSG_ERROR, "Unable to free memory of grid tile!\n");
-						gmt_M_free (GMT, Q);
-						Return (API->error);
+						error = GMT_RUNTIME_ERROR;	goto end_times;
+					}
+					if (Ctrl->I.active)	{	/* Same for intensity tile */
+						GMT_Close_VirtualFile (API, i_data);
+						if (GMT_Destroy_Data (API, &I) != GMT_NOERROR) {
+							GMT_Report (API, GMT_MSG_ERROR, "Unable to free memory of intensity tile!\n");
+							error = GMT_RUNTIME_ERROR;	goto end_times;
+						}
 					}
 					if (error == GMT_IMAGE_NO_DATA) {	/* Must have found non-NaNs in the pad since the image is all NaN? */
 						GMT_Report (API, GMT_MSG_WARNING, "No image content for current tile (%d, %d, %d) - skipped\n", level, row, col);
@@ -931,8 +929,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 								sprintf (cmd, "%s -T%c -D%s -FR%3.3dC%3.3d %s", ps_cmd, img_code[im_type], level_dir, row, col, psfile);
 							if (GMT_Call_Module (API, "psconvert", GMT_MODULE_CMD, cmd)) {
 								GMT_Report (API, GMT_MSG_ERROR, "Unable to rasterize current PNG tile!\n");
-								gmt_M_free (GMT, Q);
-								Return (API->error);
+								error = GMT_RUNTIME_ERROR;	goto end_times;
 							}
 						}
 						/* Update our list of tiles created */
@@ -1033,7 +1030,7 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 			sprintf (file, "%s/%2.2d/R%3.3dC%3.3d.kml", Ctrl->N.prefix, Q[k]->level, Q[k]->row, Q[k]->col);
 		if ((fp = fopen (file, "w")) == NULL) {
 			GMT_Report (API, GMT_MSG_ERROR, "Unable to create file : %s\n", file);
-			Return (GMT_RUNTIME_ERROR);
+			error = GMT_RUNTIME_ERROR;	goto end_times;
 		}
 		/* First this tile's kml info and image href */
 		minLodPixels = (Q[k]->level == 0) ? 1 : Ctrl->L.size / 2;
@@ -1117,8 +1114,11 @@ EXTERN_MSC int GMT_grd2kml (void *V_API, int mode, void *args) {
 		gmt_M_str_free (Q[k]->region);	/* Free this tile region */
 		gmt_M_free (GMT, Q[k]);		/* Free this tile information */
 	}
-	gmt_M_free (GMT, Q);
 	GMT_Report (API, GMT_MSG_NOTICE, "Done: %d tiles (%d JPG and %d PNG) written to directory %s\n", n_tiles, n_img[0], n_img[1], Ctrl->N.prefix);
 
-	Return (GMT_NOERROR);
+end_times:
+	gmt_M_free (GMT, Q);
+	if (Ctrl->W.active) GMT_Destroy_Data (API, &C);
+
+	Return (error);
 }


### PR DESCRIPTION
See #6587 for background.  The issue had to do with round-off in region coordinates when the data tile was read in via _GMT_Read_Data_ but the intensity was cut out by using the intensity file and **-R**.  This PR now also reads the intensity tile via _GMT_Read_Data_ and hence the rounding (if any) will be the same.

Give this branch a shot, @seungsep.

