### PR TITLE
Allow format flags F and G in FORMAT_GEO_MAP to come first or last

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -292,6 +292,8 @@ FORMAT Parameters
         **G**      Same as **F** but with a leading space before suffix
         ========   =================================================================
 
+        **Note**: **F** and **G** can either be the first or last character in the template.
+
     **FORMAT_FLOAT_MAP**
         Format (C language printf syntax, see :term:`FORMAT_FLOAT_OUT`) to be used when plotting double
         precision floating point numbers along plot frames and contours [default is **%.12g**].

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -288,11 +288,11 @@ FORMAT Parameters
         **mm**     Fixed format integer arc minutes
         **ss**     Fixed format integer arc seconds
         **.xxx**   Floating fraction of previous integer field, fixed width
-        **F**      Encode sign using WESN suffix or prefix
-        **G**      As **F** but with a leading space before suffix or after prefix
+        **F**      Encode sign using WESN suffix
+        **G**      Same as **F** but with a leading space before suffix
         ========   =================================================================
 
-        **Note**: If used, **F** and **G** must be the first or last character in the template.
+        **Note**: With :term:`FORMAT_GEO_MAP`, **F** and **G** may also be used as a prefix.
 
     **FORMAT_FLOAT_MAP**
         Format (C language printf syntax, see :term:`FORMAT_FLOAT_OUT`) to be used when plotting double

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -288,11 +288,11 @@ FORMAT Parameters
         **mm**     Fixed format integer arc minutes
         **ss**     Fixed format integer arc seconds
         **.xxx**   Floating fraction of previous integer field, fixed width
-        **F**      Encode sign using WESN suffix
-        **G**      Same as **F** but with a leading space before suffix
+        **F**      Encode sign using WESN suffix or prefix
+        **G**      As **F** but with a leading space before suffix or after prefix
         ========   =================================================================
 
-        **Note**: **F** and **G** can either be the first or last character in the template.
+        **Note**: If used, **F** and **G** must be the first or last character in the template.
 
     **FORMAT_FLOAT_MAP**
         Format (C language printf syntax, see :term:`FORMAT_FLOAT_OUT`) to be used when plotting double

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10574,6 +10574,12 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 			gmt_M_compat_translate ("FORMAT_GEO_OUT");
 			break;
 		case GMTCASE_FORMAT_GEO_OUT:
+			if (value[len-1] == 'G')
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "FORMAT_GEO_OUT = %s will produce GMT-incompatible text files\n", value);
+#if 0		/* Remove this if-endif when gmtio_format_geo_output can write leading hemisphere letters */
+			if (strchr ("FG", value[0]))	/* Leading W|E|S|N in data output produce a format that cannot be read back into GMT */
+				GMT_Report (GMT->parent, GMT_MSG_WARNING, "FORMAT_GEO_OUT = %s will produce GMT-incompatible text files\n", value);
+#endif
 			strncpy (GMT->current.setting.format_geo_out, value, GMT_LEN64-1);
 			error = gmtlib_geo_C_format (GMT);	/* Can fail if FORMAT_FLOAT_OUT not yet set, but is repeated at the end of gmt_begin */
 			break;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -2109,13 +2109,14 @@ GMT_LOCAL int gmtio_get_dms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 	 */
 
 	unsigned int j, n_d, n_m, n_s, n_x, n_dec, n_period, order, error = 0;
+	unsigned int n_F, n_G, n_DD;
 	int sequence[3], last, i_signed, n_delim;
 	size_t i1, i;
 	bool big_to_small;
 
 	for (i = 0; i < 3; i++) S->order[i] = GMT_NOTSET;	/* Meaning not encountered yet */
 
-	n_d = n_m = n_s = n_x = n_dec = n_delim = n_period = 0;
+	n_d = n_m = n_s = n_x = n_F = n_G = n_DD = n_dec = n_delim = n_period = 0;
 	S->delimiter[0][0] = S->delimiter[0][1] = S->delimiter[1][0] = S->delimiter[1][1] = 0;
 	sequence[0] = sequence[1] = sequence[2] = GMT_NOTSET;
 
@@ -2137,14 +2138,17 @@ GMT_LOCAL int gmtio_get_dms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 			case 'D':	/* Want to use decimal degrees using FORMAT_FLOAT_OUT [Default] */
 				S->decimal = true;
 				if (i > 1) error++;		/* Only valid as first or second flag */
+				n_DD++;
 				break;
 			case 'F':	/* Want to use WESN to encode sign */
 				S->wesn = (i == 0) ? -1 : 1;
 				if (S->no_sign) error++;		/* Cannot mix A and F */
