### PR TITLE
Let GMT determine position for text in example 33

### DIFF
--- a/doc/examples/ex33/ex33.bat
+++ b/doc/examples/ex33/ex33.bat
@@ -24,7 +24,7 @@ gmt begin ex33
 	gmt convert stack.txt -o0,6 -I -T >> env.txt
 	gmt plot -R-200/200/-3500/-2000 -JX6i/3i -Glightgray env.txt -Yh+3c
 	gmt plot -W3p stack.txt -Bxafg1000+l"Distance from ridge (km)" -Byaf+l"Depth (m)" -BWSne
-	echo 0 -2000 MEDIAN STACKED PROFILE | gmt text -Gwhite -F+jTC+f14p -Dj8p
+	echo MEDIAN STACKED PROFILE | gmt text -Gwhite -F+cTC+f14p -Dj8p
 	REM cleanup
 	del ridge.txt table.txt env.txt stack.txt
 gmt end show

--- a/doc/examples/ex33/ex33.sh
+++ b/doc/examples/ex33/ex33.sh
@@ -25,7 +25,7 @@ gmt begin ex33
 	# Show upper/lower 2-sigma confidence bounds encountered as an envelope
 	gmt plot -R-200/200/-3500/-2000 -JX15c/7.5c -W3p stack.txt -i0,1,5,6 -L+b -Glightgray -Yh+3c
 	gmt basemap  -Bxafg1000+l"Distance from ridge (km)" -Byaf+l"Depth (m)" -BWSne
-	echo "0 -2000 MEDIAN STACKED PROFILE" | gmt text -Gwhite -F+jTC+f14p -Dj8p
+	echo "MEDIAN STACKED PROFILE" | gmt text -Gwhite -F+cTC+f14p -Dj8p
 	# cleanup
 	rm -f ridge.txt table.txt stack.txt spac_33.nc
 gmt end show


### PR DESCRIPTION
In example 33, we are placing a title inside the box but we are hardwiring the coordinate values instead of relying on **text -F+cTC** to simplify things and avoid problems if the domain ever changed.  The _PostScript_ plot stays the same.
