### PR TITLE
Fix gmt info's longitude-range output

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -273,7 +273,7 @@ FORMAT Parameters
         Formatting template that indicates how an output geographical
         coordinate is to be formatted. This template is then used to guide
         the writing of geographical coordinates in data fields. The template
-        is in general of the form **[±]D** or **[±]ddd[:mm[:ss]][.xxx]** [default is **D**].
+        is in general of the form **[±]D[DD]** or **[±]ddd[:mm[:ss]][.xxx]** [default is **D**].
         By default, longitudes will be reported in the range [-180,180]. The
         various terms have the following purpose:
 

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -411,7 +411,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTINFO_CTRL *Ctrl, struct GMT_OP
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_M_free (GMT, xyzmin); gmt_M_free (GMT, xyzmax); gmt_M_free (GMT, xyzminL); gmt_M_free (GMT, lonmin);  gmt_M_free (GMT, lonmax); gmt_M_free (GMT, xyzmaxL); gmt_M_free (GMT, Q); gmt_M_free (GMT, Z); gmt_M_free (GMT, Out); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
 EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
-	bool got_stuff = false, first_data_record, give_r_string = false, save_t;
+	bool got_stuff = false, first_data_record, give_r_string = false, save_t, first_time = true;;
 	bool brackets = false, work_on_abs_value, do_report, done, full_range = false;
 	int i, j, error = 0, col_type[GMT_MAX_COLUMNS];
 	unsigned int fixed_phase[2] = {1, 1}, min_cols, save_range, n_items = 0;
@@ -591,7 +591,10 @@ EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
 			gmt_quad_reset (GMT, Q, ncol);
 			if (gmt_M_rec_is_segment_header (GMT) && Ctrl->A.mode != REPORT_PER_SEGMENT) continue;	/* Since we are not reporting per segment they are just headers as far as we are concerned */
 		}
-
+		if (first_time && gmt_M_is_geographic (GMT, GMT_IN)) {	/* Learned that an OGR file is geographic so output is the same */
+			gmt_set_geographic (GMT, GMT_OUT);
+			first_time = false;
+		}
 		if (gmt_M_rec_is_segment_header (GMT) || (Ctrl->A.mode == REPORT_PER_TABLE && gmt_M_rec_is_file_break (GMT)) || gmt_M_rec_is_eof (GMT)) {	/* Time to report */
 			if (Ctrl->A.active) {
 				if (Ctrl->A.mode == REPORT_PER_TABLE && gmt_M_rec_is_file_break (GMT)) {


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/gmtinfo-i-outputs-longitude-in-0-360-degree-range-format/4261) for background.

Problem is that we must do this:

```
save_range = GMT->current.io.geo.range;
GMT->current.io.geo.range = GMT_IGNORE_RANGE;	/* No adjustment since we must control it here */
```
to ensure we end up with `east > west`.  .This makes some sense since each column is written out individually and there is no check in the i/o that two longitude next to each other are "sorted", which is a unique thing in **gmt info**.  At the end of **gmt info** we revert:

`GMT->current.io.geo.range = save_range;	/* Restore what we changed */`

but by then the _GMT_Put_Record_ has already been called, with` range == GMT_IGNORE_RANGE`. 

Because **gmtinfo** is special, I have added a check that considers the save_range setting and the sign of the two longitudes.  I also found that when reading OGR files and learn from a head record that it contains geographical lon/lat values then we (internally) turn on **-fig**.  However, in gmt info the output then should also be flagged via **-fog**; this PR checks for this special case. Now gmt info on the OP's file yields

```
gmt info -Ie a.gmt    $ Detects it is geographic and does the default -180/+180
-R-84.62/-72.26/-19.9399399399/-3.36336336336
gmt info -Ie a.gmt -fg --FORMAT_GEO_OUT=+D   # Force positive range
-R275.38/287.74/-19.9399399399/-3.36336336336
gmt info -Ie a.gmt -fg --FORMAT_GEO_OUT=D   # Just said decimals, default goes -180/+180
-R-84.62/-72.26/-19.9399399399/-3.36336336336
gmt info -Ie a.gmt -fg --FORMAT_GEO_OUT=-D  # Force just negative longitude (here no change)
-R-84.62/-72.26/-19.9399399399/-3.36336336336

```
