### PR TITLE
gmt.conf.rst: MAP_GRID_CROSS_SIZE_SECONDARY, simplify and refer to MA…

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -792,12 +792,9 @@ MAP Parameters
         draw symmetric ticks [default is **0p**].
 
     **MAP_GRID_CROSS_SIZE_SECONDARY**
-        Size of grid cross at secondary lon-lat intersections. **0** means draw
-        continuous gridlines instead.  A nonzero size will draw a symmetric grid
-        cross.  Signed sizes have special meaning and imply grid line ticks that
-        embellish an already drawn set of gridlines: A negative size will only
-        draw ticks away from Equator and Greenwich, while a positive size will
-        draw symmetric ticks [default is **0p**].
+        Size of grid cross at secondary lon-lat intersections.
+        See :term:`MAP_GRID_CROSS_SIZE_PRIMARY` for details.
+        [default is **0p**].
 
     **MAP_GRID_PEN**
         Sets both :term:`MAP_GRID_PEN_PRIMARY` and :term:`MAP_GRID_PEN_SECONDARY` to


### PR DESCRIPTION
Remove redundant text, and refer to MAP_GRID_CROSS_SIZE_PRIMARY.