### PR TITLE
Correct input machinery for multiple grids for grdflexure

### DIFF
--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -71,12 +71,13 @@ Required Arguments
       coincide with the times given via |-T| (but not all times need
       to have a corresponding file). 
     - A file list given as *flist*\ **+l**, where *flist* is an ASCII
-      table with one load time  and topography grid filename per record (e.g.,
+      table with one load time and topography grid filename per record (e.g.,
       as produced by :doc:`grdseamount </supplements/potential/grdseamount>` |-M|).
       These load times can be different from the evaluation times given
       via |-T|.  For load time format, see |-T|. **Note**: If *flist* has
-      two trailing words the the second will be interpreted as a load density grid and
-      used for that layer instead of the fixed *rl* setting in |-D|.
+      three trailing words the the second will be interpreted as a load density grid and
+      used for that layer instead of the fixed *rl* setting in |-D|. The last
+      trailing word is a formatted age string.
     - A file list with extension ".lis" does not need the **+l** modifier
       and will be automatically recognized as a file list.
 

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: ../../common_SYN_OPTs.rst_
 
-**gmt grdflexure** *topogrd*
+**gmt grdflexure** *input*
 |-D|\ *rm*/*rl*\ [/*ri*]\ /*rw*
 |-E|\ [*Te*\ [**k**][/*Te2*\ [**k**]]]
 |-G|\ *outgrid*
@@ -60,22 +60,25 @@ rheology and related constants, including in-plate forces.
 Required Arguments
 ------------------
 
-*topogrd*
-    2-D binary grid file with the topography of the load (in meters);
-    (See :ref:`Grid File Formats <grd_inout_full>`).
-    If |-T| is used, *topogrd* may be a filename template with a
-    floating point format (C syntax) and a different load file name
-    will be set and loaded for each time step.  The load times thus
-    coincide with the times given via |-T| (but not all times need
-    to have a corresponding file).  Alternatively, give *topogrd* as
-    =\ *flist*, where *flist* is an ASCII table with one *topogrd* filename
-    and load time per record (e.g., as produced by
-    :doc:`grdseamount </supplements/potential/grdseamount>` |-M|).
-    These load times can be different from
-    the evaluation times given via |-T|.  For load time format, see
-    |-T|. **Note**: If *flist* has an optional third column it will be
-    interpreted as a load density and used for that layer instead of
-    the fixed *rl* setting in |-D|.
+*input*
+    Supplies the topographic load information in one of many forms:
+
+    - A single 2-D binary grid file with the topography of the load
+      (in meters); (See :ref:`Grid File Formats <grd_inout_full>`).
+    - If |-T| is used, *input* may be a filename *template* with a
+      floating point format (C syntax) and a different load file name
+      will be set and loaded for each time step.  The load times thus
+      coincide with the times given via |-T| (but not all times need
+      to have a corresponding file). 
+    - A file list given as *flist*\ **+l**, where *flist* is an ASCII
+      table with one topography grid filename and load time per record (e.g.,
+      as produced by :doc:`grdseamount </supplements/potential/grdseamount>` |-M|).
+      These load times can be different from the evaluation times given
+      via |-T|.  For load time format, see |-T|. **Note**: If *flist* has
+      an optional third column it will be interpreted as a load density and
+      used for that layer instead of the fixed *rl* setting in |-D|.
+    - A file list with extension ".lis" does not need the **+l** modifier
+      and will be automatically recognized as a file list.
 
 .. _-D:
 
@@ -141,8 +144,8 @@ Optional Arguments
 
 **-H**\ *rhogrid*
     Supply optional variable load density grid.  It can be a single
-    grid or a grid name template, i.e., same as for *topogrd*. Requires
-    *rho_l* be set to - in |-D|.  **Note**: If *topogrd* is given as
+    grid or a grid name template, i.e., same as for *input*. Requires
+    *rho_l* be set to - in |-D|.  **Note**: If *input* is given as
     a list file then the optional density grids must be given as part of
     the list and not via |-H|.
 

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -71,11 +71,11 @@ Required Arguments
       coincide with the times given via |-T| (but not all times need
       to have a corresponding file). 
     - A file list given as *flist*\ **+l**, where *flist* is an ASCII
-      table with one topography grid filename and load time per record (e.g.,
+      table with one load time  and topography grid filename per record (e.g.,
       as produced by :doc:`grdseamount </supplements/potential/grdseamount>` |-M|).
       These load times can be different from the evaluation times given
       via |-T|.  For load time format, see |-T|. **Note**: If *flist* has
-      an optional third column it will be interpreted as a load density and
+      two trailing words the the second will be interpreted as a load density grid and
       used for that layer instead of the fixed *rl* setting in |-D|.
     - A file list with extension ".lis" does not need the **+l** modifier
       and will be automatically recognized as a file list.

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -29,6 +29,7 @@ Synopsis
 [ |SYN_OPT-V| ]
 [ |-W|\ *wd*]\ [**k**]
 [ |-Z|\ *zm*]\ [**k**]
+[ |SYN_OPT-h| ]
 [ |SYN_OPT-f| ]
 [ |SYN_OPT--| ]
 
@@ -75,9 +76,9 @@ Required Arguments
       as produced by :doc:`grdseamount </supplements/potential/grdseamount>` |-M|).
       These load times can be different from the evaluation times given
       via |-T|.  For load time format, see |-T|. **Note**: If *flist* has
-      three trailing words the the second will be interpreted as a load density grid and
-      used for that layer instead of the fixed *rl* setting in |-D|. The last
-      trailing word is a formatted age string.
+      three trailing words the the second will be interpreted as a load
+      density grid name and used for that layer instead of the fixed *rl*
+      setting in |-D|. The last trailing word is a formatted age string.
     - A file list with extension ".lis" does not need the **+l** modifier
       and will be automatically recognized as a file list.
 
@@ -218,6 +219,9 @@ Optional Arguments
 |SYN_OPT-f|
    Geographic grids (dimensions of longitude, latitude) will be converted to
    meters via a "Flat Earth" approximation using the current ellipsoid parameters.
+
+.. |Add_-h| unicode:: 0x20 .. just an invisible code
+.. include:: ../../explain_-h.rst_
 
 .. include:: ../../explain_help.rst_
 

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -1313,7 +1313,7 @@ EXTERN_MSC int GMT_grdflexure (void *V_API, int mode, void *args) {
 
 	error = GMT_NOERROR;
 	if (Ctrl->L.active) {	/* Write out list of times and flexure grids */
-		char *header = "Time(yr)\tFlexgrid\tTimeTag";
+		char *header = "Time(yr)\tFlexgrid\tTimetag";
 		if (GMT_Set_Comment (API, GMT_IS_DATASET, GMT_COMMENT_IS_COLNAMES, header, L)) Return (API->error);
 		if (Ctrl->L.active && GMT_Write_Data (API, GMT_IS_DATASET, GMT_IS_FILE, GMT_IS_NONE, GMT_WRITE_NORMAL, NULL, Ctrl->L.file, L) != GMT_NOERROR) {
 			if (Ctrl->L.file)

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -1273,7 +1273,7 @@ EXTERN_MSC int GMT_grdflexure (void *V_API, int mode, void *args) {
 		gmt_scale_and_offset_f (GMT, Out->data, Out->header->size, 1.0, -Ctrl->Z.zm);
 
 		/* 4e. WRITE OUTPUT GRID */
-		if (Ctrl->T.active) { /* Separate output grid since there are many time steps */
+		if (Ctrl->T.active) { /* Separate and unique output grid names from time since there are many time steps */
 			char remark[GMT_GRID_REMARK_LEN160] = {""};
 			gmt_modeltime_name (GMT, zfile, Ctrl->G.file, &Ctrl->T.time[t_eval]);
 			sprintf (remark, "Solution for t = %g %s", Ctrl->T.time[t_eval].value * Ctrl->T.time[t_eval].scale,
@@ -1283,7 +1283,7 @@ EXTERN_MSC int GMT_grdflexure (void *V_API, int mode, void *args) {
 				Return (API->error);
 			}
 		}
-		else	/* Single output grid */
+		else	/* Single output grid (no -T set) */
 			strcpy (zfile, Ctrl->G.file);
 		if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, Out)) {
 			if (retain_original) gmt_M_free (GMT, orig_load);
@@ -1300,13 +1300,14 @@ EXTERN_MSC int GMT_grdflexure (void *V_API, int mode, void *args) {
 			gmt_grd_mux_demux (GMT, Out->header, Out->data, GMT_GRID_IS_INTERLEAVED);
 		}
 
-		if (Ctrl->L.active) {	/* Add filename and evaluation time to dataset */
+		if (Ctrl->L.active) {	/* Add filename and evaluation time to list dataset */
+			/* Output will be: <numerical-time> <flexgridname> <timetag> */
 			char record[GMT_BUFSIZ] = {""}, tmp[GMT_LEN64] = {""};
+			sprintf (record, "%s\t", zfile);	/* Flexure output grid for this time */
 			/* Add formatted time tag after file name */
-			sprintf (record, "%s\t", zfile);
 			sprintf (tmp, time_fmt, Ctrl->T.time[t_eval].value * Ctrl->T.time[t_eval].scale, Ctrl->T.time[t_eval].unit);
 			strcat (record, tmp);
-			L->table[0]->segment[0]->data[GMT_X][t_eval] = Ctrl->T.time[t_eval].value;	/* In years */
+			L->table[0]->segment[0]->data[GMT_X][t_eval] = Ctrl->T.time[t_eval].value;	/* Output time in years */
 			L->table[0]->segment[0]->text[t_eval] = strdup (record);
 		}
 	}

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -798,7 +798,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Set density of mantle, load(crust), optional moat infill [same as load], and water|air in kg/m^3 or g/cm^3. "
 		"Set <rhol> to - if <list> contains variable density grid names.");
 	GMT_Usage (API, 1, "\n-E[<te>[k][/<te2>[k]]]");
-	GMT_Usage (API, -2, "Sets elastic plate thickness in m; append k for km.  If Te > 1e10 it will be interpreted n"
+	GMT_Usage (API, -2, "Sets elastic plate thickness in m; append k for km.  If Te > 1e10 it will be interpreted "
 		"as the flexural rigidity [Default computes D from Te, Young's modulus, and Poisson's ratio]. "
 		"Default of 0 km may be used with -F for a pure viscous response (no plate rigidity). "
 		"Select General Linear Viscoelastic model by giving initial and final elastic thicknesses (requires -M).");


### PR DESCRIPTION
The documentation talked about providing a list of input grids via _=flist_ (which is a GMT_wide mechanism for expanding its contents onto the command line as file names), but that does not work since in our context the list has both time and grids. By the time the **grdflexure** parser gets into the action the _GMT_Create_Options_ has already replaced _=flist_ with what it finds in the list and that gives crazy filenames composed of a record with numbers, tabs, and filenames. This cannot work, obviously.  We have no test examples that exercise multiple input grids so only found out now (there may have been some regression since last time I tried this as well).

This PR not only clarifies what the input options are (and updates the documentation), it no longer discusses the _=flist_ mechanism (since it is inappropriate for this module) and adds _flist_**+l** as one mechanism to pass a list (same way as we do it in **grdtrack**) but also will allow a _flist_ that ends with the extension `.lis` to be automatically recognized as such.

As for **grdseamount** I improved the **-L** list output by setting column names - again these are only visible if the user uses **-ho**.  The module did not support **-h** so I had to add the **THIS_MODULE_OPTIONS** listing and documentation.