### PR TITLE
Attempt to fix coast holes in Canada for some -A settings

### DIFF
--- a/src/gmt_shore.c
+++ b/src/gmt_shore.c
@@ -856,7 +856,11 @@ int gmt_get_shore_bin (struct GMT_CTRL *GMT, unsigned int b, struct GMT_SHORE *c
 			ID = c->GSHHS_node[node];	/* GSHHS Id of the polygon that determined the level of the current node */
 			while (ID >= 0 && c->node_level[k] && c->GSHHS_area[ID] < c->min_area) {	/* Polygon must be skipped and node level reset */
 				ID = c->GSHHS_parent[ID];	/* Pick the parent polygon since that is the next polygon up */
-				if (c->node_level[k] != c->node_level_g[k])
+				if (c->lat_sw < -60.0) {	/* Special check for Antarctica due to the two versions of the continent */
+					if (c->node_level[k] != c->node_level_g[k])
+						c->node_level[k]--;		/* ...and drop down one level to that of the parent polygon */
+				}
+				else	/* Not in Antarctica and we need to drop the level as we lost that polygon that covered this node */
 					c->node_level[k]--;		/* ...and drop down one level to that of the parent polygon */
 			}	/* Keep doing this until the polygon containing the node is "too big to fail" or we are in the ocean */
 		}


### PR DESCRIPTION
See #7109 for background.  We did have checks for this but it seemed only tailored to the Antarctica case and the code refers to #1295 which we tried to fix.  This PR restricts that Antarctica check to Antarctica only (< 60S) and applies the general fix elsewhere, which is to reduce the node level of the corner if a polygon covering it is skipped.  This seems to fix the problem and older tests still work.
