### PR TITLE
Allow grdimage to process byte images without indexed colors, via CPT

### DIFF
--- a/doc/rst/source/grdimage.rst
+++ b/doc/rst/source/grdimage.rst
@@ -255,6 +255,14 @@ have chosen (perhaps implicitly) with **-nn+a** that turns *on* nearest neighbor
 gridding and turns *off* anti-aliasing.  Alternatively, use |-T|
 instead to plot individual polygons centered on each node.
 
+Imaging Categorical Images
+--------------------------
+
+If a 1-byte single layer image is given and the file has no color map then we will
+interpret the byte values as categories and a categorical CPT is required via |-C|.
+If no |-C| is given then we assume the image is a grayscale image with values in the
+0-255 range.
+
 Image formats recognized
 ------------------------
 

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1354,7 +1354,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 	}
 	byte_image_no_cmap = (I && I->type == GMT_UCHAR && I->n_indexed_colors == 0);
 	if (byte_image_no_cmap && !Ctrl->C.active) {
-		GMT_Report (API, GMT_MSG_INFORMATION, "Byte image without indexed color requires a CPT via -C\n");
+		GMT_Report (API, GMT_MSG_ERROR, "Byte image without indexed color requires a CPT via -C\n");
 		Return (GMT_RUNTIME_ERROR);
 	}
 

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1006,7 +1006,7 @@ GMT_LOCAL void grdimage_img_gray_no_intensity (struct GMT_CTRL *GMT, struct GRDI
 }
 
 GMT_LOCAL void grdimage_img_byte_index (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GRDIMAGE_CONF *Conf, unsigned char *image) {
-	/* Function that fills out the image in the special case of 1) image, 2) no colormap, 3) external CPT */
+	/* Function that fills out the image in the special case of 1) 1-byte image, 2) no colormap, 3) external CPT given */
 	int64_t srow, scol;	/* Due to OPENMP on Windows requiring signed int loop variables */
 	uint64_t byte, kk_s, node_s;
 	int index, k;
@@ -1018,7 +1018,7 @@ GMT_LOCAL void grdimage_img_byte_index (struct GMT_CTRL *GMT, struct GRDIMAGE_CT
 #pragma omp parallel for private(srow,byte,kk_s,scol,node_s,k) shared(GMT,Conf,Ctrl,H_s,image)
 #endif
 	for (srow = 0; srow < Conf->n_rows; srow++) {	/* March along scanlines in the output bitimage */
-		byte = (uint64_t)srow * Conf->n_columns;
+		byte = (uint64_t)(3 * srow * Conf->n_columns);
 		kk_s = gmt_M_ijpgi (H_s, Conf->actual_row[srow], 0);	/* Start pixel of this image row */
 		for (scol = 0; scol < Conf->n_columns; scol++) {	/* Compute rgb for each pixel along this scanline */
 			node_s = kk_s + Conf->actual_col[scol];	/* Start of current pixel node */

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1017,7 +1017,7 @@ GMT_LOCAL void grdimage_img_byte_index (struct GMT_CTRL *GMT, struct GRDIMAGE_CT
 	if (gmt_M_is_dnan (Conf->Image->header->nan_value)) /* Nodata not set, offset to 1 if CPT indicates first key is 1 */
 		start = (irint (Conf->P->data[0].z_low) == 1) ? 1 : 0;	/* No "0" key in CPT so we skip it */
 	else	/* Check if the nan_value is 0 or 255 */
-		start = (irint (Conf->Image->header->nan_value) == 0) ? 1 : 0;	/* No "0" key in CPT so we skip it */
+		start = (irint (Conf->Image->header->nan_value) == 0 || irint (Conf->P->data[0].z_low) == 1) ? 1 : 0;	/* No "0" key in CPT so we skip it */
 
 #ifdef _OPENMP
 #pragma omp parallel for private(srow,byte,kk_s,scol,node_s,k) shared(GMT,Conf,Ctrl,H_s,image)

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -829,7 +829,6 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 	if (P->categorical && !Ctrl->L.active) {	/* For categorical CPTs the default is -L<gap> with sum of all gaps = 15% of bar length  */
 		Ctrl->L.active = true;
 		Ctrl->L.spacing = 0.01 * PSSCALE_GAP_PERCENT * Ctrl->D.dim[GMT_X] / (P->n_colors - 1);
-		fprintf (stderr, "Gap set to %lg\n", Ctrl->L.spacing);
 	}
 	max_intens[0] = Ctrl->I.min;
 	max_intens[1] = Ctrl->I.max;


### PR DESCRIPTION
See [forum](https://forum.generic-mapping-tools.org/t/thematic-mapping-of-land-cover-by-pygmt/4271/20) discussion for background. This PR is almost there - 45 minutes of work is not bad. Perhaps @joa-quim knows what to improve.  There are an issue to resolve:

The image has values 0-8 for a total of 9, but CPT has 8. Since these are "keys" to categories 1-8 there are only 8 but GMT does not know the image contains categories and not index into a color table. I inserted a 0 row (white) to make this work for now.

Perhaps a 1-byte image without color table is expected to hold categories? If so we can subtract one and be OK

Should not be too hard to fix this but want @joa-quim input on this.  See new renderer _grdimage_img_byte_index_.

![t](https://github.com/GenericMappingTools/gmt/assets/26473567/b285f375-ccb7-4c17-99d8-7cdee9d2d6ef)
