### PR TITLE
Fix docstring typo in coupe.rst

### DIFF
--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -54,7 +54,7 @@ will plot a cross-section of focal mechanisms.
 The name "coupe" comes from the French
 verb “to cut”.  The best translation is a (vertical) cross section.
 
-Unless |-Q| is used, new file is created with the new coordinates
+Unless |-Q| is used, a new file is created with the new coordinates
 (**x**, **y**) and the mechanism (from lower focal half-sphere for
 horizontal plane, to half-sphere behind a vertical plane). When the
 plane is not horizontal,


### PR DESCRIPTION
This fixes the grammar to say that "a new file" is crated



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
