### PR TITLE
Using basemap -D in modern mode shall yield an error

### DIFF
--- a/src/psbasemap.c
+++ b/src/psbasemap.c
@@ -163,7 +163,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSBASEMAP_CTRL *Ctrl, struct GMT_
 					n_errors += gmt_getinset (GMT, 'D', opt->arg, &Ctrl->D.inset);
 				}
 				else {
-					GMT_Report (API, GMT_MSG_COMPAT, "Option -D is not available in modern mode - see inset instead\n");
+					GMT_Report (API, GMT_MSG_ERROR, "Option -D is not available in modern mode - see inset instead\n");
 					n_errors++;
 				}
 				break;


### PR DESCRIPTION
In modern mode one should use **gmt inset** and there is no good way to pretend a classic option should somehow call **inset** within **basemap**.
