### PR TITLE
Make clear which arguments are optional in plot -S

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -100,37 +100,39 @@
         Upper-case versions **E**, **J**, and **W** are similar to **e**, **j** and **w**
         but expect geographic azimuths and distances.
 
-    **-Se**\ *direction*/*major_axis*/*minor_axis*
+    **-Se**\ [*direction*/]\ *major_axis*\ [/*minor_axis*]
         **e**\ llipse. If not given, then *direction* (in degrees counter-clockwise from horizontal),
         *major_axis*, and *minor_axis* must be found after the *coordinates* [and *value*] columns. This option yields
         a Cartesian ellipse whose shape is unaffected by the map projection.  If only a single
-        *size* is given then we plot a degenerate ellipse (circle) with given diameter.
+        *argument* is given then we plot a degenerate ellipse (circle) with that diameter.
 
-    **-SE**\ *azimuth*/*major_axis*/*minor_axis*
+    **-SE**\ [*azimuth*/]\ *major_axis*\ [/*minor_axis*]
         Same as **-Se**, except *azimuth* (in degrees east of north) should be
         given instead of *direction*. The *azimuth* will be mapped into an angle
         based on the chosen map projection (**-Se** leaves the directions
         unchanged.)  Furthermore, *major_axis* and *minor_axis* must be given in
         geographical instead of plot-distance units.  For degenerate ellipses (i.e.,
-        circles) with just a *diameter* given via the input data, use **-SE-**. For a
+        circles) with just a *diameter* given via the input data, use **-SE-**, while on
+        the command line **-SE**\ *diameter* will plot the degenerate ellipse. For a
         linear projection we assume the dimensions are given in the same units as |-R|.
         For allowable geographical units, see `Units`_ and append desired unit to the dimension(s);
         if dimensions are read from the input then either just append the unit for these values
         or append the unit to each dimension in the file (do not do both) [Default is k for km].
         The shape of the ellipse will be affected by the properties of the map projection.
 
-    **-Sj**\ *direction*/*width*/*height*
+    **-Sj**\ [*direction*/]\ *width*\ [/*height*]
         Rotated rectangle. If not given, then *direction* (in degrees counter-clockwise from
         horizontal), *width*, and *height* must be found after the location [and *value*] columns.
-        If only a single *size* is given then we plot a degenerate rectangle (square) with given size.
+        If only a single *argument* is given then we plot a degenerate rectangle (square) with given size.
 
-    **-SJ**\ *azimuth*/*width*/*height*
+    **-SJ**\ [*azimuth*/]\ *width*\ [/*height*]
         Same as **-Sj**, except *azimuth* (in degrees east of north) should be
         given instead of *direction*. The *azimuth* will be mapped into an angle
         based on the chosen map projection (**-Sj** leaves the directions
         unchanged.) Furthermore, the two dimensions must be given in geographical
         instead of plot-distance units. For a degenerate rectangle (i.e., square)
-        with one *dimension* expected to be given via the input data, use **-SJ-**. For
+        with one *dimension* expected to be given via the input data, use **-SJ-**, while on
+        the command line **-SJ**\ *side* will plot the degenerate rectangle (square). For
         a linear projection we assume the dimensions are given in the same units as |-R|.
         For allowable geographical units, see `Units`_ and append desired unit to the dimension(s);
         if dimensions are read from the input then either just append the unit for these values


### PR DESCRIPTION
This applies to **-Se**, **-SE**, **-Sj** and **-SJ** where you can either give 3 args (azimuth, major, minor side) or one (diameter or side).  However, those args were not in brackets to indicate optional.  Now they are.
