### PR TITLE
Add GMT version badges for some package managers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,6 +3,7 @@
 [![GitHub release](https://img.shields.io/github/release/GenericMappingTools/gmt)](https://github.com/GenericMappingTools/gmt/releases)
 ![Ubuntu package](https://img.shields.io/ubuntu/v/gmt)
 ![Debian package](https://img.shields.io/debian/v/gmt)
+![Fedora package](https://img.shields.io/fedora/v/GMT)
 ![homebrew version](https://img.shields.io/homebrew/v/gmt)
 ![Conda](https://img.shields.io/conda/v/conda-forge/gmt)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,9 +1,9 @@
 # Installing GMT
 
 [![GitHub release](https://img.shields.io/github/release/GenericMappingTools/gmt)](https://github.com/GenericMappingTools/gmt/releases)
-![homebrew version](https://img.shields.io/homebrew/v/gmt)
 ![Ubuntu package](https://img.shields.io/ubuntu/v/gmt)
 ![Debian package](https://img.shields.io/debian/v/gmt)
+![homebrew version](https://img.shields.io/homebrew/v/gmt)
 ![Conda](https://img.shields.io/conda/v/conda-forge/gmt)
 
 GMT is available on Windows, macOS, Linux and FreeBSD.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,10 @@
 # Installing GMT
 
 [![GitHub release](https://img.shields.io/github/release/GenericMappingTools/gmt)](https://github.com/GenericMappingTools/gmt/releases)
+![homebrew version](https://img.shields.io/homebrew/v/gmt)
+![Ubuntu package](https://img.shields.io/ubuntu/v/gmt)
+![Debian package](https://img.shields.io/debian/v/gmt)
+![Conda](https://img.shields.io/conda/v/conda-forge/gmt)
 
 GMT is available on Windows, macOS, Linux and FreeBSD.
 Source and binary packages are provided for the latest release,


### PR DESCRIPTION
**Description of proposed changes**

Add version badges for Ubuntu, Debian, Homebrew and conda, so that we know which platforms provide the latest GMT version.

Preview:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/3974108/167347812-f54ad411-0e6d-43a9-a96e-b589c4e747ab.png">
