### PR TITLE
Allow plot/plot3d -N to work with lines and polygons

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -224,12 +224,13 @@ Optional Arguments
 
 **-N**\ [**c**\|\ **r**]
     Do **not** clip symbols that fall outside map border [Default plots points
-    whose coordinates are strictly inside the map border only]. The option does not apply to lines and polygons
-    which are always clipped to the map region. For periodic (360-longitude)
+    whose coordinates are strictly inside the map border only]. For periodic (360-longitude)
     maps we must plot all symbols twice in case they are clipped by the repeating
     boundary. The |-N| will turn off clipping and not plot repeating symbols.
     Use **-Nr** to turn off clipping but retain the plotting of such repeating symbols, or
     use **-Nc** to retain clipping but turn off plotting of repeating symbols.
+    **Note**: A plain |-N| may also be used with lines or polygons but note that this deactivates
+    any consideration of periodicity (e.g., longitudes) and may have unintended consequences.
 
 .. _-S:
 

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -183,12 +183,13 @@ Optional Arguments
 
 **-N**\ [**c**\|\ **r**]
     Do **not** clip symbols that fall outside map border [Default plots points
-    whose coordinates are strictly inside the map border only]. The option does not apply to lines and polygons
-    which are always clipped to the map region. For periodic (360-longitude)
+    whose coordinates are strictly inside the map border only]. For periodic (360-longitude)
     maps we must plot all symbols twice in case they are clipped by the repeating
     boundary. The |-N| will turn off clipping and not plot repeating symbols.
     Use **-Nr** to turn off clipping but retain the plotting of such repeating symbols, or
     use **-Nc** to retain clipping but turn off plotting of repeating symbols.
+    **Note**: A plain |-N| may also be used with lines or polygons but note that this deactivates
+    any consideration of periodicity (e.g., longitudes) and may have unintended consequences.
 
 .. _-Q:
 

--- a/doc/scripts/GMT_mapscale.sh
+++ b/doc/scripts/GMT_mapscale.sh
@@ -6,7 +6,7 @@ gmt begin GMT_mapscale
 	h=$(gmt mapproject -Wh -Di)
 	h=$(gmt math -Q $h 2 DIV =)
 	lat=$(echo 0 $h | gmt mapproject -I -Di -o1)
-	gmt plot -Wfaint -A -N << EOF
+	gmt plot -Wfaint -A << EOF
 >
 0	$lat
 40	$lat

--- a/doc/scripts/GMT_pstext_justify.sh
+++ b/doc/scripts/GMT_pstext_justify.sh
@@ -10,7 +10,7 @@ R=1.98
 gmt text -R0/3/0/1.5 -Jx1i -N -C0 -Wthin,- -F+f36p,Helvetica-Bold+jLB << EOF
 0.1	0.2	My Text
 EOF
-gmt plot -N << EOF
+gmt plot << EOF
 >
 0.05	$B
 2.04	$B
@@ -30,7 +30,7 @@ $C	0.65
 $R	0
 $R	0.65
 EOF
-gmt plot -N -Wthinner << EOF
+gmt plot -Wthinner << EOF
 >
 0.7	-0.1
 $L	$M

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -217,6 +217,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "r: Turn off clipping and plot repeating symbols for periodic maps.");
 	GMT_Usage (API, 3, "c: Retain clipping but turn off plotting of repeating symbols for periodic maps.");
 	GMT_Usage (API, -2, "[Default will clip or skip symbols that fall outside and plot repeating symbols].");
+	GMT_Usage (API, -2, "Note: May also be used with lines or polygons but no periodicity will be honored.");
 	GMT_Option (API, "O,P");
 	GMT_Usage (API, 1, "\n-Q Do NOT sort symbols based on distance to viewer before plotting.");
 	GMT_Usage (API, 1, "\n-S[<symbol>][<size>]");
