### PR TITLE
Let movie open and play movie if gmt end show is used

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -60,7 +60,8 @@ Required Arguments
     written using the Bourne shell (.sh), the Bourne again shell (.bash), the csh (.csh)
     or DOS batch language (.bat).  The script language is inferred from the file extension
     and we build hidden movie scripts using the same language.  Parameters that can be accessed
-    are discussed below.
+    are discussed below. **Note**: If the final **gmt end** statement ends with **show** then
+    we automatically open and play the movie once assembled.
 
 .. _-C:
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -18,7 +18,7 @@ Synopsis
 |-T|\ *nframes*\|\ *min*/*max*/*inc*\ [**+n**]\|\ *timefile*\ [**+p**\ *width*]\ [**+s**\ *first*]\ [**+w**\ [*str*]\|\ **W**]
 [ |-D|\ *displayrate* ]
 [ |-E|\ *titlepage*\ [**+d**\ [*duration*\ [**s**]]][**+f**\ [**i**\|\ **o**]\ [*fade*\ [**s**]]]\ [**+g**\ *fill*] ]
-[ |-F|\ *gif*\|\ *mp4*\|\ *webm*\|\ *png*\ [**+l**\ [*n*]][**+o**\ *options*][**+s**\ *stride*][**+t**] ]
+[ |-F|\ *gif*\|\ *mp4*\|\ *webm*\|\ *png*\ [**+l**\ [*n*]][**+o**\ *options*][**+s**\ *stride*][**+t**][**+v**] ]
 [ |-G|\ [*fill*]\ [**+p**\ *pen*] ]
 [ |-H|\ *scale*]
 [ |-I|\ *includefile* ]
@@ -61,7 +61,7 @@ Required Arguments
     or DOS batch language (.bat).  The script language is inferred from the file extension
     and we build hidden movie scripts using the same language.  Parameters that can be accessed
     are discussed below. **Note**: If the final **gmt end** statement ends with **show** then
-    we automatically open and play the movie once assembled.
+    we display the movie master frame (but only if |-M| is active).
 
 .. _-C:
 
@@ -154,7 +154,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ *gif*\|\ *mp4*\|\ *webm*\|\ *png*\ [**+l**\ [*n*]][**+o**\ *options*][**+s**\ *stride*][**+t**]
+**-F**\ *gif*\|\ *mp4*\|\ *webm*\|\ *png*\ [**+l**\ [*n*]][**+o**\ *options*][**+s**\ *stride*][**+t**][**+v**]
     Select a video product.  Repeatable to make more than one product.  Choose from *gif* (animated GIF),
     *mp4* (MPEG-4 movie), *webm* (WebM movie) or just *png* images (implied by all the others).  If just
     *png* is chosen then no animation will be assembled. No |-F| means no video products are created at
@@ -167,6 +167,7 @@ Optional Arguments
       can limit the frames being used to make a GIF animation by appending *stride* to only use every *stride*
       frame, with *stride* being one of a fixed set of strides: 2, 5, 10, 20, 50, 100, 200, and 500.
     - **+t** selects generation of transparent PNG images [opaque]; see `Transparency`_ for more details.
+    - **+v** opens the movie in the default movie viewer.
 
 .. _-G:
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -24,7 +24,7 @@ Synopsis
 [ |-I|\ *includefile* ]
 [ |-K|\ [**+f**\ [**i**\|\ **o**]\ [*fade*\ [**s**]]]\ [**+g**\ *fill*]\ [**+p**\ [**i**\|\ **o**]] ]
 [ |-L|\ *labelinfo* ]
-[ |-M|\ [*frame*],[*format*][**+r**\ *dpu*] ]
+[ |-M|\ [*frame*],[*format*][**+r**\ *dpu*][**+v**] ]
 [ |-P|\ *progress* ]
 [ |-Q|\ [**s**] ]
 [ |-Sb|\ *background* ]
@@ -250,12 +250,12 @@ Optional Arguments
 
 .. _-M:
 
-**-M**\ [*frame*\|\ **f**\|\ **m**\|\ **l**],[*format*][**+r**\ *dpu*]
+**-M**\ [*frame*\|\ **f**\|\ **m**\|\ **l**],[*format*][**+r**\ *dpu*][**+v**]
     In addition to making the animation sequence, select a single master frame [0] for a cover page.  The master frame will
     be written to the current directory with name *prefix.format*, where *format* can be one of the
     graphics extensions from the allowable graphics :ref:`formats <tbl-formats>` [pdf].  Instead of a frame number
     we also recognize the codes **f**\ irst, **m**\ iddle, and **l**\ ast frame. **Note**: For raster frame formats
-    you may optionally specify an alternate *dpu* of that frame via the **+r** modifier [same dpu as the movie frames].
+    you may optionally specify an alternate *dpu* of that frame via the **+r** modifier [same dpu as the movie frames]. Finally, to open the master plot in the default viewer, append **+v**.
 
 .. _-P:
 

--- a/src/movie.c
+++ b/src/movie.c
@@ -686,7 +686,7 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 	int n;
 	bool do_view = false;
 	char txt_a[GMT_LEN32] = {""}, txt_b[GMT_LEN32] = {""}, arg[GMT_LEN64] = {""}, p[GMT_LEN256] = {""};
