### PR TITLE
Fix typo in docs of Polar coordinate transformations

### DIFF
--- a/doc/rst/source/cookbook/coordinate-transformations.rst
+++ b/doc/rst/source/cookbook/coordinate-transformations.rst
@@ -272,7 +272,7 @@ Polar coordinate transformations
 **Syntax**
 
     **-Jp**\|\ **P**\ *scale*\|\ *width*\ [**+a**]\ [**+f**\ [**e**\|\ **p**\|\ *radius*]]\
-    [**+r**\ *offset*][**+t**\ *origin*][**+z**\ [**p**\|\ *radius*]]]
+    [**+r**\ *offset*][**+t**\ *origin*][**+z**\ [**p**\|\ *radius*]]
 
 **Parameters**
 


### PR DESCRIPTION
**Description of proposed changes**

This PR fixes a typo in the documentation of the [Polar coordinate transformations](https://docs.generic-mapping-tools.org/dev/cookbook/coordinate-transformations.html#jp).

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
