### PR TITLE
Add -Fe for step-up sampling in sample1d

### DIFF
--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -97,7 +97,8 @@ Optional Arguments
     **l** (Linear), **n** (no interpolation: nearest point), or **s** (smoothing cubic
     spline; append fit parameter *p*) [Default is **-Fa**]. You may change the default interpolant; see :term:`GMT_INTERPOLANT` in your :doc:`gmt.conf` file.
     You may optionally evaluate the first or second derivative of the spline
-    by appending **+d1** or **+d2**, respectively.
+    by appending **+d1** or **+d2**, respectively. **Note**: If you use the derivatives
+    with directives **e** or **n** then the result is always zero.
 
 .. figure:: /_images/GMT_splines.*
    :width: 500 px

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt sample1d** [ *table* ]
 [ |-A|\ [**f**\|\ **p**\|\ **m**\|\ **r**\|\ **R**][**+d**][**+l**] ]
 [ |-E| ]
-[ |-F|\ **l**\|\ **a**\|\ **c**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**] ]
+[ |-F|\ **a**\|\ **c**\|\ **e**\|\ **l**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**] ]
 [ |-N|\ *col* ]
 [ |-T|\ [*min/max*\ /]\ *inc*\ [**+a**][**+i**\|\ **n**][**+u**] \| [|-T|\ *file*\|\ *list*]]
 [ |SYN_OPT-V| ]
@@ -92,12 +92,10 @@ Optional Arguments
 
 .. _-F:
 
-**-Fl**\|\ **a**\|\ **c**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**]
-    Choose from **l** (Linear), **a** (Akima spline), **c** (natural
-    cubic spline), **n** (no interpolation: nearest point), or **s**
-    (smoothing cubic spline; append fit parameter *p*) [Default
-    is **-Fa**]. You may change the default interpolant; see
-    :term:`GMT_INTERPOLANT` in your :doc:`gmt.conf` file.
+**-Fl**\|\ **a**\|\ **c**\|\ **e**\|\ **l**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**]
+    Choose from **a** (Akima spline), **e** step-up curve, **c** (natural cubic spline),
+    **l** (Linear), **n** (no interpolation: nearest point), or **s** (smoothing cubic
+    spline; append fit parameter *p*) [Default is **-Fa**]. You may change the default interpolant; see :term:`GMT_INTERPOLANT` in your :doc:`gmt.conf` file.
     You may optionally evaluate the first or second derivative of the spline
     by appending **+d1** or **+d2**, respectively.
 

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -97,7 +97,8 @@ Optional Arguments
     **l** (Linear), **n** (no interpolation: nearest point), or **s** (smoothing cubic
     spline; append fit parameter *p*) [Default is **-Fa**]. You may change the default interpolant; see :term:`GMT_INTERPOLANT` in your :doc:`gmt.conf` file.
     You may optionally evaluate the first or second derivative of the spline
