### PR TITLE
WIP Clarify z is positive up and eliminate -A in gravprisms

### DIFF
--- a/doc/rst/source/supplements/potential/explain_geometry.rst_
+++ b/doc/rst/source/supplements/potential/explain_geometry.rst_
@@ -1,0 +1,12 @@
+Geometry Setup
+--------------
+
+We operate in a right-handed coordinate system where the positive *z*-axis
+is directed upwards.  In this scenario, topographic surfaces may be above
+or below a reference surface (typically the observation level) but the
+positive direction is always up.  Positive geopotential anomalies are
+thus aligned with the positive source (topographic relief) direction.
+If your input data are positive down (e.g., depths) then you will need
+to change the sign. For grids you can use the **+s** and **+o** modifiers
+to scale and offset the grid, while for table data you can use the **-i**
+modifier to scale and offset any column required.

--- a/doc/rst/source/supplements/potential/gmtflexure.rst
+++ b/doc/rst/source/supplements/potential/gmtflexure.rst
@@ -137,14 +137,18 @@ Optional Arguments
 
 **-W**\ *wd*\ [**k**]
     Specify water depth in m; append **k** for km.  Must be positive [0].
-    Any subaerial topography will be scaled via the densities set in |-D|
+    Any subaerial topography (i.e., amplitudes in the input relief that
+    exceeds this depth) will be scaled via the densities set in |-D|
     to compensate for the larger density contrast with air.
 
 .. _-Z:
 
 **-Z**\ *zm*\ [**k**]
-    Specify reference depth to flexed surface in m; append **k** for km.  Must be positive [0].
-    We add this value to the flexed surface before output.
+    Undeformed plate flexure means *z = 0*. Specify the distance between the
+    observation level [*z = 0*] and the undeformed flexed surface in m; append **k** for km.
+    Must be positive [0]. We subtract this value from the flexed surface before output.
+    Thus, if the observation level is at sealevel and you are looking a seafloor deformation
+    in 5 km of water, use -Z5k and the undeformed surface will have *z = -5000* on output.
 
 .. |Add_-bi| unicode:: 0x20 .. just an invisible code
 .. include:: ../../explain_-bi.rst_
@@ -168,6 +172,8 @@ Optional Arguments
 .. include:: ../../explain_help.rst_
 
 .. include:: ../../explain_array.rst_
+
+.. include:: explain_geometry.rst_
 
 Note on Units
 -------------

--- a/doc/rst/source/supplements/potential/gravprisms.rst
+++ b/doc/rst/source/supplements/potential/gravprisms.rst
@@ -13,7 +13,6 @@ Synopsis
 .. include:: ../../common_SYN_OPTs.rst_
 
 **gmt gravprisms** [ *table* ]
-[ |-A| ]
 [ |-C|\ [**+q**][**+w**\ *file*][**+z**\ *dz*] ]
 [ |-D|\ *density* ]
 [ |-E|\ *dx*\ [/*dy*] ]
@@ -90,11 +89,6 @@ Required Arguments
 
 Optional Arguments
 ------------------
-
-.. _-A:
-
-**-A**
-    The *z*-axis should be positive upwards [Default is down].
 
 .. _-C:
 
@@ -264,8 +258,10 @@ prism file and restrict calculations to the same crossing profile, i.e.::
     gmt plot faa_crossing.txt -R-30/30/0/350 -i0,3 -W1p -B -pdf faa_crossing
 
 
-Note
-----
+.. include:: explain_geometry.rst_
+
+Note on Precision
+-----------------
 
 The analytical expression for the geoid over a vertical prism (Nagy et al., 2000) is
 fairly involved and contains 48 terms.  Due to various cancellations the end result

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -208,16 +208,19 @@ Optional Arguments
 .. _-W:
 
 **-W**\ *wd*\ [**k**]
-    Set reference water depth for the undeformed flexed surface in m.  Must be positive. [0].  Append **k** to indicate
-    km.  If |-W| is used and your load exceeds this depth then we scale the subaerial part of the
-    load to account for the change in surrounding density (air vs water).
+    Specify water depth in m; append **k** for km.  Must be positive [0].
+    Any subaerial topography (i.e., amplitudes in the input relief that
+    exceeds this depth) will be scaled via the densities set in |-D|
+    to compensate for the larger density contrast with air.
 
 .. _-Z:
 
 **-Z**\ *zm*\ [**k**]
-    Specify reference depth to flexed surface (e.g., Moho) in m; append **k** for km.
-    Must be positive. [0].  We subtract this value from the flexed surface before
-    writing the results.
+    Undeformed plate flexure means *z = 0*. Specify the distance between the
+    observation level [*z = 0*] and the undeformed flexed surface in m; append **k** for km.
+    Must be positive [0]. We subtract this value from the flexed surface before output.
+    Thus, if the observation level is at sealevel and you are looking a seafloor deformation
+    in 5 km of water, use -Z5k and the undeformed surface will have *z = -5000* on output.
 
 |SYN_OPT-f|
    Geographic grids (dimensions of longitude, latitude) will be converted to

--- a/src/potential/gmtflexure.c
+++ b/src/potential/gmtflexure.c
@@ -44,8 +44,8 @@
  * input files. 1) Load file having x and load, and 2) Rigidity file
  * having x and rigidity. If both files are present, they must list load and
  * rigidity at the same x positions. All units must be in SI. The program writes
- * the deflections to standard output. Z axis is positive DOWN, so
- * positive loads, moments, and forces will all generate positive deflections.
+ * the deflections to standard output. Z axis is positive UP, so
+ * positive loads, moments, and forces will all generate negative deflections.
  * The load file is optional, whereas the rigidity file OR a uniform plate
  * thickness (-E) must be supplied. If no input files are given, then the min/max
  * distance and increment must be given on the command line using the -T option.
@@ -355,7 +355,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Specify water depth in m; append k for km.  Must be positive. "
 		"Subaerial topography will be scaled via -D to account for density differences.");
 	GMT_Usage (API, 1, "\n-Z<zm>[k]");
-	GMT_Usage (API, -2, "Specify reference depth to flexed surface in m; append k for km.  Must be positive [0].");
+	GMT_Usage (API, -2, "Specify distance from observation level (z = 0) to flexed surface in m; append k for km.  Must be positive [0].");
 	GMT_Option (API, "bi,bo,d,e,h,i,o,.");
 	return (GMT_MODULE_USAGE);
 }

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -897,7 +897,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Specify water depth in m; append k for km.  Must be positive. "
 		"Subaerial topography will be scaled via -D to account for density differences.");
 	GMT_Usage (API, 1, "\n-Z<zm>[k]");
-	GMT_Usage (API, -2, "Specify reference depth to flexed surface in m; append k for km.  Must be positive.");
+	GMT_Usage (API, -2, "Specify distance from observation level (z = 0) to flexed surface in m; append k for km.  Must be positive [0].");
 	GMT_Usage (API, 1, "\n-fg Convert geographic grids to meters using a \"Flat Earth\" approximation.");
 	GMT_Option (API, "h,.");
 	return (GMT_MODULE_USAGE);


### PR DESCRIPTION
See #6818 for background.  This PR improves the discussion of water depth (related to density contrasts) and reference depth (-Z, now specified as a distance).  Also added an include _rst file that explains the geometry.  This file will be included in other modules as I revise them.

Work in progress so no need to review yet - I am still working on it