### PR TITLE
Fix documentation and handing of -J in histogram

### DIFF
--- a/doc/rst/source/histogram.rst
+++ b/doc/rst/source/histogram.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt histogram** [ *table* ] |-J|\ **x**\|\ **X**\ *parameters*
+**gmt histogram** [ *table* ]
 |-T|\ [*min/max*\ /]\ *inc*\ [**+i**\|\ **n**] \|\ |-T|\ *file*\|\ *list*
 [ |-A| ]
 [ |SYN_OPT-B| ]
@@ -22,6 +22,7 @@ Synopsis
 [ |-F| ]
 [ |-G|\ *fill* ]
 [ |-I|\ [**o**\|\ **O**] ]
+[ |-J|\ **x**\|\ **X**\ *parameters* ]
 [ |-Jz|\ \|\ **Z**\ *parameters* ]
 [ |-L|\ **l**\|\ **h**\|\ **b** ]
 [ |-N|\ [*mode*][**+p**\ *pen*] ]
@@ -69,7 +70,7 @@ Required Arguments
 
 **-Jx**
     *xscale*\ [/*yscale*] (Linear scale(s) in distance unit/data unit), or
-    **-JX** with *width*\ [/*height*] dimensions.
+    **-JX** with *width*\ [/*height*] dimensions.  **Note**: Optional in modern mode.
 
 .. _-T:
 

--- a/src/pshistogram.c
+++ b/src/pshistogram.c
@@ -927,9 +927,15 @@ EXTERN_MSC int GMT_pshistogram (void *V_API, int mode, void *args) {
 
 	/*---------------------------- This is the pshistogram main code ----------------------------*/
 
-	if (!Ctrl->I.active && GMT->current.proj.projection != GMT_LINEAR) {
-		GMT_Report (API, GMT_MSG_ERROR, "Option -J: Only Cartesian scaling available in this module.\n");
-		Return (GMT_RUNTIME_ERROR);
+	if (!Ctrl->I.active) {	/* Need a linear projection either set explicitly (classic) or implicitly (modern only) */
+		if (GMT->current.setting.run_mode == GMT_CLASSIC && !GMT->common.J.active) {	/* -J is required, exit at this point */
+			GMT_Report (API, GMT_MSG_ERROR, "Must specify Cartesian scales or dimensions of the domain via -Jx or -JX.\n");
+			Return (GMT_RUNTIME_ERROR);
+		}
+		if (GMT->current.proj.projection != GMT_LINEAR) {	/* Must have given a nonlinear map projection by mistake */
+			GMT_Report (API, GMT_MSG_ERROR, "Option -J: Only Cartesian scaling available in this module.\n");
+			Return (GMT_RUNTIME_ERROR);
+		}
 	}
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input table data\n");


### PR DESCRIPTION
See #6847 for background.  The handling of **-J** in **histogram** is special since only a Cartesian scaling or dimensions is allowed (i.e., map projections are not allowed).  Hence we need specific checks.  This PR does the following:

1. Updates the documentation for **histogram** to state that **-J** is optional in modern mode (it is required for classic mode).
2. Gives an error if no **-J** given in classic mode.
3. Gives an error if an unsuitable projection was specified via **-J**.

Closes #6847.
