### PR TITLE
Clean up grdseamount a bit

### DIFF
--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -212,7 +212,7 @@ Optional Arguments
 **-M**\ [*list*]
     Write the times and names of all relief grids (and density grids if |-W| is set) that were created
     to the text file *list*. Requires |-T|.  If no *list* file is given then we write to standard output.
-    The leading numerical column will be time in years, while the last trailing text word is formatted time.
+    The leading single numerical column will be time in years, while the last trailing text word is formatted time.
     The output listing is suitable as input to :doc:`grdflexure </supplements/potential/grdflexure>`.
     **Note**: The output records thus contain *time reliefgrid* [ *densitygrid* ] *timetag*.
 


### PR DESCRIPTION
Just maintenance tasks really:

- The **-M** had a test for _T.active_ but **-M** requires **-T** so that test is silly - now gone
- Added some more comments related to the output via **-M**
- Added column names to output for **-M**.  Note that those only show depending on **-ho** setting.
- Clarified that there is a single numerical column and multi-word trailing test from **-M**.
