### PR TITLE
Wrong divisor in grdmath D2DXY

### DIFF
--- a/src/grdmath.c
+++ b/src/grdmath.c
@@ -2023,10 +2023,10 @@ GMT_LOCAL void grdmath_D2DXY (struct GMT_CTRL *GMT, struct GRDMATH_INFO *info, s
 
 	z = gmt_M_memory (GMT, NULL, info->size, float);
 	cx = gmt_M_memory (GMT, NULL, info->G->header->n_rows, double);
-	gmt_M_row_loop (GMT, info->G, row) cx[row] = 0.5 / (info->dx[row] * info->dx[row]);
+	gmt_M_row_loop (GMT, info->G, row) cx[row] = 0.5 / info->dx[row];
 
 	mx = info->G->header->mx;
-	cy = 0.5 / (info->dy * info->dy);
+	cy = 0.5 / info->dy;
 
 	gmt_M_grd_loop (GMT, info->G, row, col, node) {
 		z[node] = (float)(cx[row] * cy * (stack[last]->G->data[node-mx+1] - stack[last]->G->data[node-mx-1] + \


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/grdmath-d2dxy-operator-usage/3773) for background on this **grdmath** bug.  Classic copy-paste error where we ended up dividing by dx^2 and dy^2 instead of just dx*dy.

After the fix proposed in this PR and setting the CPT for the **D2DXY** case to that of the others, we get

![gaussian_test_diff](https://user-images.githubusercontent.com/26473567/227179367-ac20ead3-95b2-445b-b20e-e21b5b9a9aaf.png)

