### PR TITLE
Add a function for reading triangle indices

### DIFF
--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -410,6 +410,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, uint64_t n, int **link);
 EXTERN_MSC unsigned int gmt_get_no_argument (struct GMT_CTRL *GMT, char *text, char option, char modifier);
 EXTERN_MSC unsigned int gmt_get_required_uint64 (struct GMT_CTRL *GMT, char *text, char option, char modifier, uint64_t *value);
 EXTERN_MSC unsigned int gmt_get_required_uint (struct GMT_CTRL *GMT, char *text, char option, char modifier, unsigned int *value);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4194,7 +4194,7 @@ int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, u
 	}
 	GMT_Report (API, GMT_MSG_INFORMATION, "Read %d triplets of triangulation indices from %s.\n", np, file);
 	if (n_skipped) GMT_Report (API, GMT_MSG_WARNING, "Found %d indices triplets exceeding range of known vertices - skipped.\n", n_skipped);
-	if (n_bad) GMT_Report (API, GMT_MSG_WARNING, "Found %d indices triplets with negative indices - skipped.\n", n_bad);
+	if (n_bad) GMT_Report (API, GMT_MSG_WARNING, "Found %d triplets with negative indices - skipped.\n", n_bad);
 
 	*link = ind;	/* Pass the array back out */
 	return (np);	/* Number of triplets returned */


### PR DESCRIPTION
With **contour -E**_file_ we can read previously generated Delaunay triangle indices tables.  As we plan to add that option to other modules I have moved the relevant code section from _pscontour.c_ to create a new function _gmt_read_triangulation_ which is now called in **contour**.  Tests pass, and all is well.  Future PRs will use this functions in other contexts.

