### PR TITLE
Add a uggly patch to workaround a GDAL bug that misidentifies uint8 with CFloat64

### DIFF
--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -1058,6 +1058,9 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 
 	switch (GDALGetRasterDataType(hBand)) {
 		case GDT_Byte:
+			/* Because of a GDAL bug that misidentifies uint8 as GDT_CFloat64 (enum 14) we are forced to do this
+			   ugly patch. Make this conditional on a GDAL version when it is fixed upstream. */
+		case 14:
 			if (prhs->c_ptr.active)	/* We have a pointer with already allocated memory ready to use */
 				Ctrl->UInt8.data = prhs->c_ptr.grd;
 			else if ((Ctrl->UInt8.data = gmt_M_memory (GMT, NULL, n_alloc, uint8_t)) == NULL)
@@ -1245,6 +1248,9 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 
 				switch (GDALGetRasterDataType(hBand)) {
 					case GDT_Byte:
+						/* Because of a GDAL bug that misidentifies uint8 as GDT_CFloat64 we are forced to do this
+						   ugly patch. Make this conditional on a GDAL version when it is fixed upstream. */
+					case 14:
 						/* This chunk is kind of complicated because we want to take into account several different cases */
 						for (n = 0; n < nXSize[piece]; n++) {
 							if (do_BIP)			/* Vector for Pixel Interleaving */


### PR DESCRIPTION
Our `WL_example_3` test is failing because now GDAL badly identifies the uint8 subdatasets. It says the layer is a complex float64. 

This is not easy to prove because `gdal_translate` is able to deal with that layer just file (how?). I have posted this in the GDAL mailing list but this time there was no answer, which is very rare but happened.

Note that I hit the same bug with GMT.jl that uses a completely different code (accesses the GDAL lib directly).