### PR TITLE
Fix parser error in movie

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -669,7 +669,8 @@ GMT_LOCAL unsigned int movie_parse_common_item_attributes (struct GMT_CTRL *GMT,
 		}
 		I->kind = toupper ((int)I->kind);	/* Use upper case B-F to indicate that labeling is requested */
 		I->n_labels = (strchr ("EF", I->kind)) ? 2 : 1;
-		if (I->mode == MOVIE_LABEL_IS_ELAPSED && gmt_get_modifier (arg, 'z', string)) {
+		if (I->mode == MOVIE_LABEL_IS_ELAPSED && (gmt_get_modifier (arg, 's', string) || gmt_get_modifier (arg, 'z', string))) {
+			/* Changed from +z to +s but we do backwards compatibility here */
 			/* Gave frame time length-scale */
 			I->scale = atof (string);
 		}


### PR DESCRIPTION
Many moons ago we streamlined some of the **movie** modifiers to match other modules with similar modifiers.  One was that I had used **+z**_scale_ to scale from frame number to, say, seconds. Forgot to change the parsing for **-Pae****+s** from **+z** so we got no scaling and test _movie_indicator_de_ failed. Do backwards compatibility so that **+z** is also accepted (but not documented).
