### PR TITLE
Fix typo in general syntax for Lambert Azimuthal Equal-Area projection (a|A)

### DIFF
--- a/doc/rst/source/cookbook/map-projections.rst
+++ b/doc/rst/source/cookbook/map-projections.rst
@@ -223,7 +223,7 @@ Lambert Azimuthal Equal-Area (**-Ja** **-JA**)
 
 **Syntax**
 
-    **-Ja**\|\ **A**\ *lon0/lat0*\ [*/horizon*]\ *scale*\|\ *width*
+    **-Ja**\|\ **A**\ *lon0/lat0*\ [*/horizon*]/\ *scale*\|\ *width*
 
 **Parameters**
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the general syntax for the Lambert Azimuthal Equal-Area projection (**a**|**A**).

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
