### PR TITLE
CI: Skip the installation of pngquant on Windows CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@
 name: Docs
 
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -132,7 +132,9 @@ jobs:
           set -x -e
           cd build
           cmake --build . --target docs_depends
-          cmake --build . --target optimize_images
+          if [ -x "$(command -v pngquant)" ]; then  # optional step
+            cmake --build . --target optimize_images
+          fi
           cmake --build . --target docs_html
           # if html.log isn't empty (i.e., sphinx raise warnings), return 1
           ! [ -s doc/rst/html.log ]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@
 name: Docs
 
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master

--- a/ci/build-gmt.sh
+++ b/ci/build-gmt.sh
@@ -31,7 +31,7 @@ fi
 
 # General settings
 GSHHG_VERSION="2.3.7"
-DCW_VERSION="2.0.0"
+DCW_VERSION="2.1.1"
 GSHHG="gshhg-gmt-${GSHHG_VERSION}"
 DCW="dcw-gmt-${DCW_VERSION}"
 EXT="tar.gz"

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -37,7 +37,7 @@ if [ "$BUILD_DOCS" = "true" ]; then
     # Add sphinx to PATH
     echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
 
-    choco install pngquant
+    # choco install pngquant
 fi
 
 if [ "$RUN_TESTS" = "true" ]; then


### PR DESCRIPTION
**Description of proposed changes**

`choco install pngquant` doesn't work due to unknown network connection issues of GitHub Actions, which makes the docs building CI fail on Windows.

In this PR, `choco install pngquant` is disabled to make the CI pass again.