### PR TITLE
Let the PSL structure remember layer transparencies

### DIFF
--- a/doc/rst/source/explain_transparency.rst_
+++ b/doc/rst/source/explain_transparency.rst_
@@ -10,4 +10,6 @@ on a per-object or per-layer basis.  This means that a color specifications (suc
 those in CPTs of given via command-line options) only apply to vector graphic items
 (i.e., text, lines, polygon fills) or to an entire layer (which could include items
 such as PostScript images).  This limitation rules out any
-mechanism of controlling transparency in such images on a pixel level.
+mechanism of controlling transparency in such images on a pixel level. Note that
+polygons and lines will honor any object-specific transparency, but if none is set
+then these items will inherit the layer transparency (if any) set via |SYN_OPT-t|.

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -9189,9 +9189,13 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "A transparency of 0/0 is the same as opaque. Skipped\n");
 			GMT->common.t.active = false;
 		}
-		else 	/* Place both fill and stroke transparencies in 0-1 normalized range, plus the blend mode name */
+		else	/* Place both fill and stroke transparencies in 0-1 normalized range, plus the blend mode name */
 			PSL_command (PSL, "%.12g %.12g /%s PSL_transp\n", 1.0 - 0.01 * GMT->common.t.value[GMT_FILL_TRANSP], 1.0 - 0.01 * GMT->common.t.value[GMT_PEN_TRANSP], GMT->current.setting.ps_transpmode);
 	}
+    PSL->init.transparencies[PSL_FILL_TRANSP] = 1.0 - 0.01 * GMT->common.t.value[GMT_FILL_TRANSP];  /* Update layer fill transparency [0/0] */
+    PSL->init.transparencies[PSL_PEN_TRANSP]  = 1.0 - 0.01 * GMT->common.t.value[GMT_PEN_TRANSP];  /* Update layer stroke transparency [0/0] */
+    PSL->init.layer_transp = (int)GMT->common.t.active;  /* 1 if we have set -t */
+
 	/* If requested, place the timestamp (text set here but plotting happens in gmt_plotend) */
 
 	if (GMT->current.ps.logo_cmd) {

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -9192,6 +9192,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 		else	/* Place both fill and stroke transparencies in 0-1 normalized range, plus the blend mode name */
 			PSL_command (PSL, "%.12g %.12g /%s PSL_transp\n", 1.0 - 0.01 * GMT->common.t.value[GMT_FILL_TRANSP], 1.0 - 0.01 * GMT->common.t.value[GMT_PEN_TRANSP], GMT->current.setting.ps_transpmode);
 	}
