### PR TITLE
List gmt function exported by gdalcall.c

### DIFF
--- a/src/gmt_gdalcall.c
+++ b/src/gmt_gdalcall.c
@@ -15,6 +15,16 @@
  *	Contact info: www.generic-mapping-tools.org
  *--------------------------------------------------------------------*/
 
+/*
+ * A) List of exported gmt_* functions available to modules and libraries via gmt_dev.h:
+ *	gmt_gdal_dem
+ *	gmt_gdal_grid
+ *	gmt_gdal_info
+ *	gmt_gdal_rasterize
+ *	gmt_gdal_translate
+ *	gmt_gdal_warp
+ */
+
 #include "gmt_dev.h"
 #include "gmt_internals.h"
 
@@ -216,7 +226,7 @@ GMT_LOCAL int save_grid_with_GMT(struct GMT_CTRL *GMT, GDALDatasetH hDstDS, stru
 }
 
 /* ------------------------------------------------------------------------------------------------------------ */
-char *out_name(struct GMT_GDALLIBRARIFIED_CTRL *GDLL) {
+GMT_LOCAL char *out_name(struct GMT_GDALLIBRARIFIED_CTRL *GDLL) {
 	/* Pick the right output name when saving grids depending on if that writing is done with GMT or GDAL */
 	if (GDLL->M.write_gdal)			/* Write grid with the GDAL machinery */
 		return GDLL->fname_out;


### PR DESCRIPTION
Also turn _out_name_ to a static function
