### PR TITLE
Improve parsing of -l for legend labels with font changes

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9660,16 +9660,20 @@ GMT_LOCAL int gmtinit_parse_l_option (struct GMT_CTRL *GMT, char *arg) {
 		c[0] = '\0';	/* Chop'em off */
 	}
 	if (arg[0]) {	/* Gave a label, which may be a constant string, code, or format statement */
-		char *d = strchr (arg, '%');
-		if (d && strchr (d, 'd')) {
-			GMT->common.l.item.label_type = GMT_LEGEND_LABEL_FORMAT;
+		char *d = strstr (arg, "@%");	/* First rule out font settings before hunt for integer formats */
+		if (d) {	/* Font settings are not integer formats */
+			GMT->common.l.item.label_type = GMT_LEGEND_LABEL_FIXED;
 			strncpy (GMT->common.l.item.label, arg, GMT_LEN128-1);
 		}
-		else if (arg[strlen(arg)-1] == '#') {	/* Short hand for integer %d */
+		else if (arg[strlen(arg)-1] == '#') {	/* # in label string is short hand for an integer %d */
 			GMT->common.l.item.label_type = GMT_LEGEND_LABEL_FORMAT;
 			arg[strlen(arg)-1] = '\0';
 			snprintf (GMT->common.l.item.label, GMT_LEN128, "%s%%d", arg);
 			arg[strlen(arg)-1] = '#';
+		}
+		else if ((d = strchr (arg, '%')) && (d[0] == 'd' || isdigit (d[0]))) {	/* Got %d, %<w>d or %<w>.<p>% */
+			GMT->common.l.item.label_type = GMT_LEGEND_LABEL_FORMAT;
+			strncpy (GMT->common.l.item.label, arg, GMT_LEN128-1);
 		}
 		else if (strchr (arg, ',')) {
 			GMT->common.l.item.label_type = GMT_LEGEND_LABEL_LIST;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9671,7 +9671,7 @@ GMT_LOCAL int gmtinit_parse_l_option (struct GMT_CTRL *GMT, char *arg) {
 			snprintf (GMT->common.l.item.label, GMT_LEN128, "%s%%d", arg);
 			arg[strlen(arg)-1] = '#';
 		}
-		else if ((d = strchr (arg, '%')) && (d[0] == 'd' || isdigit (d[0]))) {	/* Got %d, %<w>d or %<w>.<p>% */
+		else if ((d = strchr (arg, '%')) && (d[1] == 'd' || isdigit (d[1]))) {	/* Got %d, %<w>d or %<w>.<p>% */
 			GMT->common.l.item.label_type = GMT_LEGEND_LABEL_FORMAT;
 			strncpy (GMT->common.l.item.label, arg, GMT_LEN128-1);
 		}

--- a/test/baseline/pslegend.dvc
+++ b/test/baseline/pslegend.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: d3e313ed08e46568f46d3692d8c25f0a.dir
-  size: 855500
-  nfiles: 19
+- md5: 474181218768668c45b5e70c769c8927.dir
+  size: 882783
+  nfiles: 20
   path: pslegend

--- a/test/pslegend/fontswitch.sh
+++ b/test/pslegend/fontswitch.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Testing gmt pslegend with font changes in -l
+# See https://forum.generic-mapping-tools.org/t/font-change-in-plot-l-string-not-correctly-intpreted-in-legend-command/3989
+
+# Generate dummy file outside the region
+cat <<- END > dummy.dat
+-10	-0
+-8		0
+END
+
+gmt begin fontswitch
+	gmt basemap -JX15c "-R0/1/0/1" -Bewsn
+	gmt plot dummy.dat -Wthick      -l'@%1%m@%% (rot. feedb.)'
+	gmt plot dummy.dat -Wthick,blue -l'@%1%m@%% (rot. pot. only)'
+	gmt plot dummy.dat -Wthin       -l'm@-x@-'
+	gmt plot dummy.dat -Wthin,-     -l'm@-y@-'
+	gmt plot dummy.dat -Wthin,.     -l'm@-z@-'
+gmt end show


### PR DESCRIPTION
See https://github.com/GenericMappingTools/gmt/issues/7538 for background. This PR uses the leading string` @%` to identify font changes before looking for `%` integer formats.  Fixes the OP's troubles and cause no further failures. Added a test based on the OP post.