### PR TITLE
Address a few grdflexure issues

### DIFF
--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -87,6 +87,8 @@ Required Arguments
     Sets density for mantle, load, infill, and water (or air).  If *ri* differs from
     *rl* then an approximate solution will be found.  If *ri* is not given
     then it defaults to *rl*.  Values may be given in km/m^3 or g/cm^3.
+    **Note**: If a variable load density grid is supplied via |-H| then *rl*
+    must be given as -.
 
 .. _-E:
 
@@ -95,9 +97,9 @@ Required Arguments
     If the elastic thickness exceeds 1e10 it will be interpreted as
     a flexural rigidity *D* (by default, *D* is computed from *Te*, Young's
     modulus, and Poisson's ratio; see |-C| to change these values).
-    If just |-E| is given and |-F| is used it means no plate is given
+    If |-E| is given with no arguments and |-F| is given it means no plate is present
     and we will return a purely viscous response with or without an asthenospheric layer.
-    Select a general linear viscoelastic response by supplying both an initial and
+    Select a general linear viscoelastic response instead by supplying both an initial and
     final elastic thickness *Te2*; this response also requires |-M|.
 
 .. _-G:
@@ -143,7 +145,8 @@ Optional Arguments
 **-H**\ *rhogrid*
     Supply optional variable load density grid.  It can be a single
     grid or a grid name template (see `Name Template`_ for details). Requires
-    *rho_l* be set to - in |-D|.  **Note**: If *input* is given as
+    *rho_l* be set to - in |-D|.  The density grid may be NaN at nodes where the
+    load grid is NaN (or zero).  **Note**: If *input* is given as
     a list file then the optional density grids must be given as part of
     the list and not via |-H|.
 
@@ -330,6 +333,21 @@ topographic load in the wavenumber domain, *A* is the Airy density ratio, :math:
 on the infill density, and :math:`\Phi(\mathbf{k},t)` is the response function for the selected rheology. The **grdflexure**
 module read one or more loads *h*, transforms them to *H*, evaluates and applies the response function, and
 inversely transform the results back to yield on or more *w* solutions.
+
+Variable load density
+~~~~~~~~~~~~~~~~~~~~~
+
+If the load density is variable (i.e., provided as a grid via |-H|) then we simply adjust the load height to be
+the equivalent height for the average load density. This is accomplished on a node-by-node basis by honoring the
+equality :math:`\rho_l(\mathbf{x})\cdot h(\mathbf{x}) = \bar{\rho_l}\cdot h'(\mathbf{x})`, where the prime height
+is the adjusted amplitude.
+
+Submarine and subaerial loads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the water depth is specified via |-W| then we check if the (possibly adjusted) load height exceeds the water
+depth for any node.  If so, then we adjust the load height that is above water to what it needs to be if the density
+contrast were against water and not air.  The subaerial height component is thus extended by :math:`\frac{\rho_l}{\rho_l - \rho_w}`.
 
 Variable infill approximation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -81,6 +81,10 @@ Required Arguments
     - A file list with extension ".lis" does not need the **+l** modifier
       and will be automatically recognized as a file list.
 
+    **Note**: The horizontal dimensions are expected to be in meters.  If you
+    have grids in km then you can append **+uk** to do the required conversion
+    when the grid is read.  All input grids must have the same dimensions.
+
 .. _-D:
 
 **-D**\ *rm*/*rl*\ [/*ri*]\ /*rw*

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3892,3 +3892,27 @@ unsigned int gmt_grid_perimeter (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h
 	*x = xx;	*y = yy;
 	return (n);
 }
+
+bool gmt_grd_domains_match (struct GMT_CTRL *GMT, struct GMT_GRID *A, struct GMT_GRID *B, char *comment) {
+	/* Return true if both grids A and B have exactly the same domain, registration, intervals.
+	 * Otherwise we print an error message and return false.
+	 */
+	char *msg = (comment = NULL) ? "two" : comment;
+	if (A->header->registration != B->header->registration) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "The %s grids have different registrations!\n", msg);
+		return (false);
+	}
+	if (!gmt_M_grd_same_shape (GMT, A, B)) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "The %s grids have different dimensions\n", msg);
+		return (false);
+	}
+	if (!gmt_M_grd_same_region (GMT, A, B)) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "The %s grids have different regions\n", msg);
+		return (false);
+	}
+	if (!gmt_M_grd_same_inc (GMT, A, B)) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "The %s grids have different intervals\n", msg);
+		return (false);
+	}
+	return (true);
+}

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -204,6 +204,7 @@ EXTERN_MSC bool gmt_file_is_cache (struct GMTAPI_CTRL *API, const char *file);
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC bool gmt_grd_domains_match (struct GMT_CTRL *GMT, struct GMT_GRID *A, struct GMT_GRID *B, char *comment);
 EXTERN_MSC unsigned int gmt_grid_perimeter (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, double **x, double **y);
 EXTERN_MSC void gmt_change_grid_history (struct GMTAPI_CTRL *API, unsigned int mode, struct GMT_GRID_HEADER *h, char *command);
 EXTERN_MSC char *gmt_get_grd_title (struct GMT_GRID_HEADER *h);

