### PR TITLE
Improve events documentation

### DIFF
--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -17,7 +17,7 @@ Synopsis
 |SYN_OPT-Rz|
 |-T|\ *now*
 [ *table* ]
-[ |-A|\ **r**\ [*dpu*\ [**c**\|\ **i**][**+z**\ [*z*]]]\|\ **s** ]
+[ |-A|\ **r**\ [*dpu*\ [**c**\|\ **i**][**+v**\ [*value*]]]\|\ **s** ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-D|\ [**j**\|\ **J**]\ *dx*\ [/*dy*][**+v**\ [*pen*]] ]
@@ -26,7 +26,7 @@ Synopsis
 [ |-G|\ *color* ]
 [ |-H|\ *labelbox* ]
 [ |-L|\ [*length*\|\ **t**] ]
-[ |-M|\ **i**\|\ **s**\|\ **t**\|\ **z**\ *val1*\ [**+c**\ *val2*] ]
+[ |-M|\ **i**\|\ **s**\|\ **t**\|\ **v**\ *val1*\ [**+c**\ *val2*] ]
 [ |-N|\ [**c**\|\ **r**] ]
 [ |-Q|\ *prefix* ]
 [ |-S|\ *symbol*\ [*size*] ]
@@ -111,29 +111,34 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ **r**\ [*dpu*\ [**c**\|\ **i**][**+z**\ [*z*]]]\|\ **s**
+**-A**\ **r**\ [*dpu*\ [**c**\|\ **i**][**+v**\ [*value*]]]\|\ **s**
     When no |-S| is given we expect to read lines or polygons.  Two different forms for input are
-    supported and specified via the chosen |-A| directives: (1) Choose **-Ar** if your input data are *trajectories*, the data
-    format is given as *x, y, time*, and the "event" is the portion of that trajectories limited by the current
-    time (*now*), event duration (via |-L|) and rise/fade periods (via **-Es**). If current time falls between
-    two points on the trajectory then we linearly interpolate to find the current end point. Alternatively, (2) choose **-As**
-    to read each complete segment (i.e., a polygon or line with just *x, y* coordinates) from a multisegment
-    file and get a common *time* for each segment via a required **-T**\ *string* specified in the segment
-    header.  Here, the entire polygon or line is the "event" if inside the limits of current time (*now*), event
-    duration (via |-L|) and rise/fade periods (via **-Es**).  If **-L**\ [**t**] is set then the *string*
-    must be either of the format *begin*/*length*\|\ *end* or *begin*,\ *length*\|\ *end*.  Use a comma to
-    separate absolute time specifications, otherwise a slash is also supported. **Note**:
-    Neither lines nor polygons allow for any labels to be placed. Finally, you can use **-Ar**\ *dpu* to
+    supported and specified via the chosen |-A| directives:
+
+    - Choose **-Ar** if your input data are *trajectories* (for more details, see `Trajectories`_), the data
+      format is given as *x, y, time*, and the "event" is the portion of that trajectories limited by the current
+      time (*now*), event duration (via |-L|) and rise/fade periods (via **-Es**). If current time falls between
+      two points on the trajectory then we linearly interpolate to find the current end point.
+    - Choose **-As** to read each complete segment (i.e., a polygon or line with just *x, y* coordinates)
+      from a multisegment file and get a common *time* for each segment via a required **-T**\ *string* specified
+      in the segment header.  Here, the entire polygon or line is the "event" if inside the limits of current time
+      (*now*), event duration (via |-L|) and rise/fade periods (via **-Es**).  If **-L**\ [**t**] is set then the *string*
+      must be either of the format *begin*/*length*\|\ *end* or *begin*,\ *length*\|\ *end*.  Use a comma to
+      separate absolute time specifications, otherwise a slash is also supported.
+
+    **Note**: Neither lines nor polygons allow for any labels to be placed.
+
+    Alternatively, you can use **-Ar**\ *dpu* to
     perform no plotting but instead convert your *x, y*\ [, *zcols* ], *time* data into *densely sampled points* so that
-    later calls to **events** may use this sampled data set instead and plot it as circles with **-Sc**\ [*width*].
+    a later call to **events** may use this sampled data set instead and plot it as circles with **-Sc**\ [*width*].
     This way you can plot "lines" that can have variable pen color and fixed or variable pen width as well as
     taking advantage of the full machinery of **-Es** and **-Et** and all the effects controlled by |-M| for symbols.
-    The *dpu* must match the intended dpu when running :doc:`movie`. Note *dpu* means pixels per cm if you are using
+    The *dpu* must match the intended dpu when running :doc:`movie`. Note that *dpu* means pixels per cm if you are using
     SI units and pixels per inch if you are using US units (hence it depends on your :term:`PROJ_LENGTH_UNIT` setting).
     Alternatively, append **c** or **i** to set the unit used explicitly. Also note that if your movie involves
     changes to the region or the map projection then you may need to run the **-Ar**\ *dpu* as part of the main script.
-    Finally, use **+z**\ [*z*] to insert a *z*-column (initialized to zero unless another *z* value is appended) in
-    the dense point data file for use with **-Mz**.
+    Finally, you can use **+v**\ [*value*] to insert a *z*-column (initialized to zero unless another *z* value is appended) in
+    the dense point data file for use with **-Mv**.
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_
@@ -161,31 +166,39 @@ Optional Arguments
 .. _-E:
 
 **-E**\ [**s**\|\ **t**\ ][**+o**\|\ **O**\ *dt*][**+r**\ *dt*][**+p**\ *dt*][**+d**\ *dt*][**+f**\ *dt*][**+l**\ *dt*]
-    Set the relative time knots for the **s**\ ymbol or **t**\ ext time-functions (see `The four time-functions`_).  Append
-    **+o** to shift the event start and end times by a constant offset (basically shifting
-    the event in time by *dt*\ ; or use **+O** to only shift the start time, effectively shortening
-    the duration of the event), **+r** to indicate the
-    duration of the rise phase, **+p** to set the duration of the plateau phase, **+d**
-    to specify the duration of the decay phase, and **+f** to set the duration of the
-    fade phase.  These are all optional [and default to zero], and can be set separately for symbols and texts.
-    If neither **s** or **t** is given then we set the time knots for both features. **Note 1**: The **+l** modifier is
-    restricted to **-Et** and specifies an alternative duration (visibility) of the text [same duration as symbol].
-    Furthermore, the **+p** and **+d** periods do not apply to text labels.  **Note 2**: The **-Et** option is
-    required if you wish to plot labels [plot symbols only].  **Note 3**: For lines or polygons the **+p**
-    and **+d** periods do not apply, and for lines none of the modifiers are allowed.
+    Set the relative time knots for the **s**\ ymbol or **t**\ ext time-functions (see `The four time-functions`_) via
+    these modifiers:
+
+    - **+o** will shift both the event start and end times by a constant offset (basically delaying
+      the event in time by *dt*.
+    - **+O** is similar to **+o** but will only shift the start time, effectively shortening
+      the duration of the event).
+    - **+l** specifies an alternative duration (visibility) of the text (**-Et** only) [same duration as symbol].
+    - **+r** sets the duration of the rise phase.
+    - **+p** sets the duration of the plateau phase.
+    - **+d** sets the duration of the decay phase.
+    - **+f** sets the duration of the fade phase.
+
+    These are all optional [and default to zero], and can be set separately for symbols and texts.
+    If neither the **s** or **t** directive is given then we set the time knots for both features.
+    **Note 1**: The **+p** and **+d** periods do not apply to text labels, lines or polygons.
+    **Note 2**: The **-Et** option is required if you wish to plot labels [Default plots symbols only].
+    **Note 3**: None of the modifiers are allowed for lines.
 
 .. _-F:
 
 **-F**\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+r**\ [*first*]\|\ **z**\ [*format*]]
-    By default, event label text will be placed horizontally, using the primary
-    annotation font attributes (:term:`FONT_ANNOT_PRIMARY`), and centered
-    on the data point. Use this option to override these defaults by specifying up to three
-    text attributes (font, angle, and justification) directly on the command line. Use **+f**
-    to set the font (size,fontname,color), **+a** to set the angle, and **+j** to set the justification.
-    Normally, the text to be plotted is the trailing text.  Instead, use **+r** to use the
-    record number (counting up from *first* [0]) or **+z** to format incoming *z* values (requires |-C|)
-    to a string using the supplied *format* [use :term:`FORMAT_FLOAT_MAP`].
+    By default, event label text will be placed horizontally, using the primary annotation font
+    attributes, and centered on the data point. Normally, the text to be plotted is the trailing text.
+    Use this option's modifiers to override these defaults by specifying alternative attributes:
 
+    - **+f** sets the font (size,fontname,color) [:term:`FONT_ANNOT_PRIMARY`].
+    - **+a** sets the angle of the baseline relative to the horizontal [0].
+    - **+j** sets the justification of the label relative to the coordinates given [CM].
+    - **+r** will use the record number (counting up from *first* [0]) as the text label.
+    - **+z** will format incoming *z* value and use it as the text label (requires |-C| and
+      the optional *format* [:term:`FORMAT_FLOAT_MAP`]).
+   
 .. _-G:
 
 **-G**\ *fill* :ref:`(more ...) <-Gfill_attrib>`
@@ -195,13 +208,14 @@ Optional Arguments
 
 **-H**\ [**+c**\ *dx*/*dy*][**+g**\ *fill*][**+p**\ [*pen*]][**+r**][**+s**\ [[*dx*/*dy*/][*shade*]]]
     Enable bounding boxes around text labels and provide one or more of these specific parameters:
-    Add **+c** to adjust the clearance between the text and the surrounding box [15% of font size].
-    Add **+p** to draw the box outline with :term:`MAP_DEFAULT_PEN` or append a different pen.
-    Add **+g**\ *fill* to fill the text box [no fill].
-    Append **+r** to use a rounded rectangular box instead of straight rectangular box.
-    Append **+s** to place an offset, background shaded box behind the text box. Here, *dx*/*dy*
-    indicates the shift relative to the foreground text box [4\ **p**/-4\ **p**] and *shade* changes
-    the fill used for shading [gray50]. **Note**: Modifier **+s** requires **+g** as well.
+
+    - **+c** adjusts the clearance between the text and the surrounding box [15% of font size].
+    - **+g**\ *fill* will fill the text box [no fill].
+    - **+p** draws the box outline with :term:`MAP_DEFAULT_PEN` or append a different pen.
+    - **+r** will use a rounded rectangular box [straight rectangular box].
+    - **+s** places an offset, background shaded box behind the text box. Here, *dx*/*dy*
+      indicates the shift relative to the foreground text box [4\ **p**/-4\ **p**] and *shade* changes
+      the fill used for shading [gray50]. **Note**: Modifier **+s** requires **+g** as well.
 
 .. include:: explain_-Jz.rst_
 
