### PR TITLE
Let -JV take optional meridian without failure

### DIFF
--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -1024,7 +1024,7 @@ EXTERN_MSC int GMT_pscoast (void *V_API, int mode, void *args) {
 	if (GMT->common.R.wesn[XLO] < 0.0 && GMT->common.R.wesn[XHI] <= 0.0) {	/* Temporarily shift boundaries */
 		GMT->common.R.wesn[XLO] += 360.0;
 		GMT->common.R.wesn[XHI] += 360.0;
-		if (GMT->current.proj.central_meridian < 0.0) GMT->current.proj.central_meridian += 360.0;
+		if (GMT->current.proj.central_meridian <= 0.0) GMT->current.proj.central_meridian += 360.0;
 	}
 	if (need_coast_base) {
 		west_border = floor (GMT->common.R.wesn[XLO] / c.bsize) * c.bsize;

--- a/test/baseline/pscoast.dvc
+++ b/test/baseline/pscoast.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1c524d4674303bd7286377847705b453.dir
-  size: 8320796
-  nfiles: 25
+- md5: 9ba83727032dff6585ad88cbbb4dae26.dir
+  size: 8681957
+  nfiles: 26
   path: pscoast

--- a/test/pscoast/pscoast_JV_set.sh
+++ b/test/pscoast/pscoast_JV_set.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Test Van der Grinten w/e/s/n map regions when setting a central meridian of 0.
+# Original problem reported in https://github.com/GenericMappingTools/gmt/issues/7282
+
+gmt begin pscoast_JV_set ps
+	gmt subplot begin 4x2 -Fs6c -M2c/2p -T"Van der Grinten Greenwich central meridian" -A+o-32p/0 -Y0.5c
+		while read minX maxX minY maxY area size
+		do
+			gmt subplot set -A${area}
+			gmt coast -R${minX}/${maxX}/${minY}/${maxY} -JV0/6c+d${size} -Bg -Dc -Glightgray -Scornsilk -A10000 -Wthinnest
+		done <<- EOF
+		-180   0   0 90 NW	h
+		0 180   0 90 NE	h
+		0 180 -90  0 SE	h
+		-180   0 -90  0 SW	h
+		-180   0 -90 90 W	h
+		-180 180   0 90 N	w	
+		0 180 -90 90 E	h
+		-180 180 -90  0 S	w
+		EOF
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
Well, at least the original troubles reported in #7282 are fixed.  The final issue appreas to have been that when the region was negative we shifted it in **coast** by 360 but unfortunately the check for doing the same to the central meridian had `<` instead of `<= `so it was left behind to cause chaos, I added another test _pscoast_JV_set.sh_ which uses a fixed Greenwich as the central meridian and those quadrants and hemispheres now work:

![pscoast_JV_set](https://user-images.githubusercontent.com/26473567/222692217-a882b793-cd84-4087-bf4e-35353543a40c.png)
