### PR TITLE
Fix tiny typo in documentation of "G" of "gmtwhich"

### DIFF
--- a/doc/rst/source/gmtwhich.rst
+++ b/doc/rst/source/gmtwhich.rst
@@ -62,7 +62,7 @@ Optional Arguments
 .. _-G:
 
 **-G**\ [**a**\|\ **c**\|\ **l**\|\ **u**]
-    If a file argument is a downloadable file (either a complete URL, a @file for
+    If a file argument is a downloadable file (either a complete URL, an @file for
     downloading from the GMT data server, or @earth_relief_xxy or any other of the
     remote datasets at https://www.generic-mapping-tools.org/remote-datasets/)
     we will try to download the file if it is not found in your local data or cache dirs.


### PR DESCRIPTION
**Description of proposed changes**

Following the review in https://github.com/GenericMappingTools/pygmt/pull/2519#discussion_r1285013056, this PR aims to fix a tiny typo in the documentation of **G** of `gmtwhich`. 

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
