### PR TITLE
Fix harmless issues in movie

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -232,7 +232,7 @@ Optional Arguments
 
     - **+c**\ *dx*\ [/*dy*] sets the clearance between label and bounding box; only used if **+g** or **+p** are set.
       Append units **c**\|\ **i**\|\ **p** or % of the font size [15%].
-    - **+f** seelcts a specific *font* [:term:`FONT_TAG`].
+    - **+f** selects a specific *font* [:term:`FONT_TAG`].
     - **+g** will fill the label bounding box with *fill* color [no fill].
     - **+h**\ [*dx*/*dy*/][*shade*] will place drop-down shade behind the label bounding box. You can
       adjust the offset with *dx*/*dy* [4p/-4p] and shade color [gray50]; requires **+g** [no shade].

--- a/src/movie.c
+++ b/src/movie.c
@@ -2062,7 +2062,6 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		else
 			gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_BACKGROUND", "");		/* Nothing */
 		if (Ctrl->F.transparent && Ctrl->F.active[MOVIE_GIF]) place_background = false;	/* Only place background once if transparent images */
-		gmt_set_tvalue (fp, Ctrl->In.mode, false, "MOVIE_ITEM", state_tag);		/* Current frame tag (formatted frame number) */
 		for (col = 0; col < n_values; col++) {	/* Derive frame variables from <timefile> in each parameter file */
 			sprintf (string, "MOVIE_COL%u", col);
 			gmt_set_value (GMT, fp, Ctrl->In.mode, col, string, D->table[0]->segment[0]->data[col][data_frame]);


### PR DESCRIPTION
Since at least 6.3, the **MOVIE_ITEM** setting was written out twice to the parameter file.
Also fix a typo in the docs.
