### PR TITLE
Patch the case when externals try to cut from global grids.

### DIFF
--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -1032,6 +1032,10 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 	if (Ctrl->In.type == GMT_IS_GRID) {	/* Write a grid */
 		if (GMT_Set_Comment (API, GMT_IS_GRID, GMT_COMMENT_IS_OPTION | GMT_COMMENT_IS_COMMAND, options, G))
 			Return (API->error);
+		if (API->external) {	/* No need to BC and, mainly, avoid a bug that plagues cutting global grids from externals */
+			HH = gmt_get_H_hidden (G->header);
+			HH->no_BC = 1;
+		} 
 		if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, Ctrl->G.file, G) != GMT_NOERROR)
 			Return (API->error);
 	}


### PR DESCRIPTION
The problem:

On Julia (but it should be the same with all externals) this works:

grdcut("@earth_relief_06m_p", R=(-180,-90,-90,90));

but this crashes

G0 = gmtread("@earth_relief_06m_p");
grdcut(G0, R=(-180,-90,-90,90));

The problem is in the BC functions where passing a grid object sets ``HH->nxp`` to != 0 (contrary to what CLI and passing the grid file name does) and keeps that value when trying to write the file. Since that value was not reset to 0 for the output grid we have an invalid memory access.

Now fixing this on its origin is hard (need to find out where and why) but we can make patch of not letting the BC functions (where the crash occurs) be called. 

The image case might need a similar patch but I've not looked at it.