### PR TITLE
Ensure trend1d -Fm output is sorted

### DIFF
--- a/doc/rst/source/trend1d.rst
+++ b/doc/rst/source/trend1d.rst
@@ -60,7 +60,8 @@ Required Arguments
     weight used in fitting. Alternatively, choose just the single
     selection **p** to output a record with the polynomial model coefficients,
     **P** for the normalized polynomial model coefficients, or **c**
-    for the normalized Chebyshev model coefficients.
+    for the normalized Chebyshev model coefficients. **Note**: If **m** is included
+    then we sort the output on increasing **x** (whether **x** is selected or not).
 
 .. _-N:
 

--- a/src/trend1d.c
+++ b/src/trend1d.c
@@ -198,13 +198,32 @@ GMT_LOCAL void trend1d_allocate_the_memory (struct GMT_CTRL *GMT, unsigned int n
 	*w_model = gmt_M_memory (GMT, NULL, np, double);
 }
 
+/*! Sort on x */
+GMT_LOCAL int trend1d_compare_x (const void *point_1, const void *point_2) {
+	const struct TREND1D_DATA *p1 = point_1, *p2 = point_2;
+
+	/* First sort on bin index ij */
+	if (p1->x < p2->x) return (-1);
+	if (p1->x > p2->x) return (+1);
+	/* Values are the same, return 0 */
+	return (0);
+}
+
 GMT_LOCAL void trend1d_write_output_trend (struct GMT_CTRL *GMT, struct TREND1D_DATA *data, uint64_t n_data, char *output_choice, unsigned int n_outputs) {
+	bool sort_on_x = false;
 	uint64_t i;
 	unsigned int j;
 	double out[5] = {0, 0, 0, 0, 0};
 	struct GMT_RECORD Out;
 
 	Out.data = out;	Out.text = NULL;
+	for (j = 0; j < n_outputs; j++) {
+		if (output_choice[j] == 'm')
+			sort_on_x = true;
+	}
+	if (sort_on_x)	/* Sort model prediction on increasing x */
+		qsort (data, n_data, sizeof (struct TREND1D_DATA), trend1d_compare_x);
+
 	for (i = 0; i < n_data; i++) {
 		for (j = 0; j < n_outputs; j++) {
 			switch (output_choice[j]) {


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/polynomial-fit-with-trend1d/3850/5) for origin of this issue.  When model predictions are requested (i.e., **m** is one of the directives in **-F**) we ensure the output from **trend1d**  is sorted so that plotting the model gives sensible results.
