### PR TITLE
Cookbook 3.22 fixed typos

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1705,7 +1705,7 @@ GMT strings using the Standard+ encoding:
 | ``10@+-3 @Angstr@om`` = 10\ :math:`^{-3}` Ångstrøm
 | ``Stresses are @~s@~@+*@+@-xx@- MPa`` = Stresses are :math:`\sigma^{*}_{xx}` MPa
 | ``Se@nor Gar@con`` = Señor Garçon
-| ``M@!\305anoa stra@se`` = Manoa straße
+| ``M@!\305anoa Stra@se`` = Mānoa Straße
 | ``A@#cceleration@# (ms@+-2@+)`` = ACCELERATION (ms\ :math:`^{-2}`)
 
 The option in :doc:`/text` to draw a


### PR DESCRIPTION
**Description of proposed changes**

Fixes depiction of `@!\305a` from undecorated small letter _a_ to _ā_ (small letter _a_ with macron) and changes _straße_ to _Straße_:

**current**

`M@!\305anoa stra@se` = Manoa straße

**new**

`M@!\305anoa Stra@se` = Mānoa Straße

See #7203 for context.

Fixes #7203 