+    /* Convert from percentage transparency to normalized opacity */
     PSL->init.transparencies[PSL_FILL_TRANSP] = 1.0 - 0.01 * GMT->common.t.value[GMT_FILL_TRANSP];  /* Update layer fill transparency [0/0] */
     PSL->init.transparencies[PSL_PEN_TRANSP]  = 1.0 - 0.01 * GMT->common.t.value[GMT_PEN_TRANSP];  /* Update layer stroke transparency [0/0] */
     PSL->init.layer_transp = (int)GMT->common.t.active;  /* 1 if we have set -t */

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -4102,7 +4102,8 @@ int PSL_setfill (struct PSL_CTRL *PSL, double rgb[], int outline) {
 	}
 	else if (PSL_eq (rgb[3], 0.0) && !PSL_eq (PSL->current.rgb[PSL_IS_STROKE][3], 0.0)) {
 		/* If stroke color is transparent and fill is not, explicitly set transparency for fill */
-		PSL_command (PSL, "{%s 1 1 /Normal PSL_transp} FS\n", psl_putcolor (PSL, rgb, 0));
+		PSL_command (PSL, "{%.12g %.12g /%s PSL_transp} FS\n",
+			PSL->init.transparencies[PSL_FILL_TRANSP], PSL->init.transparencies[PSL_PEN_TRANSP], PSL->current.transparency_mode, psl_putcolor (PSL, rgb, 0));
 		PSL_rgb_copy (PSL->current.rgb[PSL_IS_FILL], rgb);
 	}
 	else {	/* Set new r/g/b fill, after possibly changing fill transparency */
@@ -4959,7 +4960,8 @@ int PSL_setcolor (struct PSL_CTRL *PSL, double rgb[], int mode) {
 	if (PSL_same_rgb (rgb, PSL->current.rgb[mode])) return (PSL_NO_ERROR);	/* Same color as already set */
 
 	/* Because psl_putcolor does not set transparency if it is 0%, we reset it here when needed */
-	if (PSL_eq (rgb[3], 0.0) && !PSL_eq (PSL->current.rgb[mode][3], 0.0)) PSL_command (PSL, "1 1 /Normal PSL_transp ");
+	if (PSL_eq (rgb[3], 0.0) && !PSL_eq (PSL->current.rgb[mode][3], 0.0))
+			PSL_command (PSL, "%.12g %.12g /Normal PSL_transp ", PSL->init.transparencies[PSL_FILL_TRANSP], PSL->init.transparencies[PSL_PEN_TRANSP]);
 
 	/* Then, finally, set the color using psl_putcolor */
 	PSL_command (PSL, "%s\n", psl_putcolor (PSL, rgb, 0));

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -199,6 +199,8 @@ enum PSL_enum_const {PSL_CM	= 0,
 	PSL_OUTLINE		= 1,
 	PSL_LINEAR		= 0,
 	PSL_BEZIER		= 1,
+	PSL_FILL_TRANSP		= 0,
+	PSL_PEN_TRANSP		= 1,
 	PSL_MAX_EPS_FONTS	= 6,
 	PSL_MAX_DIMS		= 13,		/* Max number of dim arguments to PSL_plot_symbol */
 	PSL_N_PATTERNS		= 91,		/* Current number of predefined patterns + 1, # 91 is user-supplied */
@@ -329,9 +331,11 @@ struct PSL_CTRL {
 		int runmode;			/* Nonzero if we are being called from a multi-module environment (0 for commandline)	*/
 		int unit;			/* 0 = cm, 1 = inch, 2 = meter			*/
 		int copies;			/* Number of copies for this plot		*/
+		int layer_transp;			/* 0 = no layer transparency, 1 -t was used			*/
 		double page_rgb[4];		/* RGB color for background paper [white]	*/
 		double page_size[2];		/* Width and height of paper used in points	*/
 		double magnify[2];		/* Global scale values [1/1]			*/
+		double transparencies[2];		/* Current layer transparencies				*/
 	} init;
 	struct CURRENT {	/* Variables and settings that changes via PSL_* calls */
 		char string[PSL_BUFSIZ];	/* Last text string plotted			*/

--- a/src/postscriptlight.h
+++ b/src/postscriptlight.h
@@ -331,11 +331,11 @@ struct PSL_CTRL {
 		int runmode;			/* Nonzero if we are being called from a multi-module environment (0 for commandline)	*/
 		int unit;			/* 0 = cm, 1 = inch, 2 = meter			*/
 		int copies;			/* Number of copies for this plot		*/
-		int layer_transp;			/* 0 = no layer transparency, 1 -t was used			*/
+		int layer_transp;		/* 0 = no layer transparency, 1 -t was used	*/
 		double page_rgb[4];		/* RGB color for background paper [white]	*/
 		double page_size[2];		/* Width and height of paper used in points	*/
 		double magnify[2];		/* Global scale values [1/1]			*/
-		double transparencies[2];		/* Current layer transparencies				*/
+		double transparencies[2];	/* Current layer transparencies			*/
 	} init;
 	struct CURRENT {	/* Variables and settings that changes via PSL_* calls */
 		char string[PSL_BUFSIZ];	/* Last text string plotted			*/
@@ -348,8 +348,8 @@ struct PSL_CTRL {
 		double linewidth;		/* Current pen thickness			*/
 		double rgb[3][4];		/* Current stroke, fill, and fs fill rgb	*/
 		double offset;			/* Current setdash offset			*/
-		double transparency;		/* Current transparency	[deprecated]			*/
-		double transparencies[2];		/* Current transparencies				*/
+		double transparency;		/* Current transparency	[deprecated]		*/
+		double transparencies[2];	/* Current transparencies			*/
 		double fontsize;		/* Current font size				*/
 		double subsupsize;		/* Fractional size of super/sub-scripts		*/
 		double scapssize;		/* Fractional size of small caps		*/


### PR DESCRIPTION
We had no way inside PSL to know if a layer transparency (via **-t**) was set and what the reference level was for that layer.  Now we use that to reset transparency from an item back to the layer transparency. This PR fixes the bug that a combination of **-t** and `-Wpen,color@transp `would disable the effect of **-t**.

