### PR TITLE
Change "triple"/"quadruple" to "triplet"/"quadruplet" in the documentation

### DIFF
--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -41,7 +41,7 @@ Synopsis
 Description
 -----------
 
-**blockmean** reads arbitrarily located (*x*,\ *y*,\ *z*) triples [or
+**blockmean** reads arbitrarily located (*x*,\ *y*,\ *z*) triplets [or
 optionally weighted quadruples (*x*,\ *y*,\ *z*,\ *w*)] from standard
 input [or *table*] and writes to standard output a mean position and
 value for every non-empty block in a grid region defined by the |-R|

--- a/doc/rst/source/blockmean.rst
+++ b/doc/rst/source/blockmean.rst
@@ -42,7 +42,7 @@ Description
 -----------
 
 **blockmean** reads arbitrarily located (*x*,\ *y*,\ *z*) triplets [or
-optionally weighted quadruples (*x*,\ *y*,\ *z*,\ *w*)] from standard
+optionally weighted quadruplets (*x*,\ *y*,\ *z*,\ *w*)] from standard
 input [or *table*] and writes to standard output a mean position and
 value for every non-empty block in a grid region defined by the |-R|
 and |-I| arguments. See |-G| for writing gridded output directly.

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -42,7 +42,7 @@ Synopsis
 Description
 -----------
 
-**blockmedian** reads arbitrarily located (*x*,\ *y*,\ *z*) triples [or
+**blockmedian** reads arbitrarily located (*x*,\ *y*,\ *z*) triplets [or
 optionally weighted quadruples (*x*,\ *y*,\ *z*,\ *w*)] from standard
 input [or *table*] and writes to standard output a median position and
 value for every non-empty block in a grid region defined by the |-R|

--- a/doc/rst/source/blockmedian.rst
+++ b/doc/rst/source/blockmedian.rst
@@ -43,7 +43,7 @@ Description
 -----------
 
 **blockmedian** reads arbitrarily located (*x*,\ *y*,\ *z*) triplets [or
-optionally weighted quadruples (*x*,\ *y*,\ *z*,\ *w*)] from standard
+optionally weighted quadruplets (*x*,\ *y*,\ *z*,\ *w*)] from standard
 input [or *table*] and writes to standard output a median position and
 value for every non-empty block in a grid region defined by the |-R|
 and |-I| arguments. See |-G| for writing gridded output directly.

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -43,7 +43,7 @@ Description
 -----------
 
 **blockmode** reads arbitrarily located (*x*,\ *y*,\ *z*) triplets [or
-optionally weighted quadruples (*x*,\ *y*,\ *z*,\ *w*)] from standard
+optionally weighted quadruplets (*x*,\ *y*,\ *z*,\ *w*)] from standard
 input [or *table*] and writes to standard output mode estimates of
 position and value for every non-empty block in a grid region defined by
 the |-R| and |-I| arguments. See |-G| for writing gridded output directly.

--- a/doc/rst/source/blockmode.rst
+++ b/doc/rst/source/blockmode.rst
@@ -42,7 +42,7 @@ Synopsis
 Description
 -----------
 
-**blockmode** reads arbitrarily located (*x*,\ *y*,\ *z*) triples [or
+**blockmode** reads arbitrarily located (*x*,\ *y*,\ *z*) triplets [or
 optionally weighted quadruples (*x*,\ *y*,\ *z*,\ *w*)] from standard
 input [or *table*] and writes to standard output mode estimates of
 position and value for every non-empty block in a grid region defined by

--- a/doc/rst/source/nearneighbor.rst
+++ b/doc/rst/source/nearneighbor.rst
@@ -39,7 +39,7 @@ Synopsis
 Description
 -----------
 
-**nearneighbor** reads arbitrarily located (*x,y,z*\ [,\ *w*]) triples
+**nearneighbor** reads arbitrarily located (*x,y,z*\ [,\ *w*]) triplets
 [quadruplets] from standard input [or *table*] and uses a nearest
 neighbor algorithm to assign a weighted average value to each node that
 has one or more data points within a search radius (*R*) centered on the

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -53,7 +53,7 @@ and *z* is all remaining columns in the input (beyond the required :math:`x`
 and :math:`y` columns).
 
 Alternatively, **project** may be used to generate (:math:`r,s,p`)
-triples at equal increments *dist* along a profile using |-G|. In this case, no input is read.
+triplets at equal increments *dist* along a profile using |-G|. In this case, no input is read.
 
 Projections are defined in one of three ways:
 

--- a/doc/rst/source/surface.rst
+++ b/doc/rst/source/surface.rst
@@ -46,7 +46,7 @@ Synopsis
 Description
 -----------
 
-**surface** reads randomly-spaced (x,y,z) triples from standard input
+**surface** reads randomly-spaced (x,y,z) triplets from standard input
 [or *table*] and produces a binary file of gridded values z(x,y) by
 solving the differential equation (away from data points)
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to change "triple" to "triplet" and "quadruple" to "quadruplet" in the documentation, as discussed here https://github.com/GenericMappingTools/pygmt/pull/2186#discussion_r1020995070.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
