### PR TITLE
Fix incorrect Van Grinten map clip path

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -8654,7 +8654,6 @@ uint64_t gmt_map_clip_path (struct GMT_CTRL *GMT, double **x, double **y, bool *
 			case GMT_AZ_EQDIST:
 			case GMT_ALBERS:
 			case GMT_ECONIC:
-			case GMT_VANGRINTEN:
 				np = (GMT->current.proj.polar && (GMT->common.R.wesn[YLO] <= -90.0 || GMT->common.R.wesn[YHI] >= 90.0)) ? GMT->current.map.n_lon_nodes + 2: 2 * (GMT->current.map.n_lon_nodes + 1);
 				break;
 			case GMT_MOLLWEIDE:
@@ -8666,6 +8665,7 @@ uint64_t gmt_map_clip_path (struct GMT_CTRL *GMT, double **x, double **y, bool *
 			case GMT_HAMMER:
 			case GMT_ECKERT4:
 			case GMT_ECKERT6:
+			case GMT_VANGRINTEN:
 				np = 2 * GMT->current.map.n_lat_nodes + 2;
 				if (GMT->common.R.wesn[YLO] != -90.0) np += GMT->current.map.n_lon_nodes - 1;
 				if (GMT->common.R.wesn[YHI] != 90.0) np += GMT->current.map.n_lon_nodes - 1;
@@ -8769,9 +8769,6 @@ uint64_t gmt_map_clip_path (struct GMT_CTRL *GMT, double **x, double **y, bool *
 			case GMT_GENPER:
 				gmtlib_genper_map_clip_path (GMT, np, work_x, work_y);
 				break;
-			case GMT_VANGRINTEN:
-				do_circle = GMT->current.map.is_world;
-				/* Intentionally fall through */
 			case GMT_LAMB_AZ_EQ:
 			case GMT_AZ_EQDIST:
 			case GMT_ORTHO:
@@ -8821,6 +8818,9 @@ uint64_t gmt_map_clip_path (struct GMT_CTRL *GMT, double **x, double **y, bool *
 					gmt_geo_to_xy (GMT, GMT->common.R.wesn[XLO], GMT->common.R.wesn[YLO] + (i-1) * GMT->current.map.dlat, &work_x[j], &work_y[j]);
 				}
 				break;
+			case GMT_VANGRINTEN:
+				//do_circle = GMT->current.map.is_world;
+				/* Intentionally fall through */
 			case GMT_HAMMER:
 			case GMT_WINKEL:
 			case GMT_ECKERT4:

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -8818,13 +8818,11 @@ uint64_t gmt_map_clip_path (struct GMT_CTRL *GMT, double **x, double **y, bool *
 					gmt_geo_to_xy (GMT, GMT->common.R.wesn[XLO], GMT->common.R.wesn[YLO] + (i-1) * GMT->current.map.dlat, &work_x[j], &work_y[j]);
 				}
 				break;
-			case GMT_VANGRINTEN:
-				//do_circle = GMT->current.map.is_world;
-				/* Intentionally fall through */
 			case GMT_HAMMER:
 			case GMT_WINKEL:
 			case GMT_ECKERT4:
 			case GMT_ECKERT6:
+			case GMT_VANGRINTEN:
 				for (i = j = 0; i <= GMT->current.map.n_lat_nodes; i++, j++) {	/* Right */
 					lat = (i == GMT->current.map.n_lat_nodes) ? GMT->common.R.wesn[YHI] : GMT->common.R.wesn[YLO] + i * GMT->current.map.dlat;
 					gmt_geo_to_xy (GMT, GMT->common.R.wesn[XHI], lat, &work_x[j], &work_y[j]);


### PR DESCRIPTION
The Van Grinten is similar to, say, Hammer, in that it has curved meridians and parallels.  However, the code had it placed with other cases who either had pole point or straight parallels, leading to stuff @KristofKoch reported in https://github.com/GenericMappingTools/gmt/issues/7282.  This PR just fixes the calculation of the map clip path - there may be other issues but tackling those next (assuming they are still there - I think so since not giving central longitude works in general OK...).

Below is from master, then from this PR.  All tests are unaffected (since not testing the central longitude).:

Master:

![bad](https://user-images.githubusercontent.com/26473567/222389746-ca3500f2-ad2f-419c-ac36-fccc5777d7e1.png)

This PR:
![good](https://user-images.githubusercontent.com/26473567/222389875-5a7eb354-9640-4aaa-bc18-34e8a2af65f5.png)