-    by appending **+d1** or **+d2**, respectively. **Note**: If you use the derivatives
+    by appending **+d1** or **+d2**, respectively. **Notes**: (1) The **e** directive
+    expects your data to be monotonically increasing, (2) If you use the derivatives
     with directives **e** or **n** then the result is always zero.
 
 .. figure:: /_images/GMT_splines.*

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -508,6 +508,7 @@ enum GMT_enum_spline {
 	GMT_SPLINE_CUBIC,      /* Cubic spline */
 	GMT_SPLINE_SMOOTH,     /* Smooth cubic spline */
 	GMT_SPLINE_NN,         /* Nearest neighbor */
+	GMT_SPLINE_STEP,       /* Step up to next value */
 	GMT_SPLINE_NONE};      /* No spline set */
 
 /*! Various 1-D interpolation derivatives */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1849,7 +1849,7 @@ GMT_LOCAL int gmtsupport_intpol_sub (struct GMT_CTRL *GMT, double *x, double *y,
 			case GMT_SPLINE_NN+GMT_SPLINE_CURVATURE:	/* Nearest neighbor curvatures are zero  */
 				v[i] = 0.0;
 				break;
-			case GMT_SPLINE_STEO+GMT_SPLINE_CURVATURE:	/* Step curvatures are zero  */
+			case GMT_SPLINE_STEP+GMT_SPLINE_CURVATURE:	/* Step curvatures are zero  */
 				v[i] = 0.0;
 				break;
 			case GMT_SPLINE_SMOOTH:	/* Smoothing spline */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1358,8 +1358,8 @@ GMT_LOCAL bool gmtsupport_is_penstyle (char *word) {
 	if (n == 0) return (false);
 
 	if (!strncmp (word, "dotdash", 7U) || !strncmp (word, "dashdot", 7U) \
-		|| !strncmp (word, "dash", 4U) || !strncmp (word, "dot", 3U) \
-		|| !strncmp (word, "solid", 5U)) return (true);
+        || !strncmp (word, "dash", 4U) || !strncmp (word, "dot", 3U) \
+        || !strncmp (word, "solid", 5U)) return (true);
 
 	n--;
 	if (strchr (GMT_DIM_UNITS, word[n])) n--;	/* Reduce length by 1; the unit character */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1813,10 +1813,10 @@ GMT_LOCAL int gmtsupport_intpol_sub (struct GMT_CTRL *GMT, double *x, double *y,
 				v[i] = ((u[i] - x[j]) < (x[j+1] - u[i])) ? y[j] : y[j+1];
 				break;
 			case GMT_SPLINE_STEP: /* Step up to next value when passing it */
-				if (j == 0)	/* Start at the beginning */
+                if (i == (m-1))    /* End at the end */
+                    v[i] = y[n-1];
+				else if (j == 0)	/* Start at the beginning */
 					v[i] = y[0];
-				else if (i == (m-1))	/* End at the end */
-					v[i] = y[n-1];
 				else	/* Pick the smallest before the step happens */
 					v[i] = MIN (y[j], y[j+1]);
 				break;

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -10338,7 +10338,7 @@ GMT_LOCAL unsigned int gmtsupport_contour_old_T_parser (struct GMT_CTRL *GMT, ch
 		}
 		else {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR,
-						"Option -T: Give low and high labels either as :LH or :<low>,<high>.\n");
+			            "Option -T: Give low and high labels either as :LH or :<low>,<high>.\n");
 			I->label = false;
 			n_errors++;
 		}
