### PR TITLE
Remove bugs related to SI units in movie

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -1440,6 +1440,30 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		}
 	}
 
+	/* Get canvas size in pixels */
+	p_width =  urint (round (Ctrl->C.dim[GMT_X] * dpu));
+	p_height = urint (round (Ctrl->C.dim[GMT_Y] * dpu));
+	if (p_width % 2) {	/* Don't like odd pixel widths */
+		unsigned int p2_width;
+		GMT_Report (API, GMT_MSG_WARNING, "Your frame width is an odd number of pixels (%u). This will not work with FFmpeg\n", p_width);
+		do {	/* Make small increments to width in 0.1 pixels until we hit an even integer */
+			Ctrl->C.dim[GMT_X] += 0.1 / dpu;
+			p2_width = urint (round (Ctrl->C.dim[GMT_X] * dpu));
+		} while (p2_width == p_width);	/* Ends when we go from odd to even */
+		p_width = p2_width;
+		GMT_Report (API, GMT_MSG_WARNING, "Your frame width was adjusted to %g%c, giving an even width of %u pixels\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit , p_width);
+	}
+	if (p_height % 2) {	/* Don't like odd pixel heights */
+		unsigned int p2_height;
+		GMT_Report (API, GMT_MSG_WARNING, "Your frame height is an odd number of pixels (%u). This will not work with FFmpeg\n", p_height);
+		do {	/* Make small increments to height in 0.1 pixels until we hit an even integer */
+			Ctrl->C.dim[GMT_Y] += 0.1 / dpu;
+			p2_height = urint (round (Ctrl->C.dim[GMT_Y] * dpu));
+		} while (p2_height == p_height);	/* Ends when we go from odd to even */
+		p_height = p2_height;
+		GMT_Report (API, GMT_MSG_WARNING, "Your frame height was adjusted to %g%c, giving an even height of %u pixels\n", Ctrl->C.dim[GMT_Y], Ctrl->C.unit , p_height);
+	}
+
 	if (Ctrl->Q.scripts) {	/* No movie, but scripts will be produced */
 		GMT_Report (API, GMT_MSG_INFORMATION, "Dry-run enabled - Movie scripts will be created and any pre/post scripts will be executed.\n");
 		if (Ctrl->M.active) {
@@ -1476,29 +1500,6 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				movie_close_files (Ctrl);
 				Return (GMT_RUNTIME_ERROR);
 			}
-		}
-		/* Get canvas size in pixels */
-		p_width =  urint (ceil (Ctrl->C.dim[GMT_X] * dpu));
-		p_height = urint (ceil (Ctrl->C.dim[GMT_Y] * dpu));
-		if (p_width % 2) {	/* Don't like odd pixel widths */
-			unsigned int p2_width;
-			GMT_Report (API, GMT_MSG_WARNING, "Your frame width is an odd number of pixels (%u). This will not work with FFmpeg\n", p_width);
-			do {	/* Make small increments to width in 0.1 pixels until we hit an even integer */
-				Ctrl->C.dim[GMT_X] += 0.1 / dpu;
-				p2_width = urint (ceil (Ctrl->C.dim[GMT_X] * dpu));
-			} while (p2_width == p_width);	/* Ends when we go from odd to even */
-			p_width = p2_width;
-			GMT_Report (API, GMT_MSG_WARNING, "Your frame width was adjusted to %g%c, giving an even width of %u pixels\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit , p_width);
-		}
-		if (p_height % 2) {	/* Don't like odd pixel heights */
-			unsigned int p2_height;
-			GMT_Report (API, GMT_MSG_WARNING, "Your frame height is an odd number of pixels (%u). This will not work with FFmpeg\n", p_height);
-			do {	/* Make small increments to height in 0.1 pixels until we hit an even integer */
-				Ctrl->C.dim[GMT_Y] += 0.1 / dpu;
-				p2_height = urint (ceil (Ctrl->C.dim[GMT_Y] * dpu));
-			} while (p2_height == p_height);	/* Ends when we go from odd to even */
-			p_height = p2_height;
-			GMT_Report (API, GMT_MSG_WARNING, "Your frame height was adjusted to %g%c, giving an even height of %u pixels\n", Ctrl->C.dim[GMT_Y], Ctrl->C.unit , p_height);
 		}
 	}
 

--- a/src/movie.c
+++ b/src/movie.c
@@ -1407,8 +1407,6 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	if (Ctrl->F.transparent) GMT_Report (API, GMT_MSG_WARNING, "Building transparent PNG images is an experimental feature\n");
 	/* Determine pixel dimensions of individual images */
 	dpu = Ctrl->C.dim[GMT_Z];	/* As given, suiting the provided canvas dim units */
-	p_width =  urint (ceil (Ctrl->C.dim[GMT_X] * dpu));
-	p_height = urint (ceil (Ctrl->C.dim[GMT_Y] * dpu));
 	one_frame = (Ctrl->M.active && Ctrl->M.exit);	/* true if we want to create a single master plot only (no frames nor animations) */
 	if (Ctrl->C.unit == 'c') Ctrl->C.dim[GMT_Z] *= 2.54;		/* Since gs requires dots per inch but we gave dots per cm */
 	else if (Ctrl->C.unit == 'p') Ctrl->C.dim[GMT_Z] *= 72.0;	/* Since gs requires dots per inch but we gave dots per point */
@@ -1472,32 +1470,35 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			if (gmt_check_executable (GMT, "ffmpeg", "-version", "FFmpeg developers", line)) {
 				sscanf (line, "%*s %*s %s %*s", version);
 				GMT_Report (API, GMT_MSG_INFORMATION, "FFmpeg %s found.\n", version);
-				if (p_width % 2) {	/* Don't like odd pixel widths */
-					unsigned int p2_width;
-					GMT_Report (API, GMT_MSG_WARNING, "Your frame width is an odd number of pixels (%u). This will not work with FFmpeg\n", p_width);
-					do {	/* Make small increments to width in 0.1 pixels until we hit an even integer */
-						Ctrl->C.dim[GMT_X] += 0.1 / dpu;
-						p2_width = urint (ceil (Ctrl->C.dim[GMT_X] * dpu));
-					} while (p2_width == p_width);	/* Ends when we go from odd to even */
-					p_width = p2_width;
-					GMT_Report (API, GMT_MSG_WARNING, "Your frame width was adjusted to %g%c, giving an even width of %u pixels\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit , p_width);
-				}
-				if (p_height % 2) {	/* Don't like odd pixel heights */
-					unsigned int p2_height;
-					GMT_Report (API, GMT_MSG_WARNING, "Your frame height is an odd number of pixels (%u). This will not work with FFmpeg\n", p_height);
-					do {	/* Make small increments to height in 0.1 pixels until we hit an even integer */
-						Ctrl->C.dim[GMT_Y] += 0.1 / dpu;
-						p2_height = urint (ceil (Ctrl->C.dim[GMT_Y] * dpu));
-					} while (p2_height == p_height);	/* Ends when we go from odd to even */
-					p_height = p2_height;
-					GMT_Report (API, GMT_MSG_WARNING, "Your frame height was adjusted to %g%c, giving an even height of %u pixels\n", Ctrl->C.dim[GMT_Y], Ctrl->C.unit , p_height);
-				}
 			}
 			else {
 				GMT_Report (API, GMT_MSG_ERROR, "FFmpeg is not installed - cannot build MP4 or WEbM movies.\n");
 				movie_close_files (Ctrl);
 				Return (GMT_RUNTIME_ERROR);
 			}
+		}
+		/* Get canvas size in pixels */
+		p_width =  urint (ceil (Ctrl->C.dim[GMT_X] * dpu));
+		p_height = urint (ceil (Ctrl->C.dim[GMT_Y] * dpu));
+		if (p_width % 2) {	/* Don't like odd pixel widths */
+			unsigned int p2_width;
+			GMT_Report (API, GMT_MSG_WARNING, "Your frame width is an odd number of pixels (%u). This will not work with FFmpeg\n", p_width);
+			do {	/* Make small increments to width in 0.1 pixels until we hit an even integer */
+				Ctrl->C.dim[GMT_X] += 0.1 / dpu;
+				p2_width = urint (ceil (Ctrl->C.dim[GMT_X] * dpu));
+			} while (p2_width == p_width);	/* Ends when we go from odd to even */
+			p_width = p2_width;
+			GMT_Report (API, GMT_MSG_WARNING, "Your frame width was adjusted to %g%c, giving an even width of %u pixels\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit , p_width);
+		}
+		if (p_height % 2) {	/* Don't like odd pixel heights */
+			unsigned int p2_height;
+			GMT_Report (API, GMT_MSG_WARNING, "Your frame height is an odd number of pixels (%u). This will not work with FFmpeg\n", p_height);
+			do {	/* Make small increments to height in 0.1 pixels until we hit an even integer */
+				Ctrl->C.dim[GMT_Y] += 0.1 / dpu;
+				p2_height = urint (ceil (Ctrl->C.dim[GMT_Y] * dpu));
+			} while (p2_height == p_height);	/* Ends when we go from odd to even */
+			p_height = p2_height;
+			GMT_Report (API, GMT_MSG_WARNING, "Your frame height was adjusted to %g%c, giving an even height of %u pixels\n", Ctrl->C.dim[GMT_Y], Ctrl->C.unit , p_height);
 		}
 	}
 


### PR DESCRIPTION
Closes #7587.  The "1920 is odd" message was cut/paste from the width check into the height check (which was odd).  Then, the huge height was due to scaling the dpu of 80 by 2.54.
