### PR TITLE
Add figure and example in cookbook for radians

### DIFF
--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -320,6 +320,26 @@ One solution is to request slanted annotations for the x-axis (e.g., Figure :ref
 via the **+a**\ *angle* modifier.
 
 
+.. _axis_radians_basemap:
+
+.. figure:: /_images/GMT_-B_radians.*
+   :width: 500 px
+   :align: center
+
+   Linear Cartesian projection axis with annotations and ticks in radians.
+
+.. toggle::
+
+   Here is the source script for the figure above:
+
+   .. literalinclude:: /_verbatim/GMT_-B_radians.txt
+
+There are occasions when the length of the annotations are such that placing them
+horizontally (which is the default) may lead to overprinting or too few annotations.
+One solution is to request slanted annotations for the x-axis (e.g., Figure :ref:`Axis label <axis_slanted_basemap>`)
+via the **+a**\ *angle* modifier.
+
+
 .. _axis_slanted_basemap:
 
 .. figure:: /_images/GMT_-B_slanted.*

--- a/doc/scripts/GMT_-B_radians.sh
+++ b/doc/scripts/GMT_-B_radians.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt basemap -R-4/2/0/3 -Jx1i -Bxapi3fpi6 -BS --GMT_THEME=cookbook -view GMT_-B_radians
+gmt basemap -R-4/2/0/1 -Jx2.5c -Bxapi3fpi6 -BS --GMT_THEME=cookbook -view GMT_-B_radians

--- a/doc/scripts/GMT_-B_radians.sh
+++ b/doc/scripts/GMT_-B_radians.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+gmt basemap -R-4/2/0/3 -Jx1i -Bxapi3fpi6 -BS --GMT_THEME=cookbook -view GMT_-B_radians


### PR DESCRIPTION
This PR adds another basic south-axis plot but here we demonstrate annotations in powers and fractions of pi.  The only problem is why is the figure not generated during building the docs?  Hence the WIP.  It is near identical to GMT_-B_slanted.sh but no PS is generated and hence no PNG. WOUld @maxrjones know why? I usually follow the CONTRIBUTION guide and it always works, but here something non-dvc is failing?