### PR TITLE
Fix signal function list

### DIFF
--- a/src/gmt.c
+++ b/src/gmt.c
@@ -52,14 +52,14 @@ int main (int argc, char *argv[]) {
 #ifndef NO_SIGHANDLER
 	/* Install a signal handler */
 #ifdef WIN32	/* Only handle Ctrl-C under Windows */
-    if (!SetConsoleCtrlHandler ((PHANDLER_ROUTINE)sig_handler_win32, TRUE)) {
+    if (!SetConsoleCtrlHandler ((PHANDLER_ROUTINE)gmt_sig_handler_win32, TRUE)) {
         fprintf (stderr, "Unable to install Windows signal handler!\n");
         return EXIT_FAILURE;
     }
 #else	/* Unix/Linux/macOS */
 	struct sigaction act;
 	sigemptyset(&act.sa_mask); /* Empty mask of signals to be blocked during execution of the signal handler */
-	act.sa_sigaction = sig_handler_unix;
+	act.sa_sigaction = gmt_sig_handler_unix;
 	act.sa_flags = SA_SIGINFO;
 	sigaction (SIGINT,  &act, NULL);	/* Catching Ctrl-C will also wipe a session work directory and destroy GMT session */
 	sigaction (SIGILL,  &act, NULL);	/* The other signals will exit with a full backtrace */

--- a/src/gmt_common_sighandler.c
+++ b/src/gmt_common_sighandler.c
@@ -23,6 +23,13 @@
  * Version: 5
  */
 
+/*
+ *
+ * A) List of exported gmt_* functions available to modules and libraries via gmt_dev.h:
+ * gmt_sig_handler_unix
+ * gmt_sig_handler_win32
+ */
+
 #ifndef NO_SIGHANDLER
 
 #include "gmt_dev.h"
@@ -31,13 +38,13 @@
 #ifdef WIN32
 #include <windows.h>
 /* win32: Install Windows SIGINT handling only */
-BOOL sig_handler_win32 (DWORD dwType) {
+BOOL gmt_sig_handler_win32 (DWORD dwType) {
     if (dwType == CTRL_C_EVENT)
 		gmtlib_terminate_session ();	/* Delete session dir, call GMT_Destroy_Session, and for CLI call exit */
 	return TRUE;
 }
 /* install WIN32 signal handler like this: 
- *  SetConsoleCtrlHandler((PHANDLER_ROUTINE)sig_handler_win32,TRUE));
+ *  SetConsoleCtrlHandler((PHANDLER_ROUTINE)gmt_sig_handler_win32,TRUE));
  */
 #else
 /* unix: Install broader sighandler via backtrace handling of SIGINT, SIGILL, SIGFPE, SIGBUS and SIGSEGV */
@@ -55,10 +62,11 @@ BOOL sig_handler_win32 (DWORD dwType) {
 #include <execinfo.h>
 #else
 #include <stdbool.h>
-int backtrace(void **buffer, int size) {
+GMT_LOCAL int backtrace(void **buffer, int size) {
 	return 0;
 }
-void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
+
+GMT_LOCAL void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 	static bool once = false;
 	if (once) return;
 	once = true;
@@ -190,7 +198,7 @@ static void process_info() {
 }
 #endif
 
-void sig_handler_unix (int sig_num, siginfo_t *info, void *ucontext) {
+void gmt_sig_handler_unix (int sig_num, siginfo_t *info, void *ucontext) {
 	if (sig_num == SIGINT) {
 		/* Catch Ctrl-c and remove modern session sub-directory (if it exists) before exit */
 		struct sigaction act, oldact;
@@ -227,7 +235,7 @@ void sig_handler_unix (int sig_num, siginfo_t *info, void *ucontext) {
  *   struct sigaction act;
  *   sigemptyset (&act.sa_mask);
  *   act.sa_flags = SA_NODEFER;
- *   act.sa_handler = sig_handler_unix;
+ *   act.sa_handler = gmt_sig_handler_unix;
  *   sigaction (SIGINT,  &act, NULL);
  *   act.sa_flags = 0;
  *   sigaction (SIGBUS,  &act, NULL);

--- a/src/gmt_common_sighandler.h
+++ b/src/gmt_common_sighandler.h
@@ -34,10 +34,10 @@
 #ifndef NO_SIGHANDLER
 #   ifdef WIN32
 #       include <windows.h>
-        EXTERN_MSC BOOL sig_handler_win32 (DWORD dwType);
+        EXTERN_MSC BOOL gmt_sig_handler_win32 (DWORD dwType);
 #   else
 #       include <signal.h>
-        EXTERN_MSC void sig_handler_unix (int sig_num, siginfo_t *info, void *ucontext);
+        EXTERN_MSC void gmt_sig_handler_unix (int sig_num, siginfo_t *info, void *ucontext);
 #   endif
 #endif /* !defined(NO_SIGHANDLER) */
 


### PR DESCRIPTION
Also add `gmt_` in front of those functions to be consistent with all other such functions, and add **GMT_LOCAL** to those not used elsewhere.
