### PR TITLE
Improve memory cleanup in grdflexure

### DIFF
--- a/src/gmt_fft.c
+++ b/src/gmt_fft.c
@@ -1639,7 +1639,7 @@ int GMT_FFT_1D (void *V_API, gmt_grdfloat *data, uint64_t n, int direction, unsi
 	int status, use;
 	struct GMTAPI_CTRL *API = gmtfft_get_api_ptr (V_API);
 	struct GMT_CTRL *GMT = API->GMT;
-	assert (mode == GMT_FFT_COMPLEX); /* GMT_FFT_REAL not implemented yet */
+	assert (mode & GMT_FFT_COMPLEX); /* GMT_FFT_REAL not implemented yet */
 	use = gmtfft_1d_selection (GMT, n);
 	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "1-D FFT using %s\n", GMT_fft_algo[use]);
 	status = GMT->session.fft1d[use] (GMT, data, (unsigned int)n, direction, mode);
@@ -1659,7 +1659,7 @@ int GMT_FFT_2D (void *V_API, gmt_grdfloat *data, unsigned int n_columns, unsigne
 	int status, use;
 	struct GMTAPI_CTRL *API = gmtfft_get_api_ptr (V_API);
 	struct GMT_CTRL *GMT = API->GMT;
-	assert (mode == GMT_FFT_COMPLEX); /* GMT_FFT_REAL not implemented yet */
+	assert (mode & GMT_FFT_COMPLEX); /* GMT_FFT_REAL not implemented yet */
 	use = gmtfft_2d_selection (GMT, n_columns, n_rows);
 
 	GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "2-D FFT using %s\n", GMT_fft_algo[use]);

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -1336,7 +1336,7 @@ EXTERN_MSC int GMT_grdflexure (void *V_API, int mode, void *args) {
 			error = API->error;	goto cleanup_time;
 		}
 
-		if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY,
+		if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA | GMT_GRID_IS_COMPLEX_REAL,
 			NULL, zfile, Out) != GMT_NOERROR) {
 			error = API->error;	goto cleanup_time;
 		}


### PR DESCRIPTION
As in many other module, if we get an error we have lots of thing to free up, so it is more economical do to so at the end of **grdflexure** via an emergency _goto_ statement.

Also fixes a recently introduced issue in _gmt_fft.c_ due to the introduction of an extra bit flag: We must check for bits not using equal signs.