### PR TITLE
gmt.conf.rst: MAP_ANNOT_OBLIQUE, put keywords in table

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -656,17 +656,17 @@ MAP Parameters
         and parallels.  We expect a comma-separated list of up to seven
         keywords [default is **anywhere**]:
 
-        ============== ==========================================================================================================================================
+        ============== ============================================================================================================
         Keyword        Meaning
-        ============== ==========================================================================================================================================
-        separate       longitudes will be annotated on the lower and upper boundaries only, and latitudes will be annotated on the left and right boundaries only
-        anywhere       annotations will occur wherever an imaginary gridline crosses the map boundaries
-        lon_horizontal longitude annotations will be plotted horizontally
-        lat_horizontal latitude annotations will be plotted horizontally
-        tick_extend    tick-marks are extended so the distance from the tip of the oblique tick to the map frame equals the specified tick length
-        tick_normal    tick-marks will be drawn normal to the border regardless of gridline angle
-        lat_parallel   latitude annotations will be plotted parallel to the border
-        ============== ==========================================================================================================================================
+        ============== ============================================================================================================
+        separate       Annotate longitudes on lower and upper boundaries only, and latitudes on the left and right boundaries only
+        anywhere       Annotations will occur wherever an imaginary gridline crosses the map boundaries
+        lon_horizontal Longitude annotations will be plotted horizontally
+        lat_horizontal Latitude annotations will be plotted horizontally
+        tick_extend    Extend tick-marks so distance from tip of the oblique tick to map frame equals specified tick length
+        tick_normal    Draw tick-marks normal to the border regardless of gridline angle
+        lat_parallel   Latitude annotations will be plotted parallel to the border
+        ============== ============================================================================================================
 
     **MAP_ANNOT_OFFSET**
         Sets both :term:`MAP_ANNOT_OFFSET_PRIMARY` and

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -653,18 +653,20 @@ MAP Parameters
     **MAP_ANNOT_OBLIQUE**
         This setting applies to "oblique" projections, which in this context
         means maps whose boundary is a rectangle not specified by meridians
-        and parallels.  We expect a comma-separated list of up to seven keywords:
-        **separate** means longitudes will be annotated on the lower and upper
-        boundaries only, and latitudes will be annotated on the left and right
-        boundaries only; **anywhere** means annotations will occur wherever an
-        imaginary gridline crosses the map boundaries; **lon_horizontal** means
-        longitude annotations will be plotted horizontally; **lat_horizontal**
-        means latitude annotations will be plotted horizontally; **tick_extend**
-        means tick-marks are extended so the distance from the tip of the oblique
-        tick to the map frame equals the specified tick length; **tick_normal**
-        means tick-marks will be drawn normal to the border regardless of
-        gridline angle; **lat_parallel** means latitude annotations will be
-        plotted parallel to the border [default is **anywhere**].
+        and parallels.  We expect a comma-separated list of up to seven
+        keywords [default is **anywhere**]:
+
+        ============== ==========================================================================================================================================
+        Keyword        Meaning
+        ============== ==========================================================================================================================================
+        separate       longitudes will be annotated on the lower and upper boundaries only, and latitudes will be annotated on the left and right boundaries only
+        anywhere       annotations will occur wherever an imaginary gridline crosses the map boundaries
+        lon_horizontal longitude annotations will be plotted horizontally
+        lat_horizontal latitude annotations will be plotted horizontally
+        tick_extend    tick-marks are extended so the distance from the tip of the oblique tick to the map frame equals the specified tick length
+        tick_normal    tick-marks will be drawn normal to the border regardless of gridline angle
+        lat_parallel   latitude annotations will be plotted parallel to the border
+        ============== ==========================================================================================================================================
 
     **MAP_ANNOT_OFFSET**
         Sets both :term:`MAP_ANNOT_OFFSET_PRIMARY` and


### PR DESCRIPTION
Put keywords and meaning in table for ``MAP_ANNOT_OBLIQUE``.

I was hoping to be able to break lines in the table (both in the unrendered and rendered gmt.conf.rst) to make it narrower (i.e. see all text without scrolling), but this turned out to be more difficult than I thought. Any tips?

![snip](https://user-images.githubusercontent.com/29237824/174979580-ee07490b-73fa-492c-aca3-0974feda4dd4.PNG)

