### PR TITLE
Remove a trailing dot in the -x option syntax

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7638,7 +7638,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 #ifdef GMT_MP_ENABLED
 		case 'y':	/* Number of threads (reassigned from -x in GMT_Option) */
 			cores = gmtlib_get_num_processors();
-			GMT_Usage (API, 1, "\n%s.", GMT_x_OPT);
+			GMT_Usage (API, 1, "\n%s", GMT_x_OPT);
 			GMT_Usage (API, -2, "Limit the number of cores used in multi-threaded algorithms [Default uses all %d cores]. "
 				"If <n> is negative then we select (%d - <n>) cores (or at least 1).", cores, cores);
 			break;


### PR DESCRIPTION
**Description of proposed changes**

Run `gmt grdimage`, you will see a trailing dot in the `-x` option syntax.
```
[-x[[-]<n>]] .
```
This PR removes it.