### PR TITLE
Fix wrong pen for contour legends

### DIFF
--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -1437,8 +1437,10 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 				gmt_strlshift (copy.label, (size_t)(p - GMT->common.l.item.label)+1);	/* Remove the leading annotated contour label first */
 				gmt_add_legend_item (API, NULL, false, NULL, true, &(Ctrl->W.pen[PEN_CONT]), &copy);	/* Place the second regular contour entry */
 			}
-			else	/* Got a single entry for annotated contours */
+			else if (Ctrl->A.active)	/* Got a single entry for annotated contours */
 				gmt_add_legend_item (API, NULL, false, NULL, true, &(Ctrl->W.pen[PEN_ANNOT]), &(GMT->common.l.item));
+			else	/* Got a single entry for plain contours */
+				gmt_add_legend_item (API, NULL, false, NULL, true, &(Ctrl->W.pen[PEN_CONT]), &(GMT->common.l.item));
 		}
 	}
 

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -1128,8 +1128,10 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 				gmt_strlshift (copy.label, (size_t)(p - GMT->common.l.item.label)+1);	/* Remove the leading annotated contour label first */
 				gmt_add_legend_item (API, NULL, false, NULL, true, &(Ctrl->W.pen[PEN_CONT]), &copy);	/* Place the second regular contour entry */
 			}
-			else	/* Got a single entry for annotated contours */
+			else if (Ctrl->A.active)	/* Got a single entry for annotated contours */
 				gmt_add_legend_item (API, NULL, false, NULL, true, &(Ctrl->W.pen[PEN_ANNOT]), &(GMT->common.l.item));
+			else	/* Got a single entry for plain contours */
+				gmt_add_legend_item (API, NULL, false, NULL, true, &(Ctrl->W.pen[PEN_CONT]), &(GMT->common.l.item));
 		}
 	}
 


### PR DESCRIPTION
The auto-legend code for **grdcontour** and **pscontour** made an assumption that if only one label was given then it was for the annotated contour.  But if the user only sets` -C10 -Wc0.5p,red `we want to see a red pen since **-A** was not specified.  This PR fixes this problem.  No tests were affected.
