### PR TITLE
Fix LaTeX fail on Windows

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -451,15 +451,15 @@ GMT_LOCAL unsigned char * gmtplot_latex_eps (struct GMT_CTRL *GMT, struct GMT_FO
 		GMT_Report (API, GMT_MSG_ERROR, "gmtplot_latex_eps: Unable to load EPS file equation.eps\n");
 		return NULL;
 	}
-	/* Clean up */
-	if (gmt_remove_dir (API, tmpdir, false)) {
-		GMT_Report (API, GMT_MSG_ERROR, "gmtplot_latex_eps: Unable to remove temporary directory %s!\n", tmpdir);
-		PSL_free (picture);
-		return NULL;
-	}
 	/* Change back to original directory */
 	if (chdir (here)) {
 		GMT_Report (API, GMT_MSG_ERROR, "gmtplot_latex_eps: Unable to change directory back to %s - exiting.\n", here);
+		PSL_free (picture);
+		return NULL;
+	}
+	/* Clean up */
+	if (gmt_remove_dir (API, tmpdir, false)) {
+		GMT_Report (API, GMT_MSG_ERROR, "gmtplot_latex_eps: Unable to remove temporary directory %s!\n", tmpdir);
 		PSL_free (picture);
 		return NULL;
 	}


### PR DESCRIPTION
**Description of proposed changes**

Fix LaTeX Fail on Windows.

On Windows, the current directory cannot be deleted (but on Linux it can), so we need to switch to another directory to delete it. So I adjusted the order of `chdir` and `gmt_remove_dir`. 