### PR TITLE
Finalize greenspline 1-D for mixed data/slope case

### DIFF
--- a/test/baseline/greenspline.dvc
+++ b/test/baseline/greenspline.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: dc4c0a60f451431561511fcfef08f3ca.dir
-  size: 1483260
-  nfiles: 6
+- md5: cbc1f5c0f8566a671e5c76ae5cddda31.dir
+  size: 1520815
+  nfiles: 7
   path: greenspline

--- a/test/greenspline/gspline_7.sh
+++ b/test/greenspline/gspline_7.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Testing 1-D greenspline with mix of data and gradients
+
+# Create 7 data points
+cat <<- EOF > oneD_data.txt
+-2.5	4
+-2	2
+-1	-0.5
+0	0
+1	1
+1.5	0
+2	-2
+EOF
+# Create 2 gradient constraints
+cat <<-EOF > oneD_grad.txt
+0.5	1
+2.5	-0.5
+EOF
+# Fit the data and gradients
+gmt greenspline oneD_data.txt -AoneD_grad.txt+f0 -Z0 -R-3/3 -I0.01 -Sc -GoneD_out.txt
+# Just fit the data
+gmt greenspline oneD_data.txt  -Z0 -R-3/3 -I0.01 -Sc -GoneD_noA.txt
+# Create data and text for slope lines and annotations
+gmt math -T-2/2/0.5 T = | awk '{printf ">\n-1\t%s\n1\t%s\n", $1, -$1}' > lines.txt
+cat <<- EOF >> lines.txt
+> vertical line
+0	-2
+0	+2
+EOF
+gmt math -T-2/2/0.5 T = | awk '{printf "1 %s %.1lf\n", $1, $1}' > labels.txt
+
+gmt begin gspline_7 ps
+	gmt plot oneD_data.txt -R-4/4/-5/5 -Jx1i -Sc10p -Gblack -Baf -l"Values"+jBL
+	gmt plot oneD_noA.txt -W3p,gray -l"No slopes used"
+	gmt plot oneD_out.txt -W3p,red -l"With slope constraints"
+	gmt plot oneD_out.txt -W0.25p
+	LEG="-lSlopes"
+	# Loop over gradients and place grid and labels
+	while read X S; do
+		pattern="^${X}\t"	# Search pattern for finding y-value at gradient
+		Y=$(grep ${pattern} oneD_out.txt | awk '{print $2}')
+		# Lay down grid/labels after shifting origin to tangent point
+		gmt plot -W0.25p,blue -X${X}i -Y${Y}i lines.txt
+		gmt text -F+f12p+jML -Dj8p labels.txt
+		echo 0 0 1 ${S} | gmt plot -Sv12p+e+s -W1p -Gblack
+		the_X=$(gmt math -Q ${X} NEG =)
+		the_Y=$(gmt math -Q ${Y} NEG =)
+		echo 0 2 s = ${S} | gmt text -F+f12p+jCB -DJ3p
+		# Undo shift and place gradient circle
+		echo $X $Y | gmt plot -Sc10p -W0.5p ${LEG} -X${the_X}i -Y${the_Y}i
+		LEG=
+	done < oneD_grad.txt
+gmt end


### PR DESCRIPTION
**Description of proposed changes**

Lots of work on **greenspline** over the last few weeks.  There were several issues that have been fixed in the process.  The most recent (in this PR) is how the` Ax = b` system was built.  When **-A** was used (constraints on slopes) it was not done correctly.  I have broken the hard-to-decode single loop into two sections: One for the data constraints (the most common case) and then under an if-test the extra rows for slope constraints.  This makes it easier to understand what is going on.  With that and previous fixes to the 1-D slope green's function for minimum curvature the 1-D spline for minimum curvature constrained by a mix of data and slopes seems to work well.  I have added a new test `gspline_7.sh` to illustrate this and it fits 7 data point and 2 slopes correctly:

![oneDmix](https://user-images.githubusercontent.com/26473567/206850434-c3ee23b8-ae8a-4001-a4ca-5e3591380d4d.png)

You can see the two tangent vectors (black arrows) are tangent to the spline at the two locations were we specified a gradient condition, whereas the curve goes through the solid data constraints as well.  I will test if adding tension for this case also works - if not I will fix separately.

A previous PR also dealt with the fact that a linear line is not representable by the Green functions for this spline so we (as before) always fit and remote/restore the LS line fit.  New is that we then adjust the gradient constraints by the determined slope, just as we adjust the data constraints by the line values.  This now all works well.