### PR TITLE
CI: Do not use the deprecated set-output commands

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: Create Issue From File
       uses: peter-evans/create-issue-from-file@v4

--- a/.github/workflows/scm-check.yml
+++ b/.github/workflows/scm-check.yml
@@ -30,11 +30,11 @@ jobs:
           echo "SCM version ${scm_version} (${scm_version_date})"
 
           # Set output of the current step
-          echo "::set-output name=scm_version::${scm_version}"
-          echo "::set-output name=scm_version_date::${scm_version_date}"
+          echo "scm_version=${scm_version}" >> $GITHUB_OUTPUT
+          echo "scm_version_date=${scm_version_date}" >> $GITHUB_OUTPUT
           if [ "${scm_version}" != ${scm_version_in_gmt} ]; then
             echo "The latest SCM version (${scm_version}) is different from the one in GMT (${scm_version_in_gmt})!"
-            echo "::set-output name=error_code::2"
+            echo "error_code=2" >> $GITHUB_OUTPUT
           fi
 
       - name: Create an update request


### PR DESCRIPTION
**Description of proposed changes**

Fix the workflow warnings:
```
The `set-output` command is deprecated and will be disabled soon. 
Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.