### PR TITLE
Clarify what happens in gravfft with NaNs

### DIFF
--- a/doc/rst/source/explain_fft.rst_
+++ b/doc/rst/source/explain_fft.rst_
@@ -29,9 +29,9 @@
     Control extension and tapering of data:
     Use modifiers to control how the extension and tapering are to be performed:
 
-        **+e** extends the grid by imposing edge-point symmetry [Default],
+        **+e** extends the grid by imposing edge-point symmetry [Default].
 
-        **+m** extends the grid by imposing edge mirror symmetry
+        **+m** extends the grid by imposing edge mirror symmetry.
 
         **+n** turns off data extension.
 

--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *n/wavelength/mean\_depth*/**t**\|\ **b**\|\ **w** ]
 [ |-D|\ *density*\|\ *rhogrid* ]
 [ |-E|\ *n_terms* ]
-[ |-F|\ [**f**\ [**+s**]\|\ **b**\|\ **g**\|\ **v**\|\ **n**\|\ **e**] ]
+[ |-F|\ [**f**\ [**+s**\|\ **z**]\|\ **b**\|\ **g**\|\ **v**\|\ **n**\|\ **e**] ]
 [ |-I|\ **w**\|\ **b**\|\ **c**\|\ **t**\|\ **k** ]
 [ |-N|\ *params* ]
 [ |-Q| ]
@@ -103,12 +103,14 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**f**\ [**+s**]\|\ **b**\|\ **g**\|\ **v**\|\ **n**\|\ **e**]
+**-F**\ [**f**\ [**+s**\|\ **z**]\|\ **b**\|\ **g**\|\ **v**\|\ **n**\|\ **e**]
     Specify desired geopotential field: compute geoid rather than gravity
 
        **f** = Free-air anomalies (mGal) [Default].  Append **+s** to add
        in the slab implied when removing the mean value from the topography.
-       This requires zero topography to mean no mass anomaly.
+       This requires zero topography to mean no mass anomaly. Alternatively,
+       to force the far-field to be exactly zero (i.e., the corner nodes of
+       the grid), select **+z** instead.
 
        **b** = Bouguer gravity anomalies (mGal).
 

--- a/doc/rst/source/supplements/potential/gravfft.rst
+++ b/doc/rst/source/supplements/potential/gravfft.rst
@@ -99,7 +99,7 @@ Optional Arguments
 
 **-E**\ *n_terms*
     Number of terms used in Parker expansion (limit is 10, otherwise
-    terms depending on n will blow out the program) [Default = 3]
+    terms depending on n will blow out the program) [Default = 3].
 
 .. _-F:
 
@@ -146,7 +146,7 @@ Optional Arguments
     Writes out a grid with the flexural topography (with z positive up)
     whose average depth was set by **-Z**\ *zm* and model parameters by |-T|
     (and output by |-G|). That is the "gravimetric Moho". |-Q|
-    implicitly sets **-N+h**
+    implicitly sets **-N+h**.
 
 .. _-S:
 
@@ -167,7 +167,7 @@ Optional Arguments
     is > 1e10 it will be interpreted as the flexural rigidity (by default it is
     computed from *te* and Young modulus). Optionally, append *+m* to write a grid
     with the Moho's geopotential effect (see |-F|) from model selected by |-T|.
-    If *te* = 0 then the Airy response is returned. **-T+m** implicitly sets **-N+h**
+    If *te* = 0 then the Airy response is returned. **-T+m** implicitly sets **-N+h**.
 
 .. _-W:
 
@@ -206,6 +206,13 @@ other grids geographical grids were you want to convert degrees into
 meters, select |SYN_OPT-f|. If the data are close to either pole, you should
 consider projecting the grid file onto a rectangular coordinate system
 using :doc:`grdproject </grdproject>`.
+
+Handling of Grids with NaNs
+---------------------------
+
+Since we cannot take FFTs of 2-D grids that contain NaNs, we perform simple substitutions.
+If any of the input grids contain NaNs they will be replaced with zeros. In contrast, if **-D**
+passes a grid with density contrasts then we replace any NaNs with the minimum density in the grid.
 
 Data Detrending
 ---------------


### PR DESCRIPTION
Because residual grids with NaNs in areas of no data are common in isostatic studies, we allow **gravfft** to handle such grids rather than having to use **grdmath** **DENAN**.  This PR:

1. Replaces NaNs in the 1-2 input grids with zeros
2. WIth **-Vl** we report the number of NaNs as well
3. The documentation now has a new section that discussion what happens with the NaN grids in input and via **-D** as a density grid.
4. Minor typographical fixes in **-N** and **gravfft** documentations.
