### PR TITLE
CI: Do not build the source code for doc-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,16 @@ name: Build
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '!doc/**/CMakeLists.txt'
   push:
     branches:
       - master
       - 6.[0-9]+
+    paths-ignore:
+      - 'doc/**'
+      - '!doc/**/CMakeLists.txt'
 
 defaults:
   run:

--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -6,6 +6,9 @@ on:
       - master
       - '[0-9]+.[0-9]+'
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '!doc/**/CMakeLists.txt'
 
 name: Code Validator
 


### PR DESCRIPTION
**Description of proposed changes**

Inspired by https://github.com/GenericMappingTools/gmt/pull/7782#issuecomment-1704226376.

It makes no sense to build the GMT source code if someone makes minor changes to the docs.