### PR TITLE
Add -Wm|M to mapprojects's reportoire

### DIFF
--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -27,7 +27,7 @@ Synopsis
 [ |-S| ]
 [ |-T|\ [**h**]\ *from*\ [/*to*] ]
 [ |SYN_OPT-V| ]
-[ |-W|\ [**e**\|\ **E**\|\ **g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**][**+n**\ [*nx*\ [/*ny*]]] ]
+[ |-W|\ [**e**\|\ **E**\|\ **g**\|\ **h**\|\ **j**\|\ **m**\|\ **M**\\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**][**+n**\ [*nx*\ [/*ny*]]] ]
 [ |-Z|\ [*speed*][**+a**][**+i**][**+f**][**+t**\ *epoch*] ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -230,7 +230,7 @@ Optional Arguments
 
 .. _-W:
 
-**-W**\ [**e**\|\ **E**\|\ **g**\|\ **h**\|\ **j**\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**][**+n**\ [*nx*\ [/*ny*]]]
+**-W**\ [**e**\|\ **E**\|\ **g**\|\ **h**\|\ **j**\|\ **m**\|\ **M**\\|\ **n**\|\ **o**\|\ **O**\|\ **r**\|\ **R**\|\ **w**\|\ **x**][**+n**\ [*nx*\ [/*ny*]]]
     Prints map width and height on standard output.  No input files are read.
     To only output the width or the height, append **w** or **h**, respectively.
     To output the plot coordinates of a map point, give **g**\ *lon*/*lat*.
@@ -246,6 +246,7 @@ Optional Arguments
     *llx urx lly ury*) or use **O** to get the equivalent |-R| string as trailing
     text. To return the coordinates of the rectangular area encompassing the non-rectangular
     area defined by your |-R| |-J|, use **e**, or **E** for the trailing text string.
+    Similarly, use **m** or **M** to get the rectangular region in projected coordinates instead.
     Alternatively (for **e** or **r**), append **+n** to set how many points [100]
     you want along each side for a closed polygon of the oblique area instead
     [Default returns the width and height of the map].

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1152,18 +1152,18 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 			case GMT_MP_M_MREGION:
 				if (GMT->current.proj.search && (error = gmt_map_perimeter_search (GMT, GMT->common.R.wesn, false)))
 					Return (GMT_RUNTIME_ERROR);
-		if (Ctrl->F.active) {	/* Convert to meter, then to chosen unit */
-			strncpy (unit_name, scale_unit_name, GMT_LEN64);
-			xmin /= GMT->current.proj.scale[GMT_X];
-			xmax /= GMT->current.proj.scale[GMT_X];
-			ymin /= GMT->current.proj.scale[GMT_Y];
-			ymax /= GMT->current.proj.scale[GMT_Y];
-			if (unit) {	/* Change the 1:1 unit used */
-				xmin *= fwd_scale;
-				xmax *= fwd_scale;
-				ymin *= fwd_scale;
-				ymax *= fwd_scale;
-			}
+				if (Ctrl->F.active) {	/* Convert to meter, then to chosen unit */
+					strncpy (unit_name, scale_unit_name, GMT_LEN64);
+					xmin /= GMT->current.proj.scale[GMT_X];
+					xmax /= GMT->current.proj.scale[GMT_X];
+					ymin /= GMT->current.proj.scale[GMT_Y];
+					ymax /= GMT->current.proj.scale[GMT_Y];
+					if (unit) {	/* Change the 1:1 unit used */
+						xmin *= fwd_scale;
+						xmax *= fwd_scale;
+						ymin *= fwd_scale;
+						ymax *= fwd_scale;
+					}
 		}
 				w_out[XLO] = xmin;	w_out[XHI] = xmax;
 				w_out[YLO] = ymin;	w_out[YHI] = ymax;

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -72,7 +72,9 @@ enum GMT_mp_Wcodes {	/* Support for -W parsing */
 	GMT_MP_M_OREGION = 6,	/* Converts -R<xmin/xmax/ymin/ymax>+u<unit> to <llx/lly/urx/ury> returned as llx urx lly ury */
 	GMT_MP_M_OSTRING = 7,	/* As 6, but return string -Rw/e/s/n */
 	GMT_MP_M_EREGION = 8,	/* Converts -R<xmin/xmax/ymin/ymax>+u<unit> to <llx/lly/urx/ury> returned as llx urx lly ury */
-	GMT_MP_M_ESTRING = 9	/* As 6, but return string -Rw/e/s/n */
+	GMT_MP_M_ESTRING = 9,	/* As 6, but return string -Rw/e/s/n */
+	GMT_MP_M_MREGION = 10,	/* As 6, but return string -Rxmin/xmax/ymn/ymax */
+	GMT_MP_M_MSTRING = 11	/* As 6 but as string */
 };
 
 enum GMT_mp_Zcodes {	/* Support for -Z parsing */
@@ -210,7 +212,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <table> %s %s [-Ab|B|f|F|o|O[<lon0>/<lat0>][+v]] [-C[<dx></dy>][+m]] [-D%s] "
 		"[-E[<datum>]] [-F[<%s|%s>]] [-G[<lon0>/<lat0>][+a][+i][+u<unit>][+v]] [-I] [-L<table>[+p][+u<unit>]] "
-		"[-N[a|c|g|m]] [-Q[d|e]] [-S] [-T[h]<from>[/<to>]] [%s] [-W[e|E|g|h|j|n|o|O|r|R|w|x]][+n[<nx>[/<ny>]]] [-Z[<speed>][+a][+i][+f][+t<epoch>]] "
+		"[-N[a|c|g|m]] [-Q[d|e]] [-S] [-T[h]<from>[/<to>]] [%s] [-W[e|E|g|h|j|m|M|n|o|O|r|R|w|x]][+n[<nx>[/<ny>]]] [-Z[<speed>][+a][+i][+f][+t<epoch>]] "
 		"[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_DIM_UNITS_DISPLAY, GMT_LEN_UNITS2_DISPLAY, GMT_DIM_UNITS_DISPLAY, GMT_V_OPT,
 		GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT, GMT_h_OPT, GMT_i_OPT, GMT_j_OPT, GMT_o_OPT, GMT_p_OPT,
@@ -293,13 +295,15 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"If <from> equals - we use WGS-84.  If /<to> is not given we assume WGS-84. "
 		"Note: -T can be used as pre- or post- (-I) processing for -J -R.");
 	GMT_Option (API, "V");
-	GMT_Usage (API, 1, "\n-W[e|E|g|h|j|n|o|O|r|R|w|x][+n[<nx>[/<ny>]]]");
+	GMT_Usage (API, 1, "\n-W[e|E|g|h|j|m|M|n|o|O|r|R|w|x][+n[<nx>[/<ny>]]]");
 	GMT_Usage (API, -2, "Print map width and/or height or a reference point. No input files are read. Select optional directive:");
 	GMT_Usage (API, 3, "e: Print oblique <llx>/<lly>/<urx>/<ury>+r coordinates for rectangular region encompassing the -R -J area.");
 	GMT_Usage (API, 3, "E: Same as e but prints -Rw/s/e/n+r string as trailing text instead.");
 	GMT_Usage (API, 3, "g: Print map coordinates of reference point <gx/gy>.");
 	GMT_Usage (API, 3, "h: Print map height (See -D for plot units).");
 	GMT_Usage (API, 3, "j: Print map coordinates of justification point given as 2-char justification code (BL, MC, etc.).");
+	GMT_Usage (API, 3, "m: Print <xmin>/<xmax>/<ymin>/<ymax> projected coordinates for rectangular region encompassing the -R -J area.");
+	GMT_Usage (API, 3, "M: Same as m but prints -R<xmin>/<xmax>/<ymin>/<ymax> string as trailing text instead.");
 	GMT_Usage (API, 3, "n: Print map coordinates of reference point with normalized coordinates <rx/ry> in 0-1 range.");
 	GMT_Usage (API, 3, "o: Print oblique <llx>/<lly>/<urx>/<ury>+r coordinates and -R string for an oblique input region given via <xmin/xmax/ymin/ymax>+u<unit>.");
 	GMT_Usage (API, 3, "r: Print rectangular region for an oblique -R -J selection.");
@@ -735,8 +739,10 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 					case 'O': Ctrl->W.mode = GMT_MP_M_OSTRING; break;
 					case 'r': Ctrl->W.mode = GMT_MP_M_REGION; break;
 					case 'R': Ctrl->W.mode = GMT_MP_M_RSTRING; break;
+					case 'm': Ctrl->W.mode = GMT_MP_M_MREGION; break;
+					case 'M': Ctrl->W.mode = GMT_MP_M_MSTRING; break;
 					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Expected -W[e|E|g|h|j|n|o|O|r|R|w|x]\n");
+						GMT_Report (API, GMT_MSG_ERROR, "Option -W: Expected -W[e|E|g|h|j|m|M|n|o|O|r|R|w|x]\n");
 						n_errors++;
 						break;
 				}
@@ -1043,6 +1049,11 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 
 	if (!Ctrl->W.poly) Out = gmt_new_record (GMT, NULL, NULL);
 
+	xmin = (Ctrl->C.active) ? GMT->current.proj.rect[XLO] - GMT->current.proj.origin[GMT_X] : GMT->current.proj.rect[XLO];
+	xmax = (Ctrl->C.active) ? GMT->current.proj.rect[XHI] - GMT->current.proj.origin[GMT_X] : GMT->current.proj.rect[XHI];
+	ymin = (Ctrl->C.active) ? GMT->current.proj.rect[YLO] - GMT->current.proj.origin[GMT_Y] : GMT->current.proj.rect[YLO];
+	ymax = (Ctrl->C.active) ? GMT->current.proj.rect[YHI] - GMT->current.proj.origin[GMT_Y] : GMT->current.proj.rect[YHI];
+
 	if (Ctrl->W.active) {	/* Print map dimensions or reference point and exit */
 		double w_out[4] = {0.0, 0.0, 0.0, 0.0}, x_orig, y_orig;
 		unsigned int wmode = 0, tmode = GMT_COL_FIX_NO_TEXT;
@@ -1136,6 +1147,28 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 				gmt_M_memcpy (w_out, GMT->common.R.wesn, 4, double);
 				n_output = (tmode == GMT_COL_FIX) ? 0 : 4;
 				break;
+			case GMT_MP_M_MSTRING:
+				tmode = GMT_COL_FIX;	/* Fall through on purpose here */
+			case GMT_MP_M_MREGION:
+				if (GMT->current.proj.search && (error = gmt_map_perimeter_search (GMT, GMT->common.R.wesn, false)))
+					Return (GMT_RUNTIME_ERROR);
+		if (Ctrl->F.active) {	/* Convert to meter, then to chosen unit */
+			strncpy (unit_name, scale_unit_name, GMT_LEN64);
+			xmin /= GMT->current.proj.scale[GMT_X];
+			xmax /= GMT->current.proj.scale[GMT_X];
+			ymin /= GMT->current.proj.scale[GMT_Y];
+			ymax /= GMT->current.proj.scale[GMT_Y];
+			if (unit) {	/* Change the 1:1 unit used */
+				xmin *= fwd_scale;
+				xmax *= fwd_scale;
+				ymin *= fwd_scale;
+				ymax *= fwd_scale;
+			}
+		}
+				w_out[XLO] = xmin;	w_out[XHI] = xmax;
+				w_out[YLO] = ymin;	w_out[YHI] = ymax;
+				n_output = (tmode == GMT_COL_FIX) ? 0 : 4;
+				break;
 			default:
 				GMT_Report (API, GMT_MSG_INFORMATION, "Reporting map width and height in %s\n", unit_name);
 				w_out[GMT_X] = GMT->current.proj.rect[XHI] * inch_to_unit;
@@ -1163,7 +1196,7 @@ EXTERN_MSC int GMT_mapproject (void *V_API, int mode, void *args) {
 			sprintf (region, "-R%.16lg/%.16lg/%.16lg/%.16lg+r", w_out[XLO], w_out[YLO], w_out[XHI], w_out[YHI]);
 			Out->text = region;
 		}
-		else if (Ctrl->W.mode == GMT_MP_M_RSTRING) {
+		else if (Ctrl->W.mode == GMT_MP_M_RSTRING || Ctrl->W.mode == GMT_MP_M_MSTRING) {
 			sprintf (region, "-R%.16lg/%.16lg/%.16lg/%.16lg", w_out[XLO], w_out[XHI], w_out[YLO], w_out[YHI]);
 			Out->text = region;
 		}


### PR DESCRIPTION
See #7541.  This experimental branch implements **-Wm** and **-WM** with this result:

**-Wm:**

```
gmt mapproject -R95/5/108/20+r -Ju46/1:10000000 -F -C -Wm
721387.055456	2080949.09788	552077.474203	2279563.58956

```
**-WM:**

```
gmt mapproject -R95/5/108/20+r -Ju46/1:10000000 -F -C -WM
-R721387.0554559267/2080949.097875784/552077.4742030394/2279563.589555113

```
This should make it easier to mix basemaps with geographic or Cartesian annotations:

```
gmt begin utm
	gmt coast -W -Na --MAP_FRAME_AXES=SE -R95/5/108/20+r -Ju46/1:10000000 -B
	Rcart=$(gmt mapproject -F -C -WM)
	gmt basemap --MAP_FRAME_AXES=NW $Rcart -Jx1:10000000 -B
gmt end show

```
Hoping @jidanni can build and test and hunt for any errors.
