### PR TITLE
Let -U take +ttext to override time stamp

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -310,7 +310,6 @@ are known. The **auto** flag is supported for the following parameters:
 :term:`FONT_ANNOT_SECONDARY`       Secondary annotation font [13.20p]
 :term:`FONT_HEADING`               Subplot heading font [30.80p]
 :term:`FONT_LABEL`                 Axis label font [15.40p]
-:term:`FONT_LOGO`                  Logo font [8.80p]
 :term:`FONT_SUBTITLE`              Plot subtitle font [19.80p]
 :term:`FONT_TAG`                   Tag/labeling font [17.60p]
 :term:`FONT_TITLE`                 Plot title font [24.20p]

--- a/doc/rst/source/explain_-U.rst_
+++ b/doc/rst/source/explain_-U.rst_
@@ -5,7 +5,7 @@ The **-U** option
 
 .. _-U:
 
-**-U**\ [*label*\|\ **+c**][**+j**\ *just*][**+o**\ *dx*\ [/*dy*]]
+**-U**\ [*label*\|\ **+c**][**+j**\ *just*][**+o**\ *dx*\ [/*dy*]][**+t**\ *text*]
     Draw GMT time stamp logo on plot. |Add_-U|
 
 **Description**
@@ -19,6 +19,8 @@ The **-U** option draws the GMT system time stamp on the plot. The following mod
   **R**\ (ight)) and a vertical (**T**\ (op), **M**\ (iddle), or **B**\ (ottom)) code [default is **BL**].
 - **+o**\ *dx*\ [/*dy*] to offset the :ref:`anchor point <Anchor_Point_o>` for the time stamp by *dx* and optionally
   *dy* (if different than *dx*).
+- **+t** can be used to replace the UNIX time stamp with a custom *text* instead. Place multi-word *text* in quotes
+  and let **+t** be the last modifier used.
 
 The GMT parameters :term:`MAP_LOGO`, :term:`MAP_LOGO_POS`, :term:`FONT_LOGO` and :term:`FORMAT_TIME_STAMP` can affect
 the appearance; see the :doc:`/gmt.conf` man page for details. The time string will be in the locale set by the

--- a/doc/rst/source/explain_-U.rst_
+++ b/doc/rst/source/explain_-U.rst_
@@ -19,8 +19,8 @@ The **-U** option draws the GMT system time stamp on the plot. The following mod
   **R**\ (ight)) and a vertical (**T**\ (op), **M**\ (iddle), or **B**\ (ottom)) code [default is **BL**].
 - **+o**\ *dx*\ [/*dy*] to offset the :ref:`anchor point <Anchor_Point_o>` for the time stamp by *dx* and optionally
   *dy* (if different than *dx*).
-- **+t** can be used to replace the UNIX time stamp with a custom *text* instead. Place multi-word *text* in quotes
-  and let **+t** be the last modifier used.
+- **+t** can be used to replace the UNIX time stamp with a custom *text* instead (< 64 characters). Place multi-word
+  *text* in quotes and let **+t** be the last modifier used.
 
 The GMT parameters :term:`MAP_LOGO`, :term:`MAP_LOGO_POS`, :term:`FONT_LOGO` and :term:`FORMAT_TIME_STAMP` can affect
 the appearance; see the :doc:`/gmt.conf` man page for details. The time string will be in the locale set by the

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -168,8 +168,9 @@ FONT Parameters
 
     **FONT_LOGO**
         Font to use for text plotted as part of the GMT time logo [:doc:`theme
-        dependent <theme-settings>`]. Choose **auto** for :ref:`automatic scaling
-        with plot size <auto-scaling>`.
+        dependent <theme-settings>`]. **Note**: Since the time logo has a fixed height
+        the font size for the time stamp is 8p and for the optional label it is 7p.
+        Hence, changing this font only affects the font style and color but not its size.
 
     **FONT_SUBTITLE**
         Font to use when plotting titles over graphs that involve a subtitle

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -169,7 +169,7 @@ FONT Parameters
     **FONT_LOGO**
         Font to use for text plotted as part of the GMT time logo. **Note**: Since the
         time logo has a fixed height the font size for the time stamp is 8p and for the
-        optional label it is 7p. Hence, changing this font only affects the font style \
+        optional label it is 7p. Hence, changing this font only affects the font style
         and color but not its size.
 
     **FONT_SUBTITLE**

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -167,10 +167,10 @@ FONT Parameters
         size <auto-scaling>`.
 
     **FONT_LOGO**
-        Font to use for text plotted as part of the GMT time logo [:doc:`theme
-        dependent <theme-settings>`]. **Note**: Since the time logo has a fixed height
-        the font size for the time stamp is 8p and for the optional label it is 7p.
-        Hence, changing this font only affects the font style and color but not its size.
+        Font to use for text plotted as part of the GMT time logo. **Note**: Since the
+        time logo has a fixed height the font size for the time stamp is 8p and for the
+        optional label it is 7p. Hence, changing this font only affects the font style \
+        and color but not its size.
 
     **FONT_SUBTITLE**
         Font to use when plotting titles over graphs that involve a subtitle

--- a/doc/rst/source/std-opts-classic.rst
+++ b/doc/rst/source/std-opts-classic.rst
@@ -22,7 +22,7 @@ Common Options (Classic Mode)
      - :ref:`Select Portrait orientation <-P_full>`
    * - **-R**\ *west/east/south/north*\ [*/zmin/zmax*][**+r**][**+u**\ *unit*]
      - :ref:`Specify region of interest <-R_full>`
-   * - **-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*]
+   * - **-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*][**+t**\ *text*]
      - :ref:`Plot time-stamp on plot <-U_full>`
    * - **-V**\ [*verbosity*]
      - :ref:`Run in verbose mode <-V_full>`

