### PR TITLE
Avoid creating local intermediate PDF file (#6711)

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -2486,7 +2486,7 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 				Ctrl->T.device = GS_DEV_PDF;
 				/* After conversion, we convert the tmp PDF file to desired format via a 2nd gs call */
 				GMT_Report (API, GMT_MSG_INFORMATION, "Convert to intermediate PDF...\n");
-				strncat (out_file, &ps_file[pos_file], (size_t)(pos_ext - pos_file));
+				strncat (out_file, ps_file, (size_t)pos_ext);
 				strcat (out_file, "_intermediate");
 			}
 			else {	/* Output is the final result */


### PR DESCRIPTION
**Description of proposed changes**

This lets psconvert not create a local intermediate PDF file under certain circumstances.
Fixes #6711


**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
