### PR TITLE
Option to use build-release no gdal on the macports

### DIFF
--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -21,7 +21,7 @@ GDAL_VIA_HOMEBREW=$3
 
 if [ ${DISTRO} = "MacPorts" ]; then
 	top=/opt/local
-	if [ ${GDAL_VIA_HOMEBREW} = "Y" ]; then
+	if [ "X${GDAL_VIA_HOMEBREW}" = "XY" ]; then
 		topgdal=/opt/homebrew
 	else
 		topgdal=/opt/local
@@ -60,7 +60,7 @@ EXELINKS=${top}/bin/gs
 EXEONLY=
 # 1d. Shared directories to be added (except ghostscript which we do separately)
 #     Use full path if you need something not in your path
-if [ ${GDAL_VIA_HOMEBREW} = "Y" ]; then
+if [ "X${GDAL_VIA_HOMEBREW}" = "XY" ]; then
 	EXESHARED="${proj}"
 else
 	EXESHARED="gdal ${proj}"
@@ -114,7 +114,7 @@ if [ ! "X$EXESHARED" = "X" ]; then
 	echo ""
 	echo "install (DIRECTORY"
 fi
-if [ ${GDAL_VIA_HOMEBREW} = "Y" ]; then
+if [ "X${GDAL_VIA_HOMEBREW}" = "XY" ]; then
 	echo "	$topgdal/share/gdal"
 fi
 for P in $EXESHARED; do

--- a/admin/build-macos-external-list.sh
+++ b/admin/build-macos-external-list.sh
@@ -12,12 +12,20 @@
 #
 # Notes:
 #   1. This is tested on macports where gs is a symbolic link to gsc.
+#	2. Since the latest macports is fucked related to GDAL we must get GDAL and executables
+#	   from homebrew installation instead.
 
 GSVERSION=$1	# Get the version of gs from build-release.sh
 DISTRO=$2
+GDAL_VIA_HOMEBREW=$3
 
 if [ ${DISTRO} = "MacPorts" ]; then
 	top=/opt/local
+	if [ ${GDAL_VIA_HOMEBREW} = "Y" ]; then
+		topgdal=/opt/homebrew
+	else
+		topgdal=/opt/local
+	fi
 	omp="libomp/"
 	proj="${top}/lib/proj8/share/proj"
 	gm="${top}/lib/GraphicsMagick-\${GMT_CONFIG_GM_VERSION}"
@@ -42,8 +50,8 @@ TMPDIR=${TMPDIR:-/tmp}
 
 # 1a. List of executables needed and whose shared libraries also are needed.
 #     Use full path if you need something not in your path
-EXEPLUSLIBS="${top}/bin/gsc ${top}/bin/gm ${top}/bin/ffmpeg ${top}/bin/ogr2ogr \
- ${top}/bin/gdal_translate ${top}/lib/libfftw3f_threads.dylib ${top}/lib/${omp}libomp.dylib"
+EXEPLUSLIBS="${top}/bin/gsc ${top}/bin/gm ${top}/bin/ffmpeg ${topgdal}/bin/ogr2ogr \
+ ${topgdal}/bin/gdal_translate ${top}/lib/libfftw3f_threads.dylib ${top}/lib/${omp}libomp.dylib"
 # 1b. List of any symbolic links needed
 #     Use full path if you need something not in your path
 EXELINKS=${top}/bin/gs
@@ -52,7 +60,11 @@ EXELINKS=${top}/bin/gs
 EXEONLY=
 # 1d. Shared directories to be added (except ghostscript which we do separately)
 #     Use full path if you need something not in your path
-EXESHARED="gdal ${proj}"
+if [ ${GDAL_VIA_HOMEBREW} = "Y" ]; then
+	EXESHARED="${proj}"
+else
+	EXESHARED="gdal ${proj}"
+fi
 #-----------------------------------------
 # 2a. Add the executables to the list given their paths
 rm -f ${TMPDIR}/raw.lis
