### PR TITLE
Smarter area weight grid saves memory in grdfilter

### DIFF
--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -155,6 +155,7 @@ struct GMTAPI_CTRL {
 	bool got_remote_wesn;				/* true if we obtained w/e/sn via a remote grid/image with no resolution given */
 	bool use_gridline_registration;	/* true if default remote grid registration should be gridline, not pixel */
 	bool use_gridline_registration_warn;	/* true if we should warn about the above */
+	bool ignore_BC;       	   /* temporarily set true for, say, weight grids in grdfilter which do not need a BC wrap-around check */
 	size_t n_objects_alloc;			/* Allocation counter for data objects */
 	int error;				/* Error code from latest API call [GMT_OK] */
 	int last_error;				/* Error code from previous API call [GMT_OK] */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12244,6 +12244,7 @@ int gmt_BC_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h) {
 	else if (gmt_grd_is_global (GMT, h)) {	/* Grid is truly global */
 		double xtest = fmod (180.0, h->inc[GMT_X]) * HH->r_inc[GMT_X];
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Grid is considered to have a 360-degree longitude range.\n");
+		if (GMT->parent->ignore_BC) xtest = 0.0;	/* To bypass the checks below */
 		/* xtest should be within GMT_CONV4_LIMIT of zero or of one.  */
 		if (xtest > GMT_CONV4_LIMIT && xtest < (1.0 - GMT_CONV4_LIMIT) ) {
 			/* Error.  We need it to divide into 180 so we can phase-shift at poles.  */

--- a/src/grdfilter.c
+++ b/src/grdfilter.c
@@ -533,15 +533,23 @@ GMT_LOCAL struct GMT_GRID *init_area_weights (struct GMT_CTRL *GMT, struct GMT_G
 	 * 2. Geographic poles for grid-registered grids require a separate weight formula
 	 * 3. Grid-registered grids have boundary nodes that only apply to 1/2 the area
 	 *    (and the four corners (unless poles) only 1/4 the area of other cells).
+	 *
+	 * While the outermost nodes can have funny pole and 1/2 weights, all the inside columns
+	 * are identical.  To save memory we only use 3 columns: west, middle, east but all rows.
 	 */
 	openmp_int row, col, last_row;
 	uint64_t ij;
-	double row_weight, col_weight, dy_half = 0.0, dx, y, lat, lat_s, lat_n, s2 = 0.0, f;
+	double row_weight, col_weight, dy_half = 0.0, dx, y, lat, lat_s, lat_n, s2 = 0.0, f, a_inc[2];
 	struct GMT_GRID *A = NULL;
+	struct GMT_GRID_HEADER_HIDDEN *HH = NULL;
 
 	/* Base the area weight grid on the input grid domain and increments. */
-	if ((A = GMT_Create_Data (GMT->parent, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, G->header->wesn, G->header->inc, \
+	a_inc[GMT_X] = ((G->header->registration == GMT_GRID_NODE_REG) ? 0.5 : 1.0 / 3.0) * (G->header->wesn[XHI] - G->header->wesn[XLO]);
+	a_inc[GMT_Y] = G->header->inc[GMT_Y];
+	GMT->parent->ignore_BC = true;	/* To avoid irrelevant BC setting warnings for this weight grid */
+	if ((A = GMT_Create_Data (GMT->parent, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, G->header->wesn, a_inc, \
 		G->header->registration, GMT_NOTSET, NULL)) == NULL) return (NULL);
+	GMT->parent->ignore_BC = false;	/* Reset */
 	if (mode > GRDFILTER_XY_CARTESIAN) {	/* Geographic data */
 		if (mode == GRDFILTER_GEO_MERCATOR) dy_half = 0.5 * A->header->inc[GMT_Y];	/* Half img y-spacing */
 		dx = A->header->inc[GMT_X] * D2R;			/* Longitude increment in radians */
@@ -1437,7 +1445,7 @@ GMT_LOCAL void grdfilter_threaded_function (struct THREAD_STRUCT *t) {
 	bool visit_check = false, go_on;
 	unsigned int n_in_median, n_nan = 0, col_out, row_out, n_span;
 	unsigned int GMT_n_multiples = 0;
-	int col_in, row_in, ii, jj, row_origin;
+	int col_in, row_in, ii, jj, row_origin, last_col;
 	char *visit;
 #ifdef DEBUG
 	unsigned int n_conv = 0;
@@ -1488,6 +1496,7 @@ GMT_LOCAL void grdfilter_threaded_function (struct THREAD_STRUCT *t) {
 		else
 			work_array = gmt_M_memory (GMT, NULL, F.n_columns*F.n_rows, double);
 	}
+	last_col = (int)Gin->header->n_columns - 1;
 
 	for (row_out = r_start; row_out < r_stop; row_out++) {
 
@@ -1562,7 +1571,9 @@ GMT_LOCAL void grdfilter_threaded_function (struct THREAD_STRUCT *t) {
 					}
 
 					/* Get here when point is inside and usable  */
-					ij_area = gmt_M_ijp (A->header, row_in, col_in);	/* Finally, the current input data point inside the filter */
+					ij_area = gmt_M_ijp (A->header, row_in, 1);	/* The inside point weight node at this latitude */
+					if (col_in == 0) ij_area--;	/* Needed the left-side/west weight at this latitude */
+					else if (col_in == last_col) ij_area++;	/* Need the right-side/east weight at this latitude */
 					if (slow) {	/* Add it to the relevant temporary work array */
 						if (slower) {	/* Need to store both value and weight */
 							work_data[n_in_median].value = Gin->data[ij_in];


### PR DESCRIPTION
Instead of precomputing an area weight grid for all input nodes (and hence doubling the memory requirement of the grid), we now only do so for 3 nodes along each row (west, middle, east) since all the columns away from the ends have the same weight along a row and only vary with latitude. The west and east columns may differ depending on boundary conditions, periodicity (360), and gridline vs pixel registration. It also speeds up the precalculation itself but mostly saves memory for large grids to be filtered in **grdfilter**. The case that  triggered this was a 16 Gb in-memory grid that resulted in another 16 Gb memory grid being used - this now drops down to 1 Mb.

I have run all tests and it looks unchanged.  Happy to have someone do a few filter operations to see if they notice anything, but the new logic looks solid to me.  I had to add a silly API bool variable to bypass a test that for this strange grid (say 3 columns and 43600 rows) would fail in BC setting - this skips that check.