### PR TITLE
Handle automatic CPT for constant grids

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8610,9 +8610,15 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "All data points are NaNs so cannot do meaningful automatic CPT generation\n");
 			zmin = 0.0;	zmax = 1.0;	/* Does not matter since only NaN color will be used */
 		}
-		if (zmax <= zmin) {	/* Safety valve 2 */
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Passing zmax <= zmin prevents automatic CPT generation!\n");
-			return (NULL);
+		if (zmax <= zmin) {	/* Safety valve 2 [min == max] */
+			/* Have a constant grid or a mask grid with NaNs and a constant [1] - adjust min or max so that we can do an automatic CPT */
+			if (zmin > 0.0)	/* Both are positive so just increase max */
+				zmax = 2.0 * zmin;
+			else if (zmin < 0.0)	/* Both are negative so just decrease min */
+				zmin = 2.0 * zmax;
+			else	/* All zeros, must set max to 1 */
+				zmax = 1.0;
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Found zmax == zmin, replaced with %lg and %lg to allow automatic CPT generation!\n", zmin, zmax);
 		}
 
 		if (file == NULL && (current_cpt = gmt_get_current_item (GMT, "cpt", false))) {	/* There is a current CPT in modern mode */

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1631,10 +1631,6 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 			double zmin = Grid_orig->header->z_min, zmax = Grid_orig->header->z_max;
 			char *cpt = gmt_cpt_default (API, Ctrl->C.file, Ctrl->In.file, Grid_orig->header);
 			grdimage_reset_grd_minmax (GMT, Grid_orig, &zmin, &zmax);
-			HH = gmt_get_H_hidden (Grid_orig->header);
-			if (HH->has_NaNs == GMT_GRID_HAS_NANS && doubleAlmostEqual (zmin, 1.0) && doubleAlmostEqual (zmax, 1.0)) {	/* Mask grid, just nudge max to 2 */
-				zmax = 2.0;	/* Otherwise we get annoying warning */
-			}
 			if ((P = gmt_get_palette (GMT, cpt, GMT_CPT_OPTIONAL, zmin, zmax, Ctrl->C.dz)) == NULL) {
 				GMT_Report (API, GMT_MSG_ERROR, "Failed to read CPT %s.\n", Ctrl->C.file);
 				gmt_free_header (API->GMT, &header_G);


### PR DESCRIPTION
This PR overwrites the changes in #6930 following the discussion therein.  A mask grid is just a special case of a constant grid and such grids are allowed.  However, without upgrading the automatic CPT creation for grids with zero range we run into trouble.

This PR always produces a valid CPT for grids with no range.
