### PR TITLE
Reset character set if given via --PS_CHAR_ENCODING

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -1625,13 +1625,13 @@ GMT_LOCAL int gmtinit_parse_dash_option (struct GMT_CTRL *GMT, char *text) {
 		/* Got --PAR=VALUE */
 		this_c[0] = '\0';	/* Temporarily remove the '=' character */
 		n = gmtlib_setparameter (GMT, text, &this_c[1], false);
+		if (!strcmp (text, "PS_CHAR_ENCODING")) GMT->current.ps.switch_set = true;
 		this_c[0] = '=';	/* Put it back were it was */
 	}
 	else {
 		/* Got --PAR */
 		n = gmtlib_setparameter (GMT, text, "true", false);
 	}
-	if (!strcmp (text, "PS_CHAR_ENCODING")) GMT->current.ps.switch_set = true;
 	return (n);
 }
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -9140,7 +9140,7 @@ struct PSL_CTRL *gmt_plotinit (struct GMT_CTRL *GMT, struct GMT_OPTION *options)
 
 	if (O_active && GMT->current.ps.switch_set) {	/* User used --PS_CHAR_ENCODING=<encoding> to change it */
 		GMT->current.ps.switch_set = false;
-		switch_charset = 4;
+		switch_charset = PSL_CHANGESET;
 	}
 
 	/* Get title */


### PR DESCRIPTION
This usually means we are switching between different character sets and we must rewrite the set and reset fonts used before plotting more. Addresses this forum [post](https://forum.generic-mapping-tools.org/t/dependency-of-codepage-processing-on-the-gmt-version/3853/2).

Note: Most of the work for this PR was done a long time ago but it looks like I can side-tracked before finishing it.  It also had a bug preventing _switch_set_ to be set to true.  Once that was done then the example in the forum works for me.