### PR TITLE
Fi remote name for day image and spelling

### DIFF
--- a/test/baseline/grdview.dvc
+++ b/test/baseline/grdview.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a15b9b1652e49f1e0b7c9727d7c5a08d.dir
+- md5: 2cf22317b740e82bb431d74b025e7986.dir
   size: 6768275
   nfiles: 11
   path: grdview

--- a/test/grdview/texture2_classic.sh
+++ b/test/grdview/texture2_classic.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Drape a texture image on top of 3-D topo relief. Once with a plain image and another with a georeferenced one. 
 
-ps=texture2_calssic.ps
+ps=texture2_classic.ps
 gmt grdcut @earth_relief_01m_p -R0/10/0/10 -Gtopo.nc
 gmt grdview topo.nc -I+nt0.5 -JM10c -JZ4c -p145/35 -G@wood_texture.jpg -Baf -BWSne -Qi100 -P -K -Y2.0c > $ps
-gmt grdview topo.nc -I+nt0.5 -JM10c -JZ4c -p145/35 -G@earth_day_01m_p.tif -Baf -BWSne -Qi100 -O -Y10.0c >> $ps
+gmt grdview topo.nc -I+nt0.5 -JM10c -JZ4c -p145/35 -G@earth_day_01m -Baf -BWSne -Qi100 -O -Y10.0c >> $ps

--- a/test/grdview/texture2_modern.sh
+++ b/test/grdview/texture2_modern.sh
@@ -4,5 +4,5 @@
 gmt begin texture2_modern ps
 	gmt grdcut @earth_relief_01m_p -R0/10/0/10 -Gtopo.nc
 	gmt grdview topo.nc -I+nt0.5 -JM10c -JZ4c -p145/35 -G@wood_texture.jpg -Baf -BWSne -Qi100
-	gmt grdview topo.nc -I+nt0.5 -JM10c -JZ4c -p145/35 -G@earth_day_01m_p.tif -Baf -BWSne -Qi100 -Y10.0c
+	gmt grdview topo.nc -I+nt0.5 -JM10c -JZ4c -p145/35 -G@earth_day_01m -Baf -BWSne -Qi100 -Y10.0c
 gmt end show


### PR DESCRIPTION
Two minor things:

1. Remove "_p.tif" from a reference to the day image in two scripts
2. Rename texture2_calssic.* (and PS) to texture2_classic.*
