### PR TITLE
Increase length of var holding the custom symbol names.

### DIFF
--- a/src/gmt_decorate.h
+++ b/src/gmt_decorate.h
@@ -71,7 +71,7 @@ struct GMT_DECORATE {
 	char fill[GMT_LEN64];		/* The symbol fill */
 	char pen[GMT_LEN64];		/* The symbol outline pen */
 	struct GMT_PEN debug_pen;	/* Pen for drawing the debugging lines */
-	char symbol_code[GMT_LEN64];	/* The symbol code only as a null-terminated string */
+	char symbol_code[GMT_LEN256];	/* The symbol code only as a null-terminated string */
 	char flag;			/* Char for the option key */
 	struct GMT_DATASET *X;		/* Dataset with list of structures with crossing-line coordinates */
 	struct GMT_XSEGMENT *ylist_XP;	/* Sorted y-segments for crossing-lines */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -19629,7 +19629,7 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 			fprintf (fp, "S - %s - %s %s - %s\n", scode, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 		}
 		else if (symbol == '~') {	/* Decorated line [Experimental] */
-			char scode[GMT_LEN64] = {""};
+			char scode[GMT_LEN256] = {""};
 			sprintf (scode, "~n1:+s%s%s", S->D.symbol_code, S->D.size);
 			if (S->D.pen[0])  strcat (scode, "+p"), strcat (scode, S->D.pen);
 			if (S->D.fill[0]) strcat (scode, "+g"), strcat (scode, S->D.fill);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -10577,7 +10577,7 @@ int gmtlib_decorate_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_DECORATE 
 							}
 							else {	/* Size seems OK */
 								s[0] = '\0';	/* Truncate size */
-								strncpy (G->symbol_code, &p[1], GMT_LEN64-1);
+								strncpy (G->symbol_code, &p[1], GMT_LEN256-1);
 								s[0] = '/';	/* Restore size */
 								if (gmtlib_invalid_symbolname (GMT, G->symbol_code))
 									bad++;


### PR DESCRIPTION
Custom symbol names can carry their path and a length of 64 is way too short.
This was damn tricky to find and only fantastic VSC searching capabilities helped.