--- a/doc/rst/source/std-opts.rst
+++ b/doc/rst/source/std-opts.rst
@@ -14,7 +14,7 @@ Common Options
      - :ref:`Select map projection <-J_full>`
    * - **-R**\ *west/east/south/north*\ [*/zmin/zmax*][**+r**][**+u**\ *unit*]
      - :ref:`Specify region of interest <-R_full>`
-   * - **-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*]
+   * - **-U**\ [*label*][**+c**][**+j**\ *just*][**+o**\ *dx*/*dy*][**+t**\ *text*]
      - :ref:`Plot time-stamp on plot <-U_full>`
    * - **-V**\ [*verbosity*]
      - :ref:`Run in verbose mode <-V_full>`

--- a/doc/rst/source/theme-settings.rst
+++ b/doc/rst/source/theme-settings.rst
@@ -21,8 +21,6 @@ Default settings for built-in themes
 +-----------------------------------+---------------------------------+---------------------------------+---------------------------------+
 | :term:`FONT_LABEL`                | 16p,Helvetica,black             | auto,Helvetica,black            | auto,AvantGarde-Book,black      |
 +-----------------------------------+---------------------------------+---------------------------------+---------------------------------+
-| :term:`FONT_LOGO`                 | 8p,Helvetica,black              | auto,Helvetica,black            | auto,Helvetica,black            |
-+-----------------------------------+---------------------------------+---------------------------------+---------------------------------+
 | :term:`FONT_SUBTITLE`             | 18p,Helvetica,black             | auto,Helvetica-Bold,black       | auto,AvantGarde-Book,black      |
 +-----------------------------------+---------------------------------+---------------------------------+---------------------------------+
 | :term:`FONT_TAG`                  | 20p,Helvetica,black             | auto,Helvetica,black            | auto,AvantGarde-Book,black      |

--- a/share/themes/modern.conf
+++ b/share/themes/modern.conf
@@ -7,7 +7,6 @@ FONT_ANNOT_PRIMARY             = auto,Helvetica,black
 FONT_ANNOT_SECONDARY           = auto,Helvetica,black
 FONT_HEADING                   = auto,Helvetica-Bold,black
 FONT_LABEL                     = auto,Helvetica,black
-FONT_LOGO                      = auto,Helvetica,black
 FONT_SUBTITLE                  = auto,Helvetica-Bold,black
 FONT_TAG                       = auto,Helvetica,black
 FONT_TITLE                     = auto,Helvetica-Bold,black

--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -121,6 +121,7 @@ struct GMT_COMMON {
 		bool active;
 		unsigned int just;
 		double x, y;
+		char string[GMT_LEN64];	/* User override for timestamp */
 		char *label;		/* Content not counted by sizeof (struct) */
 	} U;
 	struct V {	/* -V */

--- a/src/gmt_common_longoptions.h
+++ b/src/gmt_common_longoptions.h
@@ -60,7 +60,7 @@
                 "r,u",                   "rectangular,unit" },
     {   0, 'U', "timestamp",
                 "",                      "",
-                "c,j,o",                 "command,justify,offset" },
+                "c,j,o,t",               "command,justify,offset,text" },
     {   0, 'V', "verbosity",
                 "q,e,w,t,i,c,d",         "quiet,error,warning,timing,info,compat,debug",
                 "",                      "" },

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10331,11 +10331,6 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 		auto_scale = true;
 		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_SUBTITLE] = true;
 	}
