### PR TITLE
WIP Enhance the curves in events to do linear, quadratic or cosine ramp

### DIFF
--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
 [ |-D|\ [**j**\|\ **J**]\ *dx*\ [/*dy*][**+v**\ [*pen*]] ]
-[ |-E|\ [**s**\|\ **t**\ ][**+o**\|\ **O**\ *dt*][**+r**\ *dt*][**+p**\ *dt*][**+d**\ *dt*][**+f**\ *dt*][**+l**\ *dt*] ]
+[ |-E|\ [**s**\|\ **t**\ ][**+o**\|\ **O**\ *dt*][**+r**\ [**c**\|\ **l**\|\ **q**]*dt*][**+p**\ *dt*][**+d**\ [**c**\|\ **l**\|\ **q**]\ *dt*][**+f**\ [**c**\|\ **l**\|\ **q**]\ *dt*][**+l**\ *dt*] ]
 [ |-F|\ [**+a**\ *angle*][**+f**\ *font*][**+j**\ *justify*][**+r**\ [*first*]\|\ **z**\ [*format*]] ]
 [ |-G|\ *color* ]
 [ |-H|\ *labelbox* ]
@@ -165,7 +165,7 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ [**s**\|\ **t**\ ][**+o**\|\ **O**\ *dt*][**+r**\ *dt*][**+p**\ *dt*][**+d**\ *dt*][**+f**\ *dt*][**+l**\ *dt*]
+**-E**\ [**s**\|\ **t**\ ][**+o**\|\ **O**\ *dt*][**+r**\ [**c**\|\ **l**\|\ **q**]*dt*][**+p**\ *dt*][**+d**\ [**c**\|\ **l**\|\ **q**]\ *dt*][**+f**\ [**c**\|\ **l**\|\ **q**]\ *dt*][**+l**\ *dt*] ]
     Set the relative time knots for the **s**\ ymbol or **t**\ ext time-functions (see `The four time-functions`_) via
     these modifiers:
 
@@ -174,10 +174,13 @@ Optional Arguments
     - **+O** is similar to **+o** but will only shift the start time, effectively shortening
       the duration of the event).
     - **+l** specifies an alternative duration (visibility) of the text (**-Et** only) [same duration as symbol].
-    - **+r** sets the duration of the rise phase.
+    - **+r** sets the duration of the rise phase. Prepend optional raise curve shape via **c**\ osine, **l**\ inear
+      or **q**\ uadratic [Quadratic].
     - **+p** sets the duration of the plateau phase.
-    - **+d** sets the duration of the decay phase.
-    - **+f** sets the duration of the fade phase.
+    - **+d** sets the duration of the decay phase. Prepend optional decay curve shape via **c**\ osine, **l**\ inear
+      or **q**\ uadratic [Quadratic].
+    - **+f** sets the duration of the fade phase. Prepend optional fade curve shape via **c**\ osine, **l**\ inear
+      or **q**\ uadratic [Linear].
 
     These are all optional [and default to zero], and can be set separately for symbols and texts.
     If neither the **s** or **t** directive is given then we set the time knots for both features.

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -56,6 +56,11 @@ enum Psevent {	/* Misc. named array indices */
 	PSEVENTS_LINE_REC = 1,
 	PSEVENTS_LINE_SEG = 2,
 	PSEVENTS_LINE_TO_POINTS = 4,
+	PSEVENTS_RAMP_QUAD = 0,
+	PSEVENTS_RAMP_LINEAR = 1,
+	PSEVENTS_RAMP_COSINE = 2,
+	PSEVENTS_RAMP_UP = 0,
+	PSEVENTS_RAMP_DOWN = 1,
 	PSEVENTS_T_RISE = 0,
 	PSEVENTS_T_EVENT = 1,
 	PSEVENTS_T_PLATEAU = 2,
@@ -85,9 +90,10 @@ struct PSEVENTS_CTRL {
 		bool active;
 		char *string;
 	} D;
-	struct PSEVENTS_E {	/* 	-E[s|t][+o|O<dt>][+r<dt>][+p<dt>][+d<dt>][+f<dt>][+l<dt>] */
+	struct PSEVENTS_E {	/* 	-E[s|t][+o|O<dt>][+r<dt>][+p<dt>][+d<dt>][+f<dt>][+l<dt>][+c] */
 		bool active[2];
 		bool trim[2];
+		unsigned int ramp[5];	/* Default is t^2 ramp */
 		double dt[2][6];
 	} E;
 	struct PSEVENTS_F {	/*	-F[+f<fontinfo>+a<angle>+j<justification>+r|z] */
@@ -151,7 +157,6 @@ struct PSEVENTS_CTRL {
 
 /* The names of the three external modules.  We skip first 2 letters if in modern mode */
 static char *coupe = "pscoupe", *meca = "psmeca", *velo = "psvelo";
-
 
 static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new control structure */
 	struct PSEVENTS_CTRL *C;
@@ -279,6 +284,18 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	return (GMT_MODULE_USAGE);
 }
 
+GMT_LOCAL unsigned int psevents_parse_ramp_type (struct GMT_CTRL *GMT, char *string, unsigned int *start) {
+	/* Detect optional ramp codes l, q, c and start of parsing text for value */
+	unsigned int type = PSEVENTS_RAMP_QUAD;	/* Default ramp */
+	switch (string[0]) {
+		case 'c':	type = PSEVENTS_RAMP_COSINE;	*start = 2;	break;
+		case 'l':	type = PSEVENTS_RAMP_LINEAR;	*start = 2;	break;
+		case 'q':	type = PSEVENTS_RAMP_QUAD;		*start = 2;	break;
+		default:	*start = 1;	break;
+	}
+	return (type);
+}
+
 static int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GMT_OPTION *options) {
 	/* This parses the options provided to psevents and sets parameters in CTRL.
 	 * Any GMT common options will override values set previously by other commands.
@@ -286,7 +303,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GMT_O
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, pos, n_col = 3, k = 0, id = 0;
+	unsigned int n_errors = 0, pos, n_col = 3, k = 0, id = 0, start;
 	unsigned int s = (GMT->current.setting.run_mode == GMT_MODERN) ? 2 : 0;
 	char *c = NULL, *t_string = NULL, txt_a[GMT_LEN256] = {""}, *events = "psevents";
 	struct GMT_OPTION *opt = NULL;
@@ -367,10 +384,16 @@ static int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GMT_O
 				pos = 0;	txt_a[0] = 0;
 				while (gmt_getmodopt (GMT, 'E', c, PSEVENTS_MODS, &pos, txt_a, &n_errors) && n_errors == 0) {
 					switch (txt_a[0]) {
-						case 'd': Ctrl->E.dt[id][PSEVENTS_DECAY]   = atof (&txt_a[1]);	break;	/* Decay duration */
+						case 'd':	/* Decay duration and optional ramp directive */
+							Ctrl->E.ramp[PSEVENTS_DECAY] = psevents_parse_ramp_type (GMT, txt_a, &start);
+							Ctrl->E.dt[id][PSEVENTS_DECAY]   = atof (&txt_a[1]);
+							break;
 						case 'f': Ctrl->E.dt[id][PSEVENTS_FADE]    = atof (&txt_a[1]);	break;	/* Fade duration */
 						case 'p': Ctrl->E.dt[id][PSEVENTS_PLATEAU] = atof (&txt_a[1]);	break;	/* Plateau duration */
-						case 'r': Ctrl->E.dt[id][PSEVENTS_RISE]    = atof (&txt_a[1]);	break;	/* Rise duration */
+						case 'r':	/* Rise duration and optional ramp directive */
+							Ctrl->E.ramp[PSEVENTS_RISE] = psevents_parse_ramp_type (GMT, txt_a, &start);
+							Ctrl->E.dt[id][PSEVENTS_RISE]   = atof (&txt_a[start]);
+							break;
 						case 'O': Ctrl->E.trim[id] = true;	/* Intentionally fall through - offset start but not end. Fall through to case 'o' */
 						case 'o': Ctrl->E.dt[id][PSEVENTS_OFFSET]   = atof (&txt_a[1]);	break;	/* Event time offset */
 						case 'l':	/* Event length override for text */
@@ -754,6 +777,27 @@ GMT_LOCAL unsigned int psevents_determine_columns (struct GMT_CTRL *GMT, char *m
 	return n;
 }
 
+GMT_LOCAL double psevents_ramp (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, unsigned int kind, unsigned int section, double t[], double t_now) {
+	/* section is either PSEVENTS_RISE, PSEVENTS_DECAY, or PSEVENTS_FADE.
+	 * kind is either PSEVENTS_SYMBOL or PSEVENTS_TEXT.
+	 * direction = PSEVENTS_RAMP_DOWN (1) if we ramp down, not up.
+	 */
+	unsigned int direction = (section == PSEVENTS_RISE) ? PSEVENTS_RAMP_UP : PSEVENTS_RAMP_DOWN;
+	double t_norm = (t_now - t[section])/Ctrl->E.dt[kind][section], ramp = 0.0;
+	switch (Ctrl->E.ramp[section]) {
+		case PSEVENTS_RAMP_LINEAR:	/* Linear ramp */
+			ramp = t_norm;
+		case PSEVENTS_RAMP_COSINE:	/* Cosine ramp */
+			ramp = pow (t_norm, 2.0);	/* Quadratic function that goes from 0 to 1 */
+			break;
+		case PSEVENTS_RAMP_QUAD:	/* Quadratic ramp */
+			ramp = 0.5 - 0.5 * cos (t_norm * M_PI);	/* Cosine ramp */
+			break;
+	}
+	if (gmt_M_is_dnan (ramp)) ramp = 0.0;	/* Probably division by zero */
+	return (direction == PSEVENTS_RAMP_UP) ? ramp : 1.0 - ramp;
+}
+
 GMT_LOCAL void psevents_set_outarray (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, double t_now, double *t, bool finite_duration, bool coda, unsigned int x_col, unsigned int i_col, unsigned int t_col, unsigned int z_col, double *out) {
 	double x;
 	gmt_M_unused (GMT);
@@ -762,8 +806,7 @@ GMT_LOCAL void psevents_set_outarray (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL
 		out[t_col] = Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL1];
 	}
 	else if (t_now < t[PSEVENTS_T_EVENT]) {	/* We are within the rise phase */
-		x = pow ((t_now - t[PSEVENTS_T_RISE])/Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_RISE], 2.0);	/* Quadratic function that goes from 0 to 1 */
-		if (gmt_M_is_dnan (x)) x = 0.0;	/* Probably division by zero */
+		x = psevents_ramp (GMT, Ctrl, PSEVENTS_SYMBOL, PSEVENTS_RISE, t, t_now);	/* Ramp function */
 		out[x_col] = Ctrl->M.value[PSEVENTS_SIZE][PSEVENTS_VAL1] * x;	/* Magnification of amplitude */
 		out[i_col] = Ctrl->M.value[PSEVENTS_INT][PSEVENTS_VAL1] * x;		/* Magnification of intensity */
 		out[t_col] = Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL1] * (1.0-x);	/* Magnification of opacity */
@@ -776,8 +819,7 @@ GMT_LOCAL void psevents_set_outarray (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL
 		if (Ctrl->M.active[PSEVENTS_DZ]) out[z_col] += Ctrl->M.value[PSEVENTS_DZ][PSEVENTS_VAL1];		/* Changing of color via dz */
 	}
 	else if (t_now < t[PSEVENTS_T_DECAY]) {	/* We are within the decay phase */
-		x = pow ((t[PSEVENTS_T_DECAY] - t_now)/Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_DECAY], 2.0);	/* Quadratic function that goes from 1 to 0 */
-		if (gmt_M_is_dnan (x)) x = 0.0;	/* Probably division by zero */
+		x = psevents_ramp (GMT, Ctrl, PSEVENTS_SYMBOL, PSEVENTS_DECAY, t, t_now);	/* Ramp function */
 		out[x_col] = Ctrl->M.value[PSEVENTS_SIZE][PSEVENTS_VAL1] * x + (1.0 - x);	/* Reduction of size down to the nominal size */
 		out[i_col] = Ctrl->M.value[PSEVENTS_INT][PSEVENTS_VAL1] * x;	/* Reduction of intensity down to 0 */
 		out[t_col] = 0.0;
@@ -788,8 +830,7 @@ GMT_LOCAL void psevents_set_outarray (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL
 		out[i_col] = out[t_col] = 0.0;	/* No intensity or transparency during normal phase */
 	}
 	else if (finite_duration && t_now <= t[PSEVENTS_T_FADE]) {	/* We are within the fade phase */
-		x = pow ((t[PSEVENTS_T_FADE] - t_now)/Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_FADE], 2.0);	/* Quadratic function that goes from 1 to 0 */
-		if (gmt_M_is_dnan (x)) x = 0.0;	/* Probably division by zero */
+		x = psevents_ramp (GMT, Ctrl, PSEVENTS_SYMBOL, PSEVENTS_FADE, t, t_now);	/* Ramp function */
 		out[x_col] = x + (1.0 - x) * Ctrl->M.value[PSEVENTS_SIZE][PSEVENTS_VAL2];	/* Reduction of size down to coda size */
 		out[i_col] = Ctrl->M.value[PSEVENTS_INT][PSEVENTS_VAL2] * (1.0 - x);		/* Reduction of intensity down to coda intensity */
 		out[t_col] = Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL2] * (1.0 - x);		/* Increase of transparency up to code transparency */
@@ -1294,13 +1335,13 @@ Do_txt:			if (Ctrl->E.active[PSEVENTS_TEXT] && has_text) {	/* Also plot trailing
 					/* Labels have variable transparency during optional rise and fade, and fully opaque during normal section, and skipped otherwise unless coda */
 
 					if (Ctrl->T.now < t[PSEVENTS_T_EVENT]) {	/* We are within the rise phase */
-						x = (gmt_M_is_zero (Ctrl->E.dt[PSEVENTS_TEXT][PSEVENTS_RISE])) ? 1.0 : pow ((Ctrl->T.now - t[PSEVENTS_T_RISE])/Ctrl->E.dt[PSEVENTS_TEXT][PSEVENTS_RISE], 2.0);	/* Quadratic function that goes from 1 to 0 */
+						x = psevents_ramp (GMT, Ctrl, PSEVENTS_TEXT, PSEVENTS_DECAY, t, Ctrl->T.now);	/* Ramp function */
 						out[GMT_Z] = Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL1] * (1.0-x);		/* Magnification of opacity */
 					}
 					else if (finite_duration && Ctrl->T.now < t[PSEVENTS_T_END])	/* We are within the normal phase, keep everything constant */
 						out[GMT_Z] = 0.0;	/* No transparency during this phase */
 					else if (finite_duration && Ctrl->T.now <= t[PSEVENTS_T_FADE]) {	/* We are within the fade phase */
-						x = (gmt_M_is_zero (Ctrl->E.dt[PSEVENTS_TEXT][PSEVENTS_FADE])) ? 0.0 : pow ((t[PSEVENTS_T_FADE] - Ctrl->T.now)/Ctrl->E.dt[PSEVENTS_TEXT][PSEVENTS_FADE], 2.0);	/* Quadratic function that goes from 1 to 0 */
+						x = psevents_ramp (GMT, Ctrl, PSEVENTS_TEXT, PSEVENTS_FADE, t, Ctrl->T.now);	/* Ramp function */
 						out[GMT_Z] = Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL2] * (1.0 - x);		/* Increase of transparency up to coda transparency */
 					}
 					else if (do_coda)	/* If there is a coda then the label is visible given its coda attributes */

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -877,8 +877,8 @@ GMT_LOCAL void psevents_test_functions (struct GMT_CTRL *GMT, struct PSEVENTS_CT
 	t[PSEVENTS_T_FADE]    = t[PSEVENTS_T_END] + Ctrl->E.dt[PSEVENTS_SYMBOL][PSEVENTS_FADE];
 	Ctrl->M.active[PSEVENTS_DZ] = true;
 	for (k = 0; k < 5; k++) Ctrl->E.ramp[k] = Ctrl->debug.mode;
-	Ctrl->M.value[PSEVENTS_SIZE][PSEVENTS_VAL1] = 2.0;	/* Default size scale for -Ms and dz amplitude for -Mv */
-	Ctrl->M.value[PSEVENTS_INT][PSEVENTS_VAL1]  = 0.5;	/* Default size scale for -Mi */
+	Ctrl->M.value[PSEVENTS_SIZE][PSEVENTS_VAL1] = 2.0;		/* Default size scale for -Ms and dz amplitude for -Mv */
+	Ctrl->M.value[PSEVENTS_INT][PSEVENTS_VAL1]  = 0.5;		/* Default size scale for -Mi */
 	Ctrl->M.value[PSEVENTS_TRANSP][PSEVENTS_VAL2]  = 50;	/* Default size scale for -Mt coda */
 	fprintf (fp, "# t_rise = -1.0, t_event = 0.0, t_plateau = 1.0, t_decay = 2.0, t_end = 3.0, t_fade = 4.0, now = -2/5, mode = %d\n", Ctrl->debug.mode);
 	fprintf (fp, "# now\tsize\tintens\ttransp\tdz\n");

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -393,7 +393,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl, struct GMT_O
 							break;
 						case 'f':	/* Fade duration  and optional ramp directive */
 							Ctrl->E.ramp[PSEVENTS_FADE] = psevents_parse_ramp_type (GMT, txt_a, &start);
-							if (start == 1) Ctrl->E.ramp[PSEVENTS_FADE] PSEVENTS_RAMP_LINEAR;	/* Different default here */
+							if (start == 1) Ctrl->E.ramp[PSEVENTS_FADE] = PSEVENTS_RAMP_LINEAR;	/* Different default here */
 							Ctrl->E.dt[id][PSEVENTS_FADE] = atof (&txt_a[start]);
 							break;
 						case 'p': Ctrl->E.dt[id][PSEVENTS_PLATEAU] = atof (&txt_a[1]);	break;	/* Plateau duration */


### PR DESCRIPTION
So far all of the magnification curves have been quadratic.  This PR adds optional directives **l**(inear), **q**(uadratic) or **c**(osine ramp) to the rise, decay and fade sections.  E.g, cosine ramp rise of 2 time units would use the **-E** modifier **+rc**2. Below shows the 4 curves for each type (the dashed curve is the default size curve when no curve tweaks have been requested (i.e., no rise, plateau, etc):

![lines](https://github.com/GenericMappingTools/gmt/assets/26473567/7d68478a-da80-44d8-9a98-3f3e438e056e)

It is a WIP for now since we are playing with this a bit and may add this one as new test eventually.