### PR TITLE
Special case to find the gs executable full name from within Julia artifacts

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -215,3 +215,8 @@ set (CMAKE_FIND_FRAMEWORK LAST)
 if (NOT DEFINED BUILD_DEVELOPER)
 	set (BUILD_DEVELOPER true)
 endif (NOT DEFINED BUILD_DEVELOPER)
+
+# To allow setting this PreProcessor on command line when BinaryBuilder (Julia) builds GMT
+if (JULIA_GHOST_JLL)
+	add_definitions(/DJULIA_GHOST_JLL)
+endif (JULIA_GHOST_JLL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -335,12 +335,6 @@ else (NOT LICENSE_RESTRICTED) # on
 	set (GMT_TRIANGULATE "Watson" PARENT_SCOPE)
 endif (NOT LICENSE_RESTRICTED)
 
-##
-## To allow setting this PreProcessor on command line when BinaryBuilder (Julia) builds GMT
-##
-if (JULIA_GHOST_JLL)
-	add_definitions(/DJULIA_GHOST_JLL)
-endif (JULIA_GHOST_JLL)
 
 ##
 ##	Set list of source codes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -335,6 +335,12 @@ else (NOT LICENSE_RESTRICTED) # on
 	set (GMT_TRIANGULATE "Watson" PARENT_SCOPE)
 endif (NOT LICENSE_RESTRICTED)
 
+##
+## To allow setting this PreProcessor on command line when BinaryBuilder (Julia) builds GMT
+##
+if (JULIA_GHOST_JLL)
+	add_definitions(/DJULIA_GHOST_JLL)
+endif (JULIA_GHOST_JLL)
 
 ##
 ##	Set list of source codes


### PR DESCRIPTION
In Julia when using the precompiled Artifacts, the Ghost is also shipped with but when gmt_init makes calls to psconvert it doesn't set -G with the path to the Ghostscript_jll executable and those processes fail (mostly modern mode stuff). The solution is to try to read the gs path from ~/.gmt/ghost_jll_path.txt

This code should only be executed by binaries created with Julia's BinaryBuilder.
