### PR TITLE
Fix sign error in FAA slab correction

### DIFF
--- a/doc/rst/source/explain_fft.rst_
+++ b/doc/rst/source/explain_fft.rst_
@@ -16,9 +16,9 @@
         dimensions >= data which optimize speed and accuracy of FFT. If FFT
         dimensions > grid file dimensions, data are extended and tapered to zero.
 
-    Control detrending of data: Append modifiers for removing a linear trend:
+    Control detrending of data: Append modifiers for removing a linear trend. Consult module documentation for the default action:
 
-        **+d**: Detrend data, i.e. remove best-fitting linear trend [Default].
+        **+d**: Detrend data, i.e. remove best-fitting linear trend.
 
         **+a**: Only remove mean value.
 

--- a/doc/rst/source/grdfft.rst
+++ b/doc/rst/source/grdfft.rst
@@ -200,6 +200,12 @@ meters, select |SYN_OPT-f|. If the data are close to either pole, you should
 consider projecting the grid file onto a rectangular coordinate system
 using :doc:`grdproject`
 
+Data Detrending
+---------------
+
+The default detrending mode is to remove a best-fitting linear plane (**+d**).
+Consult and use |-N| to select other modes.
+
 Normalization of Spectrum
 -------------------------
 

--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -207,6 +207,12 @@ meters, select |SYN_OPT-f|. If the data are close to either pole, you should
 consider projecting the grid file onto a rectangular coordinate system
 using :doc:`grdproject </grdproject>`.
 
+Data Detrending
+---------------
+
+The default detrending mode follows Parker [1972] and removes the mid-value (**+h**).
+Consult and use |-N| to select other modes.
+
 Plate Flexure
 -------------
 

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -263,6 +263,12 @@ The calculations are done using a rectangular Cartesian FFT operation. If your
 geographic region is close to either pole, you should consider using a Cartesian
 setup instead; you can always project it back to geographic using :doc:`grdproject </grdproject>`.
 