+				n_F++;
 				break;
 			case 'G':	/* Want to use WESN to encode sign but have leading space */
 				S->wesn = (i == 0) ? -2 : 2;
 				if (S->no_sign) error++;		/* Cannot mix A and G */
+				n_G++;
 				break;
 			case 'A':	/* Want no sign in plot string */
 				S->no_sign = true;
@@ -2219,6 +2223,9 @@ GMT_LOCAL int gmtio_get_dms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 	error += (n_x && n_dec != 1);			/* .xxx is the proper form */
 	error += (n_x == 0 && n_dec);			/* Period by itself and not delimiter? */
 	error += (n_dec > 1);				/* Only one period with xxx */
+	error += (n_DD > 1);				/* Only one occurrence of D */
+	error += ((n_F > 1) || (n_G > 1));		/* Only one occurrence of F or G */
+	error += ((n_G + n_F) > 1);				/* Only one of either F or G */
 	S->n_sec_decimals = n_x;
 	S->f_sec_to_int = rint (pow (10.0, (double)S->n_sec_decimals));			/* To scale fractional seconds to an integer form */
 	if (error) {

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -2140,11 +2140,11 @@ GMT_LOCAL int gmtio_get_dms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 				break;
 			case 'F':	/* Want to use WESN to encode sign */
 				S->wesn = (i == 0) ? -1 : 1;
-				if (i != i1 || S->no_sign) error++;		/* Only valid as last flag */
+				if (S->no_sign) error++;		/* Cannot mix A and F */
 				break;
 			case 'G':	/* Want to use WESN to encode sign but have leading space */
 				S->wesn = (i == 0) ? -2 : 2;
-				if (i != i1 || S->no_sign) error++;		/* Only valid as last flag */
+				if (S->no_sign) error++;		/* Cannot mix A and G */
 				break;
 			case 'A':	/* Want no sign in plot string */
 				S->no_sign = true;
@@ -7045,11 +7045,6 @@ int gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 
 		/* Level 0: degrees only. index 0 is integer degrees, index 1 is [possibly] fractional degrees */
 
-		/* First start with %s for the [W,E,S,N][leading space] char (or NULL) */
-
-		for (i = 0; i < 3; i++) for (j = 0; j < 2; j++) {
-			strncpy (GMT->current.plot.format[i][j], "%s", GMT_LEN64);
-		}
 		strcat (GMT->current.plot.format[0][0], "%d");		/* ddd */
 		if (S->order[1] == GMT_NOTSET && S->n_sec_decimals > 0) { /* ddd.xxx format */
 			snprintf (fmt, GMT_LEN256, "%%d.%%%d.%dd", S->n_sec_decimals, S->n_sec_decimals);

--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -197,7 +197,8 @@ struct GMT_GEO_IO {			/* For geographic output and plotting */
 	double f_sec_to_int;		/* Scale to convert 0.xxx seconds to integer xxx (used for formatting) */
 	unsigned int n_sec_decimals;	/* Number of digits in decimal seconds (0 for whole seconds) */
 	unsigned int range;		/* 0 for 0/360, 1 for -360/0, 2 for -180/+180 */
-	unsigned int wesn;		/* 1 if we want sign encoded with suffix W, E, S, N, 2 if also want space before letter */
+	int wesn;				/* 1 if we want sign encoded with suffix W, E, S, N, 2 if also want space before letter.
+							   If negative -1 or -2 we place the suffix before the annotation and -2 with a space after. */
 	int order[3];			/* The relative order of degree, minute, seconds in form (-ve if unused) */
 	bool decimal;			/* true if we want to use the FORMAT_FLOAT_OUT for decimal degrees only */
 	bool no_sign;			/* true if we want absolute values (plot only) */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15539,7 +15539,7 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 	int sign, d, m, s, m_sec;
 	unsigned int k, n_items, level, type;
 	bool zero_fix = false, lat_special = (lonlat == 3), deg_special = (lonlat == 4);
-	char hemi[GMT_LEN16] = {""};
+	char hemi_pre[GMT_LEN16] = {""}, hemi_post[GMT_LEN16] = {""};
 
 	/* Must override do_minutes and/or do_seconds if format uses decimal notation for that item */
 
@@ -15560,35 +15560,38 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 			val = 0.0;
 	}
 
-	if (GMT->current.plot.calclock.geo.wesn) {
-		if (GMT->current.plot.calclock.geo.wesn == 2) strcat (hemi, " ");
+	if (GMT->current.plot.calclock.geo.wesn) {	/* Either -2, -1, +1, +2 */
+		bool post = (GMT->current.plot.calclock.geo.wesn > 0);	/* Place hemisphere string after numbers */
+		if (GMT->current.plot.calclock.geo.wesn == 2) strcat (hemi_post, " ");
 		if (!do_hemi || gmt_M_is_zero (val)) { /* Skip adding hemisphere indication */
 		}
-		else if (lonlat == 0) {
+		else if (lonlat == 0) {	/* Longitudes */
 			switch (GMT->current.plot.calclock.geo.range) {
 				case GMT_IS_0_TO_P360_RANGE:
 				case GMT_IS_0_TO_P360:
-					strcat (hemi, GMT->current.language.cardinal_name[1][1]);
+					strcat (post ? hemi_post : hemi_pre, GMT->current.language.cardinal_name[1][1]);
 					break;
 				case GMT_IS_M360_TO_0_RANGE:
 				case GMT_IS_M360_TO_0:
-					strcat (hemi, GMT->current.language.cardinal_name[2][1]);
+					strcat (post ? hemi_post : hemi_pre, GMT->current.language.cardinal_name[2][1]);
 					break;
 				default:
-					if (!(doubleAlmostEqual (val, 180.0) || doubleAlmostEqual (val, -180.0))) strcat (hemi, (val < 0.0) ? GMT->current.language.cardinal_name[1][0] : GMT->current.language.cardinal_name[1][1]);
+					if (!(doubleAlmostEqual (val, 180.0) || doubleAlmostEqual (val, -180.0))) strcat (post ? hemi_post : hemi_pre, (val < 0.0) ? GMT->current.language.cardinal_name[1][0] : GMT->current.language.cardinal_name[1][1]);
 					break;
 			}
 		}
-		else
-			strcat (hemi, (val < 0.0) ? GMT->current.language.cardinal_name[2][2] : GMT->current.language.cardinal_name[2][3]);
+		else	/* Latitudes */
+			strcat (post ? hemi_post : hemi_pre, (val < 0.0) ? GMT->current.language.cardinal_name[2][2] : GMT->current.language.cardinal_name[2][3]);
 
+		if (GMT->current.plot.calclock.geo.wesn == -2) strcat (hemi_pre, " ");
 		if (!deg_special) {
 			val = fabs (val);
-			if (hemi[0] == ' ' && hemi[1] == 0) hemi[0] = 0;	/* No space if no hemisphere indication */
+			if (hemi_post[0] == ' ' && hemi_post[1] == 0) hemi_post[0] = 0;	/* No space if no hemisphere indication */
+			if (hemi_pre[0]  == ' ' && hemi_pre[1]  == 0) hemi_pre[0]  = 0;	/* No space if no hemisphere indication */
 		}
 	}
 	if (deg_special)
-		hemi[0] = 0;
+		hemi_pre[0] = hemi_post[0] = 0;
 	else if (GMT->current.plot.calclock.geo.no_sign)
 		val = fabs (val);
 	sign = (val < 0.0) ? -1 : 1;
@@ -15599,7 +15602,7 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 	if (!(lat_special || deg_special) && GMT->current.plot.r_theta_annot && lonlat)	/* Special check for the r in r-theta [set via -Jp|P +fe modifier] */
 		gmt_sprintf_float (GMT, label, GMT->current.setting.format_float_map, val);
 	else if (GMT->current.plot.calclock.geo.decimal)
-		sprintf (label, GMT->current.plot.calclock.geo.x_format, val, hemi);
+		sprintf (label, GMT->current.plot.calclock.geo.x_format, val, hemi_post);
 	else {
 		(void) gmtlib_geo_to_dms (val, n_items, GMT->current.plot.calclock.geo.f_sec_to_int, &d, &m, &s, &m_sec);	/* Break up into d, m, s, and remainder */
 		if (d == 0 && sign == -1) {	/* Must write out -0 degrees, do so by writing -1 and change 1 to 0 */
@@ -15608,22 +15611,22 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 		}
 		switch (2*level+type) {
 			case 0:
-				sprintf (label, GMT->current.plot.format[level][type], d, hemi);
+				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, hemi_post);
 				break;
 			case 1:
-				sprintf (label, GMT->current.plot.format[level][type], d, m_sec, hemi);
+				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m_sec, hemi_post);
 				break;
 			case 2:
-				sprintf (label, GMT->current.plot.format[level][type], d, m, hemi);
+				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m, hemi_post);
 				break;
 			case 3:
-				sprintf (label, GMT->current.plot.format[level][type], d, m, m_sec, hemi);
+				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m, m_sec, hemi_post);
 				break;
 			case 4:
-				sprintf (label, GMT->current.plot.format[level][type], d, m, s, hemi);
+				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m, s, hemi_post);
 				break;
 			case 5:
-				sprintf (label, GMT->current.plot.format[level][type], d, m, s, m_sec, hemi);
+				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m, s, m_sec, hemi_post);
 				break;
 		}
 		if (zero_fix) label[1] = '0';	/* Undo the fix above */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15539,7 +15539,7 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 	int sign, d, m, s, m_sec;
 	unsigned int k, n_items, level, type;
 	bool zero_fix = false, lat_special = (lonlat == 3), deg_special = (lonlat == 4);
