### PR TITLE
Improve math formatting for IGF in mgd77list do

### DIFF
--- a/doc/rst/source/supplements/mgd77/mgd77list.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77list.rst
@@ -545,30 +545,31 @@ restriction is implemented since many anomaly columns contains
 corrections, usually in the form of hand-edited changes, that cannot be
 duplicated from the corresponding observation.
 
-Igrf
+IGRF
 ----
 
 The IGRF calculations are based on a Fortran program written by Susan
 Macmillan, British Geological Survey, translated to C via f2c by Joaquim
 Luis, U Algarve, and adapted to GMT-style by Paul Wessel.
 
-Igf
+IGF
 ---
 
 The equations used are reproduced here using coefficients extracted
-directly from the source code (let us know if you find errors):
+directly from the source code (let us know if you find errors). Below,
+:math:`\lambda` is longitude and :math:`\phi` is latitude:
 
-(1) :math:`g = 978052.0 \times [1 + 0.005285 \times sin^2(lat) - 7e-6 \times sin^2(2\times lat)
-+ 27e-6 \times cos^2(lat) \times cos^2(lon-18)]`
+1. :math:`g = 978052.0 \times [1 + 0.005285 \sin^2(\phi) - 7\cdot 10^{-6}  \sin^2(2\phi)
++ 27\cdot 10^{-6} \cos^2(\phi) \cos^2(\lambda-18)]`
 
-(2) :math:`g = 978049.0 \times [1 + 0.0052884 \times sin^2(lat) - 0.0000059 \times
-sin^2(2\times lat)]`
+2. :math:`g = 978049.0 \times [1 + 0.0052884 \sin^2(\phi)
+- 0.0000059 \sin^2(2\phi)]`
 
-(3) :math:`g = 978031.846 \times [1 + 0.0053024 \times sin^2(lat) - 0.0000058 \times
-sin^2(2\times lat)]`
+3. :math:`g = 978031.846 \times [1 + 0.0053024 \sin^2(\phi)
+- 0.0000058 \sin^2(2\phi)]`
 
-(4) :math:`g = 978032.67714 \times [\frac{1 + 0.00193185138639 \times sin^2(lat)}{\sqrt{ 1
-- 0.00669437999013 \times sin^2(lat) }}]`
+4. :math:`g = 978032.67714 \times [\frac{1 + 0.00193185138639 \sin^2(\phi)}{\sqrt{ 1
+- 0.00669437999013 \sin^2(\phi) }}]`
 
 Corrections
 -----------

--- a/doc/rst/source/supplements/mgd77/mgd77list.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77list.rst
@@ -560,7 +560,7 @@ directly from the source code (let us know if you find errors). Below,
 :math:`\lambda` is longitude and :math:`\phi` is latitude:
 
 1. :math:`g = 978052.0 \times [1 + 0.005285 \sin^2(\phi) - 7\cdot 10^{-6}  \sin^2(2\phi)
-+ 27\cdot 10^{-6} \cos^2(\phi) \cos^2(\lambda-18)]`
++ 27\cdot 10^{-6} \cos^2(\phi) \cos^2(\lambda-18^{\circ})]`
 
 2. :math:`g = 978049.0 \times [1 + 0.0052884 \sin^2(\phi)
 - 0.0000059 \sin^2(2\phi)]`


### PR DESCRIPTION
There were too many \times symbols in those equations and the trig functions were not set as Latex (need \sin not just sin), etc. Also, need to use 10^exp and not e-6 etc in equations.