### PR TITLE
Let OPenMP be build default for mortals

### DIFF
--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -148,7 +148,7 @@
 #set (LICENSE_RESTRICTED GPL)
 
 # Allow building of OpenMP if compiler supports it
-#set (GMT_ENABLE_OPENMP TRUE)
+set (GMT_ENABLE_OPENMP TRUE)
 
 # Configure default units (possible values are SI and US) [SI]:
 #set (UNITS "US")


### PR DESCRIPTION
It was comment out and hence FALSE so unless you looked very hard you would not notice and just end up without OpenMP builds.

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
