### PR TITLE
Fix some of the failures discussed in #7186

### DIFF
--- a/src/gmt_gdalcall.c
+++ b/src/gmt_gdalcall.c
@@ -217,7 +217,13 @@ GMT_LOCAL int save_grid_with_GMT(struct GMT_CTRL *GMT, GDALDatasetH hDstDS, stru
 		}
 	}
 
+/* At 3.6 GDAL made some internal change that when passing back the data to the grid buffer,
+   data ccomes upside-down as comparing to what it used to do. But since that in fact helps
+   us since we n o longer need to a flipud, we did not complain to GDAL dev. */
+#if (GDAL_VERSION_MAJOR < 3 && GDAL_VERSION_MINOR < 6)
 	gmt_grd_flip_vertical (Grid->data, (unsigned)nXSize, (unsigned)nYSize, 0, sizeof(float));
+#endif
+
 	if (GMT_Write_Data (GMT->parent, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA,
 						NULL, fname, Grid) != GMT_NOERROR)
 		return GMT->parent->error;


### PR DESCRIPTION
The issue is that at 3.6 GDAL changed something that caused gdal_grid to return an upside-down buffer array. But because this actually releases us from having to do a flipud, we just add #if conditions to GDAL versions.
