### PR TITLE
doc: Promote Ninja as the recommended build system

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -27,6 +27,7 @@ To build GMT, you have to install:
 - [netCDF](https://www.unidata.ucar.edu/software/netcdf/) (>=4.0, netCDF-4/HDF5 support mandatory)
 - [curl](https://curl.haxx.se/)
 - [GDAL](https://www.gdal.org/) (Ability to read and write numerous grid and image formats)
+- [Ninja](https://ninja-build.org/) (optional but recommended for faster building)
 
 ### Optional dependencies
 
@@ -56,7 +57,6 @@ Install for building GMT documentation and running tests (not required for gener
 - [Sphinx](http://www.sphinx-doc.org) (>=1.8, for building the documentation)
 - [GraphicsMagick](http://www.graphicsmagick.org/) (for running the tests)
 - [dvc](https://dvc.org/) (for running the tests and building the documentation)
-- [Ninja](https://ninja-build.org/) (optional, build system focused on speed)
 - [pngquant](https://pngquant.org/) (optional, for optimizing PNG images in the documentation)
 
 ### Required support data
@@ -138,7 +138,7 @@ where the build files will be generated, and change into your build directory:
 ```
 mkdir build
 cd build
-cmake ..
+cmake .. -G Ninja
 ```
 
 For Windows users, you need to open a command prompt and run:
@@ -150,15 +150,10 @@ via vcpkg following [these instructions](https://github.com/GenericMappingTools/
 mkdir build
 cd build
 # For x64 build
-cmake .. -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x64
+cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x64
 # For x86 build
-cmake .. -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x86
+cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x86
 ```
-
-For advanced users, you can append the option `-G Ninja` to use the
-build tool [Ninja](https://ninja-build.org/), which is a small build system
-with a focus on speed.
-
 
 ## Building GMT source codes
 


### PR DESCRIPTION
Ninja is optional but recommended for faster building.

Closes https://github.com/GenericMappingTools/gmt/issues/7230.