### PR TITLE
WIP: Leading zeros

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -2172,7 +2172,6 @@ GMT_LOCAL int gmtio_get_dms_order (struct GMT_CTRL *GMT, char *text, struct GMT_
 	S->decimal = S->no_sign = false;
 	S->wesn = 0;
 
-fprintf (stderr, "Xtring = %s\n", text);
 	i1 = strlen (text) - 1;
 	for (i = order = 0; i <= i1; i++) {
 		switch (text[i]) {
@@ -2258,7 +2257,6 @@ fprintf (stderr, "Xtring = %s\n", text);
 	}
 	else
 		S->decimal = true;
-fprintf (stderr, "n_DD = %d n_d = %d\n", n_DD, n_d);
 
 	if (S->decimal) return (GMT_NOERROR);	/* Easy formatting choice */
 
@@ -7077,7 +7075,7 @@ int gmtlib_geo_C_format (struct GMT_CTRL *GMT) {
 
 /*! . */
 int gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
-	unsigned int i, j, length, id = 0;
+	unsigned int i, j, length;
 	struct GMT_GEO_IO *S = &GMT->current.plot.calclock.geo;
     char *d_fmt[2] = {"%d", "%3.3d"};
 
@@ -7088,9 +7086,6 @@ int gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 	for (i = 0; i < 3; i++) for (j = 0; j < 2; j++) gmt_M_memset (GMT->current.plot.format[i][j], GMT_LEN256, char);
 
 	if (gmtio_get_dms_order (GMT, GMT->current.setting.format_geo_map, S)) return GMT_PARSE_ERROR;	/* Get the order of degree, min, sec in output formats */
-
-	id = (S->leading_zeros) ? 1 : 0;
-	fprintf (stderr, "Leading = %d\n", id);
 
 	if (S->decimal) {	/* Plain decimal degrees */
 		int len;
@@ -7111,6 +7106,7 @@ int gmtlib_plot_C_format (struct GMT_CTRL *GMT) {
 	}
 	else {			/* Must cover all the 6 forms of dd[:mm[:ss]][.xxx] */
 		char fmt[GMT_LEN256] = {""};
+        unsigned int id = S->leading_zeros ? 1 : 0;
 
 		/* Level 0: degrees only. index 0 is integer degrees, index 1 is [possibly] fractional degrees */
 

--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -202,6 +202,7 @@ struct GMT_GEO_IO {			/* For geographic output and plotting */
 	int order[3];			/* The relative order of degree, minute, seconds in form (-ve if unused) */
 	bool decimal;			/* true if we want to use the FORMAT_FLOAT_OUT for decimal degrees only */
 	bool no_sign;			/* true if we want absolute values (plot only) */
+	bool leading_zeros;	/* True to get leading zeros in degrees */
 	char x_format[GMT_LEN64];	/* Actual C format used to plot/output longitude */
 	char y_format[GMT_LEN64];	/* Actual C format used to plot/output latitude */
 	char delimiter[2][2];		/* Delimiter strings in date, e.g. "-" */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15792,6 +15792,7 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 	unsigned int k, n_items, level, type;
 	bool zero_fix = false, lat_special = (lonlat == 3), deg_special = (lonlat == 4);
 	char hemi_pre[GMT_LEN16] = {""}, hemi_post[GMT_LEN16] = {""}, text[GMT_LEN64] = {""};
+    char use_format[GMT_LEN64] = {""};
 
 	/* Must override do_minutes and/or do_seconds if format uses decimal notation for that item */
 
@@ -15862,24 +15863,28 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 			zero_fix = true;
 		}
 		if (hemi_pre[0]) strcpy (label, hemi_pre);
+        strncpy (use_format, GMT->current.plot.format[level][type], GMT_LEN64);
+        if (lonlat & 1)
+            gmt_strrep (use_format, "%3.3d", "%2.2d");
+        sprintf(stderr, "lonlat, use_format = %d %s\n", lonlat, use_format);
 		switch (2*level+type) {
 			case 0:
-				sprintf (text, GMT->current.plot.format[level][type], d, hemi_post);
+				sprintf (text, use_format, d, hemi_post);
 				break;
 			case 1:
-				sprintf (text, GMT->current.plot.format[level][type], d, m_sec, hemi_post);
+				sprintf (text, use_format, d, m_sec, hemi_post);
 				break;
 			case 2:
-				sprintf (text, GMT->current.plot.format[level][type], d, m, hemi_post);
+				sprintf (text, use_format, d, m, hemi_post);
 				break;
 			case 3:
-				sprintf (text, GMT->current.plot.format[level][type], d, m, m_sec, hemi_post);
+				sprintf (text, use_format, d, m, m_sec, hemi_post);
 				break;
 			case 4:
-				sprintf (text, GMT->current.plot.format[level][type], d, m, s, hemi_post);
+				sprintf (text, use_format, d, m, s, hemi_post);
 				break;
 			case 5:
-				sprintf (text, GMT->current.plot.format[level][type], d, m, s, m_sec, hemi_post);
+				sprintf (text, use_format, d, m, s, m_sec, hemi_post);
 				break;
 		}
 		if (zero_fix) text[1] = '0';	/* Undo the fix above */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15791,8 +15791,7 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 	int sign, d, m, s, m_sec;
 	unsigned int k, n_items, level, type;
 	bool zero_fix = false, lat_special = (lonlat == 3), deg_special = (lonlat == 4);
-	char hemi_pre[GMT_LEN16] = {""}, hemi_post[GMT_LEN16] = {""}, text[GMT_LEN64] = {""};
-    char use_format[GMT_LEN64] = {""};
+	char hemi_pre[GMT_LEN16] = {""}, hemi_post[GMT_LEN16] = {""}, text[GMT_LEN64] = {""}, *use_format = NULL;
 
 	/* Must override do_minutes and/or do_seconds if format uses decimal notation for that item */
 
@@ -15802,11 +15801,9 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 
 	if (lat_special) lonlat = 1;	/* Remove the special flag */
 	if (deg_special) lonlat = 0;	/* Remove the special flag */
-	if (lonlat == 0) {	/* Fix longitudes range first */
+	if (lonlat == 0)	/* Fix longitudes range first */
 		gmt_lon_range_adjust (GMT->current.plot.calclock.geo.range, &val);
-	}
-
-	if (lonlat) {	/* i.e., for geographical data */
+    else {	/* i.e., for geographical data */
 		if (doubleAlmostEqual (val, 360.0) && !worldmap)
 			val = 0.0;
 		if (doubleAlmostEqual (val, 360.0) && worldmap && GMT->current.proj.projection_GMT == GMT_OBLIQUE_MERC)
@@ -15863,10 +15860,11 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 			zero_fix = true;
 		}
 		if (hemi_pre[0]) strcpy (label, hemi_pre);
-        strncpy (use_format, GMT->current.plot.format[level][type], GMT_LEN64);
         if (lonlat & 1)
-            gmt_strrep (use_format, "%3.3d", "%2.2d");
-        sprintf(stderr, "lonlat, use_format = %d %s\n", lonlat, use_format);
+            use_format = gmt_strrep (GMT->current.plot.format[level][type], "%3.3d", "%2.2d");
+        else
+            use_format = strdup (GMT->current.plot.format[level][type]);
+
 		switch (2*level+type) {
 			case 0:
 				sprintf (text, use_format, d, hemi_post);


### PR DESCRIPTION
**Description of proposed changes**

This implements the capability to have leading zeros on the geographical coordinates on the map frame (#7475).

Example:
`gmt basemap -R-1/1/-1/1 -Baf --FORMAT_GEO_MAP=DDD:mm:ss -JM15c -pdf map`

WIP: @KristofKoch will finish the documentation of it.

Fixes #7475

**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
