### PR TITLE
WIP Allow plot -Z to also control line/polygon transparency

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -32,7 +32,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *value*\|\ *file*]
+[ |-Z|\ *value*\|\ *file*]\ [**+t**\|\ **T**] ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -187,7 +187,8 @@ Optional Arguments
     Note that this module will search for |-G| and |-W| strings in all the
     segment headers and let any values thus found over-ride the command line settings.
     If |-Z| is set, use **-G+z** to assign fill color via **-C**\ *cpt* and the
-    *z*-values obtained. Finally, if *fill* = *auto*\ [*-segment*] or *auto-table* then
+    *z*-values obtained (same if transparency is set via |-Z|). Finally, if
+    *fill* = *auto*\ [*-segment*] or *auto-table* then
     we will cycle through the fill colors implied by :term:`COLOR_SET` and change on a per-segment
     or per-table basis.  Any *transparency* setting is unchanged.
 
@@ -272,7 +273,7 @@ Optional Arguments
     at the end of the pen specification.
     See the `Vector Attributes`_ for more information.
     If |-Z| is set, then append **+z** to |-W| to assign pen color via **-C**\ *cpt* and the
-    *z*-values obtained.  Finally, if pen *color* = *auto*\ [*-segment*] or *auto-table* then
+    *z*-values obtained (same if transparency is set via |-Z|).  Finally, if pen *color* = *auto*\ [*-segment*] or *auto-table* then
     we will cycle through the pen colors implied by :term:`COLOR_SET` and change on a per-segment
     or per-table basis.  The *width*, *style*, or *transparency* settings are unchanged.
 
@@ -283,11 +284,16 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ *value*\|\ *file*
+**-Z**\ *value*\|\ *file*\ [**+t**\|\ **T**]
     Instead of specifying a symbol or polygon fill and outline color via |-G| and |-W|,
     give both a *value* via |-Z| and a color lookup table via |-C|.  Alternatively,
-    give the name of a *file* with one z-value (read from the last column) for each polygon in the input data.
-    To apply the color obtained to a fill, use **-G+z**; to apply it to the pen color, append **+z** to |-W|.
+    give the name of a *file* with one z-value (read from the last column) for each polygon
+    or line in the input data. To apply the color obtained to a fill, use **-G+z**; to
+    apply it to the pen color, append **+z** to |-W|.
+    To just modulate the transparency of the polygon or line instead, append **+t** and the
+    *z*-value will be assumed to be transparency in the 0-100 % range.  Finally, append **+T**
+    and supply two columns via *file*: The last column must be the *z*-value while the next
+    to last column must have transparencies (in 0-100 % range).
 
 .. include:: explain_-aspatial.rst_
 

--- a/doc/rst/source/psxy.rst
+++ b/doc/rst/source/psxy.rst
@@ -34,7 +34,7 @@ Synopsis
 [ |-W|\ [*pen*][*attr*] ]
 [ |SYN_OPT-X| ]
 [ |SYN_OPT-Y| ]
-[ |-Z|\ *value* [**+f**\|\ **l**] ]
+[ |-Z|\ *value*\ [**+t**\|\ **T**] ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -88,7 +88,7 @@ To plot a point with color dictated by the *t.cpt* file for the *z*-value 65, tr
 
    ::
 
-    echo 175 30 | gmt psxy -R150/200/20/50 -JX15c -Sc0.5c -Zf65 -Ct.cpt > map.ps
+    echo 175 30 | gmt psxy -R150/200/20/50 -JX15c -Sc0.5c -Z65 -Ct.cpt > map.ps
 
 To plot the data in the file misc.txt as symbols determined by the code in
 the last column, and with size given by the magnitude in the 4th column,


### PR DESCRIPTION
Currently, **-Z**_file_ is a **plot** (and **plot3d**) option used to assign colours to line segments or polygons via a CPT(z) lookup using the last column in _file_.  The number of lines in _file_ must match the number of lines or polygons. This PR adds two new modifiers to **-Z**:

**+t** Instead of modifying the colour, interpret the _z_-value as transparency in 0-100% range.
**+T** Expect the _two_ last columns in _file_ to have _transparency_ and _z_-value and change these on a per-segment basis.

This PR follows from the discussion on the [forum](https://forum.generic-mapping-tools.org/t/how-to-pass-transparency-values-for-individual-lines-in-psxy/4199).

Here is a simple example of the four ways to draw lines w/wo color and/or with/without transparency:

```
#!/bin/bash
cat << EOF > z.txt
# [transparency] z-value
35	2
85	8
EOF
cat << EOF > tr.txt
# transparency
35
85
EOF
cat << EOF > t.txt
> first header
0	1
1	2
> yet another
3	2
4	3
EOF
gmt begin linetransp png
	gmt makecpt -T0/10 -Cjet
	gmt subplot begin 2x2 -Fs8c -R-1/5/-1/5
	# Constant red lines
	gmt plot -W15p,red t.txt -c
	# Colored lines, no transparency
	gmt plot -W15p+z t.txt -C -Zz.txt -c
	# Transparent lines, no color
	gmt plot -W15p+z t.txt -Ztr.txt+t  -c
	# Transparent and colored lines
	gmt plot -W15p+z -Zz.txt+T t.txt -C -c
	gmt subplot end
gmt end show

```

![linetransp](https://github.com/GenericMappingTools/gmt/assets/26473567/7a979bb7-472c-48eb-b350-38cee522d6f2)

Once finalised I will do the same to **plot3d**.