### PR TITLE
blockmean longopts adjustments

### DIFF
--- a/src/blockmean.c
+++ b/src/blockmean.c
@@ -42,13 +42,19 @@
 
 static struct GMT_KEYWORD_DICTIONARY module_kw[] = { /* Local options for this module */
 	/* separator, short_option, long_option, short_directives, long_directives, short_modifiers, long_modifiers */
-	{ 0, 'A', "fields", "", "", "", "" },
-	{ 0, 'C', "center", "", "", "", "" },
-	{ 0, 'E', "extend", "", "", "P,p", "prop-simple,prop-weighted" },
-	{ 0, 'G', "gridfile", "", "", "", "" },
+	{ 0, 'A', "fields",    "", "", "", "" },
+	{ 0, 'C', "center",    "", "", "", "" },
+	{ 0, 'E', "extend",
+                  "",          "",
+                  "p,P",       "weighted,simple" },
+	{ 0, 'G', "outgrid",   "", "", "", "" },
 	GMT_INCREMENT_KW,	/* Defined in gmt_constant.h since not a true GMT common option (but almost) */
-	{ 0, 'S', "select", "m,n,s,w", "mean,count,sum,weight", "", "" },
-	{ 0, 'W', "weights", "i,o", "in,out", "s", "sigma" },
+	{ 0, 'S', "statistic",
+                  "m,n,s,w",   "mean,count,sum,weight",
+                  "",          "" },
+	{ 0, 'W', "weights",
+                  "i,o",       "in,out",
+                  "s",         "sigma" },
 	{ 0, '\0', "", "", "", "", ""}	/* End of list marked with empty option and strings */
 };
 


### PR DESCRIPTION
**Description of proposed changes**

This is the first in a series of PRs to better match longoption strings between the C code package and GMT.jl. Updated code in these PRs is not intended to be a perfect match with GMT.jl, but at least a much closer match. It is assumed that there will be a future decision made on an overall stylistic guideline for these strings (e.g., camelCase, under_scores, runonwords) that is likely to result in further changes.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #6968


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
