### PR TITLE
CI: Use conda to install ghostscript/ninja/dvc/sphinx on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,13 +75,13 @@ jobs:
         env:
           EXCLUDE_OPTIONAL: ${{ matrix.EXCLUDE_OPTIONAL }}
 
-      - name: Fix Ghostscript 9.56.1 registry for GraphicsMagick<1.3.37
-        # Related to https://github.com/GenericMappingTools/gmt/issues/4231
+      - name: Add Ghostscript registry so that GraphicsMagick can find it [Windows]
         shell: pwsh
         run: |
-          Get-ChildItem -Path "HKLM:\SOFTWARE\GPL Ghostscript"
-          Rename-Item -Path "HKLM:\SOFTWARE\GPL Ghostscript\9.56.1" -NewName "9.56"
-          Get-ChildItem -Path "HKLM:\SOFTWARE\GPL Ghostscript"
+          New-Item -Path "HKLM:\Software\GPL Ghostscript"
+          New-Item -Path "HKLM:\Software\GPL Ghostscript\9.56"
+          New-ItemProperty -Path "HKLM:\Software\GPL Ghostscript\9.56" -Name GS_DLL -PropertyType String -Value "C:\Miniconda\Library\bin\gsdll64.dll"
+          New-ItemProperty -Path "HKLM:\Software\GPL Ghostscript\9.56" -Name GS_LIB -PropertyType String -Value "C:\Miniconda\Library\bin;C:\Miniconda\Library\lib;C\Miniconda\Library\Font;C:\Miniconda\Library\fonts"
         if: runner.os == 'Windows'
 
       - name: Cache GSHHG and DCW data

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Bash script to install GMT dependencies on Windows via vcpkg and chocolatey
+# Bash script to install GMT dependencies on Windows via vcpkg and conda
 #
 # Environmental variables that can control the installation:
 #
@@ -28,30 +28,29 @@ echo "${VCPKG_INSTALLATION_ROOT}/installed/${WIN_PLATFORM}/tools/gdal" >> $GITHU
 # list installed packages
 vcpkg list
 
-# install more packages using chocolatey
-choco install ninja
-choco install ghostscript --version 9.56.1 --no-progress
-
+conda_packages="ninja ghostscript=9.56.1"
 if [ "$BUILD_DOCS" = "true" ]; then
-    pip install --user sphinx dvc
-    # Add sphinx to PATH
-    echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
-
+	conda_packages+=" sphinx dvc"
     # choco install pngquant
 fi
 
 if [ "$RUN_TESTS" = "true" ]; then
+    conda_packages+=" dvc"
+
+    # Install graphicsmagick via choco
     choco install graphicsmagick --version 1.3.32 --no-progress
-    pip install --user dvc
-    # Add GraphicsMagick to PATH
     echo 'C:\Program Files\GraphicsMagick-1.3.32-Q8' >> $GITHUB_PATH
-    # Add dvc to PATH
-    echo "$(python -m site --user-site)\..\Scripts" >> $GITHUB_PATH
 fi
 
 # we need the GNU tar for packaging
 if [ "$PACKAGE" = "true" ]; then
     echo 'C:\Program Files\Git\usr\bin\' >> $GITHUB_PATH
 fi
+
+# install more packages using conda
+$CONDA\\condabin\\conda.bat update -n base -c conda-forge conda --solver libmamba
+$CONDA\\condabin\\conda.bat install ${conda_packages} -c conda-forge --solver libmamba
+echo "$CONDA\\Library\\bin" >> $GITHUB_PATH
+echo "$CONDA\\Scripts" >> $GITHUB_PATH
 
 set +x +e


### PR DESCRIPTION
Use conda to install GMT dependencies on Windows. The main benefit is that now gs is installed via conda on all three operating systems, so it's much easier for us to have the same gs version on the three platforms.