### PR TITLE
Fix autoscaling -JX for double negatives

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -2716,8 +2716,8 @@ GMT_LOCAL int gmtmap_init_linear (struct GMT_CTRL *GMT, bool *search) {
 	/* If either is zero, adjust width or height to the other */
 
 	if (GMT->current.proj.scale[GMT_X] == 0) {	/* Must redo x-scaling by using y-scale */
-		GMT->current.proj.scale[GMT_X] = GMT->current.proj.autoscl[GMT_X] * GMT->current.proj.scale[GMT_Y];
-		if (GMT->current.proj.autoscl[GMT_X] == -1) GMT->current.proj.xyz_pos[GMT_X] = !GMT->current.proj.xyz_pos[GMT_Y];
+		GMT->current.proj.scale[GMT_X] = GMT->current.proj.autoscl[GMT_X] * fabs (GMT->current.proj.scale[GMT_Y]);
+		GMT->current.proj.xyz_pos[GMT_X] = (GMT->current.proj.autoscl[GMT_X] == +1);
 		switch ( (GMT->current.proj.xyz_projection[GMT_X]%3)) {	/* Modulo 3 so that GMT_TIME (3) maps to GMT_LINEAR (0) */
 			case GMT_LINEAR:	/* Regular scaling */
 				if (GMT->current.proj.xyz_pos[GMT_X]) {
@@ -2742,8 +2742,8 @@ GMT_LOCAL int gmtmap_init_linear (struct GMT_CTRL *GMT, bool *search) {
 		GMT->current.proj.pars[0] = GMT->current.proj.scale[GMT_X] * fabs (xmin - xmax);
 	}
 	else if (GMT->current.proj.scale[GMT_Y] == 0) {	/* Must redo y-scaling by using x-scale */
-		GMT->current.proj.scale[GMT_Y] = GMT->current.proj.autoscl[GMT_Y] * GMT->current.proj.scale[GMT_X];
-		if (GMT->current.proj.autoscl[GMT_Y] == -1) GMT->current.proj.xyz_pos[GMT_Y] = !GMT->current.proj.xyz_pos[GMT_X];
+		GMT->current.proj.scale[GMT_Y] = GMT->current.proj.autoscl[GMT_Y] * fabs (GMT->current.proj.scale[GMT_X]);
+		GMT->current.proj.xyz_pos[GMT_Y] = (GMT->current.proj.autoscl[GMT_Y] == +1);
 		switch (GMT->current.proj.xyz_projection[GMT_Y]%3) {	/* Modulo 3 so that GMT_TIME (3) maps to GMT_LINEAR (0) */
 			case GMT_LINEAR:	/* Regular scaling */
 				if (GMT->current.proj.xyz_pos[GMT_Y]) {

--- a/test/baseline/psbasemap.dvc
+++ b/test/baseline/psbasemap.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a25248dfe1ba748cbe2da477e953223c.dir
-  size: 2859211
-  nfiles: 55
+- md5: 95ed1649102e92898fcaf7acaeec066f.dir
+  size: 2901333
+  nfiles: 56
   path: psbasemap

--- a/test/psbasemap/autoscale.sh
+++ b/test/psbasemap/autoscale.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# We had a bug when one axis was set to -0 and the other was negative
+# Try all combinations of -JX[±]W/±0 and -JX±0/[±]H plus plain -JX[±]W
+gmt begin autoscale
+	gmt basemap -R0/10/0/5 -JX7c -B -X3c -Y1.5c
+	echo "-JX7c" | gmt text -F+cCM+f18p
+	gmt basemap -JX-7c -B -X8c
+	echo "-JX-7c" | gmt text -F+cCM+f18p
+	gmt basemap -JX7c/0 -B -X-8c -Y8c
+	echo "-JX7c/0" | gmt text -F+cCM+f18p
+	gmt basemap -JX-7c/0 -B -X8c
+	echo "-JX-7c/0" | gmt text -F+cCM+f18p
+	gmt basemap -JX7c/-0 -B -X-8c -Y4.5c
+	echo "-JX7c/-0" | gmt text -F+cCM+f18p
+	gmt basemap -JX-7c/-0 -B -X8c
+	echo "-JX-7c/-0" | gmt text -F+cCM+f18p
+	gmt basemap -JX0/3.5c -B -X-8c -Y4.5c
+	echo "-JX0/3.5c" | gmt text -F+cCM+f18p
+	gmt basemap -JX0/-3.5c -B -X8c
+	echo "-JX0/-3.5c" | gmt text -F+cCM+f18p
+	gmt basemap -JX-0/3.5c -B -X-8c -Y4.5c
+	echo "-JX-0/3.5c" | gmt text -F+cCM+f18p
+	gmt basemap -JX-0/-3.5c -B -X8c
+	echo "-JX-0/-3.5c" | gmt text -F+cCM+f18p
+gmt end show


### PR DESCRIPTION
When **-JX** was given one negative length and another as -0 then the axis with -0 scale did not properly set which direction the axis was going, leading to bad translations and annotations on the wrong side.  This PR fixes this and adds a new test (psbasemap/autoscale.sh) that checks all possible **-JX** combinations involving ±0 as one axis width.  This now passes:

![autoscale](https://user-images.githubusercontent.com/26473567/180240018-a5ff5874-6af9-47b7-b7a7-87a86645d1f1.jpg)

