### PR TITLE
Use "0.25p" instead of "default" for default of pen width in documentation

### DIFF
--- a/doc/rst/source/coast.rst
+++ b/doc/rst/source/coast.rst
@@ -176,7 +176,7 @@ Optional Arguments
 
 **-I**\ *river*\ [/*pen*]
     Draw rivers. Specify the type of rivers and [optionally] append pen
-    attributes [Default pen: width = default, color = black, style =
+    attributes [Default pen: width = 0.25p, color = black, style =
     solid].
 
     Choose from the list of river types below; repeat option |-I| as
@@ -223,7 +223,7 @@ Optional Arguments
 
 **-N**\ *border*\ [/*pen*]
     Draw political boundaries. Specify the type of boundary and
-    [optionally] append pen attributes [Default pen: width = default,
+    [optionally] append pen attributes [Default pen: width = 0.25p,
     color = black, style = solid].
 
     Choose from the list of boundaries below. Repeat option |-N| as
@@ -263,7 +263,7 @@ Optional Arguments
 
 **-W**\ [[*level*/]\ *pen*] :ref:`(more ...) <set-pens>`
     Draw shorelines [Default is no shorelines]. Append pen attributes
-    [Defaults: width = default, color = black, style = solid] which
+    [Defaults: width = 0.25p, color = black, style = solid] which
     apply to all four levels. To set the pen for each level differently,
     prepend *level*/, where *level* is 1-4 and represent coastline,
     lakeshore, island-in-lake shore, and lake-in-island-in-lake shore.

--- a/doc/rst/source/gmt2kml.rst
+++ b/doc/rst/source/gmt2kml.rst
@@ -247,7 +247,7 @@ Optional Arguments
 
 **-W**\ [*pen*][*attr*] :ref:`(more ...) <-Wpen_attrib>`
     Set pen attributes for lines, wiggles or polygon outlines. Append pen
-    attributes to use [Defaults: width = default, color = black, style =
+    attributes to use [Defaults: width = 0.25p, color = black, style =
     solid]. If the modifier **+cl** is appended then the color of the line
     are taken from the CPT (see |-C|). If instead modifier **+cf** is
     appended then the color from the cpt file is applied to symbol fill.

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -150,7 +150,7 @@ Optional Arguments
     [7\ **p**]. For box-and-whisker symbols it sets both the default box width and whisker cap length [7\ **p**].
     Append both *width*\ /*cap* to set separate width and cap dimensions for such symbols.
     Pen attributes for error bars may also be set via **+p**\ *pen*.
-    [Defaults: width = default, color = black, style = solid]. When |-C| is
+    [Defaults: width = 0.25p, color = black, style = solid]. When |-C| is
     used we can control how the look-up color is applied to our symbol.
     Append **+cf** to use it to fill the symbol, while **+cl** will just
     set the error pen color and turn off symbol fill.  Giving **+c** will
@@ -254,7 +254,7 @@ Optional Arguments
 
 **-W**\ [*pen*][*attr*] :ref:`(more ...) <-Wpen_attrib>`
     Set pen attributes for lines or the outline of symbols [Defaults:
-    width = default, color = black, style = solid]. If the modifier **+cl**
+    width = 0.25p, color = black, style = solid]. If the modifier **+cl**
     is appended then the color of the line are taken from the CPT (see
     |-C|). If instead modifier **+cf** is appended then the color from the cpt
     file is applied to symbol fill.  Use just **+c** for both effects.

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -217,7 +217,7 @@ Optional Arguments
 
 **-W**\ [*pen*][*attr*] :ref:`(more ...) <-Wpen_attrib>`
     Set pen attributes for lines or the outline of symbols [Defaults:
-    width = default, color = black, style = solid]. If the modifier **+cl**
+    width = 0.25p, color = black, style = solid]. If the modifier **+cl**
     is appended then the color of the line are taken from the CPT (see
     |-C|). If instead modifier **+cf** is appended then the color from the cpt
     file is applied to symbol fill.  Use just **+c** for both effects.

--- a/doc/rst/source/psrose.rst
+++ b/doc/rst/source/psrose.rst
@@ -74,7 +74,7 @@ azimuth, and shown in Portrait orientation, use:
 To plot a full circle wind rose diagram of the data in the file
 lines.r_az, on a circle of diameter = 10 cm, grid going out to radius =
 500 units in steps of 100 with a 45 degree sector interval, using a
-solid pen (width = 0.5 point, and shown in landscape [Default]
+solid pen (width = 0.5 point), and shown in landscape [Default]
 orientation with UNIX timestamp and command line plotted, use:
 
    ::

--- a/doc/rst/source/solar.rst
+++ b/doc/rst/source/solar.rst
@@ -124,7 +124,7 @@ Optional Arguments
 
 **-W**\ [*pen*] :ref:`(more ...) <-Wpen_attrib>`
     Set pen attributes for lines or the outline of symbols [Defaults:
-    width = default, color = black, style = solid].
+    width = 0.25p, color = black, style = solid].
 
 .. |Add_-XY| replace:: |Add_-XY_links|
 .. include:: explain_-XY.rst_

--- a/doc/rst/source/text.rst
+++ b/doc/rst/source/text.rst
@@ -273,7 +273,7 @@ Optional Arguments
 
 **-W**\ *pen*
     Sets the pen used to draw a rectangle around the text string (see
-    |-C|) [Default is width = default, color = black, style = solid].
+    |-C|) [Default is width = 0.25p, color = black, style = solid].
     **Note**: cannot be used with LaTeX expressions.
 
 .. |Add_-XY| replace:: |Add_-XY_links|


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to improve the `width` default for `pen` in the documentation. It is changed from `width = default` to `width = 0.25p`.

Related to
- https://github.com/GenericMappingTools/gmt/pull/3993
- https://github.com/GenericMappingTools/gmt/pull/4006 
- https://github.com/GenericMappingTools/pygmt/pull/2134

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
