### PR TITLE
Add grid sampling as new algorithm to grdfill

### DIFF
--- a/doc/rst/source/grdfill.rst
+++ b/doc/rst/source/grdfill.rst
@@ -49,9 +49,9 @@ Optional Arguments
 **-A**\ **c**\|\ **g**\|\ **n**\|\ **s**\ [*arg*]
     Specify the hole-filling algorithm to use.  Choose among **c** for constant
     fill (and append the constant fill *value*), **g** to sample the (possibly coarser)
-    grid *arg* at the nodes in the holes, **n** for nearest neighbor (and optionally
-    append a search *radius* in pixels [default radius is :math:`r = \sqrt{X^2 + Y^2}`,
-    where (*X,Y*) are the node dimensions of the grid]), or
+    grid *arg* at the nodes making up the holes, **n** for nearest neighbor (and optionally
+    append a search *radius* in pixels [default radius is :math:`r = \sqrt{n^2 + m^2}`,
+    where (*n,m*) are the node dimensions of the grid]), or
     **s** for bicubic spline (optionally append a *tension* parameter [no tension]).
 
 .. _-G:
@@ -119,7 +119,7 @@ To replace all NaN values in the file data.grd with a spline interpolation using
 
     gmt grdfill data.grd -As0.2 -Gno_NaNs_spline_data.grd
 
-To replace all NaN values in the file data.grd by sampling another grid background.grd, try::
+To replace all NaN values in the file data.grd by sampling another grid named background.grd, try::
 
     gmt grdfill data.grd -Agbackground.grd -Gno_NaNs_sampled_data.grd
 

--- a/doc/rst/source/grdfill.rst
+++ b/doc/rst/source/grdfill.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grdfill** *ingrid*
-[ |-A|\ **c**\|\ **n**\|\ **s**\ [*arg*] ]
+[ |-A|\ **c**\|\ **g**\|\ **n**\|\ **s**\ [*arg*] ]
 [ |-G|\ *outgrid* ]
 [ |-L|\ [**p**] ]
 [ |-N|\ *value* ]
@@ -46,9 +46,10 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ **c**\|\ **n**\|\ **s**\ [*arg*]
+**-A**\ **c**\|\ **g**\|\ **n**\|\ **s**\ [*arg*]
     Specify the hole-filling algorithm to use.  Choose among **c** for constant
-    fill (and append the constant fill *value*), **n** for nearest neighbor (and optionally
+    fill (and append the constant fill *value*), **g** to sample the (possibly coarser)
+    grid *arg* at the nodes in the holes, **n** for nearest neighbor (and optionally
     append a search *radius* in pixels [default radius is :math:`r = \sqrt{X^2 + Y^2}`,
     where (*X,Y*) are the node dimensions of the grid]), or
     **s** for bicubic spline (optionally append a *tension* parameter [no tension]).
@@ -117,6 +118,10 @@ nearest non-NaN neighbor, try::
 To replace all NaN values in the file data.grd with a spline interpolation using a tension of 0.2, try::
 
     gmt grdfill data.grd -As0.2 -Gno_NaNs_spline_data.grd
+
+To replace all NaN values in the file data.grd by sampling another grid background.grd, try::
+
+    gmt grdfill data.grd -Agbackground.grd -Gno_NaNs_sampled_data.grd
 
 
 See Also

--- a/src/grdfill.c
+++ b/src/grdfill.c
@@ -110,7 +110,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"No grid fill takes place and -G is ignored. "
 		"Optionally, append p to write polygons corresponding to these regions.");
 	GMT_Usage (API, 1, "\n-N<value>");
-	GMT_Usage (API, -2, "Set alternate node <value> to indicate a on input hole [Default looks for NaN-nodes].");
+	GMT_Usage (API, -2, "Set alternate node <value> to indicate a hole [Default looks for NaN-nodes].");
 	GMT_Option (API, "R,V,f,.");
 
 	return (GMT_MODULE_USAGE);

