### PR TITLE
surface -r changed the pad twice

### DIFF
--- a/src/surface.c
+++ b/src/surface.c
@@ -937,7 +937,7 @@ GMT_LOCAL int surface_write_grid (struct GMT_CTRL *GMT, struct SURFACE_CTRL *Ctr
 	char *limit[2] = {"lower", "upper"};
 	gmt_grdfloat *u = C->Grid->data;
 
-	if (!Ctrl->Q.active) {	/* Probably need to shrink region to the desired one by increasing the pads */
+	if (!Ctrl->Q.active && Ctrl->Q.adjusted) {	/* Probably need to shrink region to the desired one by increasing the pads */
 		int del_pad[4] = {0, 0, 0, 0}, k, n = 0;
 		struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (C->Grid->header);
 		/* Determine the shifts inwards for each side */


### PR DESCRIPTION
The **surface** output code failed to detect that no different **-R** was used, yet it went in there and then changed the pad.  Then the section for **-rp** got involved and changed it further (one too much). This seems to have been a relatively recent modification that probably did not get tested properly.

This simple fix addresses the initial concern and has no negative effect on any of our tests. Closes #7132.

With this fix, this sequence of commands yields the correct plot below:

```
gmt blockmedian Site01_scatInterp_v1_final_adj.xyzi -bi4 -R-19/-3/-20/-4 -I0.005 -C -bo3 -r | gmt surface -r -bi3 -R-19/-3/-20/-4 -I0.005 -T0.75 -Gtmp.grd -C0.001 -Ll-11 -Lu11 
gmt grdimage tmp.grd -I+d -B -png map
```

![t2](https://user-images.githubusercontent.com/26473567/211027816-eefcbc4c-c09f-4ca0-b380-3bea739a29b0.png)
