### PR TITLE
Take into account the value reported by GDAL for noData in Images

### DIFF
--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -909,6 +909,10 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 		if (gmtgdalread_populate_metadata (GMT, Ctrl, gdal_filename, got_R, nXSize[0], nYSize, dfULX, dfULY, dfLRX, dfLRY, z_min, z_max, first_layer))
 			return(GMT_NOTSET);
 
+		/* See if uint8 images have set a noData */
+		if (Ctrl->band_field_names[0].nodata > -1e10)
+			Ctrl->nodata = Ctrl->band_field_names[0].nodata;
+
 		/* Return registration based on data type of first band. Byte is pixel reg otherwise set grid registration */
 		if (!Ctrl->hdr[6]) {		/* Grid registration */
 			Ctrl->hdr[0] += Ctrl->hdr[7] / 2;	Ctrl->hdr[1] -= Ctrl->hdr[7] / 2;

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3736,6 +3736,7 @@ int gmtlib_read_image_info (struct GMT_CTRL *GMT, char *file, bool must_be_image
 		}
 	}
 
+	I->header->nan_value = from_gdalread->nodata;
 	I->color_interp    = from_gdalread->color_interp;     /* Must find out how to release this mem */
 	I->n_indexed_colors = from_gdalread->nIndexedColors;
 	gmt_M_str_free (I->header->ProjRefPROJ4);		/* Make sure we don't leak due to a previous copy */


### PR DESCRIPTION
We were ignoring this value before (in images) so it shouldn't break anything.