### PR TITLE
Use "0.25p" instead of "default" for default of pen width in supplements

### DIFF
--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -281,7 +281,7 @@ Optional Arguments
 
 **-W**\ [*pen*][**+c**\ [**f**\|\ **l**]]
     Set pen attributes for velocity arrows, ellipse circumference and
-    fault plane edges. [Defaults: width = default, color = black, style = solid].
+    fault plane edges. [Defaults: width = 0.25p, color = black, style = solid].
     If the modifier **+cl** is appended then the color of the pen are updated from the CPT (see
     |-C|). If instead modifier **+cf** is appended then the color from the cpt
     file is applied to symbol fill only [Default].  Use just **+c** to set both

--- a/doc/rst/source/supplements/mgd77/mgd77track.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77track.rst
@@ -154,7 +154,7 @@ Optional Arguments
 
 **-W**\ [*pen*]
     Append *pen* used for the trackline. [Defaults:
-    width = default, color = black, style = solid].
+    width = 0.25p, color = black, style = solid].
 
 .. |Add_-XY| replace:: |Add_-XY_links|
 .. include:: ../../explain_-XY.rst_

--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -256,7 +256,7 @@ Optional Arguments
 
 **-W**\ [*pen*] :ref:`(more ...) <-Wpen_attrib>`
     Set pen attributes for text string or default pen attributes for
-    fault plane edges. [Defaults: default,black,solid].
+    fault plane edges. [Defaults: 0.25p,black,solid].
 
 .. |Add_-XY| replace:: |Add_-XY_links|
 .. include:: ../../explain_-XY.rst_

--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -203,7 +203,7 @@ Optional Arguments
 
 **-W**\ *pen*
     Set pen attributes for all lines and the outline of symbols
-    [Defaults: default,black,solid]. This
+    [Defaults: 0.25p,black,solid]. This
     setting applies to |-A|, |-L|, |-T|, **-Fp**, **-Ft**, and
     **-Fz**, unless overruled by options to those arguments.
 

--- a/doc/rst/source/supplements/seis/polar.rst
+++ b/doc/rst/source/supplements/seis/polar.rst
@@ -183,7 +183,7 @@ Optional Arguments
 .. _-W:
 
 **-W**\ [**-**\|\ **+**][*pen*][*attr*] :ref:`(more ...) <-Wpen_attrib>`
-    Set current pen attributes [Default pen is default,black,solid].
+    Set current pen attributes [Default pen is 0.25p,black,solid].
 
 .. |Add_-XY| replace:: |Add_-XY_links|
 .. include:: ../../explain_-XY.rst_

--- a/doc/rst/source/supplements/seis/sac.rst
+++ b/doc/rst/source/supplements/seis/sac.rst
@@ -195,7 +195,7 @@ Optional Arguments
 
 **-W**\ *pen*
     Set pen attributes for all traces unless overruled by *pen* specified in *saclist*.
-    [Defaults: width = default, color = black, style = solid].
+    [Defaults: width = 0.25p, color = black, style = solid].
 
 .. |Add_-XY| replace:: |Add_-XY_links|
 .. include:: ../../explain_-XY.rst_


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to improve the `width` default for `pen` in the documentation of the supplements. It is changed from `default` to  `0.25p`. Changing this also in the supplements was unfortunately overlooked in PR #7074 - sorry!

In case it is welcome, I can change the `pen` default in "coupe.rst", "meca.rst", and "polar.rst" to the form `[Defaults: width = 0.25p, color = black, style = solid]` for the sake of consistency.

Related to
- #7074 
- #3993
- #4006 
- https://github.com/GenericMappingTools/pygmt/pull/2134

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
