### PR TITLE
one-liner.rst: remove word

### DIFF
--- a/doc/rst/source/cookbook/one-liner.rst
+++ b/doc/rst/source/cookbook/one-liner.rst
@@ -20,7 +20,7 @@ The syntax for this special mechanism involves a few simple rules:
    of :doc:`/pscoast`, no **-O**, **-K**, **-P** options, etc.) is required.
 #. The plot file and type must be specified with the special option **-format** *prefix*,
    where **format** is one or more comma-separated graphics extensions from the list of
-   allowable graphics formats :ref:`formats <tbl-formats>`, and *prefix* is the prefix of
+   allowable graphics :ref:`formats <tbl-formats>`, and *prefix* is the prefix of
    the illustration (the extension is automatically set by the chosen format). Note the
    leading hyphen for the format option.
 #. The one-liner command cannot itself be part of a longer modern mode session.


### PR DESCRIPTION
Two 'formats' - remove the one without link.