### PR TITLE
Remove the unsupported SVG format

### DIFF
--- a/doc/rst/source/psconvert.rst
+++ b/doc/rst/source/psconvert.rst
@@ -38,7 +38,7 @@ Description
 -----------
 
 **psconvert** converts one or more PostScript files to other formats
-(BMP, EPS, JPEG, PDF, PNG, PPM, SVG, TIFF) using Ghostscript. Input file
+(BMP, EPS, JPEG, PDF, PNG, PPM, TIFF) using Ghostscript. Input file
 names are read from the command line or from a file that lists them. The
 size of the resulting images is determined by the BoundingBox (or
 HiResBoundingBox, if present). As an option, a tight (HiRes)BoundingBox
@@ -190,12 +190,12 @@ Optional Arguments
 
 .. _-T:
 
-**-Tb**\|\ **e**\|\ **E**\|\ **f**\|\ **F**\|\ **j**\|\ **g**\|\ **G**\|\ **m**\|\ **s**\|\ **t**\ [**+m**][**+q**\ *quality*]
+**-Tb**\|\ **e**\|\ **E**\|\ **f**\|\ **F**\|\ **j**\|\ **g**\|\ **G**\|\ **m**\|\ **t**\ [**+m**][**+q**\ *quality*]
     Sets the output format, where **b** means BMP, **e** means EPS,
     **E** means EPS with PageSize command, **f** means PDF, **F** means
     multi-page PDF, **j** means JPEG, **g** means PNG, **G** means
     transparent PNG (untouched regions are transparent), **m** means
-    PPM, **s** means SVG, and **t** means TIFF [default is JPEG]. To **bjgt** you can
+    PPM, and **t** means TIFF [default is JPEG]. To **bjgt** you can
     append **+m** in order to get a monochrome (grayscale) image. To **j** you can
     append **+q** to change JPEG quality in 0-100 range [90]. The EPS format can be
     combined with any of the other formats. For example, **-Tef**
@@ -330,23 +330,18 @@ exists in a PostScript file that is included in another document, this can wreak
 havoc on the printing or viewing of the overall document. Hence, **-TE** should only
 be used for "standalone" PostScript files.
 
-Although PDF and SVG are also vector formats, the |-E| option has an effect on
+Although PDF is also vector formats, the |-E| option has an effect on
 the resolution of pattern fills and fonts that are stored as bitmaps in
 the document. **psconvert** therefore uses a larger default resolution
-when creating PDF and SVG files. |-E| also determines the resolution of the
+when creating PDF files. |-E| also determines the resolution of the
 boundingbox values used to indicate the size of the output PDF.
-In order to obtain high-quality PDF or SVG files, the
+In order to obtain high-quality PDF files, the
 */prepress* options are in effect, allowing only loss-less DEFLATE
 compression of raster images embedded in the PostScript file.
 
 Although **psconvert** was developed as part of the GMT, it can be
 used to convert PostScript files created by nearly any graphics
 program. However, **-A+u** is GMT-specific.
-
-The **ghostscript** program continues to be developed and occasionally its
-developers make decisions that affect **psconvert**.  As of version 9.16 the
-SVG device has been removed.  Fortunately, quality SVG graphics can be obtained
-by first converting to PDF and then install and use the package **pdf2svg**.
 
 See :ref:`include-gmt-graphics` of the **GMT Technical Reference** for more
 information on how **psconvert** is used to produce graphics that can be

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -576,7 +576,7 @@ static void *New_Ctrl (struct GMT_CTRL *GMT) {	/* Allocate and initialize a new 
 #ifdef JULIA_GHOST_JLL
 	/* In Julia when using the precompiled Artifacts, the Ghost is also shipped with but when gmt_init makes
 	   calls to psconvert it doesn't set -G with the path to the Ghostscript_jll executable and those processes
-	   fail (mostly modern mode stuff). The solution is to try to read the gs path from ~/.gmt/ghost_jll_path.txt 
+	   fail (mostly modern mode stuff). The solution is to try to read the gs path from ~/.gmt/ghost_jll_path.txt
 	   This code should only be executed by binaries created Julia's BinaryBuilder.
 	 */
 	bool found_gs = false;
@@ -745,7 +745,6 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "G: Select PNG (transparent where nothing is plotted).");
 	GMT_Usage (API, 3, "j: Select JPEG.");
 	GMT_Usage (API, 3, "m: Select PPM.");
-	GMT_Usage (API, 3, "s: Select SVG [if supported by your Ghostscript version].");
 	GMT_Usage (API, 3, "t: Select TIF.");
 	GMT_Usage (API, -2, "Two raster modifiers may be appended:");
 	GMT_Usage (API, 3, "+m For b, g, j, and t, make a monochrome (grayscale) image [color].");


### PR DESCRIPTION
**Description of proposed changes**

SVG is no longer supported after gs 9.16, so remove it from the psconvert documentation. The source code remain unchanged.

Closes https://github.com/GenericMappingTools/gmt/issues/6988.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
