### PR TITLE
Fix size of buffer sequence

### DIFF
--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -2501,11 +2501,11 @@ int geos_method_linestring(struct GMT_CTRL *GMT, struct GMT_DATASET *Din, struct
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Failed to create output GEOS sequence for table %d, segment %d.\n", nt, ns);
 				continue;
 			}
-            /* geom_out's size and seq_out's size are different */
-            if (GEOSCoordSeq_getSize_r(handle, seq_out, &n_pts) == 0 ) {
+            		/* geom_out's size and seq_out's size are different */
+            		if (GEOSCoordSeq_getSize_r(handle, seq_out, &n_pts) == 0 ) {
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Failed to get size of GEOS sequence for table %d, segment %d.\n", nt, ns);
 				continue;
-            }
+            		}
 
 			Dout->table[nt]->segment[ns] = GMT_Alloc_Segment (GMT->parent, GMT_NO_STRINGS, (uint64_t)n_pts, n_col, NULL, NULL);
 			Dout->table[nt]->segment[ns]->n_rows = (uint64_t)n_pts;

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -2501,6 +2501,11 @@ int geos_method_linestring(struct GMT_CTRL *GMT, struct GMT_DATASET *Din, struct
 				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Failed to create output GEOS sequence for table %d, segment %d.\n", nt, ns);
 				continue;
 			}
+            /* geom_out's size and seq_out's size are different */
+            if (GEOSCoordSeq_getSize_r(handle, seq_out, &n_pts) == 0 ) {
+				GMT_Report (GMT->parent, GMT_MSG_NORMAL, "Failed to get size of GEOS sequence for table %d, segment %d.\n", nt, ns);
+				continue;
+            }
 
 			Dout->table[nt]->segment[ns] = GMT_Alloc_Segment (GMT->parent, GMT_NO_STRINGS, (uint64_t)n_pts, n_col, NULL, NULL);
 			Dout->table[nt]->segment[ns]->n_rows = (uint64_t)n_pts;


### PR DESCRIPTION
Hi, everyone.

I found that the buffer generated by GMT has some weird points, and the result is different from Julialang's LibGEOS.jl

```bash
    gmt begin coast_buffer

        gmt coast -ETW -M -Dc > tw.geo
        gmt spatial -Qc1000+h tw.geo -fg > tw_temp.geo
        # buffer
        gmt spatial tw_temp.geo -Sb0.5 > tw_buffer.geo
        gmt plot -R116/124/20/26 -JQ5i tw.geo -W0.5p,black -B
        gmt plot tw_buffer.geo -W0.5p,red

    gmt end show
```
```julia
# julia code
using LibGEOS
# coastline from GMT
p1 = readgom("POLYGON((
       121.601206488        23.945428759 ,
       121.605109656        23.9400906133 ,
       121.603835991        23.9382766802 ,
       121.603835991        23.9382766802 ,
       ...
))")
g1 = buffer(p1, 0.5)
```

GMT in red  and LibGEOS.jl in blue
![image](https://github.com/GenericMappingTools/gmt/assets/35285040/06345ca2-c7f4-444c-b7d8-c17ef41f6dbc)


At first, I found the numbers of buffer squeence between GMT and LibGEOS are different. 
GMT sets the `quadsegs` to 30.  `geom_out = GEOSBuffer_r(handle, geom, buf_dist, 30)`. LibGEOS sets it to 8.
When changing the parameter in GMT from 30 to 8, there are still some strange points in GMT‘s result.
Then, I found the problem is with the size of `seq_out` which is different from `geom_out`. 
I fix it and weird points from GMT disappear as follows.

![coast_buffer](https://github.com/GenericMappingTools/gmt/assets/35285040/ac2885d0-3c63-48b0-af0a-cd7f19222711)


**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
