### PR TITLE
Make qsort_r argument order the same via macros

### DIFF
--- a/src/compat/qsort.c
+++ b/src/compat/qsort.c
@@ -21,7 +21,7 @@
    Software - Practice and Experience; Vol. 23 (11), 1249-1265, 1993.  */
 
 #if GMT_USE_COMPAT_QSORT
-#warning "C Preprocessor determined we need to use compat/qsort.[ch]"
+#pragma message("C Preprocessor determined we need to use compat/qsort.[ch]")
 
 /* CMake definitions: This must be first! */
 #include "gmt_config.h"
@@ -260,8 +260,8 @@ _quicksort (void *const pbase, size_t total_elems, size_t size,
 #endif /* !HAVE_QSORT_R_GLIBC */
 #else
 #if _MSC_VER
-#warning "C Preprocessor determined we will use system function qsort_s]"
+#pragma message("C Preprocessor determined we will use system function qsort_s]")
 #else
-#warning "C Preprocessor determined we will use system function qsort_r]"
+#pragma message("C Preprocessor determined we will use system function qsort_r]")
 #endif
 #endif  /* GMT_USE_COMPAT_QSORT */

--- a/src/compat/qsort.c
+++ b/src/compat/qsort.c
@@ -21,6 +21,7 @@
    Software - Practice and Experience; Vol. 23 (11), 1249-1265, 1993.  */
 
 #if GMT_USE_COMPAT_QSORT
+#warning "C Preprocessor determined we need to use compat/qsort.[ch]"
 
 /* CMake definitions: This must be first! */
 #include "gmt_config.h"
@@ -257,4 +258,6 @@ _quicksort (void *const pbase, size_t total_elems, size_t size,
   }
 }
 #endif /* !HAVE_QSORT_R_GLIBC */
+#else
+#warning "C Preprocessor determined we will use system qsort_r]"
 #endif  /* GMT_USE_COMPAT_QSORT */

--- a/src/compat/qsort.c
+++ b/src/compat/qsort.c
@@ -259,7 +259,7 @@ _quicksort (void *const pbase, size_t total_elems, size_t size,
 }
 #endif /* !HAVE_QSORT_R_GLIBC */
 #else
-#if _WIN32
+#if _MSC_VER
 #warning "C Preprocessor determined we will use system function qsort_s]"
 #else
 #warning "C Preprocessor determined we will use system function qsort_r]"

--- a/src/compat/qsort.c
+++ b/src/compat/qsort.c
@@ -20,6 +20,8 @@
    Engineering a sort function; Jon Bentley and M. Douglas McIlroy;
    Software - Practice and Experience; Vol. 23 (11), 1249-1265, 1993.  */
 
+#if GMT_USE_COMPAT_QSORT
+
 /* CMake definitions: This must be first! */
 #include "gmt_config.h"
 #ifndef HAVE_QSORT_R_GLIBC
@@ -255,3 +257,4 @@ _quicksort (void *const pbase, size_t total_elems, size_t size,
   }
 }
 #endif /* !HAVE_QSORT_R_GLIBC */
+#endif  /* GMT_USE_COMPAT_QSORT */

--- a/src/compat/qsort.c
+++ b/src/compat/qsort.c
@@ -259,5 +259,9 @@ _quicksort (void *const pbase, size_t total_elems, size_t size,
 }
 #endif /* !HAVE_QSORT_R_GLIBC */
 #else
-#warning "C Preprocessor determined we will use system qsort_r]"
+#if _WIN32
+#warning "C Preprocessor determined we will use system function qsort_s]"
+#else
+#warning "C Preprocessor determined we will use system function qsort_r]"
+#endif
 #endif  /* GMT_USE_COMPAT_QSORT */

