### PR TITLE
Handle commas in meca if -A and CSV

### DIFF
--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -1294,7 +1294,12 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 				/* Must examine the trailing text for optional columns: newX, newY and title */
 				/* newX and newY are not used in pscoupe, but we promised psmeca and pscoupe can use the same input file */
 				if (has_text) {
-					n_scanned = sscanf (S->text[row], "%s %s %[^\n]s\n", Xstring, Ystring, event_title);
+					unsigned int n_comma = gmt_count_char (GMT, S->text[row], ',');
+					char tmp_buffer[GMT_LEN256] = {""};	/* Local buffer in case S->text is read-only */
+					strncpy (tmp_buffer, S->text[row], GMT_LEN256);
+					if (n_comma == 2)	/* CSV file so we must handle that */
+						gmt_strrepc (tmp_buffer, ',', ' ');
+					n_scanned = sscanf (tmp_buffer, "%s %s %[^\n]s\n", Xstring, Ystring, event_title);
 					if (n_scanned >= 2) { /* Got new x,y coordinates and possibly event title */
 						unsigned int type;
 						if (GMT->current.setting.io_lonlat_toggle[GMT_IN]) {	/* Expect lat lon but watch for junk */

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -836,9 +836,11 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 				/* Must examine the trailing text for optional columns: newX, newY and title */
 				if (S->text && S->text[row]) {
 					unsigned int n_comma = gmt_count_char (GMT, S->text[row], ',');
+					char tmp_buffer[GMT_LEN256] = {""};	/* Local buffer in case S->text is read-only */
+					strncpy (tmp_buffer, S->text[row], GMT_LEN256);
 					if (n_comma == 2)	/* CSV file so we must handle that */
-						gmt_strrepc (S->text[row], ',', ' ');
-					n_scanned = sscanf (S->text[row], "%s %s %[^\n]s\n", Xstring, Ystring, event_title);
+						gmt_strrepc (tmp_buffer, ',', ' ');
+					n_scanned = sscanf (tmp_buffer, "%s %s %[^\n]s\n", Xstring, Ystring, event_title);
 					if (n_scanned >= 2) { /* Got new x,y coordinates and possibly event title */
 						unsigned int type;
 						if (GMT->current.setting.io_lonlat_toggle[GMT_IN]) {	/* Expect lat lon but watch for junk */

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -835,7 +835,11 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 
 				/* Must examine the trailing text for optional columns: newX, newY and title */
 				if (S->text && S->text[row]) {
-					n_scanned = sscanf (S->text[row], "%s %s %[^\n]s\n", Xstring, Ystring, event_title);
+					unsigned int n_comma = gmt_count_char (GMT, S->text[row], ',');
+					if (n_comma == 2)	/* CSV file so we must handle that */
+						n_scanned = sscanf (S->text[row], "%s,%s,%[^\n]s\n", Xstring, Ystring, event_title);
+					else
+						n_scanned = sscanf (S->text[row], "%s %s %[^\n]s\n", Xstring, Ystring, event_title);
 					if (n_scanned >= 2) { /* Got new x,y coordinates and possibly event title */
 						unsigned int type;
 						if (GMT->current.setting.io_lonlat_toggle[GMT_IN]) {	/* Expect lat lon but watch for junk */

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -837,9 +837,8 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 				if (S->text && S->text[row]) {
 					unsigned int n_comma = gmt_count_char (GMT, S->text[row], ',');
 					if (n_comma == 2)	/* CSV file so we must handle that */
-						n_scanned = sscanf (S->text[row], "%s,%s,%[^\n]s\n", Xstring, Ystring, event_title);
-					else
-						n_scanned = sscanf (S->text[row], "%s %s %[^\n]s\n", Xstring, Ystring, event_title);
+						gmt_strrepc (S->text[row], ',', ' ');
+					n_scanned = sscanf (S->text[row], "%s %s %[^\n]s\n", Xstring, Ystring, event_title);
 					if (n_scanned >= 2) { /* Got new x,y coordinates and possibly event title */
 						unsigned int type;
 						if (GMT->current.setting.io_lonlat_toggle[GMT_IN]) {	/* Expect lat lon but watch for junk */


### PR DESCRIPTION
See pyGMT [issue](https://github.com/GenericMappingTools/pygmt/issues/1365#issuecomment-1336192548).

With **-A** we examine the trailing text, but if those items are comma-separated then the scanning will fail since the format assumes white-space.  This PR counts commas in trailing text and if 2 we change the scanning.

@seisman:

Please see if it works as is.

1. If not, please add a fprintf (stderr, trailing = %s\n", S->text[row]); so we can see the trailing text and manually check commas (not sure if there might be a leading one).
2. Once working, perhaps same is needed in other seis modules?