### PR TITLE
-R docs: Broken link to ISO codes Wikipedia page fixed.

### DIFF
--- a/doc/rst/source/explain_-R.rst_
+++ b/doc/rst/source/explain_-R.rst_
@@ -39,7 +39,7 @@ The **-R** option defines the map region or data domain of interest. It may be s
 #. **-R**\ *code1,code2,...*\ [**+e**\ \|\ **r**\ \|\ **R**\ *incs*]. This indirectly supplies the region by
    consulting the DCW (Digital Chart of the World) database and derives the bounding regions for one or more
    countries given by the codes. Simply append one or more comma-separated countries using either the two-character
-   `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)>`_ (e.g., NO) or the full
+   `ISO 3166-1 alpha-2 convention <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ (e.g., NO) or the full
    country name (e.g., Norway). To select a state within a country (if available), append .state (e.g, US.TX),
    or the full state name (e.g., Texas). To specify a whole continent, spell out the full continent name (e.g., -RAfrica).
    Finally, append any :ref:`DCW collection <dcw-collections>` abbreviations or full names for the extent of the


### PR DESCRIPTION
**Description of proposed changes**

The Wikipedia link to the ISO country codes in the [`-R` documentation](https://docs.generic-mapping-tools.org/dev/gmt.html#r-full) option 6 had an extra closing parenthesis. This made the link fail to an "article does not exist" page and also tricked the link checker.

Fixes #7162
