### PR TITLE
Left-over fprint message now removed

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -10379,7 +10379,10 @@ void gmt_set_undefined_defaults (struct GMT_CTRL *GMT, double plot_dim, bool con
 #endif
 
 	/* Refuse to do this in gmtset */
-	if (!strcmp (GMT->init.module_name, "gmtset")) {fprintf (stderr, "Not doing it\n"); return; }
+	if (!strcmp (GMT->init.module_name, "gmtset")) {
+		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "gmt_set_undefined_defaults: quietly skipping out if called from gmtset\n");
+		return;
+	}
 
 	gmt_set_undefined_axes (GMT, conf_update);	/* Determine suitable MAP_FRAME_AXES for plot if still auto */
 


### PR DESCRIPTION
See #7630.  I am guessing I had forgotten about a temporary fprintf during debugging.  It is harmless but now changed to a DBG message so not seen unless you want to via **-Vd**. Closes #7630.
