### PR TITLE
Remove the restriction in -p that Elevation must be in 0-90 range

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -2472,10 +2472,6 @@ GMT_LOCAL int gmtinit_parse_p_option (struct GMT_CTRL *GMT, char *item) {
 		return GMT_PARSE_ERROR;
 	}
 	if (k == 1) { GMT->common.p.do_z_rotation = true; el = 90.0;}
-	if (el <= 0.0 || el > 90.0) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -p: Elevation must be in 0-90 range\n");
-		return GMT_PARSE_ERROR;
-	}
 	if (c) {	/* Now process any modifiers */
 		pos = 0;
 		c[0] = '+';	/* Restore that character */


### PR DESCRIPTION
This allows for example to do mirror maps like this. Limiting to positive elevations only lets do rotations, nor mirroring.

```
gmt pscoast -W0.3 -R-180/0/-90/90 -JV0/8c -Bg -P -K > lixo.ps
gmt pscoast -W0.3 -R-180/0/-90/90 -JV0/8c -Bg -p0/-90 -X8 -O >> lixo.ps
```

![lixo](https://user-images.githubusercontent.com/537321/228403261-69768784-c61c-443f-b5c9-ff27895e8692.png)