@@ -10388,26 +10388,26 @@ unsigned int gmt_contour_T_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct 
 				}
 				else {
 					GMT_Report (API, GMT_MSG_ERROR,
-								"Option -T: Give low and high labels either as +lLH or +l<low>,<high>.\n");
+					            "Option -T: Give low and high labels either as +lLH or +l<low>,<high>.\n");
 					n_errors++;
 				}
 			}
 		}
 		else {
 			if (gmt_M_compat_check (API->GMT, 4))  {
-				GMT_Report (API, GMT_MSG_COMPAT, "Your format for -T is deprecated (but accepted); use -T[l|h][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH] instead\n",
-					GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
+			        GMT_Report (API, GMT_MSG_COMPAT, "Your format for -T is deprecated (but accepted); use -T[l|h][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH] instead\n",
+			        GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
 				n_errors += gmtsupport_contour_old_T_parser (GMT, &arg[j], I);
 			}
 			else {
 				GMT_Report (API, GMT_MSG_COMPAT, "Option -T: Your format for -T is deprecated; use -T[l|h][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH] instead\n",
-					GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
+				            GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
 				n_errors++;
 			}
 		}
 		n_errors += gmt_M_check_condition (GMT, I->dim[GMT_X] <= 0.0 || I->dim[GMT_Y] == 0.0,
-						"Option -T: Expected\n\t-T[l|h][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH], <tick_gap> must be > 0\n",
-							GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
+		                "Option -T: Expected\n\t-T[l|h][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH], <tick_gap> must be > 0\n",
+		                GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
 	}
 
 	return (n_errors);
@@ -10499,7 +10499,7 @@ int gmt_contlabel_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_CONTOUR *G)
 			case 'k':	/* Font color specification (backwards compatibility only since font color is now part of font specification */
 				if (gmt_M_compat_check (GMT, 4)) {
 					GMT_Report (GMT->parent, GMT_MSG_COMPAT,
-								"+k<fontcolor> in contour label spec is obsolete, now part of +f<font>\n");
+					            "+k<fontcolor> in contour label spec is obsolete, now part of +f<font>\n");
 					if (gmt_getfill (GMT, &p[1], &(G->font_label.fill))) bad++;
 				}
 				else

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1358,8 +1358,8 @@ GMT_LOCAL bool gmtsupport_is_penstyle (char *word) {
 	if (n == 0) return (false);
 
 	if (!strncmp (word, "dotdash", 7U) || !strncmp (word, "dashdot", 7U) \
-	    || !strncmp (word, "dash", 4U) || !strncmp (word, "dot", 3U) \
-	    || !strncmp (word, "solid", 5U)) return (true);
+		|| !strncmp (word, "dash", 4U) || !strncmp (word, "dot", 3U) \
+		|| !strncmp (word, "solid", 5U)) return (true);
 
 	n--;
 	if (strchr (GMT_DIM_UNITS, word[n])) n--;	/* Reduce length by 1; the unit character */
@@ -1809,17 +1809,17 @@ GMT_LOCAL int gmtsupport_intpol_sub (struct GMT_CTRL *GMT, double *x, double *y,
 			case GMT_SPLINE_CUBIC:	/* Natural cubic spline u(v) */
 				v[i] = gmtsupport_csplint (GMT, x, y, c, u[i], j);
 				break;
-            case GMT_SPLINE_NN: /* Nearest neighbor value */
-                v[i] = ((u[i] - x[j]) < (x[j+1] - u[i])) ? y[j] : y[j+1];
-                break;
-            case GMT_SPLINE_STEP: /* Step up to next value when passing it */
-                if (j == 0)	/* Start at the beginning */
-                    v[i] = y[0];
-                else if (i == (m-1))	/* End at the end */
-                	v[i] = y[n-1];
-                else	/* Pick the smallest before the step happens */
-                	v[i] = MIN (y[j], y[j+1]);
-                break;
+			case GMT_SPLINE_NN: /* Nearest neighbor value */
+				v[i] = ((u[i] - x[j]) < (x[j+1] - u[i])) ? y[j] : y[j+1];
+				break;
+			case GMT_SPLINE_STEP: /* Step up to next value when passing it */
+				if (j == 0)	/* Start at the beginning */
+					v[i] = y[0];
+				else if (i == (m-1))	/* End at the end */
+					v[i] = y[n-1];
+				else	/* Pick the smallest before the step happens */
+					v[i] = MIN (y[j], y[j+1]);
+				break;
 			case GMT_SPLINE_LINEAR+GMT_SPLINE_SLOPE:	/* Linear spline v'(u) */
 				v[i] = (y[j+1]-y[j])/(x[j+1]-x[j]);
 				break;
@@ -1893,9 +1893,9 @@ GMT_LOCAL unsigned int gmtsupport_is_set (unsigned int *mark, uint64_t k, unsign
 /*! . */
 GMT_LOCAL void gmtsupport_set_bit (unsigned int *mark, uint64_t k, unsigned int *bits) {
 	/* Set this bit */
- 	uint64_t w = k / 32ULL;
+	uint64_t w = k / 32ULL;
 	unsigned int b = (unsigned int)(k % 32ULL);
- 	mark[w] |= bits[b];
+	mark[w] |= bits[b];
 }
 
 /*! . */
@@ -2805,7 +2805,7 @@ GMT_LOCAL void gmtsupport_orient_contour (struct GMT_GRID *G, double *x, double 
 	}
 
 	switch (side[0]) {	/* Entry side: check heights of corner points.*/
-	                        /* if point to the right of the line is higher z_dir = +1 else -1 */
+							/* if point to the right of the line is higher z_dir = +1 else -1 */
 		case 0:	/* Bottom: check heights of lower left and lower right nodes */
 			z_dir = (G->data[ij_lr] > G->data[ij_ll]) ? +1 : -1;
 			break;
@@ -4453,7 +4453,7 @@ int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, b
 /*! . */
 GMT_LOCAL int gmtsupport_ensure_new_mapinset_syntax (struct GMT_CTRL *GMT, char option, char *in_text, char *text, char *panel_txt) {
 	/* Recasts any old syntax using new syntax and gives a warning.
- 	   Assumes text and panel_text are blank and have adequate space */
+	   Assumes text and panel_text are blank and have adequate space */
 	if (gmt_found_modifier (GMT, in_text, "cgp")) {	/* Tell-tale sign of old syntax */
 		char p[GMT_BUFSIZ] = {""}, txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""};
 		unsigned int pos = 0, start = 0, i;
@@ -5400,7 +5400,7 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 			s->operator = OP[k];	/* Use a 1-char code for operator (<, =, >, etc.); modify below where ambiguous */
 			switch (OP[k]) {
 				case '<':	/* Less than [Default] */
-				 	if (OP[k+1] == '=')	/* Let <= be called operator L */
+					if (OP[k+1] == '=')	/* Let <= be called operator L */
 						s->operator = 'L';
 					else if (OP[k+1] == '>')	/* Let <> be called operator i (exclusive in-range not including the boundaries) */
 						s->operator = 'i';
@@ -5408,13 +5408,13 @@ GMT_LOCAL int gmtsupport_init_custom_symbol (struct GMT_CTRL *GMT, char *in_name
 						s->operator = 'r';
 					break;
 				case '[':	/* Inclusive range */
-				 	if (OP[k+1] == ']')	/* Let [] be called operator I (inclusive range) */
+					if (OP[k+1] == ']')	/* Let [] be called operator I (inclusive range) */
 						s->operator = 'I';
 					else if (OP[k+1] == '>')	/* Let [> be called operator l (in range but only include left boundary) */
 						s->operator = 'l';
 					break;
 				case '>':	/* Greater than [Default] */
-				 	if (OP[k+1] == '=') s->operator = 'G';	/* Let >= be called operator G */
+					if (OP[k+1] == '=') s->operator = 'G';	/* Let >= be called operator G */
 					break;
 				case '=':	/* Equal [Default] */
 					if (OP[k+1] != '=') GMT_Report (GMT->parent, GMT_MSG_WARNING, "Please use == to indicate equality operator\n");
@@ -6313,7 +6313,7 @@ uint64_t gmt_read_list (struct GMT_CTRL *GMT, char *file, char ***list) {
 	FILE *fp = NULL;
 
 	if ((fp = gmt_fopen (GMT, file, "r")) == NULL) {
-  		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot find/open list file %s\n", file);
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cannot find/open list file %s\n", file);
 		return (0);
 	}
 
@@ -10338,7 +10338,7 @@ GMT_LOCAL unsigned int gmtsupport_contour_old_T_parser (struct GMT_CTRL *GMT, ch
 		}
 		else {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR,
-			            "Option -T: Give low and high labels either as :LH or :<low>,<high>.\n");
+						"Option -T: Give low and high labels either as :LH or :<low>,<high>.\n");
 			I->label = false;
 			n_errors++;
 		}
@@ -10388,7 +10388,7 @@ unsigned int gmt_contour_T_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct 
 				}
 				else {
 					GMT_Report (API, GMT_MSG_ERROR,
-					            "Option -T: Give low and high labels either as +lLH or +l<low>,<high>.\n");
+								"Option -T: Give low and high labels either as +lLH or +l<low>,<high>.\n");
 					n_errors++;
 				}
 			}
@@ -10406,8 +10406,8 @@ unsigned int gmt_contour_T_arg_parsing (struct GMT_CTRL *GMT, char *arg, struct 
 			}
 		}
 		n_errors += gmt_M_check_condition (GMT, I->dim[GMT_X] <= 0.0 || I->dim[GMT_Y] == 0.0,
-		                "Option -T: Expected\n\t-T[l|h][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH], <tick_gap> must be > 0\n",
-		                	GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
+						"Option -T: Expected\n\t-T[l|h][+d<tick_gap>[%s][/<tick_length>[%s]]][+lLH], <tick_gap> must be > 0\n",
+							GMT_DIM_UNITS_DISPLAY, GMT_DIM_UNITS_DISPLAY);
 	}
 
 	return (n_errors);
@@ -10499,7 +10499,7 @@ int gmt_contlabel_specs (struct GMT_CTRL *GMT, char *txt, struct GMT_CONTOUR *G)
 			case 'k':	/* Font color specification (backwards compatibility only since font color is now part of font specification */
 				if (gmt_M_compat_check (GMT, 4)) {
 					GMT_Report (GMT->parent, GMT_MSG_COMPAT,
-					            "+k<fontcolor> in contour label spec is obsolete, now part of +f<font>\n");
+								"+k<fontcolor> in contour label spec is obsolete, now part of +f<font>\n");
 					if (gmt_getfill (GMT, &p[1], &(G->font_label.fill))) bad++;
 				}
 				else