-	char hemi_pre[GMT_LEN16] = {""}, hemi_post[GMT_LEN16] = {""};
+	char hemi_pre[GMT_LEN16] = {""}, hemi_post[GMT_LEN16] = {""}, text[GMT_LEN64] = {""};
 
 	/* Must override do_minutes and/or do_seconds if format uses decimal notation for that item */
 
@@ -15598,7 +15598,7 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 
 	level = do_minutes + do_seconds;		/* 0, 1, or 2 */
 	type = (GMT->current.plot.calclock.geo.n_sec_decimals > 0) ? 1 : 0;
-
+	label[0] = '\0';	/* Start with clean slate */
 	if (!(lat_special || deg_special) && GMT->current.plot.r_theta_annot && lonlat)	/* Special check for the r in r-theta [set via -Jp|P +fe modifier] */
 		gmt_sprintf_float (GMT, label, GMT->current.setting.format_float_map, val);
 	else if (GMT->current.plot.calclock.geo.decimal)
@@ -15609,26 +15609,28 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 			d = -1;
 			zero_fix = true;
 		}
+		if (hemi_pre[0]) strcpy (label, hemi_pre);
 		switch (2*level+type) {
 			case 0:
-				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, hemi_post);
+				sprintf (text, GMT->current.plot.format[level][type], d, hemi_post);
 				break;
 			case 1:
