### PR TITLE
Allow building GMT documentation without compiling GMT

### DIFF
--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -219,8 +219,8 @@ set (GMT_ENABLE_OPENMP TRUE)
 #set (GMT_RELEASE_PREFIX "release-src-prefix")
 
 # If set to false, image conversion from PS images to PNG and PDF does
-# not depend on the gmt binary target. Note: "make gmt" is then required
-# before docs_depends [TRUE].
+# not depend on the gmt binary target. It assumes that you already have the
+# gmt executable in your PATH [TRUE].
 #set (GMT_DOCS_DEPEND_ON_GMT FALSE)
 
 #

--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -28,6 +28,13 @@ if (SPHINX_FOUND)
 	# Convert figures to PNG
 	file (GLOB _examples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/images/*.ps")
 	set (_examples_png)
+
+	if (GMT_DOCS_DEPEND_ON_GMT)
+		set (_gmt_command ${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt)
+	else (GMT_DOCS_DEPEND_ON_GMT)
+		set (_gmt_command gmt)
+	endif (GMT_DOCS_DEPEND_ON_GMT)
+
 	foreach (_ps ${_examples})
 		get_filename_component (_fig ${_ps} NAME)
 		string (REPLACE ".ps" ".png" _png_fig ${_fig})
@@ -35,7 +42,7 @@ if (SPHINX_FOUND)
 		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
 			COMMAND ${CMAKE_COMMAND} -E env
 			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
+			${_gmt_command} psconvert
 			-A -P -E150 -Tg -Qg4 -Qt4
 			-C-sFONTPATH="${GMT_SOURCE_DIR}/doc/examples/ex31/fonts"
 			-D${RST_BINARY_DIR}/_images

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -25,6 +25,12 @@ if (SPHINX_FOUND)
 		add_depend_to_target (gmt_release _scripts_images_release)
 	endif (GIT_FOUND AND HAVE_GIT_VERSION)
 
+	if (GMT_DOCS_DEPEND_ON_GMT)
+		set (_gmt_command ${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt)
+	else (GMT_DOCS_DEPEND_ON_GMT)
+		set (_gmt_command gmt)
+	endif (GMT_DOCS_DEPEND_ON_GMT)
+
 	# Convert PS to PNG
 	file (GLOB _scripts_ps2png RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/images/*.ps")
 	set (_scripts_png)
@@ -35,7 +41,7 @@ if (SPHINX_FOUND)
 		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_png_fig}
 			COMMAND ${CMAKE_COMMAND} -E env
 			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert
+			${_gmt_command} psconvert
 			-A -P -E150 -Tg -Qg4 -Qt4
 			-D${RST_BINARY_DIR}/_images
 			${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
@@ -53,7 +59,7 @@ if (SPHINX_FOUND)
 		add_custom_command (OUTPUT ${RST_BINARY_DIR}/_images/${_pdf_fig}
 			COMMAND ${CMAKE_COMMAND} -E env
 			GMT_SHAREDIR=${GMT_SOURCE_DIR}/share
-			${GMT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/src/gmt psconvert -A -P -Tf
+			${_gmt_command} psconvert -A -P -Tf
 			-D${RST_BINARY_DIR}/_images
 			${CMAKE_CURRENT_SOURCE_DIR}/${_ps}
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
Currently, building the GMT documentation requires compiling GMT first, because we need `gmt` to convert PS images to PNG/PDF. However, as GMT developers and contributors, we definitely already have `gmt` installed in our PATH (either a stable version or a dev version). So, why not just call the `gmt` executable in the **PATH**?

I found the cmake option `GMT_DOCS_DEPEND_ON_GMT` which makes the `docs_html` target independent of the `gmt` executable. However, it still requires us to build the `gmt` executable manually (via `ninja gmt`) before building the documentation (via `ninja docs_html)`. It's useful if you already have the `gmt` executable in the build directory and want to update and build docs, but `ninja gmt` should be very fast in this case because there are no code changes. So, the `GMT_DOCS_DEPEND_ON_GMT` option seems useless to me.

This PR changes the behavior of the `GMT_DOCS_DEPEND_ON_GMT` cmake option. If `GMT_DOCS_DEPEND_ON_GMT=FALSE`, cmake will call the `gmt` executable in your **PATH** to do the PS conversion. Thus, even in a clean build directory, you can still build the GMT documentation without compiling GMT. I.e., the following commands will build the documentation only:
```
mkdir rbuild
cd rbuild
cmake .. -G Ninja
ninja docs_html 
```

I think the new behavior makes more sense. What do you think?