### PR TITLE
Pause 1 sec before viewing master frame

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -2365,6 +2365,7 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			error = GMT_RUNTIME_ERROR;
 			goto out_of_here;
 		}
+		gmt_sleep (MOVIE_PAUSE_A_SEC);	/* Wait 1 second to ensure master frame is ready to be viewed */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Single master plot (frame %d) built: %s.%s\n", Ctrl->M.frame, Ctrl->N.prefix, Ctrl->M.format);
 		if (!Ctrl->Q.active) {
 			/* Delete the masterfile script */


### PR DESCRIPTION
We do something similar before assembling frmes to video since we cannot be 100% that the image(s) have been finished written and ready to be used.  Before this PR we would sometimes (but not aways) get messages like

`mv: rename 1.png to /Users/pwessel/1.png: No such file or directory`

This waits a second before trying to access the master frame.

Let me know if this works on Linux as wells it does on macOS