--- a/src/compat/qsort.h
+++ b/src/compat/qsort.h
@@ -34,6 +34,8 @@ extern "C" {
 /* CMake definitions: This must be first! */
 #include "gmt_config.h"
 
+#if GMT_USE_COMPAT_QSORT
+
 #ifndef HAVE_QSORT_R_GLIBC
 
 /* Declaration modifiers for DLL support (MSC et al) */
@@ -62,4 +64,5 @@ static inline void qsort_r_glibc (void *base, size_t nmemb, size_t size,
 #define qsort_r qsort_r_glibc /* override builtin qsort_r */
 
 #endif /* !HAVE_QSORT_R_GLIBC */
+#endif  /* GMT_USE_COMPAT_QSORT */
 #endif /* !_QSORT_H */

--- a/src/compat/qsort.h
+++ b/src/compat/qsort.h
@@ -31,10 +31,10 @@
 extern "C" {
 #endif
 
+#if GMT_USE_COMPAT_QSORT
+
 /* CMake definitions: This must be first! */
 #include "gmt_config.h"
-
-#if GMT_USE_COMPAT_QSORT
 
 #ifndef HAVE_QSORT_R_GLIBC
 

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -188,9 +188,9 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 #ifdef APPLE_SILICON
     /* Argument order is unusual, ends with thunk pointer */
     #define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, thunk, compar);
-    #warning "C Preprocessor detected Silicon and we use different qsort_r order!"
+    //#warning "C Preprocessor detected Silicon and we use different qsort_r order!"
 #else
-    #warning "Not Apple Silicon (but could be Intel), probably Linux or Windows and we use different qsort_r order!"
+    //#warning "Not Apple Silicon (but could be Intel), probably Linux or Windows and we use different qsort_r order!"
     /* If GLIBC compatible QSORT_R is not available */
     #ifndef HAVE_QSORT_R_GLIBC
         #include "compat/qsort.h"

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -79,6 +79,9 @@ extern "C" {
 #       define vImage_Utilities_h
 #       define vImage_CVUtilities_h
 #   endif
+#   if defined __arm64__
+#       define APPLE_SILICON
+#   endif
 #endif
 
 /* Avoid some annoying warnings from MS Visual Studio */
@@ -182,7 +185,7 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 #include "gmt_mb.h"		/* GMT redefines for MB-system compatibility */
 
 /* qsort_r is a mess: https://stackoverflow.com/questions/39560773/different-declarations-of-qsort-r-on-mac-and-linux */
-#ifdef __APPLE__
+#ifdef APPLE_SILICON
     /* Argument order is unusual, ends with thunk pointer */
     #define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, thunk, compar);
 #else

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -181,9 +181,17 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 
 #include "gmt_mb.h"		/* GMT redefines for MB-system compatibility */
 
-/* If GLIBC compatible qsort_r is not available */
-#ifndef HAVE_QSORT_R_GLIBC
-#	include "compat/qsort.h"
+/* qsort_r is a mess: https://stackoverflow.com/questions/39560773/different-declarations-of-qsort-r-on-mac-and-linux */
+#ifdef __APPLE__
+    /* Argument order is unusual, ends with thunk pointer */
+    #define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, thunk, compar);
+#else
+    /* If GLIBC compatible QSORT_R is not available */
+    #ifndef HAVE_QSORT_R_GLIBC
+        #include "compat/qsort.h"
+        #define GMT_USE_COMPAT_QSORT
+    #endif
+    #define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, compar, thunk);
 #endif
 
 #ifdef __cplusplus

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -188,7 +188,9 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 #ifdef APPLE_SILICON
     /* Argument order is unusual, ends with thunk pointer */
     #define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, thunk, compar);
+    #warning "C Preprocessor detected Silicon and we use different qsort_r order!"
 #else
+    #warning "Not Apple Silicon (but could be Intel), probably Linux or Windows and we use different qsort_r order!"
     /* If GLIBC compatible QSORT_R is not available */
     #ifndef HAVE_QSORT_R_GLIBC
         #include "compat/qsort.h"

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -189,7 +189,7 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 #include "gmt_mb.h"		/* GMT redefines for MB-system compatibility */
 
 /* qsort_r is a mess: https://stackoverflow.com/questions/39560773/different-declarations-of-qsort-r-on-mac-and-linux */
-#ifdef _WIN32
+#ifdef _MSC_VER
 	#include <search.h>
 	/* Argument order is unusual, starts with thunk pointer, and is called qsort_s */
 	#define QSORT_R(base, nel, width, compar, thunk) qsort_s(base, nel, width, thunk, compar);

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -192,7 +192,7 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 #ifdef _MSC_VER
 	#include <search.h>
 	/* Argument order is unusual, starts with thunk pointer, and is called qsort_s */
-	#define QSORT_R(base, nel, width, compar, thunk) qsort_s(base, nel, width, thunk, compar);
+	#define QSORT_R(base, nel, width, compar, thunk) qsort_s(base, nel, width, compar, thunk);
 #elif defined(QSORT_R_THUNK_FIRST)
 	/* Argument order is unusual, starts with thunk pointer */
 	#define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, thunk, compar);

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -189,12 +189,13 @@ struct GMT_CTRL; /* forward declaration of GMT_CTRL */
 	#include <search.h>
 	/* Argument order is unusual, starts with thunk pointer, and is called qsort_s */
 	#define QSORT_R(base, nel, width, compar, thunk) qsort_s(base, nel, width, compar, thunk);
+    //#pragma message("C Preprocessor determined we need to use qsort_s on Windows")
 #elif defined(QSORT_R_THUNK_FIRST)
 	/* Argument order is unusual, starts with thunk pointer */
 	#define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, thunk, compar);
-	//#warning "C Preprocessor detected Silicon and we use different qsort_r order!"
+	//#pragma message("C Preprocessor detected Silicon and we use different qsort_r order!")
 #else
-	//#warning "Not Apple Silicon (but could be Intel), probably Linux or Windows and we use different qsort_r order!"
+	//#pragma message("Not Apple Silicon (but could be Intel), probably Linux and we use different qsort_r order!")
 	/* If GLIBC compatible QSORT_R is not available */
 	/* Argument order is unusual, ends with thunk pointer */
 	#ifndef HAVE_QSORT_R_GLIBC

--- a/src/gmt_dev.h
+++ b/src/gmt_dev.h
@@ -84,10 +84,6 @@ extern "C" {
 #   endif
 #endif
 
-#ifdef _WIN32
-#       define QSORT_R_THUNK_FIRST
-#endif
-
 /* Avoid some annoying warnings from MS Visual Studio */
 #ifdef _MSC_VER
 #	pragma warning( disable : 4091 )	/* 'static ': ignored on left of 'XXX' when no variable is declared */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4821,9 +4821,15 @@ GMT_LOCAL int gmtsupport_getrose_old (struct GMT_CTRL *GMT, char option, char *t
 }
 
 /* Here lies GMT Crossover core functions that previously was in X2SYS only */
-/* gmtsupport_ysort must be an int since it is passed to qsort! */
+/* gmtsupport_ysort must be an int since it is passed to qsort_r! */
 /*! . */
+#ifdef APPLE_SILICON
+/* arg is first argument to compare function */
+GMT_LOCAL int gmtsupport_ysort (void *arg, const void *p1, const void *p2) {
+#else
+/* arg is last argument to compare function */
 GMT_LOCAL int gmtsupport_ysort (const void *p1, const void *p2, void *arg) {
+#endif
 	const struct GMT_XSEGMENT *a = p1, *b = p2;
 	double *x2sys_y = arg;
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4823,7 +4823,7 @@ GMT_LOCAL int gmtsupport_getrose_old (struct GMT_CTRL *GMT, char option, char *t
 /* Here lies GMT Crossover core functions that previously was in X2SYS only */
 /* gmtsupport_ysort must be an int since it is passed to qsort_r! */
 /*! . */
-#ifdef APPLE_SILICON
+#ifdef QSORT_R_THUNK_FIRST
 /* arg is first argument to compare function */
 GMT_LOCAL int gmtsupport_ysort (void *arg, const void *p1, const void *p2) {
 #else

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14842,7 +14842,7 @@ int gmt_init_track (struct GMT_CTRL *GMT, double y[], uint64_t n, struct GMT_XSE
 	}
 
 	/* Sort on minimum y-coordinate, if tie then on 2nd coordinate */
-	qsort_r (L, nl, sizeof (struct GMT_XSEGMENT), gmtsupport_ysort, y);
+	QSORT_R (L, nl, sizeof (struct GMT_XSEGMENT), gmtsupport_ysort, y);
 
 	*S = L;
 

--- a/src/surface.c
+++ b/src/surface.c
@@ -466,7 +466,7 @@ GMT_LOCAL void fill_in_forecast (struct GMT_CTRL *GMT, struct SURFACE_INFO *C) {
 	status[C->node_ne_corner] = SURFACE_IS_CONSTRAINED;
 }
 
-#ifdef APPLE_SILICON
+#ifdef QSORT_R_THUNK_FIRST
 /* arg is first argument to compare function */
 GMT_LOCAL int surface_compare_points (void *arg, const void *point_1v, const void *point_2v) {
 #else

--- a/src/surface.c
+++ b/src/surface.c
@@ -452,7 +452,7 @@ GMT_LOCAL void fill_in_forecast (struct GMT_CTRL *GMT, struct SURFACE_INFO *C) {
 	/* Next do linear interpolation along the north edge */
 	index_10 = C->node_nw_corner;	/* Left NW node */
 	for (previous_col = 0; previous_col < (C->previous_nx-1); previous_col++) {	/* To ensure last edge ends at col = C->previous_nx-1 */
-		index_00 = index_10;		/* Previous right node becmes current left node */
+		index_00 = index_10;		/* Previous right node becomes current left node */
 		index_10 = index_00 + expand;	/* Right node after striding to the right */
 		sx = u[index_10] - u[index_00];	/* Horizontal gradient in u toward xmax (for increasing i) */
 		index_new = index_00 + 1;	/* Start at 1 since we skip the constrained index_00 node */
@@ -466,7 +466,13 @@ GMT_LOCAL void fill_in_forecast (struct GMT_CTRL *GMT, struct SURFACE_INFO *C) {
 	status[C->node_ne_corner] = SURFACE_IS_CONSTRAINED;
 }
 
+#ifdef APPLE_SILICON
+/* arg is first argument to compare function */
+GMT_LOCAL int surface_compare_points (void *arg, const void *point_1v, const void *point_2v) {
+#else
+/* arg is last argument to compare function */
 GMT_LOCAL int surface_compare_points (const void *point_1v, const void *point_2v, void *arg) {
+#endif
 	/* Routine for QSORT_R to sort data structure for fast access to data by node location.
 	   Sorts on index first, then on radius to node corresponding to index, so that index
 	   goes from low to high, and so does radius.  Note: These are simple Cartesian distance

--- a/src/surface.c
+++ b/src/surface.c
@@ -204,7 +204,7 @@ struct SURFACE_BRIGGS {		/* Coefficients in Taylor series for Laplacian(z) a la 
 	gmt_grdfloat b[6];
 };
 
-struct SURFACE_SEARCH {		/* Things needed inside compare function will be passed to qsort_r */
+struct SURFACE_SEARCH {		/* Things needed inside compare function will be passed to QSORT_R */
 	int current_nx;		/* Number of nodes in y-dir for a given grid factor */
 	int current_ny;		/* Number of nodes in y-dir for a given grid factor */
 	double inc[2];		/* Size of each grid cell for a given grid factor */
@@ -228,7 +228,7 @@ struct SURFACE_INFO {	/* Control structure for surface setup and execution */
 	struct GMT_GRID *Grid;		/* The final grid */
 	struct GMT_GRID *Bound[2];	/* Optional grids for lower and upper limits on the solution */
 	struct GMT_GRID_HEADER *Bh;	/* Grid header for one of the limit grids [or NULL] */
-	struct SURFACE_SEARCH info;	/* Information needed by the compare function passed to qsort_r */
+	struct SURFACE_SEARCH info;	/* Information needed by the compare function passed to QSORT_R */
 	unsigned int n_factors;		/* Number of factors in common for the dimensions (n_rows-1, n_columns-1) */
 	unsigned int factors[32];	/* Array of these common factors */
 	unsigned int set_limit[2];	/* For low and high: NONE = unconstrained, DATA = by min data value, VALUE = by user value, SURFACE by a grid */
@@ -467,7 +467,7 @@ GMT_LOCAL void fill_in_forecast (struct GMT_CTRL *GMT, struct SURFACE_INFO *C) {
 }
 
 GMT_LOCAL int surface_compare_points (const void *point_1v, const void *point_2v, void *arg) {
-	/* Routine for qsort_r to sort data structure for fast access to data by node location.
+	/* Routine for QSORT_R to sort data structure for fast access to data by node location.
 	   Sorts on index first, then on radius to node corresponding to index, so that index
 	   goes from low to high, and so does radius.  Note: These are simple Cartesian distance
 	 * calculations.  The metadata needed to do the calculations are passed via *arg.
@@ -530,7 +530,7 @@ GMT_LOCAL void surface_set_index (struct GMT_CTRL *GMT, struct SURFACE_INFO *C) 
 			C->data[k].index = row_col_to_index (row, col, C->current_nx);
 	}
 
-	qsort_r (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
+	QSORT_R (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
 
 	C->npoints -= k_skipped;
 }
@@ -1303,7 +1303,7 @@ GMT_LOCAL void surface_throw_away_unusables (struct GMT_CTRL *GMT, struct SURFAC
 
 	/* Sort the data  */
 
-	qsort_r (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
+	QSORT_R (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
 
 	/* If more than one datum is indexed to the same node, only the first should be kept.
 	   Mark the additional ones as SURFACE_OUTSIDE.
@@ -1322,7 +1322,7 @@ GMT_LOCAL void surface_throw_away_unusables (struct GMT_CTRL *GMT, struct SURFAC
 	}
 
 	if (n_outside) {	/* Sort again; this time the SURFACE_OUTSIDE points will be sorted to end of the array */
-		qsort_r (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
+		QSORT_R (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
 		C->npoints -= n_outside;	/* Effectively chopping off the eliminated points */
 		C->data = gmt_M_memory (GMT, C->data, C->npoints, struct SURFACE_DATA);	/* Adjust memory accordingly */
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "%" PRIu64 " unusable points were supplied; these will be ignored.\n", n_outside);

--- a/src/surface_experimental.c
+++ b/src/surface_experimental.c
@@ -222,7 +222,7 @@ struct SURFACE_BRIGGS {		/* Coefficients in Taylor series for Laplacian(z) a la 
 	gmt_grdfloat b[6];
 };
 
-struct SURFACE_SEARCH {		/* Things needed inside compare function will be passed to qsort_r */
+struct SURFACE_SEARCH {		/* Things needed inside compare function will be passed to QSORT_R */
 	int current_nx;		/* Number of nodes in y-dir for a given grid factor */
 	int current_ny;		/* Number of nodes in y-dir for a given grid factor */
 	double inc[2];		/* Size of each grid cell for a given grid factor */
@@ -248,7 +248,7 @@ struct SURFACE_INFO {	/* Control structure for surface setup and execution */
 	struct SURFACE_BRIGGS *Briggs;	/* Array with Briggs 6-coefficients per nearest active data constraint */
 	struct GMT_GRID *Grid;		/* The final grid */
 	struct GMT_GRID *Bound[2];	/* Optional grids for lower and upper limits on the solution */
-	struct SURFACE_SEARCH info;	/* Information needed by the compare function passed to qsort_r */
+	struct SURFACE_SEARCH info;	/* Information needed by the compare function passed to QSORT_R */
 	unsigned int n_factors;		/* Number of factors in common for the dimensions (n_rows-1, n_columns-1) */
 	unsigned int factors[32];	/* Array of these common factors */
 	unsigned int set_limit[2];	/* For low and high: NONE = unconstrained, DATA = by min data value, VALUE = by user value, SURFACE by a grid */
@@ -496,7 +496,7 @@ GMT_LOCAL void fill_in_forecast (struct GMT_CTRL *GMT, struct SURFACE_INFO *C) {
 }
 
 GMT_LOCAL int surface_compare_points (const void *point_1v, const void *point_2v, void *arg) {
-	/* Routine for qsort_r to sort data structure for fast access to data by node location.
+	/* Routine for QSORT_R to sort data structure for fast access to data by node location.
 	   Sorts on index first, then on radius to node corresponding to index, so that index
 	   goes from low to high, and so does radius.  Note: These are simple Cartesian distance
 	 * calculations.  The metadata needed to do the calculations are passed via *arg.
@@ -559,7 +559,7 @@ GMT_LOCAL void surface_set_index (struct GMT_CTRL *GMT, struct SURFACE_INFO *C) 
 			C->data[k].index = row_col_to_index (row, col, C->current_nx);
 	}
 
-	qsort_r (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
+	QSORT_R (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
 
 	C->npoints -= k_skipped;
 }
@@ -1497,7 +1497,7 @@ GMT_LOCAL void surface_throw_away_unusables (struct GMT_CTRL *GMT, struct SURFAC
 
 	/* Sort the data  */
 
-	qsort_r (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
+	QSORT_R (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
 
 	/* If more than one datum is indexed to the same node, only the first should be kept.
 	   Mark the additional ones as SURFACE_OUTSIDE.
@@ -1526,7 +1526,7 @@ GMT_LOCAL void surface_throw_away_unusables (struct GMT_CTRL *GMT, struct SURFAC
 	}
 
 	if (n_outside) {	/* Sort again; this time the SURFACE_OUTSIDE points will be sorted to end of the array */
-		qsort_r (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
+		QSORT_R (C->data, C->npoints, sizeof (struct SURFACE_DATA), surface_compare_points, &(C->info));
 		C->npoints -= n_outside;	/* Effectively chopping off the eliminated points */
 		C->data = gmt_M_memory (GMT, C->data, C->npoints, struct SURFACE_DATA);	/* Adjust memory accordingly */
 		if (n_ignored) {


### PR DESCRIPTION
THis is trying to fix #7586. For background, see https://stackoverflow.com/questions/39560773/different-declarations-of-qsort-r-on-mac-and-linux.

Not doing it right yet but we will have to deal with different argument order, since Linux has a different order than macOS.  Here is what my attempt of a macro that is in effect on Linus:

`#define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, compar, thunk);`

while if Apple the we have 

`#define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, thunk, compar);`

All places were we used to call qsort_r now calls Q_SORT_R instead to get the order right.  However, on Apple is still get compile errors like this:

```
[28/231] Building C object src/CMakeFiles/gmtlib.dir/gmt_support.c.o
/Users/pwessel/UH/RESEARCH/CVSPROJECTS/GMTdev/gmt-dev/src/gmt_support.c:14845:48: warning: incompatible function pointer types passing 'int (const void *, const void *, void *)' to parameter of type 'int (* _Nonnull)(void *, const void *, const void *)' [-Wincompatible-function-pointer-types]
        QSORT_R (L, nl, sizeof (struct GMT_XSEGMENT), gmtsupport_ysort, y);
                                                      ^~~~~~~~~~~~~~~~
/Users/pwessel/UH/RESEARCH/CVSPROJECTS/GMTdev/gmt-dev/src/gmt_dev.h:187:87: note: expanded from macro 'QSORT_R'
    #define QSORT_R(base, nel, width, compar, thunk) qsort_r(base, nel, width, thunk, compar);
                                                                                      ^~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/stdlib.h:345:22: note: passing argument to parameter '__compar' here
            int (* _Nonnull __compar)(void *, const void *, const void *));

```

Need to know what Windows does, @joa-quim.  Note the original problem seems limited to Apple Silicon (which I am on) so have not added `_arm_` stuff yet.