### PR TITLE
Clarify grdflexure -L list and address related issues

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -82,7 +82,8 @@ Required Arguments
     with constraints coded, return 1 at constraints and 0 elsewhere, and
     optionally the max latitude in the IMG file [80.738]. You may repeat
     |-G| as many times as you have grids you wish to sample.
-    Alternatively, use **-G+l**\ *list* to pass a list of file names.
+    Alternatively, use **-G+l**\ *list* to pass a file whose first word
+    in the trailing text record will be extracted as the file names.
     The grids are sampled and results are output in the order given.
     (See :ref:`Grid File Formats <grd_inout_full>`). **Note**: If *gridfile*
     is a remote global grid and no registration is specified then **grdtrack**

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -150,7 +150,9 @@ Optional Arguments
 
 **-L**\ *list*
     Write the names and evaluation times of all grids that were created
-    to the text file *list*. Requires |-T|.
+    to the text file *list*. Requires |-T|.  The leading numerical column
+    will be time in years, while the last trailing text word is formatted time. 
+    The output records thus contain *time flexuregrid timetag*.
 
 .. _-N:
 

--- a/test/potential/firmoviscous.sh
+++ b/test/potential/firmoviscous.sh
@@ -48,7 +48,7 @@ drho=$(gmt math -Q ${rhol} ${rhow} SUB =)
 gmt gravfft smt.nc+uk -Gsmt_grav.nc -Nf+a -Ff -E4 -D${drho} -W6k
 paste flist times.txt > flist.txt
 drho=$(gmt math -Q ${rhom} ${rhos} SUB =)
-while read file t t2 color; do
+while read t1 file t t2 color; do
 	gmt gravfft ${file}+uk -Gflx_grav.nc -Nf+a -Ff -E2 -D${drho} -W13k
 	gmt grdtrack t.txt -Gflx_grav.nc > b.txt
 	gmt psxy -R -J -O -K -W0.25p,${color},- b.txt -i0,2 >> $ps

--- a/test/potential/firmoviscous2.sh
+++ b/test/potential/firmoviscous2.sh
@@ -50,7 +50,7 @@ drho=$(gmt math -Q ${rhol} ${rhow} SUB =)
 gmt gravfft smt.nc+uk -Gsmt_grav.nc -Nf+a -Ff -E4 -D${drho} -W6k
 paste flist times.txt > flist.txt
 drho=$(gmt math -Q ${rhom} ${rhos} SUB =)
-while read file t t2 color; do
+while read t1 file t t2 color; do
 	gmt gravfft ${file}+uk -Gflx_grav.nc -Nf+a -Ff -E2 -D${drho} -W13k
 	gmt grdtrack t.txt -Gflx_grav.nc > b.txt
 	gmt psxy -R -J -O -K -W0.25p,${color},- b.txt -i0,2 >> $ps


### PR DESCRIPTION
This PR follows up on a similar and previous **grdseamount -M** issue related to the output format of **-L**.  It was not defined in the documentaiton.  However, what is required for the _research_ use is to write a leading numerical column with time in years, followed by trailing text that has two words: File name and time tag.  This matches the concept in **grdseamount** where the numerical time in years must be written as well.  The format is now clearly described in the documentation.

This change broke some vulnerable spots elsewhere that had to be fixed:

1. **grdtrack -G+l**list can read a list of files but it was done via a local _fopen_ and _fscanf_.  Hence, it was vulnerable to lists with leading numerical contents.  This PR improves this by using _GMT_Read_Data_ instead and then to select the first word of the trailing text as the file names.  The documentation has been updated to clarify this.  There is no backwards compatibility issues here since most use of this had no leading numerical columns but now it can.
2. Two test scripts showing firmoviscous flexure calculations had bash loops over the content of these undocumented lists.  Now that the contents is known and has a leading numerical value those loops had to be adjusted accordingly.

With those changes all tests work.
