### PR TITLE
Fix a cmake warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -375,7 +375,7 @@ set (GMT_PSL_SRCS postscriptlight.c declspec.h psl_config.h PSL_Standard+.h
 
 set (GMT_MBSYSTEM_SRCS gmt_mbsystem_glue.c)
 
-AUX_SOURCE_DIRECTORY (longopt GMT_LONG_OPT_H) 
+AUX_SOURCE_DIRECTORY (longopt GMT_LONG_OPT_H)
 
 # libgmt
 set (GMT_LIB_SRCS block_subs.h gmt_common_byteswap.h gmt_common_math.h
@@ -534,7 +534,7 @@ endif (HAVE_DLADDR AND HAVE_LIBDL)
 
 if ((MSVC OR MINGW) AND FFTW3_FOUND)
 	target_link_libraries (gmtlib ws2_32)
-endif (MSVC AND FFTW3_FOUND)
+endif ((MSVC OR MINGW) AND FFTW3_FOUND)
 
 # set the build version (VERSION) and the API version (SOVERSION)
 set_target_properties (gmtlib


### PR DESCRIPTION
**Description of proposed changes**

Building GMT gives this warning.
```
CMake Warning (dev) in src/CMakeLists.txt:
  A logical block opening on the line

    /home/seisman/OSS/gmt/gmt/src/CMakeLists.txt:535 (if)

  closes on the line

    /home/seisman/OSS/gmt/gmt/src/CMakeLists.txt:537 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
This PR fixes it.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