--- a/src/grdfill.c
+++ b/src/grdfill.c
@@ -37,7 +37,8 @@
 enum GRDFILL_mode {
 	ALG_CONSTANT,
 	ALG_NN,
-	ALG_SPLINE
+	ALG_SPLINE,
+	ALG_GRID
 };
 
 struct GRDFILL_CTRL {
@@ -49,6 +50,7 @@ struct GRDFILL_CTRL {
 		bool active;
 		unsigned int mode;
 		double value;
+		char *file;
 	} A;
 	struct GRDFILL_G {	/* -G<outgrid> */
 		bool active;
@@ -77,6 +79,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDFILL_CTRL *C) {	/* Deallocate control structure */
 	if (!C) return;
 	gmt_M_str_free (C->In.file);
+	gmt_M_str_free (C->A.file);
 	gmt_M_str_free (C->G.file);
 	gmt_M_free (GMT, C);
 }
@@ -84,7 +87,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDFILL_CTRL *C) {	/* Deallo
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s %s [-Ac|n|s[<arg>]] [-G%s] [-L[p]] [-N<value>] [%s] [%s] [%s] [%s]\n",
+	GMT_Usage (API, 0, "usage: %s %s [-Ac|g|n|s[<arg>]] [-G%s] [-L[p]] [-N<value>] [%s] [%s] [%s] [%s]\n",
 		name, GMT_INGRID, GMT_OUTGRID, GMT_Rgeo_OPT, GMT_V_OPT, GMT_f_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -95,6 +98,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-Ac|n|s[<arg>]");
 	GMT_Usage (API, -2, "Specify algorithm and any required parameters for in-fill:");
 	GMT_Usage (API, 3, "c: Fill in NaN holes with the given constant <value>.");
+	GMT_Usage (API, 3, "g: Fill in NaN holes by sampling the gridfile we appended.");
 	GMT_Usage (API, 3, "n: Fill in NaN holes with nearest neighbor values; "
 		"append <max_radius> nodes for the outward search "
 		"[Default radius is sqrt(nx^2+ny^2), with (nx,ny) the dimensions of the grid].");
@@ -143,6 +147,10 @@ static int parse (struct GMT_CTRL *GMT, struct GRDFILL_CTRL *Ctrl, struct GMT_OP
 					case 'c':	/* Constant fill */
 						Ctrl->A.mode = ALG_CONSTANT;
 						Ctrl->A.value = atof (&opt->arg[1]);
+						break;
+					case 'g':	/* Sample a coarser(?) grid */
+						Ctrl->A.mode = ALG_GRID;
+						n_errors += gmt_get_required_file (GMT, &opt->arg[1], opt->option, 0, GMT_IS_GRID, GMT_OUT, GMT_FILE_LOCAL, &(Ctrl->A.file));
 						break;
 					case 'n':	/* Nearest neighbor fill */
 						Ctrl->A.mode = ALG_NN;
@@ -489,7 +497,7 @@ GMT_LOCAL void grdfill_nearest_interp (struct GMT_CTRL *GMT, struct GMT_GRID *In
 EXTERN_MSC int GMT_grdfill (void *V_API, int mode, void *args) {
 	char *ID = NULL, *RG_orig_hist = NULL;
 	int error = 0, RG_id = 0;
-	openmp_int row, col;
+	openmp_int row, col, k;
 	unsigned int hole_number = 0, limit[4], n_nodes;
 	uint64_t node, offset;
 	int64_t off[4];
@@ -557,6 +565,68 @@ EXTERN_MSC int GMT_grdfill (void *V_API, int mode, void *args) {
 		grdfill_nearest_interp (GMT, Grid, New, radius);	/* Perform the NN replacements */
 
 		if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, NULL, Ctrl->G.file, New)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Failed to write output grid!\n");
+			Return (API->error);
+		}
+		Return (GMT_NOERROR);
+	}
+
+	if (Ctrl->A.mode == ALG_GRID) {	/* Basically a grdtrack exercise */
+		/* 1. Create x,y list of NaN locations in the grid
+		 * 2. Call grdtrack with virtual input and virtual output
+		 * 3. Fill in the holes
+		 */
+		uint64_t dim[4] = {0, 0, 0, 0}, n_NaNs = 0, n_alloc = 0;
+		char input[GMT_VF_LEN] = {""}, output[GMT_VF_LEN] = {""}, args[GMT_LEN256] = {""};
+		double *data[3] = {NULL, NULL, NULL};
+		struct GMT_VECTOR *V_in = NULL, *V_out = NULL;
+		struct GMT_GRID *Out = NULL;
+		gmt_M_grd_loop (GMT, Grid, row, col, node) {	/* Build array list of node coordinates where we have NaNs */
+			if (!gmt_M_is_fnan (Grid->data[node])) continue;	/* Not part of a hole */
+			if (n_NaNs >= n_alloc) {
+				if (n_alloc == 0) n_alloc = GMT_INITIAL_MEM_ROW_ALLOC; else n_alloc *= 2;
+				for (k = 0; k < 3; k++) data[k] = gmt_M_memory (GMT, data[k], n_alloc, double);
+			}
+			data[GMT_X][n_NaNs] = Grid->x[col];
+			data[GMT_Y][n_NaNs] = Grid->y[row];
+			n_NaNs++;
+		}
+		for (k = 0; k < 3; k++) data[k] = gmt_M_memory (GMT, data[k], n_NaNs, double);
+		/* Allocate two vector containers for input and output separately */
+		dim[0] = 2;	/* Want two input columns but let length be 0 - this signals that no vector allocations should take place */
+		if ((V_in = GMT_Create_Data (API, GMT_IS_VECTOR, GMT_IS_POINT, 0, dim, NULL, NULL, 0, 0, NULL)) == NULL) Return (API->error);
+		dim[0] = 3;	/* Want three output columns [we will share the first two with input] */
+		if ((V_out = GMT_Create_Data (API, GMT_IS_VECTOR, GMT_IS_POINT, 0, dim, NULL, NULL, 0, 0, NULL)) == NULL) Return (API->error);
+		V_in->n_rows = V_out->n_rows = n_NaNs;	/* Must specify how many input points we have */
+		/* Hook these up to our containers, reusing x,y as both in and out x/y vectors */
+		GMT_Put_Vector (API, V_in,  GMT_X, GMT_DOUBLE, data[GMT_X]);
+		GMT_Put_Vector (API, V_in,  GMT_Y, GMT_DOUBLE, data[GMT_Y]);
+		GMT_Put_Vector (API, V_out, GMT_X, GMT_DOUBLE, data[GMT_X]);
+		GMT_Put_Vector (API, V_out, GMT_Y, GMT_DOUBLE, data[GMT_Y]);
+		GMT_Put_Vector (API, V_out, GMT_Z, GMT_DOUBLE, data[GMT_Z]);
+		if (GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, GMT_IS_POINT, GMT_IN, V_in, input)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Failed to use vectors as a virtual dataset!\n");
+			Return (API->error);
+		}
+		if (GMT_Open_VirtualFile (API, GMT_IS_DATASET|GMT_VIA_VECTOR, GMT_IS_POINT, GMT_OUT, V_out, output)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Failed to use vectors as a virtual dataset!\n");
+			Return (API->error);
+		}
+		sprintf (args, "-G%s %s > %s", Ctrl->A.file, input, output);
+		if (GMT_Call_Module (API, "grdtrack", GMT_MODULE_CMD, args)) {
+			GMT_Report (API, GMT_MSG_ERROR, "Run-time error from grdtrack\n");
+			Return (API->error);
+		}
+		if (gmt_set_outgrid (GMT, Ctrl->In.file, false, 0, Grid, &Out))	/* true if input is a read-only array */
+			gmt_M_memcpy (Out->data, Grid->data, Out->header->size, gmt_grdfloat);	/* First duplicate all */
+		n_NaNs = 0;	/* Rewind and march to the grid again */
+		gmt_M_grd_loop (GMT, Grid, row, col, node) {	/* Replace the values at NaN-nodes */
+			if (!gmt_M_is_fnan (Grid->data[node])) continue;	/* Not part of a hole */
+			Out->data[node] = data[GMT_Z][n_NaNs++];
+		}
+		for (k = 0; k < 3; k++) gmt_M_free (GMT, data[k]);
+
+		if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, NULL, Ctrl->G.file, Out)) {
 			GMT_Report (API, GMT_MSG_ERROR, "Failed to write output grid!\n");
 			Return (API->error);
 		}

