### PR TITLE
Update triangulate docs to explain why Shewchuk is missing

### DIFF
--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -59,12 +59,14 @@ input file. As an option, you may choose to create a multiple segment
 file that can be piped through :doc:`plot` to draw the triangulation
 network. If |-G| |-I| are set a grid will be calculated based on the
 surface defined by the planar triangles. The actual algorithm used in
-the triangulations is either that of *Watson* [1982] or *Shewchuk* [1996] [Default]
+the triangulation is either that of *Watson* [1982] or *Shewchuk* [1996] [Default]
 (if installed; type **gmt get GMT_TRIANGULATE** to see which method is
 selected). This choice is made during the GMT installation.  Furthermore,
 if the Shewchuk algorithm is installed then you can also perform the
 calculation of Voronoi polygons and optionally grid your data via the
-natural nearest neighbor algorithm.  **Note**: For geographic data with
+natural nearest neighbor algorithm.  Some Linux users may find their distribution
+does not provide Shewchuk due to it not being released under a GNU License.
+**Note**: For geographic data with
 global or very large extent you should consider :doc:`sphtriangulate`
 instead since **triangulate** is a Cartesian or small-geographic area operator
 and is unaware of periodic or polar boundary conditions.


### PR DESCRIPTION
See the [forum](https://forum.generic-mapping-tools.org/t/update-the-apt-get-version-of-gmt/4136/10) for the silliness.
