### PR TITLE
Do no free external trailing text strings

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4127,6 +4127,7 @@ GMT_LOCAL struct GMT_DATASET * gmtapi_import_dataset (struct GMTAPI_CTRL *API, i
 					S->data[col_pos_out] = V_obj->data[col_pos].f8;
 					SH->alloc_mode[col_pos_out] = GMT_ALLOC_EXTERNALLY;	/* Not this objects job to free what was passed in by reference */
 				}
+				SH->alloc_mode_text = GMT_ALLOC_EXTERNALLY; /* Not this object's job to free what was passed in by reference */
 				DH = gmt_get_DD_hidden (D_obj);
 				if (smode) S->text = V_obj->text;	/* Hook up trailing text array */
 				gmtapi_increment_d (D_obj, V_obj->n_rows, n_columns, 1U);	/* Update counters for D_obj with 1 segment */
@@ -4520,7 +4521,7 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 				}
 				if (S->text) {
 					V_obj->text = S->text;
-					VH->alloc_mode_text = GMT_ALLOC_EXTERNALLY;	/* Since not duplicated, just pointed to */
+					VH->alloc_mode_text = SH->alloc_mode_text = GMT_ALLOC_EXTERNALLY;	/* Since not duplicated, just pointed to */
 				}
 				V_obj->n_rows = n_rows;
 				VH->alloc_level = S_obj->alloc_level;	/* Otherwise D_obj will be freed before we get to use data */

--- a/src/gmt_hidden.h
+++ b/src/gmt_hidden.h
@@ -79,7 +79,8 @@ struct GMT_DATASEGMENT_HIDDEN {    /* Supporting information hidden from the API
 	double lat_limit;		/* For polar caps: the latitude of the point closest to the pole */
 	struct GMT_OGR_SEG *ogr;	/* NULL unless OGR/GMT metadata exist for this segment */
 	struct GMT_DATASEGMENT *next;	/* NULL unless polygon and has holes and pointing to next hole */
-	enum GMT_enum_alloc *alloc_mode;	/* Allocation mode per column [GMT_ALLOC_INTERNALLY] */
+	enum GMT_enum_alloc *alloc_mode;	/* Allocation mode per data column [GMT_ALLOC_INTERNALLY] */
+	enum GMT_enum_alloc alloc_mode_text;	/* Allocation mode for trailing text column [GMT_ALLOC_INTERNALLY] */
 	char *file[2];			/* Name of file or source [0 = in, 1 = out] */
 };
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8802,8 +8802,9 @@ GMT_LOCAL void gmtio_free_segment_text (struct GMT_CTRL *GMT, struct GMT_DATASEG
 	if (SH->alloc_mode_text == GMT_ALLOC_INTERNALLY) {  /* We can free these strings */
 		for (row = 0; row < S->n_rows; row++)
 			gmt_M_str_free (S->text[row]);
-	}
-	gmt_M_free (GMT, S->text); /* Always free the array holding the strings */
+		gmt_M_free (GMT, S->text);
+	} else
+		S->text = NULL;
 }
 
 /*! . */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -8799,10 +8799,10 @@ GMT_LOCAL void gmtio_free_segment_text (struct GMT_CTRL *GMT, struct GMT_DATASEG
 	/* Frees any array of trailing text items unless externally allocated */
 	uint64_t row;
 	if (S->text == NULL) return;	/* No trailing text array */
-    if (SH->alloc_mode_text == GMT_ALLOC_INTERNALLY) {  /* We can free these strings */
-        for (row = 0; row < S->n_rows; row++)
-	       gmt_M_str_free (S->text[row]);
-    }
+	if (SH->alloc_mode_text == GMT_ALLOC_INTERNALLY) {  /* We can free these strings */
+		for (row = 0; row < S->n_rows; row++)
+			gmt_M_str_free (S->text[row]);
+	}
 	gmt_M_free (GMT, S->text); /* Always free the array holding the strings */
 }
 


### PR DESCRIPTION
See https://github.com/GenericMappingTools/pygmt/issues/2524 for background.  Sees we are trying to free strings thar belong to Python and not GMT.  However, not solved yet.

@seisman if you see other places in the code where we need to do something like here, let me know.  I see we have a VECTOR hidden flag for `VH->alloc_mode_text `and now we added a per segment `SH->alloc_mode_text`.  Suspect there is still some lack of communication between vector and segment internally that is missing.
Will return to this later but feel tree to try it.  It still have me the same messages.
