### PR TITLE
Report dimensions of transposed data via -V

### DIFF
--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -234,6 +234,9 @@ Optional Arguments
 
 **-Z**
     Transpose the single segment in a dataset. Any trailing text will be lost.
+    **Note**: If you are using binary tables then add |-V| to have the dimensions
+    of the transposed table reported since you will need to specify **-bi**\ *ncols*
+    when reading the binary transposed table.
 
 .. include:: explain_-aspatial.rst_
 

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -576,6 +576,7 @@ EXTERN_MSC int GMT_gmtconvert (void *V_API, int mode, void *args) {
 			GMT_Report (API, GMT_MSG_ERROR, "Transposing of input data segment failed.\n");
 			Return (GMT_RUNTIME_ERROR);
 		}
+		GMT_Report (API, GMT_MSG_INFORMATION, "Transposed dimensions: n_rows = %" PRIu64 " n_columns = %" PRIu64"\n", Dt->n_records, Dt->n_columns);
 		if (GMT_Destroy_Data (API, &D[GMT_IN]) != GMT_NOERROR) {	/* Be gone with the original input */
 			Return (API->error);
 		}


### PR DESCRIPTION
For those who use binary tables in **gmtconvert -Z** one needs to know the transposed dimensions of columns to correctly set **-bi** when reading it.  This PR implements that and explains this in the docs as well.
