### PR TITLE
Redo how alloc_mode is set in objects

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4340,7 +4340,7 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 			n_rows = (GMT->current.io.multi_segments[GMT_OUT]) ? D_obj->n_records + D_obj->n_segments : D_obj->n_records;	/* Number of rows needed to hold the data [incl any segment headers] */
 			n_columns = (GMT->common.o.select) ? GMT->common.o.n_cols : D_obj->n_columns;					/* Number of columns needed to hold the data records */
 			if ((M_obj = S_obj->resource) == NULL) {	/* Must allocate suitable matrix */
-				M_obj = gmtlib_create_matrix (GMT, 1U, GMT_OUT, 0);	/* 1-layer matrix (i.e., 2-D) */
+				M_obj = gmtlib_create_matrix (GMT, 1U, 0);	/* 1-layer matrix (i.e., 2-D) */
 				/* Allocate final output space since we now know all dimensions */
 				MH = gmt_get_M_hidden (M_obj);
 				M_obj->n_rows = n_rows;
@@ -4351,6 +4351,7 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 				/* Allocate output matrix space or die */
 				if ((error = gmtlib_alloc_univector (GMT, &(M_obj->data), M_obj->type, S_obj->n_alloc)) != GMT_NOERROR) return (gmtlib_report_error (API, error));
 				MH->alloc_mode = GMT_ALLOC_INTERNALLY;
+				MH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 				if (D_obj->type >= GMT_READ_TEXT) { /* Also has trailing text */
 					if ((M_obj->text = gmt_M_memory (GMT, NULL, n_rows, char *)) == NULL) return (gmtlib_report_error (API, GMT_MEMORY_ERROR));
 					MH->alloc_mode_text = GMT_ALLOC_INTERNALLY;
@@ -4818,6 +4819,7 @@ GMT_LOCAL struct GMT_IMAGE *gmtapi_import_image (struct GMTAPI_CTRL *API, int ob
 			}
 			IH = gmt_get_I_hidden (I_obj);
 			IH->alloc_mode = GMT_ALLOC_INTERNALLY;
+			IH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 			break;
 
 	 	case GMT_IS_DUPLICATE:	/* GMT image and header in a GMT_IMAGE container object. */
@@ -4843,6 +4845,7 @@ GMT_LOCAL struct GMT_IMAGE *gmtapi_import_image (struct GMTAPI_CTRL *API, int ob
 			}
 			IH = gmt_get_I_hidden (I_obj);
 			IH->alloc_mode = GMT_ALLOC_INTERNALLY;
+			IH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 			if (!S_obj->region && gmt_grd_pad_status (GMT, I_obj->header, GMT->current.io.pad)) {	/* Want an exact copy with no subset and same padding */
 				GMT_Report (API, GMT_MSG_INFORMATION, "Duplicating image data from GMT_IMAGE memory location\n");
 				gmt_M_memcpy (I_obj->data, I_orig->data, I_orig->header->size * I_orig->header->n_bands, char);
@@ -4908,6 +4911,7 @@ GMT_LOCAL struct GMT_IMAGE *gmtapi_import_image (struct GMTAPI_CTRL *API, int ob
 			}
 			IH = gmt_get_I_hidden (I_obj);
 			IH->alloc_mode = GMT_ALLOC_INTERNALLY;
+			IH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 			/* Must convert to new array */
 			GMT_Report (API, GMT_MSG_INFORMATION, "Importing image data from user memory location\n");
 			gmt_set_grddim (GMT, I_obj->header);	/* Set all dimensions */
@@ -5306,6 +5310,7 @@ start_over_import_grid:		/* We may get here if we cannot honor a GMT_IS_REFERENC
 			if (gmt_M_err_pass (GMT, gmt_grd_BC_set (GMT, G_obj, GMT_IN), S_obj->filename))
 				return_null (API, GMT_GRID_BC_ERROR);	/* Set boundary conditions */
 			GH->alloc_mode = GMT_ALLOC_INTERNALLY;
+			GH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 			break;
 
 	 	case GMT_IS_DUPLICATE:	/* GMT grid and header in a GMT_GRID container object. */
@@ -5330,6 +5335,7 @@ start_over_import_grid:		/* We may get here if we cannot honor a GMT_IS_REFERENC
 			}
 			GH = gmt_get_G_hidden (G_obj);
 			GH->alloc_mode = GMT_ALLOC_INTERNALLY;
+			GH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 			HH = gmt_get_H_hidden (G_obj->header);
 			if (HH->grdtype > GMT_GRID_CARTESIAN) gmt_set_geographic (GMT, GMT_IN);
 			if (!S_obj->region && gmt_grd_pad_status (GMT, G_obj->header, GMT->current.io.pad)) {	/* Want an exact copy with no subset and same padding */
@@ -5846,7 +5852,7 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 					return (gmtlib_report_error (API, GMT_DIM_TOO_SMALL));
 			}
 			else {	/* Must allocate stuff */
-		 		M_obj = gmtlib_create_matrix (API->GMT, 1, GMT_IS_OUTPUT, 0);
+		 		M_obj = gmtlib_create_matrix (API->GMT, 1, 0);
 				M_obj->type = S_obj->type;
 			}
 			MH = gmt_get_M_hidden (M_obj);
@@ -5881,7 +5887,7 @@ GMT_LOCAL int gmtapi_export_grid (struct GMTAPI_CTRL *API, int object_ID, unsign
 				assert (M_obj->type == GMT_GRDFLOAT);	/* That is the whole point of getting here, no? */
 			}
 			else {	/* Must allocate stuff */
-		 		M_obj = gmtlib_create_matrix (API->GMT, 1, GMT_IS_OUTPUT, 1);
+		 		M_obj = gmtlib_create_matrix (API->GMT, 1, 1);
 				M_obj->type = GMT_GRDFLOAT;	/* A grid is always gmt_grdfloat */
 			}
 			MH = gmt_get_M_hidden (M_obj);
@@ -6156,6 +6162,7 @@ start_over_import_cube:		/* We may get here if we cannot honor a GMT_IS_REFERENC
 			}
 			UH = gmt_get_U_hidden (U_obj);
 			UH->alloc_mode = GMT_ALLOC_INTERNALLY;
+			UH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 			if (!S_obj->region && gmt_grd_pad_status (GMT, U_obj->header, GMT->current.io.pad)) {	/* Want an exact copy with no subset and same padding */
 				gmt_M_memcpy (U_obj->data, U_orig->data, U_orig->header->size * U_orig->header->n_bands, gmt_grdfloat);
 				gmt_BC_init (GMT, U_obj->header);	/* Initialize cube interpolation and boundary condition parameters */
@@ -6590,7 +6597,7 @@ GMT_LOCAL int gmtapi_export_cube (struct GMTAPI_CTRL *API, int object_ID, unsign
 					return (gmtlib_report_error (API, GMT_DIM_TOO_SMALL));
 			}
 			else {	/* Must allocate stuff */
-		 		M_obj = gmtlib_create_matrix (API->GMT, U_obj->header->n_bands, GMT_IS_OUTPUT, 0);
+		 		M_obj = gmtlib_create_matrix (API->GMT, U_obj->header->n_bands, 0);
 				M_obj->type = S_obj->type;
 			}
 			MH = gmt_get_M_hidden (M_obj);
@@ -6603,6 +6610,7 @@ GMT_LOCAL int gmtapi_export_cube (struct GMTAPI_CTRL *API, int object_ID, unsign
 				size = gmt_M_get_nm (GMT, U_obj->header->n_columns, U_obj->header->n_rows) * M_obj->n_layers;
 				if ((error = gmtlib_alloc_univector (GMT, &(M_obj->data), M_obj->type, size)) != GMT_NOERROR) return (error);
 				MH->alloc_mode = GMT_ALLOC_INTERNALLY;
+				MH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 			}
 			if ((GMT_2D_to_index = gmtapi_get_2d_to_index (API, M_obj->shape, GMT_GRID_IS_REAL)) == NULL)
 				return (gmtlib_report_error (API, GMT_WRONG_MATRIX_SHAPE));
@@ -6631,7 +6639,7 @@ GMT_LOCAL int gmtapi_export_cube (struct GMTAPI_CTRL *API, int object_ID, unsign
 				assert (M_obj->type == GMT_GRDFLOAT);	/* That is the whole point of getting here, no? */
 			}
 			else {	/* Must allocate stuff */
-		 		M_obj = gmtlib_create_matrix (API->GMT, U_obj->header->n_bands, GMT_IS_OUTPUT, 1);
+		 		M_obj = gmtlib_create_matrix (API->GMT, U_obj->header->n_bands, 1);
 				M_obj->type = GMT_GRDFLOAT;	/* A cube is always gmt_grdfloat */
 			}
 			MH = gmt_get_M_hidden (M_obj);
@@ -6818,7 +6826,7 @@ GMT_LOCAL void *gmtapi_grid2matrix (struct GMTAPI_CTRL *API, struct GMT_GRID *In
 	GMT_putfunction api_put_val = NULL;
 	p_func_uint64_t GMT_2D_to_index = NULL;
 
-	if (alloc) Out = gmtlib_create_matrix (API->GMT, 1U, GMT_OUT, 0);
+	if (alloc) Out = gmtlib_create_matrix (API->GMT, 1U, 0);
 
 	gmtapi_grdheader_to_matrixinfo (API->GMT, In->header, Out);
 	if (alloc) {	/* Allocate the matrix itself */
@@ -10663,7 +10671,7 @@ GMT_LOCAL int gmtapi_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode
 					break;
 				}
 				size = S_obj->n_alloc = GMT_CHUNK;
-				M_obj = gmtlib_create_matrix (GMT, 1U, GMT_OUT, 0);
+				M_obj = gmtlib_create_matrix (GMT, 1U, 0);
 				M_obj->type = S_obj->type;	/* Use selected data type for export */
 				M_obj->dim = M_obj->n_columns = col;	/* If COL_FORMAT the dim will change in end_io_matrix after transpose */
 				size *= M_obj->n_columns;	/* Size in bytes of the initial matrix allocation */
@@ -10671,6 +10679,7 @@ GMT_LOCAL int gmtapi_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode
 				if (record->text && (M_obj->text = gmt_M_memory (GMT, NULL, S_obj->n_alloc, char *)) == NULL) return (gmtlib_report_error (API, GMT_MEMORY_ERROR));
 				MH = gmt_get_M_hidden (M_obj);
 				S_obj->alloc_mode = MH->alloc_mode = GMT_ALLOC_INTERNALLY;
+				MH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 				S_obj->resource = M_obj;	/* Save so we can get it next time */
 				M_obj->n_rows = S_obj->rec;	/* So we start on the same output record due to the delayed NaNs */
 			}
@@ -11392,7 +11401,7 @@ void * GMT_Create_Data (void *V_API, unsigned int family, unsigned int geometry,
 		case GMT_IS_MATRIX:	/* GMT matrix container, allocate one with the requested number of layers, rows & columns */
 			if (data) return_null (API, GMT_PTR_NOT_NULL);	/* Error if data is not NULL */
 			n_layers = (this_dim == NULL || (this_dim[GMTAPI_DIM_COL] == 0 && this_dim[GMTAPI_DIM_ROW] == 0)) ? 1U : this_dim[GMT_Z];	/* Only by specifying nx,ny dimension might there be > 1 layer */
-		 	new_obj = gmtlib_create_matrix (API->GMT, n_layers, def_direction, pad);
+		 	new_obj = gmtlib_create_matrix (API->GMT, n_layers, pad);
 			if ((API->error = gmtapi_init_matrix (API, this_dim, range, inc, registration, mode, def_direction, new_obj))) {	/* Failure, must free the object */
 				struct GMT_MATRIX *M = gmtapi_return_address (new_obj, GMT_IS_MATRIX);	/* Get pointer to resource */
 				gmtlib_free_matrix (API->GMT, &M, true);
@@ -14669,7 +14678,7 @@ GMT_LOCAL void *gmtapi_dataset2matrix (struct GMTAPI_CTRL *API, struct GMT_DATAS
 
 	if (alloc) {	/* Must allocate the output matrix */
 		struct GMT_MATRIX_HIDDEN *MH = NULL;
-		if ((Out = gmtlib_create_matrix (GMT, 1U, GMT_OUT, 0)) == NULL) return (NULL);
+		if ((Out = gmtlib_create_matrix (GMT, 1U, 0)) == NULL) return (NULL);
 		Out->n_rows = In->n_records + (add_NaN_record ? In->n_segments : 0);
 		Out->n_columns = Out->dim = In->n_columns;
 		Out->type = (mode) ? mode - 1 : API->GMT->current.setting.export_type;
@@ -14679,6 +14688,7 @@ GMT_LOCAL void *gmtapi_dataset2matrix (struct GMTAPI_CTRL *API, struct GMT_DATAS
 		}
 		MH = gmt_get_M_hidden (Out);
 		MH->alloc_mode = GMT_ALLOC_INTERNALLY;
+		MH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 	}
 	if ((api_put_val = gmtapi_select_put_function (API, Out->type)) == NULL) {
 		gmt_M_free (GMT, Out);
@@ -14880,7 +14890,7 @@ GMT_LOCAL void * gmtapi_vector2matrix (struct GMTAPI_CTRL *API, struct GMT_VECTO
 	if (header) GMT_Report (API, GMT_MSG_WARNING, "gmtapi_vector2matrix: Header stripping not implemented yet - ignored!\n");
 	if (alloc) {
 		struct GMT_MATRIX_HIDDEN *MH = NULL;
-		Out = gmtlib_create_matrix (GMT, 1U, GMT_OUT, 0);
+		Out = gmtlib_create_matrix (GMT, 1U, 0);
 		Out->n_columns = In->n_columns;
 		Out->n_rows = In->n_rows;
 		Out->type = (mode) ? mode - 1 : API->GMT->current.setting.export_type;
@@ -14890,6 +14900,7 @@ GMT_LOCAL void * gmtapi_vector2matrix (struct GMTAPI_CTRL *API, struct GMT_VECTO
 		}
 		MH = gmt_get_M_hidden (Out);
 		MH->alloc_mode = GMT_ALLOC_INTERNALLY;
+		MH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 	}
 
 	if ((GMT_2D_to_index = gmtapi_get_2d_to_index (API, Out->shape, GMT_GRID_IS_REAL)) == NULL) {

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2894,7 +2894,8 @@ struct GMT_GRID *gmt_create_grid (struct GMT_CTRL *GMT) {
 #else
 	G->header->type = GMT_GRID_IS_NF;
 #endif
-	GH->id = GMT->parent->unique_var_ID++;		/* Give unique identifier */
+	GH->id = GMT->parent->unique_var_ID++;	/* Give unique identifier */
+	GH->alloc_mode = GMT_ALLOC_EXTERNALLY;	/* Since nothing is assigned or allocated yet */
 	return (G);
 }
 
@@ -3536,7 +3537,8 @@ struct GMT_CUBE *gmtlib_create_cube (struct GMT_CTRL *GMT) {
 	C->header->type = GMT_GRID_IS_NF;
 #endif
 	GMT_Set_Index (GMT->parent, C->header, GMT_GRID_LAYOUT);
-	GU->id = GMT->parent->unique_var_ID++;		/* Give unique identifier */
+	GU->id = GMT->parent->unique_var_ID++;	/* Give unique identifier */
+	GU->alloc_mode = GMT_ALLOC_EXTERNALLY;	/* Since nothing is assigned or allocated yet */
 	return (C);
 }
 

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2894,8 +2894,6 @@ struct GMT_GRID *gmt_create_grid (struct GMT_CTRL *GMT) {
 #else
 	G->header->type = GMT_GRID_IS_NF;
 #endif
-	GH->alloc_mode = GMT_ALLOC_INTERNALLY;		/* Memory can be freed by GMT. */
-	GH->alloc_level = GMT->hidden.func_level;	/* Must be freed at this level. */
 	GH->id = GMT->parent->unique_var_ID++;		/* Give unique identifier */
 	return (G);
 }
@@ -2998,6 +2996,11 @@ int gmt_set_outgrid (struct GMT_CTRL *GMT, char *file, bool separate, unsigned i
 	bool add_pad = false;
 	unsigned int k, pad[4] = {min_pad, min_pad, min_pad, min_pad};
 	struct GMT_GRID_HIDDEN *GH = gmt_get_G_hidden (G);
+
+	if (G->data == NULL) {	/* Nothing related to the data can be done */
+		(*Out) = G;
+		return (false);
+	}
 
 	for (k = 0; !add_pad && k < 4; k++)
 		if (G->header->pad[k] < min_pad) add_pad = true;
@@ -3533,8 +3536,6 @@ struct GMT_CUBE *gmtlib_create_cube (struct GMT_CTRL *GMT) {
 	C->header->type = GMT_GRID_IS_NF;
 #endif
 	GMT_Set_Index (GMT->parent, C->header, GMT_GRID_LAYOUT);
-	GU->alloc_mode = GMT_ALLOC_INTERNALLY;		/* Memory can be freed by GMT. */
-	GU->alloc_level = GMT->hidden.func_level;	/* Must be freed at this level. */
 	GU->id = GMT->parent->unique_var_ID++;		/* Give unique identifier */
 	return (C);
 }

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -258,7 +258,7 @@ EXTERN_MSC void gmtlib_free_palette (struct GMT_CTRL *GMT, struct GMT_PALETTE **
 EXTERN_MSC void gmtlib_write_ogr_header (FILE *fp, struct GMT_OGR *G);
 EXTERN_MSC struct GMT_IMAGE * gmtlib_create_image (struct GMT_CTRL *GMT);
 EXTERN_MSC void gmtlib_free_image (struct GMT_CTRL *GMT, struct GMT_IMAGE **I, bool free_image);
-EXTERN_MSC struct GMT_MATRIX * gmtlib_create_matrix (struct GMT_CTRL *GMT, uint64_t n_layers, unsigned int direction, int flag);
+EXTERN_MSC struct GMT_MATRIX * gmtlib_create_matrix (struct GMT_CTRL *GMT, uint64_t n_layers, int flag);
 EXTERN_MSC void gmtlib_free_matrix (struct GMT_CTRL *GMT, struct GMT_MATRIX **M, bool free_matrix);
 EXTERN_MSC int gmtlib_determine_pole (struct GMT_CTRL *GMT, double *lon, double *lat, uint64_t n);
 EXTERN_MSC void gmtlib_write_newheaders (struct GMT_CTRL *GMT, FILE *fp, uint64_t n_columns);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8948,6 +8948,7 @@ int gmtlib_alloc_vectors (struct GMT_CTRL *GMT, struct GMT_VECTOR *V, uint64_t n
 		if ((error = gmtlib_alloc_univector (GMT, &V->data[col], V->type[col], n_alloc)) != GMT_NOERROR) return (error);
 		VH->alloc_mode[col] = GMT_ALLOC_INTERNALLY;
 	}
+	VH->alloc_level = GMT->hidden.func_level;	/* Must be freed at this level. */
 	return (GMT_NOERROR);
 }
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8807,9 +8807,8 @@ struct GMT_IMAGE *gmtlib_create_image (struct GMT_CTRL *GMT) {
 	struct GMT_IMAGE *I = gmtio_get_image (GMT);
 	IH = gmt_get_I_hidden (I);
 	I->header = gmt_get_header (GMT);
-	IH->alloc_mode = GMT_ALLOC_INTERNALLY;		/* Memory can be freed by GMT. */
-	IH->alloc_level = GMT->hidden.func_level;	/* Must be freed at this level. */
 	IH->id = GMT->parent->unique_var_ID++;		/* Give unique identifier */
+	IH->alloc_mode = GMT_ALLOC_EXTERNALLY;		/* Since nothing is assigned or allocated yet */
 	gmt_grd_init (GMT, I->header, NULL, false); /* Set default values */
 	if (GMT->current.gdal_read_in.O.mem_layout[0])
 		gmt_strncpy (I->header->mem_layout, GMT->current.gdal_read_in.O.mem_layout, 4);	/* Set the current memory layout */
@@ -9044,15 +9043,13 @@ void gmt_free_vector (struct GMT_CTRL *GMT, struct GMT_VECTOR **V, bool free_vec
 }
 
 /*! . */
-struct GMT_MATRIX * gmtlib_create_matrix (struct GMT_CTRL *GMT, uint64_t layers, unsigned int direction, int flag) {
+struct GMT_MATRIX * gmtlib_create_matrix (struct GMT_CTRL *GMT, uint64_t layers, int flag) {
 	/* Allocates space for a new matrix container. */
 	struct GMT_MATRIX *M = NULL;
 	struct GMT_MATRIX_HIDDEN *MH = NULL;
 	M = gmt_M_memory (GMT, NULL, 1, struct GMT_MATRIX);
 	MH = M->hidden = gmt_M_memory (GMT, NULL, 1, struct GMT_MATRIX_HIDDEN);
-	/* We expect external memory for input and GMT-allocated memory on output */
-	MH->alloc_mode = (direction == GMT_IN) ? GMT_ALLOC_EXTERNALLY : GMT_ALLOC_INTERNALLY;
-	MH->alloc_level = GMT->hidden.func_level;	/* Must be freed at this level. */
+	MH->alloc_mode = GMT_ALLOC_EXTERNALLY;		/* No matrix allocated yet */
 	MH->id = GMT->parent->unique_var_ID++;		/* Give unique identifier */
 	M->n_layers = (layers) ? layers : 1;		/* Default to 1 if not set */
 	switch (flag) {

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -10565,12 +10565,12 @@ struct GMT_POSTSCRIPT * gmtlib_create_ps (struct GMT_CTRL *GMT, uint64_t length)
 	/* Makes an empty GMT_POSTSCRIPT struct - If length > 0 then we also allocate the string */
 	struct GMT_POSTSCRIPT *P = gmt_get_postscript (GMT);
 	struct GMT_POSTSCRIPT_HIDDEN *PH = gmt_get_P_hidden (P);
-	PH->alloc_level = GMT->hidden.func_level;	/* Must be freed at this level. */
 	PH->id = GMT->parent->unique_var_ID++;		/* Give unique identifier */
 	if (length) {	/* Allocate a blank string */
 		P->data = gmt_M_memory (GMT, NULL, length, char);
 		PH->n_alloc = length;	/* But P->n_bytes = 0 since nothing was placed there */
 		PH->alloc_mode = GMT_ALLOC_INTERNALLY;		/* Memory can be freed by GMT. */
+		PH->alloc_level = GMT->hidden.func_level;   /* Must be freed at this level. */
 	}
 	return (P);
 }

--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -6450,6 +6450,8 @@ GMT_LOCAL void grdmath_free (struct GMT_CTRL *GMT, struct GRDMATH_STACK *stack[]
 	gmt_M_free (GMT, info->f_grd_yn);
 	gmt_M_free (GMT, info->dx);
 	gmt_M_str_free (info->ASCII_file);
+	info->A = NULL;
+	gmt_free_grid (GMT, &(info->G), false);
 }
 
 GMT_LOCAL void grdmath_expand_recall_cmd (struct GMT_OPTION *list) {

--- a/src/testapi_gmtgrid.c
+++ b/src/testapi_gmtgrid.c
@@ -1,4 +1,7 @@
 #include "gmt.h"
+/*
+ * Testing the use of user grid memory allocated externally.
+ */
 
 int main () {
 	unsigned int mode = GMT_SESSION_EXTERNAL;
@@ -11,25 +14,24 @@ int main () {
 
 	API = GMT_Create_Session ("testapi_gmtgrid", 2U, mode, NULL);
 
-	/* create a container for the grid */
-	G = GMT_Create_Data(API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, dim, NULL, NULL, 0, 2, NULL);
-	GMT_Set_AllocMode(API, GMT_IS_GRID, G);
+	/* Create a container for the grid */
+	G = GMT_Create_Data (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, dim, NULL, NULL, 0, 2, NULL);
 
-	/* allocate memory of the data array in the external program (C or PyGMT) */
+	/* Allocate memory of the data array in the external program (C or PyGMT) */
 	data = (float *)malloc(sizeof(float) * 9 * 8);
-	for (int i=0; i < 9 * 8; i++) data[i] = (float)i;
+	for (int i = 0; i < 9 * 8; i++) data[i] = (float)i;
 
-	/* assign the user data to the GMT_GRID structure */
+	/* Assign the user data to the GMT_GRID structure */
 	G->data = data;
 
 	/* Using the grid */
 	GMT_Open_VirtualFile (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_IN, G, input);
 	sprintf (args, "%s", input);
-	GMT_Call_Module(API, "grd2xyz", GMT_MODULE_CMD, args);
+	GMT_Call_Module (API, "grd2xyz", GMT_MODULE_CMD, args);
 	GMT_Close_VirtualFile (API, input);
 
 	/* Free the data array allocated by the external program */
-	free(data);
+	free (data);
 
 	if (GMT_Destroy_Session (API)) return EXIT_FAILURE;
 	exit (0);


### PR DESCRIPTION
See #7316 for background.  This PR lets the _alloc_mode_ remain unset (**GMT_ALLOC_EXTERNALLY**) until a grid, cube ,etc are actually allocated by GMT, at which point we set it to **GMT_ALLOC_INTERNALLY**.  Quite a few other changes had to be made to work with the new scheme, especially odd handling in **grdmath** and **grdblend**, but now all tests pass.

However, it is important that the wrappers try this new branch to see if anything else shows up since it is more likely that there are subtle things related to passing memory that the CLI tests dont exercise.  So I need an approval from you all before we merge this one.

@seisman, I removed the _GMT_Set_AllocMode_ call from `testapi_gmtgrid.c` since the new scheme no longer incorrectly sets that alloc_mode to  **GMT_ALLOC_INTERNALLY**.