### PR TITLE
Allow MAP_FRAME_TYPE=graph-origin

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -753,8 +753,8 @@ MAP Parameters
         to shift the **W** and **S** axes so they intersect at the user data
         (0, 0) origin instead.  In this mode, only the **W** and **S** axes can be 
         selected (or **w**, **s**, **l**, and **b** too); the **E** and **N** (and
-        **e**, **n**, **r** and **t**) will be ignored.  **Note**: The annotations
-        at the intersection will be suppressed.  To select another intersection point
+        **e**, **n**, **r** and **t**) will be ignored.  **Note**: Annotations
+        at any axes intersections will be suppressed.  To select another intersection point
         than the data origin you may append **+o**\ *xorig*/*yorig* [0/0].
 
         .. toggle::

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -755,7 +755,8 @@ MAP Parameters
         selected (or **w**, **s**, **l**, and **b** too); the **E** and **N** (and
         **e**, **n**, **r** and **t**) will be ignored.  **Note**: Annotations
         at any axes intersections will be suppressed.  To select another intersection point
-        than the data origin you may append **+o**\ *xorig*/*yorig* [0/0].
+        than the data origin you may append **+o**\ *xorig*/*yorig* or the short-cut
+        **+oc** to center the axes on the current data domain [0/0].
 
         .. toggle::
 

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -749,6 +749,13 @@ MAP Parameters
         instead).  The vector stem is set to match :term:`MAP_FRAME_WIDTH`, while
         the vector head length and width are 10 and 5 times this width,
         respectively.  You may control its shape via :term:`MAP_VECTOR_SHAPE`.
+        The graph vectors are plotted as normal boundary axes.  Use **graph-centered**
+        to shift the **W** and **S** axes so they intersect at the user data
+        (0, 0) origin instead.  In this mode, only the **W** and **S** axes can be 
+        selected (or **w**, **s**, **l**, and **b** too); the **E** and **N** (and
+        **e**, **n**, **r** and **t**) will be ignored.  **Note**: The annotations
+        at the intersection will be suppressed.  To select another intersection point
+        than the data origin you may append **+o**\ *xorig*/*yorig* [0/0].
 
         .. toggle::
 

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -749,7 +749,7 @@ MAP Parameters
         instead).  The vector stem is set to match :term:`MAP_FRAME_WIDTH`, while
         the vector head length and width are 10 and 5 times this width,
         respectively.  You may control its shape via :term:`MAP_VECTOR_SHAPE`.
