### PR TITLE
Expand the duration of current leap-second interval validity

### DIFF
--- a/src/geodesy/earthtide.c
+++ b/src/geodesy/earthtide.c
@@ -118,7 +118,7 @@ GMT_LOCAL double earthtide_getutcmtai (double tsec, bool *leapflag) {
 	/*  "Julian Date Converter" */
 	/*  http://aa.usno.navy.mil/data/docs/JulianDate.php */
 	/*  or https://www.aavso.org/jd-calculator */
-	/*  parameter (MJDUPPER=59393)    !*** upper limit, leap second table, 28 June 2021 */
+	/*  parameter (MJDUPPER=60306)    !*** upper limit, leap second table, 28 December 2023 */
 	/* upper limit, leap second table, */
 	/* lower limit, leap second table, */
 	/* leap second table limit flag */
@@ -138,7 +138,7 @@ GMT_LOCAL double earthtide_getutcmtai (double tsec, bool *leapflag) {
 	}
 
 	/*  test upper table limit (upper limit set by bulletin C memos) */
-	if (mjd0t > 59393) {
+	if (mjd0t > 60306) {
 		*leapflag = true;		/* true means flag *IS* raised */
 		return -37;				/* return the upper table value */
 	}


### PR DESCRIPTION
Expanded to 28 December 2023 according to https://hpiers.obspm.fr/eoppc/bul/bulc/Leap_Second_History.dat
