### PR TITLE
Improve consistency between grdseamount and grdflexure file names

### DIFF
--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -67,7 +67,7 @@ Required Arguments
     - A single 2-D binary grid file with the topography of the load
       (in meters); (See :ref:`Grid File Formats <grd_inout_full>`).
     - If |-T| is used, *input* may be a filename *template* (See
-      `File Template`_ for details).  The load times will thus
+      `Name Template`_ for details).  The load times will thus
       coincide with the times given via |-T| (but not all times need
       to have a corresponding file). 
     - A file list given as *flist*\ **+l**, where *flist* is an ASCII
@@ -103,7 +103,7 @@ Required Arguments
 .. _-G:
 
 .. |Add_outgrid| replace:: If |-T| is set then *outgrid* must be a filename template
-    (See `File Template`_ for details).
+    (See `Name Template`_ for details).
 .. include:: /explain_grd_inout.rst_
     :start-after: outgrid-syntax-begins
     :end-before: outgrid-syntax-ends
@@ -142,7 +142,7 @@ Optional Arguments
 
 **-H**\ *rhogrid*
     Supply optional variable load density grid.  It can be a single
-    grid or a grid name template (see `File Template`_ for details). Requires
+    grid or a grid name template (see `Name Template`_ for details). Requires
     *rho_l* be set to - in |-D|.  **Note**: If *input* is given as
     a list file then the optional density grids must be given as part of
     the list and not via |-H|.
@@ -191,7 +191,7 @@ Optional Arguments
     Alternatively, give a *file* with the desired times in the first column (these times
     may have individual units appended, otherwise we assume year).
     We then write a separate model grid file for each given time step; see |-G| for output
-    and `File Template`_ for the file template format.
+    and `Name Template`_ for the file template format.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: /explain_-V.rst_
@@ -221,9 +221,9 @@ Optional Arguments
 
 .. include:: ../../explain_help.rst_
 
-.. _File Template:
+.. _Name Template:
 
-File Template
+Name Template
 -------------
 
 The format statements allowed in grid file templates require you to follow these rules:
@@ -236,6 +236,9 @@ The format statements allowed in grid file templates require you to follow these
       names like smt_001.1M.grd names.  The times will be scaled to match the unit.
     - If you do not want any units then simply give a template with just one floating point
       format, e.g., smt_%05.1f_name.grd.  The times will be used as is (i.e, unscaled).
+
+For details on the format statements, see `printf <https://en.wikipedia.org/wiki/Printf_format_string>`_ 
+C language format syntax.
 
 Grid Distance Units
 -------------------

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -66,9 +66,8 @@ Required Arguments
 
     - A single 2-D binary grid file with the topography of the load
       (in meters); (See :ref:`Grid File Formats <grd_inout_full>`).
-    - If |-T| is used, *input* may be a filename *template* with a
-      floating point format (C syntax) and a different load file name
-      will be set and loaded for each time step.  The load times thus
+    - If |-T| is used, *input* may be a filename *template* (See
+      `File Template`_ for details).  The load times will thus
       coincide with the times given via |-T| (but not all times need
       to have a corresponding file). 
     - A file list given as *flist*\ **+l**, where *flist* is an ASCII
@@ -103,11 +102,8 @@ Required Arguments
 
 .. _-G:
 
-.. |Add_outgrid| replace:: If |-T| is set then *outgrid* must be a filename template that contains
-    a floating point format (C syntax).  If the filename template also contains
-    either %s (for unit name) or %c (for unit letter) then we use the corresponding time
-    (in units specified in |-T|) to generate the individual file names, otherwise
-    we use time in years with no unit.
+.. |Add_outgrid| replace:: If |-T| is set then *outgrid* must be a filename template
+    (See `File Template`_ for details).
 .. include:: /explain_grd_inout.rst_
     :start-after: outgrid-syntax-begins
     :end-before: outgrid-syntax-ends
@@ -146,7 +142,7 @@ Optional Arguments
 
 **-H**\ *rhogrid*
     Supply optional variable load density grid.  It can be a single
-    grid or a grid name template, i.e., same as for *input*. Requires
+    grid or a grid name template (see `File Template`_ for details). Requires
     *rho_l* be set to - in |-D|.  **Note**: If *input* is given as
     a list file then the optional density grids must be given as part of
     the list and not via |-H|.
