### PR TITLE
Check that files in the share-path are nonzero if in current directory

### DIFF
--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -309,26 +309,6 @@ Here, cdf.txt would be the cumulative hypsometric curve for the Earth.
 
 .. include:: cpt_notes.rst_
 
-Restriction on CPT Output Names
--------------------------------
-
-Since **grd2cpt** will also interpolate from any existing CPT you
-may have in your directory, you should never use one of the master CPT names
-as an output filename; hence the my_gebco.cpt in the example.  If you
-do create a CPT of such a name, e.g., rainbow.cpt, then **grd2cpt** will
-read that file first and not look for the master CPT in the shared GMT
-directory. For instance, the command::
-
-    gmt grd2cpt my_grid.grd -Crainbow > rainbow.cpt
-
-will return error messages like this::
-
-    grd2cpt [ERROR]: Color palette table rainbow.cpt is empty
-
-since the redirection will first create an empty file rainbow.cpt before
-**grd2cpt** even has started and it will then try to read it and it is all
-downhill from there.
-
 See Also
 --------
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -345,26 +345,6 @@ To make a categorical CPT with string keys instead of numerical lookup values, t
 
 .. include:: cpt_notes.rst_
 
-Restriction on CPT Output Names
--------------------------------
-
-Since **makecpt** will also interpolate from any existing CPT you
-may have in your directory, you should never use one of the master CPT names
-as an output filename; hence the my_gebco.cpt in the example.  If you
-do create a CPT of such a name, e.g., rainbow.cpt, then **makecpt** will
-read that file first and not look for the master CPT in the shared GMT
-directory. For instance, the command::
-
-    gmt makecpt -Crainbow -T0/10 > rainbow.cpt
-
-will return error messages like this::
-
-    makecpt [ERROR]: Color palette table rainbow.cpt is empty
-
-since the redirection will first create an empty file rainbow.cpt before
-**makecpt** even has started and it will then try to read it and it is all
-downhill from there.
-
 See Also
 --------
 

--- a/doc/rst/source/tutorial/session-4.rst
+++ b/doc/rst/source/tutorial/session-4.rst
@@ -63,7 +63,7 @@ above are done in classic mode.  If you run :doc:`/makecpt` in modern mode
 then you usually do not specify an output file via standard output since
 modern mode maintains what is known as the current CPT.  However,
 if you must explicitly name an output CPT then you will need to
-add the -H option for modern mode to allow output to standard output.
+add the **-H** option for modern mode to allow output to standard output.
 
 ======================================================= ==================================================================================
 Option                                                  Purpose


### PR DESCRIPTION
This situation can happen when users run things like

`gmt makecpt -Cturbo > turbo.cpt`

because the output is created as an empty file first by the system, and then **makecpt** reads that instead of the master file.  The simple solution is to insist that when we search for GMT files expected in the _share path_, while we will allow such a file to live in the current directory it must pass the extra test that it is not empty.

All tests run and the old problem above is gone.

Recently updated docs (#6744 ) have been edited again to remove the mention of the problem.

If anyone runs into documentation that discusses the old problem we need to update that as well - I did not find any beyond the two modules.