### PR TITLE
Silence triangulate warning

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -3417,6 +3417,7 @@ int gmt_signum (double x) {
  */
 
 #define REAL double
+#define ANSI_DECLARATORS
 #include "triangle.h"
 
 /* Leave link as int**, not uint64_t** */

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -203,7 +203,7 @@ GMT_LOCAL void pscoupe_rot_axis (struct AXIS A, struct nodal_plane PREF, struct 
 	 *
 	 */
 
-	double xn, xe, xz, x1, x2, x3, meca_zero_360();
+	double xn, xe, xz, x1, x2, x3;
 
 	xn = cosd (A.dip) * cosd (A.str);
 	xe = cosd (A.dip) * sind (A.str);


### PR DESCRIPTION
Because the **triangle** developer used a homegrown define check we never included the proper ANSI C prototype for triangulate and thus got these warnings:

```
/Users/pwessel/UH/RESEARCH/CVSPROJECTS/GMTdev/gmt-dev/src/gmt_support.c:3539:14: warning: passing arguments to 'triangulate' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
        triangulate ("zIQBvDj", &In, &Out, &vorOut);
```

With this PR I define **ANSI_DECLARATIONS** just before we include _triangle.h_ in gmt_support.c and all is well.
