### PR TITLE
meca -A+ssize passed wrong pointer to gmt_M_to_inch

### DIFF
--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -313,7 +313,7 @@ GMT_LOCAL unsigned int psmeca_A_parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL 
 					}
 					break;
 				case 's':	/* Circle diameter */
-					if (p[1] == '\0' || (Ctrl->A.size = gmt_M_to_inch (GMT, (p+2))) < 0.0) {
+					if (p[1] == '\0' || (Ctrl->A.size = gmt_M_to_inch (GMT, &p[1])) < 0.0) {
 						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -A: Circle diameter cannot be negative or not given!\n");
 						n_errors++;
 					}


### PR DESCRIPTION
The pointer to the size was off by one position hence modifiers like `+s5p` would give

`meca [WARNING]:  not a valid number and may not be decoded properly.`

while `+s0.2c` happen to work since the size is seen as `.2c`.  So we skipped the leading character and for 5p we only tried to parse p as a length...
