### PR TITLE
Fix issues with gmt which -G

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1272,7 +1272,10 @@ not_local:	/* Get here if we failed to find a remote file already on disk */
 					snprintf (local_path, PATH_MAX, "%s/%s", GMT->session.USERDIR, &file[1]);
 				break;
 			case GMT_LOCAL_DIR:
-				snprintf (local_path, PATH_MAX, "%s", &file[1]);
+				if (jp2_file)	/* Leave as JP2 file in the local directory */
+					snprintf (local_path, PATH_MAX, "%s", jp2_file);
+				else
+					snprintf (local_path, PATH_MAX, "%s", &file[1]);
 				break;
 			default:	/* Place remote data files locally per the internal rules */
 				if (GMT->session.USERDIR == NULL || access (GMT->session.USERDIR, R_OK))

--- a/src/gmtwhich.c
+++ b/src/gmtwhich.c
@@ -149,7 +149,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTWHICH_CTRL *Ctrl, struct GMT_O
 }
 
 
-GMT_LOCAL int gmtwhich_list_tiles (struct GMTAPI_CTRL *API, char *list, bool YN, struct GMT_RECORD *Out) {
+GMT_LOCAL int gmtwhich_list_tiles (struct GMTAPI_CTRL *API, char *list, unsigned int mode, bool YN, struct GMT_RECORD *Out) {
 	/* List all tiles and whether found/not found */
 	int t_data, fail;
 	uint64_t n, k, nf = 0;
@@ -158,7 +158,8 @@ GMT_LOCAL int gmtwhich_list_tiles (struct GMTAPI_CTRL *API, char *list, bool YN,
 
 	if ((t_data = gmt_get_tile_id (API, list)) == GMT_NOTSET) return GMT_RUNTIME_ERROR;
 	if ((n = gmt_read_list (API->GMT, list, &file)) == 0) return GMT_RUNTIME_ERROR;
-	snprintf (dir, PATH_MAX, "%s%s%s", API->GMT->session.USERDIR, API->remote_info[t_data].dir, API->remote_info[t_data].file);
+	if (mode == 0)	/* Not looking in local directory */
+		snprintf (dir, PATH_MAX, "%s%s%s", API->GMT->session.USERDIR, API->remote_info[t_data].dir, API->remote_info[t_data].file);
 
 	for (k = 0; k < n; k++) {
 		sprintf (path, "%s%s", dir, &file[k][1]);
@@ -251,7 +252,7 @@ EXTERN_MSC int GMT_gmtwhich (void *V_API, int mode, void *args) {
 		if (Ctrl->G.active) {
 			if (list) {
 				gmt_download_tiles (API, opt->arg, Ctrl->G.mode);
-				if ((error = gmtwhich_list_tiles (API, opt->arg, Ctrl->C.active, Out)))
+				if ((error = gmtwhich_list_tiles (API, opt->arg, Ctrl->G.mode, Ctrl->C.active, Out)))
 					Return (error);
 				continue;
 			}
@@ -265,7 +266,7 @@ EXTERN_MSC int GMT_gmtwhich (void *V_API, int mode, void *args) {
 		else
 			strcpy (file, opt->arg);
 		if (list) {
-			if ((error = gmtwhich_list_tiles (API, opt->arg, Ctrl->C.active, Out)))
+			if ((error = gmtwhich_list_tiles (API, opt->arg, Ctrl->G.mode, Ctrl->C.active, Out)))
 				Return (error);
 		}
 		else if (gmt_getdatapath (GMT, &file[first], path, fmode)) {	/* Found the file */


### PR DESCRIPTION
See #7400 for background.  This PR checks the **-G** mode and

1. Ensure that the JP2 file is converted to nc and not just stored using .nc extension
2. Looks in local dir to report the path when **-G** is set.

Seems to work. If reviewers agree we merge and close #7400.