### PR TITLE
Check if argument follows possible one-liner format

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -846,7 +846,7 @@ GMT_LOCAL int gmtapi_modern_oneliner (struct GMTAPI_CTRL *API, struct GMT_OPTION
 
 	for (opt = head; opt; opt = opt->next) {
         if (opt->option == GMT_OPT_INFILE || opt->option == GMT_OPT_OUTFILE) continue;  /* Skip file names */
-        if (opt->next && opt->next->option != GMT_OPT_INFILE) continue;  /* Skip arg not followed by file names (we expect -png map, for instance) */
+        if (opt->next == NULL || opt->next->option != GMT_OPT_INFILE) continue;  /* Skip arg not followed by file names (we expect -png map, for instance) */
 		if (strchr (gmt_session_codestr, opt->option) == NULL) continue;	/* Option not the first letter of a valid graphics format */
 		if ((len = strlen (opt->arg)) == 0 || len >= GMT_GRAPHIC_MAXLEN) continue;	/* No arg or too long args that are filenames can be skipped */
 		snprintf (format, GMT_LEN128, "%c%s", opt->option, opt->arg);	/* Get a local copy so we can mess with it */


### PR DESCRIPTION
The new improved checker and warner for bad graphics format got triggered by **-bo** since we did not check if a file argument followed, causing ex15 to fail.  This PR fixes the check and ex15 now passes.