### PR TITLE
Quiet an inaccurate complaint about subshell

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -14495,8 +14495,8 @@ GMT_LOCAL int gmtinit_get_region_from_data (struct GMTAPI_CTRL *API, int family,
 			/* Close the virtual files */
 			if (GMT_Close_VirtualFile (API, virt_file) != GMT_NOERROR)
 				return (API->error);
-			if (Out->n_columns < 4) {	/* No can do */
-				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region %s.\n", (unsigned int)Out->n_columns);
+			if (Out->n_columns < 6) {	/* No can do (6 because of -0 flag passed to gmt info to return column types in cols 4 & 5 */
+				GMT_Report (API, GMT_MSG_ERROR, "gmtinit_get_region_from_data: Not enough data columns (%d) to determine region %s.\n", (unsigned int)Out->n_columns-2);
 				return (GMT_RUNTIME_ERROR);
 			}
 			/* Get the four values from the first and only output record */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -18573,7 +18573,7 @@ int gmt_token_check (struct GMT_CTRL *GMT, FILE *fp, char *prefix, unsigned int 
 			if (mode == GMT_BASH_MODE) {	/* Some bash-specific checks */
 				if (strchr (line, '`'))	/* sub-shell call using back-ticks */
 					GMT_Report (GMT->parent, GMT_MSG_WARNING, "Main script appears to have a deprecated sub-shell call `...`, please use $(...) instead: %s", start);
-				else if (strchr (line, ')') && (p = strchr (line, '('))) {	/* sub-shell call without leading $ */
+				else if (strchr (line, ')') && (p = strchr (line, '(')) && strstr (line, "((") == NULL) {	/* sub-shell call without leading $ and it is not a modern (( )) thing */
 					prev = p - 1;	/* Get previous character */
 					if (strchr (line, '\"') == NULL && (prev < start || prev[0] != '$'))	/* No double-quotes yet we have ( ...) and no leading $.Give this message: */
 						GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Main script appears to have a sub-shell call $(...) without the leading $: %s", start);


### PR DESCRIPTION
When **movie** or **batch** scripts use modern bash syntax using (( ...)) the $ identifying a variable is not needed, hence the affected test should check for (( before complaining

`Main script appears to have a sub-shell call $(...) without the leading $`

PR has no effect except suppressing that message if `(( `is found. As an example of an if-test like that is

```
if ((XPOS > 540)) && ((XPOS < 576)) ; then
...
```