-	if (gmt_M_is_dnan (GMT->current.setting.font_logo.size)) {
-		GMT->current.setting.font_logo.size = scale * 8.0;		/* Classic 8p vs 10p */
-		auto_scale = true;
-		if (conf_update) GMT_keyword_updated[GMTCASE_FONT_LOGO] = true;
-	}
 
 	/* Offsets */
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2145,29 +2145,31 @@ int gmt_parse_model (struct GMT_CTRL *GMT, char option, char *in_arg, unsigned i
 #define is_plus(item,k)  (item[k-1] == '+')	/* Previous char is a plus, so maybe start of modifier */
 #define is_label(item,k) (item[k] == 'c' && (item[k+1] == '+' || item[k+1] == '\0'))	/* Modifier c followed by another modifier or end of string */
 #define is_just(item,k)  (item[k] == 'j' && (strchr ("LCRBMT", item[k+1]) && strchr ("LCRBMT", item[k+2])))	/* Is +j<just> */
-#define is_off(item,k)   (item[k] == 'o' && strchr ("-+.0123456789", item[k+1]))	/* Looks like +onumber> */
+#define is_off(item,k)   (item[k] == 'o' && strchr ("-+.0123456789", item[k+1]))	/* Looks like +o<number> */
+#define is_text(item,k)  (item[k] == 't' && item[k+1])	/* Modifier t followed by random text */
 
-/*! Parse the -U option.  Full syntax: -U[<label>][+c][+j<just>][+o]<dx>[/<dy>]]  Old syntax was -U[[<just>]/<dx>/<dy>/][c|<label>] */
+/*! Parse the -U option.  Full syntax: -U[<label>][+c][+j<just>][+o<dx>[/<dy>]][+t<string>]  Old syntax was -U[[<just>]/<dx>/<dy>/][c|<label>] */
 GMT_LOCAL int gmtinit_parse_U_option (struct GMT_CTRL *GMT, char *item) {
 	int just = 1, error = 0;
 
 	GMT->current.setting.map_logo = true;
+	gmt_M_memset (GMT->common.U.string, GMT_LEN64, char);	/* Initialize to nothing */
 	if (!item || !item[0]) return (GMT_NOERROR);	/* Just basic -U with no args */
 
-	if (gmt_found_modifier (GMT, item, "cjo")) {	/* New syntax */
+	if (gmt_found_modifier (GMT, item, "cjot")) {	/* New syntax */
 		unsigned int pos = 0, uerr = 0;
 		int k = 1, len = (int)strlen (item);
 		char word[GMT_LEN256] = {""}, *c = NULL;
-		/* Find the first +c|j|o that looks like it may be a modifier and not random text */
-		while (k < len && !(is_plus(item,k) && (is_label(item,k) || is_just(item,k) || is_off(item,k)))) k++;
-		if (k == len)	/* MOdifiers were just random text */
+		/* Find the first +c|j|o|t that looks like it may be a modifier and not random text */
+		while (k < len && !(is_plus(item,k) && (is_label(item,k) || is_just(item,k) || is_off(item,k) || is_text(item,k)))) k++;
+		if (k == len)	/* Modifiers were just random text */
 			strncpy (GMT->current.ps.map_logo_label, item, GMT_LEN256-1);	/* Got a label */
 		else {	/* Appears to have gotten a valid modifier or more */
 			c = &item[k-1];	/* Start of the modifier */
 			c[0] = '\0';	/* Chop off the + so we can parse the label, if any */
 			if (item[0]) strncpy (GMT->current.ps.map_logo_label, item, GMT_LEN256-1);	/* Got a label */
 			c[0] = '+';	/* Restore modifiers */
-			while (gmt_getmodopt (GMT, 'U', c, "cjo", &pos, word, &uerr) && uerr == 0) {
+			while (gmt_getmodopt (GMT, 'U', c, "cjot", &pos, word, &uerr) && uerr == 0) {
 				switch (word[0]) {
 					case 'c':	/* Maybe +c but only if at end of followed by another modifier */
 						if (word[1] == '+' || word[1] == '\0')	/* Use command string */
@@ -2181,6 +2183,9 @@ GMT_LOCAL int gmtinit_parse_U_option (struct GMT_CTRL *GMT, char *item) {
 						if (strchr ("-+.0123456789", word[1])) {	/* Seems to be a number */
 							if ((k = gmt_get_pair (GMT, &word[1], GMT_PAIR_DIM_DUP, GMT->current.setting.map_logo_pos)) < 1) error++;
 						}
+						break;
+					case 't':	/* Short text to replace dateclock string */
+						strncpy (GMT->common.U.string, &word[1], GMT_LEN64);
 						break;
 					default: break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
 				}
@@ -7697,6 +7702,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 			GMT_Usage (API, 3, "+c Use the command line as the label [%s].", GMT_choice[GMT->current.setting.map_logo]);
 			GMT_Usage (API, 3, "+j Set frame justification point [BL].");
 			GMT_Usage (API, 3, "+o Offset stamp by <dx>[/<dy>] [-54p/-54p].");
+			GMT_Usage (API, 3, "+t Override the UNIX time stamp using appended text.");
 			break;
 
 		case 'V':	/* Verbose */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -6759,7 +6759,7 @@ GMT_LOCAL void gmtinit_conf_classic (struct GMT_CTRL *GMT) {
 	if (!strncmp (GMT_DEF_UNITS, "US", 2U))
 		gmtinit_conf_classic_US (GMT);	/* Override with US settings */
 
-	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Means we switch to classic in a modern mode setssion */
+	if (GMT->current.setting.run_mode == GMT_MODERN) {	/* Means we switch to classic in a modern mode session */
 		GMT_keyword_updated[GMTCASE_FONT_ANNOT_PRIMARY] = true;
 		GMT_keyword_updated[GMTCASE_FONT_ANNOT_SECONDARY] = true;
 		GMT_keyword_updated[GMTCASE_FONT_LABEL] = true;
@@ -6825,7 +6825,7 @@ GMT_LOCAL void gmtinit_conf_modern_override (struct GMT_CTRL *GMT) {
 	error += gmt_getfont (GMT, "auto,Helvetica,black", &GMT->current.setting.font_tag);
 	GMT->current.setting.given_unit[GMTCASE_FONT_TAG] = 'p';
 	/* FONT_LOGO */
-	error += gmt_getfont (GMT, "auto,Helvetica,black", &GMT->current.setting.font_logo);
+	error += gmt_getfont (GMT, "8p,Helvetica,black", &GMT->current.setting.font_logo);
 	GMT->current.setting.given_unit[GMTCASE_FONT_LOGO] = 'p';
 
 	/* FORMAT_GEO_MAP */

--- a/src/gmt_synopsis.h
+++ b/src/gmt_synopsis.h
@@ -113,7 +113,7 @@
 #define GMT_J_OPT	"-J<args>"
 #define GMT_R2_OPT	"-R<xmin>/<xmax>/<ymin>/<ymax>[+u<unit>][+r]"
 #define GMT_R3_OPT	"-R<xmin>/<xmax>/<ymin>/<ymax>[/<zmin>/<zmax>][+u<unit>][+r]"
-#define GMT_U_OPT	"-U[<label>][+c][+j<just>][+o<dx>[/<dy>]]"
+#define GMT_U_OPT	"-U[<label>][+c][+j<just>][+o<dx>[/<dy>]][+t<text>]"
 #define GMT_V_OPT	"-V[q|e|w|t|i|c|d]"
 #define GMT_X_OPT	"-X[a|c|f|r]<xshift>"
 #define GMT_Y_OPT	"-Y[a|c|f|r]<yshift>"


### PR DESCRIPTION
See #7125 for background.  This PR implements the **+t**_text_ modifier where _text_ overrides the UNIX time stamp in the box.  Also improves documentation related to **FONT_LOGO** and sizes. Closes #7125.

`gmt basemap -R0/10/0/5 -JX5c/3c -Baf -U'Fig. 4'+t"Wessel et al. [2022]" --FONT_LOGO=240p,Helvetica-Bold,red -png map`

![map](https://user-images.githubusercontent.com/26473567/205040712-f1a5cd64-348c-4c99-b44b-1e7015d0200c.png)
