### PR TITLE
Fixed typo PSL-BR instead of PSL-BL in Justification Section.

### DIFF
--- a/doc/rst/source/devdocs/postscriptlight.rst
+++ b/doc/rst/source/devdocs/postscriptlight.rst
@@ -114,7 +114,7 @@ this diagram:
 The box represents the text or image. E.g., to plot a text string with
 its center at (*x*, *y*), you must use *justify* == 6. *justify* == 0
 means "no justification", which generally means (*x*, *y*) is at the
-bottom left. Convenience values PSL_NONE, PSL_BL, PSL_BC, PSL_BL,
+bottom left. Convenience values PSL_NONE, PSL_BL, PSL_BC, PSL_BR,
 PSL_ML, PSL_MC, PSL_MR, PSL_TL, PSL_TC and PSL_TR are available.
 
 Initialization


### PR DESCRIPTION
**Description of proposed changes**

Fixes a small typo in the PostScriptLight documentation section *Justification*. `PSL_BL` was written twice instead of `PSL_BL` and `PSL_BR`.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #7122 