### PR TITLE
gmtspatial -N+i+pstart is allowed

### DIFF
--- a/doc/rst/source/gmtspatial.rst
+++ b/doc/rst/source/gmtspatial.rst
@@ -144,7 +144,7 @@ Optional Arguments
 .. _-N:
 
 **-N**\ *pfile*\ [**+a**][**+i**][**+p**\ *start*][**+r**][**+z**]
-    Determine if one (or all, with **+a**) points of each feature in the
+    Lines and polygons: Determine if one (or all, with **+a**) points of each feature in the
     input data are inside any of the polygons given in the *pfile*. If
     inside, then report which polygon it is; the polygon ID is either
     taken from the aspatial value assigned to Z, the segment header
@@ -156,8 +156,8 @@ Optional Arguments
     polygon contains a feature or **+z** to have the IDs added as an
     extra data column on output. Segments that fail to be inside a
     polygon are not written out. If more than one polygon contains the
-    same segment we skip the second (and further) scenarios. Alternatively,
-    just use modifier **+i** and we will determine the polygon ID for
+    same segment we skip the second (and further) scenarios. Point clouds:
+    Use modifier **+i** and we will determine the polygon ID for
     every **i**\ ndividual input point and add it as the last column.
 
 .. _-Q:

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -2039,7 +2039,7 @@ EXTERN_MSC int GMT_gmtspatial (void *V_API, int mode, void *args) {
 
 		T = C->table[0];	/* Only one input file so only one table */
 		count = gmt_M_memory (GMT, NULL, D->n_segments, unsigned int);
-		ID = Ctrl->N.ID - 1;	/* May be overridden below */
+		ID = Ctrl->N.ID - 1;	/* May be overridden below by header info, otherwise will be incremented to 0 (or whatever +p set) */
 		for (seg2 = 0; seg2 < T->n_segments; seg2++) {	/* For all polygons */
 			S2 = T->segment[seg2];
 			SH = gmt_get_DS_hidden (S2);


### PR DESCRIPTION
The updated **gmtspatial** checks would refuse **+p**_start_ if **+i** is used.  Now that is relaxed, the usage messages are cleaned up a bit, as is the docs.
