### PR TITLE
Clean up docs for grdtrack

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -240,7 +240,8 @@ Optional Arguments
     (**+a**), followed by deviations (**+d**) and finally residuals (**+r**);
     actual output depends on which of these modifiers were actually used.
     When more than one grid is sampled this sequence of 1-3 columns is
-    repeated for each grid.
+    repeated for each grid. (3) See Illustration Gallery 33 for an example
+    of grid profile stacking.
 
 .. _-T:
 

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -66,7 +66,9 @@ Required Arguments
 *table*
     This is an ASCII (or binary, see **-bi**) file where the first 2 columns
     hold the (x,y) positions where the user wants to sample the 2-D data set.
-    If no tables are given then we read from standard input, unless |-E| is set.
+    If no tables are given then we read from standard input. If |-E| is set
+    then no input table is read since we will create one from the given
+    |-E| parameters.
 
 .. _-G:
 
@@ -112,7 +114,7 @@ Optional Arguments
 **-C**\ *length*/\ *ds*\ [*/spacing*][**+a**\|\ **v**][**d**\|\ **f**\ *value*][**l**\|\ **r**]
     Use input line segments to create an equidistant and (optionally)
     equally-spaced set of crossing profiles along which we sample the
-    grid(s) [Default simply samples the grid(s) at the input locations].
+    grid(s).
     Specify two length scales that control how the sampling is done:
     *length* sets the full length of each cross-profile, while *ds* is
     the sampling spacing along each cross-profile. Optionally, append
@@ -121,7 +123,7 @@ Optional Arguments
     for how resampling the input track is controlled. By
     default, all cross-profiles have the same direction (left to right
     as we look in the direction of the input line segment). Append **+a**
-    to alternate the direction of cross-profiles, or **v** to enforce
+    to alternate the direction of cross-profiles, or **+v** to enforce
     either a "west-to-east" or "south-to-north" view. By default the entire
     profiles are output.  Choose to only output the left or right halves
     of the profiles by appending **+l** or **+r**, respectively.  Append suitable units
@@ -169,12 +171,12 @@ Optional Arguments
     this option requires either **+n** or **+i**.  The **+n**\ *np* modifier sets
     the desired number of points, while **+l**\ *length* gives the
     total length of the profile. Append **+d** to output the along-track
-    distances after the coordinates.  **Note**: No track file will be read.
+    distances after the coordinates.  **Notes**: (1) No track file will be read.
     Also note that only one distance unit can be chosen.  Giving different units
     will result in an error.  If no units are specified we default to
     great circle distances in km (if geographic).  If working with geographic
     data you can use **-j** to control distance calculation mode [Great Circle].
-    **Note**: If |-C| is set and *spacing* is given the that sampling scheme
+    (2) If |-C| is set and *spacing* is given the that sampling scheme
     overrules any modifier set in |-E|.
 
 .. _-F:
@@ -190,7 +192,7 @@ Optional Arguments
     of that distance.  When searching for the center peak and the extreme first and last
     values that exceed the threshold we assume the profile is positive up.  If we instead
     are looking for a trough then you must use **+n** to temporarily flip the profile to
-    positive. The threshold *z0* value is always given as >= 0; use **+z** to change it [0].
+    positive (internally). The threshold *z0* value is always given as >= 0; use **+z** to change it [0].
     Alternatively, use **+b** to determine the balance point and standard deviation of the
     profile; this is the weighted mean and weighted standard deviation of the distances,
     with *z* acting as the weight. Finally, use **+r** to obtain the weighted rms about the
