### PR TITLE
Fix KEYS for grdflexure and a typo

### DIFF
--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -187,7 +187,7 @@ Optional Arguments
     For a logarithmic time scale, append **+l** and specify *n* steps instead of *dt*.
     Alternatively, give a *file* with the desired times in the first column (these times
     may have individual units appended, otherwise we assume year).
-    We then write a separate model grid file for each given time step; see *-G** for output
+    We then write a separate model grid file for each given time step; see |-G| for output
     file template format.
 
 .. |Add_-V| replace:: |Add_-V_links|

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -37,7 +37,7 @@
 #define THIS_MODULE_LIB		"potential"
 #define THIS_MODULE_PURPOSE	"Compute flexural deformation of 3-D surfaces for various rheologies"
 #define THIS_MODULE_KEYS	"<G{,GG},LD),TD("
-#define THIS_MODULE_NEEDS	"g"
+#define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS "-Vf"
 
 #define GMT_FFT_DIM	2	/* Dimension of FFT needed */


### PR DESCRIPTION
The **KEYS** had "g" meaning we need to get the region from a grid.  However, **grdflexure** _requires_ grid input so that is guaranteed, and it does not take **-R**.  All was well in classic mode but in modern mode such a **KEY** means we actually find and add a valid **-R** string, which was then causing parsing errors since **-R** is not a valid option...
