### PR TITLE
Fix typo in docs for "F" of "grd2cpt"

### DIFF
--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -130,7 +130,7 @@ Optional Arguments
     If *label* is appended then we create labels for each category to be used
     when the CPT is plotted. The *label* may be a comma-separated list of
     category names (you can skip a category by not giving a name), or give
-    *start*[-], where we automatically build monotonically increasing labels
+    *start*\ [-], where we automatically build monotonically increasing labels
     from *start* (a single letter or an integer). Append - to build ranges
     *start*-*start+1* instead.  **Note**: If **+cM** is given and the number
     of categories is 12, then we automatically create a list of month names.


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the documentation for **F** of `grd2cpt`. 

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