+Data Detrending
+---------------
+
+The default detrending mode is to remove a best-fitting linear plane (**+d**).
+Consult and use |-N| to select other modes.
+
 Transfer Functions
 ------------------
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -11745,12 +11745,20 @@ unsigned int GMT_FFT_Option (void *V_API, char option, unsigned int dim, const c
 	/* For programs that needs to do either 1-D or 2-D FFT work */
 	unsigned int d1 = dim - 1;	/* Index into the info text strings below for 1-D (0) and 2-D (1) case */
 	char *data_type[2] = {"table", "grid"}, *dim_name[2] = {"<n_columns>", "<n_columns>/<n_rows>"}, *trend_type[2] = {"line", "plane"};
-	char *dim_ref[2] = {"dimension", "dimensions"}, *linear_type[2] = {"linear", "planar"};
-    struct GMTAPI_CTRL *API = NULL;
+	char *dim_ref[2] = {"dimension", "dimensions"}, *linear_type[2] = {"linear", "planar"}, *d_msg, *h_msg;
+	struct GMTAPI_CTRL *API = NULL;
 	if (V_API == NULL) return_error (V_API, GMT_NOT_A_SESSION);
 	if (dim > 2) return_error (V_API, GMT_DIM_TOO_LARGE);
 	if (dim == 0) return_error (V_API, GMT_DIM_TOO_SMALL);
-    API = gmtapi_get_api_ptr (V_API);
+	API = gmtapi_get_api_ptr (V_API);
+	if (API->parker_fft_default) {	/* +h is default here as a special case */
+		d_msg = "";
+		h_msg = " [Default]";
+	}
+	else {	/* +d is default */
+		d_msg = " [Default]";
+		h_msg = "";
+	}
 	if (string && string[0] == ' ') GMT_Report (V_API, GMT_MSG_ERROR, "Option -%c parsing failure.  Correct syntax:\n", option);
 	GMT_Usage (API, 1, "\n-%c%s", option, GMT_FFT_OPT);
 	GMT_Usage (API, -2, "Choose or inquire about suitable %s %s for %u-D FFT, and set modifiers.", data_type[d1], dim_ref[d1], dim);
@@ -11763,9 +11771,9 @@ unsigned int GMT_FFT_Option (void *V_API, char option, unsigned int dim, const c
 	GMT_Usage (API, -2, "Alternatively, append %s to do FFT on array size %s (Must be >= %s size) "
 	   "[Default chooses %s >= %s %s to optimize speed and accuracy of the FFT.]", dim_name[d1], dim_name[d1], data_type[d1], dim_ref[d1], data_type[d1], dim_ref[d1]);
 	GMT_Usage (API, -2, "%s Append modifiers for removing a %s trend:", GMT_LINE_BULLET, linear_type[d1]);
-	GMT_Usage (API, 3, "+d Detrend data, i.e., remove best-fitting %s [Default].", trend_type[d1]);
+	GMT_Usage (API, 3, "+d Detrend data, i.e., remove best-fitting %s%s.", trend_type[d1], d_msg);
 	GMT_Usage (API, 3, "+a Only remove mean value.");
-	GMT_Usage (API, 3, "+h Only remove mid value, i.e., 0.5 * (max + min).");
+	GMT_Usage (API, 3, "+h Only remove mid value, i.e., 0.5 * (max + min)%s.", h_msg);
 	GMT_Usage (API, 3, "+l Leave data alone.");
 	GMT_Usage (API, -2, "%s If FFT %s > %s %s, data are extended via edge point symmetry "
 	   "and tapered to zero.  Several modifiers can be set to change this behavior:", GMT_LINE_BULLET, dim_ref[d1], data_type[d1], dim_ref[d1]);

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -172,6 +172,7 @@ struct GMTAPI_CTRL {
 	char error_msg[4096];			/* The cached last error message */
 	bool internal;				/* true if session was initiated by gmt.c */
 	bool deep_debug;			/* temporary for debugging */
+	bool parker_fft_default;	/* Used to alter the default in -N FFT settings */
 	int (*print_func) (FILE *, const char *);	/* Pointer to fprintf function (may be reset by external APIs like MEX) */
 	unsigned int do_not_exit;		/* 0 by default, meaning it is OK to call exit  (may be reset by external APIs like MEX to call return instead) */
 	struct GMT_LIBINFO *lib;		/* List of shared libs to consider */

--- a/src/potential/gravfft.c
+++ b/src/potential/gravfft.c
@@ -512,6 +512,7 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
 	/*----------------------- Standard module initialization and parsing ----------------------*/
 
 	if (API == NULL) return (GMT_NOT_A_SESSION);
+	API->parker_fft_default = true;	/* So that GMT_FFT_Option can report +h as default */
 	if (mode == GMT_MODULE_PURPOSE) return (usage (API, GMT_MODULE_PURPOSE));	/* Return the purpose of program */
 	options = GMT_Create_Options (API, mode, args);
 	if (API->error) return (API->error);	/* Set or get option list */

--- a/src/potential/gravfft.c
+++ b/src/potential/gravfft.c
@@ -767,7 +767,7 @@ EXTERN_MSC int GMT_gravfft (void *V_API, int mode, void *args) {
 			if (Ctrl->F.slab) {	/* Do the slab adjustment */
 				if (Ctrl->D.variable) Ctrl->misc.rho = Rho->header->z_min;
 				slab_gravity = (gmt_grdfloat) (1.0e5 * 2 * M_PI * Ctrl->misc.rho * NEWTON_G *
-				                        fabs (Ctrl->W.water_depth - Ctrl->misc.z_level));
+				                        (Ctrl->W.water_depth - Ctrl->misc.z_level));
 				GMT_Report (API, GMT_MSG_INFORMATION, "Add %g mGal to predicted FAA grid to account for implied slab\n", slab_gravity);
 				if (Ctrl->F.bouguer)		/* The complete Bouguer contribution */
 					for (m = 0; m < Grid[0]->header->size; m++) Grid[0]->data[m] = slab_gravity - Grid[0]->data[m];


### PR DESCRIPTION
The -Ff+s option in **gravfft** adds back in the slab that was removed when we find the mid-level of our topography and remove it.  However, The sign of this level matters: Contrast these two cases, both with a water depth W = 5000 m:

1. Input z is a positive bump on the seafloor, varying from 0 to 1000 m.  We first subtract sea level and now z goes from -5000 to -4000.  We find mid level to be -4500 and keep the absolute value z_level = 4500.  It is used in Parker exponent exp (-k*z_level) for upward continuation. We then compute slab thickness as h = W - z_level = 5000 - 4500 = 500m. We need to add the 500m slab gravity (a positive value) to the undulations obtained by the FFT to make sure all values are positive.
2. Input z is a negative bump on the seafloor, varying from 0 to -1000 m.  We first subtract sea level and now z goes from -6000 to -5000.  We find mid level to be -5500 and keep the absolute value z_level = 5500. It is used in Parker exponent exp (-k*z_level) for upward continuation. We then compute slab thickness as h = W - z_level = 5000 - 5500 = -500m. We need to add the -500m slab gravity (a negative value) to the undulations obtained by the FFT to make sure all values are negative.

In master, h is computed as absolute value of (W - z_level), hence both of the above cases end up with a positive correction due to a 500 m slab, yet the second case needs it subtracted.  Hence the sign of W - z_level needs to be retained.

No tests were affected, apparently.  We need more tests, obviously.