@@ -1946,7 +1947,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 		gmt_reset_meminc (GMT);
 	}
 	else {	/* Line/polygon part */
-		bool duplicate = false, conf_line = false;
+		bool duplicate = false, conf_line = false, no_line_clip = (Ctrl->N.active && S.symbol == GMT_SYMBOL_LINE);
 		int outline_setting;
 		uint64_t seg;
 		struct GMT_PALETTE *A = NULL;
@@ -2164,7 +2165,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 				xp = gmt_M_memory (GMT, NULL, n, double);
 				yp = gmt_M_memory (GMT, NULL, n, double);
 
-				if (polygon) {
+				if (polygon && !no_line_clip) {
 					gmt_plane_perspective (GMT, -1, 0.0);
 					for (i = 0; i < n; i++) gmt_geoz_to_xy (GMT, L->data[GMT_X][i], L->data[GMT_Y][i], L->data[GMT_Z][i], &xp[i], &yp[i]);
 					gmt_setfill (GMT, &current_fill, outline_setting);
@@ -2286,7 +2287,22 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 					else {
 						for (i = 0; i < n; i++) gmt_geoz_to_xy (GMT, L->data[GMT_X][i], L->data[GMT_Y][i], L->data[GMT_Z][i], &xp[i], &yp[i]);
 					}
-					if (draw_line && (S.symbol != GMT_SYMBOL_FRONT || !S.f.invisible)) {
+					if (no_line_clip) {	/* Draw line or polygon without border clipping at all */
+						if ((GMT->current.plot.n = gmt_cart_to_xy_line (GMT, xp, yp, n)) == 0) continue;
+						if (outline_active) gmt_setpen (GMT, &Ctrl->W.pen);	/* Select separate pen for polygon outline */
+						if (Ctrl->G.active) {	/* Specify the fill, possibly set outline */
+							gmt_setfill (GMT, &current_fill, outline_active);
+							PSL_plotpolygon (PSL, xp, yp, (int)n);
+						}
+						else {	/* No fill, just outline but may still be polygon */
+							gmt_setfill (GMT, NULL, outline_active);
+							if (polygon)
+								PSL_plotpolygon (PSL, xp, yp, (int)n);
+							else
+								PSL_plotline (PSL, xp, yp, (int)n, PSL_MOVE|PSL_STROKE);
+						}
+					}
+					else if (draw_line && (S.symbol != GMT_SYMBOL_FRONT || !S.f.invisible)) {
 						PSL_plotline (PSL, xp, yp, (int)n, PSL_MOVE|PSL_STROKE);
 					}
 				}

--- a/test/baseline/psxy.dvc
+++ b/test/baseline/psxy.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: bac31d281e71fbcedcf6ae7166ba2e5e.dir
-  size: 9331268
-  nfiles: 142
+- md5: d2024853f6fb7677065b0529ef52bb2b.dir
+  size: 9367032
+  nfiles: 143
   path: psxy

--- a/test/baseline/psxyz.dvc
+++ b/test/baseline/psxyz.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 817364f35149dd02f20424cf38cc0f60.dir
-  size: 1109038
-  nfiles: 26
+- md5: ba9d421159ad3008be4ce6374e2f7e2c.dir
+  size: 1147627
+  nfiles: 27
   path: psxyz

--- a/test/psxy/noclip_lines.sh
+++ b/test/psxy/noclip_lines.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Test plot -N with lines and polygons in 2-D
+cat << EOF > t.txt
+-1	0
+2	1
+3	-1
+1	-1.5
+EOF
+
+gmt begin noclip_lines ps
+	gmt subplot begin 3x2 -Fs6c -R0/3/-2/2 -M32p/4p -Y6c
+	gmt plot t.txt -W2p -c
+	gmt plot t.txt -W2p -N -c
+	gmt plot t.txt -Glightgray -W1p -c
+	gmt plot t.txt -Glightgray -W1p -N -c
+	gmt plot t.txt -Glightgray -c
+	gmt plot t.txt -Glightgray -W1p -N -c
+	gmt plot t.txt -W1p,- -N -L
+	gmt plot t.txt -W3p -L
+	gmt subplot end
+gmt end

--- a/test/psxyz/noclip_lines3.sh
+++ b/test/psxyz/noclip_lines3.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Test plot3d -N with lines and polygons in 3-D
+cat << EOF > z.txt
+-1	0	0
+2	1	0
+3	-1	0
+1	-1.5	0
+EOF
+
+gmt begin noclip_lines3 ps
+	gmt subplot begin 3x2 -Fs6c -R0/3/-2/2 -M32p/4p -Y6c
+	gmt plot3d -R0/3/-2/2 -p155/35 z.txt -W2p -c
+	gmt plot3d -R0/3/-2/2 -p155/35 z.txt -W2p -N -c
+	gmt plot3d -R0/3/-2/2 -p155/35 z.txt -Glightgray -W1p -c
+	gmt plot3d -R0/3/-2/2 -p155/35 z.txt -Glightgray -W1p -N -c
+	gmt plot3d -R0/3/-2/2 -p155/35 z.txt -Glightgray -c
+	gmt plot3d -R0/3/-2/2 -p155/35 z.txt -Glightgray -W1p -N -c
+	gmt plot3d -R0/3/-2/2 -p155/35 z.txt -W1p,- -N -L
+	gmt plot3d -R0/3/-2/2 -p155/35 z.txt -W3p -L
+	gmt subplot end
+gmt end


### PR DESCRIPTION
This PR is in response to this forum [post](https://forum.generic-mapping-tools.org/t/psxy-n-does-not-allow-w-lines-to-go-outside-box/3551) and it looks like my implementation here works well (no failing tests and two new tests show it works).  I implemented the fix for both **plot** and **plot3d** but just showing the effect of the new **plot** test here.  I also had to remove a few stray **-N** from other tests that never caused any trouble (since **-N** was ignored for lines) but of course now acted up.  Also updated the docs and as mentioned added two tests.

The data set used below has 4 points with the first outside the region:

```
-1	0
2	1
3	-1
1	-1.5
```

TL shows GMT default auto-clipping. TR shows effect of **-N** which allows the whole line to be seen. ML shows same plotted as polygon with default auto-clipping, while MR shows polygon and outline extending outside given **-N**. BL is default GMT crop for polygon with no outline while BR is plotted twice: One with **-N** and think line and second with a fat line and **-L** (to convert to closed polygon) but clipped by border.

![noclip_lines](https://user-images.githubusercontent.com/26473567/208674039-141d1d07-246a-4b7a-99ad-eae7f3bbcdc6.png)
