### PR TITLE
grdvector.rst: minor improvements

### DIFF
--- a/doc/rst/source/grdvector.rst
+++ b/doc/rst/source/grdvector.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt grdvector** *compx.nc* *compy.nc* |-J|\ *parameters*
+**gmt grdvector** *grid1* *grid2* |-J|\ *parameters*
 [ |-A| ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
@@ -24,7 +24,7 @@ Synopsis
 [ |-T| ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
-[ |-W|\ *pen* ]
+[ |-W|\ *pen*\ [**+c**] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
 [ |-Z| ]
@@ -40,21 +40,25 @@ Description
 -----------
 
 **grdvector** reads two 2-D grid files which represents the *x*\ - and
-*y*\ -components of a vector field and produces a vector field plot by
+*y*\ -components, :math:`(x,y)`, of a vector field and produces a vector field plot by
 drawing vectors with orientation and length according to the information
-in the files. Alternatively, polar coordinate *r*, *theta* grids may be given
-instead.
+in the files. Alternatively, polar coordinate grids, :math:`(r,\theta)`, may be given
+instead (see |-A| and |-Z|).
 
 Required Arguments
 ------------------
 
-*compx.nc*
-    Contains the x-components of the vector field. (See :ref:`Grid File Formats
+*grid1*
+    Contains the *x*\ -components of the vector field. (See :ref:`Grid File Formats
     <grd_inout_full>`).
-    
-*compy.nc*
-    Contains the y-components of the vector field. (See :ref:`Grid File Formats
+
+*grid2*
+    Contains the *y*\ -components of the vector field. (See :ref:`Grid File Formats
     <grd_inout_full>`).
+
+Order is important.
+For :math:`(x,y)`, *grid1* is expected to be the *x*\ -component, and *grid2* to be the *y*\ -component.
+For :math:`(r,\theta)`, *grid1* is expected to be the magnitude (:math:`r`), and *grid2* to be the azimuth (see |-Z|) or direction, (:math:`\theta`).
 
 .. |Add_-J| replace:: |Add_-J_links|
 .. include:: explain_-J.rst_
@@ -67,8 +71,8 @@ Optional Arguments
 .. _-A:
 
 **-A**
-    The grid files contain polar (r, theta) components instead of
-    Cartesian (x, y) [Default is Cartesian components].
+    The grid files contain polar :math:`(r,\theta)` components instead of
+    Cartesian :math:`(x,y)` [Default is Cartesian components].
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_
@@ -160,9 +164,11 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ *pen*
+**-W**\ *pen*\ [**+c**\]
     Change the pen attributes used for vector outlines [Default: width =
     default, color = black, style = solid].
+    If the modifier **+c** is appended then the color of the vector head
+    and stem are taken from the CPT (see |-C|).
 
 .. |Add_-XY| replace:: |Add_-XY_links|
 .. include:: explain_-XY.rst_
@@ -172,7 +178,7 @@ Optional Arguments
 .. _-Z:
 
 **-Z**
-    The theta grid provided contains azimuths rather than directions (implies |-A|).
+    The :math:`\theta` grid provided contains azimuths rather than directions (implies |-A|).
 
 .. |Add_-f| unicode:: 0x20 .. just an invisible code
 .. include:: explain_-f.rst_
@@ -225,7 +231,7 @@ The scale given via |-S| may require some consideration. As explained in |-S|,
 it is specified in data-units per plot or distance unit. The plot or distance unit
 chosen will affect the type of vector you select. In all cases, we first compute
 the magnitude *r* of the user's data vectors at each selected node from the *x* and *y*
-components (unless you are passing *r*, *theta* grids directly with |-A|).  These
+components (unless you are passing :math:`(r,\theta)` grids directly with |-A| or |-Z|).  These
 magnitudes are given in whatever data units they come with.  Let us pretend our data
 grids record secular changes in the Earth's magnetic horizontal vector field in units
 of nTesla/year, and that at a particular node the magnitude is 28 nTesla/year (in some


### PR DESCRIPTION
Work on #7148.

* describe order of input grids
* use :math: where appropriate
* add -W+c  - note that When ``-W+c`` is given -``Wpen`` specification is ignored. So p.t. ``-Wpen`` and ``-W+c`` are mutually exclusive. Not sure if the formatting is appropriate - the *pen* should maybe also be in ``[]``? A nice feature would be to be able to color vector head+stem and have an outline (set with *pen*, e.g. ``-Wblack+c``).