### PR TITLE
Do not try to access key[k][K_MODIFIER] without checking the key[k] size

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12792,20 +12792,20 @@ GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key,
 		strcpy (argument, inarg);	/* Any colon-string will be added back in GMT_Encode_Options */
 		gmt_M_str_free (inarg);
 		/* Also return 1 or 2, depending on -G vs -S */
-		*n_pre = (k >= 0 && key[k][K_MODIFIER] > 0 && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
+		*n_pre = (k >= 0 && strlen (key[k]) >= 5 && key[k][K_MODIFIER] > 0 && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
 		return (0);
 	}
 
 	if (k >= 0 && key[k][K_EQUAL] == '=') {	/* Special handling */
 		*takes_mod = 1;	/* Flag that KEY was special */
-		*n_pre = (key[k][K_MODIFIER] && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
+		*n_pre = (strlen (key[k]) >= 5 && key[k][K_MODIFIER] && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
 		if ((*n_pre || key[k][K_MODIFIER] == 0) && (c = strchr (inarg, '+'))) {	/* Strip off trailing +<modifiers> */
 			c[0] = 0;
 			strcpy (argument, inarg);
 			c[0] = '+';
 			if (!argument[0]) *takes_mod = 2;	/* Flag that option is missing the arg and needs it later */
 		}
-		else if (key[k][K_MODIFIER]) {	/* Look for a specific +<mod> in the option */
+		else if (strlen (key[k]) >= 5 && key[k][K_MODIFIER]) {	/* Look for a specific +<mod> in the option */
 			char code[3] = {"+?"};
 			code[1] = key[k][K_MODIFIER];
 			if ((c = strstr (inarg, code))) {	/* Found +<modifier> */
@@ -13351,6 +13351,7 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 				GMT_Report (API, GMT_MSG_DEBUG, "GMT_Encode_Options: Option -%c needs implicit arg via argument-less +%c modifier\n", opt->option, key[k][K_MODIFIER]);
 			else
 				implicit = false;
+//fprintf(stderr, "K = %d\t%s\t%d\n", k, argument, n_pre_arg);
 			if (implicit) {
 				/* This is an implicit reference and we must explicitly add the missing item by adding the questionmark */
 				info[n_items].option    = opt;
@@ -13360,6 +13361,7 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 				info[n_items].mode = (api_is_required_IO (key[k][K_DIR])) ? K_PRIMARY : K_SECONDARY;
 				key[k][K_DIR] = api_not_required_io (key[k][K_DIR]);	/* Change to ( or ) since option was provided, albeit implicitly */
 				info[n_items].pos = pos = (direction == GMT_IN) ? input_pos++ : output_pos++;
+//fprintf(stderr, "MERDA0 family = %d\tPos = %d\tdirection = %d\n", family, input_pos, direction);
 				/* Explicitly add the missing marker (e.g., ?) to the option argument */
 				if (mod_pos) {	/* Must expand something like 300k+s+d+u into 300k+s?+d+u (assuming +s triggered this test) */
 					strncpy (txt, opt->arg, mod_pos);

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -12782,9 +12782,11 @@ GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key,
 	 */
 	char *c = NULL, *inarg = strdup (optarg);  /* Local duplicate we can mess with */
 	unsigned int pos = 0;
+	size_t len;
 	*n_pre = 0;
 	*takes_mod = 0;
 
+	len = strlen (key[k]);
 	if (colon_opt) {    /* Either -S (from psxy[z]) or -G (from grdcontour or pscontour) */
 		if (colon && (c = strchr (inarg, ':')))  /* Chop off :<more arguments> from quoted/decorated lines or contour setups **/
 			c[0] = '\0';
@@ -12792,20 +12794,20 @@ GMT_LOCAL int gmtapi_extract_argument (char *optarg, char *argument, char **key,
 		strcpy (argument, inarg);	/* Any colon-string will be added back in GMT_Encode_Options */
 		gmt_M_str_free (inarg);
 		/* Also return 1 or 2, depending on -G vs -S */
-		*n_pre = (k >= 0 && strlen (key[k]) >= 5 && key[k][K_MODIFIER] > 0 && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
+		*n_pre = (k >= 0 && len > K_MODIFIER && key[k][K_MODIFIER] > 0 && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
 		return (0);
 	}
 
 	if (k >= 0 && key[k][K_EQUAL] == '=') {	/* Special handling */
 		*takes_mod = 1;	/* Flag that KEY was special */
-		*n_pre = (strlen (key[k]) >= 5 && key[k][K_MODIFIER] && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
+		*n_pre = (len > K_MODIFIER && key[k][K_MODIFIER] && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
 		if ((*n_pre || key[k][K_MODIFIER] == 0) && (c = strchr (inarg, '+'))) {	/* Strip off trailing +<modifiers> */
 			c[0] = 0;
 			strcpy (argument, inarg);
 			c[0] = '+';
 			if (!argument[0]) *takes_mod = 2;	/* Flag that option is missing the arg and needs it later */
 		}
-		else if (strlen (key[k]) >= 5 && key[k][K_MODIFIER]) {	/* Look for a specific +<mod> in the option */
+		else if (len > K_MODIFIER && key[k][K_MODIFIER]) {	/* Look for a specific +<mod> in the option */
 			char code[3] = {"+?"};
 			code[1] = key[k][K_MODIFIER];
 			if ((c = strstr (inarg, code))) {	/* Found +<modifier> */


### PR DESCRIPTION
I have trace a mysterious Julia failure that occurs randomly to the test at line 12795 in ``gmtapi_extract_argument()``
```
*n_pre = (k >= 0 && key[k][K_MODIFIER] > 0 && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
```
The problem is that most of KEYs have less than 5 characters (K_MODIFIER = 4) and so the above test most of times is accessing uninitialized memory since ``key[k]`` is set via a ``strdup`` call and hence it will not have 5 chars almost never. Setting a test on the key size as in
```
*n_pre = (k >= 0 && strlen (key[k]) >= 5 && key[k][K_MODIFIER] > 0 && isdigit (key[k][K_MODIFIER])) ? (int)(key[k][K_MODIFIER]-'0') : 0;
```
seems to make the random failure to go. I've added a couple of those test in ``gmtapi_extract_argument()`` except in one place (``if ((*n_pre || key[k][K_MODIFIER] == 0) ...`` because doing so caused test failures namely in one that complained that
```
mapproject [ERROR]: No filename provided
```
but none of the ``mapproject`` KEYs have 5 characters, so that ``if`` test seems to be passing by chance but the size root problem remains there as well.