### PR TITLE
Fix punctuation in Cookbook section 3

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -879,7 +879,7 @@ different phase *offset* and color. See the :doc:`/gmt.conf` man page for more i
    :width: 500 px
    :align: center
 
-   Line appearance can be varied by using :term:`PS_LINE_CAP`
+   Line appearance can be varied by using :term:`PS_LINE_CAP`.
 
 .. toggle::
 

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -2445,7 +2445,7 @@ does not allow piping.
 
 Everything looks clearer after a few examples:
 
-*  To write a native binary float grid file, specify the name as ``my_file.f4=bf`` .
+*  To write a native binary float grid file, specify the name as ``my_file.f4=bf``.
 
 *  To read a native short integer grid file, multiply the data by 10 and
    then add 32000, but first let values that equal 32767 be set to NaN,
@@ -2466,13 +2466,13 @@ Everything looks clearer after a few examples:
    offset, give filename as ``=nb+oa``.
 
 *  To read a short integer *.bil* grid file stored in binary and and force
-   the reading via GDAL, add suffix *=gd* as in ``n45_e008_1arc_v3.bil=gd``
+   the reading via GDAL, add suffix *=gd* as in ``n45_e008_1arc_v3.bil=gd``.
 
 *  To write a lossless, deflate compressed, and tiled GeoTIFF grid (or image) use,
-   ``output.tif=gd:GTiff+cTILED=YES+cCOMPRESS=DEFLATE+cPREDICTOR=3``
+   ``output.tif=gd:GTiff+cTILED=YES+cCOMPRESS=DEFLATE+cPREDICTOR=3``.
    See also :ref:`Writing grids and images <Write-grids-images>` as well as available options
    for each output format from the GDAL driver documentation,
-   `for example <https://gdal.org/drivers/raster/gtiff.html>`_
+   `for example <https://gdal.org/drivers/raster/gtiff.html>`_.
 
 Programs that both read and/or write more than one grid file may specify
 different formats and/or scaling for the files involved. The only


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a few typos regarding punctuation in Cookbook section 3. General Features.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