-				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m_sec, hemi_post);
+				sprintf (text, GMT->current.plot.format[level][type], d, m_sec, hemi_post);
 				break;
 			case 2:
-				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m, hemi_post);
+				sprintf (text, GMT->current.plot.format[level][type], d, m, hemi_post);
 				break;
 			case 3:
-				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m, m_sec, hemi_post);
+				sprintf (text, GMT->current.plot.format[level][type], d, m, m_sec, hemi_post);
 				break;
 			case 4:
-				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m, s, hemi_post);
+				sprintf (text, GMT->current.plot.format[level][type], d, m, s, hemi_post);
 				break;
 			case 5:
-				sprintf (label, hemi_pre, GMT->current.plot.format[level][type], d, m, s, m_sec, hemi_post);
+				sprintf (text, GMT->current.plot.format[level][type], d, m, s, m_sec, hemi_post);
 				break;
 		}
+		strcat (label, text);
 		if (zero_fix) label[1] = '0';	/* Undo the fix above */
 	}
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15630,8 +15630,8 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 				sprintf (text, GMT->current.plot.format[level][type], d, m, s, m_sec, hemi_post);
 				break;
 		}
+		if (zero_fix) text[1] = '0';	/* Undo the fix above */
 		strcat (label, text);
-		if (zero_fix) label[1] = '0';	/* Undo the fix above */
 	}
 
 	return;


### PR DESCRIPTION
See https://github.com/GenericMappingTools/gmt/issues/5153 for background.  This PR seeks to implement that scheme. The **FORMAT_GEO_OUT** documentation now explains that the **F** and **G** can be used with **FORMAT_GEO_MAP** as either prefix or suffix.  Seems to work but need @KristofKoch to give it a better test.  Note that it does not work with **FORMAT_GEO_OUT** since the result would be data that GMT would only recognise as text (since it starts with a letter).  If there is a need to produce data output like

```
W23:55 S19:44
E16:05 N05:15

```
then we would need to recognise the above as valid data ascii input when reading it.  Not sure if we want to go that road yet.

### Example:

`gmt basemap -R-1/1/-1/1 -JM15c -Baf -png map --FORMAT_GEO_MAP=Gddd.mm`

![map](https://user-images.githubusercontent.com/26473567/212481283-7889a510-4c1f-43a5-822c-736d69b1aa7e.png)

We should probably add a test.  I can imagine a 2x2 subplot with this example using F and G as suffix or prefix which gives 4 cases.