### PR TITLE
Update dvc images after disallowing -Xc|f in modern mode

### DIFF
--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 205417ccc178ca0cfe8350d807ebb3f8.dir
-  size: 33294651
+- md5: 522c357a54bb1eb5395bbb36a02c33ce.dir
+  size: 33290059
   nfiles: 200
   path: images

--- a/test/baseline/grdfill.dvc
+++ b/test/baseline/grdfill.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 56384968a9590c4aace60b5e75344b63.dir
-  size: 207386
+- md5: de633d11cdb21dbc1f683ffb854beb82.dir
+  size: 207682
   nfiles: 5
   path: grdfill

--- a/test/baseline/modern.dvc
+++ b/test/baseline/modern.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 322d08a16112444fbe06c7c6e363c404.dir
-  size: 1661390
+- md5: 35bea584cab01c745f4e7aaa73e8c239.dir
+  size: 1661701
   nfiles: 20
   path: modern

--- a/test/baseline/psbasemap.dvc
+++ b/test/baseline/psbasemap.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 95ed1649102e92898fcaf7acaeec066f.dir
-  size: 2901333
+- md5: c6a5d32499e74d4a19c6978436f61e07.dir
+  size: 2901913
   nfiles: 56
   path: psbasemap


### PR DESCRIPTION
**Description of proposed changes**

Patches https://github.com/GenericMappingTools/gmt/issues/7304. 

Tests like `test/psbasemap/absrelaxis` fails because Paul forgot to update these PS files  after updating the scripts in https://github.com/GenericMappingTools/gmt/pull/7304.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