@@ -11086,7 +11086,7 @@ unsigned int gmt_get_dist_units (struct GMT_CTRL *GMT, char *args, char *unit, u
 /*! . */
 struct GMT_DATASET *gmt_make_profiles (struct GMT_CTRL *GMT, char option, char *args, bool resample, bool project, bool get_distances, double step, enum GMT_enum_track mode, double xyz[2][3], unsigned int *dtype) {
 	/* Given a list of comma-separated start/stop coordinates, build a data table
- 	 * of the profiles. xyz holds the grid min/max coordinates (or NULL if used without a grid;
+	 * of the profiles. xyz holds the grid min/max coordinates (or NULL if used without a grid;
 	 * in that case the special Z+, Z- coordinate shorthands are unavailable).
 	 * If resample is true then we sample the track between the end points.
 	 * If project is true then we convert to plot units.
@@ -11545,7 +11545,7 @@ int gmt_contlabel_prep (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G, double xyz[
 		}
 		if ((G->f_n = (unsigned int)k) == 0) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Fixed position file %s does not have any data records\n",
-			            G->flag, G->file);
+						G->flag, G->file);
 			error++;
 			gmt_M_free (GMT, G->f_xy[GMT_X]);
 			gmt_M_free (GMT, G->f_xy[GMT_Y]);
@@ -11553,7 +11553,7 @@ int gmt_contlabel_prep (struct GMT_CTRL *GMT, struct GMT_CONTOUR *G, double xyz[
 		}
 		if (GMT_Destroy_Data (GMT->parent, &T) != GMT_NOERROR)
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "Option -%c:  Failed to free DATASET allocated to parse %s\n",
-			            G->flag, G->file);
+						G->flag, G->file);
 	}
 
 	return (error);
@@ -11705,8 +11705,8 @@ int64_t gmt_contours (struct GMT_CTRL *GMT, struct GMT_GRID *G, unsigned int smo
 	if (side == 4) {	/* Then loop over interior boxes (vertical edges) */
 		for (row = row_0; row < (openmp_int)G->header->n_rows; row++) {
 			for (col = col_0; col < (openmp_int)G->header->n_columns-1; col++) {
-                if (row == 60 && col == 1)
-                    n = 0;
+				if (row == 60 && col == 1)
+					n = 0;
 				if ((n = gmtsupport_trace_contour (GMT, G, true, edge, x, y, col, row, 3, offset, bit, &nans))) {
 					if (nans && (n2 = gmtsupport_trace_contour (GMT, G, false, edge, &x2, &y2, col-1, row, 1, offset, bit, &nans))) {
 						/* Must trace in other direction, then splice */
@@ -11852,10 +11852,10 @@ GMT_LOCAL void gmtsupport_make_fraction (struct GMT_CTRL *GMT, double x0, int ma
 		if (x == (double)ai) break;     // AF: division by zero
 		x = 1 / (x - (double) ai);
 		if (x > (double)0x7FFFFFFF) break;  // AF: representation failure
- 	}
+	}
 
 	*n = m[0][0];	*d = m[1][0];
- 	e = x0 - ((double) *n / (double) *d);
+	e = x0 - ((double) *n / (double) *d);
 	if (e > GMT_CONV4_LIMIT)
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Bad fraction, error = %g\n", e);
 }
@@ -12309,7 +12309,7 @@ on_edge_case:
 /*! . */
 unsigned int gmt_inonout (struct GMT_CTRL *GMT, double x, double y, struct GMT_DATASEGMENT *S) {
 	/* Front end for both spherical and Cartesian in-on-out functions.
- 	 * Knows to check for polygons with holes as well. */
+	 * Knows to check for polygons with holes as well. */
 	unsigned int side, side_h;
 	struct GMT_DATASEGMENT *H = NULL;
 	struct GMT_DATASEGMENT_HIDDEN *SH = gmt_get_DS_hidden (S);
@@ -14588,7 +14588,7 @@ int gmt_just_validate (struct GMT_CTRL *GMT, char *key, char *def) {
 	/* Ensure given justification key is kosher.  If not, then
 	 * use def unless NULL, else error */
 	if ((strchr ("LCRlcr", key[0]) && strchr ("BMTbmt", key[1])) ||
-	    (strchr ("LCRlcr", key[1]) && strchr ("BMTbmt", key[0]))) return 0;	/* We are good */
+		(strchr ("LCRlcr", key[1]) && strchr ("BMTbmt", key[0]))) return 0;	/* We are good */
 	if (def == NULL) return GMT_RUNTIME_ERROR;	/* No fallback */
 	GMT_Report (GMT->parent, GMT_MSG_WARNING, "Malformed justification/position code %s replaced by %s\n", key, def);
 	strncpy (key, def, 2U);	/* Override using default code */
@@ -15485,7 +15485,7 @@ unsigned int gmtlib_load_custom_annot (struct GMT_CTRL *GMT, struct GMT_PLOT_AXI
 	unsigned int save_coltype, save_max_cols_to_read;
 	uint64_t row;
 	bool text, found, save_trailing;
- 	unsigned int k = 0, n_annot = 0, n_int = 0;
+	unsigned int k = 0, n_annot = 0, n_int = 0;
 	double *x = NULL, limit[2] = {-DBL_MAX, +DBL_MAX};
 	char **L = NULL, type[GMT_LEN8] = {""}, txt[GMT_BUFSIZ] = {""};
 	struct GMT_DATASET *D = NULL;
@@ -16669,13 +16669,13 @@ unsigned int gmt_optimal_dim_for_surface (struct GMT_CTRL *GMT, unsigned int fac
 
 	for (nx2 = 2; nx2 <= xstop; nx2 *= 2) {
 	  for (nx3 = 1; nx3 <= xstop; nx3 *= 3) {
-	    for (nx5 = 1; nx5 <= xstop; nx5 *= 5) {
+		for (nx5 = 1; nx5 <= xstop; nx5 *= 5) {
 		nxg = nx2 * nx3 * nx5;
 		if (nxg < n_columns || nxg > xstop) continue;
 
 		for (ny2 = 2; ny2 <= ystop; ny2 *= 2) {
 		  for (ny3 = 1; ny3 <= ystop; ny3 *= 3) {
-		    for (ny5 = 1; ny5 <= ystop; ny5 *= 5) {
+			for (ny5 = 1; ny5 <= ystop; ny5 *= 5) {
 			nyg = ny2 * ny3 * ny5;
 			if (nyg < n_rows || nyg > ystop) continue;
 
@@ -16688,10 +16688,10 @@ unsigned int gmt_optimal_dim_for_surface (struct GMT_CTRL *GMT, unsigned int fac
 				sug[n_sug-1].factor = users_time/current_time;
 			}
 
-		    }
+			}
 		  }
 		}
-	    }
+		}
 	  }
 	}
 
@@ -16872,7 +16872,7 @@ bool gmt_get_segtext_selection (struct GMT_CTRL *GMT, struct GMT_TEXT_SELECTION 
 		while (!match && k < S->n) {
 #if !defined(WIN32) || (defined(WIN32) && defined(HAVE_PCRE)) || (defined(WIN32) && defined(HAVE_PCRE2))
 			if (S->regexp[k])
-			 	match = gmtlib_regexp_match (GMT, T->header, S->pattern[k], S->caseless[k]);	/* true if we matched */
+				match = gmtlib_regexp_match (GMT, T->header, S->pattern[k], S->caseless[k]);	/* true if we matched */
 			else
 #endif
 				match = gmtsupport_match (T->header, S->pattern[k], exact);
@@ -16951,8 +16951,8 @@ struct GMT_TEXT_SELECTION * gmt_set_text_selection (struct GMT_CTRL *GMT, char *
 /*! . */
 void gmt_just_to_lonlat (struct GMT_CTRL *GMT, int justify, bool geo, double *x, double *y) {
 	/* See gmt_just_decode for how text code becomes the justify integer.
- 	 * If an oblique projection is in effect OR the spacing between graticules is
- 	 * nonlinear AND we are requesting a justification centered in y, then we must
+	 * If an oblique projection is in effect OR the spacing between graticules is
+	 * nonlinear AND we are requesting a justification centered in y, then we must
 	 * use the projectioned coordinates and invert for lon,lat, else we can do our
 	 * calculation on the original (geographic or Cartesian) coordinates. */
 	int i, j;
@@ -16989,8 +16989,8 @@ void gmt_just_to_lonlat (struct GMT_CTRL *GMT, int justify, bool geo, double *x,
 
 void gmt_just_to_xy (struct GMT_CTRL *GMT, int justify,double *x, double *y) {
 	/* See gmt_just_decode for how text code becomes the justify integer.
- 	 * If an oblique projection is in effect OR the spacing between graticules is
- 	 * nonlinear AND we are requesting a justification centered in y, then we must
+	 * If an oblique projection is in effect OR the spacing between graticules is
+	 * nonlinear AND we are requesting a justification centered in y, then we must
 	 * use the projected coordinates directly and return x,y in plot coordinates. */
 	int i, j;
 
@@ -17166,8 +17166,8 @@ struct GMT_REFPOINT * gmt_get_refpoint (struct GMT_CTRL *GMT, char *arg_in, char
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Anchor point specified via normalized coordinates: %g, %g\n", A->x, A->y);
 			break;
 		case GMT_REFPOINT_PLOT:
-		 	A->x = gmt_M_to_inch (GMT, txt_x);
-		 	A->y = gmt_M_to_inch (GMT, txt_y);
+			A->x = gmt_M_to_inch (GMT, txt_x);
+			A->y = gmt_M_to_inch (GMT, txt_y);
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Anchor point specified via plot coordinates (in inches): %g, %g\n", A->x, A->y);
 			break;
 		case GMT_REFPOINT_JUST:
@@ -17394,11 +17394,11 @@ void gmt_mean_point (struct GMT_CTRL *GMT, double x[], double y[], uint64_t n, i
 void gmt_adjust_refpoint (struct GMT_CTRL *GMT, struct GMT_REFPOINT *ref, double dim[], double off[], int justify, int anchor) {
 	/* Adjust reference point based on size and justification of plotted item, towards a given anchor */
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Before justify = %d, Dim x = %g y = %g, Reference x = %g y = %g\n",
-	            justify, dim[GMT_X], dim[GMT_Y], ref->x, ref->y);
+				justify, dim[GMT_X], dim[GMT_Y], ref->x, ref->y);
 	ref->x += 0.5 * (anchor%4 - justify%4) * dim[GMT_X];
 	ref->y += 0.5 * (anchor/4 - justify/4) * dim[GMT_Y];
 	GMT_Report (GMT->parent, GMT_MSG_DEBUG, "After justify = %d, Offset x = %g y = %g, Reference x = %g y = %g\n",
-	            justify, off[GMT_X], off[GMT_Y], ref->x, ref->y);
+				justify, off[GMT_X], off[GMT_Y], ref->x, ref->y);
 	/* Also deal with any justified offsets if given */
 	if (justify%4 == 3)	/* Right aligned */
 		ref->x -= off[GMT_X];
@@ -17534,14 +17534,14 @@ char * gmt_argv2str (struct GMT_CTRL *GMT, int argc, char *argv[]) {
  */
 
 GMT_LOCAL void gmtsupport_predigit(char num1, char num2, char string[], unsigned int *i) {
-    string[(*i)++] = num1;
-    string[(*i)++] = num2;
+	string[(*i)++] = num1;
+	string[(*i)++] = num2;
 }
 
 GMT_LOCAL void gmtsupport_postdigit (char c, unsigned int n, char string[], unsigned int *i) {
-    unsigned int j;
-    for (j = 0; j < n; j++)
-        string[(*i)++] = c;
+	unsigned int j;
+	for (j = 0; j < n; j++)
+		string[(*i)++] = c;
 }
 
 char *gmt_arabic2roman (unsigned int number, char string[], size_t size, bool lower) {
@@ -17551,9 +17551,9 @@ char *gmt_arabic2roman (unsigned int number, char string[], size_t size, bool lo
 	gmt_M_memset (string, size, char);
 	while (number != 0) {
 		if (number >= 1000) {
-            gmtsupport_postdigit ('M', number / 1000, string, &i);
-            number = number - (number / 1000) * 1000;
-        }
+			gmtsupport_postdigit ('M', number / 1000, string, &i);
+			number = number - (number / 1000) * 1000;
+		}
 		else if (number >= 500) {
 			if (number < (500 + 4 * 100)) {
 				gmtsupport_postdigit('D', number / 500, string, &i);
@@ -17562,8 +17562,8 @@ char *gmt_arabic2roman (unsigned int number, char string[], size_t size, bool lo
 			else {
 				gmtsupport_predigit('C','M', string, &i);
 				number = number - (1000-100);
-            }
-        }
+			}
+		}
 		else if (number >= 100) {
 			if (number < (100 + 3 * 100)) {
 				gmtsupport_postdigit('C', number / 100, string, &i);
@@ -18292,12 +18292,12 @@ bool gmt_run_process_get_first_line (struct GMT_CTRL *GMT, char *program, char *
 }
 
 bool gmt_check_executable (struct GMT_CTRL *GMT, char *program, char *arg, char *pattern, char *text) {
-    /* To avoid function name change in several GMT files. */
-    bool status = gmt_run_process_get_first_line (GMT, program, arg, text);
+	/* To avoid function name change in several GMT files. */
+	bool status = gmt_run_process_get_first_line (GMT, program, arg, text);
 	if (status && pattern && strstr (text, pattern) == NULL) {
-        GMT_Report (GMT->parent, GMT_MSG_DEBUG, "gmt_check_executable failed pattern %s test\n", pattern);
-    }
-    return (status);
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "gmt_check_executable failed pattern %s test\n", pattern);
+	}
+	return (status);
 }
 
 void gmt_extend_region (struct GMT_CTRL *GMT, double wesn[], unsigned int mode, double inc[]) {

--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -102,7 +102,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<table>] [-A[f|m|p|r|R][+d][+l]] [-E] [-Fl|a|c|n|s<p>[+d1|2]] [-N<time_col>] "
+	GMT_Usage (API, 0, "usage: %s [<table>] [-A[f|m|p|r|R][+d][+l]] [-E] [-Fa|c|e||l|n|s<p>[+d1|2]] [-N<time_col>] "
 		"[-T[<min>/<max>/]<inc>[+i|n][+a][+t][+u]] [%s] [-W<w_col>] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT,
 		GMT_o_OPT, GMT_q_OPT, GMT_s_OPT, GMT_w_OPT, GMT_PAR_OPT);
@@ -125,11 +125,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+l Compute distances along rhumblines (loxodromes) [no].");
 	GMT_Usage (API, -2, "Note: +l uses spherical calculations - cannot be combined with -je.");
 	GMT_Usage (API, 1, "\n-E Add input data trailing text to output records when possible [Ignore trailing text].");
-	GMT_Usage (API, 1, "\n-Fl|a|c|n|s<p>[+d1|2]");
+	GMT_Usage (API, 1, "\n-Fa|c|e||l|n|s<p>[+d1|2]");
 	GMT_Usage (API, -2, "Set the interpolation mode.  Choose from:");
-	GMT_Usage (API, 3, "l: Linear interpolation.");
 	GMT_Usage (API, 3, "a: Akima spline interpolation.");
 	GMT_Usage (API, 3, "c: Cubic spline interpolation.");
+	GMT_Usage (API, 3, "e: Step-up interpolation (to next value).");
+	GMT_Usage (API, 3, "l: Linear interpolation.");
 	GMT_Usage (API, 3, "n: No interpolation (nearest point).");
 	GMT_Usage (API, 3, "s: Smooth spline interpolation (append fit parameter <p>).");
 	GMT_Usage (API, -2, "Optionally, request a spline derivative via a modifier:");
@@ -238,6 +239,9 @@ static int parse (struct GMT_CTRL *GMT, struct SAMPLE1D_CTRL *Ctrl, struct GMT_O
 						break;
 					case 'n':
 						Ctrl->F.mode = GMT_SPLINE_NN;
+						break;
+					case 'e':
+						Ctrl->F.mode = GMT_SPLINE_STEP;
 						break;
 					case 's':
 						Ctrl->F.mode = GMT_SPLINE_SMOOTH;


### PR DESCRIPTION
See the forum [post](https://forum.generic-mapping-tools.org/t/interpolate-data-values-with-dates-vlookup/3985) for details.  This interpolator keeps the previous value until we pass a new input node and then we step up to that value.

@Esteban82, I think this reproduces your example but I do not know if it is generally correct since I only tested it on yours.