### PR TITLE
Finalize greenspline for 2-D slope constraints

### DIFF
--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -202,7 +202,7 @@ Optional Arguments
 .. _-L:
 
 **-L**\ [**t**][**r**]
-    Specifically control how we detrend (i.e., adjusting :math:`T(\mathbf{x})`)
+    Specifically control how we detrend (i.e., adjust :math:`T(\mathbf{x})`)
     and normalize the data (and possibly gradients) prior to determining the
     solution coefficients.  The order of adjustments is always the same even if
     some steps may be deselected:

--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |SYN_OPT-D3| ]
 [ |-E|\ [*misfitfile*] ]
 [ |-I|\ *xinc*\ [/*yinc*\ [/*zinc*]] ]
-[ |-L| ]
+[ |-L|\ [**t**][**r**] ]
 [ |-N|\ *nodefile* ]
 [ |-Q|\ [*az*\|\ *x/y/z*] ]
 [ |-R|\ *xmin*/*xmax*\ [/*ymin*/*ymax*\ [/*zmin*/*zmax*]] ]
@@ -201,13 +201,24 @@ Optional Arguments
 
 .. _-L:
 
-**-L**
-    Do *not* remove a linear (1-D) or planer (2-D) trend when |-Z|
-    selects mode 0-3 [For those Cartesian cases a least-squares line or
-    plane is modeled and removed, then restored after fitting a spline
-    to the residuals]. However, in mixed cases with both data values and
-    gradients, or for spherical surface data, only the mean data value
-    is removed (and later and restored).
+**-L**\ [**t**][**r**]
+    Specifically control how we detrend (i.e., adjusting :math:`T(\mathbf{x})`)
+    and normalize the data (and possibly gradients) prior to determining the
+    solution coefficients.  The order of adjustments is always the same even if
+    some steps may be deselected:
+
+    - We always determine and then remove and restore the mean data value :math:`\bar{w}`.
+    - We determine a linear least-squares trend (directive **t**) and remove this trend
+      from residual data and slopes. **Note**: For spherical and 3-D interpolation the
+      **t** directive is not available.
+    - We determine the maximum absolute value of the minimum and maximum data residuals
+      (directive **r**) and normalize the residual data and slopes by that range value.
+
+    After evaluating the solution based on the residuals, we undo any normalization and
+    detrending in reverse order.
+    Use **-L** to specifically append one of both of these directives to override
+    the default. If no directives are given then no detrending nor normalization will
+    take place. 
 
 .. _-N:
 

--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -2264,7 +2264,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 			for (col = 0; col < (openmp_int)nm; col++) {	/* We do all columns here since most are not symmetrical */
 				ij = row * nm + col;
 				r = greenspline_get_radius (GMT, X[col], X[row], dimension);
-				if (r > 0.0) {	/* For all pairs except self-pairs */
+				if (!gmt_M_is_zero (r)) {	/* For all pairs except self-pairs */
 					grad = dGdr (GMT, r, par, Lg);
 					C = greenspline_get_dircosine (GMT, D[row-n], X[col], X[row], dimension, true);
 					A[ij] = grad * C;
@@ -2540,7 +2540,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 				out[dimension] = 0.0;
 				for (p = 0; p < nm; p++) {
 					r = greenspline_get_radius (GMT, out, X[p], dimension);
-					if (r > 0.0) {	/* For all pairs except self-pairs */
+					if (!gmt_M_is_zero (r)) {	/* For all pairs except self-pairs */
 						if (Ctrl->Q.active) {
 							C = greenspline_get_dircosine (GMT, Ctrl->Q.dir, out, X[p], dimension, false);
 							part = dGdr (GMT, r, par, Lz) * C;
@@ -2643,7 +2643,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 							/* Here, V holds the current output coordinates */
 							for (p = 0, wp = 0.0; p < nm; p++) {
 								r = greenspline_get_radius (GMT, V, X[p], 2U);
-								if (r > 0.0) {	/* For all pairs except self-pairs */
+								if (!gmt_M_is_zero (r)) {	/* For all pairs except self-pairs */
 									C = greenspline_get_dircosine (GMT, Ctrl->Q.dir, V, X[p], 2U, false);
 									part = dGdr (GMT, r, par, Lz) * C;
 									wp += alpha[p] * part;
@@ -2659,7 +2659,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 						double dev, rms = 0.0, chi2_sum = 0.0;
 						for (j = 0; j < nm; j++) {	/* For each data constraint */
 							for (p = 0, wp = 0.0; p < nm; p++) {	/* Add contribution for each data constraint */
-								if (r > 0.0) {	/* For all pairs except self-pairs */
+								if (!gmt_M_is_zero (r)) {	/* For all pairs except self-pairs */
 									r = greenspline_get_radius (GMT, X[j], X[p], 2U);
 									part = G (GMT, r, par, Lz);
 									wp += alpha[p] * part;	/* Just add this scaled Green's function */
@@ -2777,7 +2777,7 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 							/* Here, V holds the current output coordinates */
 							for (p = 0, wp = 0.0; p < (int64_t)nm; p++) {	/* Loop over Green's function components */
 								r = greenspline_get_radius (GMT, V, X[p], dimension);
-								if (r > 0.0) {	/* For all pairs except self-pairs */
+								if (!gmt_M_is_zero (r)) {	/* For all pairs except self-pairs */
 									C = greenspline_get_dircosine (GMT, Ctrl->Q.dir, V, X[p], dimension, false);
 									part = dGdr (GMT, r, par, Lz) * C;
 									wp += alpha[p] * part;

--- a/test/baseline/greenspline.dvc
+++ b/test/baseline/greenspline.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 5dcec8b7f05882b26b1bc44d4796d9f0.dir
-  size: 1521900
-  nfiles: 7
+- md5: f1509c2ff25cdb2b2fc09d836a3d1cf6.dir
+  size: 1581934
+  nfiles: 8
   path: greenspline

--- a/test/greenspline/gspline_8.sh
+++ b/test/greenspline/gspline_8.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Make and test 2-D Cartesian interpolation using both
+# data values and gradients.  We generate input data from
+# a Gaussian bump on a plane:
+gmt grdmath -R-2/2/-2/2 -I1 0 0 CDIST 2 DIV 2 POW NEG EXP X 0.1 MUL ADD = bump.grd
+# Take DDX to get gradients in x-direction
+gmt grdmath bump.grd DDX = grads.grd
+# High res versions of same grids for plotting
+gmt grdmath -R-2/2/-2/2 -I0.1 0 0 CDIST 2 DIV 2 POW NEG EXP X 0.1 MUL ADD = bump1.grd
+# Raw values of value and slope at all nodes inside frame (excluding the border)
+gmt grd2xyz -R-1/1/-1/1 bump.grd > bump_raw.txt
+gmt grd2xyz -R-1/1/-1/1 grads.grd > grads_raw.txt
+# Select two gradients and 7 values for final input
+awk '{if ($1 == -1 || $2 != 0) print $0}' bump_raw.txt > bump_z.txt
+#awk '{if ($2 == 0 && $1 != -1) print $0, 90}' grads_raw.txt > bump_g.txt
+# But because DDX is approximate I redid this on a finer grid to get better values:
+cat << EOF > bump_g.txt
+0	0	0.100000202656 90
+1	0	-0.288589894772 90
+EOF
+# Make the test plot
+gmt begin gspline_8 ps
+	gmt makecpt -Cjet -T-1.5/1.5	# Keep fixed CPT for all plots
+	gmt subplot begin 3x2 -Fs8c
+	# First show only data (left) and splined result (right) from just using data values
+	gmt grdimage bump.grd -c
+	gmt plot bump_raw.txt -Sc4p -Gblack
+	gmt greenspline bump_raw.txt -R-2/2/-2/2 -I1 -Sc -Gbump_raw.grd -Z1
+	gmt grdimage bump_raw.grd -c
+	gmt plot bump_raw.txt -Sc4p -Gblack
+	# Now grid both the data (left) and the slope samples and display the splined result
+	gmt grdimage bump.grd -c
+	gmt plot bump_z.txt -Sc4p -Gblack
+	gmt plot bump_g.txt -Sc4p -W0.5p
+	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I1 -Sc -Ggrads_out.grd -Z1
+	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I0.05 -Sc -Ggrads_out1.grd -Z1
+	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I0.05 -Sc -Q90 -Ggrad_out1.grd -Z1
+	gmt grdimage grads_out.grd -c
+	gmt plot bump_z.txt -Sc4p -Gblack
+	gmt plot bump_g.txt -Sc4p -W0.5p
+	# Sample the two grids along y = 0 where we have the gradient constraints for x = 0,1
+	gmt grdtrack -Gbump1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W0.25p -Bafg1 -c -l"Without slopes"+jBL
+	gmt grdtrack -Ggrads_out1.grd -ELM/RM -o0,2 | gmt plot -W1p -l"With slopes"
+	awk '{if ($2 == 0) print $1, $3}' bump_z.txt | gmt plot -Sc4p -Gblack -l"Data point"
+	gmt grdtrack -Gbump1.grd -nn bump_g.txt -o0,4,2 | gmt plot -Sc4p -W0.25p -l"Slope point"
+	gmt grdtrack -Gbump1.grd -nn bump_g.txt -o0,4,2 | awk '{print $1, $2, 1, $3}' | gmt plot -Sv9p+e+z3 -W0.75p -Gred
+	gmt grdtrack -Ggrad_out1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W1p -Bafg1 -c -l"Slope grid"+jBL
+	gmt plot bump_g.txt -Sc4p -W0.5p -i0,2 -l"Slope value"
+	gmt subplot end
+	gmt colorbar -DJBC
+gmt end

--- a/test/greenspline/gspline_8.sh
+++ b/test/greenspline/gspline_8.sh
@@ -23,7 +23,7 @@ EOF
 # Make the test plot
 gmt begin gspline_8 ps
 	gmt makecpt -Cjet -T-1.5/1.5	# Keep fixed CPT for all plots
-	gmt subplot begin 3x2 -Fs8c
+	gmt subplot begin 3x2 -Fs8c -R-2/2/-2/2 -Scb -Srl
 	# First show only data (left) and splined result (right) from just using data values
 	gmt grdimage bump.grd -c
 	gmt plot bump_raw.txt -Sc6p -Gblack

--- a/test/greenspline/gspline_8.sh
+++ b/test/greenspline/gspline_8.sh
@@ -8,6 +8,7 @@ gmt grdmath -R-2/2/-2/2 -I1 0 0 CDIST 2 DIV 2 POW NEG EXP X 0.1 MUL ADD = bump.g
 gmt grdmath bump.grd DDX = grads.grd
 # High res versions of same grids for plotting
 gmt grdmath -R-2/2/-2/2 -I0.1 0 0 CDIST 2 DIV 2 POW NEG EXP X 0.1 MUL ADD = bump1.grd
+gmt grdmath bump1.grd DDX = grads1.grd
 # Raw values of value and slope at all nodes inside frame (excluding the border)
 gmt grd2xyz -R-1/1/-1/1 bump.grd > bump_raw.txt
 gmt grd2xyz -R-1/1/-1/1 grads.grd > grads_raw.txt
@@ -36,17 +37,20 @@ gmt begin gspline_8 ps
 	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I1 -Sc -Ggrads_out.grd -Z1
 	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I0.05 -Sc -Ggrads_out1.grd -Z1
 	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I0.05 -Sc -Q90 -Ggrad_out1.grd -Z1
-	gmt grdimage grads_out.grd -Bafg10 -c
+	gmt grdimage grads_out.grd -Bxaf -Byafg10 -c
 	gmt plot bump_z.txt -Sc6p -Gblack
 	gmt plot bump_g.txt -Sc6p -W0.5p
 	# Sample the two grids along y = 0 where we have the gradient constraints for x = 0,1
-	gmt grdtrack -Gbump1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W0.5p -Bafg1 -c -l"Without slopes"+jBL
-	gmt grdtrack -Ggrads_out1.grd -ELM/RM -o0,2 | gmt plot -W1.5p -l"With slopes"
-	awk '{if ($2 == 0) print $1, $3}' bump_z.txt | gmt plot -Sc6p -Gblack -l"Data point"
-	gmt grdtrack -Gbump1.grd -nn bump_g.txt -o0,4,2 | gmt plot -Sc6p -W0.25p -l"Slope point"
+	gmt grdtrack -Gbump1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W0.5p -Bafg1 -c -l"Without input slope constraints"+jBL
+	gmt grdtrack -Ggrads_out1.grd -ELM/RM -o0,2 | gmt plot -W1.5p -l"With input slope constraints"
+	awk '{if ($2 == 0) print $1, $3}' bump_z.txt | gmt plot -Sc6p -Gblack -l"Data constraint"
+	gmt grdtrack -Gbump1.grd -nn bump_g.txt -o0,4,2 | gmt plot -Sc6p -W0.25p -l"Slope constraint"
 	gmt grdtrack -Gbump1.grd -nn bump_g.txt -o0,4,2 | awk '{print $1, $2, 1, $3}' | gmt plot -Sv9p+e+z3 -W0.75p -Gred
-	gmt grdtrack -Ggrad_out1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W1p -Bafg1 -c -l"Slope grid"+jBL
-	gmt plot bump_g.txt -Sc6p -W0.5p -i0,2 -l"Slope value"
+	echo "SURFACE ALONG y = 0" | gmt text -F+cTL+f10p -Dj5p -Gwhite -W0.25p
+	gmt grdtrack -Ggrads1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W0.5p -Bafg1 -c -l"Without input slopes"+jBL
+	gmt grdtrack -Ggrad_out1.grd -ELM/RM -o0,2 | gmt plot -W1p -l"With input slopes"
+	gmt plot bump_g.txt -Sc6p -W0.5p -i0,2 -l"Slope constraint"
+	echo "GRADIENT ALONG y = 0" | gmt text -F+cTL+f10p -Dj5p -Gwhite -W0.25p
 	gmt subplot end
 	gmt colorbar -DJBC
 gmt end

--- a/test/greenspline/gspline_8.sh
+++ b/test/greenspline/gspline_8.sh
@@ -25,28 +25,28 @@ gmt begin gspline_8 ps
 	gmt subplot begin 3x2 -Fs8c
 	# First show only data (left) and splined result (right) from just using data values
 	gmt grdimage bump.grd -c
-	gmt plot bump_raw.txt -Sc4p -Gblack
+	gmt plot bump_raw.txt -Sc6p -Gblack
 	gmt greenspline bump_raw.txt -R-2/2/-2/2 -I1 -Sc -Gbump_raw.grd -Z1
 	gmt grdimage bump_raw.grd -c
-	gmt plot bump_raw.txt -Sc4p -Gblack
+	gmt plot bump_raw.txt -Sc6p -Gblack
 	# Now grid both the data (left) and the slope samples and display the splined result
 	gmt grdimage bump.grd -c
-	gmt plot bump_z.txt -Sc4p -Gblack
-	gmt plot bump_g.txt -Sc4p -W0.5p
+	gmt plot bump_z.txt -Sc6p -Gblack
+	gmt plot bump_g.txt -Sc6p -W0.5p
 	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I1 -Sc -Ggrads_out.grd -Z1
 	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I0.05 -Sc -Ggrads_out1.grd -Z1
 	gmt greenspline bump_z.txt -Abump_g.txt+f2 -R-2/2/-2/2 -I0.05 -Sc -Q90 -Ggrad_out1.grd -Z1
-	gmt grdimage grads_out.grd -c
-	gmt plot bump_z.txt -Sc4p -Gblack
-	gmt plot bump_g.txt -Sc4p -W0.5p
+	gmt grdimage grads_out.grd -Bafg10 -c
+	gmt plot bump_z.txt -Sc6p -Gblack
+	gmt plot bump_g.txt -Sc6p -W0.5p
 	# Sample the two grids along y = 0 where we have the gradient constraints for x = 0,1
-	gmt grdtrack -Gbump1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W0.25p -Bafg1 -c -l"Without slopes"+jBL
-	gmt grdtrack -Ggrads_out1.grd -ELM/RM -o0,2 | gmt plot -W1p -l"With slopes"
-	awk '{if ($2 == 0) print $1, $3}' bump_z.txt | gmt plot -Sc4p -Gblack -l"Data point"
-	gmt grdtrack -Gbump1.grd -nn bump_g.txt -o0,4,2 | gmt plot -Sc4p -W0.25p -l"Slope point"
+	gmt grdtrack -Gbump1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W0.5p -Bafg1 -c -l"Without slopes"+jBL
+	gmt grdtrack -Ggrads_out1.grd -ELM/RM -o0,2 | gmt plot -W1.5p -l"With slopes"
+	awk '{if ($2 == 0) print $1, $3}' bump_z.txt | gmt plot -Sc6p -Gblack -l"Data point"
+	gmt grdtrack -Gbump1.grd -nn bump_g.txt -o0,4,2 | gmt plot -Sc6p -W0.25p -l"Slope point"
 	gmt grdtrack -Gbump1.grd -nn bump_g.txt -o0,4,2 | awk '{print $1, $2, 1, $3}' | gmt plot -Sv9p+e+z3 -W0.75p -Gred
 	gmt grdtrack -Ggrad_out1.grd -ELM/RM -o0,2 | gmt plot -R-2/2/-2/2 -W1p -Bafg1 -c -l"Slope grid"+jBL
-	gmt plot bump_g.txt -Sc4p -W0.5p -i0,2 -l"Slope value"
+	gmt plot bump_g.txt -Sc6p -W0.5p -i0,2 -l"Slope value"
 	gmt subplot end
 	gmt colorbar -DJBC
 gmt end


### PR DESCRIPTION
This PR continues previous work on **greenspline** 1-D by extending it to 2-D. Specifically, this PR does the following (apart from some minor changes):

1. Correctly reduce input gradient constraints by the slope of a LS plane in the direction of the constraint vector
2. Computes the slope adjustment due to the LS plane in the given direction set if **-Q** is used
3. Enhance **-L** option and parsing to better specify exactly what adjustment and normalisation to use and warn if choice is not possible for given geometry
4. Improve documentation on how **-L** works [all is backwards compatible]
5. Add _gspline_8.sh_ which demonstrate the 2-D Cartesian case works.
6. Update gspline_3.ps orig solution due to previous fixes in the code.

Here is the plot of the new test which starts with a Gaussian bump on a sloping plane (in the x-direction only); top left.  Then sample the 9 points shown and grid those (top right) which matches exactly where there are constraints.  Next was to replace two of the data constraints along y = 0 with the slopes there instead (Circles); mid left.  Then, gridding that mixed case yields the image on mid right.  The y = 0 crossection of both surface (with or without gradient constraints) and slopes are shown in bottom row,  where data and slope constraints are indicated.  As can be seen, both data values and slopes are honoured exactly in the solution.  

![gspline_8](https://user-images.githubusercontent.com/26473567/208295683-1f7eb380-8c38-4693-ab63-76824fb0fdc4.png)
