### PR TITLE
Enhance triangulate -S with modifier +z so we can write -Zvalue in headers

### DIFF
--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -175,9 +175,9 @@ Optional Arguments
     Incompatible with |-Q|. Alternatively, use modifier **+z** to instead
     request that **-Z**\ *zvalue* is placed in the segment headers, where
     *zvalue* is the mean of the three nodes' *z* values. Append **l**
-    (lowest value), **m** (median), **p** (model) or **u** upper value
+    (lowest value), **m** (median), **p** (mode) or **u** (upper value)
     to select another representative *zvalue* [Default is **a** for mean].
-    Implies |-Z|.
+    **Note**: Modifier **+z** implies |-Z|.
 
 .. _-T:
 
@@ -195,7 +195,7 @@ Optional Arguments
 
 **-Z**
     Controls whether we read (*x,y*) or (*x,y,z*) data and if *z* should be
-    output when |-M| or |-S| are used [Read (*x,y*) only].
+    output when |-M| or |-S| (without **+z**) are used [Read (*x,y*) only].
 
 .. |Add_-bi| replace:: [Default is 2 input columns].
 .. include:: explain_-bi.rst_

--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -177,6 +177,7 @@ Optional Arguments
     *zvalue* is the mean of the three nodes' *z* values. Append **l**
     (lowest value), **m** (median), **p** (model) or **u** upper value
     to select another representative *zvalue* [Default is **a** for mean].
+    Implies |-Z|.
 
 .. _-T:
 

--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -25,7 +25,7 @@ Synopsis
 [ |-N| ]
 [ |-Q|\ [**n**] ]
 [ |SYN_OPT-R| ]
-[ |-S|\ [*n*]  ]
+[ |-S|\ [*first*][**+z**\ [**a**\|\ **l**\|\ **m**\|\ **p**\|\ **u**]] ]
 [ |-T| ]
 [ |SYN_OPT-V| ]
 [ |-Z| ]
