### PR TITLE
Add missing +d case to exceptions

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14157,7 +14157,7 @@ char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, 
 					case 'o': case 's':	/* +o<offset>|a,  +s<scale>|a */
 						allow_a = true;	/* Argument "a" for auto is OK for these modifiers */
 						/* Fall through on purpose */
-					case 'h': case 'i': case 'n': 	/* +h[<hinge>], +i<inc>, +n<nodata> */
+					case 'd': case 'h': case 'i': case 'n': 	/* +d<div>, +h[<hinge>], +i<inc>, +n<nodata> */
 						k++;	/* Move to start of argument, next modifier, or NULL */
 						while (modifiers[k] && modifiers[k] != '+' && strchr ("-+.0123456789eE", modifiers[k])) k++;	/* Skip a numerical argument */
 						if (allow_a && modifiers[k] == 'a') k++;	/* Ok with a for this modifier */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14179,7 +14179,7 @@ char *gmtlib_last_valid_file_modifier (struct GMTAPI_CTRL *API, char* filename, 
 				error = true;
 		}
 		if (error) {
-			GMT_Report (API, GMT_MSG_WARNING, "Your filename %s have what appears as valid GMT modifiers (from list +%s) but are embedded rather than appended to the filename - modifiers ignored\n", filename, mods);
+			GMT_Report (API, GMT_MSG_WARNING, "Your filename %s has what appears as valid GMT modifiers (from list +%s) but they are embedded rather than appended to the filename - modifiers ignored\n", filename, mods);
 			modifiers = NULL;
 		}
 	}


### PR DESCRIPTION
The _gmtlib_last_valid_file_modifier_ function which checks the validity of gridfile modifiers was not updated to handle the relatively new **+d** for division (added since +d3 is cleaner than +s0.33333333).

I noticed this when using one of the old age grids given in units of 0.01 Myr integers and I got odd messages:

```
gmt grdtrack -Gage.3.2.nc=ns+d100 traildata_HI.txt > 2008_data.txt
grdtrack [WARNING]: Your filename .nc=ns+d100 have what appears as valid GMT modifiers (from list +donsuU) but are embedded rather than appended to the filename - modifiers ignored
```

Tracked it down to the missing 'd' case.  FYI, that warning might appear if a user has a filename with what looks like modifiers inside, e.g., myoddfile+s10.grd=ns (I think).

I also fixed the grammar of that message while at it, so it is all good.
