### PR TITLE
WIP Update admin/build-release.sh for 6.5

### DIFF
--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -51,15 +51,15 @@ elif [ "X${1}" = "X-t" ]; then
 	release=0
 elif [ $# -gt 0 ]; then
 	cat <<- EOF  >&2
-	Usage: build-release.sh [-p|m]
+	Usage: build-release.sh [-p|m|t]
 	
 	build-release.sh must be run from top-level gmt directory.
 	Will create the release compressed tarballs and (under macOS) the bundle.
 	Requires you have set GMT_PACKAGE_VERSION_* and GMT_PUBLIC_RELEASE in cmake/ConfigDefaults.cmake.
 	Requires GMT_GSHHG_SOURCE and GMT_DCW_SOURCE to be set in the environment.
-	Passing -p means we copy the files to the SOEST ftp directory
-	Passing -m means only copy the macOS bundle to the SOEST ftp directory
-	Passing -t means test the build-release script without requiring GMT_PUBLIC_RELEASE
+		Passing -p means we copy the files to the SOEST ftp directory
+		Passing -m means only copy the macOS bundle to the SOEST ftp directory
+		Passing -t means test the build-release script without requiring GMT_PUBLIC_RELEASE
 	[Default places no files in the SOEST ftp directory]
 	EOF
 	exit 1


### PR DESCRIPTION
Given the macport's GDAL seems perpetually f**ed  I am trying to see if we can build the macOS installer with homebrew.  It goes a ways but then I get this rpath error from

```
 error:
  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic:
  can't open file: @rpath/libIlmThread-3_1.30.dylib (No such file or
  directory)

```
The file do exist but in /opt/homebrew/lib

However, homebrew is not always installed there but in /usr/local/bin?

Hoping @seisman and @maxrjones might have some insight here since we've waited several months for macports to get their act together.