### PR TITLE
Add function list to gmt_proj.c

### DIFF
--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -72,6 +72,17 @@
  * Version:	5.x
  */
 
+/*
+ * B) List of exported gmtlib_* functions available to libraries via gmt_internals.h:
+ *
+ *	gmtlib_genper_map_clip_path
+ *	gmtlib_iobl
+ *	gmtlib_itranslin
+ *	gmtlib_translin
+ *
+ * NOTE: gmt_proj.c is included directly into gmt_map.c
+ */
+
 #include "gmt_dev.h"
 #include "gmt_internals.h"
 


### PR DESCRIPTION
But note the whole file is included by gmt_map.c which is thus where things are exported.
