### PR TITLE
Update docs for "G" of "gmtwhich" regarding remote datasets

### DIFF
--- a/doc/rst/source/gmtwhich.rst
+++ b/doc/rst/source/gmtwhich.rst
@@ -62,9 +62,9 @@ Optional Arguments
 .. _-G:
 
 **-G**\ [**a**\|\ **c**\|\ **l**\|\ **u**]
-    If a file argument is a downloadable file (either a complete URL or a @file for
-    downloading from the GMT data server, i.e., one of the sample datasets or one of
-    the remote datasets at https://www.generic-mapping-tools.org/remote-datasets/)
+    If a file argument is a downloadable file (either a complete URL, a @file for
+    downloading from the GMT data server, or @earth_relief_rru or any other of the
+    remote datasets at https://www.generic-mapping-tools.org/remote-datasets/)
     we will try to download the file if it is not found in your local data or cache dirs.
     By default [**-Gl**] we download to the current directory. Append **a** to
     place files in the appropriate folder under the user directory (this is where

--- a/doc/rst/source/gmtwhich.rst
+++ b/doc/rst/source/gmtwhich.rst
@@ -63,7 +63,7 @@ Optional Arguments
 
 **-G**\ [**a**\|\ **c**\|\ **l**\|\ **u**]
     If a file argument is a downloadable file (either a complete URL, a @file for
-    downloading from the GMT data server, or @earth_relief_rru or any other of the
+    downloading from the GMT data server, or @earth_relief_xxy or any other of the
     remote datasets at https://www.generic-mapping-tools.org/remote-datasets/)
     we will try to download the file if it is not found in your local data or cache dirs.
     By default [**-Gl**] we download to the current directory. Append **a** to

--- a/doc/rst/source/gmtwhich.rst
+++ b/doc/rst/source/gmtwhich.rst
@@ -62,9 +62,10 @@ Optional Arguments
 .. _-G:
 
 **-G**\ [**a**\|\ **c**\|\ **l**\|\ **u**]
-    If a file argument is a downloadable file (either a complete URL, a @file for
-    downloading from the GMT data server, or @earth_relief_xxy) we will try
-    to download the file if it is not found in your local data or cache dirs.
+    If a file argument is a downloadable file (either a complete URL or a @file for
+    downloading from the GMT data server, i.e., one of the sample datasets or one of
+    the remote datasets at https://www.generic-mapping-tools.org/remote-datasets/)
+    we will try to download the file if it is not found in your local data or cache dirs.
     By default [**-Gl**] we download to the current directory. Append **a** to
     place files in the appropriate folder under the user directory (this is where
     GMT normally places downloaded files), **c** to place it in the user cache directory,


### PR DESCRIPTION
**Description of proposed changes**

GMT now supports several remote datasets, not only `@earth_relief_xxy`. This PR aims to update the documentation for **G** of `gmtwhich`. This was first mentioned by @seisman in https://github.com/GenericMappingTools/pygmt/pull/2519#discussion_r1178599444.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
