### PR TITLE
Do not turn on polygon flag when -L args are given

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -2582,7 +2582,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 						current_fill = Ctrl->G.fill;
 				}
 				else if (z_for_cpt == NULL) {
-					if (change & 1) polygon = true;
+					if (change & 1 && Ctrl->L.anchor == 0) polygon = true;
 					if (change & 2 && !Ctrl->L.polygon) {
 						polygon = false;
 						PSL_setcolor (PSL, current_fill.rgb, PSL_IS_STROKE);

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -2133,7 +2133,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 						current_fill = Ctrl->G.fill;
 				}
 				else if (z_for_cpt == NULL) {
-					if (change & 1) polygon = true;
+					if (change & 1 && Ctrl->L.anchor == 0) polygon = true;
 					if (change & 2 && !Ctrl->L.polygon) {
 						polygon = false;
 						PSL_setcolor (PSL, current_fill.rgb, PSL_IS_STROKE);


### PR DESCRIPTION
See #7116 for background.  The trouble was this line:

`if (change & 1) polygon = true;`

which detected a fill change in the segment header and turns the polygon flag to true even though in this case (**-L+D**) the polygon has not yet been built from the line, hence the automatic closing of the open polygon is premature.  As it was, we wrongly closed the "polygon" (which was just a line) and wreaked havoc further down.  The bug affected both psxy.c and psxyz.c.

Once approved and merged I will add a test based on this case.  Closes #7116.