### PR TITLE
Use plus/minus char instead of -1/+1 kludges

### DIFF
--- a/doc/rst/source/cookbook/features.rst
+++ b/doc/rst/source/cookbook/features.rst
@@ -1360,7 +1360,7 @@ of zero leaves the color unchanged. Higher values will brighten the
 color, lower values will darken it, all without changing the original
 hue of the color (see Chapter :doc:`colorspace` for more details). The
 illumination is decoupled from the data grid file in that a separate
-grid file holding intensities in the [-1,+1] range must be provided.
+grid file holding intensities in the ±1 range must be provided.
 Such intensity files can be derived from the data grid using
 :doc:`/grdgradient` and modified with
 :doc:`/grdhisteq`, but could equally well be

--- a/doc/rst/source/grd2kml.rst
+++ b/doc/rst/source/grd2kml.rst
@@ -40,8 +40,8 @@ tile size.  We downsample the grid depending on the
 viewing level in the quadtree using a Gaussian filter, but other
 filters can be selected as well.
 Optionally, illumination may be added by providing a grid file with
-intensities in the (-1,+1) range or by giving instructions to derive intensities
-from the input data grid automatically (see |-I|). Values outside the (-1,+1) intensity range will be
+intensities in the ±1 range or by giving instructions to derive intensities
+from the input data grid automatically (see |-I|). Values outside the ±1 intensity range will be
 clipped. Map colors are specified via a color palette lookup table. Contour overlays are optional.
 If plain tiles are selected (i.e., no contours specified) then the PNG tiles are written directly from
 :doc:`grdimage`. Otherwise, we must first make a PostScript plot that is then converted to raster image via
@@ -110,7 +110,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ [*intensfile*\|\ *intensity*\|\ *modifiers*]
-    Gives the name of a grid file with intensities in the (-1,+1) range,
+    Gives the name of a grid file with intensities in the ±1 range,
     or a constant intensity to apply everywhere (affects the ambient light).
     Alternatively, derive an intensity grid from the input data grid *grid*
     via a call to :doc:`grdgradient`; append **+a**\ *azimuth* and **+n**\ *args*

--- a/doc/rst/source/grdimage.rst
+++ b/doc/rst/source/grdimage.rst
@@ -46,7 +46,7 @@ Description
 colored) map by building a rectangular image and assigning pixels
 a gray-shade (or color) based on the z-value and the CPT file.
 Optionally, illumination may be added by providing a file with
-intensities in the (-1,+1) range or instructions to derive intensities
+intensities in the ±1 range or instructions to derive intensities
 from the input data grid. Values outside this range will be
 clipped. Such intensity files can be created from the grid using
 :doc:`grdgradient` and, optionally, modified by :doc:`grdmath` or
@@ -140,7 +140,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ [*intensfile*\|\ *intensity*\|\ *modifiers*]
-    Gives the name of a grid file with intensities in the (-1,+1) range,
+    Gives the name of a grid file with intensities in the ±1 range,
     or a constant intensity to apply everywhere (affects the ambient light).
     Alternatively, derive an intensity grid from the input data grid *grid*
     via a call to :doc:`grdgradient`; append **+a**\ *azimuth*, **+n**\ *args*,

--- a/doc/rst/source/grdmix.rst
+++ b/doc/rst/source/grdmix.rst
@@ -95,7 +95,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ *intensity*
-    A constant intensity or grid (-1 to +1 range) to modify final output image colors.
+    A constant intensity or grid (in ±1 range) to modify final output image colors.
 
 .. _-M:
 

--- a/doc/rst/source/grdview.rst
+++ b/doc/rst/source/grdview.rst
@@ -87,7 +87,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ [*intensgrid*\|\ *intensity*\|\ *modifiers*]
-    Gives the name of a grid file with intensities in the (-1,+1) range,
+    Gives the name of a grid file with intensities in the ±1 range,
     or a constant intensity to apply everywhere (affects the ambient light).
     Alternatively, derive an intensity grid from the input data grid *reliefgrid*
     via a call to :doc:`grdgradient`; append **+a**\ *azimuth*, **+n**\ *args*,

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -202,7 +202,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ *intens*
-    Use the supplied *intens* value (nominally in the -1 to +1 range) to
+    Use the supplied *intens* value (nominally in the ±1 range) to
     modulate the fill color by simulating illumination [none]. If no intensity
     is provided we will instead read *intens* from the first data column after
     the symbol parameters (if given).

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -160,7 +160,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ *intens*
-    Use the supplied *intens* value (nominally in the -1 to +1 range) to
+    Use the supplied *intens* value (nominally in the ±1 range) to
     modulate the fill color by simulating illumination [none]. If no intensity
     is provided we will instead read *intens* from the first data column after
     the symbol parameters (if given).

--- a/doc/rst/source/supplements/geodesy/velo.rst
+++ b/doc/rst/source/supplements/geodesy/velo.rst
@@ -245,7 +245,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ *intens*
-    Use the supplied *intens* value (nominally in the -1 to +1 range) to
+    Use the supplied *intens* value (nominally in the ±1 range) to
     modulate the symbol fill color by simulating illumination [none].
     If no intensity is provided we will instead read *intens* from an extra
     data column after the required input columns determined by |-S|.

--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -202,7 +202,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ *intens*
-    Use the supplied *intens* value (nominally in the -1 to +1 range) to
+    Use the supplied *intens* value (nominally in the ±1 range) to
     modulate the compressional fill color by simulating illumination [none].
     If no intensity is provided we will instead read *intens* from an extra
     data column after the required input columns determined by |-S|.

--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -153,7 +153,7 @@ Optional Arguments
 .. _-I:
 
 **-I**\ *intens*
-    Use the supplied *intens* value (nominally in the -1 to +1 range) to
+    Use the supplied *intens* value (nominally in the ±1 range) to
     modulate the compressional fill color by simulating illumination [none].
     If no intensity is provided we will instead read *intens* from an extra
     data column after the required input columns determined by |-S|.

--- a/doc/rst/source/tutorial/session-4.rst
+++ b/doc/rst/source/tutorial/session-4.rst
@@ -112,7 +112,7 @@ toward the sun mean if we are plotting a grid of heat flow anomalies?
 While there are many ways to accomplish what we want, GMT offers
 a relatively simple way:  We may calculate the gradient of the surface
 in the direction of the sun and normalize these values to fall in
-the -1 to +1 range; +1 means maximum sun exposure and -1 means complete
+the ±1 range; +1 means maximum sun exposure and -1 means complete
 shade. Although we will not show it here, it should be added that
 GMT treats the intensities as a separate data set.  Thus, while
 these values are often derived from the relief surface we want to

--- a/doc/rst/source/tutorial/session-4_jl.rst
+++ b/doc/rst/source/tutorial/session-4_jl.rst
@@ -108,7 +108,7 @@ calculations, there is clearly an arbitrary element when the surface is not topo
 other quantity. For instance, what does the slope toward the sun mean if we are plotting a grid of heat
 flow anomalies?  While there are many ways to accomplish what we want, GMT offers a relatively simple way:
 We may calculate the gradient of the surface in the direction of the sun and normalize these values to fall
-in the -1 to +1 range; +1 means maximum sun exposure and -1 means complete shade. Although we will not
+in the ±1 range; +1 means maximum sun exposure and -1 means complete shade. Although we will not
 show it here, it should be added that GMT treats the intensities as a separate data set. Thus, while these
 values are often derived from the relief surface we want to image they could be separately observed
 quantities such as back-scatter information.


### PR DESCRIPTION
Since RST man pages can handle that character, we use ±1 instead.
