### PR TITLE
Must erase any input grid CPT in grdmath

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1035,7 +1035,7 @@ L100:
 
 		/* Define z variable. Attempt to remove "scale_factor" or "add_offset" when no longer needed */
 		gmtnc_put_units (ncid, z_id, header->z_units);
-		if (GMT->parent->remote_info && GMT->parent->remote_id != GMT_NOTSET && GMT->parent->remote_info[GMT->parent->remote_id].CPT[0] != '-')	/* Subset of remote grid with default CPT, save name as an attribute */
+		if (!GMT->parent->ignore_remote_cpt && GMT->parent->remote_info && GMT->parent->remote_id != GMT_NOTSET && GMT->parent->remote_info[GMT->parent->remote_id].CPT[0] != '-')	/* Subset of remote grid with default CPT, save name as an attribute */
 			HH->cpt = strdup (GMT->parent->remote_info[GMT->parent->remote_id].CPT);
 
 		if (header->z_scale_factor != 1.0) {

--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -1035,7 +1035,7 @@ L100:
 
 		/* Define z variable. Attempt to remove "scale_factor" or "add_offset" when no longer needed */
 		gmtnc_put_units (ncid, z_id, header->z_units);
-		if (!GMT->parent->ignore_remote_cpt && GMT->parent->remote_info && GMT->parent->remote_id != GMT_NOTSET && GMT->parent->remote_info[GMT->parent->remote_id].CPT[0] != '-')	/* Subset of remote grid with default CPT, save name as an attribute */
+		if (!GMT->parent->meta.ignore_remote_cpt && GMT->parent->remote_info && GMT->parent->remote_id != GMT_NOTSET && GMT->parent->remote_info[GMT->parent->remote_id].CPT[0] != '-')	/* Subset of remote grid with default CPT, save name as an attribute */
 			HH->cpt = strdup (GMT->parent->remote_info[GMT->parent->remote_id].CPT);
 
 		if (header->z_scale_factor != 1.0) {

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -120,6 +120,10 @@ struct GMTAPI_DATA_OBJECT {
 #endif
 };
 
+struct API_META {	/* Items related to passing or not passing certain meta data from one grid to the next */
+	bool ignore_remote_cpt;			/* true if we should not store the remote CPT associated with the origin of this grid */
+};
+
 struct GMTAPI_CTRL {
 	/* Master controller which holds all GMT API related information at run-time for a single session.
 	 * Users can run several GMT sessions concurrently; each session requires its own structure.
@@ -151,7 +155,6 @@ struct GMTAPI_CTRL {
 	bool got_remote_wesn;				/* true if we obtained w/e/sn via a remote grid/image with no resolution given */
 	bool use_gridline_registration;	/* true if default remote grid registration should be gridline, not pixel */
 	bool use_gridline_registration_warn;	/* true if we should warn about the above */
-	bool ignore_remote_cpt;			/* true if we should not store the remote CPT associated with the origin of this grid */
 	size_t n_objects_alloc;			/* Allocation counter for data objects */
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */
@@ -219,6 +222,7 @@ struct GMTAPI_CTRL {
 	struct GMT_COMMON *common_snapshot;	/* Holds the latest GMT common option settings after a module completes. */
 	bool inset_shrink;	/* True if gmt inset gets a -R -J that forces us to shrink the scale to fit the inset size */
 	double inset_shrink_scale;	/* The amount of shrinking.  Reset to false and 1 in gmt inset end */
+	struct API_META meta;	/* For controlling meta data */
 };
 
 /* Macro to test if filename is a special name indicating memory location */

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -151,7 +151,7 @@ struct GMTAPI_CTRL {
 	bool got_remote_wesn;				/* true if we obtained w/e/sn via a remote grid/image with no resolution given */
 	bool use_gridline_registration;	/* true if default remote grid registration should be gridline, not pixel */
 	bool use_gridline_registration_warn;	/* true if we should warn about the above */
-	bool ignore_remote_cpt;	/* true if we should not store the remote CPT associated with the origin of this grid */
+	bool ignore_remote_cpt;			/* true if we should not store the remote CPT associated with the origin of this grid */
 	size_t n_objects_alloc;			/* Allocation counter for data objects */
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -151,6 +151,7 @@ struct GMTAPI_CTRL {
 	bool got_remote_wesn;				/* true if we obtained w/e/sn via a remote grid/image with no resolution given */
 	bool use_gridline_registration;	/* true if default remote grid registration should be gridline, not pixel */
 	bool use_gridline_registration_warn;	/* true if we should warn about the above */
+	bool ignore_remote_cpt;	/* true if we should not store the remote CPT associated with the origin of this grid */
 	size_t n_objects_alloc;			/* Allocation counter for data objects */
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -6897,6 +6897,7 @@ EXTERN_MSC int GMT_grdmath (void *V_API, int mode, void *args) {
 
 			HH = gmt_get_H_hidden (stack[this_stack]->G->header);
 			if (HH->cpt) gmt_M_str_free (HH->cpt);	/* Must wipe any CPT inherited from input grid */
+			API->ignore_remote_cpt = true;	/* Since we cannot keep track of what grdimath did to this grid */
 
 			if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, stack[this_stack]->G)) Return (API->error);
 			if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, opt->arg, stack[this_stack]->G) != GMT_NOERROR) {

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -6872,6 +6872,7 @@ EXTERN_MSC int GMT_grdmath (void *V_API, int mode, void *args) {
 		if (op == GRDMATH_ARG_IS_BAD) Return (GMT_RUNTIME_ERROR);		/* Horrible way to go... */
 
 		if (op == GRDMATH_ARG_IS_SAVE) {	/* Time to save the current stack to output and pop the stack */
+			struct GMT_GRID_HEADER_HIDDEN *HH = NULL;
 			if (nstack <= 0) {
 				GMT_Report (API, GMT_MSG_ERROR, "No items on stack are available for output!\n");
 				Return (GMT_RUNTIME_ERROR);
@@ -6893,6 +6894,9 @@ EXTERN_MSC int GMT_grdmath (void *V_API, int mode, void *args) {
 			gmt_grd_init (GMT, stack[this_stack]->G->header, options, true);	/* Update command history only */
 
 			gmt_set_pad (GMT, API->pad);	/* Reset to session default pad before output */
+
+			HH = gmt_get_H_hidden (stack[this_stack]->G->header);
+			if (HH->cpt) gmt_M_str_free (HH->cpt);	/* Must wipe any CPT inherited from input grid */
 
 			if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, stack[this_stack]->G)) Return (API->error);
 			if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, opt->arg, stack[this_stack]->G) != GMT_NOERROR) {

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -6897,7 +6897,7 @@ EXTERN_MSC int GMT_grdmath (void *V_API, int mode, void *args) {
 
 			HH = gmt_get_H_hidden (stack[this_stack]->G->header);
 			if (HH->cpt) gmt_M_str_free (HH->cpt);	/* Must wipe any CPT inherited from input grid */
-			API->ignore_remote_cpt = true;	/* Since we cannot keep track of what grdimath did to this grid */
+			API->meta.ignore_remote_cpt = true;	/* Since we cannot keep track of what grdimath did to this grid */
 
 			if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, stack[this_stack]->G)) Return (API->error);
 			if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, opt->arg, stack[this_stack]->G) != GMT_NOERROR) {


### PR DESCRIPTION
See https://github.com/GenericMappingTools/gmt/issues/6909 for background.

This PR introduces a hidden parameters that some modules (right now just **grdmath**) can set to prevent a grid deriving from a remote data set to inherit (and save) the CPT name in the grid file.

Closes https://github.com/GenericMappingTools/gmt/issues/6909.