### PR TITLE
Incorrect comparison in gmt_grd_domains_match function

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3897,7 +3897,7 @@ bool gmt_grd_domains_match (struct GMT_CTRL *GMT, struct GMT_GRID *A, struct GMT
 	/* Return true if both grids A and B have exactly the same domain, registration, intervals.
 	 * Otherwise we print an error message and return false.
 	 */
-	char *msg = (comment = NULL) ? "two" : comment;
+	char *msg = (comment == NULL) ? "two" : comment;
 	if (A->header->registration != B->header->registration) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "The %s grids have different registrations!\n", msg);
 		return (false);


### PR DESCRIPTION
This function is used to check if two grids have the same domain and increment and registration.  It takes a comment string to give the error message context. Unfortunately, there check for NULL was instead an assignment, leading to messages like

`gravfft [ERROR]: The (null) grids have different regions`

This PR fixes this so we now get

`gravfft [ERROR]: The surface and density grids have different regions`
