### PR TITLE
Do not allow -Xc|f in modern mode

### DIFF
--- a/doc/rst/source/explain_-XY.rst_
+++ b/doc/rst/source/explain_-XY.rst_
@@ -22,10 +22,11 @@ previous plot unless the origin is shifted using these options. The following di
 [default is **r**]:
 
 - Prepend **a** to shift the origin back to the original position after plotting.
-- Prepend **c** to center the plot on the center of the paper (optionally add a *shift*).
-- Prepend **f** to shift the origin relative to the fixed lower left.
+- Prepend **c** to center the plot on the center of the paper (optionally add a *shift*) (classic mode only).
+- Prepend **f** to shift the origin relative to the fixed lower left (classic mode only).
 - Prepend **r** to move the origin relative to its current location.
 
+**Note**: Directives **c** and **f** are only available in classic mode.
 When **-X** or **-Y** are used without any further arguments, the values from the last use of that option in a previous
 GMT command will be used. In modern mode, **-X** and **-Y** can also access the previous plot bounding box dimensions *w* and
 *h* and construct offsets that involve them.  Thus, *xshift* can in general be [[±][*f*]\ *w*\ [/\ *d*\ ]±]\ *xoff*, where optional signs, factor *f*

--- a/doc/scripts/GMT_API_use.sh
+++ b/doc/scripts/GMT_API_use.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 gmt begin GMT_API_use
 	gmt set GMT_THEME cookbook
-	gmt plot -R-4.5/4.5/-2/2 -Jx0.8i -W2p+ve0.2i+gblack+h0.5 -Xc << EOF
+	gmt plot -R-4.5/4.5/-2/2 -Jx0.8i -W2p+ve0.2i+gblack+h0.5 << EOF
 >
 -2	0.75
 -0.65	0.4

--- a/doc/scripts/GMT_blend.sh
+++ b/doc/scripts/GMT_blend.sh
@@ -17,7 +17,7 @@ gmt begin GMT_blend
 	1	lightyellow	2	lightorange
 	2	lightorange	3	lightred
 	EOF
-	gmt grdimage blend.grd -Jx0.2c -B -Ct.cpt
+	gmt grdimage blend.grd -Jx0.18c -B -Ct.cpt
 	gmt grdinfo -Ib 2.grd | gmt plot -W2p
 	gmt grdinfo -Ib 3.grd | gmt plot -W2p
 	gmt plot -W0.5,- -L <<- EOF
@@ -39,5 +39,5 @@ gmt begin GMT_blend
 	75  35 TR z = 3, w = 4
 	EOF
 	gmt colorbar -DjRM -F+gwhite+p0.25p -Bx -By+lz
-	gmt grdtrack -Gblend.grd -E0/22/100/22 -o0,2 | gmt plot -R0/100/0.8/2.8 -Jx0.2c/1c -Bya1g1 -BWbrt -Y9.2c -W1p,blue
+	gmt grdtrack -Gblend.grd -E0/22/100/22 -o0,2 | gmt plot -R0/100/0.8/2.8 -Jx0.18c/1c -Bya1g1 -BWbrt -Y9.2c -W1p,blue
 gmt end show

--- a/doc/scripts/GMT_inset.sh
+++ b/doc/scripts/GMT_inset.sh
@@ -5,7 +5,7 @@
 gmt begin GMT_inset
 # Bottom map of Australia
 	gmt set GMT_THEME cookbook
-	gmt coast -R110E/170E/44S/9S -JM6i -B -BWSne -Wfaint -N2/1p  -EAU+gbisque -Gbrown -Sazure1 -Da -Xc --FORMAT_GEO_MAP=dddF
+	gmt coast -R110E/170E/44S/9S -JM6i -B -BWSne -Wfaint -N2/1p  -EAU+gbisque -Gbrown -Sazure1 -Da --FORMAT_GEO_MAP=dddF
 	gmt inset begin -DjTR+w1.5i+o0.15i -F+gwhite+p1p+s -C0.05i
 	gmt coast -Rg -JG120/30S/ -Da -Gbrown -A5000 -Bg -Wfaint -EAU+gbisque
 	gmt inset end

