### PR TITLE
Add data server candidate

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3588,8 +3588,14 @@ GMT_LOCAL int gmtinit_set_env (struct GMT_CTRL *GMT) {
 		}
 	}
 
-	if ((this_c = getenv ("GMT_DATA_SERVER")) != NULL)		/* GMT_DATA_SERVER was set */
-		GMT->session.DATASERVER = strdup (this_c);
+	if ((this_c = getenv ("GMT_DATA_SERVER")) != NULL) {		/* GMT_DATA_SERVER was set */
+		if ((strcmp (this_c, GMT_TEST_SERVER_NAME) == 0)) {	/* Special case. Use candidate.generic-mapping-tools.org and set test_run */
+			GMT->session.DATASERVER = strdup (GMT_CANDIDATE_SERVER_NAME);
+			GMT->session.test_run = true;
+		}
+		else
+			GMT->session.DATASERVER = strdup (this_c);
+	}
 	else if ((this_c = getenv ("GMT_DATA_URL")) != NULL)		/* GMT_DATA_URL [deprecated in 6.0.0] was set */
 		GMT->session.DATASERVER = strdup (this_c);
 	else
@@ -11941,8 +11947,17 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 						break; /* stop here if string in place is equal */
 					gmt_M_str_free (GMT->session.DATASERVER);
 				}
-				/* Set session DATASERVER dir */
-				GMT->session.DATASERVER = strdup (value);
+				/* Set session DATASERVER URL */
+				if ((strcmp (value, GMT_TEST_SERVER_NAME) == 0)) {	/* Special case. Use candidate.generic-mapping-tools.org and set test_run */
+					GMT->session.DATASERVER = strdup (GMT_CANDIDATE_SERVER_NAME);
+					GMT->session.test_run = true;
+				}
+				else
+						GMT->session.DATASERVER = strdup (value);
+			}
+			else {
+				GMT_Report (GMT->parent, GMT_MSG_ERROR, "No server name given to GMT_DATA_SERVER.\n");
+				error = true;
 			}
 			break;
 

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1848,6 +1848,7 @@ char *gmt_dataserver_url (struct GMTAPI_CTRL *API) {
 			snprintf (URL, GMT_LEN256-1, "http://%s", name);
 		else	/* Expand server name to full URL */
 			snprintf (URL, GMT_LEN256-1, "http://%s.generic-mapping-tools.org", name);
+		if (API->GMT->session.test_run) strcat (URL, GMT_TEST_SERVER_DIR);	/* Running tests with data under this hidden directory */
 	}
 	else	/* Must use the URL as is */
 		snprintf (URL, GMT_LEN256-1, "%s", API->GMT->session.DATASERVER);

