### PR TITLE
Update 4 PS files following subtle gs 9.56 change

### DIFF
--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: ce32684b1f6f1097bb8926de89eb0fc8.dir
-  size: 33293034
+- md5: 205417ccc178ca0cfe8350d807ebb3f8.dir
+  size: 33294651
   nfiles: 200
   path: images

--- a/test/baseline/grdcontour.dvc
+++ b/test/baseline/grdcontour.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 7dfd91bf713c9ecb83453f1d68e231b4.dir
-  size: 3974244
+- md5: 5fd10e0a166b99a4349ce05d373ce1df.dir
+  size: 3971541
   nfiles: 23
   path: grdcontour

--- a/test/baseline/pscoast.dvc
+++ b/test/baseline/pscoast.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 182a51ac9bc00da5eaa3947e49c5de67.dir
-  size: 7972547
+- md5: 589165a3670b79f2c69ca10a02f4547e.dir
+  size: 7968188
   nfiles: 24
   path: pscoast

--- a/test/baseline/pstext.dvc
+++ b/test/baseline/pstext.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 0f3567b1be600526864aa374c0885a3b.dir
-  size: 734238
+- md5: cc3f79d0b3d11ebdcfe61ee6096d060c.dir
+  size: 726418
   nfiles: 16
   path: pstext


### PR DESCRIPTION
Tiny hairline errors appeared after 9.56 was updated for macports so we update those 4 PS files.  Closes #6598.
