### PR TITLE
Add test program testapi_modern.c

### DIFF
--- a/src/testapi_modern.c
+++ b/src/testapi_modern.c
@@ -1,0 +1,21 @@
+/* Issue from GitHub: https://github.com/GenericMappingTools/gmt/issues/4518
+ * Problem seems to be that gmt begin comes after GMT_Create_Session in the
+ * code so there are orientation and page size issues. In gmt end, the
+ * psconvert call is missing the -A.
+ */
+
+#include "gmt.h"
+
+int main () {
+	void *API = NULL;
+
+	/* Initialize the GMT session */
+	if ((API = GMT_Create_Session ("testapi_modern", 2, GMT_SESSION_RUNMODE, NULL)) == NULL)
+		 return EXIT_FAILURE;
+	GMT_Call_Module(API, "begin", GMT_MODULE_CMD, "testapi_modern jpg");
+	GMT_Call_Module(API, "basemap", GMT_MODULE_CMD, "-BWESN -Bxa30mg30m -Bya20mg20m -JM7.27/42.27/16.25c -R5.5/41.425/9.0/43.1+r");
+	GMT_Call_Module(API, "end", GMT_MODULE_CMD, "show");
+	/* Destroy session */
+	if (GMT_Destroy_Session (API))
+		return EXIT_FAILURE;
+}

--- a/src/testapi_modern.c
+++ b/src/testapi_modern.c
@@ -2,6 +2,8 @@
  * Problem seems to be that gmt begin comes after GMT_Create_Session in the
  * code so there are orientation and page size issues. In gmt end, the
  * psconvert call is missing the -A.
+ *
+ * See test script api/apimodern.sh
  */
 
 #include "gmt.h"
@@ -12,8 +14,8 @@ int main () {
 	/* Initialize the GMT session */
 	if ((API = GMT_Create_Session ("testapi_modern", 2, GMT_SESSION_RUNMODE, NULL)) == NULL)
 		 return EXIT_FAILURE;
-	GMT_Call_Module(API, "begin", GMT_MODULE_CMD, "testapi_modern jpg");
-	GMT_Call_Module(API, "basemap", GMT_MODULE_CMD, "-BWESN -Bxa30mg30m -Bya20mg20m -JM7.27/42.27/16.25c -R5.5/41.425/9.0/43.1+r");
+	GMT_Call_Module(API, "begin", GMT_MODULE_CMD, "apimodern ps");
+	GMT_Call_Module(API, "basemap", GMT_MODULE_CMD, "-BWESN -Bafg -JM7.27/42.27/16.25c -R5.5/41.425/9.0/43.1+r");
 	GMT_Call_Module(API, "end", GMT_MODULE_CMD, "show");
 	/* Destroy session */
 	if (GMT_Destroy_Session (API))

--- a/test/api/apimodern.sh
+++ b/test/api/apimodern.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# 
+# Purpose: This is a CLI version of what testapi_modern.c should produce
+# Fails until we fix the page size and orientation from the C program.
+
+# This is the fixed baseline DVC plot we will compare with
+#gmt begin apimodern ps
+#	gmt set PS_MEDIA letter
+#	gmt basemap -BWESN -Bafg -JM7.27/42.27/16.25c -R5.5/41.425/9.0/43.1+r
+#gmt end show
+
+# Run the C code to produce apimodern.ps
+testapi_modern
+ps=apimodern.ps

--- a/test/baseline/api.dvc
+++ b/test/baseline/api.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b985dda50abc7f6dcceb4a8848e0a83a.dir
-  size: 3041741
-  nfiles: 16
+- md5: b02bb074d97d27aaec4f9d515ebfdc00.dir
+  size: 3066737
+  nfiles: 17
   path: api


### PR DESCRIPTION
This makes sure the issue #4518 reported by @sarzeaud is preserved.  The test fails for now (well we need to add an actual comparison of the output) but this lets us play in the debugger. We need to determine why **-A** is not given to **psconvert** in **gmt end**. Passing the **GMT_SESSION_RUNMODE** is not enough.

**Note**: Any C program that is called `testapi_*.c` will automatically be built.