--- a/doc/scripts/GMT_tut_14.sh
+++ b/doc/scripts/GMT_tut_14.sh
@@ -3,7 +3,7 @@ gmt begin GMT_tut_14
 	gmt set GMT_THEME cookbook
 	gmt makecpt -H -Crainbow -T-20/60/10 > disc.cpt
 	gmt makecpt -H -Crainbow -T-20/60 > cont.cpt
-	gmt basemap -R0/6/0/9 -Jx1i -B0 -Xc
+	gmt basemap -R0/6/0/9 -Jx1i -B0
 	gmt colorbar -Dx1i/1i+w4i/0.5i+h -Cdisc.cpt -Ba -B+tdiscrete
 	gmt colorbar -Dx1i/3i+w4i/0.5i+h -Ccont.cpt -Ba -B+tcontinuous
 	gmt colorbar -Dx1i/5i+w4i/0.5i+h -Cdisc.cpt -Ba -B+tdiscrete -I0.5

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -1133,6 +1133,10 @@ GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
 		default:
 			GMT->current.ps.origin[GMT_X] = GMT->common.X.mode = 'r'; break;
 	}
+	if (GMT->current.setting.run_mode == GMT_MODERN && strchr ("cf", GMT->common.X.mode)) {	/* Modern mode: Disallow -Xc|f */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Centered (-Xc) and fixed (-Xf) shifts are not available in modern mode\n");
+		return (GMT_PARSE_ERROR);
+	}
 	if (text[i]) {	/* Gave some argument */
 		if (strchr (text, 'w')) {	/* Used previous width as part of offset */
 			GMT->current.setting.map_origin[GMT_X] = GMT->current.map.last_width;
@@ -1184,6 +1188,10 @@ GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
 			GMT->current.ps.origin[GMT_Y] = GMT->common.Y.mode = text[0]; i++; break;
 		default:
 			GMT->current.ps.origin[GMT_Y] = GMT->common.Y.mode = 'r'; break;
+	}
+	if (GMT->current.setting.run_mode == GMT_MODERN && strchr ("cf", GMT->common.Y.mode)) {	/* Modern mode: Disallow -Yc|f */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Centered (-Yc) and fixed (-Tf) shifts are not available in modern mode\n");
+		return (GMT_PARSE_ERROR);
 	}
 	if (text[i]) {	/* Gave some argument */
 		if (strchr (text, 'h')) {	/* Used previous height as part of offset */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -1190,7 +1190,7 @@ GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
 			GMT->current.ps.origin[GMT_Y] = GMT->common.Y.mode = 'r'; break;
 	}
 	if (GMT->current.setting.run_mode == GMT_MODERN && strchr ("cf", GMT->common.Y.mode)) {	/* Modern mode: Disallow -Yc|f */
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Centered (-Yc) and fixed (-Tf) shifts are not available in modern mode\n");
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Centered (-Yc) and fixed (-Yf) shifts are not available in modern mode\n");
 		return (GMT_PARSE_ERROR);
 	}
 	if (text[i]) {	/* Gave some argument */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7754,6 +7754,7 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 				"adjustment of origin, prepend f to position relative to lower left corner of page, "
 				"prepend c for offset of center of plot to center of page. "
 				"For overlays (-O), the default setting is [r0], otherwise [f%g%c].", GMT->current.setting.map_origin[GMT_Y] * s, u);
+			GMT_Usage (API, -2, "Note: Under modern mode only directives r and a are available.");
 			break;
 
 		case 'x':	/* Just linear -Jx|X allowed for this program */

--- a/test/grdfill/splinefill.sh
+++ b/test/grdfill/splinefill.sh
@@ -6,7 +6,7 @@ gmt begin splinefill ps
 	gmt makecpt -Csealand -T-5000/5000 -H > t.cpt
 	# Now replace NaN holes with cubic spline solutions
 	gmt grdfill islands.nc -As -Gnew.nc
-	gmt grdimage islands.nc -JQ6i -Ct.cpt -B -BWSne -Xc -Y0.75i
+	gmt grdimage islands.nc -JQ6i -Ct.cpt -B -BWSne -Y0.75i
 	gmt grdimage new.nc -Ct.cpt -B -BWSne -Y5.15i
 	gmt text -F+f24p+cTR+t"-As" -Dj0.2i -Gwhite
 gmt end show

--- a/test/modern/insetlegend.sh
+++ b/test/modern/insetlegend.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test that the auto-legend works in a map inset
 gmt begin insetlegend ps
-  gmt psbasemap -R0/7/3/7 -Jx1i -B0 -B+t"Inset with plot and legend" -Xc
+  gmt psbasemap -R0/7/3/7 -Jx1i -B0 -B+t"Inset with plot and legend"
   gmt inset begin -DjTR+w3.8i/2.5i+o0.1i -C1c -F+p1p,red
     gmt plot -R0/7/3/7 -B @Table_5_11.txt -Sc0.15i -Glightgreen -Wfaint -lApples+HLEGEND+f16p+D+jTL+s0.5+glightblue+p2p+o0.3c
     gmt plot @Table_5_11.txt -W1.5p,gray -l"My Lines"

--- a/test/psbasemap/absrelaxis.sh
+++ b/test/psbasemap/absrelaxis.sh
@@ -2,7 +2,7 @@
 # Test the 3 frames in https://forum.generic-mapping-tools.org/t/incoherent-gridline-behaviour/1319/13
 gmt begin absrelaxis ps
 	gmt set MAP_GRID_PEN_PRIMARY thinner,grey MAP_GRID_PEN_SECONDARY thin,black TIME_INTERVAL_FRACTION 0.1
-	gmt basemap -R110/280/373420800/381369600 -JX16cd/8ct -Bxa20f10g10 -Bpyf1Og1O -Bsya1Yf1Yg1Y -BWSen -Xc -Y1c
+	gmt basemap -R110/280/373420800/381369600 -JX16cd/8ct -Bxa20f10g10 -Bpyf1Og1O -Bsya1Yf1Yg1Y -BWSen -Y1c
 	gmt basemap -JX16cd/8cT -Bxa20f10g10 -Bpyf1Og1O -Bsya1Yf1Yg1Y -BWSen -Y9c
 	gmt basemap -R110/280/1981-11-01T/1982-02-01T -JX16cd/8cT -Bxa20f10g10 -Bpyf1Og1O -Bsya1Yf1Yg1Y -BWSen -Y9c
 gmt end show

--- a/test/psbasemap/sub1saxis.sh
+++ b/test/psbasemap/sub1saxis.sh
@@ -2,7 +2,7 @@
 #
 # Test basemap time axis for gridline inc < 1 second
 gmt begin sub1saxis ps
-	gmt basemap -JX18ct/5c -R0/30/-15/1 -BlSrn -Bxa5Sf1g0.2+a60+l"time (s)" -Byg1 -Xc -Y3c
+	gmt basemap -JX18ct/5c -R0/30/-15/1 -BlSrn -Bxa5Sf1g0.2+a60+l"time (s)" -Byg1 -Y3c
 	gmt basemap -BlSrn -Bxa5Sf1g1+a60+l"time (s)" -Byg1 -Y9c
 	gmt basemap -BlSrn -Bxa5Sf1g5+a60+l"time (s)" -Byg1 -Y9c
 gmt end show


### PR DESCRIPTION
A handful of stray modern mode scripts had left-over **-Xc** settings which does northing to affect the final cropped plot but does cause failure when comparing to orig PS since those are US letter size and the -Xc shifts things.  I have updated those few PS in dvc after removing the -Xc and recreating the outputs.  Other scripts were not affected and tests are similarly working.  The documentation and usage message now mention the limitation in modern mode.
