### PR TITLE
Better doc on prohibited CPT output names

### DIFF
--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -309,6 +309,26 @@ Here, cdf.txt would be the cumulative hypsometric curve for the Earth.
 
 .. include:: cpt_notes.rst_
 
+Restriction on CPT Output Names
+-------------------------------
+
+Since **grd2cpt** will also interpolate from any existing CPT you
+may have in your directory, you should never use one of the master CPT names
+as an output filename; hence the my_gebco.cpt in the example.  If you
+do create a CPT of such a name, e.g., rainbow.cpt, then **grd2cpt** will
+read that file first and not look for the master CPT in the shared GMT
+directory. For instance, the command::
+
+    gmt grd2cpt my_grid.grd -Crainbow > rainbow.cpt
+
+will return error messages like this::
+
+    grd2cpt [ERROR]: Color palette table rainbow.cpt is empty
+
+since the redirection will first create an empty file rainbow.cpt before
+**grd2cpt** even has started and it will then try to read it and it is all
+downhill from there.
+
 See Also
 --------
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -345,15 +345,25 @@ To make a categorical CPT with string keys instead of numerical lookup values, t
 
 .. include:: cpt_notes.rst_
 
-Bugs
-----
+Restriction on CPT Output Names
+-------------------------------
 
 Since **makecpt** will also interpolate from any existing CPT you
-may have in your directory, you should not use one of the listed cpt names
+may have in your directory, you should never use one of the master CPT names
 as an output filename; hence the my_gebco.cpt in the example.  If you
 do create a CPT of such a name, e.g., rainbow.cpt, then **makecpt** will
 read that file first and not look for the master CPT in the shared GMT
-directory.
+directory. For instance, the command::
+
+    gmt makecpt -Crainbow -T0/10 > rainbow.cpt
+
+will return error messages like this::
+
+    makecpt [ERROR]: Color palette table rainbow.cpt is empty
+
+since the redirection will first create an empty file rainbow.cpt before
+**makecpt** even has started and it will then try to read it and it is all
+downhill from there.
 
 See Also
 --------


### PR DESCRIPTION
Since from time to time people learn about redirection [the hard way](https://forum.generic-mapping-tools.org/t/problems-with-makecpt-using-roma-or-batlow-color-palettes/2366/3) I have improved the comments in **makecpt** and duplicated to **grd2cpt**.
