### PR TITLE
Check if @N etc is at start of OGR/GMT line

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -821,7 +821,7 @@ GMT_LOCAL bool gmtio_ogr_header_parser (struct GMT_CTRL *GMT, char *record) {
 	 * set to point to gmtio_ogr_data_parser instead, to speed up data record processing.
 	 */
 
-	unsigned int n_aspatial, k, geometry = 0;
+	unsigned int n_aspatial, k, geometry = 0, gap = 0;
 	bool quote;
 	char *p = NULL;
 	struct GMT_OGR *S = NULL;
@@ -952,8 +952,11 @@ GMT_LOCAL bool gmtio_ogr_header_parser (struct GMT_CTRL *GMT, char *record) {
 				break;
 
 			default:	/* Just record, probably means this is NOT a GMT/OGR file after all */
-				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad OGR/GMT: @%c not allowed before FEATURE_DATA\n", (int)p[0]);
-				GMT->current.io.ogr = GMT_OGR_FALSE;
+				gap = (unsigned int)(p - record);
+				if (gap < 3) {
+					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad OGR/GMT: @%c not allowed before FEATURE_DATA\n", (int)p[0]);
+					GMT->current.io.ogr = GMT_OGR_FALSE;
+				}
 				break;
 		}
 

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -953,7 +953,7 @@ GMT_LOCAL bool gmtio_ogr_header_parser (struct GMT_CTRL *GMT, char *record) {
 
 			default:	/* Just record, probably means this is NOT a GMT/OGR file after all */
 				gap = (unsigned int)(p - record);
-				if (gap < 3) {
+				if (gap < 3 && isupper (p[0])) {
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad OGR/GMT: @%c not allowed before FEATURE_DATA\n", (int)p[0]);
 					GMT->current.io.ogr = GMT_OGR_FALSE;
 				}


### PR DESCRIPTION
Closes #7712. Must allow strings starting with `@` once the initial line-check finds a `@` code.
