### PR TITLE
Fix typo in general syntax for Transverse Mercator projection (t|T)

### DIFF
--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -95,7 +95,7 @@
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
    * - :ref:`Transverse Mercator <-Jt>`
      - **-Jt**\|\ **T**
-     - [|lon0|/\ [|lat0|/]]\ *scale*\|\ *width*
+     - |lon0|/\ [|lat0|/]\ *scale*\|\ *width*
    * - :ref:`Universal Transverse Mercator (UTM) <-Ju>`
      - **-Ju**\|\ **U**
      - *zone*/*scale*\|\ *width*


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the general syntax for the Transverse Mercator projection (**t**|**T**).

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
