### PR TITLE
Ensure --FONT_ANNOT_PRIMARY=+ sets proper dimensions

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10758,7 +10758,9 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 		case GMTCASE_FONT_ANNOT_PRIMARY:
 			if (value[0] == '+') {
 				/* When + is prepended, scale fonts, offsets and ticklengths relative to FONT_ANNOT_PRIMARY (except LOGO font) */
-				double scale = GMT->current.setting.font_annot[GMT_PRIMARY].size;
+				double scale = 1.0;
+				gmt_set_undefined_defaults (GMT, 0.0, false);	/* Must set undefined to their reference values for now */
+				scale = GMT->current.setting.font_annot[GMT_PRIMARY].size;
 				if (gmt_getfont (GMT, &value[1], &GMT->current.setting.font_annot[GMT_PRIMARY])) error = true;
 				scale = GMT->current.setting.font_annot[GMT_PRIMARY].size / scale;
 				GMT->current.setting.font_annot[GMT_SECONDARY].size *= scale;


### PR DESCRIPTION
See #7420 for background.  This PR initialises the classic defaults when this setting is given so that we can scale the individual dimensions in the same way. The problem was that modern mode sets them all the NaN as a flag to have them reset based on plot dimension.  However, the **FONT_ANNOT_PRIMARY**=+ setting is a classic mode construct where plot dimension is not considered, just the reference size.

This now gives "invisible" ticks:

`gmt basemap -R0/100/0/70 -JX14 -Ba --FONT_ANNOT_PRIMARY=+1 -png lixo1`
