### PR TITLE
Let gmtdefaults -D follow what man page says

### DIFF
--- a/doc/rst/source/gmtdefaults.rst
+++ b/doc/rst/source/gmtdefaults.rst
@@ -23,7 +23,7 @@ Description
 There are three ways to change some of the settings: (1) use the command
 :doc:`gmtset`, (2) use any text editor to edit the file :doc:`gmt.conf` in your
 home, ~/.gmt or current directory (if you do not have this file, run
-:doc:`gmtdefaults` |-D| > gmt.conf to get one with the system default
+:doc:`gmtdefaults` |-D| > gmt.conf to get one with the system SI default
 settings), or (3) override any parameter by specifying one or more
 **-**\ **-PARAMETER**\ =\ *VALUE* statements on the command line of any GMT
 command (**PARAMETER** and *VALUE* are any combination in :doc:`gmt.conf`). In
@@ -49,7 +49,7 @@ Optional Arguments
 **-D**\ [**u**\|\ **s**]
     Print the system GMT defaults settings to standard output. Append **u**
     for US defaults or **s** for SI defaults. [|-D| alone gives the
-    version selected at compile time; If |-D| is omitted, the user's
+    SI defaults; If |-D| is omitted, the user's
     currently active defaults are printed.]
 
 .. include:: explain_help.rst_
@@ -70,7 +70,7 @@ are user-definable in GMT.
 Examples
 --------
 
-To get a copy of the GMT parameter defaults in your home directory, run::
+To get a copy of the GMT parameter SI defaults in your home directory, run::
 
     gmt defaults -D > ~/gmt.conf
 

--- a/src/gmtdefaults.c
+++ b/src/gmtdefaults.c
@@ -99,7 +99,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTDEFAULTS_CTRL *Ctrl, struct GM
 				if (opt->arg[0]) {	/* Specified and argument */
 					n_errors += gmt_get_required_char (GMT, opt->arg, opt->option, 0, &Ctrl->D.mode);
 					if (strchr ("su", Ctrl->D.mode) == NULL) {
-						GMT_Report (API, GMT_MSG_COMPAT, "Option -D: Argument %s is not recognized.\n", opt->arg);
+						GMT_Report (API, GMT_MSG_ERROR, "Option -D: Argument %s is not recognized.\n", opt->arg);
 						n_errors++;
 					}
 				}

--- a/src/gmtdefaults.c
+++ b/src/gmtdefaults.c
@@ -96,7 +96,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTDEFAULTS_CTRL *Ctrl, struct GM
 
 			case 'D':	/* Get GMT system-wide defaults settings */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->D.active);
-				if (opt->arg[0]) {	/* Specified and argument */
+				if (opt->arg[0]) {	/* Specified an argument */
 					n_errors += gmt_get_required_char (GMT, opt->arg, opt->option, 0, &Ctrl->D.mode);
 					if (strchr ("su", Ctrl->D.mode) == NULL) {
 						GMT_Report (API, GMT_MSG_ERROR, "Option -D: Argument %s is not recognized.\n", opt->arg);

--- a/src/gmtdefaults.c
+++ b/src/gmtdefaults.c
@@ -66,7 +66,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "  OPTIONAL ARGUMENTS:\n");
 	GMT_Usage (API, 1, "\n-D[s|u]");
 	GMT_Usage (API, -2, "Print the current GMT default settings. Optionally append a directive:");
-	GMT_Usage (API, 3, "s: Print the SI version of the system defaults.");
+	GMT_Usage (API, 3, "s: Print the SI version of the system defaults [Default].");
 	GMT_Usage (API, 3, "u: Print the US version of the system defaults.");
 	GMT_Usage (API, -2, "Note: ALL settings will be written to standard output.");
 	GMT_Option (API, "V");
@@ -96,7 +96,13 @@ static int parse (struct GMT_CTRL *GMT, struct GMTDEFAULTS_CTRL *Ctrl, struct GM
 
 			case 'D':	/* Get GMT system-wide defaults settings */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->D.active);
-				n_errors += gmt_get_required_char (GMT, opt->arg, opt->option, 0, &Ctrl->D.mode);
+				if (opt->arg[0]) {	/* Specified and argument */
+					n_errors += gmt_get_required_char (GMT, opt->arg, opt->option, 0, &Ctrl->D.mode);
+					if (strchr ("su", Ctrl->D.mode) == NULL) {
+						GMT_Report (API, GMT_MSG_COMPAT, "Option -D: Argument %s is not recognized.\n", opt->arg);
+						n_errors++;
+					}
+				}
 				break;
 			case 'L':	/* List the user's current GMT defaults settings */
 				if (gmt_M_compat_check (GMT, 4)) {


### PR DESCRIPTION
Says argument to **-D** is optional and the default internally is then SI.  This PR fixes the error in the code to let **-D** basically mean **-Ds**.  Man page updated to remove babble of compile time setting. Means #7677 can be deleted since -D shall have a default setting.