### PR TITLE
Spell out directives nd modifiers for -S in synopisis and docs

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -21,6 +21,7 @@ Synopsis
 [ |-N| ]
 [ |SYN_OPT-R| ]
 [ |-S|\ *method*/*modifiers* ]
+[ |-S|\ [**a**\|\ **l**\|\ **L**\|\ **m**\|\ **p**\|\ **u**\|\ **U**][**+a**][**+c**][**+d**][**+r**][**+s**\ [*file*] ]
 [ |-T|\ [*radius*][**+e**\|\ **p**]]
 [ |-V|\ [*level*] ]
 [ |-Z| ]
@@ -213,7 +214,7 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ *method*/*modifiers*
+**-S**\ [**a**\|\ **l**\|\ **L**\|\ **m**\|\ **p**\|\ **u**\|\ **U**][**+a**][**+c**][**+d**][**+r**][**+s**\ [*file*]
     In conjunction with |-C|, compute a single stacked profile from
     all profiles across each segment. Append a method for how stacking should be
     computed: **a** = mean (average), **m** = median, **p** = mode

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -493,7 +493,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDTRACK_CTRL *Ctrl, struct GMT_O
 						GMT_Report (API, GMT_MSG_ERROR, "Bad mode (%c) given to -S.\n", (int)opt->arg[0]);
 						break;
 				}
-				pos = 0;
+				pos = 0;	/* This skips over any useless slash */
 				while (gmt_strtok (&opt->arg[1], "+", &pos, p)) {
 					switch (p[0]) {
 						case 'a': Ctrl->S.selected[STACK_ADD_VAL] = true; break;	/* Gave +a to add stacked value to all output profiles */


### PR DESCRIPTION
We only said method/modifiers which is not that informative and also is misleading since no slash is ever expected (but it was tolerated from a previous syntax).
