### PR TITLE
Update text around -B radians dicussion

### DIFF
--- a/doc/rst/source/cookbook/options.rst
+++ b/doc/rst/source/cookbook/options.rst
@@ -303,11 +303,9 @@ each annotation (see Figure :ref:`Axis label <axis_label_basemap>`).
 
    .. literalinclude:: /_verbatim/GMT_-B_linear.txt
 
-There are occasions when the length of the annotations are such that placing them
-horizontally (which is the default) may lead to overprinting or too few annotations.
-One solution is to request slanted annotations for the x-axis (e.g., Figure :ref:`Axis label <axis_slanted_basemap>`)
-via the **+a**\ *angle* modifier.
-
+For axes with angles in radians you can also specify annotation, tick, and gridline
+intervals using multiples or fractions of :math:`\pi` (using *pi*)
+(e.g., as in Figure :ref:`Axis label <axis_radians_basemap>`)
 
 .. _axis_radians_basemap:
 
@@ -327,7 +325,6 @@ There are occasions when the length of the annotations are such that placing the
 horizontally (which is the default) may lead to overprinting or too few annotations.
 One solution is to request slanted annotations for the x-axis (e.g., Figure :ref:`Axis label <axis_slanted_basemap>`)
 via the **+a**\ *angle* modifier.
-
 
 .. _axis_slanted_basemap:
 

--- a/doc/scripts/images.dvc
+++ b/doc/scripts/images.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: d3c6302c85c4a44c278bffd5ea8be37b.dir
-  size: 33307295
-  nfiles: 200
+- md5: c64285581218a30e2732721684dcb374.dir
+  size: 33330249
+  nfiles: 201
   path: images


### PR DESCRIPTION
Finally, the doc build shows the radian -B example after re-adding the figure and also fixing the copy/paste text used as boilerplate.

![GMT_-B_radians](https://github.com/GenericMappingTools/gmt/assets/26473567/94fec309-8f23-4a1e-b7a4-6c138361d042)