@@ -195,7 +191,7 @@ Optional Arguments
     Alternatively, give a *file* with the desired times in the first column (these times
     may have individual units appended, otherwise we assume year).
     We then write a separate model grid file for each given time step; see |-G| for output
-    file template format.
+    and `File Template`_ for the file template format.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: /explain_-V.rst_
@@ -224,6 +220,22 @@ Optional Arguments
 .. include:: ../../explain_-h.rst_
 
 .. include:: ../../explain_help.rst_
+
+.. _File Template:
+
+File Template
+-------------
+
+The format statements allowed in grid file templates require you to follow these rules:
+
+    - To use the formatted time-tag as part of the file name you must use just a single %s
+      format as part of the template (e.g., smt_%s.grd).
+    - If you want to control the numerical formatting of the names but still have the common
+      time unit appended then you must compose a template that has a floating point format
+      before a later %c format for the unit.  For example, smt_%05.1f%c.grd will create
+      names like smt_001.1M.grd names.  The times will be scaled to match the unit.
+    - If you do not want any units then simply give a template with just one floating point
+      format, e.g., smt_%05.1f_name.grd.  The times will be used as is (i.e, unscaled).
 
 Grid Distance Units
 -------------------

--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -81,10 +81,7 @@ Required Arguments (if |-L| is not given)
 .. _-G:
 
 .. |Add_outgrid| replace:: Give the name of the output grid file. If |-T| is set then *outgrid* must be
-    a filename template that contains a floating point format to hold the output time (C language syntax).
-    If the filename template also contains either %s (for unit name) or %c (for unit letter) then we use
-    the corresponding time (in units specified in |-T|) to generate the individual file names, otherwise
-    we use time in years with no unit included.
+    a filename template (See `File Template`_ for details).
 .. include:: /explain_grd_inout.rst_
     :start-after: outgrid-syntax-begins
     :end-before: outgrid-syntax-ends
@@ -334,10 +331,8 @@ Optional Arguments
 
 **-W**\ *avedensity*
     Give the name of the vertically averaged density grid file. If |-T| is set then *avedensity* must
-    be a filename template that contains a floating point format (C syntax; see |-G| for details).  If the filename
-    template also contains either %s (for unit name) or %c (for unit letter) then we use the corresponding
-    time (in units specified in |-T|) to generate the individual file names, otherwise we use time in years
-    with no unit. Requires |-H| to define the density model.
+    be a filename template (See `File Template`_ for details). 
+    Requires |-H| to define the density model.
 
 .. _-Z:
 
@@ -370,6 +365,23 @@ Optional Arguments
 
 .. include:: ../../explain_distunits.rst_
 
+.. _File Template:
+
+File Template
+-------------
+
+The format statements allowed in grid file templates require you to follow these rules:
+
+    - To use the formatted time-tag as part of the file name you must use just a single %s
+      format as part of the template (e.g., smt_%s.grd).
+    - If you want to control the numerical formatting of the names but still have the common
+      time unit appended then you must compose a template that has a floating point format
+      before a later %c format for the unit.  For example, smt_%05.1f%c.grd will create
+      names like smt_001.1M.grd names.  The times will be scaled to match the unit.
+    - If you do not want any units then simply give a template with just one floating point
+      format, e.g., smt_%05.1f_name.grd.  The times will be used as is (i.e, unscaled).
+
+For details on the format statements, see `printf <https://en.wikipedia.org/wiki/Printf_format_string>`_  C language format syntax).
 
 Slide simulation specifics
 --------------------------

--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -381,7 +381,8 @@ The format statements allowed in grid file templates require you to follow these
     - If you do not want any units then simply give a template with just one floating point
       format, e.g., smt_%05.1f_name.grd.  The times will be used as is (i.e, unscaled).
 
-For details on the format statements, see `printf <https://en.wikipedia.org/wiki/Printf_format_string>`_  C language format syntax).
+For details on the format statements, see `printf <https://en.wikipedia.org/wiki/Printf_format_string>`_ 
+C language format syntax.
 
 Slide simulation specifics
 --------------------------

--- a/src/potential/CMakeLists.txt
+++ b/src/potential/CMakeLists.txt
@@ -25,7 +25,7 @@
 #
 
 set (SUPPL_NAME potential)
