### PR TITLE
Update makecpt.rst

### DIFF
--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -332,7 +332,7 @@ we always get a color regardless of the *z* value, try
 To build a categorical table with 3 categories and add specific category
 names to them, try::
 
-    gmt makecpt -Ccubhelix -T0/3/1 -F+cClouds,Trees,Water > cat.cpt
+    gmt makecpt -Ccubhelix -T0/2/1 -F+cClouds,Trees,Water > cat.cpt
 
 To instead add unique category labels A, B, C, ... to a 10-item categorical CPT, try::
 


### PR DESCRIPTION
I change the value becuase when I run the example I got a warning. 
I think that the warning is ok and that the command should be changed. Please check. 


I try the following command and got a warning:

```
gmt makecpt -Ccubhelix -T0/3/1 -F+cClouds,Trees,Water
makecpt [WARNING]: The comma-separated string Clouds,Trees,Water had 3 entries but 4 were expected
```

The output is:
```
0	26/28.875/58.75	L	;Clouds
1	66.25/118.63/48.375	L	;Trees
2	211/131/166.5	L	;Water
3	202.12/230.12/239	B
N	red
```
