### PR TITLE
Let API handle matrix input with repeated NaNs

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -3910,6 +3910,9 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 					if ((status = gmtapi_bin_input_memory (GMT, M_obj->n_columns, n_use)) < 0) {	/* Segment header found, finish the segment we worked on and goto next */
 						if (status == GMTAPI_GOT_SEGGAP) API->current_rec[GMT_IN]--;	/* Since we inserted a segment header we must revisit this record as the first in next segment */
 						if (got_data) {	/* If first input segment has header then we already have that segment allocated */
+							if (n_records == 0) {  /* Repeated NaN records we skip since no need to build empty segments */
+								continue;
+							}
 							(void)GMT_Alloc_Segment (API, GMT_IS_DATASET, n_records, n_columns, NULL, S);	/* Reallocate to exact length */
 							D_obj->table[D_obj->n_tables]->n_records += n_records;			/* Update record count for this table */
 							seg++;	/* Increment number of segments */
@@ -3981,6 +3984,9 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 					if ((status = gmtapi_bin_input_memory (GMT, V_obj->n_columns, n_use)) < 0) {	/* Segment header found, finish the one we had and add more */
 						if (status == GMTAPI_GOT_SEGGAP) API->current_rec[GMT_IN]--;	/* Since we inserted a segment header we must revisit this record as first in next segment */
 						if (got_data) {	/* If first input segment has header then we already have a segment allocated */
+							if (n_records == 0) {  /* Repeated NaN records we skip since no need to build empty segments */
+								continue;
+							}
 							(void)GMT_Alloc_Segment (API, GMT_IS_DATASET, n_records, n_columns, NULL, S);
 							D_obj->table[D_obj->n_tables]->n_records += n_records;
 							seg++;	/* Increment number of segments */


### PR DESCRIPTION
See #7168 for background.  The cause was that the code for importing datasets via either **MATRIX** or **VECTOR** did not have a check for this case (repeated NaN records, not just one indicating a segment header).  The solution was relatively simple: When finding further NaN records after the first NaN record we just skip and go on to the next entry in the matrix.  I also tested this PR by adding several leading NaN records at the start of the matrix and that part worked already from previously.  The **VECTOR** case was **not** actually tested, but the logic is identical so assuming it would work the same way. If @seisman want to try in a PyGMT case where vectors are passed and simulate a similar NaN block then we will know for sure!  The Julia case now works fine for me here in macOS land.

Closes #7168.