### PR TITLE
Let grdmath control what happens to grid CPT settings

### DIFF
--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -14,6 +14,7 @@ Synopsis
 
 **gmt grdmath**
 [ |SYN_OPT-Area| ]
+[ |-C|\ [*cpt*] ]
 [ |-D|\ *resolution*\ [**+f**] ]
 [ |SYN_OPT-I| ]
 [ |-M| ] [ |-N| ]
@@ -72,6 +73,12 @@ Optional Arguments
 
 .. |Add_-A| replace:: (|-A| is only relevant to the **LDISTG** operator)
 .. include:: explain_-A.rst_
+
+.. _-C:
+
+**-C**\ [*cpt*]
+    Retain the grid's default CPT (if it has one), or alternatively replace it with a
+    new default *cpt* [Default removes any default CPT from the output grid].
 
 .. _-D:
 


### PR DESCRIPTION
See #6909 to which this is a follow up.  It adds the new **-C** option that can be used to keep or update the output grid's default CPT setting.  By default, those CPTs are wiped on output.
