### PR TITLE
Let batch -D drop the mandatory moving of product files

### DIFF
--- a/doc/rst/source/batch.rst
+++ b/doc/rst/source/batch.rst
@@ -15,6 +15,7 @@ Synopsis
 **gmt batch** *mainscript*
 |-N|\ *prefix*
 |-T|\ *njobs*\|\ *min*/*max*/*inc*\ [**+n**]\|\ *timefile*\ [**+p**\ *width*]\ [**+s**\ *first*]\ [**+w**\ [*str*]\|\ **W**]
+[ |-D| ]
 [ |-I|\ *includefile* ]
 [ |-M|\ [*job*] ]
 [ |-Q|\ [**s**] ]
@@ -81,6 +82,12 @@ Required Arguments
 
 Optional Arguments
 ------------------
+
+.. _-D:
+
+**-D**
+    The main script does not produce products that are named using the prefix **BATCH_NAME**, so we do not attempt
+    to move such files to the top directory.  The main script will instead handle this in a different way.
 
 .. _-I:
 

--- a/src/batch.c
+++ b/src/batch.c
@@ -199,7 +199,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+W Same as +w but only use TAB as separator.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-D");
-	GMT_Usage (API, -2, "There are no product files up to main directory [Default assumes there are named products].");
+	GMT_Usage (API, -2, "No product files to move to the main directory [Default assumes there are named products].");
 	GMT_Usage (API, 1, "\n-I<includefile>");
 	GMT_Usage (API, -2, "Specify a script file to be inserted into the batch_init.sh script [none]. "
 		"Used to add constant variables needed by all batch scripts.");


### PR DESCRIPTION
See #6932 for discussion.  This PR implements a **-D** option that stops any copying of batch products to the top directory.  This solution does not preempt further consideration of the other suggestion which is to generalize the naming of product files via a **-F**_template_ option.
