### PR TITLE
Simplify inline function scale_and_offset_f

### DIFF
--- a/src/gmt_grdio.h
+++ b/src/gmt_grdio.h
@@ -169,7 +169,7 @@ static inline void scale_and_offset_f (gmt_grdfloat *data, size_t length, gmt_gr
 			data[n] += offset;
 	}
 	else if (offset == 0) { /* scale only */
-		for (n = 0; n < L; ++n)
+		for (n = 0; n < length; ++n)
 			data[n] *= scale;
 	}
 	else { /* scale + offset */

--- a/src/gmt_grdio.h
+++ b/src/gmt_grdio.h
@@ -135,60 +135,47 @@ struct GMT_GRID_ROWBYROW {
 #undef I /* Because otherwise we are in trouble with, e.g., struct GMT_IMAGE *I */
 #endif
 
-/*! Routine that scales and offsets the data in a vector */
+/*! Inline routine that scales and/or offsets the data in a vector */
 static inline void scale_and_offset_f (gmt_grdfloat *data, size_t length, gmt_grdfloat scale, gmt_grdfloat offset) {
-	/*  data:   Single-precision real input vector
-	 *  length: The number of elements to process
-	 * This function uses the vDSP portion of the Accelerate framework if possible
-	 * However, due to strange errors for extremely long (>32-bit) arrays I drop back to manual until we know more. */
-#ifndef __APPLE__
-	size_t n;
-#endif
+	/*  data:   gmt_grdfloat (single or double) precision real input vector
+	 *  length: size_t number of elements to process
+	 *	scale:	gmt_grdfloat number to multiply each element of data
+	 *	offset:	gmt_grdfloat number to add to each scaled element of data
+	 */
+#ifdef __APPLE__ /*	We can take advantage of the Accelerate framework on macOS */
+	/* Must use different vDSP functions depending on size of grid type gmt_grdfloat */
 	if (scale == 1) /* offset only */
-#ifdef __APPLE__ /* Accelerate framework */
-		if (length > INT_MAX) { /* Bypass vDSP for > 32-bit signed lengths for now */
-			for (size_t n = 0; n < length; ++n) data[n] += offset;
-		}
-		else
-#ifdef DOUBLE_PRECISION_GRID
-			vDSP_vsaddD (data, 1, &offset, data, 1, length);
-#else
-			vDSP_vsadd (data, 1, &offset, data, 1, length);
-#endif
-#else
+		#ifdef DOUBLE_PRECISION_GRID
+		vDSP_vsaddD (data, 1L, &offset, data, 1L, length);
+		#else
+		vDSP_vsadd (data, 1L, &offset, data, 1L, length);
+		#endif
+	else if (offset == 0) /* scale only */
+		#ifdef DOUBLE_PRECISION_GRID
+		vDSP_vsmulD (data, 1L, &scale, data, 1L, length);
+		#else
+		vDSP_vsmul (data, 1L, &scale, data, 1L, length);
+		#endif
+	else /* scale + offset */
+		#ifdef DOUBLE_PRECISION_GRID
+		vDSP_vsmsaD (data, 1L, &scale, &offset, data, 1L, length);
+		#else
+		vDSP_vsmsa (data, 1L, &scale, &offset, data, 1L, length);
+		#endif
+#else	/* Anything but Apple */
+	size_t n;
+	if (scale == 1) { /* offset only */
 		for (n = 0; n < length; ++n)
 			data[n] += offset;
-#endif
-	else if (offset == 0) /* scale only */
-#ifdef __APPLE__ /* Accelerate framework */
-		if (length > INT_MAX) { /* Bypass vDSP for > 32-bit signed lengths for now */
-			fprintf (stderr, "Bypassing vDSP since L = %" PRIu64 "\n", (uint64_t)length);
-			for (size_t n = 0; n < length; ++n) data[n] *= scale;
-		}
-		else
-#ifdef DOUBLE_PRECISION_GRID
-			vDSP_vsmulD (data, 1, &scale, data, 1, length);
-#else
-			vDSP_vsmul (data, 1, &scale, data, 1, length);
-#endif
-#else
-		for (n = 0; n < length; ++n)
+	}
+	else if (offset == 0) { /* scale only */
+		for (n = 0; n < L; ++n)
 			data[n] *= scale;
-#endif
-	else /* scale + offset */
-#ifdef __APPLE__ /* Accelerate framework */
-		if (length > INT_MAX) { /* Bypass vDSP for > 32-bit signed lengths for now */
-			for (size_t n = 0; n < length; ++n) data[n] = data[n] * scale + offset;
-		}
-		else
-#ifdef DOUBLE_PRECISION_GRID
-			vDSP_vsmsaD (data, 1, &scale, &offset, data, 1, length);
-#else
-			vDSP_vsmsa (data, 1, &scale, &offset, data, 1, length);
-#endif
-#else
+	}
+	else { /* scale + offset */
 		for (n = 0; n < length; ++n)
 			data[n] = data[n] * scale + offset;
+	}
 #endif
 }
 


### PR DESCRIPTION
The original **inline** function _scale_and_offset_f_ in _gmt_grdio.h_ has seemingly worked well, but once the grid array length exceeded 32-bit or so I would get strange crashes in the vDSP_ functions used on macOS.  The crash was not reproducible with a tiny simple program that allocated a large array and then called _vDSP_vsmul_. However, our inline function was full of various `#ifdef` branches for Apple versus any other OS plus further checks for single versus double precision arguments.  I can only guess that some confusion happened as the only clue I get in the Xcode debugger is that the crash happened inside _vDSP_vsmul_ when calling a lower level function that expected a **double precision** array!  How that is possible remains a mystery.

This PR breaks up _scale_and_offset_f_ into two very different and separate chunks: One just for Apple which uses those vDSP functions and the flavour of them depends on size of _gmt_grdfloat_, while the `#else` branch has clean and simple loops over the data.

With this change I no longer get the crashes and can write grids large grids.  Running the standard tests shows no difference. As for Windows and Linux there should be no change at all, just different packaging.
