### PR TITLE
Reset V.active before parsing again

### DIFF
--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -466,6 +466,7 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 		}
 		if (do_sample) {	/* One or more reasons to call upon grdsample before using this grid */
 			gmt_filename_set (B[n].file);	/* Replace any spaces in filename with ASCII 29 */
+			GMT->common.V.active = false;	/* Since we will parse again below */
 			if (do_sample & 1) {	/* Resampling of the grid into a netcdf grid */
 
 				if (gmt_get_tempname (GMT->parent, "grdblend_resampled", ".nc", buffer))


### PR DESCRIPTION
See #7380 for background.  Problem is that **grdblend** adds a **-V** option to the commands it may issue to **grdsample** or **grdreformat** and this may lead to multiple parsings of **-V** which then complains.  This PR resets V.active to false when we know we are issuing **-V** options to the next command.
