### PR TITLE
Add modifer +r to -S to only annotate the CPT limits

### DIFF
--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -26,7 +26,7 @@ Synopsis
 [ |-N|\ [**p**\|\ *dpi* ]]
 [ |-Q| ]
 [ |SYN_OPT-R| ]
-[ |-S|\ [**+a**\ *angle*][**+c**\|\ **n**\ ][**+s**][**+x**\ *label*][**+y**\ *unit*] ]
+[ |-S|\ [**+a**\ *angle*][**+c**\|\ **n**\ ][**+r**][**+s**][**+x**\ *label*][**+y**\ *unit*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *scale* ]
@@ -214,11 +214,12 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ [**+a**\ *angle*][**+c**\|\ **n**\ ][**+s**][**+x**\ *label*][**+y**\ *unit*]
+**-S**\ [**+a**\ *angle*][**+c**\|\ **n**\ ][**+r**][**+s**][**+x**\ *label*][**+y**\ *unit*]
     Control various aspects of color bar appearance when |-B| is *not* used.
     Append **+a** to place annotations at the given *angle* [default is no slanting].
     Append **+c** to use custom labels if given in the CPT as annotations.
     Append **+n** to use numerical labels [Default].
+    Append **+r** to only annotate lower and upper limits in the CPT [Default follows CPT boundaries].
     Append **+s** to skip drawing gridlines separating different color intervals [Default draws gridlines].
     If |-L| is used then |-B| cannot be used, hence you may optionally set a bar label via **+x**\ *label*
     and any unit (i.e., y-label) via **+y**\ *unit*.

--- a/doc/rst/source/psscale.rst
+++ b/doc/rst/source/psscale.rst
@@ -27,7 +27,7 @@ Synopsis
 [ |-O| ]
 [ |-P| ] [ |-Q| ]
 [ |SYN_OPT-R| ]
-[ |-S|\ [**+a**\ *angle*][**+c**\|\ **n**\ ][**+s**][**+x**\ *label*][**+y**\ *unit*] ]
+[ |-S|\ [**+a**\ *angle*][**+c**\|\ **n**\ ][**+r**][**+s**][**+x**\ *label*][**+y**\ *unit*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *scale* ]

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -231,7 +231,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+a Place annotations at an angle [no slanting].");
 	GMT_Usage (API, 3, "+c Use any custom labels in the CPT for annotations, if available.");
 	GMT_Usage (API, 3, "+n Use numerical values for annotations [Default].");
-	GMT_Usage (API, 3, "+r Only annotate min and max color [Default follows CPT boundaries].");
+	GMT_Usage (API, 3, "+r Only annotate lower and upper CPT bounds [Default annotates all enabled CPT boundaries].");
 	GMT_Usage (API, 3, "+s Skip drawing gridlines between different color sections [Default draws lines].");
 	GMT_Usage (API, 3, "+x Set a colorbar label [No label].");
 	GMT_Usage (API, 3, "+y Set a colorbar unit [No unit].");

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -114,9 +114,10 @@ struct PSSCALE_CTRL {
 	struct PSSCALE_Q {	/* -Q */
 		bool active;
 	} Q;
-	struct PSSCALE_S {	/* -S[+c|n][+s][+a<angle>][+x<label>][+y<unit>] */
+	struct PSSCALE_S {	/* -S[+c|n][+s][+a<angle>][+r][+x<label>][+y<unit>] */
 		bool active;
 		bool skip;
+		bool range;
 		double angle;
 		unsigned int mode;
 		char unit[GMT_LEN256], label[GMT_LEN256];
@@ -166,7 +167,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [%s] [-C<cpt>] [-D%s[+w<length>[/<width>]][+e[b|f][<length>]][+h|v][+j<justify>][+ma|c|l|u][+n[<txt>]]%s[+r]] "
 		"[-F%s] [-G<zlo>/<zhi>] [-I[<max_intens>|<low_i>/<high_i>]] [%s] %s[-L[i][<gap>]] [-M] [-N[p|<dpi>]] %s%s[-Q] [%s] "
-		"[-S[+a<angle>][+c|n][+s][+x<label>][+y<unit>]] [%s] [%s] [-W<scale>] [%s] [%s] [-Z<widthfile>] %s[%s] [%s] [%s]\n",
+		"[-S[+a<angle>][+c|n][+r][+s][+x<label>][+y<unit>]] [%s] [%s] [-W<scale>] [%s] [%s] [-Z<widthfile>] %s[%s] [%s] [%s]\n",
 			name, GMT_B_OPT, GMT_XYANCHOR, GMT_OFFSET, GMT_PANEL, GMT_J_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeoz_OPT,
 			GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_p_OPT, GMT_t_OPT, GMT_PAR_OPT);
 
@@ -230,6 +231,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+a Place annotations at an angle [no slanting].");
 	GMT_Usage (API, 3, "+c Use any custom labels in the CPT for annotations, if available.");
 	GMT_Usage (API, 3, "+n Use numerical values for annotations [Default].");
+	GMT_Usage (API, 3, "+r Only annotate min and max color [Default follows CPT boundaries].");
 	GMT_Usage (API, 3, "+s Skip drawing gridlines between different color sections [Default draws lines].");
 	GMT_Usage (API, 3, "+x Set a colorbar label [No label].");
 	GMT_Usage (API, 3, "+y Set a colorbar unit [No unit].");
@@ -399,13 +401,14 @@ static int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT_OP
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
 				Ctrl->S.mode = PSSCALE_ANNOT_NUMERICAL;	/* The default */
 				if (opt->arg[0]) {	/* Modern syntax with modifiers */
-					if ((c = gmt_first_modifier (GMT, opt->arg, "acnsxy"))) {	/* Process any modifiers */
+					if ((c = gmt_first_modifier (GMT, opt->arg, "acnrsxy"))) {	/* Process any modifiers */
 						unsigned int pos = 0;	/* Reset to start of new word */
-						while (gmt_getmodopt (GMT, 'S', c, "acnsxy", &pos, txt_a, &n_errors) && n_errors == 0) {
+						while (gmt_getmodopt (GMT, 'S', c, "acnrsxy", &pos, txt_a, &n_errors) && n_errors == 0) {
 							switch (txt_a[0]) {
 								case 'a': Ctrl->S.angle = atof (&txt_a[1]); Ctrl->S.mode |= PSSCALE_ANNOT_ANGLED;	break;
 								case 'c': Ctrl->S.mode |= PSSCALE_ANNOT_CUSTOM;	break;
 								case 'n': Ctrl->S.mode = PSSCALE_ANNOT_NUMERICAL;	break;
+								case 'r': Ctrl->S.range = true;	break;
 								case 's': Ctrl->S.skip = true;	break;
 								case 'x': strncpy (Ctrl->S.label, &txt_a[1], GMT_LEN256); break;
 								case 'y': strncpy (Ctrl->S.unit,  &txt_a[1], GMT_LEN256); break;
@@ -1378,6 +1381,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 
 			if (!center) {
 				for (i = 0; i < P->n_colors; i++) {		/* For all z_low coordinates */
+					if (Ctrl->S.range && i > 0) continue;	/* Only annotate min color */
 					t_len = (all || ((P->data[i].annot & GMT_CPT_L_ANNOT) || (i && P->data[i-1].annot & GMT_CPT_U_ANNOT))) ? dir * len : dir * len2;	/* Annot or frame length */
 					PSL_plotsegment (PSL, xpos[i], y_base, xpos[i], y_base+t_len);
 				}
@@ -1395,6 +1399,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 			if (center) x1 += 0.5 * z_width[0];	/* Can use z_width[0] since -L forces all widths to be equal */
 
 			for (i = 0; i < P->n_colors; i++) {
+				if (Ctrl->S.range && i > 0) continue;
 				xx = (reverse) ? xright - x1 : x1;
 				if (all || P->data[i].annot) {	/* Annotate this */
 					this_just = justify;
@@ -1726,6 +1731,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 			if (!center) {
 				gmt_setpen (GMT, &GMT->current.setting.map_tick_pen[GMT_PRIMARY]);
 				for (i = 0; i < P->n_colors; i++) {
+					if (Ctrl->S.range && i > 0) continue;
 					t_len = (all || ((P->data[i].annot & GMT_CPT_L_ANNOT) || (i && P->data[i-1].annot & GMT_CPT_U_ANNOT))) ? dir * len : dir * len2;	/* Annot or frame length */
 					PSL_plotsegment (PSL, xpos[i], y_base, xpos[i], y_base+t_len);
 				}
@@ -1743,8 +1749,9 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 			if (center) x1 += 0.5 * z_width[0];	/* Can use z_width[0] since -L forces all widths to be equal */
 
 			for (i = 0; i < P->n_colors; i++) {
+				if (Ctrl->S.range && i > 0) continue;
 				xx = (reverse) ? xright - x1 : x1;
-				if (all || P->data[i].annot) {
+				if (all || P->data[i].annot || (Ctrl->S.range && i == 0)) {
 					this_just = justify;
 					do_annot = true;
 					if (use_labels && (no_B_mode & PSSCALE_ANNOT_CUSTOM))


### PR DESCRIPTION
See discussion on the [forum](https://forum.generic-mapping-tools.org/t/colorbar-for-the-subplots-in-pygmt/4180).  This modifier is added to **-S** for when **-B** is _not_ used and limits annotations to the lower and upper CPT boundary.
