### PR TITLE
Let grdimage handle mask grids

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1631,6 +1631,10 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			double zmin = Grid_orig->header->z_min, zmax = Grid_orig->header->z_max;
 			char *cpt = gmt_cpt_default (API, Ctrl->C.file, Ctrl->In.file, Grid_orig->header);
 			grdimage_reset_grd_minmax (GMT, Grid_orig, &zmin, &zmax);
+			HH = gmt_get_H_hidden (Grid_orig->header);
+			if (HH->has_NaNs == GMT_GRID_HAS_NANS && doubleAlmostEqual (zmin, 1.0) && doubleAlmostEqual (zmax, 1.0)) {	/* Mask grid, just nudge max to 2 */
+				zmax = 2.0;	/* Otherwise we get annoying warning */
+			}
 			if ((P = gmt_get_palette (GMT, cpt, GMT_CPT_OPTIONAL, zmin, zmax, Ctrl->C.dz)) == NULL) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failed to read CPT %s.\n", Ctrl->C.file);
 				gmt_free_header (API->GMT, &header_G);


### PR DESCRIPTION
If you create a mask grid (NaN and 1) and want to see how it looks in **grdimage** you get this annoyance:

```
gmt grdimage E_obl_inside_mask.grd -B -pdf t
grdimage [ERROR]: Passing zmax <= zmin prevents automatic CPT generation!
grdimage [ERROR]: Failed to read CPT (null).
psconvert [ERROR]: Unable to decode BoundingBox file /Users/pwessel/.gmt/sessions/gmt_session.11534/psconvert_30470c.bb (maybe no non-white features were plotted?)
```
and a failed plot.   The reason is that _zmin_ = _zmax_ = 1 and no CPT can be crafted.  Since this is a common situation, this PR allows for this by checking if

- We have a grid with NaNs
- The rest of the data are all 1.0

If so we have a NaN mask and we can then set the internal _zmax_ to 2 so that we get a map when no CPT is given.
