### PR TITLE
Revert #7545

### DIFF
--- a/doc/rst/source/gmtinfo.rst
+++ b/doc/rst/source/gmtinfo.rst
@@ -47,13 +47,12 @@ Description
 **info** reads its standard input [or from files] and finds the
 extreme values in each of the columns reported as slash-separated min/max
 pairs. It recognizes NaNs and will print warnings if the number of columns
-vary from record to record. The reported number of rows ignores records where at least one column is a NaN.
-The pairs can be split into two separate columns
-by using the |-C| option. As another option, **info** can find the extent
+vary from record to record. The pairs can be split into two separate columns
+by using the |-C| option.  As another option, **info** can find the extent
 of data in the first two columns rounded up and down to the nearest multiple of the
 supplied increments given by |-I|. Such output will be in the text form
 |-R|\ *w/e/s/n*, which can be used directly on the command line for other
-modules (hence only *dx* and *dy* are needed). If |-C| is combined with
+modules (hence only *dx* and *dy* are needed).  If |-C| is combined with
 |-I| then the output will be in column form and rounded up/down for as many
 columns as there are increments provided in |-I|. A similar option (|-T|)
 will provide a |-T|\ *zmin/zmax/dz* string for makecpt.

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -414,7 +414,7 @@ EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
 	bool got_stuff = false, first_data_record, give_r_string = false, save_t;
 	bool brackets = false, work_on_abs_value, do_report, done, full_range = false;
 	int i, j, error = 0, col_type[GMT_MAX_COLUMNS];
-	unsigned int fixed_phase[2] = {1, 1}, min_cols, save_range, n_items = 0, n_skiped = 0;
+	unsigned int fixed_phase[2] = {1, 1}, min_cols, save_range, n_items = 0;
 	uint64_t col, ncol = 0, n = 0, n_alloc = GMT_BIG_CHUNK;
 
 	char file[PATH_MAX] = {""}, chosen[GMT_BUFSIZ] = {""}, record[GMT_BUFSIZ] = {""};
@@ -753,9 +753,8 @@ EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
 						sprintf (record, "%s-%" PRIu64, file, GMT->current.io.seg_no);
 					else									/* Either table mode or only one table in dataset */
 						sprintf (record, "%s", file);
-					sprintf (buffer, ": N = %" PRIu64 "\t", n - n_skiped);		/* Number of non-NaN records in this item */
+					sprintf (buffer, ": N = %" PRIu64 "\t", n);					/* Number of records in this item */
 					strcat (record, buffer);
-					n_skiped = 0;
 				}
 				for (col = 0; col < ncol; col++) {	/* Report min/max for each column in the format controlled by -C */
 					if (xyzmin[col] == DBL_MAX)	/* Encountered NaNs only */
@@ -922,7 +921,7 @@ EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
 		}
 		else {	/* Update min/max values for each column */
 			for (col = 0; col < ncol; col++) {
-				if (gmt_M_is_dnan (in[col])) {n_skiped++; continue;}	/* We always skip NaNs */
+				if (gmt_M_is_dnan (in[col])) continue;	/* We always skip NaNs */
 				if (GMT->current.io.col_type[GMT_IN][col] == GMT_IS_LON) {	/* Longitude requires more work */
 					/* We must keep separate min/max for both Dateline and Greenwich conventions */
 					gmt_quad_add (GMT, &Q[col], in[col]);


### PR DESCRIPTION
See [forum post](https://forum.generic-mapping-tools.org/t/gmtinfo-on-binary-file-incorrect-count-for-non-nan-records/4033)

I couldn't make a sense out of my attempts to implement a sane working **-s**. In fact the problem seems to come first from **-s**.

This works ``gmtconvert -bi3d tph.bin -s1``

but this not

```
gmtconvert -bi3d tph.bin -s

0.750425130129  NaN     59.5208293094
1.5034276545    NaN     59.5685981041
2.2546659112    NaN     59.6162504501
...
```