### PR TITLE
Allow gmtmath trailing text to be kept for output

### DIFF
--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -562,7 +562,7 @@ Trailing Text
 -------------
 
 Any trialing text in the first input file will be passed to the output data set.  You can turn off the
-output of text with |-o|\ **nn**.
+output of text with |-o|\ **n**.
 
 Examples
 --------

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -561,8 +561,8 @@ will return the result as 64.34 points.
 Trailing Text
 -------------
 
-Any trialing text in the first input file will be passed to the output data set.  You can turn off the
-output of text with |-o|\ **n**.
+Any trailing text in the first input file will be passed to the output data set.  You can turn off the
+output of text with **-on**.
 
 Examples
 --------

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -558,6 +558,12 @@ the unit is in inches squared and scaling by 2.54 once will give 0.3937 inch tim
 Thus, conversions only work for linear unit calculations, such as gmt math -Qp 1c 0.5i ADD =, which
 will return the result as 64.34 points.
 
+Trailing Text
+-------------
+
+Any trialing text in the first input file will be passed to the output data set.  You can turn off the
+output of text with |-o|\ **nn**.
+
 Examples
 --------
 

--- a/src/gmtmath.c
+++ b/src/gmtmath.c
@@ -238,7 +238,7 @@ GMT_LOCAL void gmtmath_load_text (struct GMT_DATASET *to, struct GMT_DATASET *fr
 	/* Copies trailing text from all input segments to all output segments */
 	uint64_t tbl, seg, row;
 	char **Tf = NULL, **Tt = NULL;
-	struct GMT_DATASEGMENT_HIDDEN *SH = gmt_get_DS_hidden (to);
+	struct GMT_DATASEGMENT_HIDDEN *SH = NULL;
 	if (from->type != GMT_READ_MIXED) return;	/* No text in this one */
 	for (tbl = 0; tbl < from->n_tables; tbl++) {
 		for (seg = 0; seg < from->table[tbl]->n_segments; seg++) {


### PR DESCRIPTION
This came from this forum [post](https://forum.generic-mapping-tools.org/t/passing-trailing-text-to-output-file/4198).  I see no reason to not keep the trailing text in **gmtmath** as it can always be ignored with **-on**. The change in this PR is to not force prevention of text output and also due the initial duplication from input to output text.

```
cay << EOF > in.txt
-317516 109061 high ms0334
-317517 109062 low ms0334
EOF

# Keep trailing text
gmt math -Ca in.txt 3600 DIV =
-88.1988888889	30.2947222222	high ms0334
-88.1991666667	30.295	low ms0334

# Discard trailing text
gmt math -Ca -on in.txt 3600 DIV =
-88.1988888889	30.2947222222
-88.1991666667	30.295

```