### PR TITLE
Reset time to current TIME_UNIT

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -17905,10 +17905,9 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 		}
 		T->n = gmt_make_equidistant_array (GMT, tmp_t0, tmp_t1, T->reverse ? -inc : inc, &(T->array));
 	}
-	if (T->vartime && GMT->current.setting.time_system.unit != unit) {
+	if (T->temporal && GMT->current.setting.time_system.unit != unit) {
 		uint64_t k;
 		/* Restore to original TIME_UNIT unit and update val array to have same units */
-		//scale = GMT->current.setting.time_system.scale / scale;
 		GMT->current.setting.time_system.unit = unit;
 		(void) gmt_init_time_system_structure (GMT, &GMT->current.setting.time_system);
 		for (k = 0; k < T->n; k++) T->array[k] *= scale;


### PR DESCRIPTION
For unclear reason, this only happened when the non-second time-unit selected was a variable one (1o) but not a fixed one (30d).  I fixed this (and removed a commented-out line in the process) and all tests still pass. Close #6757.
