### PR TITLE
Replace mktemp with secure versions

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -87,6 +87,7 @@
 #include <glob.h>
 #else
 #include <windows.h>
+#include <io.h>
 #include <tchar.h>
 #endif
 
@@ -4984,7 +4985,11 @@ int gmt_get_tempname (struct GMTAPI_CTRL *API, char *stem, char *extension, char
 
 	gmtsupport_make_template (API, stem, path);	/* Readying the name template */
 
-	if (mktemp (path) == NULL) {
+#ifdef _WIN32
+	if (_mktemp_s (path) == EINVAL) {
+#else
+	if (mkstemp (path) == GMT_NOTSET) {
+#endif
 		GMT_Report (API, GMT_MSG_ERROR, "Could not create a temporary name from template %s.\n", path);
 		return (GMT_RUNTIME_ERROR);
 	}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4986,7 +4986,7 @@ int gmt_get_tempname (struct GMTAPI_CTRL *API, char *stem, char *extension, char
 	gmtsupport_make_template (API, stem, path);	/* Readying the name template */
 
 #ifdef _WIN32
-	if (_mktemp_s (path) == EINVAL) {
+	if (_mktemp_s (path, strlen(path) + 1) == EINVAL) {
 #else
 	if (mkstemp (path) == GMT_NOTSET) {
 #endif


### PR DESCRIPTION
See #7101 for background. Means an `ifdef` on Windows to get the underscored version __mkdemp_s_.  Hopefully, @joa-quim can test this branch and let us know if this works OK under both pure Windows and MinGW. Obviously no change on macOS or Linux.
