### PR TITLE
Remove duplicate dot in copyright

### DIFF
--- a/doc/rst/conf.py.in
+++ b/doc/rst/conf.py.in
@@ -29,7 +29,7 @@ if tags.has("nosphinxpanels"):
 
 # -- Project configuration ------------------------------------------------
 project = 'GMT'
-copyright = "@GMT_VERSION_YEAR@, The GMT Team."
+copyright = "@GMT_VERSION_YEAR@, The GMT Team"
 # The version shown at the top of the sidebar
 version = '@GMT_PACKAGE_VERSION_MAJOR@.@GMT_PACKAGE_VERSION_MINOR@'
 # The full version shown in the page title


### PR DESCRIPTION
**Description of proposed changes**

There are two dots after "The GMT Team".

![image](https://user-images.githubusercontent.com/3974108/168743185-e5e2576d-4f52-452e-8320-ab571dad0f5b.png)