### PR TITLE
Improve gspline_7.sh test

### DIFF
--- a/test/baseline/greenspline.dvc
+++ b/test/baseline/greenspline.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: cbc1f5c0f8566a671e5c76ae5cddda31.dir
-  size: 1520815
+- md5: 5dcec8b7f05882b26b1bc44d4796d9f0.dir
+  size: 1521900
   nfiles: 7
   path: greenspline

--- a/test/greenspline/gspline_7.sh
+++ b/test/greenspline/gspline_7.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Testing 1-D greenspline with mix of data and gradients
+# This also exercises -Q for 1-D and plots the solution slopes
+# to show the match the input slopes (arrows).
 
 # Create 7 data points
 cat <<- EOF > oneD_data.txt
@@ -20,6 +22,10 @@ EOF
 gmt greenspline oneD_data.txt -AoneD_grad.txt+f0 -Z0 -R-3/3 -I0.01 -Sc -GoneD_out.txt
 # Just fit the data
 gmt greenspline oneD_data.txt  -Z0 -R-3/3 -I0.01 -Sc -GoneD_noA.txt
+# Estimate gradient of solution at gradient constraint locations
+gmt greenspline oneD_data.txt -AoneD_grad.txt+f0 -Z0 -NoneD_grad.txt -Sc -Q -GoneD_slp.txt
+paste oneD_grad.txt oneD_slp.txt > oneD_grad2.txt
+
 # Create data and text for slope lines and annotations
 gmt math -T-2/2/0.5 T = | awk '{printf ">\n-1\t%s\n1\t%s\n", $1, -$1}' > lines.txt
 cat <<- EOF >> lines.txt
@@ -34,13 +40,19 @@ gmt begin gspline_7 ps
 	gmt plot oneD_noA.txt -W3p,gray -l"No slopes used"
 	gmt plot oneD_out.txt -W3p,red -l"With slope constraints"
 	gmt plot oneD_out.txt -W0.25p
-	LEG="-lSlopes"
+	LEG="-lData-Slopes"
+	LEGS=-l"Solution-Slopes"
 	# Loop over gradients and place grid and labels
-	while read X S; do
+	while read X S X2 Sout; do
 		pattern="^${X}\t"	# Search pattern for finding y-value at gradient
 		Y=$(grep ${pattern} oneD_out.txt | awk '{print $2}')
 		# Lay down grid/labels after shifting origin to tangent point
 		gmt plot -W0.25p,blue -X${X}i -Y${Y}i lines.txt
+		the_Sout=$(gmt math -Q ${Sout} NEG =)
+		gmt plot -W0.25p,green ${LEGS} <<- EOF
+		-1	${the_Sout}
+		1	${Sout}
+		EOF
 		gmt text -F+f12p+jML -Dj8p labels.txt
 		echo 0 0 1 ${S} | gmt plot -Sv12p+e+s -W1p -Gblack
 		the_X=$(gmt math -Q ${X} NEG =)
@@ -49,5 +61,6 @@ gmt begin gspline_7 ps
 		# Undo shift and place gradient circle
 		echo $X $Y | gmt plot -Sc10p -W0.5p ${LEG} -X${the_X}i -Y${the_Y}i
 		LEG=
-	done < oneD_grad.txt
+		LEGS=
+	done < oneD_grad2.txt
 gmt end


### PR DESCRIPTION
Since **greenspline -Q** now works for 1-D I added its use in _gspline_7.sh_ to get the solution slopes at the input slope locations so we can show that the input and result matches exactly at the constrains (green line now shows solution slope).  Minor change to script and revised PS file in dvc.
