### PR TITLE
Further minor improvements in greenspline 1D

### DIFF
--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -1486,8 +1486,8 @@ GMT_LOCAL double greenspline_get_radius (struct GMT_CTRL *GMT, double *X0, doubl
 	double r = 0.0;
 	/* Get distance between the two points */
 	switch (dim) {
-		case 1:	/* 1-D, just get x difference */
-			r = (X0[GMT_X] - X1[GMT_X]);
+		case 1:	/* 1-D, just get signed x difference */
+			r = X0[GMT_X] - X1[GMT_X];
 			break;
 		case 2:	/* 2-D Cartesian or spherical surface in meters */
 			r = gmt_distance (GMT, X0[GMT_X], X0[GMT_Y], X1[GMT_X], X1[GMT_Y]);

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -871,7 +871,7 @@ GMT_LOCAL double greenspline_spline1d_sandwell (struct GMT_CTRL *GMT, double r, 
 
 GMT_LOCAL double greenspline_grad_spline1d_sandwell (struct GMT_CTRL *GMT, double r, double par[], struct GREENSPLINE_LOOKUP *unused) {
 	gmt_M_unused(GMT); gmt_M_unused(par); gmt_M_unused(unused);
-	return (3.0 * fabs (r) * r);	/* Just regular spline; par not used */
+	return (-3.0 * fabs (r) * r);	/* Just regular spline; par not used */
 }
 
 GMT_LOCAL double greenspline_spline1d_Wessel_Bercovici (struct GMT_CTRL *GMT, double r, double par[], struct GREENSPLINE_LOOKUP *unused) {
@@ -896,7 +896,7 @@ GMT_LOCAL double greenspline_grad_spline1d_Wessel_Bercovici (struct GMT_CTRL *GM
 	if (r == 0.0) return (0.0);
 
 	cx = par[0] * r;
-	return (1.0 - exp (-cx));
+	return ((1.0 - exp (-cx)) * par[2]);	/* Dividing by p, basically */
 }
 
 /*----------------------  TWO DIMENSIONS ---------------------- */
@@ -2095,6 +2095,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 			if (Ctrl->S.value[1] == 0.0) Ctrl->S.value[1] = 1.0;
 			par[0] = sqrt (Ctrl->S.value[0] / (1.0 - Ctrl->S.value[0])) / Ctrl->S.value[1];
 			par[1] = 2.0 / par[0];
+			par[2] = 1.0 / par[0];	/* Used in grad function */
 			G = &greenspline_spline1d_Wessel_Bercovici;
 			dGdr = &greenspline_grad_spline1d_Wessel_Bercovici;
 			break;

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -849,7 +849,7 @@ GMT_LOCAL void greenspline_dump_green (struct GMT_CTRL *GMT, double (*G) (struct
 GMT_LOCAL double greenspline_spline1d_linear (struct GMT_CTRL *GMT, double r, double par[], struct GREENSPLINE_LOOKUP *unused) {
 	/* Dumb linear spline */
 	gmt_M_unused(GMT); gmt_M_unused(par); gmt_M_unused(unused);
-	return (r);	/* Just regular spline; par not used */
+	return (fabs (r));	/* Just regular spline; par not used */
 }
 
 GMT_LOCAL double greenspline_grad_spline1d_linear (struct GMT_CTRL *GMT, double r, double par[], struct GREENSPLINE_LOOKUP *unused) {
@@ -866,12 +866,12 @@ GMT_LOCAL double greenspline_spline1d_sandwell (struct GMT_CTRL *GMT, double r, 
 	gmt_M_unused(GMT); gmt_M_unused(par); gmt_M_unused(unused);
 	if (r == 0.0) return (0.0);
 
-	return (pow (r, 3.0));	/* Just regular spline; par not used */
+	return (pow (fabs (r), 3.0));	/* Just regular spline; par not used */
 }
 
 GMT_LOCAL double greenspline_grad_spline1d_sandwell (struct GMT_CTRL *GMT, double r, double par[], struct GREENSPLINE_LOOKUP *unused) {
 	gmt_M_unused(GMT); gmt_M_unused(par); gmt_M_unused(unused);
-	return (r);	/* Just regular spline; par not used */
+	return (3.0 * fabs (r) * r);	/* Just regular spline; par not used */
 }
 
 GMT_LOCAL double greenspline_spline1d_Wessel_Bercovici (struct GMT_CTRL *GMT, double r, double par[], struct GREENSPLINE_LOOKUP *unused) {
@@ -885,7 +885,7 @@ GMT_LOCAL double greenspline_spline1d_Wessel_Bercovici (struct GMT_CTRL *GMT, do
 
 	if (r == 0.0) return (0.0);
 
-	cx = par[0] * r;
+	cx = par[0] * fabs (r);
 	return (exp (-cx) + cx - 1.0);
 }
 
@@ -1487,7 +1487,7 @@ GMT_LOCAL double greenspline_get_radius (struct GMT_CTRL *GMT, double *X0, doubl
 	/* Get distance between the two points */
 	switch (dim) {
 		case 1:	/* 1-D, just get x difference */
-			r = fabs (X0[GMT_X] - X1[GMT_X]);
+			r = (X0[GMT_X] - X1[GMT_X]);
 			break;
 		case 2:	/* 2-D Cartesian or spherical surface in meters */
 			r = gmt_distance (GMT, X0[GMT_X], X0[GMT_Y], X1[GMT_X], X1[GMT_Y]);
@@ -1510,8 +1510,8 @@ GMT_LOCAL double greenspline_get_dircosine (struct GMT_CTRL *GMT, double *D, dou
 	double az, C = 0.0, N[3];
 
 	switch (dim) {
-		case 1:	/* 1-D: As 3*r*x we place the 3x here */
-			C = 3.0 * (X1[GMT_X] - X0[GMT_X]);
+		case 1:	/* 1-D */
+			C = 1.0;
 			break;
 		case 2:	/* 2-D */
 			az = gmt_az_backaz (GMT, X0[GMT_X], X0[GMT_Y], X1[GMT_X], X1[GMT_Y], baz);

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -1510,7 +1510,7 @@ GMT_LOCAL double greenspline_get_dircosine (struct GMT_CTRL *GMT, double *D, dou
 	double az, C = 0.0, N[3];
 
 	switch (dim) {
-		case 1:	/* 1-D */
+		case 1:	/* 1-D (no directional cosine) */
 			C = 1.0;
 			break;
 		case 2:	/* 2-D */


### PR DESCRIPTION
Because the gradient of the Green's function in 1-D retains the sign of` r = dx` we need the 1-D radius function to return the signed radius and not the absolute value.  This PR makes that change so that the gradient term can be computed correctly.  The value term (Green's function) now takes `fabs (r) `to compensate.  This way no further complications need to be added and the kludge of adding` 3*x` into the directional cosine function for 1-D has been removed and restored to just returning 1.  No change to anything else, including tests.  I checked that this approach gives the right sign for the 1-D spline in tension gradient as well but a test using that spline with slope constraint will still need more work, separately.