### PR TITLE
Clarify that -i will convert anything

### DIFF
--- a/doc/rst/source/explain_-icols_full.rst_
+++ b/doc/rst/source/explain_-icols_full.rst_
@@ -27,4 +27,7 @@ any trailing text will be read but when **-i** is used to specify specific input
 "column" **t** to retain the trailing text internally. To only ingest a single word from the trailing text, append
 the word number (first word is 0).  If your trailing text columns start with a valid number and you want to ensure
 the content from column *col* to the end of the record will be considered trailing text, use **-f**\ *col*\ **s**.
-Finally, **-in** will simply read the numerical input and skip any trailing text.
+Finally, **-in** will simply read the numerical input and skip any trailing text. **Note**: Using **-i** assumes
+there are as many numerical columns as implied in **-i**, so if you have a mix of numerical and text columns we will forge
+ahead and read those text columns (most likely returned as NaNs) and return your selection as numerical values.  The default (no **-i** provided)
+will examine the record and stop conversions when the record switches to trailing text.


### PR DESCRIPTION
Following the comments on the [forum](https://forum.generic-mapping-tools.org/t/filter1d-and-sample1d-with-no-data-colums/2955/7), I have added a note to **-i** to clarify that **-i** will override how many columns we have found in the record and barge ahead and try to convert what it finds to numbers.  This is likely to be NaN but if someone has a column with a mix of flags containing numbers, then those will presumably be concerted to numbers.  Also unpredictable if there are multi-word columns. Messy and not recommended, but there it is.
