### PR TITLE
Set segment's alloc_mode_text so we can free it

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7919,6 +7919,7 @@ int gmt_alloc_segment (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S, uint64_t
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "gmt_alloc_segment: Unable to reallocate string array new length %" PRIu64 "\n", n_rows);
 				return 1;
 			}
+			SH->alloc_mode_text = GMT_ALLOC_INTERNALLY;
 		}
 		SH->n_alloc = n_rows;
 	}
@@ -7954,6 +7955,7 @@ void gmtlib_assign_segment (struct GMT_CTRL *GMT, unsigned int direction, struct
 				GMT->hidden.mem_txt = gmt_M_memory (GMT, GMT->hidden.mem_txt, n_rows, char *);	/* Trim back */
 			S->text = GMT->hidden.mem_txt;	/* Pass the pointer */
 			GMT->hidden.mem_txt = NULL;		/* Null this out to start over for next segment */
+			SH->alloc_mode_text = GMT_ALLOC_INTERNALLY;
 		}
 		GMT->hidden.mem_cols = 0;	/* Flag that we need to reallocate new temp arrays for next segment, if any */
 	}
@@ -7966,6 +7968,7 @@ void gmtlib_assign_segment (struct GMT_CTRL *GMT, unsigned int direction, struct
 		if (GMT->current.io.record_type[direction] & GMT_READ_TEXT) {
 			uint64_t row;
 			S->text = gmt_M_memory (GMT, S->text, n_rows, char *);
+			SH->alloc_mode_text = GMT_ALLOC_INTERNALLY;
 			for (row = 0; row < n_rows; row++) {
 				S->text[row] = GMT->hidden.mem_txt[row];
 				GMT->hidden.mem_txt[row] = NULL;


### PR DESCRIPTION
Like the data columns have `S_>alloc_mode[col]`, the optional trailing text has `alloc_mode_text` but like all allocation modes it defaults to **GMT_ALLOC_EXTERNAL** and needs to be set to **GMT_ALLOC_INTERNALLY** when GMT is allocating them - otherwise we cannot free the memory and we get a memory leak (only visible to developers if **-DMEMDEBUG** (Developers should use this) is set in cmake:

```
gmt math  t.txt -Ca 3600 DIV  =
-88.1988888889	30.2947222222
-88.1991666667	30.295
gmt [WARNING]: Max total memory allocated was 48.040 Mb [50373668 bytes]
gmt [WARNING]: Single largest allocation was 16.000 Mb [16777216 bytes]
gmt [WARNING]: MEMORY NOT FREED: 0.078 kb [80 bytes]
# MEMORY NOT FREED: 0.078 kb [80 bytes]
gmt [WARNING]: Items allocated: 252 reallocated: 20 freed: 247
gmt [WARNING]: Items NOT PROPERLY FREED: 5
# Items NOT PROPERLY FREED: 5
gmt [WARNING]: Memory not freed first allocated in gmt_io.c:7968(gmtlib_assign_segment) (ID = 161): 0.016 kb [16 bytes]
# Memory not freed first allocated in gmt_io.c:7968(gmtlib_assign_segment) (ID = 161): 0.016 kb [16 bytes]
gmt [WARNING]: Memory not freed first allocated in gmt_io.c:7918(gmt_alloc_segment) (ID = 186): 0.016 kb [16 bytes]
...and more...

```

After this fix I get

```
gmt math  t.txt 3600 DIV  =
-317516	30.2947222222
-317517	30.295

```

Since it is just a leak and perhaps just me who gets these warnings, it is a benign bug but now fixed.