### PR TITLE
Update explain_-J.rst_

### DIFF
--- a/doc/rst/source/explain_-J.rst_
+++ b/doc/rst/source/explain_-J.rst_
@@ -85,8 +85,8 @@ respectively):
         **-Jo**\|\ **O**\ [**c**\|\ **C**]\ *lon0/lat0/lonp/latp/*\ *scale*\|\ *width*\ [**+v**]
             Set projection center *lon0/lat0*, pole of oblique projection *lonp/latp*, and *scale* or *width*
 
-        Give *scale* along oblique equator (with **-Ja**\|\ **b**\|\ **c**; **1:**\ *xxxx* or
-        :ref:`plot-units <plt-units>`/degree) or *width* (with **-JA**\|\ **B**\|\ **C**; in
+        Give *scale* along oblique equator (with **-Jo**
+        :ref:`plot-units <plt-units>`/degree) or *width* (with **-JO**
         :ref:`plot-units <plt-units>`). Use upper-case **A**\|\ **B**\|\ **C** to remove enforcement of a northern
         hemisphere pole. Append **+v** to let the oblique Equator align with the *y*-axis [*x*-axis].  **Note**: If
         the region (**-R**) is given without the **+r** modifier then the arguments are considered oblique degrees


### PR DESCRIPTION
1. The previous author had confused o/O with abc/ABC !
2. Note that attempting to use 1:xxxx syntax will result in:
```
basemap [ERROR]: Cannot specify map width with 1:xxxx format in -J option
basemap [ERROR]: Option -J parsing failure. Correct syntax:

   -J Select map proJection (<scale> in cm/degree, <width> in cm).
```

**Description of proposed changes**