-	char *c = NULL, *s = NULL, string[GMT_LEN128] = {""};
+	char *c = NULL, *s = NULL, *o = NULL, string[GMT_LEN128] = {""};
 	double width = 24.0, height16x9 = 13.5, height4x3 = 18.0, dpu = 160.0;	/* SI values for dimensions and dpu */
 	struct GMT_FILL fill;	/* Only used to make sure any fill is given with correct syntax */
 	struct GMT_PEN pen;	/* Only used to make sure any pen is given with correct syntax */
@@ -852,6 +852,7 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				if ((c = gmt_first_modifier (GMT, opt->arg, "lostv"))) {	/* Process any modifiers */
 					do_view = false;
 					pos = 0;	/* Reset to start of new word */
+					o = NULL;
 					while (gmt_getmodopt (GMT, 'F', c, "lostv", &pos, p, &n_errors) && n_errors == 0) {
 						switch (p[0]) {
 							case 'l':	/* Specify loops for GIF */
@@ -859,7 +860,7 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 								Ctrl->F.loops = (p[1]) ? atoi (&p[1]) : 0;
 								break;
 							case 'o':	/* FFmpeg option to pass along */
-								s = strdup (&p[1]);	/* Retain start of encoding options for later */
+								o = strdup (&p[1]);	/* Retain start of encoding options for later */
 								break;
 							case 's':	/* Specify GIF stride, 2,5,10,20,50,100,200,500 etc. */
 								Ctrl->F.skip = true;
@@ -919,9 +920,9 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 					Ctrl->F.active[k] = true;
 					Ctrl->F.view[k] = do_view;
 					if (k != MOVIE_PNG) Ctrl->animate = true;
-					if (s) {	/* Gave specific encoding options */
+					if (o) {	/* Gave specific encoding options */
 						if (Ctrl->F.options[k]) gmt_M_str_free (Ctrl->F.options[k]);	/* Free old setting first */
-						Ctrl->F.options[k] = s;
+						Ctrl->F.options[k] = o;
 					}
 				}
 				if (c) c[0] = '+';	/* Now we can restore the optional text we chopped off */

--- a/src/movie.c
+++ b/src/movie.c
@@ -1019,10 +1019,10 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active);
 				if ((c = gmt_first_modifier (GMT, opt->arg, "rv"))) {	/* Process any modifiers */
 					pos = 0;	/* Reset to start of new word */
-					while (gmt_getmodopt (GMT, 'K', c, "rv", &pos, p, &n_errors) && n_errors == 0) {	
+					while (gmt_getmodopt (GMT, 'M', c, "rv", &pos, p, &n_errors) && n_errors == 0) {	
 						switch (p[0]) {
 							case 'r':	/* Gave specific resolution for master frame */
-								Ctrl->M.dpu = atof (&s[2]);
+								Ctrl->M.dpu = atof (&p[2]);
 								Ctrl->M.dpu_set = true;
 								break;
 							case 'v':	/* View master frame */
@@ -1032,21 +1032,21 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 								break;	/* These are caught in gmt_getmodopt so break is just for Coverity */
 						}
 					}								
-					c[0] = '\0';	/* Chop off modifiers */
+					c[0] = '\0';	/* Chop off modifiers so we just have -M[<frame>|f|l|m][,format] */
 				}
-				if ((s = strchr (opt->arg, ',')) ) {	/* Gave frame and format */
+				if ((s = strchr (opt->arg, ',')) ) {	/* Gave both frame and format */
 					if (!strncmp (&s[1], "view", 4U))  /* Check for using 'view' to set with GMT_GRAPHICS_FORMAT */
 						Ctrl->M.format = strdup (gmt_session_format[API->GMT->current.setting.graphics_format]);
 					else
 						Ctrl->M.format = strdup (&s[1]);
-					s[0] = '\0';	/* Chop off format */
+					s[0] = '\0';	/* Chop off format specification; now we have just -M[<frame>|f|l|m] */
 					switch (opt->arg[0]) {
 						case 'f':	Ctrl->M.frame  = 0; break;
 						case 'm':	Ctrl->M.update = 1; break;
 						case 'l':	Ctrl->M.update = 2; break;
 						default:	Ctrl->M.frame = atoi (opt->arg); break;
 					}
-					s[0] = ',';	/* Restore format */
+					s[0] = ',';	/* Restore format specification */
 				}
 				else if (isdigit (opt->arg[0]) || (strchr ("fml", opt->arg[0]) && opt->arg[1] == '\0')) {	/* Gave just a frame, default to PDF format */
 					Ctrl->M.format = strdup ("pdf");
@@ -1057,11 +1057,12 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 						default:	Ctrl->M.frame = atoi (opt->arg); break;
 					}
 				}
-				else if (opt->arg[0])	/* Must be format, with frame = 0 implicit */
-					if (strchr ("v", opt->arg[0])) /* Check for using 'view' to set with GMT_GRAPHICS_FORMAT */
+				else if (opt->arg[0]) {	/* Must be format only, with frame = 0 implicit */
+					if (!strncmp ("view", opt->arg, 4U)) /* Check for using 'view' to set with GMT_GRAPHICS_FORMAT */
 						Ctrl->M.format = strdup (gmt_session_format[API->GMT->current.setting.graphics_format]);
 					else
 						Ctrl->M.format = strdup (opt->arg);
+				}
 				else /* Default is PDF of frame 0 */
 					Ctrl->M.format = strdup ("pdf");
 				if (c) c[0] = '+';	/* Restore modifier */


### PR DESCRIPTION
If the _mainscript_ ends with

`gmt end show`

we will use **gmt docs** to open and play the movie after it has been assembled.  Closes #7455.