### PR TITLE
More robust checking for single L|U|B flags in CPTs

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8400,7 +8400,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 		/* Determine if psscale need to label these steps by looking for the optional single L|U|B character at the end */
 
 		L = strlen(line) - 1;   /* Position in line of last character. Will be 0 if just L|U|B */
-		if (L == 0) {   /* Got a single character - check if L|U|B */
+		if (L > 0 && strchr (" \t", line[L-1])) {   /* Got a single character - check if L|U|B */
 			c = line[L];
 			if (c == 'L')
 				X->data[n].annot = 1;

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8400,14 +8400,15 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 		/* Determine if psscale need to label these steps by looking for the optional single L|U|B character at the end */
 
 		L = strlen(line) - 1;   /* Position in line of last character. Will be 0 if just L|U|B */
+		/* Must check previous char since hex colors like #5CC3EB should not trigger on 'B' */
 		if (L > 0 && strchr (" \t", line[L-1])) {   /* Got a single character - check if L|U|B */
 			c = line[L];
 			if (c == 'L')
-				X->data[n].annot = 1;
+				X->data[n].annot = GMT_CPT_L_ANNOT;
 			else if (c == 'U')
-				X->data[n].annot = 2;
+				X->data[n].annot = GMT_CPT_U_ANNOT;
 			else if (c == 'B')
-				X->data[n].annot = 3;
+				X->data[n].annot = GMT_CPT_B_ANNOT;
 			if (X->data[n].annot) line[strlen(line)-1] = '\0';	/* Chop off this information so it does not affect our column count below */
 		}
 
@@ -8632,8 +8633,8 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 	}
 
 	if (!annot) {	/* Must set default annotation flags */
-		for (i = 0; i < X->n_colors; i++) X->data[i].annot = 1;
-		X->data[i-1].annot = 3;
+		for (i = 0; i < X->n_colors; i++) X->data[i].annot = GMT_CPT_L_ANNOT;
+		X->data[i-1].annot = GMT_CPT_B_ANNOT;
 	}
 
 	/* Reset the color model to what it was in the GMT defaults when a + is used there. */
@@ -9351,9 +9352,9 @@ struct GMT_PALETTE *gmt_sample_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *Pi
 	}
 
 	/* Must set default annotation flags */
-	for (i = 0; i < P->n_colors; i++) P->data[i].annot = 1;
-	if (i) P->data[i-1].annot = 3;
-	else P->data[i].annot = 3;
+	for (i = 0; i < P->n_colors; i++) P->data[i].annot = GMT_CPT_L_ANNOT;
+	if (i) P->data[i-1].annot = GMT_CPT_B_ANNOT;
+	else P->data[i].annot = GMT_CPT_B_ANNOT;
 
 	gmtsupport_copy_palette_hdrs (GMT, P, Pin);
 	return (P);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8151,7 +8151,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 	 */
 
 	unsigned int n = 0, i, nread, annot, id, n_cat_records = 0, color_model, hinge_mode = 0;
-	size_t k;
+	size_t k, L;
 	bool gap, overlap, error = false, close_file = false, check_headers = true;
 	size_t n_alloc = GMT_SMALL_CHUNK, n_hdr_alloc = 0;
 	double dz, z_hinge;
@@ -8397,16 +8397,19 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 			XH->alloc_mode_text[GMT_CPT_INDEX_LBL] = GMT_ALLOC_INTERNALLY;
 		}
 
-		/* Determine if psscale need to label these steps by looking for the optional L|U|B character at the end */
+		/* Determine if psscale need to label these steps by looking for the optional single L|U|B character at the end */
 
-		c = line[strlen(line)-1];
-		if (c == 'L')
-			X->data[n].annot = 1;
-		else if (c == 'U')
-			X->data[n].annot = 2;
-		else if (c == 'B')
-			X->data[n].annot = 3;
-		if (X->data[n].annot) line[strlen(line)-1] = '\0';	/* Chop off this information so it does not affect our column count below */
+		L = strlen(line) - 1;   /* Position in line of last character. Will be 0 if just L|U|B */
+		if (L == 0) {   /* Got a single character - check if L|U|B */
+			c = line[L];
+			if (c == 'L')
+				X->data[n].annot = 1;
+			else if (c == 'U')
+				X->data[n].annot = 2;
+			else if (c == 'B')
+				X->data[n].annot = 3;
+			if (X->data[n].annot) line[strlen(line)-1] = '\0';	/* Chop off this information so it does not affect our column count below */
+		}
 
 		nread = sscanf (line, "%s %s %s %s %s %s %s %s %s %s", T0, T1, T2, T3, T4, T5, T6, T7, T8, T9);	/* Hope to read 4, 8, or 10 fields */
 


### PR DESCRIPTION
See this form [post](https://forum.generic-mapping-tools.org/t/issue-creating-cpt/3890) for background.  The problem was that the code which checked for a trailing L|U|B flag did not consider that we might be reading a hex color string which might actually end in **B**:

```
-1000 #5CC3EB -500 #5CC3EB
...
500 #99762B 600 #99762B
```

and thus be flagged as as bottom annotation setting.  This PR checks that the previous character is white space before interpreting any L|U|B flags. **Note:** The L|U|B logic was implemented a long time before we started to consider hex colors so we never anticipated letters in those positions.

While at it I noticed that in gmt_support.c _gmtlib_read_cpt_ function the annotation flags were still 1-3 while elsewhere we had switched to named constants such as **GMT_CPT_B_ANNOT**, so I updated those assignments for better readability.