### PR TITLE
Fix outdated documentation for rose size

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1971,7 +1971,7 @@ This option accepts the *reference* point where the map rose's *anchor* should b
 pinned.  In addition to the required *refpoint* and *anchor* arguments (and their standard
 modifiers discussed earlier) there are three optional modifiers:
 
-#. Size of map rose.  Use **+w**\ *size* to specify the full width and height of the rose. A 3 cm
+#. Size of map rose.  Use **+w**\ *size* to specify the full width and height of the rose. E.g., a 3 cm
    rose would require **+w**\ 3c.  Alternatively, append % to set the *size* as a percentage of the
    map width [Default is 10% if **+w** is not given].
 
@@ -2018,7 +2018,7 @@ map rose is added with :doc:`/basemap` or :doc:`/coast` and selected by the **-T
 As for other features, append the required *reference* point where the magnetic map rose's *anchor*
 should be pinned.  There several optional modifiers:
 
-#. Specify size of map rose.  Use **+w**\ *size* to specify the full width of the rose.  A 3 cm
+#. Specify size of map rose.  Use **+w**\ *size* to specify the full width of the rose.  E.g., a 3 cm
    rose would imply **+w**\ 3c. Alternatively, append % to set the *size* as a percentage of the map
    width [Default is 15% if **+w** is not given].
 

--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1969,13 +1969,11 @@ have ornamental value and can be used on any map projection.  As for map scales,
 map rose is added with :doc:`/basemap` or :doc:`/coast` and selected by the **-Td** option.
 This option accepts the *reference* point where the map rose's *anchor* should be
 pinned.  In addition to the required *refpoint* and *anchor* arguments (and their standard
-modifiers discussed earlier) there is one required and two optional modifiers. The required
-modifier sets the side:
+modifiers discussed earlier) there are three optional modifiers:
 
-#. Size of map rose.  Use **+w**\ *size* to specify the full width and height of the rose.  A 3 cm
-   rose would require **+w**\ 3c.
-
-The next two modifiers are optional:
+#. Size of map rose.  Use **+w**\ *size* to specify the full width and height of the rose. A 3 cm
+   rose would require **+w**\ 3c.  Alternatively, append % to set the *size* as a percentage of the
+   map width [Default is 10% if **+w** is not given].
 
 #. Cardinal points.  By default only the four cardinal points (W, E, S, N) are included in the rose.
    You can extend that with the **+f**\ *level* modifier, where *level* is 1 [Default], 2, or 3.  Selecting
@@ -2018,12 +2016,11 @@ magnetic directions, which differ for nonzero declination. As for style, the two
 bit like a standard compass.  As for directional roses, a magnetic
 map rose is added with :doc:`/basemap` or :doc:`/coast` and selected by the **-Tm** option.
 As for other features, append the required *reference* point where the magnetic map rose's *anchor*
-should be pinned.  There is one required and several optional modifiers.  First up is the size:
+should be pinned.  There several optional modifiers:
 
 #. Specify size of map rose.  Use **+w**\ *size* to specify the full width of the rose.  A 3 cm
-   rose would imply **+w**\ 3c.
-
-The remaining modifiers are optional:
+   rose would imply **+w**\ 3c. Alternatively, append % to set the *size* as a percentage of the map
+   width [Default is 15% if **+w** is not given].
 
 #. Specify Declination.  To add the inner angular scale, append **d**\ *dec*\ [/\ *dlabel*], where
    *dec* is the declination value in decimal or ddd:mm:ss format, and *dlabel* is an optional string


### PR DESCRIPTION
See #7661 for background from @jidanni.  We added default sizes in terms of a percentage of the map width, but that did not make it into the documentation. This PR fixes that.  The synopsis was already correct.
Closes #7661.
