### PR TITLE
Added the missing semi-/colon to @;color; and @:size: in text documentation

### DIFF
--- a/doc/rst/source/text.rst
+++ b/doc/rst/source/text.rst
@@ -70,9 +70,9 @@ caps are supported as follows:
      - Toggles superscript on/off
    * - @#
      - Toggles small caps on/off
-   * - @;\ *color*
+   * - @;\ *color*\ ;
      - Changes the font color (@;; resets it)
-   * - @:\ *size*
+   * - @:\ *size*\ :
      - Changes the font size (@:: resets it)
    * - @\_
      - Toggles underline on/off


### PR DESCRIPTION
**Description of proposed changes**

The `text` module documentation missed a semicolon and a colon for @;color; and @:size: in the escape sequences table. 

Fixes #7205 