### PR TITLE
Fix formatting n a few places

### DIFF
--- a/doc/rst/source/explain_clabelinfo.rst_
+++ b/doc/rst/source/explain_clabelinfo.rst_
@@ -34,7 +34,7 @@
        is to see annotations and labels and not the lines that guides them.
 
     **+j**\ *just*
-       Sets label justification relative to the line center point [Default is MC].
+       Sets label justification relative to the line center point [Default is **MC**].
 
     **+n**\ *dx*\ [/*dy*]
         Nudges the placement of labels by the specified amount (append

--- a/doc/rst/source/explain_contlabel.rst_
+++ b/doc/rst/source/explain_contlabel.rst_
@@ -23,7 +23,7 @@
         *line* specification is *start/stop*, where *start* and *stop*
         are either a specified point *lon/lat* or a 2-character **XY**
         key that uses the justification format employed in :doc:`text` to
-        indicate a point on the map, given as [LCR][BMT].
+        indicate a point on the map, given as [**LCR**][**BMT**].
         In addition, you can use Z-, Z+ to mean the global minimum and
         maximum locations in the grid. **L** will interpret the point pairs
         as defining great circles [Default is straight line].

--- a/doc/rst/source/grdconvert.rst
+++ b/doc/rst/source/grdconvert.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
-[ |-Z|\ [**+s**\ *factor*][**+o**\ *offset*] ]
+[ |-Z|\ [**+o**\ *offset*][**+s**\ *factor*] ]
 [ |SYN_OPT-f| ]
 [ |SYN_OPT--| ]
 
@@ -78,7 +78,7 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ [**+s**\ *factor*][**+o**\ *offset*]
+**-Z**\ [**+o**\ *offset*][**+s**\ *factor*]
     Use to subtract *offset* from the data and then multiply the results by
     *factor* before writing the output file [1/0]. **Note**: This
     *changes* the values in the grid.  In contrast, while options to supply
@@ -160,7 +160,7 @@ fails you may append the =\ *ID* suffix to the filename *ingrid*.
 | **gd**   | Import/export through GDAL                                    |
 +----------+---------------------------------------------------------------+
 
-GMT Standard Netcdf Files
+GMT Standard netCDF Files
 -------------------------
 
 The standard format used for grdfiles is based on netCDF and conforms to


### PR DESCRIPTION
Consistently use upper case for justification codes and show modifiers in alphabetical order.
