### PR TITLE
Fix typo in documentation for "-A" of xyz2grd

### DIFF
--- a/doc/rst/source/xyz2grd.rst
+++ b/doc/rst/source/xyz2grd.rst
@@ -84,7 +84,7 @@ Optional Arguments
     ignored if |-Z| is given. Append **f** or **s** to simply keep the
     first or last data point that was assigned to each node. Append
     **l** or **u** or **d** to find the lowest (minimum) or upper (maximum) value
-    or the difference between the maximum and miminum value
+    or the difference between the maximum and minimum values
     at each node, respectively. Append **m** or **r** or **S** to compute mean or
     RMS value or standard deviation at each node, respectively. Append **n** to simply count
     the number of data points that were assigned to each node (this only


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the documentation for **-A** of [`xyz2grd`](https://docs.generic-mapping-tools.org/dev/xyz2grd.html#a).

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
