### PR TITLE
Fix the PDIST fiasco where squared distances were used

### DIFF
--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -3298,8 +3298,10 @@ GMT_LOCAL struct GMT_DATASET *grdmath_ASCII_read (struct GMT_CTRL *GMT, struct G
 	int error;
 	if (gmt_M_is_geographic (GMT, GMT_IN))
 		error = gmt_init_distaz (GMT, 'k', gmt_M_sph_mode (GMT), GMT_MAP_DIST);
-	else
-		error = gmt_init_distaz (GMT, 'R', 0, GMT_MAP_DIST);	/* Cartesian squared distances */
+	else {
+		char code = strcmp (op, "PDIST") ? 'R' : 'X';
+		error = gmt_init_distaz (GMT, code, 0, GMT_MAP_DIST);	/* Cartesian distances of some flavor */
+	}
 	if (error == GMT_NOT_A_VALID_TYPE) return NULL;
 	if (GMT_Set_Columns (GMT->parent, GMT_IN, 2, GMT_COL_FIX_NO_TEXT) != GMT_NOERROR) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failure in operator %s setting number of input columns\n", op);

--- a/test/grdmath/pdist.sh
+++ b/test/grdmath/pdist.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Purpose:  Compute Cartesian and Geographic distances from center point
+# Prevent a repeat of https://forum.generic-mapping-tools.org/t/potential-bug-in-gmt6-3-dev-grdmath-pdist/3512/2
+
+ps=pdist.ps
+echo 0 0 > p.txt
+# Cartesian 5 and 1 contours
+gmt grdmath -R-10/10/-10/10 -I0.1 p.txt PDIST = c.nc
+gmt grdcontour c.nc -JX4i -P -A5 -C1 -Bafg -K -Xc -GlCM/TR > $ps
+gmt psxy -R -J p.txt -Sc4p -Gred -O -K >> $ps
+# Geographic 500 and 100 km contours
+gmt grdmath -R-10/10/-10/10 -I0.1 -fg p.txt LDIST = g.nc
+gmt grdcontour g.nc -J -O -A500 -C100 -Bafg -K -Y4.75i -GlCM/TR >> $ps
+gmt psxy -R -J p.txt -Sc4p -Gred -O >> $ps


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/potential-bug-in-gmt6-3-dev-grdmath-pdist/3512/2) for background.  Possibly either a copy/paste from **gmtselect** or failed to complete a PR.  In either case we ended up computing squared Cartesian distances in **PDIST**.  I see I had added operator name to the _grdmath_ASCII_read_ function argument list where these distance choices are set and I suppose I forgot to add code that would select X for **PDIST** and R for others.  With this fix the **PDIST** and **LDIST** both work.  I added a new _ptest.sh_ test - PS coming later.
