### PR TITLE
Fix wrong noise direction in grdsample wesn checking

### DIFF
--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -264,11 +264,15 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 		/* Adjust wesn used to READ subset unless 360 geographic */
 		if (!wrap_360_i) {
 			k = 0;
-			while (wesn_i[YLO] < (wesn_o[YLO] + ince[GMT_Y])) wesn_i[YLO] += Gin->header->inc[GMT_Y], k++;	/* Now on or inside grid boundary */
-			if (wesn_i[YLO] > (Gin->header->wesn[YLO] + ince[GMT_Y]) && k) wesn_i[YLO] -= Gin->header->inc[GMT_Y];	/* Now exactly on boundary or just outside but still inside input grid south boundary */
+			while (wesn_i[YLO] < (wesn_o[YLO] + ince[GMT_Y]))
+				wesn_i[YLO] += Gin->header->inc[GMT_Y], k++;	/* Now on or inside grid boundary */
+			if (wesn_i[YLO] > (Gin->header->wesn[YLO] + ince[GMT_Y]) && k)
+				wesn_i[YLO] -= Gin->header->inc[GMT_Y];	/* Now exactly on boundary or just outside but still inside input grid south boundary */
 			k = 0;
-			while (wesn_i[YHI] > (wesn_o[YHI] - ince[GMT_Y])) wesn_i[YHI] -= Gin->header->inc[GMT_Y], k++;	/* Now on or inside boundary */
-			if (wesn_i[YHI] < (Gin->header->wesn[YHI] + ince[GMT_Y]) && k) wesn_i[YHI] += Gin->header->inc[GMT_Y];	/* Now exactly on boundary or just outside but still inside input grid north boundary */
+			while (wesn_i[YHI] > (wesn_o[YHI] - ince[GMT_Y]))
+				wesn_i[YHI] -= Gin->header->inc[GMT_Y], k++;	/* Now on or inside boundary */
+			if (wesn_i[YHI] < (Gin->header->wesn[YHI] - ince[GMT_Y]) && k)
+				wesn_i[YHI] += Gin->header->inc[GMT_Y];	/* Now exactly on boundary or just outside but still inside input grid north boundary */
 		}
 		if (gmt_M_x_is_lon (GMT, GMT_IN)) {	/* Must carefully check the longitude overlap between grid and -R */
 			int shift = 0;
@@ -290,12 +294,12 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 					wesn_i[XLO] -= 360.0, wesn_i[XHI] -= 360.0;
 			}
 			k = 0;
-			while (wesn_i[XLO] < (wesn_o[XLO] - ince[GMT_X]))
+			while (wesn_i[XLO] < (wesn_o[XLO] + ince[GMT_X]))
 				wesn_i[XLO] += Gin->header->inc[GMT_X], k++;	/* Now on or inside boundary */
 			if (wesn_i[XLO] > (Gin->header->wesn[XLO] + ince[GMT_X]) && k)
 				wesn_i[XLO] -= Gin->header->inc[GMT_X];	/* Now exactly on boundary or just outside but still inside input grid south boundary */
 			k = 0;
-			while (wesn_i[XHI] > (wesn_o[XHI] + ince[GMT_X]))
+			while (wesn_i[XHI] > (wesn_o[XHI] - ince[GMT_X]))
 				wesn_i[XHI] -= Gin->header->inc[GMT_X], k++;	/* Now on or inside boundary */
 			if (wesn_i[XHI] < (Gin->header->wesn[XHI] - ince[GMT_X]) && k)
 				wesn_i[XHI] += Gin->header->inc[GMT_X];	/* Now exactly on boundary or just outside but still inside input grid south boundary */
@@ -327,6 +331,9 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 
 	/* Here, wesn_i is compatible with the INPUT grid so we can read the subset from which we will resample.
 	 * Here, wesn_o is the region we wish to use when creating the output grid */
+
+	fprintf (stderr, "wesn_i = %lg/%lg/%lg/%lg\n", wesn_i[XLO], wesn_i[XHI], wesn_i[YLO], wesn_i[YHI]);
+	fprintf (stderr, "wesn_o = %lg/%lg/%lg/%lg\n", wesn_o[XLO], wesn_o[XHI], wesn_o[YLO], wesn_o[YHI]);
 
 	if ((Gout = GMT_Create_Data (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, wesn_o, inc, \
 		registration, GMT_NOTSET, NULL)) == NULL) Return (API->error);

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -331,10 +331,9 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 
 	/* Here, wesn_i is compatible with the INPUT grid so we can read the subset from which we will resample.
 	 * Here, wesn_o is the region we wish to use when creating the output grid */
