### PR TITLE
Default to color bars with gaps for categorical CPTs

### DIFF
--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -183,7 +183,10 @@ Optional Arguments
     annotation on each rectangle, using the lower boundary z-value for
     the annotation. If **i** is prepended we annotate the interval range
     instead. If |-I| is used then each rectangle will have its
-    constant color modified by the specified intensity.
+    constant color modified by the specified intensity.  **Note**: For
+    categorical CPTs we default to activating |-L| with a *gap* such
+    that the sum of all the gaps equal 15% of the bar width.  You may
+    chose no gaps by giving |-L| only or explicitly set *gap = 0*.
 
 .. _-M:
 

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -826,6 +826,11 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 	unsigned int dump_k_val = 0;
 #endif
 
+	if (P->categorical && !Ctrl->L.active) {	/* For categorical CPTs the default is -L<gap> with sum of all gaps = 15% of bar length  */
+		Ctrl->L.active = true;
+		Ctrl->L.spacing = 0.01 * PSSCALE_GAP_PERCENT * Ctrl->D.dim[GMT_X] / (P->n_colors - 1);
+		fprintf (stderr, "Gap set to %lg\n", Ctrl->L.spacing);
+	}
 	max_intens[0] = Ctrl->I.min;
 	max_intens[1] = Ctrl->I.max;
 
@@ -1936,10 +1941,6 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 		}
 	}
 
-	if (P->categorical && !Ctrl->L.active) {	/* For categorical CPTs the default is -L<gap> with sum of all gaps = 15% of bar length  */
-		Ctrl->L.active = true;
-		Ctrl->L.spacing = 0.01 * PSSCALE_GAP_PERCENT * Ctrl->D.dim[GMT_X] / (P->n_colors - 1);
-	}
 	if (!Ctrl->N.active && !P->is_continuous)	/* If -N not set we should default to rectangles if possible due to macOS Preview blurring */
 		Ctrl->N.mode = N_FAVOR_POLY;
 
@@ -1966,11 +1967,6 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 	}
 	if (Ctrl->W.active)	/* Scale all z values */
 		gmt_scale_cpt (GMT, P, Ctrl->W.scale);
-
-	if (P->categorical) {
-		Ctrl->L.active = Ctrl->L.interval = true;
-		GMT_Report (API, GMT_MSG_INFORMATION, "CPT is for categorical data.\n");
-	}
 
 	GMT_Report (API, GMT_MSG_INFORMATION, "  CPT range from %g to %g\n", P->data[0].z_low, P->data[P->n_colors-1].z_high);
 
@@ -2063,6 +2059,12 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 				gmtlib_parse_B_option (GMT, p);
 			gmt_M_str_free (tmp);
 		}
+	}
+
+	if (P->categorical && !Ctrl->L.active) {	/* For categorical CPTs the default is -L<gap> with sum of all gaps = 15% of bar length  */
+		Ctrl->L.active = true;
+		Ctrl->L.spacing = 0.01 * PSSCALE_GAP_PERCENT * Ctrl->D.dim[GMT_X] / (P->n_colors - 1);
+		fprintf (stderr, "Gap set to %lg\n", Ctrl->L.spacing);
 	}
 
 	if (Ctrl->Z.active) {	/* Widths of slices per color is prescribed manually via this file */

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -43,6 +43,7 @@ EXTERN_MSC double gmtlib_get_map_interval (struct GMT_CTRL *GMT, unsigned int ty
 #define PSSCALE_L_SCALE	80	/* Set scale length to 80% of map side length under auto-setting */
 #define PSSCALE_W_SCALE	4	/* Set scale width to 4% of scale length under auto-setting */
 #define PSSCALE_CYCLE_DIM 0.45	/* Cyclic symbol radius is 0.45 of width */
+#define PSSCALE_GAP_PERCENT 15	/* Percentage of bar length set aside for gaps for categorical CPTs */
 #define N_FAVOR_IMAGE	1
 #define N_FAVOR_POLY	2
 
@@ -213,7 +214,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Append i to annotate the interval range instead of lower/upper. "
 		"If <gap> is appended, we separate each rectangle by <gap> units and center each "
 		"lower (z0) annotation on the rectangle.  Ignored if not a discrete CPT. "
-		"If -I is used then each rectangle will have the illuminated constant color.");
+		"If -I is used then each rectangle will have the illuminated constant color. "
+		"Note: If the CPT is categorical and -L not set we default to -L with gaps making up %d%% of the bar width.", PSSCALE_GAP_PERCENT);
 	GMT_Usage (API, 1, "\n-M");
 	GMT_Usage (API, -2, "Force monochrome colorbar using the YIQ transformation.");
 	GMT_Usage (API, 1, "\n-N[p|<dpi>]");
@@ -1934,6 +1936,10 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 		}
 	}
 
+	if (P->categorical && !Ctrl->L.active) {	/* For categorical CPTs the default is -L<gap> with sum of all gaps = 15% of bar length  */
+		Ctrl->L.active = true;
+		Ctrl->L.spacing = 0.01 * PSSCALE_GAP_PERCENT * Ctrl->D.dim[GMT_X] / (P->n_colors - 1);
+	}
 	if (!Ctrl->N.active && !P->is_continuous)	/* If -N not set we should default to rectangles if possible due to macOS Preview blurring */
 		Ctrl->N.mode = N_FAVOR_POLY;
 

--- a/test/baseline/psscale.dvc
+++ b/test/baseline/psscale.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 291aec1467617b1acba8594013963cf1.dir
-  size: 1402357
+- md5: da7aee2651150c8973015165303b4e5a.dir
+  size: 1402195
   nfiles: 25
   path: psscale


### PR DESCRIPTION
See #7830 for background.  This PR implements the change.  Old (and in our opinion wrong) behavior can be retained by just giving **-L** with no or zero gap.

Part 1 (implementation) is done
Part 2 (hence WIP) is to update some scripts that currently plot no gaps.  I will let a few of those add **-**L so the PS does not change but at least one should give the new behaviour and I will dvc that plot only.

Closes #7830.