### PR TITLE
Consistency in wiggle docs

### DIFF
--- a/doc/rst/source/explain_-F_box.rst_
+++ b/doc/rst/source/explain_-F_box.rst_
@@ -1,6 +1,6 @@
 - **+c**\ *clearance* where *clearance* is either *gap*, *xgap*\ /\ *ygap*, or *lgap*\ /\ *rgap*\ /\ *bgap*\ /\
   *tgap* and *gap* gives a uniform :ref:`clearance <plt-units>`, *xgap*\ /\ *ygap* gives separate
-  :ref:`clearances <plt-units>` in the x- and y- directions, and *lgap*\ /\ *rgap*\ /\ *bgap*\ /\ *tgap* gives
+  :ref:`clearances <plt-units>` in the *x*- and *y*- directions, and *lgap*\ /\ *rgap*\ /\ *bgap*\ /\ *tgap* gives
   individual :ref:`clearances <plt-units>` between the map embellishment and the border for each side.
 - **+g**\ *fill* to fill the box with a color specified by :doc:`fill <gmtcolors>` [default is no fill].
 - **+i**\ [[*gap*/]\ *pen*] to draw a secondary, inner border as well. Optionally, specify the

--- a/doc/rst/source/pswiggle.rst
+++ b/doc/rst/source/pswiggle.rst
@@ -82,7 +82,7 @@ and obtain
 Bugs
 ----
 
-Sometimes the (x,y) coordinates are not printed with enough significant
+Sometimes the (*x,y*) coordinates are not printed with enough significant
 digits, so the local perpendicular to the track swings around a lot. To
 see if this is the problem, you should do this:
 

--- a/doc/rst/source/wiggle.rst
+++ b/doc/rst/source/wiggle.rst
@@ -46,7 +46,7 @@ Description
 -----------
 
 Reads (*x*,\ *y*,\ *z*) triplets from files [or standard
-input] and plots z as a function of distance along track. This means
+input] and plots *z* as a function of distance along track. This means
 that two consecutive (*x*,\ *y*) points define the local distance axis,
 and the local *z* axis is then perpendicular to the distance axis,
 forming a right-handed coordinate system. The
@@ -148,7 +148,7 @@ Optional Arguments
 **-I**\ *fix_az*
     Set a fixed azimuth projection for wiggles [Default uses track
     azimuth, but see |-A|]. With this option, the calculated
-    track-normal azimuths are overridden by *fixed_az*.
+    track-normal azimuths are overridden by *fix_az*.
 
 .. _-T:
 
@@ -249,7 +249,7 @@ and obtain
 Bugs
 ----
 
-Sometimes the (x,y) coordinates are not printed with enough significant
+Sometimes the (*x,y*) coordinates are not printed with enough significant
 digits, so the local perpendicular to the track swings around a lot. To
 see if this is the problem, you should do this:
 


### PR DESCRIPTION
Apply italics to x, y, z parameters. Fix typo in -I.
