### PR TITLE
Be clear on directive versus modifier

### DIFF
--- a/doc/rst/source/explain_-B.rst_
+++ b/doc/rst/source/explain_-B.rst_
@@ -26,8 +26,8 @@ The Frame settings are specified by
    **-B**\ [*axes*][**+b**][**+g**\ *fill*][**+i**\ [*val*]][**+n**][**+o**\ *lon/lat*][**+s**\ *subtitle*]\
    [**+t**\ *title*][**+w**\ [*pen*]][**+x**\ *fill*][**+y**\ *fill*][**+z**\ *fill*]
 
-The frame setting is optional but can be invoked once to override the defaults. The following modifiers can be appended
-to **-B** to control the Frame settings:
+The frame setting is optional but can be invoked once to override the defaults. The following directives and modifiers
+can be appended to **-B** to control the Frame settings:
 
 - *axes* to set which of the axes should be drawn and possibly annotated using a combination of the codes listed
   below [default is :doc:`theme dependent </theme-settings>`]. Borders omitted from the set of codes will not be drawn.
@@ -99,7 +99,7 @@ but you may also split this into two separate invocations for clarity, i.e.,
      [**+l**\|\ **L**\ *label*][**+p**\ *prefix*][**+s**\|\ **S**\ *seclabel*][**+u**\ *unit*]
    | **-B**\ [**p**\|\ **s**][**x**\|\ **y**\|\ **z**]\ *intervals*
 
-The following modifiers can be appended to **-B** to control the Axes settings:
+The following directives and modifiers can be appended to **-B** to control the Axes settings:
 
 - **p**\|\ **s** to set whether the modifiers apply to the **p**\ (rimary) or **s**\ (econdary) axes [Default is **p**].
   These settings are mostly used for time axes annotations but are available for geographic axes as well. **Note**:

--- a/doc/rst/source/explain_-U.rst_
+++ b/doc/rst/source/explain_-U.rst_
@@ -10,7 +10,7 @@ The **-U** option
 
 **Description**
 
-The **-U** option draws the GMT system time stamp on the plot. The following modifiers are supported:
+The **-U** option draws the GMT system time stamp on the plot. The following argument and modifiers are supported:
 
 - *label* to append the text string given in *label* (which must be surrounded by double quotes if it contains spaces).
 - **+c** to plot the current command string.

--- a/doc/rst/source/explain_-XY.rst_
+++ b/doc/rst/source/explain_-XY.rst_
@@ -18,7 +18,7 @@ The **-X** **-Y** options
 The **-X** and **-Y** options shift the plot origin relative to the current origin by (*xshift*,\ *yshift*). Optionally,
 append the length unit (**c**, **i**, or **p**). Default is (:term:`MAP_ORIGIN_X`, :term:`MAP_ORIGIN_Y`) for new
 plots, which ensures that boundary annotations fit on the page. Subsequent overlays will be co-registered with the
-previous plot unless the origin is shifted using these options. The following modifiers are supported
+previous plot unless the origin is shifted using these options. The following directives are supported
 [default is **r**]:
 
 - Prepend **a** to shift the origin back to the original position after plotting.


### PR DESCRIPTION
In GMT option lingo, a directive is whatever value, word, or letter that follow the option letter, while modifier is something that starts with a plus-sign, has a letter code, and then it may take optional arguments as well.  We had a few sections where we used the word modifier even though we referred to directives.
