### PR TITLE
Changed link of online reStructuredText editor to a working one

### DIFF
--- a/doc/rst/source/devdocs/rst-cheatsheet.rst
+++ b/doc/rst/source/devdocs/rst-cheatsheet.rst
@@ -10,7 +10,7 @@ You can see the literal source code of the ReST file on the right,
 and the rendered web page on the left.
 
 .. note::
-    Try a online reStructuredText editor (e.g. https://livesphinx.herokuapp.com/),
+    Try a online reStructuredText editor (e.g. https://www.notex.ch/editor),
     if you want to preview texts written in ReST.
 
     For a more complete description of ReST syntax, please visit


### PR DESCRIPTION
**Description of proposed changes**

The reStructuredText online editor (https://livesphinx.herokuapp.com) given in the [ReST Cheat Sheet](https://docs.generic-mapping-tools.org/dev/devdocs/rst-cheatsheet.html) seems to be no longer available as it generates a 503 - service unavailable error. Therefore I propose to replace the link with 

https://www.notex.ch/editor

I have no connection/affiliation with that service, I just found it useful. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #7211 