### PR TITLE
Enclose filenames given to gdal_translate with quotes

### DIFF
--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -37,6 +37,12 @@
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS "-JRVf"
 
+#ifdef WIN32	/* Special for Windows */
+	static char quote = '\"';
+#else
+	static char quote = '\'';
+#endif
+
 /* Control structure for grdcut */
 
 struct GRDCUT_CTRL {
@@ -1039,7 +1045,8 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 				sprintf (driver, "-of GTiff -co COMPRESS=DEFLATE");
 			else
 				sprintf (driver, "-of netCDF -co COMPRESS=DEFLATE -co FORMAT=NC4 -co ZLEVEL=%d -a_nodata NaN", GMT->current.setting.io_nc4_deflation_level);
-			sprintf (cmd, "gdal_translate -projwin %.10lg %.10lg %.10lg %.10lg %s %s %s", wesn_new[XLO], wesn_new[YHI], wesn_new[XHI], wesn_new[YLO], driver, Ctrl->In.file, Ctrl->G.file);
+			sprintf (cmd, "gdal_translate -projwin %.10lg %.10lg %.10lg %.10lg %s %c%s%c %c%s%c", wesn_new[XLO], wesn_new[YHI], wesn_new[XHI], wesn_new[YLO], driver,
+					quote, Ctrl->In.file, quote, quote, Ctrl->G.file, quote);
 			if (c) c[0] = '=';	/* Restore full file name */
 			if (b) b[0] = '+';	/* Restore band requests */
 			if (b) {	/* Parse and add specific band request(s) to gdal_translate */


### PR DESCRIPTION
Addresses this issue posted on the [forum](https://forum.generic-mapping-tools.org/t/internal-call-gdal-translate-from-grdcut-source-grid-filename-with-spaces-not-working/3439/2).  This PR adds the quotes in the calling of this command line via the system function from **grdcut**.
Note: I have not actually tested this on a file/directory with spaces but the fix is identical to what is used in **psconvert**.