### PR TITLE
Fix places where declaration come after statements

### DIFF
--- a/src/blockmedian.c
+++ b/src/blockmedian.c
@@ -47,8 +47,8 @@
 
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
-	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	const char *extra1[2] = {" [-G<grdfile>]", ""}, *extra2[2] = {" (requires -G)", ""};
+	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<table>] %s %s [-A<fields>] [-C] [-E[b|r|s[+l|h]]]%s [-Q] [-T<q>] [%s] "
 		"[-W[i|o][+s|w]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_I_OPT, GMT_Rgeo_OPT, extra1[API->external], GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT,

--- a/src/blockmode.c
+++ b/src/blockmode.c
@@ -58,8 +58,8 @@ struct BIN_MODE_INFO {	/* Used for histogram binning */
 
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
-	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	const char *extra1[2] = {" [-G<grdfile>]", ""}, *extra2[2] = {" (requires -G)", ""};
+	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [<table>] %s %s [-A<fields>] [-C] [-D[<width>][+c][+a|l|h]] [-E[r|s[+l|h]]]%s "
 		"[-Q] [-W[i|o][+s|w]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_I_OPT, GMT_Rgeo_OPT, extra1[API->external], GMT_V_OPT, GMT_a_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT,

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7760,8 +7760,9 @@ int gmt_list_cpt (struct GMT_CTRL *GMT, char option) {
 	divider[L] = '\0';	/* Truncate the line */
 	gmt_message (GMT, "     %s\n", divider);
 	for (unsigned int k = 0; k < GMT_N_CPT_MASTERS; k++) {
+		char *c = NULL;
 		strncpy (line, GMT_CPT_master[k], GMT_LEN256);
-		char *c = strchr (line, ':');	/* Find the start of the info */
+		c = strchr (line, ':');	/* Find the start of the info */
 		c[0] = '\0';
 		gmt_message (GMT, "     %s: ", line);
 		GMT_Usage (API, -19, "%s", &c[2]);
@@ -10024,8 +10025,8 @@ unsigned int gmt_contour_first_pos (struct GMT_CTRL *GMT, char *arg) {
 	/* Because of backwards compatibility, we need to anticipate shits like -A+1 for a
 	 * single annotated contour and hence cannot confuse it with a modifier for contour specs.
 	 * Thus, here we scan past any leading single contour specification using deprecated syntax. */
-	gmt_M_unused(GMT);
 	unsigned int k = 1;
+	gmt_M_unused(GMT);
 	if (arg[0] != '+') return 0;	/* Start checking from start */
 	if (isalpha (arg[1]) || arg[1] == '=') return 0;	/* Standard modifier */
 	/* Here we must have +<value> which we wish to skip */

--- a/src/gmt_vector.c
+++ b/src/gmt_vector.c
@@ -1349,8 +1349,8 @@ void gmt_matrix_matrix_mult (struct GMT_CTRL *GMT, double *A, double *B, uint64_
 }
 
 void gmt_matrix_matrix_add (struct GMT_CTRL *GMT, double *A, double *B, uint64_t n_rowsA, uint64_t n_colsA, double *C) {
-	gmt_M_unused(GMT);
 	uint64_t row, col, ij;
+	gmt_M_unused(GMT);
 	for (row = ij = 0; row < n_rowsA; row++) {
 		for (col = 0; col < n_colsA; col++, ij++) {
 			C[ij] = A[ij] + B[ij];

--- a/src/potential/grdflexure.c
+++ b/src/potential/grdflexure.c
@@ -420,8 +420,8 @@ GMT_LOCAL double grdflexure_transfer_elastic (double *k, struct GRDFLEXURE_RHEOL
 
 GMT_LOCAL double grdflexure_transfer_Airy (double *k, struct GRDFLEXURE_RHEOLOGY *R) {
 	/* Airy transfer function (isotropic and independent of k) */
-	gmt_M_unused (k);
 	double grdflexure_transfer_fn = R->scale;
+	gmt_M_unused (k);
 	return (grdflexure_transfer_fn);
 }
 

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -736,8 +736,8 @@ GMT_LOCAL unsigned int psscale_cpt_transparency (struct GMT_CTRL *GMT, struct GM
 	 * Bit 2 means different slices have different transparencies
 	 * Bit 3 means at least one slice has different transparencies within it
 	 */
-	gmt_M_unused(GMT);
 	unsigned int k, status = 0;
+	gmt_M_unused(GMT);
 	for (k = 0; k < P->n_colors; k++) {
 		if (P->data[k].rgb_low[3] > 0.0 || P->data[k].rgb_high[3] > 0.0) status |= 1;	/* Transparency detected */
 		if (k && !doubleAlmostEqualZero (P->data[k].rgb_low[3], P->data[k-1].rgb_low[3]))     status |= 2;	/* Unequal transparencies between slices */


### PR DESCRIPTION
Wile this is seemingly OK in C99 and beyond, there is no reason to violate that old principle since we things to compile on anything
