### PR TITLE
cmake: Fix the bug that some images are rebuilt in every build

### DIFF
--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -28,7 +28,8 @@ if (SPHINX_FOUND)
 	# Convert PS to PNG
 	file (GLOB _scripts_ps2png RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/images/*.ps")
 	set (_scripts_png)
-	foreach (_fig ${_scripts_ps2png})
+	foreach (_ps ${_scripts_ps2png})
+		get_filename_component (_fig ${_ps} NAME)
 		string (REPLACE ".ps" ".png" _png_fig ${_fig})
 		list (APPEND _scripts_png ${RST_BINARY_DIR}/_images/${_png_fig})
 		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
@@ -37,15 +38,16 @@ if (SPHINX_FOUND)
 			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
 			-A -P -E150 -Tg -Qg4 -Qt4
 			-D${RST_BINARY_DIR}/_images
-			${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
+			${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${_fig})
-	endforeach (_fig ${_scripts_ps2png})
+			DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${CMAKE_CURRENT_SOURCE_DIR}/${_ps})
+	endforeach (_ps ${_scripts_ps2png})
 
 	# Convert PS to PDF
 	set (_scripts_ps2pdf images/GMT_RGBchart.ps images/GMT_App_F_stand+_iso+.ps images/GMT_App_F_symbol_dingbats.ps)
 	set (_scripts_pdf)
-	foreach (_fig ${_scripts_ps2pdf})
+	foreach (_ps ${_scripts_ps2pdf})
+		get_filename_component (_fig ${_ps} NAME)
 		string (REPLACE ".ps" ".pdf" _pdf_fig ${_fig})
 		list (APPEND _scripts_pdf ${RST_BINARY_DIR}/_images/${_pdf_fig})
 		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
@@ -53,10 +55,10 @@ if (SPHINX_FOUND)
 			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
 			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert -A -P -Tf
 			-D${RST_BINARY_DIR}/_images
-			${CMAKE_CURRENT_SOURCE_DIR}/${_fig}
+			${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${_fig})
-	endforeach (_fig ${_scripts_ps})
+			DEPENDS gmt_for_img_convert _docs_rst_mkdir_images ${CMAKE_CURRENT_SOURCE_DIR}/${_ps})
+	endforeach (_ps ${_scripts_ps})
 
 	# Convert script to verbatim txt
 	file (GLOB _scripts_sh2txt RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*.sh")


### PR DESCRIPTION
**Description of proposed changes**

Image conversions from PS to PNG/PDF are performed in every build because we had a cmake target dependency bug when migrating to DVC. This PR fixes it.

Address https://github.com/GenericMappingTools/gmt/issues/7225.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
