### PR TITLE
Fix regression that movie scripts could not use -Xc|f -Yc|f

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -1202,7 +1202,7 @@ GMT_LOCAL int gmtinit_parse_X_option (struct GMT_CTRL *GMT, char *text) {
 		default:
 			GMT->current.ps.origin[GMT_X] = GMT->common.X.mode = 'r'; break;
 	}
-	if (GMT->current.setting.run_mode == GMT_MODERN && strchr ("cf", GMT->common.X.mode)) {	/* Modern mode: Disallow -Xc|f */
+	if (GMT->current.setting.run_mode == GMT_MODERN && strchr ("cf", GMT->common.X.mode) && GMT->current.setting.ps_def_page_size[GMT_X] == GMT_PAPER_DIM) {	/* Modern mode: Disallow -Xc|f */
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Centered (-Xc) and fixed (-Xf) shifts are not available in modern mode\n");
 		return (GMT_PARSE_ERROR);
 	}
@@ -1258,7 +1258,7 @@ GMT_LOCAL int gmtinit_parse_Y_option (struct GMT_CTRL *GMT, char *text) {
 		default:
 			GMT->current.ps.origin[GMT_Y] = GMT->common.Y.mode = 'r'; break;
 	}
-	if (GMT->current.setting.run_mode == GMT_MODERN && strchr ("cf", GMT->common.Y.mode)) {	/* Modern mode: Disallow -Yc|f */
+	if (GMT->current.setting.run_mode == GMT_MODERN && GMT->current.setting.ps_def_page_size[GMT_Y] == GMT_PAPER_DIM) {	/* Modern mode: Disallow -Yc|f */
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Centered (-Yc) and fixed (-Yf) shifts are not available in modern mode\n");
 		return (GMT_PARSE_ERROR);
 	}


### PR DESCRIPTION
In 6.4 we added a hard test that disallowed the **-Xc|f** and **-Yc|f** options from being used in modern mode.  But **movie** scripts aer also modern mode but they explicitly set the paper size so it is OK.  This PR checks that the current paper size remains at 32767x32767 before applying that test.

Until 6.5 is released any move scripts will need to use specific coordinates.