### PR TITLE
Fix typo in the docs for "E" of "coast"

### DIFF
--- a/doc/rst/source/coast.rst
+++ b/doc/rst/source/coast.rst
@@ -122,7 +122,7 @@ Optional Arguments
       state of a country (if available), e.g., US.TX for Texas.
     - Append =\ *continent* to specify a continent, using either the full names or the abbreviations AF (Africa),
       AN (Antarctica), AS (Asia), EU (Europe), OC (Oceania), NA (North America), or SA (South America).
-    - To specify a collection or named region, give either the code of the full name.
+    - To specify a collection or named region, give either the code or the full name.
 
     The following modifiers are supported:
 


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes a typo in the docs for **E** of `coast` (https://docs.generic-mapping-tools.org/dev/coast.html#e).

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