-        The graph vectors are plotted as normal boundary axes.  Use **graph-centered**
+        The graph vectors are plotted as normal boundary axes.  Use **graph-origin**
         to shift the **W** and **S** axes so they intersect at the user data
         (0, 0) origin instead.  In this mode, only the **W** and **S** axes can be 
         selected (or **w**, **s**, **l**, and **b** too); the **E** and **N** (and

--- a/doc/scripts/GMT_map_frame_type.sh
+++ b/doc/scripts/GMT_map_frame_type.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 gmt begin GMT_map_frame_type
   gmt set GMT_THEME cookbook
-  gmt set FONT_TITLE 18p
-  gmt subplot begin 1x5 -Fs3.5c/3.5c -M0.4c -R0/10/0/10
-    gmt basemap -JM? -Baf -BWSen+t"fancy" -c --MAP_FRAME_TYPE=fancy
-    gmt basemap -JM? -Baf -BWSen+t"fancy+" -c --MAP_FRAME_TYPE=fancy+
-    gmt basemap -JM? -Baf -BWSen+t"plain" -c --MAP_FRAME_TYPE=plain
-    gmt basemap -JX? -Baf -BWSen+t"inside" -c --MAP_FRAME_TYPE=inside
-    gmt basemap -JX? -Baf -BWS+t"graph" -c --MAP_FRAME_TYPE=graph
+  gmt set FONT_TAG 12p,Helvetica-Bold
+  gmt subplot begin 2x3 -Fs4c/3.5c -M0.5c -R-5/5/-4/5 -A+JTC+o4p/10p
+    gmt subplot set -Afancy
+    gmt basemap -JM? -Baf -BWSen --MAP_FRAME_TYPE=fancy
+    gmt subplot set -Afancy+
+    gmt basemap -JM? -Baf -BWSen --MAP_FRAME_TYPE=fancy+
+    gmt subplot set -Aplain
+    gmt basemap -JM? -Baf -BWSen --MAP_FRAME_TYPE=plain
+    gmt subplot set -Ainside
+    gmt basemap -JX? -Baf -BWSen --MAP_FRAME_TYPE=inside
+    gmt subplot set -Agraph
+    gmt basemap -JX? -Baf -BWS --MAP_FRAME_TYPE=graph
+    gmt subplot set -Agraph-origin
+    gmt basemap -JX? -Baf -BWS --MAP_FRAME_TYPE=graph-origin
   gmt subplot end
 gmt end show

--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: dcfeeff36661bf41588f2ef2a297b6f5.dir
-  size: 33290389
+- md5: f4ae55604e0d2325ddef6a2afb9dd5af.dir
+  size: 33292646
   nfiles: 200
   path: images

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -153,6 +153,7 @@ struct GMT_DEFAULTS {
 	double map_vector_shape;		/* 0.0 = straight vectorhead, 1.0 = arrowshape, with continuous range in between */
 	double map_graph_extension;		/* If map_frame_type is graph, how must longer to make axis length. [7.5%] */
 	double map_graph_origin[2];		/* x- and y-origin of graph axis if graph-centered is in use [data 0/0] */
+	double map_graph_shift;			/* Extra offset for title to avoid overwriting the centered y-axis */
 	unsigned int map_annot_oblique;	/* Controls annotations and tick angles etc. [GMT_OBL_ANNOT_ANYWHERE] */
 	unsigned int map_grid_cross_type[2];	/* 0 = normal cross, 1 = symmetric tick, 2 = asymmetric tick */
 	unsigned int map_logo_justify;		/* Justification of the GMT timestamp box [1 (BL)] */

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -161,6 +161,7 @@ struct GMT_DEFAULTS {
 	double map_label_mode[2];		/* If label is relative to annotation (0) or axis (1) for x/t [0/0] */
 	bool map_annot_oblique_set;		/* true if user changed map_annot_oblique via a gmt.conf or --par=val */
 	bool map_logo;			/* Plot time and map projection on map [false] */
+	bool map_graph_centered;			/* Center any GRAPH frames [false] */
 	struct GMT_PEN map_default_pen;		/* Default pen for most pens [0.25p] */
 	struct GMT_PEN map_frame_pen;		/* Pen attributes for map boundary [1.25p] */
 	struct GMT_PEN map_grid_pen[2];		/* Pen attributes for primary and secondary gridlines [default,black/thinner,black] */

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -152,6 +152,7 @@ struct GMT_DEFAULTS {
 	double map_title_offset;		/* Distance between lowermost annotation (or label) and base of plot title [14p] */
 	double map_vector_shape;		/* 0.0 = straight vectorhead, 1.0 = arrowshape, with continuous range in between */
 	double map_graph_extension;		/* If map_frame_type is graph, how must longer to make axis length. [7.5%] */
+	double map_graph_origin[2];		/* x- and y-origin of graph axis if graph-centered is in use [data 0/0] */
 	unsigned int map_annot_oblique;	/* Controls annotations and tick angles etc. [GMT_OBL_ANNOT_ANYWHERE] */
 	unsigned int map_grid_cross_type[2];	/* 0 = normal cross, 1 = symmetric tick, 2 = asymmetric tick */
 	unsigned int map_logo_justify;		/* Justification of the GMT timestamp box [1 (BL)] */
@@ -168,6 +169,7 @@ struct GMT_DEFAULTS {
 	struct GMT_PEN map_tick_pen[2];		/* Pen attributes for primary and secondary tickmarks [thinner,black] */
 	char map_frame_axes[6];			/* Which axes to draw and annotate ["WESNZ"]  */
 	char map_annot_ortho[6];		/* Which axes have orthogonal annotations in linear projections ["we"] */
+	char map_graph_origin_txt[GMT_LEN256];	/* x- and y-origin modifier prior to parsing into double */
 	enum GMT_enum_symbol { gmt_none = -1, gmt_ring, gmt_degree, gmt_colon, gmt_squote, gmt_dquote, gmt_minus, gmt_hyphen, gmt_lastsym } map_degree_symbol;
 	/* PROJ group */
 	double proj_scale_factor;		/* Central mapscale factor, typically 0.9996-1 (or -1 for default action) */

--- a/src/gmt_defaults.h
+++ b/src/gmt_defaults.h
@@ -152,7 +152,7 @@ struct GMT_DEFAULTS {
 	double map_title_offset;		/* Distance between lowermost annotation (or label) and base of plot title [14p] */
 	double map_vector_shape;		/* 0.0 = straight vectorhead, 1.0 = arrowshape, with continuous range in between */
 	double map_graph_extension;		/* If map_frame_type is graph, how must longer to make axis length. [7.5%] */
-	double map_graph_origin[2];		/* x- and y-origin of graph axis if graph-centered is in use [data 0/0] */
+	double map_graph_origin[2];		/* x- and y-origin of graph axis if graph-origin is in use [data 0/0] */
 	double map_graph_shift;			/* Extra offset for title to avoid overwriting the centered y-axis */
 	unsigned int map_annot_oblique;	/* Controls annotations and tick angles etc. [GMT_OBL_ANNOT_ANYWHERE] */
 	unsigned int map_grid_cross_type[2];	/* 0 = normal cross, 1 = symmetric tick, 2 = asymmetric tick */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10817,6 +10817,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			else if (!strncmp (lower_value, "graph", 5U)) {
 				char *c = NULL;
 				GMT->current.setting.map_frame_type = GMT_IS_GRAPH;
+				if (strstr (lower_value, "-centered")) GMT->current.setting.map_graph_centered = true;
 				if ((c = strchr (lower_value, ','))) {	/* Also specified vector extension setting */
 					size_t last = strlen (lower_value) - 1;
 					char unit = lower_value[last];
@@ -12404,6 +12405,7 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 				strcpy (value, "plain");
 			else if (GMT->current.setting.map_frame_type == GMT_IS_GRAPH) {
 				strcpy (value, "graph");
+				if (GMT->current.setting.map_graph_centered) strcat (value, "-centered");
 				if (GMT->current.setting.map_graph_extension_unit != GMT_GRAPH_EXTENSION_UNIT || !doubleAlmostEqual (GMT->current.setting.map_graph_extension, GMT_GRAPH_EXTENSION)) {
 					char tmp[GMT_LEN32] = {""};
 					/* Not the default, specify what we are using */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10822,7 +10822,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 					/* Future expansion will look for x/y graph origin, save, and convert once we know coordinate type */
 					/* For now GMT->current.setting.map_graph_origin is [0, 0] */
 					GMT->current.setting.map_graph_centered = true;
-					if ((o = strstr (lower_value, "+o")) && strchr (o, '/'))	/* Also specified graph origin */
+					if ((o = strstr (lower_value, "+o")) && (strchr (o, '/') || !strcmp (o, "+oc")))	/* Also specified graph origin or c*/
 						strncpy (GMT->current.setting.map_graph_origin_txt, o, GMT_LEN256);
 				}
 				if ((c = strchr (lower_value, ','))) {	/* Also specified vector extension setting */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10818,7 +10818,7 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				char *c = NULL, *o = NULL;
 				GMT->current.setting.map_frame_type = GMT_IS_GRAPH;
 				gmt_M_memset (GMT->current.setting.map_graph_origin_txt, GMT_LEN256, char);
-				if (strstr (lower_value, "-centered")) {
+				if (strstr (lower_value, "-origin")) {
 					/* Future expansion will look for x/y graph origin, save, and convert once we know coordinate type */
 					/* For now GMT->current.setting.map_graph_origin is [0, 0] */
 					GMT->current.setting.map_graph_centered = true;
@@ -12413,7 +12413,7 @@ char *gmtlib_getparameter (struct GMT_CTRL *GMT, const char *keyword) {
 				strcpy (value, "plain");
 			else if (GMT->current.setting.map_frame_type == GMT_IS_GRAPH) {
 				strcpy (value, "graph");
-				if (GMT->current.setting.map_graph_centered) strcat (value, "-centered");
+				if (GMT->current.setting.map_graph_centered) strcat (value, "-origin");
 				if (GMT->current.setting.map_graph_extension_unit != GMT_GRAPH_EXTENSION_UNIT || !doubleAlmostEqual (GMT->current.setting.map_graph_extension, GMT_GRAPH_EXTENSION)) {
 					char tmp[GMT_LEN32] = {""};
 					/* Not the default, specify what we are using */

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5786,7 +5786,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 				dim[1] = g_scale_begin * length - g_ext;
 			PSL_plotsymbol (PSL, x_axis_pos, y, dim, PSL_VECTOR);
 			PSL_setorigin (PSL, x_axis_pos, 0.0, 0.0, PSL_FWD);
-			GMT->current.setting.map_graph_shift = fabs (dim[1] - length);
+			if (GMT->current.setting.map_graph_centered) GMT->current.setting.map_graph_shift = fabs (dim[1] - length);
 		}
 		if (axis == GMT_X)
 			skip_val = GMT->current.setting.map_graph_origin[GMT_X];

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5801,6 +5801,12 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 	}
 
 	if (side == GMT_AXIS_DRAW) {	/* Just drawing the axis for this one */
+		if (center_reset) {	/* Undo temporary origin shifts needed to move axes */
+			if (horizontal) 
+				PSL_setorigin (PSL, 0.0, -y_axis_pos, 0.0, PSL_INV);
+			else
+				PSL_setorigin (PSL, -x_axis_pos, 0.0, 0.0, PSL_INV);
+		}
 		PSL_setorigin (PSL, -x0, -y0, 0.0, PSL_INV);
 		return;
 	}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -466,6 +466,8 @@ GMT_LOCAL void gmtplot_linear_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTR
 				GMT->current.setting.map_graph_origin_txt);
 			gmt_M_memset (GMT->current.setting.map_graph_origin, 2, double);
 		}
+		GMT->current.setting.map_graph_shift = 0.0;
+
 	}
 
 	PSL_command (PSL, "/PSL_slant_y 0 def /PSL_slant_x 0 def\n");	/* Unless x-annotations are slanted there is no adjustment. PSL_slant_y may be revised in gmt_xy_axis */
@@ -488,6 +490,8 @@ GMT_LOCAL void gmtplot_linear_map_boundary (struct GMT_CTRL *GMT, struct PSL_CTR
 	if (!GMT->current.map.frame.header[0] || GMT->current.map.frame.plotted_header) return;	/* No title (and optional subtitle) today */
 
 	PSL_comment (PSL, "Placing plot title\n");
+
+	y_length += GMT->current.setting.map_graph_shift;  /* Extra shift (set in gmt_xy_axis) for map title when we have a centered y-axis with vector */
 
 	if (!GMT->current.map.frame.draw || GMT->current.map.frame.side[N_SIDE] <= GMT_AXIS_DRAW || GMT->current.setting.map_frame_type == GMT_IS_INSIDE)
 		PSL_defunits (PSL, "PSL_H_y", GMT->current.setting.map_title_offset);	/* No ticks or annotations, offset by map_title_offset only */
@@ -5782,6 +5786,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 				dim[1] = g_scale_begin * length - g_ext;
 			PSL_plotsymbol (PSL, x_axis_pos, y, dim, PSL_VECTOR);
 			PSL_setorigin (PSL, x_axis_pos, 0.0, 0.0, PSL_FWD);
+			GMT->current.setting.map_graph_shift = fabs (dim[1] - length);
 		}
 		if (axis == GMT_X)
 			skip_val = GMT->current.setting.map_graph_origin[GMT_X];

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5714,7 +5714,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		center_reset = true;
         skip_center_annot = (GMT->current.map.frame.side[W_SIDE] && GMT->current.map.frame.side[S_SIDE]);
 		if (!below) { /* Warn that these are skipped */
-            GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_xy_axis: MAP_FRAME_TYPE=graph-centered only expects -B frame selections W, S, w, s, l, b\n");
+            GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_xy_axis: MAP_FRAME_TYPE=graph-origin only expects -B frame selections W, S, w, s, l, b\n");
            return;
         }
 	}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5618,6 +5618,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 	bool skip = false, just_set = false;
 	bool save_pi = GMT->current.plot.substitute_pi;
     bool skip_center_annot = false; /* May be set to true to avoid annotation where two graph axes intersect */
+    bool center_reset = false;
 	double *knots = NULL, *knots_p = NULL;	/* Array pointers with tick/annotation knots, the latter for primary annotations */
 	double x, t_use, text_angle, cos_a = 0.0, sin_a = 0.0, delta;	/* Misc. variables */
 	double x_angle_add = 0.0, y_angle_add = 0.0;	/* Used when dealing with perspectives */
@@ -5706,7 +5707,8 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		else if (y_axis_pos > GMT->current.map.height) y_axis_pos = GMT->current.map.height;
 		x_axis_pos -= x0;	/* Since we do PSL_setorigin below we must counter act that for these values */
 		y_axis_pos -= y0;
-        skip_center_annot = true;
+		center_reset = true;
+        skip_center_annot = (GMT->current.map.frame.side[W_SIDE] && GMT->current.map.frame.side[S_SIDE]);
 		if (!below) return;
 	}
 
@@ -5956,7 +5958,7 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 	else
 		PSL_comment (PSL, below ? "End of front z-axis\n" : "End of back z-axis\n");
 
-	if (skip_center_annot) {
+	if (center_reset) {	/* Undo temporary origin shifts needed to move axes */
 		if (horizontal) 
 			PSL_setorigin (PSL, 0.0, -y_axis_pos, 0.0, PSL_INV);
 		else

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -5709,7 +5709,10 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 		y_axis_pos -= y0;
 		center_reset = true;
         skip_center_annot = (GMT->current.map.frame.side[W_SIDE] && GMT->current.map.frame.side[S_SIDE]);
-		if (!below) return;
+		if (!below) { /* Warn that these are skipped */
+            GMT_Report (GMT->parent, GMT_MSG_WARNING, "gmt_xy_axis: MAP_FRAME_TYPE=graph-centered only expects -B frame selections W, S, w, s, l, b\n");
+           return;
+        }
 	}
 
 	/* Ready to draw axis */
@@ -5767,7 +5770,6 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 				dim[0] = g_scale_begin * length - g_ext;
 			PSL_plotsymbol (PSL, x, y_axis_pos, dim, PSL_VECTOR);
 			PSL_setorigin (PSL, 0.0, y_axis_pos, 0.0, PSL_FWD);
-			fprintf (stderr, "Horizontal\n");
 		}
 		else {
 			double y = 0.0;
@@ -5780,7 +5782,6 @@ void gmt_xy_axis (struct GMT_CTRL *GMT, double x0, double y0, double length, dou
 				dim[1] = g_scale_begin * length - g_ext;
 			PSL_plotsymbol (PSL, x_axis_pos, y, dim, PSL_VECTOR);
 			PSL_setorigin (PSL, x_axis_pos, 0.0, 0.0, PSL_FWD);
-			fprintf (stderr, "Vertical\n");
 		}
 		if (axis == GMT_X)
 			skip_val = GMT->current.setting.map_graph_origin[GMT_X];


### PR DESCRIPTION
See #6820 for background (@gd-a).  This is a test branch for exploring this possibility.  There are some remaining decisions to be made (plus adding documentation), hence the WIP.

This matches the request for this command:

`gmt basemap -R-20/20/-20/20 -JX5i -Bafg --MAP_FRAME_TYPE=graph-origin -png 1`

yielding

![1](https://user-images.githubusercontent.com/26473567/175774161-7f406dcd-6e44-45f1-be51-b6218657a205.png)

However, if you don't select grid lines (leaving off the **g** or just use default **-B**, you get

![2](https://user-images.githubusercontent.com/26473567/175774185-e97116f3-d890-4b2b-8958-2fe6ac3e9b65.png)

where the annotations look a bit naked.  If you don't want any annotations or ticks you may try **-Bws** (lower case turns off annotation) but ticks persist even with -Ba2f0:

![3](https://user-images.githubusercontent.com/26473567/175774205-85ff3993-2f15-47ac-9306-3382d4d0791e.png)

Some possibilities:

1. If gridlines are not specified, use grid pen to draw the axis lines where they would normally have gone (e.g., **WS** here). This may be preferred since depending on **-R** you may not be able to select a grid interval that does that.
2. If annotations are not requested (i.e., **-Bws**) then honor that but also turn off tick marks
3. Here, _origin_ meant draw at _x_ = 0 and _y_ = 0, but I can imagine some joker wanting to specify the desired _x_ and _y_ placements.  So are we talking  **MAP_FRAME_TYPE**=_graph-origin[_,_x_/_y_] then, with default 0?

Finally, I can imagine some users wish to have centered annotated axes and leave out the (otherwise clobbered) zero annotation:

![4](https://user-images.githubusercontent.com/26473567/175774607-cfc0f051-abc0-4471-b111-afcf25f62168.png)

as shown in this mock-up.  It would not be too hard to implement that. Do we call that **MAP_FRAME_TYPE**=_graph-origin[_,_x_/_y_]  ?