### PR TITLE
Check if rotated nodes are outside rotated polygon

### DIFF
--- a/src/spotter/grdrotater.c
+++ b/src/spotter/grdrotater.c
@@ -678,6 +678,7 @@ EXTERN_MSC int GMT_grdrotater (void *V_API, int mode, void *args) {
 						gmt_matrix_vect_mult (GMT, 3U, R, P_rotated, P_original);	/* Rotate the vector */
 						gmt_cart_to_geo (GMT, &xx, &yy, P_original, true);	/* Recover degree lon lat representation */
 						yy = gmt_lat_swap (GMT, yy, GMT_LATSWAP_O2G);		/* Convert back to geodetic */
+						if (not_global && grdrotater_skip_if_outside (GMT, polr, xx, yy)) continue;	/* Outside rotated polygon */
 						scol = (int)gmt_M_grd_x_to_col (GMT, xx, G->header);
 						if (scol < 0) continue;
 						col_o = scol;	if (col_o >= (openmp_int)G->header->n_columns) continue;


### PR DESCRIPTION
In relation to the forum [post](https://forum.generic-mapping-tools.org/t/grdrotater/3486) whose main point is being addressed by #7118.

In **grdrotater** we have a check where we rotate the original input nodes and then check if they are inside a given polygon (blue pen) set via **-F**.  However, we failed to also check that the rotated point is inside the rotated polygon (red pen) or not, resulting in some stray pixels being set.  This PR adds the missing check.

Example of result prior to this PR:

![map](https://user-images.githubusercontent.com/26473567/204132451-3541d234-e203-457c-9500-81a6d3a285ba.png)

Result after adding the new check:

![new](https://user-images.githubusercontent.com/26473567/204132468-5f66becc-64f2-4344-a83c-37c9a470c24b.png)

Note: The fix causes _spotter_08.sh_ to fail due to some issues along the border.  Once this PR is merged I will update the spotter_08.ps file in DVC.
