### PR TITLE
Temporarily disable openMP on Linux/macOS

### DIFF
--- a/ci/config-gmt-unix.sh
+++ b/ci/config-gmt-unix.sh
@@ -10,7 +10,7 @@ set (GSHHG_ROOT "$ENV{COASTLINEDIR}/gshhg")
 set (DCW_ROOT "$ENV{COASTLINEDIR}/dcw")
 
 set (GMT_USE_THREADS TRUE)
-set (GMT_ENABLE_OPENMP TRUE)
+# set (GMT_ENABLE_OPENMP TRUE)
 
 # recommended even for release build
 set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
**Description of proposed changes**

It's still unclear to me why building GMT on macOS fails, but it's clear that the failures are related to OpenMP support, likely due to upstream changes in Homebrew packages. xref: https://github.com/GenericMappingTools/gmt/issues/6718

In this PR, openMP support is disabled on Linux and macOS so that the CI tests pass.