### PR TITLE
Better documentation of long-option translation

### DIFF
--- a/src/gmt_common_longoptions.h
+++ b/src/gmt_common_longoptions.h
@@ -22,7 +22,8 @@
      *
      * separator:        Indicates if option accepts a series of comma-separated items, e.g., -i0:3,4+s2,8:10,
      *                   where we give several column-ranges, each of which may have their own modifiers. The
-     *                   options that behave like that have separator "," which otherwise is set to 0.
+     *                   options that behave like that have separator "," which otherwise is set to 0. Another
+     *                   separator may be "/", as in -Idx/dy (see GMT_INCREMENT_KW in gmt_constants.h).
      * short_option:     The standard short GMT option letter, e.g., R for -R.
      * long_option:      The corresponding long-format option word, e.g. region for --region
      * short_directives: Comma-separated list of allowable directive letters

--- a/src/gmt_common_longoptions.h
+++ b/src/gmt_common_longoptions.h
@@ -1,13 +1,45 @@
     /* GMT Common option long-option to short-option translation table
      *
+     * The purpose of this table is to facilitate the parsing of the long-option syntax in GMT
+     * without having to rewrite 150+ parsers.  The game-plan is instead to examine the given
+     * options for long-option syntax and then replace them with the corresponding short-option
+     * syntax that the parsers expect. For this to work correctly there needs to be a one-to-one
+     * translation for each case. Thus, this aspect assumes all GMT module and common options
+     * follow a simple standardized syntax:
+     *
      * General short-option syntax:
-     *        -<short_option>[<short_directives>][+<short_modifiers>[<argument>]]
+     *        -<short_option>[<short_directives>][+<short_modifier1>[<argument1>]][+<short_modifier2>[<argument2>]][...]
+     *
+     * Such an option is then expected to correspond exactly to this long-option format:
+     *
      * General long-option syntax:
-     *        --<long_option>[=[<long_directives>:]<arg>][+<long_modifier1>[=<arg1>]][+<long_modifier2>[=<arg2>]]...
+     *        --<long_option>[=<long_directives>[:<arg>]][+<long_modifier1>[=<arg1>]][+<long_modifier2>[=<arg2>]][...]
+     *
+     * As we run into module options that DO NOT follow this template we will most likely need
+     * to introduce a revised syntax and allow for a backwards compatible parsing option.
      *
      * The items below correspond to the named parameters in the GMT_KEYWORD_DICTIONARY structure:
+     *
+     * separator:        Indicates if option accepts a series of comma-separated items, e.g., -i0:3,4+s2,8:10,
+     *                   where we give several column-ranges, each of which may have their own modifiers. The
+     *                   options that behave like that have separator "," which otherwise is set to 0.
+     * short_option:     The standard short GMT option letter, e.g., R for -R.
+     * long_option:      The corresponding long-format option word, e.g. region for --region
+     * short_directives: Comma-separated list of allowable directive letters
+     * long_directives:  Comma-separated list of the corresponding words
+     * short_modifiers:  Comma-separated list of all known modifier letters for this option
+     * long_modifiers:   Comma-separated list of the corresponding modifier words
+     *
+     * Note 1: All long_directives must be lower-case to avoid conflict with --PAR=value options.
+     *         Words cannot be hyphenated as in Julia that would mean a subtraction.
+     * Note 2: Option -q is a special case since there is both -qi and -qo but with the same modifiers.
+     * Note 3: Some options (such as -B) may be repeated but this does not affect our translation.
+     *
+     * This table for the common options is assumed to be complete unless proven otherwise!
+     *
+     * separator, short_option, long_option, short_directives, long_directives, short_modifiers, long_modifiers
      */
-    /* separator, short_option, long_option, short_directives, long_directives, short_modifiers, long_modifiers */
+
     {   0, 'B', "frame",         "",        "",                                         "b,g,i,n,o,s,t,w,x,y,z",        "box,fill,interior,noframe,pole,subtitle,pen,yzfill,xzfill,xyfill" },
     {   0, 'B', "axis",          "x,y,z",   "x,y,z",                                    "a,f,l,L,p,s,S,u",              "angle,fancy,label,hlabel,prefix,alt_label,alt_hlabel,unit" },
     {   0, 'J', "projection",    "",        "",                                         "",                             ""},


### PR DESCRIPTION
This PR just adds better comments to _gmt_common_longoptions.h_ so it is clear what the various bits mean.  I also improved some comments in gmt_init.c and fixed the (apparently) wrong syntax in the documentation of the long-option. 
 Letting Roger review and approve this PR.