@@ -213,7 +215,7 @@ Optional Arguments
 
 **-S**\ *method*/*modifiers*
     In conjunction with |-C|, compute a single stacked profile from
-    all profiles across each segment. Append how stacking should be
+    all profiles across each segment. Append a method for how stacking should be
     computed: **a** = mean (average), **m** = median, **p** = mode
     (maximum likelihood), **l** = lower, **L** = lower but only consider
     positive values, **u** = upper, **U** = upper but only consider
@@ -223,18 +225,20 @@ Optional Arguments
     all cross-profiles. **+r** : Append data residuals (data - stack) to
     all cross-profiles. **+s**\ [*file*] : Save stacked profile to
     *file* [grdtrack_stacked_profile.txt]. **+c**\ *fact* : Compute
-    envelope on stacked profile as ±\ *fact* \*\ *deviation* [2].
-    Notes: (1) Deviations depend on *method* and are st.dev (**a**), L1
-    scale, i.e., 1.4826 \* median absolute deviation (MAD) (for **m** and **p**), or half-range (upper-lower)/2. (2) The
+    uncertainty envelope on stacked profile as ±\ *fact* \*\ *deviation* [2].
+    **Notes**: (1) Deviations depend on *method* and are standard deviation (**a**), L1
+    scale, i.e., 1.4826 \* median absolute deviation (MAD) (for **m** and **p**),
+    or half-range (upper-lower)/2 (for **l**, **L**, **u** and **U**). (2) The
     stacked profile file contains a leading column plus groups of 4-6 columns, with one
     group for each sampled grid. The leading column holds cross distance,
     while the first four columns in a group hold stacked value, deviation, min
     value, and max value, respectively. If *method* is one of
-    **a**\|\ **m**\|\ **p** then we also write the lower and upper
+    **a**\|\ **m**\|\ **p** then we also write two additional columns: the lower and upper
     confidence bounds (see **+c**). When one or more of **+a**, **+d**,
     and **+r** are used then we also append the stacking results to the end of each
     row, for all cross-profiles. The order is always stacked value
-    (**+a**), followed by deviations (**+d**) and finally residuals (**+r**).
+    (**+a**), followed by deviations (**+d**) and finally residuals (**+r**);
+    actual output depends on which of these modifiers were actually used.
     When more than one grid is sampled this sequence of 1-3 columns is
     repeated for each grid.
 

--- a/doc/rst/source/module_core_purpose.rst_
+++ b/doc/rst/source/module_core_purpose.rst_
@@ -114,7 +114,7 @@
 
 .. |grdselect_purpose| replace:: Make selections or determine common regions from 2-D grids, images or 3-D cubes
 
-.. |grdtrack_purpose| replace:: Sample grids at specified (x,y) locations
+.. |grdtrack_purpose| replace:: Sample one or more grids at specified locations
 
 .. |grdtrend_purpose| replace:: Fit trend surface to grids and compute residuals
 

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -32,7 +32,7 @@
 #define THIS_MODULE_CLASSIC_NAME	"grdtrack"
 #define THIS_MODULE_MODERN_NAME	"grdtrack"
 #define THIS_MODULE_LIB		"core"
-#define THIS_MODULE_PURPOSE	"Sample grids at specified (x,y) locations"
+#define THIS_MODULE_PURPOSE	"Sample one or more grids at specified locations"
 #define THIS_MODULE_KEYS	"<D{,DD),E-<,GG(,>D},SD)=s"
 #define THIS_MODULE_NEEDS	""
 #define THIS_MODULE_OPTIONS "-:>RVabdefghijnoqsw" GMT_OPT("HMmQ")
@@ -537,6 +537,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDTRACK_CTRL *Ctrl, struct GMT_O
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->C.mode & GMT_LEFT_ONLY && Ctrl->C.mode & GMT_RIGHT_ONLY, "Option -C: Cannot chose both +l and +r modifiers.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->F.active && !Ctrl->C.active, "Option -F: Requires -C.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->F.active && ng > 1, "Option -F: Can only accept a single grid.\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->F.active && Ctrl->F.z0 < 0.0, "Option -F: z0 must be zero or positive (see +n if looking for troughs).\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && !Ctrl->C.active, "Option -S: Requires -C.\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && !(Ctrl->S.selected[STACK_ADD_VAL] || Ctrl->S.selected[STACK_ADD_DEV] ||
 	                                   Ctrl->S.selected[STACK_ADD_RES] || Ctrl->S.selected[STACK_ADD_TBL]),


### PR DESCRIPTION
Apart from fixing minor typos and clarify some of the options for **grdtrack**, we impose a check on the positivity of **-F+z**_z0_ which was not implemented despite the documentation saying so. No effect on any tests etc.