### PR TITLE
gmt.conf.rst: MAP_GRID_CROSS_SIZE_PRIMARY deals with primary lon-lat …

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -784,7 +784,7 @@ MAP Parameters
         to the value specified. This setting is not included in the **gmt.conf** file.
 
     **MAP_GRID_CROSS_SIZE_PRIMARY**
-        Size of grid cross at lon-lat intersections. **0** means draw
+        Size of grid cross at primary lon-lat intersections. **0** means draw
         continuous gridlines instead.  A nonzero size will draw a symmetric grid
         cross. Signed sizes have special meaning and imply grid line ticks that
         embellish an already drawn set of gridlines: A negative size will only


### PR DESCRIPTION
Specify that MAP_GRID_CROSS_SIZE_PRIMARY deals with primary lon-lat intersections.