### PR TITLE
Fix tiny typo in docs of "L" of "gmtselect"

### DIFF
--- a/doc/rst/source/gmtselect.rst
+++ b/doc/rst/source/gmtselect.rst
@@ -155,7 +155,7 @@ Optional Arguments
     distances are compared to *dist*. Append **+p** to ensure only points
     whose orthogonal projections onto the nearest line-segment fall
     within the segments endpoints [Default considers points "beyond" the
-    line's endpoints.
+    line's endpoints].
 
 .. _-N:
 

--- a/doc/rst/source/gmtselect.rst
+++ b/doc/rst/source/gmtselect.rst
@@ -154,7 +154,7 @@ Optional Arguments
     points, as determined by :term:`PROJ_LENGTH_UNIT`) before Cartesian
     distances are compared to *dist*. Append **+p** to ensure only points
     whose orthogonal projections onto the nearest line-segment fall
-    within the segments endpoints [Default considers points "beyond" the
+    within the segment's endpoints [Default considers points "beyond" the
     line's endpoints].
 
 .. _-N:


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a tiny typo in the documentation of **L** of `gmtselect`. 

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
