### PR TITLE
Improved detection of relative time ending in t

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7381,7 +7381,7 @@ int gmt_scanf_arg (struct GMT_CTRL *GMT, char *s, unsigned int expectation, bool
 				expectation = GMT_IS_ARGTIME;
 			else if (gmtio_is_pi (s))	/* Found a "pi" specification - will try scanning as float */
 				expectation = GMT_IS_FLOAT;
-			else if (c == 't')		/* Found trailing t - assume Relative time */
+			else if (c == 't' && (strchr ("+-", s[0] || isdigit (s[0]))))		/* Found trailing t in a signed/unsigned leading integer - assume Relative time */
 				expectation = GMT_IS_ARGTIME;
 			else if (nt > 1 || gmt_not_numeric (GMT, s)) {	/* No number has 2 or more letters at the end, or other junk, so return as NaN */
 				*val = GMT->session.d_NaN;


### PR DESCRIPTION
No longer sure if relative time might end in **t**, e.g., 131232.44t but we were checking for it.  Unfortunately, junk like `shit` also ends in **t** and was considered relative time and got caught in some odd conversion since we got 5!

```
echo "1 2 3 shit 4 5" | gmt convert -W
1	2	3	5	4	5

```
After this PR we get the correct result:

```
echo "1 2 3 shit 4 5" | gmt convert -W
1	2	3	NaN	4	5

```

My fix is not exhaustive but at least checks we start with a sign or integer.