### PR TITLE
Add -Io to grdinfo for oblique format

### DIFF
--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-E|\ [**x**\|\ **y**][**+l**\|\ **L**\|\ **u**\|\ **U**] ]
 [ |-F| ]
 [ |-G| ]
-[ |-I|\ [*dx*\ [/*dy*]\|\ **b**\|\ **i**\|\ **r**] ]
+[ |-I|\ [*dx*\ [/*dy*]\|\ **b**\|\ **i**\|\ **o**\|\ **r**] ]
 [ |-L|\ [**0**\|\ **1**\|\ **2**\|\ **p**\|\ **a**] ]
 [ |-M|\ [**c**\|\ **f**] ]
 [ |SYN_OPT-R| ]
@@ -111,10 +111,11 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ [*dx*\ [/*dy*]\|\ **b**\|\ **i**\|\ **r**]
+**-I**\ [*dx*\ [/*dy*]\|\ **b**\|\ **i**\|\ **o**\|\ **r**]
     Report the min/max of the region to the nearest multiple of *dx* and
     *dy*, and output this in the form |-R|\ *w/e/s/n* (unless |-C|
-    is set). To report the actual grid region, select |-I|\ **r**. For a
+    is set). To report the actual grid region, select |-I|\ **r** for
+    the format |-R|\ *w/e/s/n* or |-I|\ **o** for the oblique format |-R|\ *w/s/e/n*\ **+r**. For a
     grid produced by the img supplement (a Cartesian Mercator grid),
     the exact geographic region is given with |-I|\ **i** (if not found
     then we return the actual grid region instead).  If no

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -40,6 +40,7 @@
 enum Opt_I_modes {
 	GRDINFO_GIVE_INCREMENTS = 0,
 	GRDINFO_GIVE_REG_ORIG,
+	GRDINFO_GIVE_REG_OBLIQUE,
 	GRDINFO_GIVE_REG_IMG,
 	GRDINFO_GIVE_REG_ROUNDED,
 	GRDINFO_GIVE_BOUNDBOX};
@@ -118,7 +119,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDINFO_CTRL *C) {	/* Deallo
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s %s [-C[n|t]] [-D[<offx>[/<offy>]][+i]] [-E[x|y][+l|L|u|U]] [-F] [-G] [-I[<dx>[/<dy>]|b|i|r]] [-L[a|0|1|2|p]] "
+	GMT_Usage (API, 0, "usage: %s %s [-C[n|t]] [-D[<offx>[/<offy>]][+i]] [-E[x|y][+l|L|u|U]] [-F] [-G] [-I[<dx>[/<dy>]|b|i|o|r]] [-L[a|0|1|2|p]] "
 		"[-M[c|f]] [%s] [-T[<dv>][+a[<alpha>]][+s]] [%s] [%s] [%s] [%s] [%s]\n", name, GMT_INGRID, GMT_Rgeo_OPT, GMT_V_OPT, GMT_f_OPT, GMT_ho_OPT, GMT_o_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -148,12 +149,13 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+U Same as +u but only consider negative values.");
 	GMT_Usage (API, 1, "\n-F Report domain in world mapping format [Default is generic].");
 	GMT_Usage (API, 1, "\n-G Force possible download of all tiles for a remote <grid> if given as input [no report for tiled grids].");
-	GMT_Usage (API, 1, "\n-I[<dx>[/<dy>]|b|i|r]");
+	GMT_Usage (API, 1, "\n-I[<dx>[/<dy>]|b|i|o|r]");
 	GMT_Usage (API, -2, "Return various results depending on directives:");
 	GMT_Usage (API, 3, "b: Return the grid's bounding box polygon at node resolution.");
 	GMT_Usage (API, 3, "i: The original img2grd -R string is issued, if available. "
 		"If the grid is not an img grid then the regular -R string is issued.");
-	GMT_Usage (API, 3, "r: The grid's -R string is issued.");
+	GMT_Usage (API, 3, "o: The grid's -R string is issued but in oblique format (-RLLX/LLY/URX/URY+r).");
+	GMT_Usage (API, 3, "r: The grid's -R string is issued in regular -Rw/e/s/n format.");
 	GMT_Usage (API, -2, "Otherwise, return textstring -Rw/e/s/n{/b/t} to nearest multiple of dx/dy{/dz}. "
 		"If -C is set then rounding will occur but no -R string is issued. "
 		"If no argument is given then the -I<xinc>/<yinc>{/<zinc>} string is issued.");
@@ -298,6 +300,8 @@ static int parse (struct GMT_CTRL *GMT, struct GRDINFO_CTRL *Ctrl, struct GMT_OP
 					Ctrl->I.status = GRDINFO_GIVE_REG_IMG;
 				else if ((opt->arg[0] == 'r' || opt->arg[0] == '-') && opt->arg[1] == '\0')	/* -Ir: we want to output the actual -R string */
 					Ctrl->I.status = GRDINFO_GIVE_REG_ORIG;
+				else if (opt->arg[0] == 'o' && opt->arg[1] == '\0')	/* -Io means return -R string in oblique format (+r) */
+					Ctrl->I.status = GRDINFO_GIVE_REG_OBLIQUE;
 				else {	/* Report -R to nearest given multiple increment */
 					Ctrl->I.status = GRDINFO_GIVE_REG_ROUNDED;
 					if (gmt_getinc (GMT, opt->arg, Ctrl->I.inc)) {
@@ -905,6 +909,20 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 				gmt_ascii_format_col (GMT, text, U->z_range[0], GMT_OUT, GMT_Z);	strcat (record, text);	strcat (record, "/");
 				gmt_ascii_format_col (GMT, text, U->z_range[1], GMT_OUT, GMT_Z);	strcat (record, text);
 			}
+			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
+		}
+		else if (Ctrl->I.active && i_status == GRDINFO_GIVE_REG_OBLIQUE) {
+			sprintf (record, "-R");
+			gmt_ascii_format_col (GMT, text, header->wesn[XLO], GMT_OUT, GMT_X);	strcat (record, text);	strcat (record, "/");
+			gmt_ascii_format_col (GMT, text, header->wesn[YLO], GMT_OUT, GMT_Y);	strcat (record, text);	strcat (record, "/");
+			gmt_ascii_format_col (GMT, text, header->wesn[XHI], GMT_OUT, GMT_X);	strcat (record, text);	strcat (record, "/");
+			gmt_ascii_format_col (GMT, text, header->wesn[YHI], GMT_OUT, GMT_Y);	strcat (record, text);
+			if (is_cube) {
+				strcat (record, "/");
+				gmt_ascii_format_col (GMT, text, U->z_range[0], GMT_OUT, GMT_Z);	strcat (record, text);	strcat (record, "/");
+				gmt_ascii_format_col (GMT, text, U->z_range[1], GMT_OUT, GMT_Z);	strcat (record, text);
+			}
+			strcat (record, "+r");
 			GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 		}
 		else if (Ctrl->I.active && i_status == GRDINFO_GIVE_REG_IMG) {


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/grdimage-of-projected-grid-fails/3882) for background.  There are times we need **grdinfo** to report  the grid's region in the _lower left upper right_ **+r** syntax.  This PR adds **-Io** to format the region that way.