@@ -216,25 +230,34 @@ Optional Arguments
 
 .. _-M:
 
-**-M**\ **i**\|\ **s**\|\ **t**\|\ **z**\ *val1*\ [**+c**\ *val2*]
+**-M**\ **i**\|\ **s**\|\ **t**\|\ **v**\ *val1*\ [**+c**\ *val2*]
 
-    Controls how each symbol's four attributes should change from when the symbol first appears,
-    during its active duration, and optionally its fate as time moves past its end time.
-    Modify the initial **i**\ ntensity of the color, the **s**\ ize of the symbol, its **t**\ ransparency
-    or the **z** data value (to change symbol color via CPT lookup) during the *rise* interval.
-    [Defaults for these four attributes are 1, 1, 100, and 0 respectively].  These values all represent
-    maximum amplitudes that is scaled by the corresponding time-function created by **-Es** (see `The four time-functions`_).
-    Option |-M| is repeatable for the different attributes. Optionally, for finite-duration events
-    (that should remain visible for all times after their event time has been reached) you
-    may append **+c** to set the corresponding terminal value during the coda [Defaults are 0, 0, 100 and 0, 
-    respectively, meaning the symbols are not plotted unless you change these attributes with one or more **+c** modifiers].
-    The intensity setting (**i**\ ; normally with *val1* in the range ±1, with 0 having no effect) is used to brighten
-    (*val1* > 0) or darken (*val1* < 0) the symbol color during this period (the hue is kept fixed).
-    The size setting (**s**) is a magnifying factor that temporarily changes the size of the symbol by the factor *val1*.
-    The transparency setting (**t**) affects temporary changes to the symbol's transparency. Finally, the  z-data setting
-    (**z**) temporarily adds *val1* to the data set's *z*-values, scaled by the corresponding time function, and thus
-    can change the symbol's *color* via the CPT (hence |-C| is a required option for **-Mz**).
-    **Note**: Polygons can only use **-Mt** setting.
+    Controls how each symbol's four attributes (**i**\ ntensity, **s**\ ize, **t**\ ransparency, and **v**\ alue)
+    should change from when the symbol first appears, during its active duration, and optionally its fate as time
+    moves past its end time. First supply the directive [default *val1* values are given in brackets]:
+
+    - **i** will modify the intensity of the color [1].
+    - **s** will modify the relative size of the symbol [1].
+    - **t** will modify the transparency [100].
+    - **v** will modify the data value (to change symbol color via CPT lookup) during the *rise* interval [0].
+
+    The appended *val1* represents the maximum amplitude that is scaled by the corresponding time-function
+    created by **-Es** (see `The four time-functions`_). Option |-M| is repeatable for the different directives;
+    here are some further guidelines:
+
+    - The intensity directive (**i**\ ; normally with *val1* in the range ±1, with 0 having no effect) is used to brighten
+      (*val1* > 0) or darken (*val1* < 0) the symbol color during this period (the hue is kept fixed).
+    - The size directive (**s**) is a magnifying factor that temporarily changes the size of the symbol by the factor *val1*.
+    - The transparency directive (**t**) affects temporary changes to the symbol's transparency.
+    - The value directive (**v**) temporarily adds *val1* to the data set's *z*-values, scaled by the corresponding time
+      function, and thus can change the symbol's *color* via the CPT (hence |-C| is a required option for **-Mv**).
+
+    Optionally, for finite-duration events that should remain visible for all times *after* their event end time has
+    been reached you must append **+c** (for coda) to set the corresponding terminal value during the coda. If **+c**
+    is not given then the defaults are 0 (intensity), 0 (size), 100 (transparency) and 0 (value), meaning the symbols
+    are not plotted unless you change these attributes with one or more **+c** modifiers (one per directive). 
+
+   **Note**: Polygons can only use **-Mt** setting.
 
 .. _-N:
 
