### PR TITLE
Ensure we understand the mode shift in gmt.c

### DIFF
--- a/src/gmt.c
+++ b/src/gmt.c
@@ -70,9 +70,9 @@ int main (int argc, char *argv[]) {
 #endif	/* !defined(NO_SIGHANDLER) */
 
 	/* Look for and process any -V[flag] so we may use GMT_Report_Error early on for debugging.
-	 * Note: Because first GMT_VERBOSE_SHIFT bits of mode may be used for other things we must left-shift by GMT_VERBOSE_SHIFT */
+	 * Note: Because first GMT_MSG_BITSHIFT bits of mode may be used for other things we must left-shift by GMT_MSG_BITSHIFT */
 	for (k = 1; k < argc; k++) if (!strncmp (argv[k], "-V", 2U)) v_mode = gmt_get_V (argv[k][2]);
-	if (v_mode) mode = (v_mode << GMT_VERBOSE_SHIFT);	/* Left-shift the mode by GMT_VERBOSE_SHIFT */
+	if (v_mode) mode = (v_mode << GMT_MSG_BITSHIFT);	/* Left-shift the mode by GMT_MSG_BITSHIFT */
 
 	progname = strdup (basename (argv[0])); /* Last component from the pathname */
 	/* Remove any filename extensions added for example by the MSYS shell when executing gmt via symlinks */

--- a/src/gmt.c
+++ b/src/gmt.c
@@ -70,9 +70,9 @@ int main (int argc, char *argv[]) {
 #endif	/* !defined(NO_SIGHANDLER) */
 
 	/* Look for and process any -V[flag] so we may use GMT_Report_Error early on for debugging.
-	 * Note: Because first 16 bits of mode may be used for other things we must left-shift by 16 */
+	 * Note: Because first GMT_VERBOSE_SHIFT bits of mode may be used for other things we must left-shift by GMT_VERBOSE_SHIFT */
 	for (k = 1; k < argc; k++) if (!strncmp (argv[k], "-V", 2U)) v_mode = gmt_get_V (argv[k][2]);
-	if (v_mode) mode = (v_mode << 16);	/* Left-shift the mode by 16 */
+	if (v_mode) mode = (v_mode << GMT_VERBOSE_SHIFT);	/* Left-shift the mode by GMT_VERBOSE_SHIFT */
 
 	progname = strdup (basename (argv[0])); /* Last component from the pathname */
 	/* Remove any filename extensions added for example by the MSYS shell when executing gmt via symlinks */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -8247,7 +8247,7 @@ void * GMT_Create_Session (const char *session, unsigned int pad, unsigned int m
 #endif
 
 	if ((API = calloc (1, sizeof (struct GMTAPI_CTRL))) == NULL) return_null (NULL, GMT_MEMORY_ERROR);	/* Failed to allocate the structure */
-	API->verbose = (mode >> 16);	/* Pick up any -V settings from gmt.c */
+	API->verbose = (mode >> GMT_VERBOSE_SHIFT);	/* Pick up any -V settings from gmt.c */
 	API->remote_id = GMT_NOTSET;     /* Not read a remote grid yet */
 	API->pad = pad;     /* Preserve the default pad value for this session */
 	API->print_func = (print_func == NULL) ? gmtapi_print_func : print_func;	/* Pointer to the print function to use in GMT_Message|Report */

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -8247,7 +8247,7 @@ void * GMT_Create_Session (const char *session, unsigned int pad, unsigned int m
 #endif
 
 	if ((API = calloc (1, sizeof (struct GMTAPI_CTRL))) == NULL) return_null (NULL, GMT_MEMORY_ERROR);	/* Failed to allocate the structure */
-	API->verbose = (mode >> GMT_VERBOSE_SHIFT);	/* Pick up any -V settings from gmt.c */
+	API->verbose = (mode >> GMT_MSG_BITSHIFT);	/* Pick up any -V settings from gmt.c */
 	API->remote_id = GMT_NOTSET;     /* Not read a remote grid yet */
 	API->pad = pad;     /* Preserve the default pad value for this session */
 	API->print_func = (print_func == NULL) ? gmtapi_print_func : print_func;	/* Pointer to the print function to use in GMT_Message|Report */

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -200,7 +200,6 @@ enum GMT_time_period {
 #define GMT_INCREMENT_KW { '/', 'I', "increment", "", "", "e,n", "exact,number" }
 
 #define GMT_VERBOSE_CODES	"q ewticd"	/* List of valid codes to -V (the blank is for NOTICE which is not user selectable */
-#define GMT_VERBOSE_SHIFT	16		/* Left/right shift of -V integer codes when packing into mode for GMT_Create_Session */
 #define GMT_DIM_UNITS	"cip"		/* Plot dimensions in cm, inch, or point */
 #define GMT_LEN_UNITS2	"efkMnu"	/* Distances in meter, foot, survey foot, km, Mile, nautical mile */
 #define GMT_LEN_UNITS	"dmsefkMnu"	/* Distances in arc-{degree,minute,second} or meter, foot, km, Mile, nautical mile, survey foot */

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -200,6 +200,7 @@ enum GMT_time_period {
 #define GMT_INCREMENT_KW { '/', 'I', "increment", "", "", "e,n", "exact,number" }
 
 #define GMT_VERBOSE_CODES	"q ewticd"	/* List of valid codes to -V (the blank is for NOTICE which is not user selectable */
+#define GMT_VERBOSE_SHIFT	16		/* Left/right shift of -V integer codes when packing into mode for GMT_Create_Session */
 #define GMT_DIM_UNITS	"cip"		/* Plot dimensions in cm, inch, or point */
 #define GMT_LEN_UNITS2	"efkMnu"	/* Distances in meter, foot, survey foot, km, Mile, nautical mile */
 #define GMT_LEN_UNITS	"dmsefkMnu"	/* Distances in arc-{degree,minute,second} or meter, foot, km, Mile, nautical mile, survey foot */

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 260
+#define GMT_N_API_ENUMS 261
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -192,6 +192,7 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_MODULE_SHOW_MODERN", 1},
 	{"GMT_MODULE_SYNOPSIS", -8},
 	{"GMT_MODULE_USAGE", -9},
+	{"GMT_MSG_BITSHIFT", 16},
 	{"GMT_MSG_COMPAT", 6},
 	{"GMT_MSG_DEBUG", 7},
 	{"GMT_MSG_ERROR", 2},

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -320,6 +320,7 @@ enum GMT_enum_verbose {
 	GMT_MSG_INFORMATION	= 5,	/* Adds informational messages */
 	GMT_MSG_COMPAT		= 6,	/* Compatibility warnings */
 	GMT_MSG_DEBUG		= 7,	/* Debug messages for developers mostly */
+	GMT_MSG_BITSHIFT	= 16,	/* Left/right shift of MSG codes when packing into mode for GMT_Create_Session. Increase if GMT_MSG_* need more space */
 	/* For API backwards compatibility only */
 	GMT_MSG_NORMAL		= 2,	/* Now GMT_MSG_ERROR */
 	GMT_MSG_VERBOSE		= 5,	/* Now GMT_MSG_WARNING  */


### PR DESCRIPTION
When gmt.c detects **-V** it obtains the corresponding integer code and then packs it into the regular mode argument to _GMT_Create_Session_ by left-shifting by 16 bits.  It is possible that when future GMT developers look at this the 16 will be seen as some fixed number but it is possible it needs to change later on.  Thus, it is better to use a **named enum constant** for this shift so that it will change in all places (two, presently) where this number is used.

PS. I do not think this trick (shift by 16 to add **-V** code) is used by any of the wrappers but just in case it is or will be, heads up to @joa-quim and @seisman to check and if so use **GMT_MSG_BITSHIFT** which you can get via _GMT_Get_Enum_ at run-time.