### PR TITLE
Movie usage and docs update for missing modifiers

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -273,7 +273,6 @@ Optional Arguments
     - **+o**\ *dx*\ [/*dy*] offsets the indicator in direction implied by *justify*.
     - **+p**\ *pen* sets the moving item *pen*.
     - **+P**\ *pen* sets the static item *pen*.
-    - **+P**\ *pen* sets the static item *pen*.
     - **+s**\ *scale* means we compute elapsed time as frame number times *scale*.
     - **+t**\ *format* sets a C-format statement to be used with the item selected [none].
     - **+w**\ *width* sets the dimension of the indicator [5% of max canvas dimension for circular indicators and

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -273,6 +273,9 @@ Optional Arguments
     - **+o**\ *dx*\ [/*dy*] offsets the indicator in direction implied by *justify*.
     - **+p**\ *pen* sets the moving item *pen*.
     - **+P**\ *pen* sets the static item *pen*.
+    - **+P**\ *pen* sets the static item *pen*.
+    - **+s**\ *scale* means we compute elapsed time as frame number times *scale*.
+    - **+t**\ *format* sets a C-format statement to be used with the item selected [none].
     - **+w**\ *width* sets the dimension of the indicator [5% of max canvas dimension for circular indicators and
       60% of relevant canvas dimension (height or width depending on **+j**) for the linear indicators].
 

--- a/src/movie.c
+++ b/src/movie.c
@@ -444,6 +444,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+o Offset indicator by <dx>[/<dy>] in direction implied by <justify> [%d%% of font size].", GMT_TEXT_OFFSET);
 	GMT_Usage (API, 3, "+P Set background (static) pen for indicator [Depends in indicator selected].");
 	GMT_Usage (API, 3, "+p Set foreground (moving) pen for indicator [Depends in indicator selected].");
+	GMT_Usage (API, 3, "+s Compute elapsed time as frame counter times appended <scale> [no scaling].");
 	GMT_Usage (API, 3, "+t Provide a C-format statement to be used with the item selected [none].");
 	GMT_Usage (API, 3, "+w Specify indicator size [5%% of max canvas dimension for circles, 60%% for axes].");
 	GMT_Usage (API, 1, "\n-Q[s]");


### PR DESCRIPTION
The usage message for **-P** did not list **+s**_scale_ and the documentation also missed **+s** as well as **+t**_format_.  This PR fixes these omissions.
