### PR TITLE
Switch from binary to text read for Windows PS

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -168,6 +168,9 @@
 #else
 #	define PRIuS "zu"  /* printf size_t */
 #endif
+#if _WIN32
+#include <fcntl.h>     /* for _O_TEXT and _O_BINARY */
+#endif
 
 /* Define bswap32 */
 #undef bswap32
@@ -6071,15 +6074,11 @@ int PSL_loadeps (struct PSL_CTRL *PSL, char *file, struct imageinfo *h, unsigned
 	/* Scan for BoundingBox */
 
 #ifdef _WIN32
-    /* Reset I/O to text mode since we are using gets in psl_get_boundingbox */
-    if ( _setmode(_fileno(stdin), _O_TEXT) == -1 ) {
-        if (API->external)
-            GMT_Report (API, GMT_MSG_WARNING, "Could not set text mode for %s. This may no be a fatal error but...\n", file);
-        else {
-            GMT_Report (API, GMT_MSG_WARNING, "Could not set text mode for %s.\n", file);
-            return NULL;
-        }
-    }
+	/* Reset I/O to text mode since we are using gets in psl_get_boundingbox */
+	if ( _setmode(_fileno(stdin), _O_TEXT) == -1 ) {
+		PSL_message (PSL, PSL_MSG_WARNING, "Could not set text mode for %s.\n", file);
+		return 0;
+	}
 #endif
 
 	psl_get_boundingbox (PSL, fp, &llx, &lly, &trx, &try, &h->llx, &h->lly, &h->trx, &h->try);

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -6044,7 +6044,7 @@ int PSL_loadeps (struct PSL_CTRL *PSL, char *file, struct imageinfo *h, unsigned
 	unsigned char *buffer = NULL;
 	FILE *fp = NULL;
 
-	/* Open PostScript file */
+	/* Open PostScript file in binary mode; see below for reverting on Windows for gets reads */
 
 	if ((fp = fopen (file, "rb")) == NULL) {
 		PSL_message (PSL, PSL_MSG_ERROR, "Error: Cannot open image file %s!\n", file);
@@ -6069,6 +6069,18 @@ int PSL_loadeps (struct PSL_CTRL *PSL, char *file, struct imageinfo *h, unsigned
 	h->magic = (int)value;
 
 	/* Scan for BoundingBox */
+
+#ifdef _WIN32
+    /* Reset I/O to text mode since we are using gets in psl_get_boundingbox */
+    if ( _setmode(_fileno(stdin), _O_TEXT) == -1 ) {
+        if (API->external)
+            GMT_Report (API, GMT_MSG_WARNING, "Could not set text mode for %s. This may no be a fatal error but...\n", file);
+        else {
+            GMT_Report (API, GMT_MSG_WARNING, "Could not set text mode for %s.\n", file);
+            return NULL;
+        }
+    }
+#endif
 
 	psl_get_boundingbox (PSL, fp, &llx, &lly, &trx, &try, &h->llx, &h->lly, &h->trx, &h->try);
 


### PR DESCRIPTION
When _PSL_loadeps_ is called it opens the file in binary mode (which only applies to Windows) to read the binary 2-byte code,  and then later we read via gets which is a text mode operator.  This PR uses __setmode_ to switch to text mode on Windows before we read [HiRes]BoundingBox via _fgets_.

@joa-quim, please test with the EPS/Latex file that gave troubles.