### PR TITLE
Fix parsing error in gmt info -I

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8885,28 +8885,6 @@ int gmt_default_option_error (struct GMT_CTRL *GMT, struct GMT_OPTION *opt) {
 	return error;
 }
 
-unsigned int gmt_parse_region_extender_old (struct GMT_CTRL *GMT, char option, char *arg, unsigned int *mode, double inc[]) {
-	/* If given +e|r|R<incs> we must parse and get the mode and 1, 2, or 4 increments */
-	unsigned int n_errors = 0, k;
-	if (arg == NULL || arg[0] == '\0') return GMT_NOERROR;	/* Nothing to do */
-	k = (arg[0] == '+') ? 1 : 0;	/* We may get +r or e, for instance, depending on upstream strtok */
-	if (strchr ("erR", arg[k])) {	/* Want to extend the final region before reporting */
-		int j = GMT_Get_Values (GMT->parent, &arg[k+1], inc, 4);
-		*mode = (arg[k] == 'e') ? GMT_REGION_ROUND_EXTEND : ((arg[k] == 'r') ? GMT_REGION_ROUND : GMT_REGION_ADD);
-		if (j == 1)	/* Same increments in all directions */
-			inc[XHI] = inc[YLO] = inc[YHI] = inc[XLO];
-		else if (j == 2) {	/* Separate increments in x and y */
-			inc[YLO] = inc[YHI] = inc[XHI];
-			inc[XHI] = inc[XLO];
-		}
-		else if (j != 4) {	/* The only other option is 4 but somehow we failed */
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Bad number of increment to modifier +%c.\n", option, arg[k]);
-			n_errors++;
-		}
-	}
-	return (n_errors);
-}
-
 unsigned int gmt_parse_region_extender (struct GMT_CTRL *GMT, char option, char *arg, unsigned int *mode, double inc[]) {
 	/* If given +e|r|R<incs> we must parse and get the mode and 1, 2, or 4 increments */
 	unsigned int n_errors = 0;

--- a/test/gmtinfo/extender.sh
+++ b/test/gmtinfo/extender.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Test -I rounding and extension
+cat << EOF > data.txt
+-125	37.6
+-111.1	49.2
+-121.49	42.5
+EOF
+cat << EOF > answer.txt
+-R-125/-111.1/37.6/49.2
+-R-125/-111/37.5/49.5
+-R-126/-110/36.5/50.5
+-R-125/-111/37/50
+-R-126/-110/37/50
+EOF
+# 0. Exact extent
+gmt info data.txt -Ie > result.txt
+# 1. Round to nearest 0.5
+gmt info data.txt -I0.5 >> result.txt
+# 2. Extend outward by 1, then round to nearest 0.5
+gmt info data.txt -I0.5+R1 >> result.txt
+# 3. Round to nearest 0.5, then round to nearest 1
+gmt info data.txt -I0.5+r1 >> result.txt
+# 4. Round to nearest 0.5, then extend by 1
+gmt info data.txt -I0.5+e1 >> result.txt
+# Compare
+diff result.txt answer.txt --strip-trailing-cr > fail


### PR DESCRIPTION
The parsing of the modifiers ****+e**|**r**|R** failed and hence no region extension took place.  See for instance this forum [post](https://forum.generic-mapping-tools.org/t/gmtinfo-extending-the-region/3930/2) for background. This PR fixes the bug, and I added a test highlighted here:

```
cat << EOF > data.txt
-125	37.6
-111.1	49.2
-121.49	42.5
EOF
# 0. Exact extent
gmt info data.txt -Ie > result.txt
# 1. Round to nearest 0.5
gmt info data.txt -I0.5 >> result.txt
# 2. Extend outward by 1, then round to nearest 0.5
gmt info data.txt -I0.5+R1 >> result.txt
# 3. Round to nearest 0.5, then round to nearest 1
gmt info data.txt -I0.5+r1 >> result.txt
# 4. Round to nearest 0.5, then extend by 1
gmt info data.txt -I0.5+e1 >> result.txt

```
gives

```
-R-125/-111.1/37.6/49.2
-R-125/-111/37.5/49.5
-R-126/-110/36.5/50.5
-R-125/-111/37/50
-R-126/-110/37/50

```
whereas master gives the unchanged region after 0.5 rounding:

```
-R-125/-111.1/37.6/49.2
-R-125/-111/37.5/49.5
-R-125/-111/37.5/49.5
-R-125/-111/37.5/49.5
-R-125/-111/37.5/49.5

```