### PR TITLE
Watch if convert is getting -g with X, Y, or D

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -3326,7 +3326,7 @@ void gmtlib_translate_point (struct GMT_CTRL *GMT, double lon, double lat, doubl
 }
 
 void gmt_translate_point (struct GMT_CTRL *GMT, double A[3], double B[3], double a_d[], bool geo) {
-	/* Given point in A, azimuth az and distance d, return the point P away from A */
+	/* Given point in A, azimuth az and distance d, return the point B away from A */
 	if (geo)
 		GMT->current.map.second_point (GMT, A[GMT_X], A[GMT_Y], a_d[0], a_d[1], &B[GMT_X], &B[GMT_Y], NULL);
 	else {	/* Cartesian translation */

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -534,6 +534,18 @@ EXTERN_MSC int GMT_gmtconvert (void *V_API, int mode, void *args) {
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "Processing input table data\n");
 
+	if (GMT->common.g.active) {
+		unsigned int i;
+		for (i = 0; i < GMT->common.g.n_methods; i++) {	/* Go through each criterion */
+			if (GMT->common.g.method[i] == GMT_NEGGAP_IN_MAP_COL ||
+				GMT->common.g.method[i] == GMT_POSGAP_IN_MAP_COL ||
+				GMT->common.g.method[i] == GMT_GAP_IN_PDIST) {
+				GMT_Report (API, GMT_MSG_ERROR, "The -g option cannot use X, Y, or D since no projection can be set. Use mapproject first\n");
+				Return (GMT_RUNTIME_ERROR);
+			}
+		}
+	}
+
 	if (GMT_Init_IO (API, GMT_IS_DATASET, GMT_IS_POINT, GMT_IN, GMT_ADD_DEFAULT, 0, options) != GMT_NOERROR) {
 		Return (API->error);	/* Establishes data files or stdin */
 	}


### PR DESCRIPTION
Since those measures requires a map projection which is not available in **convert** we cannot accept those arguments and thus give an error.