--- a/test/baseline/grdfill.dvc
+++ b/test/baseline/grdfill.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1097ac2b404c45fba3227640c1fbe2e3.dir
-  size: 224208
+- md5: 48e0cc1b2594b1f66b7202bd4f372124.dir
+  size: 206049
   nfiles: 5
   path: grdfill

--- a/test/baseline/grdfill.dvc
+++ b/test/baseline/grdfill.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 5d004b0aef990e415fa1ecf49f684d0e.dir
-  size: 168176
-  nfiles: 4
+- md5: 1097ac2b404c45fba3227640c1fbe2e3.dir
+  size: 224208
+  nfiles: 5
   path: grdfill

--- a/test/baseline/grdfill.dvc
+++ b/test/baseline/grdfill.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 48e0cc1b2594b1f66b7202bd4f372124.dir
-  size: 206049
+- md5: 82975536c80c6bb2561c097ea194e345.dir
+  size: 207030
   nfiles: 5
   path: grdfill

--- a/test/grdfill/gridfill.sh
+++ b/test/grdfill/gridfill.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Test the -Ag algorithm in grdfill
+# Pull out a small piece of 6m DEM
+gmt grdcut -R0/10/0/10 @earth_relief_06m -Gdata.grd
+# Make a mask for two holes
+gmt grdmath -Rdata.grd 4 6 SDIST 250 GE 0 NAN 7 1.5 SDIST 100 GE 0 NAN ADD 2 DIV = mask.grd
+# Combine to get data with the holes
+gmt grdmath data.grd mask.grd MUL = holes.grd
+# Try filling in the holes via sampling from a coarser 30m grid
+gmt grdfill holes.grd -Ag@earth_relief_30m -Gnew.grd
+# Compute difference with original
+gmt grdmath data.grd new.grd SUB = diff.grd
+gmt begin gridfill
+	gmt makecpt -Cgeo
+	gmt subplot begin 3x2 -R0/10/0/10 -JQ6c -Fs6c -Sc -Sr -A1+gwhite+r
+		gmt grdimage data.grd -c
+		gmt grdimage mask.grd -c
+		gmt grdimage holes.grd -c
+		gmt grdimage holes.grd -Q -c
+		gmt grdimage new.grd -c
+		gmt grdimage diff.grd -c
+	gmt subplot end
+	gmt colorbar -Baf -DJBC
+gmt end show

