### PR TITLE
Fix typos in usage message

### DIFF
--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -91,7 +91,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Note: Run \"gmt docs data\" to learn about available data sets.");
 	GMT_Usage (API, 1, "\n-G<defaultsfile>");
 	GMT_Usage (API, -2, "Set name of specific %s file to process "
-		"Default looks for file in current directory.  If not found, n"
+		"Default looks for file in current directory.  If not found, "
 		"it looks in the home directory, if not found it uses the GMT defaults].", GMT_SETTINGS_FILE);
 	GMT_Usage (API, 1, "\n-I<inc>");
 	GMT_Usage (API, -2, "Limit the download of data sets to grid spacing of <inc> or larger [0].");

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -123,7 +123,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-C[n|t]");
 	GMT_Usage (API, -2, "Report information in fields on a single line using the format "
 		"<file w e s n {b t} v0 v1 dx dy {dz} n_columns n_rows {n_layers} [x0 y0 {z0} x1 y1 {z1}] [med L1scale] [mean std rms] [n_nan] [mode LMSscale] registration type>, "
-		"where -M adds [x0 y0 x1 y1] and [n_nan], -L1 adds [median L1scale], -L2 adds [mean std rms], n"
+		"where -M adds [x0 y0 x1 y1] and [n_nan], -L1 adds [median L1scale], -L2 adds [mean std rms], "
 		"and -Lp adds [mode LMSscale]). Ends with registration (0=gridline, 1=pixel) and type (0=Cartesian, 1=geographic). Optional directives:");
 	GMT_Usage (API, 3, "t: Place <file> at the end of the output record.");
 	GMT_Usage (API, 3, "n: Write only numerical columns.");

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -205,7 +205,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"The <dpu> must be the same as the intended <dpu> for the movie frames. "
 		"Append i if dpi and c if dpc [Default will consult GMT_LENGTH_UNIT setting, currently %s]. "
 		"Optionally, append +v[<value>] to insert a z-column into the point data with values <z> [0].", API->GMT->session.unit_name[API->GMT->current.setting.proj_length_unit]);
-	GMT_Usage (API, 3, "s: Read whole segments (lines or polygons) with no time column. n"
+	GMT_Usage (API, 3, "s: Read whole segments (lines or polygons) with no time column. "
 		"Time is set via segment header -T<start>, -T<start>,<end>, or -T<start>,<duration (see -L).");
 	GMT_Usage (API, 1, "\n-C<cpt>");
 	GMT_Usage (API, -2, "Give <cpt> and obtain symbol color via z-value in 3rd data column.");

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -208,7 +208,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Alternatively, specify <lower>/<upper> intensity values.");
 	GMT_Option (API, "J-Z,K");
 	GMT_Usage (API, 1, "\n-L[i][<gap>]");
-	GMT_Usage (API, -2, "Select equal-sized color rectangles. The -B option cannot be used. n"
+	GMT_Usage (API, -2, "Select equal-sized color rectangles. The -B option cannot be used. "
 		"Append i to annotate the interval range instead of lower/upper. "
 		"If <gap> is appended, we separate each rectangle by <gap> units and center each "
 		"lower (z0) annotation on the rectangle.  Ignored if not a discrete CPT. "


### PR DESCRIPTION
During the Great Rewrite of usage messages, a few trailing newlines (which were all unnecessary now) got truncated and left some trailing "n" at the end of a line instead.  I accidentally found that as part of #6706 in **grdflexture** and searched for others.  These four are the only ones.
