### PR TITLE
CI: Test building GMT on Ubuntu 23.04 and Debian 12

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,9 +41,11 @@ jobs:
           - ubuntu:16.04  # CMake 3.5.1  + GNU 5.4.0;  EOL: 2026-04-23
           - ubuntu:18.04  # CMake 3.10.2 + GNU 7.4.0;  EOL: 2028-04-26
           - ubuntu:20.04  # CMake 3.16.3 + GNU 9.3.0;  EOL: 2030-04-23
-          - ubuntu:22.04  # CMake 3.22.1 + GNU 11.2.0; EOL: 2030-04-01
+          - ubuntu:22.04  # CMake 3.22.1 + GNU 11.2.0; EOL: 2032-04-21
+          - ubuntu:23.04  # CMake 3.24.1 + GNU 12.2.0; EOL: 2024-01-20
           - debian:10     # CMake 3.13.4 + GNU 8.3.0;  EOL: 2024-06-01
           - debian:11     # CMake 3.18.4 + GNU 10.2.1; EOL: 2026-06-01
+          - debian:12     # CMake 3.25.1 + GNU 12.2.0; EOL: 2028-06-01
           - debian:sid    # rolling release with latest versions
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@
 name: Docker
 
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@
 name: Docker
 
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
- ubuntu:23.04  # CMake 3.24.1 + GNU 12.2.0; EOL: 2024-01-20
- debian:12     # CMake 3.25.1 + GNU 12.2.0; EOL: 2028-06-01
