### PR TITLE
Disallow oblique gridlines for Cartesian frames

### DIFF
--- a/doc/rst/source/explain_-B.rst_
+++ b/doc/rst/source/explain_-B.rst_
@@ -71,8 +71,8 @@ can be appended to **-B** to control the Frame settings:
   **0**].
 
 - **+o**\ *lon/lat* to produce oblique gridlines about another pole specified by *lon/lat* [default references to the
-  North pole]. **+o** is ignored if no gridlines are requested. Note, one cannot specify oblique gridlines for the
-  oblique Mercator projection, and results are not currently defined for non-geographic projections.
+  North pole]. **+o** is ignored if no gridlines are requested. **Note**: One cannot specify oblique gridlines for non-geographic projections as well as the
+  oblique Mercator projection.
 
 - **+n** to have no frame and annotations at all [default is controlled by *axes*].
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -4136,7 +4136,11 @@ GMT_LOCAL int gmtinit_parse4_B_option (struct GMT_CTRL *GMT, char *in) {
 		if (in[i] == '+' && in[i+1] == 'o') {	/* Found +o<plon>/<plat> */
 			double lon, lat;
 			char A[GMT_LEN64] = {""}, B[GMT_LEN64] = {""};
-			if (GMT->current.proj.projection_GMT == GMT_OBLIQUE_MERC) {
+			if (gmt_M_is_cartesian (GMT, GMT_IN)) {
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: Cannot specify oblique gridlines for non-geographic projection\n");
+				error++;
+			}
+			else if (GMT->current.proj.projection_GMT == GMT_OBLIQUE_MERC) {
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: Cannot specify oblique gridlines for the oblique Mercator projection\n");
 				error++;
 			}
@@ -4477,7 +4481,11 @@ GMT_LOCAL int gmtinit_parse5_B_frame_setting (struct GMT_CTRL *GMT, char *in) {
 					GMT->current.map.frame.no_frame = true;
 					break;
 				case 'o':	/* Specify pole for oblique gridlines */
-					if (GMT->current.proj.projection_GMT == GMT_OBLIQUE_MERC) {
+					if (gmt_M_is_cartesian (GMT, GMT_IN)) {
+						GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -B: Cannot specify oblique gridlines for non-geographic projection\n");
+						error++;
+					}
+					else if (GMT->current.proj.projection_GMT == GMT_OBLIQUE_MERC) {
 						GMT_Report (GMT->parent, GMT_MSG_ERROR,
 							"Option -B: Cannot specify oblique gridlines for the oblique Mercator projection\n");
 						error++;


### PR DESCRIPTION
There are no poles except for geographic data.  This PR assumes #7667 and adds checks to prevent bad plots where pole is not set or exists.