### PR TITLE
Typo in movie -D

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -142,7 +142,7 @@ Optional Arguments
 .. _-D:
 
 **-D**\ *displayrate*
-    Set the display frame rate in frames per seconds for the final animation [24].
+    Set the display frame rate in frames per second for the final animation [24].
 
 .. _-E:
 


### PR DESCRIPTION
Fix typo. I think that the correct way is singular.