-set (SUPPL_HEADERS okbfuns.h newton.h talwani.h)
+set (SUPPL_HEADERS okbfuns.h newton.h modeltime.h talwani.h)
 set (SUPPL_PROGS_SRCS grdredpol.c gmtgravmag3d.c gmtflexure.c gravfft.c
 	gravprisms.c grdflexure.c grdgravmag3d.c grdseamount.c talwani2d.c talwani3d.c)
 set (SUPPL_LIB_SRCS ${SUPPL_PROGS_SRCS} okbfuns.c)

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -197,7 +197,7 @@ double gmt_get_modeltime (char *A, char *unit, double *scale) {
 	return (atof (A) / (*scale));
 }
 
-unsigned int gmt_modeltime_tag (struct GMT_CTRL *GMT, struct GMT_MODELTIME *T, unsigned int n, char *format) {
+GMT_LOCAL unsigned int grdflexure_modeltime_tag (struct GMT_CTRL *GMT, struct GMT_MODELTIME *T, unsigned int n, char *format) {
 	/* Determine a suitable format statement for the time tags in grdseamount and grdflexure.
 	 * These use the most compact time unit and are consistent in the number of decimals */
 	char unit[2] = {""};	/* Unless we have unit times there is no unit in the time tag */
@@ -326,7 +326,7 @@ unsigned int gmt_modeltime_array (struct GMT_CTRL *GMT, char *arg, bool *log, st
 	}
 	if (*log) p[0] = '+';	/* Restore the +l modifier */
 	/* Now must find consistent unit for time tags since input may be a mix of kyr and Myr */
-	u = gmt_modeltime_tag (GMT, T, n_eval_times, time_fmt);	/* Get suitable format given all increments */
+	u = grdflexure_modeltime_tag (GMT, T, n_eval_times, time_fmt);	/* Get suitable format given all increments */
 	for (k = 0; k < n_eval_times; k++) {	/* Create the time tags */
 		T[k].unit = unit[u];
 		T[k].scale = scale[u];
@@ -339,7 +339,7 @@ unsigned int gmt_modeltime_array (struct GMT_CTRL *GMT, char *arg, bool *log, st
 	return (n_eval_times);
 }
 
-char *gmt_modeltime_unit (unsigned int u) {
+GMT_LOCAL char *grdflexure_modeltime_unit (unsigned int u) {
 	static char *names[3] = {"yr", "kyr", "Myr"};
 	return (names[u]);
 }
@@ -915,7 +915,7 @@ GMT_LOCAL struct GRDFLEXURE_GRID *grdflexure_prepare_load (struct GMT_CTRL *GMT,
 	struct GMTAPI_CTRL *API = GMT->parent;
 
 	if (this_time)
-		GMT_Report (API, GMT_MSG_INFORMATION, "Prepare load file %s for time %g %s\n", file, this_time->value * this_time->scale, gmt_modeltime_unit (this_time->u));
+		GMT_Report (API, GMT_MSG_INFORMATION, "Prepare load file %s for time %g %s\n", file, this_time->value * this_time->scale, grdflexure_modeltime_unit (this_time->u));
 	else
 		GMT_Report (API, GMT_MSG_INFORMATION, "Prepare load file %s\n", file);
 
@@ -1291,7 +1291,7 @@ EXTERN_MSC int GMT_grdflexure (void *V_API, int mode, void *args) {
 				if (This_Load->Time->u == Ctrl->T.time[t_eval].u) {	/* Same time units even */
 					double dt = This_Load->Time->value * This_Load->Time->scale - Ctrl->T.time[t_eval].value * Ctrl->T.time[t_eval].scale;
 					GMT_Report (API, GMT_MSG_INFORMATION, "  Accumulating flexural deformation for load emplaced at time %s [Loading time = %g %s]\n",
-						This_Load->Time->tag, dt, gmt_modeltime_unit (This_Load->Time->u));
+						This_Load->Time->tag, dt, grdflexure_modeltime_unit (This_Load->Time->u));
 				}
 				else {	/* Just state load time */
 					GMT_Report (API, GMT_MSG_INFORMATION, "  Accumulating flexural deformation for load emplaced at time %s\n", This_Load->Time->tag);

--- a/src/potential/grdseamount.c
+++ b/src/potential/grdseamount.c
@@ -1663,7 +1663,7 @@ EXTERN_MSC int GMT_grdseamount (void *V_API, int mode, void *args) {
 		/* 1. SET THE CURRENT TIME VALUE (IF USED) */
 		if (Ctrl->T.active) {	/* Set the current time in user units as well as years */
 			this_user_time = Ctrl->T.time[t].value;	/* In years */
-			GMT_Report (API, GMT_MSG_INFORMATION, "Evaluating bathymetry for time %g %s\n", Ctrl->T.time[t].value * Ctrl->T.time[t].scale, gmt_modeltime_unit (Ctrl->T.time[t].u));
+			GMT_Report (API, GMT_MSG_INFORMATION, "Evaluating bathymetry for time %s\n", Ctrl->T.time[t].tag);
 		}
 		if (Ctrl->Q.bmode == SMT_INCREMENTAL || exact)
 			gmt_M_memset (Grid->data, Grid->header->size, gmt_grdfloat);	/* Wipe clean for next increment */
@@ -1934,8 +1934,7 @@ EXTERN_MSC int GMT_grdseamount (void *V_API, int mode, void *args) {
 		}
 		prev_user_time = this_user_time;	/* Make this the previous time */
 		if (empty_grid && Ctrl->T.active) {	/* No contribution made */
-			GMT_Report (API, GMT_MSG_INFORMATION, "No contribution made for time %g %s\n",
-			            Ctrl->T.time[t].value * Ctrl->T.time[t].scale, gmt_modeltime_unit (Ctrl->T.time[t].u));
+			GMT_Report (API, GMT_MSG_INFORMATION, "No contribution made for time %s\n", Ctrl->T.time[t].tag);
 			if (exact && !exact_increments) gmt_M_memcpy (Grid->data, current, Grid->header->size, float);	/* Nothing new added so same cumulative surface as last step */
 		}
 

--- a/src/potential/grdseamount.c
+++ b/src/potential/grdseamount.c
@@ -37,6 +37,7 @@
  * */
 
 #include "gmt_dev.h"
+#include "modeltime.h"
 
 #define THIS_MODULE_CLASSIC_NAME	"grdseamount"
 #define THIS_MODULE_MODERN_NAME	"grdseamount"
@@ -67,14 +68,6 @@
 #define BETA_DEFAULT	1	/* Default psi(tau) beta power parameter */
 #define MAX_ITERATIONS	1000	/* Max tries to improve an estimate in a loop */
 #define RHO_GRID_INC	0.005	/* Fixed grid spacing for the normalized model rho grid (-K) */
-
-struct GMT_MODELTIME {	/* Hold info about modeling time */
-	double value;	/* Time in year */
-	double scale;	/* Scale factor from year to given user unit */
-	char unit;		/* Either M (Myr), k (kyr), or blank (implies y) */
-	unsigned int u;	/* For labeling: Either 0 (yr), 1 (kyr), or 2 (Myr) */
-
-};
 
 struct SLIDE {	/* Hold information for one slide */
 	/* Input parameters (some have defaults): */
@@ -210,11 +203,6 @@ struct GRDSEAMOUNT_CTRL {
 		double value;
 	} Z;
 };
-
-EXTERN_MSC double gmt_get_modeltime (char *A, char *unit, double *scale);
-EXTERN_MSC unsigned int gmt_modeltime_array (struct GMT_CTRL *GMT, char *arg, bool *log, struct GMT_MODELTIME **T_array);
-EXTERN_MSC char *gmt_modeltime_unit (unsigned int u);
-EXTERN_MSC void gmt_modeltime_name (struct GMT_CTRL *GMT, char *file, char *format, struct GMT_MODELTIME *T);
 
 static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
 	struct GRDSEAMOUNT_CTRL *C = NULL;
@@ -426,6 +414,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDSEAMOUNT_CTRL *Ctrl, struct GM
 			case 'G':	/* Output file name or name template */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->G.active);
 				n_errors += gmt_get_required_file (GMT, opt->arg, opt->option, 0, GMT_IS_GRID, GMT_OUT, GMT_FILE_LOCAL, &(Ctrl->G.file));
+				n_errors += gmt_modeltime_validate (GMT, 'G', Ctrl->G.file);
 				break;
 			case 'H':	/* Reference seamount density parameters */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->H.active);
@@ -624,6 +613,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDSEAMOUNT_CTRL *Ctrl, struct GM
 			case 'W':	/* Output file name for average density grid */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);
 				n_errors += gmt_get_required_file (GMT, opt->arg, opt->option, 0, GMT_IS_GRID, GMT_OUT, GMT_FILE_LOCAL, &(Ctrl->W.file));
+				n_errors += gmt_modeltime_validate (GMT, 'W', Ctrl->W.file);
 				break;
 			case 'Z':	/* Background relief level (or NaN) */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->Z.active);
@@ -1468,7 +1458,7 @@ EXTERN_MSC int GMT_grdseamount (void *V_API, int mode, void *args) {
 
 	uint64_t node, n_smts, smt;
 
-	char gfile[PATH_MAX] = {""}, wfile[PATH_MAX] = {""}, time_fmt[GMT_LEN64] = {""};
+	char gfile[PATH_MAX] = {""}, wfile[PATH_MAX] = {""};
 
 	gmt_grdfloat *data = NULL, *current = NULL, *previous = NULL, *rho_weight = NULL, *prev_z = NULL;
 
@@ -1592,18 +1582,12 @@ EXTERN_MSC int GMT_grdseamount (void *V_API, int mode, void *args) {
 
 	if (Ctrl->M.active) {	/* Must create dataset to hold names of all output times and corresponding grids */
 		uint64_t dim[GMT_DIM_SIZE] = {1, 1, Ctrl->T.n_times, 1};
-		unsigned int k, j;
 		if ((L = GMT_Create_Data (API, GMT_IS_DATASET, GMT_IS_NONE, GMT_WITH_STRINGS, dim, NULL, NULL, 0, 0, NULL)) == NULL) {
 			GMT_Report (API, GMT_MSG_INFORMATION, "Failure while creating text set for file %s\n", Ctrl->M.file);
 			API->error = GMT_RUNTIME_ERROR;
 			goto wrap_up;
 		}
 		L->table[0]->segment[0]->n_rows = Ctrl->T.n_times;
-		for (k = j = 0; Ctrl->G.file[k] && Ctrl->G.file[k] != '%'; k++);	/* Find first % */
-		while (Ctrl->G.file[k] && !strchr ("efg", Ctrl->G.file[k])) time_fmt[j++] = Ctrl->G.file[k++];
-		time_fmt[j++] = Ctrl->G.file[k];
-		strcat (time_fmt, "%c");	/* Append the unit */
-		GMT_Report (API, GMT_MSG_DEBUG, "Format for time will be %s\n", time_fmt);
 	}
 	/* Calculate the area, volume, height for each shape; if -L then also write the results */
 
@@ -1968,15 +1952,14 @@ EXTERN_MSC int GMT_grdseamount (void *V_API, int mode, void *args) {
 		}
 		if (Ctrl->M.active) {	/* Write list of grids to file */
 			/* Output will be: <numerical-time> <topogridname> [<densgridname>] <timetag> */
-			char record[GMT_BUFSIZ] = {""}, tmp[GMT_LEN64] = {""};
+			char record[GMT_BUFSIZ] = {""};
 			sprintf (record, "%s\t", gfile);	/* First word in trailing text is increment/cumulative grid name */
 			if (Ctrl->W.active) {	/* Optional second word holds a density grid name */
 				strcat (record, wfile);
 				strcat (record, "\t");
 			}
 			/* Final word is the formatted time tag with unit information */
-			sprintf (tmp, time_fmt, Ctrl->T.time[t].value * Ctrl->T.time[t].scale, Ctrl->T.time[t].unit);
-			strcat (record, tmp);
+			strcat (record, Ctrl->T.time[t].tag);
 			L->table[0]->segment[0]->data[GMT_X][t_use] = Ctrl->T.time[t].value;
 			L->table[0]->segment[0]->text[t_use++] = strdup (record);
 			L->table[0]->segment[0]->n_rows++;

--- a/src/potential/modeltime.h
+++ b/src/potential/modeltime.h
@@ -1,0 +1,43 @@
+/*--------------------------------------------------------------------
+ *
+ *	Copyright (c) 1991-2022 by the GMT Team (https://www.generic-mapping-tools.org/team.html)
+ *	See LICENSE.TXT file for copying and redistribution conditions.
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU Lesser General Public License as published by
+ *	the Free Software Foundation; version 3 or any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU Lesser General Public License for more details.
+ *
+ *	Contact info: www.generic-mapping-tools.org
+ *--------------------------------------------------------------------*/
+
+/*!
+ * \file modeltime.h
+ * \brief
+ */
+
+#ifndef MODELTIME_H
+#define MODELTIME_H
+
+/* Miscellaneous model time structure and external functions used in grdseamount and grdflexure */
+
+struct GMT_MODELTIME {  /* Hold info about time */
+    double value;   /* Time as given by user (e.g., 1, 1k, 1M are all 1) */
+    double scale;   /* Scale factor from user time to year */
+    char unit;  /* Either M (Myr), k (kyr), or blank (implies y) */
+    char tag[GMT_LEN32];    /* Formatted time tag probably with unit */
+    unsigned int u; /* For labeling: Either 0 (yr), 1 (kyr), or 2 (Myr) */
+};
+
+EXTERN_MSC void gmt_modeltime_name (struct GMT_CTRL *GMT, char *file, char *format, struct GMT_MODELTIME *T);
+EXTERN_MSC char *gmt_modeltime_unit (unsigned int u);
+EXTERN_MSC unsigned int gmt_modeltime_array (struct GMT_CTRL *GMT, char *arg, bool *log, struct GMT_MODELTIME **T_array);
+EXTERN_MSC unsigned int gmt_modeltime_tag (struct GMT_CTRL *GMT, struct GMT_MODELTIME *T, unsigned int n, char *format);
+EXTERN_MSC int gmt_modeltime_validate (struct GMT_CTRL *GMT, char option, char *file);
+EXTERN_MSC double gmt_get_modeltime (char *A, char *unit, double *scale);
+
+#endif /* MODELTIME_H */

--- a/src/potential/modeltime.h
+++ b/src/potential/modeltime.h
@@ -26,11 +26,11 @@
 /* Miscellaneous model time structure and external functions used in grdseamount and grdflexure */
 
 struct GMT_MODELTIME {  /* Hold info about time */
-    double value;   /* Time as given by user (e.g., 1, 1k, 1M are all 1) */
-    double scale;   /* Scale factor from user time to year */
+    double value;   /* Time as given by user in years */
+    double scale;   /* Scale factor from years to formatted unit time */
     char unit;  /* Either M (Myr), k (kyr), or blank (implies y) */
     char tag[GMT_LEN32];    /* Formatted time tag probably with unit */
-    unsigned int u; /* For labeling: Either 0 (yr), 1 (kyr), or 2 (Myr) */
+    unsigned int u; /* For custom labeling: Either 0 (yr), 1 (kyr), or 2 (Myr) */
 };
 
 EXTERN_MSC void gmt_modeltime_name (struct GMT_CTRL *GMT, char *file, char *format, struct GMT_MODELTIME *T);

--- a/src/potential/modeltime.h
+++ b/src/potential/modeltime.h
@@ -34,9 +34,7 @@ struct GMT_MODELTIME {  /* Hold info about time */
 };
 
 EXTERN_MSC void gmt_modeltime_name (struct GMT_CTRL *GMT, char *file, char *format, struct GMT_MODELTIME *T);
-EXTERN_MSC char *gmt_modeltime_unit (unsigned int u);
 EXTERN_MSC unsigned int gmt_modeltime_array (struct GMT_CTRL *GMT, char *arg, bool *log, struct GMT_MODELTIME **T_array);
-EXTERN_MSC unsigned int gmt_modeltime_tag (struct GMT_CTRL *GMT, struct GMT_MODELTIME *T, unsigned int n, char *format);
 EXTERN_MSC int gmt_modeltime_validate (struct GMT_CTRL *GMT, char option, char *file);
 EXTERN_MSC double gmt_get_modeltime (char *A, char *unit, double *scale);
 


### PR DESCRIPTION
Both of these modules share common functions defined in **grdflexure** as well as the model time structure **GMT_MODELTIME**.  To avoid duplication, these are now prototyped in a new potential supplement file _modeltime.h_.  Also, this PR documents as well as enforce harsher rules (and validation) on grid file templates to avoid crashes, and finds the smallest time increment and use that to determine consistent template formats for time tags.  Consistently use the numerical time for calculations and the formatted time tags in messages (and filenames if the template so desires).

Some of the problems solved with this PR is the fact that input times may be specified as a mix of things like

```
1.0M
750k
500000
```
in a list to **-T,** but when we make grids we want to use a consistent naming.  Hence, on output perhaps we have learned that the increments are 0.25 Myr and hence we end up with a naming scheme using 2 decimal and Myr units.  Before, these tags might be used to decode the times in years, but it is better to always use the time in years for calculations and only use the tags for naming and messages.
