### PR TITLE
Let triangulate also have ability to read prior triangulation

### DIFF
--- a/doc/rst/source/contour.rst
+++ b/doc/rst/source/contour.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |SYN_OPT-B| ]
 [ |-C|\ *contours* ]
 [ |-D|\ [*template*] ]
-[ |-E|\ *indexfile* ]
+[ |-E|\ *indexfile*\ [**+b**] ]
 [ |-G|\ [**d**\|\ **f**\|\ **n**\|\ **l**\|\ **L**\|\ **x**\|\ **X**]\ *params* ]
 [ |-I| ]
 [ |-J|\ **z**\|\ **Z**\ *parameters* ]
@@ -152,10 +152,13 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *indexfile*
+**-E**\ *indexfile*\ [**+b**]
     Give name of file with network information. Each record must contain
     triplets of node numbers for a triangle [Default computes these
-    using Delaunay triangulation (see :doc:`triangulate`)].
+    using Delaunay triangulation (see :doc:`triangulate`)]. If the
+    *indexfile* is binary and can be read the same way as the binary
+    input *table* then you can append **+b** to spead up the reading
+    [Default reads nodes as ASCII].
 
 .. _-G:
 

--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -20,6 +20,7 @@ Synopsis
 [ |-G|\ *outgrid* ]
 [ |SYN_OPT-I| ]
 [ |-J|\ *parameters* ]
+[ |-L|\ *indexfile*\ [**+b**] ]
 [ |-M| ]
 [ |-N| ]
 [ |-Q|\ [**n**] ]
@@ -126,6 +127,15 @@ Optional Arguments
 .. include:: explain_-J.rst_
     :start-after: **Syntax**
     :end-before: **Description**
+
+.. _-L:
+
+**-L**\ *indexfile*\ [**+b**]
+    Give name of file with previously computed Delaunay information. Each record must contain
+    triplets of node numbers for a triangle in the input *table* [Default computes these
+    using Delaunay triangulation]. If the *indexfile* is binary and can be read the same way
+    as the binary input *table* then you can append **+b** to spead up the reading
+    [Default reads nodes as ASCII].
 
 .. _-M:
 

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -410,6 +410,10 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+<<<<<<< Updated upstream
+=======
+EXTERN_MSC int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, uint64_t n, bool binary, int **link);
+>>>>>>> Stashed changes
 EXTERN_MSC unsigned int gmt_get_no_argument (struct GMT_CTRL *GMT, char *text, char option, char modifier);
 EXTERN_MSC unsigned int gmt_get_required_uint64 (struct GMT_CTRL *GMT, char *text, char option, char modifier, uint64_t *value);
 EXTERN_MSC unsigned int gmt_get_required_uint (struct GMT_CTRL *GMT, char *text, char option, char modifier, unsigned int *value);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -410,7 +410,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
-EXTERN_MSC int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, uint64_t n, bool binary, int **link);
+EXTERN_MSC int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, bool binary, uint64_t n, int **link);
 EXTERN_MSC unsigned int gmt_get_no_argument (struct GMT_CTRL *GMT, char *text, char option, char modifier);
 EXTERN_MSC unsigned int gmt_get_required_uint64 (struct GMT_CTRL *GMT, char *text, char option, char modifier, uint64_t *value);
 EXTERN_MSC unsigned int gmt_get_required_uint (struct GMT_CTRL *GMT, char *text, char option, char modifier, unsigned int *value);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4144,6 +4144,71 @@ GMT_LOCAL struct GMT_DATASET * gmtsupport_voronoi_watson (struct GMT_CTRL *GMT, 
 }
 
 /*! . */