-#if 0
-	fprintf (stderr, "wesn_i = %lg/%lg/%lg/%lg\n", wesn_i[XLO], wesn_i[XHI], wesn_i[YLO], wesn_i[YHI]);
-	fprintf (stderr, "wesn_o = %lg/%lg/%lg/%lg\n", wesn_o[XLO], wesn_o[XHI], wesn_o[YLO], wesn_o[YHI]);
-#endif
+
+	GMT_Report (API, GMT_MSG_DEBUG, "wesn_i = %lg/%lg/%lg/%lg\n", wesn_i[XLO], wesn_i[XHI], wesn_i[YLO], wesn_i[YHI]);
+	GMT_Report (API, GMT_MSG_DEBUG, "wesn_o = %lg/%lg/%lg/%lg\n", wesn_o[XLO], wesn_o[XHI], wesn_o[YLO], wesn_o[YHI]);
 
 	if ((Gout = GMT_Create_Data (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, wesn_o, inc, \
 		registration, GMT_NOTSET, NULL)) == NULL) Return (API->error);

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -331,9 +331,10 @@ EXTERN_MSC int GMT_grdsample (void *V_API, int mode, void *args) {
 
 	/* Here, wesn_i is compatible with the INPUT grid so we can read the subset from which we will resample.
 	 * Here, wesn_o is the region we wish to use when creating the output grid */
-
+#if 0
 	fprintf (stderr, "wesn_i = %lg/%lg/%lg/%lg\n", wesn_i[XLO], wesn_i[XHI], wesn_i[YLO], wesn_i[YHI]);
 	fprintf (stderr, "wesn_o = %lg/%lg/%lg/%lg\n", wesn_o[XLO], wesn_o[XHI], wesn_o[YLO], wesn_o[YHI]);
+#endif
 
 	if ((Gout = GMT_Create_Data (API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, wesn_o, inc, \
 		registration, GMT_NOTSET, NULL)) == NULL) Return (API->error);


### PR DESCRIPTION
This relates to #7453 but does not fix it.  When **grdsample** was changed by #7356 we got the sign of the error slop (_ince_) wrong for the x-direction.  I addition to fixing that, I have also broken some long lines into 2-lines so easier to do debug.  With this fix the original problem fixed by #7356 is still fixed but now the **grdcut** command yields the correct sub-region.  However, the spikes in the corners are still there and are there for different reasons, as discussed below.  I recommend we approve and merge this PR though.

The commented out verbose statements in **grdsample** would print this before the April 7 "fix":
```
gmt grdcut @earth_relief_03s_g -R-10/-9.8/4.9/5.0 -Glixo03s.grd
wesn_i = -10/-9.8/4.89583/5
wesn_o = -10/-9.8/4.9/5

```
which is incorrect for the south limit in _wesn_i_ (but fortuitously gives a better plot).  They should be the same as _wesn_o_.  After this PR we get the correct

```
wesn_i = -10/-9.8/4.9/5
wesn_o = -10/-9.8/4.9/5

```
I am pretty sure the spikes at the WS and NW corners have the same source.  Remember, we are resampling the 15s grid (pixel) at the 3s grid (gridline). Here are items that conspire:

1. The 3s tile ends at west = -10 and hence the boundary rows/cols are produced by the boundary conditions, not neighbour tile data.
2. We are extrapolating the 15s grid beyond the last nodes in the corners and hence things are driven almost exclusively by the boundary conditions.  Just like for the 3s grid on even degrees, the 15s data is tiled at 10x10 degrees and hence at -10 we have the same situation: padding completely determined by BC and not neighbor tile data.

Here is a zoom in on the SW corner and where we wish to estimate 15s (red dots) from the blue dots.

![zoom](https://github.com/GenericMappingTools/gmt/assets/26473567/ff270968-eb04-4fcf-92c4-e629493b9d46)

Thus, the fix to this issue may be complicated, but perhaps something like this:

- When processing the remote data set tiles, extend exact tile by 2 rows/cols.
- When reading/processing these tiles, GMT knows that it should:
- a) Read the tile with no pad requested (so we read it as is including the extra nodes)
- b) Change the region inwards by 2 steps and set padding to 2.  Now we have data in the internal grids boundary pad
- c) The interpolation would now not have crazy artefacts of PCs imposed (natural BC) since the underlying data is continuous and now only data are used as BC nodes.

This obviously means a wholesale revision of the remote data set structures, how _gmt_remote.c_ operators, etc. but probably the best solution. In fact, we should have been smart enough to think of this when the global tiling was first proposed and introduced.

Other solutions seems much messier, e.g., to somehow get the neighbouring tile data into the boundary pads, i.e., read in strips of the neighbor tiles and insert into pad.  I would hate to be the coder for that.

FYI, if we just decide to cut out the 15s subset (the raw grid) and then use **grdsample** to sample it at the 3s nodes (i.e., no blending at all, just 15s resampled), you can still see the four corners having "lips":

```
gmt grdcut ~/.gmt/server/earth/earth_relief/earth_relief_15s_p/N00W010.earth_relief_15s_p.nc -R-10/-9.8/4.9/5.0 -Glixo15s_raw.grd
gmt grdsample lixo15s_raw.grd -T -I3s -Gtmp.grd
gmt grdview tmp.grd -R-10/-9.75/4.85/5/-2200/-900 -Bxaf -Byaf -Bzaf -BWSZ+t"Blend" -JZ2i -p135/35 -png p

```
![p](https://github.com/GenericMappingTools/gmt/assets/26473567/33802246-ee9f-4ac7-a032-f9dae6e48318)

So even without any **grdblend** calls happening you can see the 2-D BCR extrapolation at the corners lack real BC constraints.  If we just plot the 15s as is: No lips:

![map15s](https://github.com/GenericMappingTools/gmt/assets/26473567/8b88e92d-0778-4494-a3cc-6c904b9cda3c)

So the spikes are all produced by teh BCR extrapolation into the voids.