### PR TITLE
Let grid array memory be of even length

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -2343,8 +2343,8 @@ GMT_LOCAL size_t gmtapi_set_grdarray_size (struct GMT_CTRL *GMT, struct GMT_GRID
 
 	if (!full_region (wesn)) {
 		gmt_M_memcpy (h_tmp->wesn, wesn, 4, double);    /* Use wesn instead of header info */
-		gmt_adjust_loose_wesn (GMT, wesn, h);	/* Subset requested; make sure wesn matches header spacing */
-		gmt_M_memcpy(h_tmp->wesn, wesn, 4, double);	    /* And update the eventually adjusted wesn */
+		gmt_adjust_loose_wesn (GMT, wesn, h);		/* Subset requested; make sure wesn matches header spacing */
+		gmt_M_memcpy(h_tmp->wesn, wesn, 4, double);	/* And update the eventually adjusted wesn */
 	}
 	gmt_M_grd_setpad (GMT, h_tmp, GMT->current.io.pad);	/* Use the system pad setting by default */
 	gmt_set_grddim (GMT, h_tmp);				/* Computes all integer parameters */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -95,7 +95,9 @@ struct GRD_PAD {	/* Local structure */
 
 /*! gmt_M_grd_get_size computes grid size including the padding, and doubles it if complex values */
 GMT_LOCAL size_t gmtgrdio_grd_get_size (struct GMT_GRID_HEADER *h) {
-	return ((((h->complex_mode & GMT_GRID_IS_COMPLEX_MASK) > 0) + 1ULL) * h->mx * h->my);
+	size_t L = (((h->complex_mode & GMT_GRID_IS_COMPLEX_MASK) > 0) + 1ULL) * h->mx * h->my;
+	if (L % 2) L++;	/* Make it an even number just in case an array is passed to an operator that expects real,imag pairs */
+	return (L);
 }
 
 int gmt_grd_layout (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt_grdfloat *grid, unsigned int complex_mode, unsigned int direction) {


### PR DESCRIPTION
This is a harmless PR that may add 4 bytes extra memory when `mx * my` is odd.  I am doing this because with some very large (hence 64-bit integer countings) I got a strange crash in _scale_and_offset_f_ on macOS:

`		vDSP_vsmul (data, 1, &scale, data, 1, length);`

but in a sub-function _vDSP_viclipD_.  Since these functions are part of Apple's Accelerate  framework and for FFT stuff I thought perhaps the crash was due to my array length being odd (3,733,128,025) but adding one did not fix it.  The _vDSP_viclipD_ is for **double** precision but we call _vDSP_vsmul_ which is for **single** precision.  If that one calls a double precision sub-function then who knows why but smells like bug (but not on the GMT side).

We still have 64-bit counting issues in GMT I believe, and things may be related to the problem seen in **grdfilter** of [large grids](https://github.com/GenericMappingTools/remote-datasets/issues/32).  Running all tests afterwards gave no changes so I think no problems is caused by my adding 4 bytes to the array, since we have separate variables for number of rows and columns etc for navigating the grid, and any loop over the size is harmless.