### PR TITLE
Fix #6891 to just not fuss but stick with gridline registration

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15097,8 +15097,10 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	#endif
 
 	is_PS = gmtinit_is_PS_module (API, mod_name, keys, options);	/* true if module will produce PS */
-	if (!is_PS && !(strcmp (mod_name, "grd2cpt") == 0 || strcmp (mod_name, "grd2kml")))	/* Override API default since module is a data processor (with some exceptions) */
+	if (!is_PS) {	/* Override API default since module is a data processor */
 		API->use_gridline_registration = true;
+		API->use_gridline_registration_warn = (strcmp (mod_name, "grd2cpt") && strcmp (mod_name, "grd2kml"));	/* Give warning unless it is these two clowns */
+	}
 
 	/* First handle any halfhearted naming of remote datasets where _g or _p should be appended */
 
@@ -15889,6 +15891,7 @@ void gmt_end_module (struct GMT_CTRL *GMT, struct GMT_CTRL *Ccopy) {
 	double spacing[2];
 
 	GMT->parent->use_gridline_registration = false;	/* Reset API default setting on grid registration */
+	GMT->parent->use_gridline_registration_warn = false;	/* Reset API default setting on grid registration warning */
 
 	gmt_M_memcpy (spacing, GMT->current.plot.gridline_spacing, 2U, double);	/* Remember these so they can survive the end of the module */
 

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -150,6 +150,7 @@ struct GMTAPI_CTRL {
 	bool no_history;					/* true if we want to disable the gmt.history mechanism */
 	bool got_remote_wesn;				/* true if we obtained w/e/sn via a remote grid/image with no resolution given */
 	bool use_gridline_registration;	/* true if default remote grid registration should be gridline, not pixel */
+	bool use_gridline_registration_warn;	/* true if we should warn about the above */
 	size_t n_objects_alloc;			/* Allocation counter for data objects */
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -487,8 +487,9 @@ void gmt_set_unspecified_remote_registration (struct GMTAPI_CTRL *API, char **fi
 	if (q == NULL) return;	/* Should never happen but definitively nothing more to do here - just a safety valve */
 	q += strlen (p);	/* Move to the end of family name after which any registration codes would be found */
 	if (strstr (q, "_p") || strstr (q, "_g")) goto clean_up;	/* Already have the registration codes */
-	if (API->use_gridline_registration_warn) {	/* Switch order so checking for g first, then p */
-		GMT_Report (API, GMT_MSG_WARNING, "Remote dataset given to a data processing module but no registration was specified - default to gridline registration (if available)\n");
+	if (API->use_gridline_registration) {	/* Switch order so checking for g first, then p */
+		if (API->use_gridline_registration_warn)
+			GMT_Report (API, GMT_MSG_WARNING, "Remote dataset given to a data processing module but no registration was specified - default to gridline registration (if available)\n");
 		kstart = 1; kstop = -1; kinc = -1;
 	}
 	for (k = kstart; k != kstop; k += kinc) {

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -487,7 +487,7 @@ void gmt_set_unspecified_remote_registration (struct GMTAPI_CTRL *API, char **fi
 	if (q == NULL) return;	/* Should never happen but definitively nothing more to do here - just a safety valve */
 	q += strlen (p);	/* Move to the end of family name after which any registration codes would be found */
 	if (strstr (q, "_p") || strstr (q, "_g")) goto clean_up;	/* Already have the registration codes */
-	if (API->use_gridline_registration) {	/* Switch order so checking for g first, then p */
+	if (API->use_gridline_registration_warn) {	/* Switch order so checking for g first, then p */
 		GMT_Report (API, GMT_MSG_WARNING, "Remote dataset given to a data processing module but no registration was specified - default to gridline registration (if available)\n");
 		kstart = 1; kstop = -1; kinc = -1;
 	}


### PR DESCRIPTION
The initial fix in #6891 caused a few failures since grd2cpt used a different resolution than in the calculations.

This attempt keeps separate bools for selecting gridline-registration grids and if we should warn about things.  Tests pass for me now.

Closes #6898.