### PR TITLE
Improve documentation of `plot` regarding asymmetric error bars (`-E+a`) 

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -131,10 +131,11 @@ Optional Arguments
 .. _-E:
 
 **-E**\ [**x**\|\ **y**\|\ **X**\|\ **Y**][**+a**\|\ **A**][**+cl**\|\ **f**][**+n**][**+w**\ *width*\ [/*cap*]][**+p**\ *pen*]
-    Draw symmetrical error bars. Append **x** and/or **y** to indicate which bars you
+    Draw error bars. Append **x** and/or **y** to indicate which bars you
     want to draw (Default is both x and y). The x and/or y errors must be
     stored in the columns after the (x,y) pair [or (x,y,z) triplet]. If
-    **+a** is appended then we will draw asymmetrical error bars; these requires
+    **+a** is appended then we will draw asymmetrical error bars [Default
+    is symmetrical error bars]; these requires
     two rather than one extra data column, with the two signed deviations.
     Use **+A** to read the low and high bounds rather than signed deviations.
     If upper case **X** and/or **Y** are used we will instead draw

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -132,7 +132,7 @@ Optional Arguments
 
 **-E**\ [**x**\|\ **y**\|\ **X**\|\ **Y**][**+a**\|\ **A**][**+cl**\|\ **f**][**+n**][**+w**\ *width*\ [/*cap*]][**+p**\ *pen*]
     Draw error bars. Append **x** and/or **y** to indicate which bars you
-    want to draw (Default is both x and y). The x and/or y errors must be
+    want to draw [Default is both x and y]. The x and/or y errors must be
     stored in the columns after the (x,y) pair [or (x,y,z) triplet]. If
     **+a** is appended then we will draw asymmetrical error bars [Default
     is symmetrical error bars]; these requires


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to improve the documentation of `plot` regarding asymmetric error bars (`-E+a`) (see https://docs.generic-mapping-tools.org/dev/plot.html#e).
Related to:
- https://github.com/GenericMappingTools/pygmt/pull/2183#discussion_r1014761634.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