--- a/src/gmt_remote.h
+++ b/src/gmt_remote.h
@@ -71,7 +71,7 @@ enum GMT_tile_coverage {	/* Values in any tile coverage grid (e.g., srtm_tiles.n
 #define GMT_INFO_SERVER_FILE		"gmt_data_server.txt"
 #define GMT_CANDIDATE_SERVER_NAME	"candidate"
 #define GMT_TEST_SERVER_NAME		"test"
-#define GMT_TEST_SERVER_DIR			"/reference"
+#define GMT_TEST_SERVER_DIR		"/reference"
 
 #define GMT_HASH_TIME_OUT		10L	/* Not waiting longer than this to time out on getting the hash file */
 #define GMT_CONNECT_TIME_OUT	10L	/* Not waiting longer than this to time out on getting a response from the server */

--- a/src/gmt_remote.h
+++ b/src/gmt_remote.h
@@ -35,7 +35,7 @@ struct GMT_RESOLUTION {	/* Struct to hold information about the various resoluti
 struct GMT_DATA_INFO {
 	int id;						/* Running number 0-(n-1) AFTER array is sorted */
 	bool used;					/* If true then do not repeat the attribution details */
-	char dir[GMT_LEN64];		/* Directory of file.  Here, / (root) means /export/gmtserver/gmt/data */
+	char dir[GMT_LEN64];		/* Directory of file.  Here, / (root) means /export/gmtserver/gmt/data (unless in candidate or test mode) */
 	char file[GMT_LEN64];		/* Full file (or tile directory) name. E.g., earth_relief_20m_g.grd or earth_relief_01m_g/ */
 	char ext[GMT_LEN8];			/* Data file extension. E.g., .grd, *tif, etc. */
 	char inc[GMT_LEN32];		/* Grid spacing in text format. E.g., 30m, 52.0732883317s */
@@ -67,8 +67,11 @@ enum GMT_tile_coverage {	/* Values in any tile coverage grid (e.g., srtm_tiles.n
 
 #define GMT_SRTM_ONLY	1	/* Mode so that when srtm_relief* is used we do not blend in earth_relief_15s */
 
-#define GMT_HASH_SERVER_FILE "gmt_hash_server.txt"
-#define GMT_INFO_SERVER_FILE "gmt_data_server.txt"
+#define GMT_HASH_SERVER_FILE		"gmt_hash_server.txt"
+#define GMT_INFO_SERVER_FILE		"gmt_data_server.txt"
+#define GMT_CANDIDATE_SERVER_NAME	"candidate"
+#define GMT_TEST_SERVER_NAME		"test"
+#define GMT_TEST_SERVER_DIR			"/reference"
 
 #define GMT_HASH_TIME_OUT		10L	/* Not waiting longer than this to time out on getting the hash file */
 #define GMT_CONNECT_TIME_OUT	10L	/* Not waiting longer than this to time out on getting a response from the server */
@@ -79,6 +82,6 @@ enum GMT_tile_coverage {	/* Values in any tile coverage grid (e.g., srtm_tiles.n
 #define GMT_TILE_EXTENSION_LOCAL_LEN	2U		/* Length of nc short int file extension */
 
 #define GMT_IMAGE_DPU_VALUE	300	/* 300 dots per inch */
-#define GMT_IMAGE_DPU_UNIT	'i'	/* 300 dpts per inch */
+#define GMT_IMAGE_DPU_UNIT	'i'	/* 300 dots per inch */
 
 #endif /* GMT_REMOTE_H */

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -432,6 +432,7 @@ struct GMT_SESSION {
 	char unit_name[4][GMT_LEN8];	/* Full name of the 4 units cm, inch, m, pt */
 	struct GMT_HASH rgb_hashnode[GMT_N_COLOR_NAMES];/* Used to translate colornames to r/g/b */
 	bool rgb_hashnode_init;		/* true once the rgb_hashnode array has been loaded; false otherwise */
+	bool test_run;			/* true if DATASERVER was given as "test" and DATASERVER set to "candidate" */
 	unsigned int n_shorthands;			/* Length of array with shorthand information */
 	char *grdformat[GMT_N_GRD_FORMATS];	/* Type and description of grid format */
 	int (*readinfo[GMT_N_GRD_FORMATS]) (struct GMT_CTRL *, struct GMT_GRID_HEADER *);	/* Pointers to grid read header functions */


### PR DESCRIPTION
See https://github.com/GenericMappingTools/gmtserver-admin/issues/159 for background. We desire to:

- Separate out a reference set of remote files (mostly earth_relief) that will not be updated so we can have steady test results from our large test suite and not get failures because SRTM got update. The few tests that might access other remote data will be treated as "failure" and we just update the _PostScript_ file.
- Rename the _test_ server to _candidate_ since it is how we get to play with candidate data sets not yet released.

The intent is that setting **GMT_DATA_SERVER** = candidate (or set it via an environmental variable) means we get access to the next release candidate data sets, while **GMT_DATA_SERVER** = test will also use the candidate server who has a hidden directory with the reference files.  It is assumed mostly developers and CI scripts will every use test, but a broader set of "testers" may want to help with exploring the next candidate data sets.

I am introducing some macros to hold the names "candidate", "test", "reference" in case we end up changing some of these names - without having to hun down where they are used.

**Note:** To avoid overwriting your working setup you may wish to set **GMT_USER_DIR** to a separate dir such as ~/.gmt-test.  Alternatively, perhaps it could save us all some grief if we instead (if not set) default to ~./gmt as we do now but if using _candidate_ or _test_ we append "-candidate" or "-test" to GMT->session.USERDIR?