+<<<<<<< Updated upstream
+=======
+int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, uint64_t n, bool binary, int **link) {
+	/* Read precalculated triangulation indices from file. Returns -1 if any trouble, else the number of triangles
+	 * with the triangle vertex indices in the array link. */
+	int *ind = NULL;	/* Must be an int due to triangle */
+	unsigned int k;
+	uint64_t seg, row, col, ij, n_skipped, n_bad;
+	int64_t np;
+	unsigned int save_col_type[3];
+	double d_n = (double)n - 0.5;	/* So we can use > in test for range below */
+	struct GMT_DATASET *Tin = NULL;
+	struct GMT_DATATABLE *T = NULL;
+	struct GMTAPI_CTRL *API = GMT->parent;
+
+	/* Must switch to Cartesian input and save whatever original input type we have since we are reading integer triplets */
+	for (k = 0; k < 3; k++) {
+		save_col_type[k] = gmt_M_type (GMT, GMT_IN, k);	/* Remember what we have */
+		gmt_set_column_type (GMT, GMT_IN, k, GMT_IS_FLOAT);	/* And temporarily set to float */
+	}
+	if (binary)
+		GMT_Report (API, GMT_MSG_INFORMATION, "Read triangulation indices from %s as binary triplets\n", file);
+	else
+		gmt_disable_bghio_opts (GMT);	/* Do not want any -b -g -h -i -o to affect the reading this file */
+	if ((Tin = GMT_Read_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL, NULL, file, NULL)) == NULL) {
+		return (GMT_NOTSET);
+	}
+	if (!binary) gmt_reenable_bghio_opts (GMT);	/* Recover settings provided by user (if -b -g -h -i were used at all) */
+	for (k = 0; k < 3; k++) gmt_set_column_type (GMT, GMT_IN, k, save_col_type[k]);	/* Undo the damage above */
+
+	if (Tin->n_columns < 3) {	/* Trouble */
+		GMT_Report (API, GMT_MSG_ERROR, "Option -%c: %s does not have at least 3 columns with indices\n", option, file);
+		if (GMT_Destroy_Data (API, &Tin) != GMT_NOERROR) {	/* Even more trouble */
+			return (GMT_NOTSET);
+		}
+		return (GMT_NOTSET);
+	}
+	T = Tin->table[0];	/* Since we only have one table here */
+	ind = gmt_M_memory (GMT, NULL, 3 * T->n_records, int);	/* Allocate the integer index array */
+	for (seg = ij = n_skipped = n_bad = 0; seg < T->n_segments; seg++) {
+		for (row = 0; row < T->segment[seg]->n_rows; row++) {
+			if (T->segment[seg]->data[0][row] > d_n || T->segment[seg]->data[1][row] > d_n || T->segment[seg]->data[2][row] > d_n)
+				n_skipped++;	/* Outside valid point range */
+			else if (T->segment[seg]->data[0][row] < -GMT_CONV8_LIMIT || T->segment[seg]->data[1][row] < -GMT_CONV8_LIMIT || T->segment[seg]->data[2][row] < -GMT_CONV8_LIMIT)
+				n_bad++;
+			else {	/* Convert to integer values */
+				for (col = 0; col < 3; col++) ind[ij++] = irint (T->segment[seg]->data[col][row]);
+			}
+		}
+	}
+	np = ij / 3;	/* The actual number of vertices passing the test */
+	if (GMT_Destroy_Data (API, &Tin) != GMT_NOERROR) {	/* That's too bad... */
+		gmt_M_free (GMT, ind);
+		return (GMT_NOTSET);
+	}
+	GMT_Report (API, GMT_MSG_INFORMATION, "Read %d triplets of triangulation indices from %s.\n", np, file);
+	if (n_skipped) GMT_Report (API, GMT_MSG_WARNING, "Found %d indices triplets exceeding range of known vertices - skipped.\n", n_skipped);
+	if (n_bad) GMT_Report (API, GMT_MSG_WARNING, "Found %d triplets with negative indices - skipped.\n", n_bad);
+
+	*link = ind;	/* Pass the array back out */
+	return (np);	/* Number of triplets returned */
+}
+
+/*! . */
+>>>>>>> Stashed changes
 GMT_LOCAL int gmtsupport_ensure_new_mapinset_syntax (struct GMT_CTRL *GMT, char option, char *in_text, char *text, char *panel_txt) {
 	/* Recasts any old syntax using new syntax and gives a warning.
  	   Assumes text and panel_text are blank and have adequate space */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4144,7 +4144,7 @@ GMT_LOCAL struct GMT_DATASET * gmtsupport_voronoi_watson (struct GMT_CTRL *GMT, 
 }
 
 /*! . */
-int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, uint64_t n, bool binary, int **link) {
+int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, bool binary, uint64_t n, int **link) {
 	/* Read precalculated triangulation indices from file. Returns -1 if any trouble, else the number of triangles
 	 * with the triangle vertex indices in the array link. Pass binary = true to read binary triplets (as per -bi). */
 	int *ind = NULL;	/* Must be an int due to triangle */

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -857,7 +857,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 
 	if (Ctrl->E.active) {	/* Read precalculated triangulation indices */
 		int64_t s_np;	/* Need a signed 64-bit integer here */
-		if ((s_np = gmt_read_triangulation (GMT, 'E', Ctrl->E.file, n, Ctrl->E.binary, &ind)) == GMT_NOTSET) {
+		if ((s_np = gmt_read_triangulation (GMT, 'E', Ctrl->E.file, Ctrl->E.binary, n, &ind)) == GMT_NOTSET) {
 			GMT_Report (API, GMT_MSG_ERROR, "Error reading triangulation indices from file %s\n", Ctrl->E.file);
 			Return (GMT_RUNTIME_ERROR);
 		}

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -52,8 +52,9 @@ struct PSCONTOUR_CTRL {
 		bool active;
 		char *file;
 	} D;
-	struct PSCONTOUR_E {	/* -E<indexfile> */
+	struct PSCONTOUR_E {	/* -E<indexfile>[+b] */
 		bool active;
+		bool binary;
 		char *file;
 	} E;
 	struct PSCONTOUR_G {	/* -G[d|f|n|l|L|x|X]<params> */
@@ -387,7 +388,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <table> %s %s [-A[n|<contours>][<labelinfo>]] [%s] [-C<contours>] [-D<template>] "
-		"[-E<indextable>] [%s] [-I] %s[-L<pen>] [-N] %s%s[-Q[<n>][+z]] [-S[p|t]] [%s] [%s] [-W[a|c]<pen>[+c[l|f]]] "
+		"[-E<indextable>[+b]] [%s] [-I] %s[-L<pen>] [-N] %s%s[-Q[<n>][+z]] [-S[p|t]] [%s] [%s] [-W[a|c]<pen>[+c[l|f]]] "
 		"%s] [%s] [%s] [%s] %s[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 	     name, GMT_J_OPT, GMT_Rgeoz_OPT, GMT_B_OPT, GMT_CONTG, API->K_OPT, API->O_OPT, API->P_OPT, GMT_CONTT, GMT_U_OPT,
 	     GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, GMT_b_OPT, API->c_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT,
@@ -431,9 +432,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"the desired number of output files (e.g., just %%c gives two files, just %%f would. "
 		"separate segments into one file per contour level, and %%d would write all segments. "
 		"to individual files; see module documentation for more examples.");
-	GMT_Usage (API, 1, "\n-E<indextable>");
+	GMT_Usage (API, 1, "\n-E<indextable>[+b]");
 	GMT_Usage (API, -2, "File with triplets of point indices for each triangle "
-		"[Default performs the Delaunay triangulation on <table>].");
+		"[Default performs the Delaunay triangulation on <table>].  Append +b to read this file using "
+		"the same binary settings as for the primary input file [Read as ASCII].");
 	GMT_Usage (API, 1, "\n%s", GMT_CONTG);
 	GMT_Usage (API, -2, "Control placement of labels along contours.  Choose among five algorithms:");
 	gmt_cont_syntax (API->GMT, 2, 0);
@@ -520,7 +522,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct GMT_
 				break;
 			case 'E':	/* Triplet file */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->E.active);
+				if ((c = strstr (opt->arg, "+b"))) {
+					Ctrl->E.binary = true;
+					c[0] = '\0';
+				}
 				n_errors += gmt_get_required_file (GMT, opt->arg, opt->option, 0, GMT_IS_DATASET, GMT_IN, GMT_FILE_REMOTE, &(Ctrl->E.file));
+				if (c) c[0] = '+';	/* Restore chopped off modifier */
 				break;
 			case 'G':	/* contour annotation settings */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->G.active);
@@ -664,6 +671,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONTOUR_CTRL *Ctrl, struct GMT_
 	n_errors += gmt_M_check_condition (GMT, Ctrl->I.active && !Ctrl->C.info.file, "Option -I: Must specify a color palette table via -C\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->W.cptmode && !Ctrl->C.info.cpt, "Option -W: Modifier +c only valid if -C sets a CPT\n");
 	n_errors += gmt_check_binary_io (GMT, 3);
+	n_errors += gmt_M_check_condition (GMT, Ctrl->E.binary && !GMT->common.b.active[GMT_IN], "Option -E: Cannot imply binary node input if main input is not also binary (see -bi)\n");
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }
@@ -848,6 +856,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 	if (convert) for (i = 0; i < n; i++) gmt_geo_to_xy (GMT, x[i], y[i], &x[i], &y[i]);
 
 	if (Ctrl->E.active) {	/* Read precalculated triangulation indices */
+<<<<<<< Updated upstream
 		uint64_t seg, row, col;
 		unsigned int save_col_type[3];
 		double d_n = (double)n - 0.5;	/* So we can use > in test near line 806 */
@@ -869,6 +878,11 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 			if (GMT_Destroy_Data (API, &Tin) != GMT_NOERROR) {
 				Return (API->error);
 			}
+=======
+		int64_t s_np;
+		if ((s_np = gmt_read_triangulation (GMT, 'E', Ctrl->E.file, n, Ctrl->E.binary, &ind)) == GMT_NOTSET) {
+			GMT_Report (API, GMT_MSG_ERROR, "Error reading triangulation indices from file %s\n", Ctrl->E.file);
+>>>>>>> Stashed changes
 			Return (GMT_RUNTIME_ERROR);
 		}
 		T = Tin->table[0];	/* Since we only have one table here */

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -583,7 +583,7 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 	}
 	if (Ctrl->L.active) {	/* Read precalculated triangulation indices instead */
 		int64_t s_np;	/* Need a signed 64-bit integer here */
-		if ((s_np = gmt_read_triangulation (GMT, 'L', Ctrl->L.file, n, Ctrl->L.binary, &link)) == GMT_NOTSET) {
+		if ((s_np = gmt_read_triangulation (GMT, 'L', Ctrl->L.file, Ctrl->L.binary, n, &link)) == GMT_NOTSET) {
 			GMT_Report (API, GMT_MSG_ERROR, "Error reading triangulation indices from file %s\n", Ctrl->L.file);
 			Return (GMT_RUNTIME_ERROR);
 		}

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -582,12 +582,12 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 			np = gmt_delaunay (GMT, xx, yy, n, &link);
 	}
 	if (Ctrl->L.active) {	/* Read precalculated triangulation indices instead */
-		int64_t s_np;
+		int64_t s_np;	/* Need a signed 64-bit integer here */
 		if ((s_np = gmt_read_triangulation (GMT, 'L', Ctrl->L.file, n, Ctrl->L.binary, &link)) == GMT_NOTSET) {
 			GMT_Report (API, GMT_MSG_ERROR, "Error reading triangulation indices from file %s\n", Ctrl->L.file);
 			Return (GMT_RUNTIME_ERROR);
 		}
-		np = (uint64_t) s_np;		
+		np = (uint64_t) s_np;	/* Set number of points as unsigned 64-bit int */	
 	}
 
 	if (Ctrl->Q.active) {


### PR DESCRIPTION
We add the new option **-L**_indexfile_ to allow us to bypass the Delauney calculation and reuse these precomputed nodes instead, say, for gridding via **-R -I -G**.  The node file may come from a prior run of triangulate or from an external program (e.g., finite elements or similar).

Also this option, for both **triangulate** and **contour** acquires a new modifier **+b** that allows these modules to read the _indexfile_ via binary i/o in the same format as the main table input.  This is necessary to speed up processing for very large triangulation networks.
