### PR TITLE
Fix typo in cookbook for Cylinderical equistant projection (q|Q)

### DIFF
--- a/doc/rst/source/cookbook/map-projections.rst
+++ b/doc/rst/source/cookbook/map-projections.rst
@@ -895,7 +895,7 @@ Cylindrical equidistant projection (**-Jq** **-JQ**)
 
 **Parameters**
 
-- Optionally, the central meridian (*lon0*) [default is the middle of the map map].
+- Optionally, the central meridian (*lon0*) [default is the middle of the map].
 - Optionally, the standard parallel (*lat0*)  [default is the equator]. When supplied, the central meridian (*lon0*)
   must be supplied as well.
 - The *scale*  in :ref:`plot-units <plt-units>`/degree or as 1:xxxxx (with **-Jq**) or map *width* in


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the cookbook for the [Cylinderical equistant projection (q|Q)](https://docs.generic-mapping-tools.org/dev/cookbook/map-projections.html#cylindrical-equidistant-projection-jq-jq).

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
