### PR TITLE
Add required check in gmtinit_get_region_from_data

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14496,7 +14496,7 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 			if (GMT_Close_VirtualFile (API, virt_file) != GMT_NOERROR)
 				return (API->error);
 			if (Out->n_columns < 6) {	/* No can do (6 because of -0 flag passed to gmt info to return column types in cols 4 & 5 */
-				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region %s.\n", (unsigned int)Out->n_columns-2);
+				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region %s.\n", (unsigned int)(Out->n_columns-2)/2);
 				return (GMT_RUNTIME_ERROR);
 			}
 			/* Get the four values from the first and only output record */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14495,8 +14495,8 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 			/* Close the virtual files */
 			if (GMT_Close_VirtualFile (API, virt_file) != GMT_NOERROR)
 				return (API->error);
-			if (Out->n_columns < 4) {	/* No can do */
-				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region %s.\n", (unsigned int)Out->n_columns);
+			if (Out->n_columns < 6) {	/* No can do (6 because of -0 flag passed to gmt info to return column types in cols 4 & 5 */
+				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region %s.\n", (unsigned int)Out->n_columns-2);
 				return (GMT_RUNTIME_ERROR);
 			}
 			/* Get the four values from the first and only output record */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14496,7 +14496,7 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 			if (GMT_Close_VirtualFile (API, virt_file) != GMT_NOERROR)
 				return (API->error);
 			if (Out->n_columns < 6) {	/* No can do (6 because of -0 flag passed to gmt info to return column types in cols 4 & 5 */
-				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region %s.\n", (unsigned int)(Out->n_columns-2)/2);
+				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region.\n", (unsigned int)(Out->n_columns-2)/2);
 				return (GMT_RUNTIME_ERROR);
 			}
 			/* Get the four values from the first and only output record */


### PR DESCRIPTION
See https://github.com/GenericMappingTools/gmt/issues/6955 for background. The reason for the crash is that the malformed input record sets n col = 1 and then later when we run gmt info on it to detect **-R** we failed to check properly that we got 4 data columns back (xmin, xmax, ymin, ymax).  In fact, we pass the hidden -0 option to also return the data column types and our check failed to detect this problem.  Also fixed a formatting but in the error message.
This PR checks that we actually get (4+2 = 6) columns back from gmt info before we try to access those.  The crash is gone and we get this error instead:

```
gmt begin test png; echo -e "0 0\10 10" | gmt plot -Gred; gmt end show
gmt [ERROR]: gmtinit_get_region_from_data: Not enough data columns (1) to determine region.
plot [ERROR]: Must specify -R option
```