--- a/test/grdfill/gridfill.sh
+++ b/test/grdfill/gridfill.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Test the -Ag algorithm in grdfill
-# Pull out a small piece of 6m DEM
-gmt grdcut -R0/10/0/10 @earth_relief_06m -Gdata.grd
+# Pull out a small piece of 20m DEM
+gmt grdcut -R0/10/0/10 @earth_relief_20m -Gdata.grd
 # Make a mask for two holes
 gmt grdmath -Rdata.grd 4 6 SDIST 250 GE 0 NAN 7 1.5 SDIST 100 GE 0 NAN ADD 2 DIV = mask.grd
 # Combine to get data with the holes
 gmt grdmath data.grd mask.grd MUL = holes.grd
-# Try filling in the holes via sampling from a coarser 30m grid
-gmt grdfill holes.grd -Ag@earth_relief_30m -Gnew.grd
+# Try filling in the holes via sampling from a coarser 1d grid
+gmt grdfill holes.grd -Ag@earth_relief_01d -Gnew.grd
 # Compute difference with original
 gmt grdmath data.grd new.grd SUB = diff.grd
 gmt begin gridfill
@@ -18,7 +18,7 @@ gmt begin gridfill
 		gmt grdimage holes.grd -c
 		gmt grdimage holes.grd -Q -c
 		gmt grdimage new.grd -c
