### PR TITLE
Close the nc file after reading cube info

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -2018,6 +2018,8 @@ int gmt_nc_read_cube_info (struct GMT_CTRL *GMT, char *file, double *w_range, ui
 	if (z_unit)	/* Passed pointer to storage for z-unit in cubes */
 		strncpy (z_unit, z_units, GMT_GRID_UNIT_LEN80);
 
+	gmt_M_err_trap (gmt_nc_close (GMT, ncid));
+
 	return GMT_NOERROR;
 }
 


### PR DESCRIPTION
**Description of proposed changes**

It seems the `gmt_nc_read_cube_info` function forgets to close the NC file after reading the cube, which keeps the NC file opened and can't be deleted on Windows.

Please double-check if the change makes sense.