### PR TITLE
Use floating points when setting PostScript setdash for short lines

### DIFF
--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: dcfeeff36661bf41588f2ef2a297b6f5.dir
-  size: 33290389
+- md5: dc04add35f8f86ce46c1f510cf93a510.dir
+  size: 33290440
   nfiles: 200
   path: images

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -3331,19 +3331,30 @@ static int psl_init_fonts (struct PSL_CTRL *PSL) {
 }
 
 static char *psl_putdash (struct PSL_CTRL *PSL, char *pattern, double offset) {
-	/* Writes the dash pattern */
+	/* Writes the dash pattern.  Note: Unlike a pen width, the dashes and gaps
+     * set here cannot all be zero - it results in a PostScript error for discussion
+     * see https://github.com/GenericMappingTools/gmt/issues/6833. Here, we will
+     * ensure that this does not happen by printing a nasty warning if it happens. */
 	static char text[PSL_BUFSIZ];
 	char mark = '[';
-	size_t len = 0;
+	size_t len = 0, non_zero = 0;
+    double w;
 	if (pattern && pattern[0]) {
 		while (*pattern) {
-			sprintf (&text[len], "%c%d", mark, psl_ip (PSL, atof(pattern)));
+            w = atof(pattern) * PSL->internal.dpp;
+            if (w > 0.0) non_zero++;
+            sprintf (&text[len], "%c%lg", mark, w);
 			while (*pattern && *pattern != ' ') pattern++;
 			while (*pattern && *pattern == ' ') pattern++;
 			mark = ' ';
 			len = strlen(text);
 		}
-		sprintf (&text[len], "] %d B", psl_ip (PSL, offset));
+		if (non_zero)
+			sprintf (&text[len], "] %lg B", offset * PSL->internal.dpp);
+		else {
+			sprintf (text, "[] 0 B");   /* Reset to continuous line */
+			PSL_message (PSL, PSL_MSG_WARNING, "Dashed line pattern invalid - ignored\n");
+		}
 	}
 	else
 		sprintf (text, "[] 0 B");	/* Reset to continuous line */

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -3341,9 +3341,12 @@ static char *psl_putdash (struct PSL_CTRL *PSL, char *pattern, double offset) {
     double w;
 	if (pattern && pattern[0]) {
 		while (*pattern) {
-            w = atof(pattern) * PSL->internal.dpp;
-            if (w > 0.0) non_zero++;
-            sprintf (&text[len], "%c%lg", mark, w);
+			w = atof(pattern) * PSL->internal.dpp;
+			if (w > 0.0) non_zero++;
+			if (w > 4.0)	/* Set as integer PS. Max error 12.5% (e.g.,  4.499999 -> 4), dropping for larger w */
+				sprintf (&text[len], "%c%d", mark, (int)rint (w));
+			else	/* Too small for integer, set as floating point */
+				sprintf (&text[len], "%c%lg", mark, w);
 			while (*pattern && *pattern != ' ') pattern++;
 			while (*pattern && *pattern == ' ') pattern++;
 			mark = ' ';


### PR DESCRIPTION
See https://github.com/GenericMappingTools/gmt/issues/6833 for background.  This PR implements the fix.