@@ -101,6 +113,9 @@ EOF
 if [ ! "X$EXESHARED" = "X" ]; then
 	echo ""
 	echo "install (DIRECTORY"
+fi
+if [ ${GDAL_VIA_HOMEBREW} = "Y" ]; then
+	echo "	$topgdal/share/gdal"
 fi
 for P in $EXESHARED; do
 	if [ $P = $(basename $P) ]; then

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -74,7 +74,10 @@ fi
 # macports or homebrew is required
 if [ $(which cmake) = "/opt/local/bin/cmake" ]; then
 	DISTRO=MacPorts
-	NO_GDAL=Y
+	if [ $(which gdalinfo) = "/opt/homebrew/bin/gdalinfo" ]; then
+		NO_GDAL=Y
+		echo "Must use GDAL from /opt/homebrew since not present in macports" >&2
+	fi
 elif [ $(which cmake) = "/usr/local/bin/cmake" ]; then
 	DISTRO=HomeBrew1
 elif [ $(which cmake) = "/opt/homebrew/bin/cmake" ]; then

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -76,7 +76,7 @@ if [ $(which cmake) = "/opt/local/bin/cmake" ]; then
 	DISTRO=MacPorts
 	if [ $(which gdalinfo) = "/opt/homebrew/bin/gdalinfo" ]; then
 		NO_GDAL=Y
-		echo "Must use GDAL from /opt/homebrew since not present in macports" >&2
+		echo "build-release.sh: Must use GDAL from /opt/homebrew since not present in macports" >&2
 	fi
 elif [ $(which cmake) = "/usr/local/bin/cmake" ]; then
 	DISTRO=HomeBrew1

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -16,7 +16,9 @@
 #  Notes:
 #	1. CMAKE_INSTALL_PATH, EXEPLUSLIBS, and EXESHARED in build-macos-external-list.sh may need to be changed for different users.
 #	2. Settings for GS_LIB, PROJ_LIB etc in cmake/dist/startup_macosx.sh.in may need to be updated as new gs,proj.gm releases are issued
-#   4. Setting for CLANG_V may need updating to set compiler version
+#   3. Setting for CLANG_V may need updating to set compiler version
+#	4. Since the latest macports is fucked related to GDAL we must get GDAL and executables
+#	   from homebrew installation instead.
 
 CLANG_V=11	# Current Clang version to use
 # Temporary ftp site for pre-release files:
@@ -72,6 +74,7 @@ fi
 # macports or homebrew is required
 if [ $(which cmake) = "/opt/local/bin/cmake" ]; then
 	DISTRO=MacPorts
+	NO_GDAL=Y
 elif [ $(which cmake) = "/usr/local/bin/cmake" ]; then
 	DISTRO=HomeBrew1
 elif [ $(which cmake) = "/opt/homebrew/bin/cmake" ]; then
@@ -147,7 +150,7 @@ cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
 rm -rf build
 mkdir build
 # 2b. Build list of external programs and shared libraries
-admin/build-macos-external-list.sh ${G_ver} ${DISTRO} > build/add_macOS_cpack.txt
+admin/build-macos-external-list.sh ${G_ver} ${DISTRO} ${NO_GDAL} > build/add_macOS_cpack.txt
 if [ $? -ne 0 ]; then
 	echo 'build-release.sh: Error: Failed to create external list' >&2
 	exit 1


### PR DESCRIPTION
This PR adds a check to determine if we do not have **GDAL** installed in **macports** (since they screwed that port up) and instead get that library, include files, and executables from a **homebrew** installation.  This seems to work well except of course the new problem of _otool_ not finding a library:

```
 error:
  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic:
  can't open file: @rpath/libIlmThread-3_1.30.dylib (No such file or
  directory)

```
Since our script always worked before and now fails with this error I can only assume that there is something stupid somewhere else that is causing this @rpath confusion.  Ideas are welcome, but this PR should be straightforward.