@@ -167,9 +167,16 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ [*n*]
-    Output triangles as polygon segments separated by a segment header record. Append *n*, where *n* is an integer,
-    to report the polygon numbers start counting at *n* [Default counts from zero]. Requires Delaunay triangulation.
+**-S**\ [*first*][**+z**\ [**a**\|\ **l**\|\ **m**\|\ **p**\|\ **u**]]
+    Output triangles as polygon segments separated by a segment header
+    record which contains node numbers *a-b-c* and **-Z**\ *polynumber*.
+    Optionally, append *first*, where *first* is an integer, to report
+    the polygon numbers by counting from *first* [Default starts at zero].
+    Incompatible with |-Q|. Alternatively, use modifier **+z** to instead
+    request that **-Z**\ *zvalue* is placed in the segment headers, where
+    *zvalue* is the mean of the three nodes' *z* values. Append **l**
+    (lowest value), **m** (median), **p** (model) or **u** upper value
+    to select another representative *zvalue* [Default is **a** for mean].
 
 .. _-T:
 

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -344,7 +344,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDTRACK_CTRL *Ctrl, struct GMT_O
 					while (gmt_getmodopt (GMT, 'C', c, "adflrv", &pos, p, &n_errors) && n_errors == 0) {
 						switch (p[0]) {
 							case 'a': Ctrl->C.mode |= GMT_ALTERNATE; break;		/* Select alternating direction of cross-profiles */
-							case 'f': Ctrl->C.mode |= GMT_FIXED_AZIM;	/* Deliberatily fall through to get fixed azimuth */
+							case 'f': Ctrl->C.mode |= GMT_FIXED_AZIM;	/* Deliberately fall through to get fixed azimuth */
 							case 'd': Ctrl->C.deviation = atof (&p[1]); break;		/* Less than orthogonal vy given deviation */
 							case 'l': Ctrl->C.mode |= GMT_LEFT_ONLY; break;		/* cross-profile starts at line and go to left side only */
 							case 'r': Ctrl->C.mode |= GMT_RIGHT_ONLY; break;	/* cross-profile starts at line and go to right side only */

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -42,6 +42,13 @@
 #define THIS_MODULE_NEEDS	"r"
 #define THIS_MODULE_OPTIONS "-:>JRVbdefhiqrsw" GMT_OPT("Hm")
 
+enum triangulate_enum_stat {TRI_NONE = 0,	/* No +z or +g given */
+	TRI_MEAN,			/* Use median instead */
+	TRI_MEDIAN,			/* Use median instead */
+	TRI_MODE,			/* Use mode (LMS) instead */
+	TRI_LOWER,			/* Use lowest value encountered instead */
+	TRI_UPPER};			/* Use highest value encountered instead */
+
 struct TRIANGULATE_CTRL {
 	struct TRIANGULATE_Out {	/* -> */
 		bool active;
@@ -89,9 +96,11 @@ struct TRIANGULATE_CTRL {
 		bool active;
 		unsigned int mode;
 	} Q;
-	struct TRIANGULATE_S {	/* -S */
+	struct TRIANGULATE_S {	/* -S[<start>][+z[a|l|m|p|u]][+g] */
 		bool active;
-		int firstpol;		/* Number of first polygon */
+		bool color;	/* If +g given */
+		int64_t firstpol;		/* Number of first polygon [0] */
+		enum triangulate_enum_stat mode;	/* Compute a <value> in header depending on mode */
 	} S;
 	struct TRIANGULATE_T {	/* -T */
 		bool active;
@@ -112,6 +121,25 @@ enum curve_enum {	/* Indices for coeff array for normalization */
 	GMT_V,
 	GMT_U = GMT_H
 };
+
+GMT_LOCAL double triangulate_median3 (double three[]) {
+	/* Fast median of three values instead of calling gmt_median().
+	 * https://stackoverflow.com/questions/17158667/minimum-no-of-comparisons-to-find-median-of-3-numbers
+	 */
+	double x = three[0] - three[1];
+	double y = three[1] - three[2], z;
+	if ((x * y) > 0.0) return three[1];
+	z = three[0] - three[2];
+	if ((x * z) > 0.0) return three[2];
+	return three[0];
+}
+
+GMT_LOCAL double triangulate_mode3 (double three[]) {
+	/* Fast mode of three values instead of calling gmt_mode(). */
+	if (three[0] == three[1] || three[0] == three[2]) return (three[0]);
+	if (three[1] == three[2]) return (three[1]);
+	return triangulate_median3 (three);	/* All three are different so return median instead */
+}
 
 GMT_LOCAL int triangulate_compare_edge (const void *p1, const void *p2) {
 	const struct TRIANGULATE_EDGE *a = p1, *b = p2;
@@ -146,7 +174,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 #ifdef NNN_MODE
 	GMT_Usage (API, 0, "usage: %s [<table>] [-A] [-C<slopegrid>] [-Dx|y] [-E<empty>] [-G%s] [%s] [%s] [-L<indextable>[+b]] [-M] [-N] "
-		"[-Q[n]] [%s] [-S[<n>]] [-T] [%s] [-Z] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n", name, GMT_OUTGRID,
+		"[-Q[n]] [%s] [-S[<n>][+z[a|l|m|p|u]]] [-T] [%s] [-Z] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n", name, GMT_OUTGRID,
 		GMT_I_OPT, GMT_J_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT,
 		GMT_qi_OPT, GMT_r_OPT, GMT_s_OPT, GMT_w_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 #else
@@ -188,8 +216,15 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Append n to produce closed Voronoi polygons.");
 #endif
 	GMT_Option (API, "R");
-	GMT_Usage (API, 1, "\n-S Output triangle polygons as multiple segments separated by segment headers. Append 'n',"
-		"where 'n' is an integer, to report the polygon numbers start counting at n [Default counts from zero]. Cannot be used with -Q.");
+	GMT_Usage (API, 1, "\n-S[<first>][+z[a|l|m|p|u]]");
+	GMT_Usage (API, -2, "Output triangle polygons as multiple segments separated by segment headers. Append <first>,"
+		"where <first> is an integer, to report the polygon numbers start counting at n [Default counts from zero]. Cannot be used with -Q. "
+		"Alternatively, compute representative value for the triplet z-values at triangle nodes via modifier +z.  Modes can be");
+	GMT_Usage (API, 3, "a: The mean of triplet [Default].");
+	GMT_Usage (API, 3, "l: The lower value of triplet.");
+	GMT_Usage (API, 3, "m: The median of triplet.");
+	GMT_Usage (API, 3, "p: The mode of triplet.");
+	GMT_Usage (API, 3, "u: The upper value of triplet.");
 	GMT_Usage (API, 1, "\n-T Output triangles or polygons even if gridding has been selected with -G. Default behavior "
 		"is to produce a grid based on the triangles or polygons only.");
 	GMT_Option (API, "V");
@@ -307,11 +342,25 @@ static int parse (struct GMT_CTRL *GMT, struct TRIANGULATE_CTRL *Ctrl, struct GM
 				break;
 			case 'S':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
-				//if (strchr (opt->arg, '1')) Ctrl->S.onebased = true;
+				if ((c = strstr (opt->arg, "+z"))) {
+					switch (c[2]) {
+						case 'a': case '\0': Ctrl->S.mode = TRI_MEAN; break;	/* Use mean of three node z-values [Default] */
+						case 'l': Ctrl->S.mode = TRI_LOWER; break;	/* Use mean of three node z-values */
+						case 'm': Ctrl->S.mode = TRI_MEDIAN; break;	/* Use mean of three node z-values */
+						case 'p': Ctrl->S.mode = TRI_MODE; break;	/* Use mean of three node z-values */
+						case 'u': Ctrl->S.mode = TRI_UPPER; break;	/* Use mean of three node z-values */
+						default:
+							GMT_Report (API, GMT_MSG_ERROR, "Option -S: Modifier +z given unavailable statistic %s.\n", &c[2]);
+							n_errors++;
+							break;
+					}
+					c[0] = '\0';	/* Truncate the modifier */
+				}
 				if (opt->arg[0])
-					Ctrl->S.firstpol = atoi(opt->arg);
+					Ctrl->S.firstpol = atol (opt->arg);
 				else
 					Ctrl->S.firstpol = 0;
+				if (c) c[0] = '+';	/* Restore chopped off modifier */
 				break;
 			case 'T':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
@@ -333,22 +382,22 @@ static int parse (struct GMT_CTRL *GMT, struct TRIANGULATE_CTRL *Ctrl, struct GM
 	n_errors += gmt_check_binary_io (GMT, 2);
 	n_errors += gmt_M_check_condition (GMT, Ctrl->L.binary && !GMT->common.b.active[GMT_IN], "Option -L: Cannot imply binary node input if main input is not also binary (see -bi)\n");
 	n_errors += gmt_M_check_condition (GMT, GMT->common.R.active[ISET] && (GMT->common.R.inc[GMT_X] <= 0.0 ||
-	                                   GMT->common.R.inc[GMT_Y] <= 0.0), "Option -I: Must specify positive increment(s)\n");
+									   GMT->common.R.inc[GMT_Y] <= 0.0), "Option -I: Must specify positive increment(s)\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->A.active && !Ctrl->S.active, "Option -A: Requires -S\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->A.active && Ctrl->Q.active, "Option -A: Not compatible with -Q\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && !Ctrl->C.file, "Option -C: Must append slope grid file name\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->G.active && (GMT->common.R.active[ISET] + GMT->common.R.active[RSET]) != 2,
-	                                   "Must specify -R, -I, -G for gridding\n");
+									   "Must specify -R, -I, -G for gridding\n");
 	(void)gmt_M_check_condition (GMT, !Ctrl->G.active && GMT->common.R.active[ISET], "Option -I: not needed when -G is not set\n");
 	(void)gmt_M_check_condition (GMT, !(Ctrl->G.active || Ctrl->Q.active) && GMT->common.R.active[RSET],
-	                             "Option -R not needed when -G or -Q are not set\n");
+								 "Option -R not needed when -G or -Q are not set\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && Ctrl->Q.active, "Option -S: Cannot be used with -Q\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->N.active && !Ctrl->G.active, "Option -N: Only required with -G\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active && !GMT->common.R.active[RSET], "Option -Q: Requires -R\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active && Ctrl->L.active, "Option -L: Cannot be used with -Q\n");
 	n_errors += gmt_M_check_condition (GMT, (Ctrl->M.active + Ctrl->N.active + Ctrl->S.active) > 1, "Can only use one of -M, -N, -S at the same time since all write to stdout\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active && GMT->current.setting.triangulate == GMT_TRIANGLE_WATSON,
-	                                   "Option -Q: Requires Shewchuk triangulation algorithm\n");
+									   "Option -Q: Requires Shewchuk triangulation algorithm\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && (GMT->common.R.active[RSET] || GMT->common.R.active[ISET] ||
 									   GMT->common.R.active[GSET]),
 									   "Option -C: No -R -I [-r] allowed, domain given by slope grid\n");
@@ -435,10 +484,14 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 	triplets[GMT_OUT] = (n_output == 3);
 	if (Ctrl->G.active && !Ctrl->S.active && !Ctrl->T.active && !Ctrl->N.active) do_output = false;	/* If gridding then we require S, -T or -N to do output */
 	if ((error = GMT_Set_Columns (API, GMT_OUT, n_output, GMT_COL_FIX_NO_TEXT)) != 0) Return (error);
-	n_input = (Ctrl->G.active || Ctrl->Z.active) ? 3 : 2;
+	n_input = (Ctrl->G.active || Ctrl->S.mode || Ctrl->Z.active) ? 3 : 2;
 	if (n_output > n_input) triplets[GMT_OUT] = false;	/* No can do. */
 	if (Ctrl->C.active) n_input += 2;	/* Curve requires the horizontal and vertical uncertainties */
 	triplets[GMT_IN] = (n_input == 3 || n_input == 5);	/* Either x,y,z or x,y,z,h,v input */
+	if (Ctrl->S.mode && n_input < 3) {
+		GMT_Report (API, GMT_MSG_ERROR, "Option -S: Your modifier(s) require (x, y, z) records.\n");
+		Return (GMT_RUNTIME_ERROR);
+	}
 
 	if (Ctrl->G.active && GMT->common.R.active[RSET] && GMT->common.J.active) { /* Gave -R -J */
 		map_them = true;
@@ -871,7 +924,7 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 		}
 		else if (Ctrl->S.active)  {	/* Write triangle polygons */
 			char area_txt[GMT_LEN64] = {""}, a_format[GMT_LEN128] = {""};
-			int first = 0 + Ctrl->S.firstpol;
+			int64_t first = Ctrl->S.firstpol;
 			if (GMT_Set_Geometry (API, GMT_OUT, GMT_IS_POLY) != GMT_NOERROR) {	/* Sets output geometry */
 				error = API->error;	goto time_to_let_go;
 			}
@@ -879,7 +932,7 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 			if (Ctrl->A.active)	/* Initialize the area format string */
 				sprintf (a_format, " Area: %s", GMT->current.setting.format_float_out);
 
-			if (triplets[GMT_OUT]) {
+			if (triplets[GMT_OUT] && Ctrl->S.mode == TRI_NONE) {
 				double z_mean;
 				for (i = ij = 0; i < np; i++, ij += 3) {
 					z_mean = (zz[link[ij]] + zz[link[ij+1]] + zz[link[ij+2]]) / 3;
@@ -899,9 +952,35 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 					GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 				}
 			}
-			else {
+			else {	/* Write polygons with various segment header information */
 				for (i = ij = 0; i < np; i++, ij += 3) {
-					sprintf (record, "Polygon %d-%d-%d -Z%" PRIu64, link[ij], link[ij+1], link[ij+2], i+first);
+					sprintf (record, "Polygon %d-%d-%d ", link[ij], link[ij+1], link[ij+2]);
+					if (Ctrl->S.mode) {
+						double z_triangle, z_node[3];
+						for (k = 0; k < 3; k++) z_node[k] = zz[link[ij+k]];	/* Get the three vertices' z-values */
+						switch (Ctrl->S.mode) {
+							case TRI_LOWER:	/* Set z to the lowest of the three nodes */
+								z_triangle = MIN (z_node[0], MIN (z_node[1], z_node[2]));
+								break;
+							case TRI_MEAN:	/* Set z to the mean of the three nodes */
+								z_triangle = (z_node[0] + z_node[1] + z_node[2]) / 3.0;
+								break;
+							case TRI_MEDIAN:	/* Set z to the median of the three nodes */
+								z_triangle = triangulate_median3 (z_node);
+								break;
+							case TRI_MODE:	/* Set z to the mode of the three nodes */
+								z_triangle = triangulate_mode3 (z_node);
+								break;
+							case TRI_UPPER:	/* Set z to the highest of the three nodes */
+								z_triangle = MAX (z_node[0], MAX (z_node[1], z_node[2]));
+								break;
+							default:	/* Just for Coverity */ 
+								break;
+						}
+						sprintf (record, "Polygon %d-%d-%d -Z%g", link[ij], link[ij+1], link[ij+2], z_triangle);
+					}
+					else
+						sprintf (record, "Polygon %d-%d-%d -Z%" PRIu64, link[ij], link[ij+1], link[ij+2], i+first);
 					if (Ctrl->A.active) {	/* Compute and report area */
 						double area = 0.5 * ((xx[link[ij]] - xx[link[ij+2]]) * (yy[link[ij+1]] - yy[link[ij]]) - (xx[link[ij]] - xx[link[ij+1]]) * (yy[link[ij+2]] - yy[link[ij]]));
 						sprintf (area_txt, a_format, area);

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -958,7 +958,7 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 			else {	/* Write polygons with various segment header information */
 				for (i = ij = 0; i < np; i++, ij += 3) {
 					sprintf (record, "Polygon %d-%d-%d ", link[ij], link[ij+1], link[ij+2]);
-					if (Ctrl->S.mode) {
+					if (Ctrl->S.mode > TRI_POLY) {
 						double z_triangle, z_node[3];
 						for (k = 0; k < 3; k++) z_node[k] = zz[link[ij+k]];	/* Get the three vertices' z-values */
 						switch (Ctrl->S.mode) {
@@ -992,6 +992,7 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 					GMT_Put_Record (API, GMT_WRITE_SEGMENT_HEADER, record);
 					for (k = 0; k < 3; k++) {	/* Three vertices */
 						out[GMT_X] = xx[link[ij+k]];	out[GMT_Y] = yy[link[ij+k]];
+						if (n_output == 3) out[GMT_Z] = zz[link[ij+k]];
 						GMT_Put_Record (API, GMT_WRITE_DATA, Out);	/* Write this to output */
 					}
 					/* Explicitly close the polygon */

--- a/test/baseline/triangulate.dvc
+++ b/test/baseline/triangulate.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a78dc2d01d33ec4140a4a884d8088a72.dir
-  size: 53346
-  nfiles: 2
+- md5: 2962a196119a67e02c8242fb30ba1b59.dir
+  size: 107323
+  nfiles: 3
   path: triangulate

--- a/test/triangulate/tripatch.sh
+++ b/test/triangulate/tripatch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Test that -S+z<mode> works using mean, median, lower and upper
+# triplet value to assign color
+#
+gmt begin tripatch ps
+	# Make CPT with suitable range
+	T=$(gmt info -T25+c2 @Table_5_11.txt)
+	gmt makecpt -Cjet $T
+	gmt subplot begin 2x2 -M0.1c -Fs8c/0 -Scb -Srl -A+jBL -R0/6.5/-0.2/6.5 -JX8c -BWSne -T"Colored Triangulation"
+	gmt subplot set 0 -A"Mean"
+	gmt triangulate @Table_5_11.txt -S+za | gmt plot -C -G+z -W0.5p
+	gmt subplot set 1 -A"Median"
+	gmt triangulate @Table_5_11.txt -S+zm | gmt plot -C -G+z -W0.5p
+	gmt subplot set 2 -A"Min"
+	gmt triangulate @Table_5_11.txt -S+zl | gmt plot -C -G+z -W0.5p
+	gmt subplot set 3 -A"Max"
+	gmt triangulate @Table_5_11.txt -S+zu | gmt plot -C -G+z -W0.5p
+	gmt subplot end
+gmt end show


### PR DESCRIPTION
This PR was "inspired" by a forum [post](https://forum.generic-mapping-tools.org/t/draw-spesific-area-of-this-triangulation/4246/4) and it seemed very easy to expand **-S** to do more.  The new **+z** modifier will put a `-Zvalue` string in each polygon header. The `value` can be determined via the optional argument to **+z**:

**a** mean of triplet [Default]
**l** Lower value of triplet
**m** Median value of triplet
**p** Modal value of triplet
**u** Upper value of triplet

Added a simple test _tripatch.sh_ which shows the various results (skipping mode since mostly will give median anyway.

![tripatch](https://github.com/GenericMappingTools/gmt/assets/26473567/e179148a-d4a3-4727-86e3-935ae8b744e9)
