### PR TITLE
Correct column naming and width unit in ternary example

### DIFF
--- a/doc/rst/source/psternary.rst
+++ b/doc/rst/source/psternary.rst
@@ -53,13 +53,13 @@ Examples
 
 .. include:: explain_example.rst_
 
-To plot circles (diameter = 0.1 cm) on a 6-inch-wide ternary diagram at the positions listed
+To plot circles (diameter = 0.1 cm) on a 15-centimeter-wide ternary diagram at the positions listed
 in the file ternary.txt, with default annotations and gridline spacings, using the
 specified labeling, try::
 
     gmt makecpt -Cturbo -T0/80/10 > t.cpt
-    gmt psternary @ternary.txt -R0/100/0/100/0/100 -JX6i -P -Sc0.1c -Ct.cpt -LWater/Air/Limestone \
-        -Baafg+l"Water component"+u" %" -Bbafg+l"Air component"+u" %" -Bcagf+l"Limestone component"+u" %" \
+    gmt psternary @ternary.txt -R0/100/0/100/0/100 -JX15c -P -Sc0.1c -Ct.cpt -LLimestone/Water/Air \
+        -Baafg+l"Limestone component"+u" %" -Bbafg+l"Water component"+u" %" -Bcagf+l"Air component"+u" %" \
         -B+givory+t"Example data from MATLAB Central" > map.ps
 
 See Also

--- a/doc/rst/source/ternary.rst
+++ b/doc/rst/source/ternary.rst
@@ -188,13 +188,13 @@ Optional Arguments
 Examples
 --------
 
-To plot circles (diameter = 0.1 cm) on a 6-inch-wide ternary diagram at the positions listed
+To plot circles (diameter = 0.1 cm) on a 15-centimeter-wide ternary diagram at the positions listed
 in the file ternary.txt, with default annotations and gridline spacings, using the
 specified labeling, try::
 
     gmt begin map
     gmt makecpt -Cturbo -T0/80/10
-    gmt ternary @ternary.txt -R0/100/0/100/0/100 -JX6i -Sc0.1c -C -LLimestone/Water/Air \
+    gmt ternary @ternary.txt -R0/100/0/100/0/100 -JX15c -Sc0.1c -C -LLimestone/Water/Air \
         -Baafg+l"Limestone component"+u" %" -Bbafg+l"Water component"+u" %" -Bcagf+l"Air component"+u" %" \
         -B+givory+t"Example data from MATLAB Central"
     gmt end show

--- a/doc/rst/source/ternary.rst
+++ b/doc/rst/source/ternary.rst
@@ -194,8 +194,8 @@ specified labeling, try::
 
     gmt begin map
     gmt makecpt -Cturbo -T0/80/10
-    gmt ternary @ternary.txt -R0/100/0/100/0/100 -JX6i -Sc0.1c -C -LWater/Air/Limestone \
-        -Baafg+l"Water component"+u" %" -Bbafg+l"Air component"+u" %" -Bcagf+l"Limestone component"+u" %" \
+    gmt ternary @ternary.txt -R0/100/0/100/0/100 -JX6i -Sc0.1c -C -LLimestone/Water/Air \
+        -Baafg+l"Limestone component"+u" %" -Bbafg+l"Water component"+u" %" -Bcagf+l"Air component"+u" %" \
         -B+givory+t"Example data from MATLAB Central"
     gmt end show
 


### PR DESCRIPTION
**Description of proposed changes**

Based on [#2227](https://github.com/GenericMappingTools/pygmt/pull/2227) this PR corrects the column naming in the ternary example. 

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
