### PR TITLE
release_checklist.md: add Windows win64 portable

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -41,6 +41,7 @@ assignees: ''
 - [ ] create source tarballs (tar.gz and tar.xz) (@PaulWessel)
 - [ ] create macOS bundle (@PaulWessel)
 - [ ] create Windows win64 installer (@joa-quim)
+- [ ] create Windows win64 portable (@joa-quim?)
 - [ ] check if the source tarballs for Linux work well (@Esteban82, @anbj)
 - [ ] check if the macOS bundles work well (@seisman, @maxrjones)
 - [ ] check if the Windows installers work well (volunteers needed!)


### PR DESCRIPTION
Add Windows win64 portable to checklist.

This was mentioned in an issue some time ago. Hope it's still valid? A portable version would be great.