### PR TITLE
Ensure grdrotator uses -F to select grid region

### DIFF
--- a/doc/rst/source/supplements/spotter/grdrotater.rst
+++ b/doc/rst/source/supplements/spotter/grdrotater.rst
@@ -91,6 +91,7 @@ Optional Arguments
 **-F**\ *polygonfile*
     Specify a multisegment closed polygon file that describes the inside
     area of the grid that should be projected [Default projects entire grid].
+    **Note**: If both |-F| and |-R| are given then |-R| takes precedence.
 
 .. _-N:
 


### PR DESCRIPTION
As shown in this forum [post](https://forum.generic-mapping-tools.org/t/grdrotater/3486), **grdrotater** did not use the polygon's bounding box as grid region which is needed when input grid is just a global raster.  The polygon file was read after we had already decided there was no region given hence defaulted to global.

I also updated the documentation to be clear that if both **-F** and **-R** are given the **-R** takes precedence for setting the grid subset.

PS. This case also highlighted another issue in grdrotator which will be dealt with in a separate issue.