### PR TITLE
Add documentation of "-x" for "grdfilter"

### DIFF
--- a/doc/rst/source/grdfilter.rst
+++ b/doc/rst/source/grdfilter.rst
@@ -22,6 +22,7 @@ Synopsis
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-f| ]
 [ |SYN_OPT-r| ]
+[ |SYN_OPT-x| ]
 [ |SYN_OPT--| ]
 
 |No-spaces|
@@ -174,6 +175,8 @@ Optional Arguments
 
 .. |Add_nodereg| unicode:: 0x20 .. just an invisible code
 .. include:: explain_nodereg.rst_
+
+.. include:: explain_core.rst_
 
 .. include:: explain_help.rst_
 


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to add the documentation of **-x** for `grdfilter`. I orientated myself on the documentations of modules which also have the **-x** option. Please indicate if there is something else to do.
This is related to:
- GMT Changelog: https://docs.generic-mapping-tools.org/6.4/changes.html#new-common-options-in-gmt-5-2
- GMT Forum: https://forum.generic-mapping-tools.org/t/pygmt-grdfilter-calculations-will-be-distributed-over-1-threads/4147/8
- PyGMT: https://github.com/GenericMappingTools/pygmt/pull/2617#discussion_r1287862861

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
