### PR TITLE
Start at 1 when counting completed frames

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -2546,7 +2546,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			status[k].completed = true;	/* Flag this frame as completed */
 			n_cores_unused++;		/* Free up the core */
 			percent = 100.0 * n_frames_completed / n_frames;
-			GMT_Report (API, GMT_MSG_INFORMATION, "Frame %*.*d of %d completed [%5.1f %%]\n", precision, precision, k, n_frames, percent);
+			GMT_Report (API, GMT_MSG_INFORMATION, "Frame %*.*d of %d completed [%5.1f %%]\n", precision, precision, k+1, n_frames, percent);
 		}
 		/* Adjust first_i_frame, if needed */
 		while (first_i_frame < n_frames && status[first_i_frame].completed) first_i_frame++;


### PR DESCRIPTION
To avoid things like

`movie [INFORMATION]: Frame 09 of 10 completed [100.0 %]`

But this one:

```
I also use  -Ml,png to get the master frame from the last one and the message is:
movie [INFORMATION]: Single master plot (frame 9) built: IndianaJones_Flight_Labels.png
```

will not change since here we are reporting a specific frame and they _are_ numbered from 0 and the last frame is thus 09.

Note: the same fix was applied in **batch** last year or earlier.
