### PR TITLE
ex05: syntax correction

### DIFF
--- a/doc/examples/ex05/ex05.bat
+++ b/doc/examples/ex05/ex05.bat
@@ -6,7 +6,7 @@ REM DOS calls:	del
 REM
 gmt begin ex05
 	gmt grdmath -R-15/15/-15/15 -I0.3 X Y HYPOT DUP 2 MUL PI MUL 8 DIV COS EXCH NEG 10 DIV EXP MUL = sombrero.nc
-	gmt makecpt -C128 -T-5,5 -N
+	gmt makecpt -C128 -T-5/5 -N
 	gmt grdview sombrero.nc -JX12c -JZ4c -B -Bz0.5 -BSEwnZ+t"z(r) = cos (2@~p@~r/8) @~\327@~e@+-r/10@+" -N-1+gwhite -Qs -I+a225+nt0.75 -C -R-15/15/-15/15/-1/1 -p120/30 --FONT_TITLE=50p,ZapfChancery-MediumItalic --MAP_TITLE_OFFSET=-1c
 	del sombrero.nc
 gmt end show

--- a/doc/examples/ex05/ex05.sh
+++ b/doc/examples/ex05/ex05.sh
@@ -7,7 +7,7 @@
 #
 gmt begin ex05
 	gmt grdmath -R-15/15/-15/15 -I0.3 X Y HYPOT DUP 2 MUL PI MUL 8 DIV COS EXCH NEG 10 DIV EXP MUL = sombrero.nc
-	gmt makecpt -C128 -T-5,5 -N
+	gmt makecpt -C128 -T-5/5 -N
 	gmt grdview sombrero.nc -JX12c -JZ4c -B -Bz0.5 -BSEwnZ+t"z(r) = cos (2@~p@~r/8) @~\327@~e@+-r/10@+" -N-1+gwhite -Qs \
 		-I+a225+nt0.75 -C -R-15/15/-15/15/-1/1 -p120/30 --FONT_TITLE=50p,ZapfChancery-MediumItalic --MAP_TITLE_OFFSET=-1c
 	rm -f sombrero.nc


### PR DESCRIPTION
**Description of proposed changes**
Correction to the syntax of -T in grdview.
-T-5,5 should be -T-5/5.
The former works, but gives a (wrong) warning message when using a discrete color map.
-T-5/5 works for all.

**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