-		gmt grdimage diff.grd -c
+		gmt grdimage diff.grd -Cpolar+h0 -c
 	gmt subplot end
 	gmt colorbar -Baf -DJBC
 gmt end show

--- a/test/grdfill/gridfill.sh
+++ b/test/grdfill/gridfill.sh
@@ -1,24 +1,19 @@
 #!/usr/bin/env bash
 # Test the -Ag algorithm in grdfill
+# The commented step are the commands making the file now in the cache
 # Pull out a small piece of 20m DEM
-gmt grdcut -R0/10/0/10 @earth_relief_20m -Gdata.grd
+# gmt grdcut -R0/10/0/10 @earth_relief_20m -Gdata.grd
 # Make a mask for two holes
-gmt grdmath -Rdata.grd 4 6 SDIST 250 GE 0 NAN 7 1.5 SDIST 100 GE 0 NAN ADD 2 DIV = mask.grd
+# gmt grdmath -Rdata.grd 4 6 SDIST 250 GE 0 NAN 7 1.5 SDIST 100 GE 0 NAN ADD 2 DIV = mask.grd
 # Combine to get data with the holes
-gmt grdmath data.grd mask.grd MUL = holes.grd
+# gmt grdmath data.grd mask.grd MUL = earth_relief_20m_holes.grd
 # Try filling in the holes via sampling from a coarser 1d grid
-gmt grdfill holes.grd -Ag@earth_relief_01d -Gnew.grd
-# Compute difference with original
-gmt grdmath data.grd new.grd SUB = diff.grd
 gmt begin gridfill
 	gmt makecpt -Cgeo
-	gmt subplot begin 3x2 -R0/10/0/10 -JQ6c -Fs6c -Sc -Sr -A1+gwhite+r
-		gmt grdimage data.grd -c
-		gmt grdimage mask.grd -c
-		gmt grdimage holes.grd -c
-		gmt grdimage holes.grd -Q -c
+	gmt grdfill @earth_relief_20m_holes.grd -Ag@earth_relief_01d -Gnew.grd
+	gmt subplot begin 2x1 -R0/10/0/10 -JQ10c -Fs10c -Sc -Sr -A1+gwhite+r
+		gmt grdimage earth_relief_20m_holes.grd -c
 		gmt grdimage new.grd -c
-		gmt grdimage diff.grd -Cpolar+h0 -c
 	gmt subplot end
 	gmt colorbar -Baf -DJBC
 gmt end show


### PR DESCRIPTION
This PR introduces **-Ag**_grid_ as a new algorithm, which will sample the given _grid_ at the nodes with NaN in the main input grid.  I have added a test that demonstrates it works well.  I realized this could be useful in working with David Sandwell on trying to speed up his 5760 x 6912 **surface** commands in GMTSAR - this algorithm is a partial answer for filling holes.  Test output looks like this - also exercises Roman numerals in **subplot**:

![gridfill](https://user-images.githubusercontent.com/26473567/167203823-f407a78c-1247-48b9-90e7-b3a000b73c9b.png)

i) original data, ii) mask,iii) masked data, iv) same with image-masking, v) filled grid, vi) differences