### PR TITLE
Let modules called by modules in inset know of shrinking

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13753,6 +13753,9 @@ void gmt_end (struct GMT_CTRL *GMT) {
 	gmt_M_free (GMT, GMT->parent->remote_info);
 	/* Free snapshot of GMT common option structure */
 	gmt_M_free (GMT, GMT->parent->common_snapshot);	/* Free snapshot */
+	/* Undo any inset shrink scaling memory */
+	GMT->parent->inset_shrink_scale = 1.0;
+	GMT->parent->inset_shrink = false;
 
 #ifdef MEMDEBUG
 	gmt_memtrack_report (GMT);

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2195,6 +2195,10 @@ GMT_LOCAL void gmtmap_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, dou
 		}
 		update_parameters = true;
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Rescaling map for inset by factors fx = %g fy = %g dx = %g dy = %g\n", fx, fy, I->dx, I->dy);
+		if (fx < 1.0) {	/* Need this for modules called within the inset */
+			GMT->parent->inset_shrink = true;
+			GMT->parent->inset_shrink_scale = fx;
+		}
 	}
 	else if (P->active && no_scaling == 0)	{	/* Must rescale to fit inside subplot dimensions and set dx,dy for centering */
 		gmtmap_adjust_panel_for_gaps (GMT, P);	/* Deal with any gaps requested via subplot -C: shrink w/h and adjust origin */
@@ -2218,6 +2222,12 @@ GMT_LOCAL void gmtmap_setxy (struct GMT_CTRL *GMT, double xmin, double xmax, dou
 			GMT->current.setting.map_annot_oblique |= GMT_OBL_ANNOT_LAT_PARALLEL;	/* Plot latitude parallel to frame for geo maps */
 		}
 	}
+	else if (GMT->parent->inset_shrink) {	/* We are in a module called inside a map inset call which may have had to adjust the scale */
+		update_parameters = true;
+		fx = fy = GMT->parent->inset_shrink_scale;
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Rescaling projection scale inside inset by factors fx = %g\n", fx);
+	}
+
 	if (update_parameters) {	/* Scale the parameters due to inset or subplot adjustments */
 		/* Update all projection parameters given the reduction factors fx, fy */
 		GMT->current.proj.scale[GMT_X] *= fx;

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -214,6 +214,8 @@ struct GMTAPI_CTRL {
 	struct GMT_DATA_INFO *remote_info;
 	bool server_announced;	/* Set to true after we have announced which GMT data server we are using */
 	struct GMT_COMMON *common_snapshot;	/* Holds the latest GMT common option settings after a module completes. */
+	bool inset_shrink;	/* True if gmt inset gets a -R -J that forces us to shrink the scale to fit the inset size */
+	double inset_shrink_scale;	/* The amount of shrinking.  Reset to false and 1 in gmt inset end */
 };
 
 /* Macro to test if filename is a special name indicating memory location */

--- a/src/inset.c
+++ b/src/inset.c
@@ -447,6 +447,9 @@ EXTERN_MSC int GMT_inset (void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_DEBUG, "inset: Removed inset file\n");
 		gmt_reload_history (API->GMT);
 		gmt_reload_settings (API->GMT);
+		/* Undo any shrink scaling memory */
+		API->inset_shrink_scale = 1.0;
+		API->inset_shrink = false;
 	}
 
 	gmt_plotend (GMT);


### PR DESCRIPTION
See this [post](https://github.com/GenericMappingTools/pygmt/issues/1930) for background. The problem was that the **coast** module called another module (**plot**) while inside the **inset** section but the called module was unaware that because of the **-R -J** and inset size setting there was a scaling of 0.73 applied.  That meant **plot** was off by that factor (unless we countered that by appending **+du** to **-J**, which the user would not know was needed).  The same would happen with any other module called inside the **inset** section that might call another module (e.g., **plot** calls **plot** when dealing with decorated lines, for instance).

The solution is to remember the computed inset scale in the API so that when the secondary module is initialized it can apply the same scaling as the mother module; this scaling happens in the belly of _gmt_proj_setup_.

With those changes, this works correctly:

```
gmt begin map
    gmt coast -R-74/-69.5/41/43 -JM15c -Baf -Wthin -Clightblue -Glightyellow
    gmt inset begin -DjBL+w3c+o0.5c/0.2c -F+pblack+gwhite
        gmt coast -R-80/-65/35/50 -JM? -Ggray -Cwhite -EUS.MA+gred -W1/thin -N1 -N2
    gmt inset end
gmt end show
```