### PR TITLE
Fix the API documentation for geometries

### DIFF
--- a/doc/rst/source/devdocs/api.rst
+++ b/doc/rst/source/devdocs/api.rst
@@ -1182,7 +1182,9 @@ unique resource ID, or ``GMT_NOTSET`` if there was an error.
     +----------------+-----------------------------------------+
     | GMT_IS_LINE    | Geographic or Cartesian line segments   |
     +----------------+-----------------------------------------+
-    | GMT_IS_POLYGON | Geographic or Cartesian closed polygons |
+    | GMT_IS_POLY    | Geographic or Cartesian closed polygons |
+    +----------------+-----------------------------------------+
+    | GMT_IS_LP      | Either lines or polygons                |
     +----------------+-----------------------------------------+
     | GMT_IS_PLP     | Either points, lines, or polygons       |
     +----------------+-----------------------------------------+


### PR DESCRIPTION
**Description of proposed changes**

- `GMT_IS_POLYGON` should be `GMT_IS_POLY`
- `GMT_IS_LP` is missing

Based on `gmt_resources.h`:
https://github.com/GenericMappingTools/gmt/blob/765c540999f6e9a22e2a45919c936895da3e7467/src/gmt_resources.h#L479-L489


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
