### PR TITLE
CI: Use concurrency to cancel previous runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ defaults:
     # default to use bash shell
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
     name: ${{ matrix.name }}
@@ -46,9 +50,6 @@ jobs:
             EXCLUDE_OPTIONAL : true
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: Checkout
         uses: actions/checkout@v3.5.3
 

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: '0 12 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   data_cache:
     name: Cache GMT data
@@ -22,11 +26,6 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Install GMT
         run: brew install gmt
 
@@ -79,11 +78,6 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v3.5.3
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,10 @@ defaults:
     # default to use bash shell
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   docker:
     name: ${{ matrix.image }}
@@ -49,9 +53,6 @@ jobs:
           - debian:sid    # rolling release with latest versions
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: Checkout
         uses: actions/checkout@v3.5.3
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,10 @@ defaults:
     # default to use bash shell
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   docs:
     name: ${{ matrix.name }}
@@ -51,9 +55,6 @@ jobs:
             os: windows-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: Checkout
         uses: actions/checkout@v3.5.3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,10 @@ defaults:
     # default to use bash shell
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   test:
     name: ${{ matrix.name }}
@@ -51,9 +55,6 @@ jobs:
             os: windows-latest
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: Checkout
         uses: actions/checkout@v3.5.3
 


### PR DESCRIPTION
GitHub Actions provides the `concurrency` key which can limit workflow runs, so that we don't have to use the `styfle/cancel-workflow-action` action.

See https://github.com/GenericMappingTools/pygmt/pull/2589 for context.