### PR TITLE
Implement -Q for greenspline 1d

### DIFF
--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-I|\ *xinc*\ [/*yinc*\ [/*zinc*]] ]
 [ |-L| ]
 [ |-N|\ *nodefile* ]
-[ |-Q|\ *az*\|\ *x/y/z* ]
+[ |-Q|\ [*az*\|\ *x/y/z*] ]
 [ |-R|\ *xmin*/*xmax*\ [/*ymin*/*ymax*\ [/*zmin*/*zmax*]] ]
 [ |-S|\ **c\|t\|l\|r\|p\|q**\ [*pars*] ] [ |-T|\ *maskgrid* ]
 [ |SYN_OPT-V| ]
@@ -210,10 +210,11 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ *az*\|\ *x/y/z*
-    Rather than evaluate the surface, take the directional derivative in
+**-Q**\ [*az*\|\ *x/y/z*]
+    Rather than evaluate the solution *w*\ (**x**), take the first derivative of
+    a 1-D solution.  For 2-D, select directional derivative in
     the *az* azimuth and return the magnitude of this derivative
-    instead. For 3-D interpolation, specify the three components of the
+    instead. For a 3-D interpolation, specify the three components of the
     desired vector direction (the vector will be normalized before use).
 
 .. _-R:


### PR DESCRIPTION
There was no way to use **-Q** with 1-D spline as you got an error with any argument. This PR now allows **-Q** with no arg when dimension is 1.  It also fixes the error that the data normalization undo was applied to the **-Q** slope output.  This is now correct for 1-D - more work will be required for 2-D (and even 3-D); see the [discussion](https://github.com/GenericMappingTools/gmt/discussions/7154).