@@ -300,10 +323,10 @@ Optional Arguments
     not use the |-I| or **-t** options since these will be set automatically
     as part of the variations imposed by **-Mi** and **-Mt**.  As an example, the
     custom command to plot a beachball may be **-Z**\ "meca -Sa5c+f0", while
-    displaying a crossection of one may require the more elaborate command
+    displaying beachballs in a crossection may require the more elaborate command
     **-Z**\ "coupe -Q -L -Sc3c -Ab128/11/120/250/90/400/0/100+f -Fa0.1i/cc".
     **Note**: If you are running a simple classic command then you must use
-    classic module names.
+    the corresponding classic module names.
 
 .. include:: explain_-aspatial.rst_
 
@@ -405,7 +428,7 @@ Figure below illustrates how transparency may vary through time.
 Finally, instead of selecting a fixed color for a symbol you can use |-C| to set a
 color table that we will use to modulate the color of the symbol.  It is done by adding
 a variable fraction of *dz* to the data's *z*-column and hence the CPT lookup will
-return different colors at different times. The amplitude is controlled with the **-Mz**
+return different colors at different times. The amplitude is controlled with the **-Mv**
 option which will create *dz* values in the range 0-*val1* [Default is 0-1]. In most
 cases the data set will have a zero z-value and hence the CPT will be set up for the
 0-1 range (but note that the coda *val2* value may be negative so compose your CPT
@@ -447,6 +470,8 @@ While only the events that should be visible will be plotted at the given time s
 the order of plotting is simply given by the order of records in the file.  Thus, if the
 file is *not* sorted into ascending time then later events might plot *beneath* earlier events.
 To prevent this, you can sort your file into ascending order via the :doc:`gmtconvert` |-N| option.
+
+.. _Trajectories:
 
 Drawing trajectories
 --------------------

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -69,12 +69,12 @@ enum Psevent {	/* Misc. named array indices */
 /* Control structure for psevents */
 
 struct PSEVENTS_CTRL {
-	struct PSEVENTS_A {	/* 	-Ar[<dpu>[+z]]|s */
+	struct PSEVENTS_A {	/* 	-Ar[<dpu>[+v<value>]]|s */
 		bool active;
-		bool add_z;
+		bool add_value;
 		unsigned int mode;
 		double dpu;		/* For resampling lines into points */
-		double z;		/* For adding z column */
+		double value;	/* For adding z column */
 	} A;
 	struct PSEVENTS_C {	/* 	-C<cpt> */
 		bool active;
@@ -112,7 +112,7 @@ struct PSEVENTS_CTRL {
 		unsigned int mode;
 		double length;
 	} L;
-	struct PSEVENTS_M {	/* 	-M[i|s|t*z]<val1>[+c<val2] */
+	struct PSEVENTS_M {	/* 	-M[i|s|t|v]<val1>[+c<val2] */
 		bool active[4];
 		double value[4][2];
 	} M;
@@ -158,9 +158,9 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 	C->H.soff[GMT_X] = GMT->session.u2u[GMT_PT][GMT_INCH] * GMT_FRAME_CLEARANCE;	/* Default is 4p */
 	C->H.soff[GMT_Y] = -C->H.soff[GMT_X];	/* Set the shadow offsets [default is (4p, -4p)] */
 	strcpy (C->H.pen, gmt_putpen (GMT, &GMT->current.setting.map_default_pen));	/* Default outline pen */
-	/* -Mi|s|t|z val1 defaults: 1, 1, 100, 1  val2 defaults: 0, 0, 100, 0 */
+	/* -Mi|s|t|v val1 defaults: 1, 1, 100, 1  val2 defaults: 0, 0, 100, 0 */
 	C->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL1] = C->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL2] = 100.0;	/* Rise from and fade to invisibility */
-	C->M.value[PSEVENTS_SIZE][PSEVENTS_VAL1]   = C->M.value[PSEVENTS_DZ][PSEVENTS_VAL1] = 1.0;	/* Default size scale for -Ms and dz amplitude for -Mz */
+	C->M.value[PSEVENTS_SIZE][PSEVENTS_VAL1]   = C->M.value[PSEVENTS_DZ][PSEVENTS_VAL1] = 1.0;	/* Default size scale for -Ms and dz amplitude for -Mv */
 	return (C);
 }
 
@@ -182,9 +182,9 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *C) {	/* Deall
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<table>] %s %s -T<now> [-Ar[<dpu>[c|i][+z[<z>]]]|s] [%s] [-C<cpt>] [-D[j|J]<dx>[/<dy>][+v[<pen>]]] "
+	GMT_Usage (API, 0, "usage: %s [<table>] %s %s -T<now> [-Ar[<dpu>[c|i][+v[<value>]]]|s] [%s] [-C<cpt>] [-D[j|J]<dx>[/<dy>][+v[<pen>]]] "
 		"[-E[s|t][+o|O<dt>][+r<dt>][+p<dt>][+d<dt>][+f<dt>][+l<dt>]] [-F[+a<angle>][+f<font>][+r[<first>]|+z[<fmt>]][+j<justify>]] "
-		"[-G<fill>] [-H<labelinfo>] [-L[t|<length>]] [-Mi|s|t|z<val1>[+c<val2]] [-N[c|r]] [-Q<prefix>] [-S<symbol>[<size>]] [%s] [%s] [-W[<pen>]] [%s] [%s] [-Z\"<command>\"] "
+		"[-G<fill>] [-H<labelinfo>] [-L[t|<length>]] [-Mi|s|t|v<val1>[+c<val2]] [-N[c|r]] [-Q<prefix>] [-S<symbol>[<size>]] [%s] [%s] [-W[<pen>]] [%s] [%s] [-Z\"<command>\"] "
 		"[%s] [%s] %s[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n", name, GMT_J_OPT, GMT_Rgeoz_OPT, GMT_B_OPT, GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, GMT_a_OPT, GMT_b_OPT,
 		API->c_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_l_OPT, GMT_qi_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -197,14 +197,14 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Option (API, "<");
 	GMT_Usage (API, -2, "Record format: lon lat [z] [size] time [length|time2].");
-	GMT_Usage (API, 1, "\n-Ar[<dpu>[c|i][+z[<z>]]]|s");
+	GMT_Usage (API, 1, "\n-Ar[<dpu>[c|i][+v[<value>]]]|s");
 	GMT_Usage (API, -2, "Select plotting of lines or polygons when no -S is given.  Choose input mode:");
 	GMT_Usage (API, 3, "r: Read records for trajectories with time in column 3. We linearly interpolate any end points.  Alternatively, "
 		"append <dpu> to convert your line records into dense point records that can be plotted as circles later. "
 		"The resampled line will be written to standard output (requires options -R -J, optionally -C). "
 		"The <dpu> must be the same as the intended <dpu> for the movie frames. "
 		"Append i if dpi and c if dpc [Default will consult GMT_LENGTH_UNIT setting, currently %s]. "
-		"Optionally, append +z[<z>] to insert a z-column into the point data with values <z> [0].", API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
+		"Optionally, append +v[<value>] to insert a z-column into the point data with values <z> [0].", API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
 	GMT_Usage (API, 3, "s: Read whole segments (lines or polygons) with no time column. n"
 		"Time is set via segment header -T<start>, -T<start>,<end>, or -T<start>,<duration (see -L).");
 	GMT_Usage (API, 1, "\n-C<cpt>");
@@ -248,8 +248,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Set finite length of events, otherwise we assume they are all infinite. "
 		"If no arg we read lengths from file; append t for reading end times instead. "
 		"If -L0 is given the event only lasts one frame.");
-	GMT_Usage (API, 1, "\n-Mi|s|t|z<val1>[+c<val2]");
-	GMT_Usage (API, -2, "Append i for intensity, s for size, t for transparency, and z for dz (requires -C); repeatable. "
+	GMT_Usage (API, 1, "\n-Mi|s|t|v<val1>[+c<val2]");
+	GMT_Usage (API, -2, "Append i for intensity, s for size, t for transparency, and v for dz (requires -C); repeatable. "
 		"Append value to use during rise, plateau, or decay phases. "
 		"Append +c to set a separate terminal value for the coda [no coda].");
 	GMT_Usage (API, 1, "\n-N[c|r]");
@@ -302,10 +302,10 @@ static int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GMT_O
 				switch (opt->arg[0]) {
 					case 'r':	/* Expects Ar[<dpu>[c|i]] */
 						if (opt->arg[1]) {	/* Want to convert a line to points */
-							if ((c = strstr (opt->arg, "+z"))) {
-								Ctrl->A.add_z = true;
-								Ctrl->A.z = atof (&c[2]);
-								c[0] = '\0';	/* Temporarily chop off */
+							if ((c = strstr (opt->arg, "+v")) || (c = strstr (opt->arg, "+z"))) {	/* Backwards for +z */
+								Ctrl->A.add_value = true;
+								if (c[2]) Ctrl->A.value = atof (&c[2]);	/* Default is 0 */
+								c[0] = '\0';	/* Temporarily chop off modifier */
 							}
 							if ((Ctrl->A.dpu = atof (&opt->arg[1])) > 0.0) {
 								char unit = opt->arg[strlen(opt->arg)-1];	/* This is either c, i, or a digit, or a bad entry */
@@ -467,7 +467,7 @@ maybe_set_two:
 					case 'i':	id = PSEVENTS_INT;		k = 1;	break;	/* Intensity settings */
 					case 's':	id = PSEVENTS_SIZE;		k = 1;	break;	/* Size settings */
 					case 't':	id = PSEVENTS_TRANSP;	k = 1;	break;	/* Transparency settings */
-					case 'z':	id = PSEVENTS_DZ;		k = 1;	break;	/* Delta z settings */
+					case 'v':	case 'z':	id = PSEVENTS_DZ;		k = 1;	break;	/* Delta value settings (backwards compatibility for -Mz) */
 					default:
 						GMT_Report (API, GMT_MSG_ERROR, "Option -M: Directive %c not valid\n", opt->arg[1]);
 						n_errors++;
@@ -618,7 +618,7 @@ maybe_set_two:
 		n_errors += gmt_M_check_condition (GMT, Ctrl->W.active, "Option -W: Not allowed with -Ar<dpu>.\n");
 		n_errors += gmt_M_check_condition (GMT, GMT->current.setting.proj_length_unit == GMT_PT, "PROJ_LENGTH_UNIT: Must be either cm or inch for -Ar<dpu> to work.\n");
 	}
-	n_errors += gmt_M_check_condition (GMT, !Ctrl->C.active && Ctrl->M.active[PSEVENTS_DZ], "Option -Mz: Requires -C");
+	n_errors += gmt_M_check_condition (GMT, !Ctrl->C.active && Ctrl->M.active[PSEVENTS_DZ], "Option -Mv: Requires -C");
 	n_errors += gmt_M_check_condition (GMT, !gmt_M_is_zero (Ctrl->E.dt[PSEVENTS_TEXT][PSEVENTS_DECAY]), "Option -Et: No decay phase for labels.\n");
 	n_errors += gmt_M_check_condition (GMT, !gmt_M_is_zero (Ctrl->E.dt[PSEVENTS_TEXT][PSEVENTS_PLATEAU]), "Option -Et: No plateau phase for labels.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->F.active && Ctrl->F.string == NULL, "Option -F: No argument given\n");
@@ -859,18 +859,18 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "Your line data must (a) have more than 1 record and (2) have at least 3 data columns (x,y[,z][,size],time).\n");
 			Return (API->error);
 		}
-		if (Ctrl->A.add_z) {	/* Must insert a zero z-column into this dataset for use with -Mz */
+		if (Ctrl->A.add_value) {	/* Must insert a zero z-column into this dataset for use with -Mv */
 			gmt_adjust_dataset (GMT, D, D->n_columns + 1);
 			for (tbl = 0; tbl < D->n_tables; tbl++) {	/* Shuffle the columns one step to the right */
 				for (seg = 0; seg < D->table[tbl]->n_segments; seg++) {
 					S = D->table[tbl]->segment[seg];
 					for (col = D->n_columns - 1; col > GMT_Z; col--)
 						gmt_M_memcpy (S->data[col], S->data[col-1], S->n_rows, double);
-					if (gmt_M_is_zero (Ctrl->A.z))	/* Set z-column to zero */
+					if (gmt_M_is_zero (Ctrl->A.value))	/* Set z-column to zero */
 						gmt_M_memset (S->data[GMT_Z], S->n_rows, double);
 					else {	/* Must assign non-zero value */
 						for (row = 0; row < S->n_rows; row++)
-							S->data[GMT_Z][row] = Ctrl->A.z;
+							S->data[GMT_Z][row] = Ctrl->A.value;
 					}
 				}
 			}


### PR DESCRIPTION
As for movie (#6683), this PR breaks up the long paragraphs for some options with bullet lists for each directive or modifier.
Also, given name of directives and shorthands I decided to change **-Mz** to **-Mv** since we refer to _value_.  The change is backwards compatible as I will look for both **-Mz** and **-Mv** for the same thing, as well as **+z** and **+v** in the **-A** option.