--- a/src/grdfft.c
+++ b/src/grdfft.c
@@ -868,20 +868,7 @@ EXTERN_MSC int GMT_grdfft (void *V_API, int mode, void *args) {
 	}
 
 	if (Ctrl->In.n_grids == 2) {	/* If given 2 grids, make sure they are co-registered and has same size, registration, etc. */
-		if(Orig[0]->header->registration != Orig[1]->header->registration) {
-			GMT_Report (API, GMT_MSG_ERROR, "The two grids have different registrations!\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_shape (GMT, Orig[0], Orig[1])) {
-			GMT_Report (API, GMT_MSG_ERROR, "The two grids have different dimensions\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_region (GMT, Orig[0], Orig[1])) {
-			GMT_Report (API, GMT_MSG_ERROR, "The two grids have different regions\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_inc (GMT, Orig[0], Orig[1])) {
-			GMT_Report (API, GMT_MSG_ERROR, "The two grids have different intervals\n");
+		if (!gmt_grd_domains_match (GMT, Orig[0], Orig[1], NULL)) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}

--- a/src/grdvector.c
+++ b/src/grdvector.c
@@ -483,8 +483,7 @@ EXTERN_MSC int GMT_grdvector (void *V_API, int mode, void *args) {
 		gmt_grd_init (GMT, Grid[k]->header, options, true);
 	}
 
-	if (!(gmt_M_grd_same_shape (GMT, Grid[0], Grid[1]) && gmt_M_grd_same_region (GMT, Grid[0], Grid[1]) && gmt_M_grd_same_inc (GMT, Grid[0], Grid[1]))) {
-		GMT_Report (API, GMT_MSG_ERROR, "files %s and %s does not match!\n", Ctrl->In.file[0], Ctrl->In.file[1]);
+	if (!gmt_grd_domains_match (GMT, Grid[0], Grid[1], "input component")) {
 		Return (GMT_RUNTIME_ERROR);
 	}
 

--- a/src/potential/gravfft.c
+++ b/src/potential/gravfft.c
@@ -587,20 +587,7 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
 	}
 
 	if (Ctrl->In.n_grids == 2) {	/* If given 2 grids, make sure they are co-registered and has same size, registration, etc. */
-		if(Orig[0]->header->registration != Orig[1]->header->registration) {
-			GMT_Report (API, GMT_MSG_ERROR, "The two grids have different registrations!\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_shape (GMT, Orig[0], Orig[1])) {
-			GMT_Report (API, GMT_MSG_ERROR, "The two grids have different dimensions\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_region (GMT, Orig[0], Orig[1])) {
-			GMT_Report (API, GMT_MSG_ERROR, "The two grids have different regions\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_inc (GMT, Orig[0], Orig[1])) {
-			GMT_Report (API, GMT_MSG_ERROR, "The two grids have different intervals\n");
+		if (!gmt_grd_domains_match (GMT, Orig[0], Orig[1], NULL)) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
@@ -608,20 +595,7 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
 	if (Ctrl->D.variable) {	/* Read density contrast grid */
 		if ((Rho = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA | GMT_GRID_IS_COMPLEX_REAL, NULL, Ctrl->D.file, NULL)) == NULL)
 			Return (API->error);
-		if(Orig[0]->header->registration != Rho->header->registration) {
-			GMT_Report (API, GMT_MSG_ERROR, "Surface and density grids have different registrations!\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_shape (GMT, Orig[0], Rho)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Surface and density grids have different dimensions\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_region (GMT, Orig[0], Rho)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Surface and density grids have different regions\n");
-			Return (GMT_RUNTIME_ERROR);
-		}
-		if (!gmt_M_grd_same_inc (GMT, Orig[0], Rho)) {
-			GMT_Report (API, GMT_MSG_ERROR, "Surface and density grids have different intervals\n");
+		if (!gmt_grd_domains_match (GMT, Orig[0], Rho, "surface and density")) {
 			Return (GMT_RUNTIME_ERROR);
 		}
 		for (m = 0; m < Rho->header->size; m++) if (gmt_M_is_fnan (Rho->data[m])) Rho->data[m] = Rho->header->z_min;	/* Replace any NaNs with the minimum density */

--- a/src/potential/grdgravmag3d.c
+++ b/src/potential/grdgravmag3d.c
@@ -679,15 +679,8 @@ EXTERN_MSC int GMT_grdgravmag3d (void *V_API, int mode, void *args) {
 			Return(API->error);
 		}
 
-		if(GridA->header->registration != GridS->header->registration) {
-			GMT_Report(API, GMT_MSG_ERROR, "Up surface and source grids have different registrations!\n");
+		if (!gmt_grd_domains_match (GMT, GridA, GridS, "up surface and source")) {
 			Return (GMT_RUNTIME_ERROR);
-		}
-
-		if (fabs (GridA->header->inc[GMT_X] - GridS->header->inc[GMT_X]) > 1.0e-6 ||
-		          fabs(GridA->header->inc[GMT_Y] - GridS->header->inc[GMT_Y]) > 1.0e-6) {
-			GMT_Report(API, GMT_MSG_ERROR, "Up surface and source grid increments do not match!\n");
-			Return(GMT_RUNTIME_ERROR);
 		}
 
 		if (GMT_Read_Data(API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_DATA_ONLY, wesn_padded,


### PR DESCRIPTION
This PR addresses a few bugs and improves documentation:

1. Let **grdflexure** handle the combination of **-H -W**: If the load has variable load density then we must use the density at each node to compute the equivalent height for an average load density.  Also, this must be done before we determine if any part of the load (now) sticks above sea level for the additional boost due to the greater density contrast with air.
2. The check for NaNs in the input grid gave an error right away, hence we never even got to the section where the NaNs were replaced by zeros.  Now fixed.
3. Since this module as well as many others (**gravfft**, **grdgravmag**, **grdvector**) need to check if the two grids are truly co-registered I have added a new function _gmt_grd_domains_match_ which consolidates the (many) checks into one function.  These modules now use this function to simplify those checks.
4. The effects of **-H** and **-W** on the load heights were never discussed - now the documentation explains what is going on.

No changes to any tests.