### PR TITLE
Reset -B machinery when colorbar is called in one-liners

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15884,7 +15884,8 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 		GMT->current.ps.oneliner = false;
 		if (gmt_get_current_item (GMT, "cpt", false)) {	/* One-liner with a current CPT, place it on top */
 			gmtinit_init_zproject (GMT);	/* Reset to 2-D view just in case */
-			if ((i = GMT_Call_Module (GMT->parent, "colorbar", GMT_MODULE_CMD, "-DJBC -Baf"))) {
+			GMT->current.map.frame.init = false;	/* Since we want -B to be parsed below */
+			if ((i = GMT_Call_Module (GMT->parent, "colorbar", GMT_MODULE_CMD, "-DJBC -Bxaf"))) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to call module colorbar for a one-liner plot.\n");
 				return;
 			}


### PR DESCRIPTION
When we are making a one-liner plot that involves a CPT, we issue a hidden **colorbar** command with its own **-B** arguments.  However, we forgot to reset the machinery first so instead  any previous axis labels remain set and mess up the final **colorbar** labeling.  E.g, below the **colorbar** remembers the **-B** axes label settings from the **grdimage** call:

`gmt grdimage McKenzie_depth_temp.grd -Bxaf+l"Lithosphere age (Ma)" -Byaf+l"Depth (m)" -B+t"McKenzie et al [2005] model" -png depth_temp`

![depth_temp](https://user-images.githubusercontent.com/26473567/176148373-c7ded05f-c36b-41ff-b38d-9de152043872.png)

This PR resets the internals so that things are wiped when **colorbar** parses the new **-B** settings.
