### PR TITLE
Increment in -T seen as zero if < 1e08

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15392,6 +15392,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 				gmt_parse_common_options (API->GMT, "V", opt->option, opt->arg);
 		}
 		for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
+			if (opt->option != GMT_OPT_INFILE) continue;	/* Only check command line input files */
 			if ((err_code = gmtinit_might_be_remotefile (opt->arg)) == 0) continue;
 			if (err_code == 2) {
 				GMT_Report (API, GMT_MSG_ERROR, "File %s is not a file and looks like pstext strings.\n", opt->arg);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -17683,7 +17683,7 @@ uint64_t gmt_make_equidistant_array (struct GMT_CTRL *GMT, double min, double ma
 	uint64_t k, n;
 	double *val = NULL;
 
-	n = (doubleAlmostEqualZero (min, max) || gmt_M_is_zero (inc)) ? 1 : lrint (fabs (max - min) / fabs (inc)) + 1;
+	n = (doubleAlmostEqualZero (min, max) || (gmt_M_is_zero (inc) && gmt_M_is_zero ((max - min)/inc))) ? 1 : lrint (fabs (max - min) / fabs (inc)) + 1;
 	val = gmt_M_memory (GMT, NULL, n, double);
 	if (inc < 0.0) {	/* Reverse direction max:inc:min */
 		for (k = 0; k < n; k++) val[k] = max + k * inc;
@@ -17965,7 +17965,8 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 	/* 5. Get the increment (or count) */
 	if (has_inc && !T->spatial) {
 		gmt_scanf_float (GMT, txt[ns], &(T->inc));
-		if (gmt_M_is_zero (T->inc)) {
+		//if (gmt_M_is_zero (T->inc)) {
+		if (fabs (T->inc) < DBL_EPSILON) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option %c: Increment is zero\n", option);
 			return GMT_PARSE_ERROR;
 		}
@@ -18162,7 +18163,7 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 	}
 	if (T->set == 2) return (GMT_NOERROR);	/* Probably makecpt giving just a range */
 
-	if (doubleAlmostEqualZero (t0, t1) && gmt_M_is_zero (T->inc)) {	/* Got a single item for our "array" */
+	if (doubleAlmostEqualZero (t0, t1) && gmt_M_is_zero (T->inc) && gmt_M_is_zero ((t1 - t0)/T->inc)) {	/* Got a single item for our "array" */
 		T->array = gmt_M_memory (GMT, NULL, 1, double);
 		T->array[0] = t0;
 		T->n = 1;
@@ -18201,7 +18202,7 @@ unsigned int gmt_create_array (struct GMT_CTRL *GMT, char option, struct GMT_ARR
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Information from -%c option: (max - min) is not a whole multiple of inc. Adjusted max to %g\n", option, tmp_t1);
 				break;
 			case 2:
-				if (inc != 1.0 && gmt_M_is_zero (t0) && gmt_M_is_zero (t1)) {	/* Allow for somebody explicitly saying -T0/0/1, otherwise an error */
+				if (inc != 1.0 && gmt_M_is_zero (t0) && gmt_M_is_zero (t1) && gmt_M_is_zero ((t1 - t0)/T->inc)) {	/* Allow for somebody explicitly saying -T0/0/1, otherwise an error */
 					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option %c: (max - min) is <= 0\n", option);
 					return (GMT_PARSE_ERROR);
 				}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -17965,7 +17965,6 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 	/* 5. Get the increment (or count) */
 	if (has_inc && !T->spatial) {
 		gmt_scanf_float (GMT, txt[ns], &(T->inc));
-		//if (gmt_M_is_zero (T->inc)) {
 		if (fabs (T->inc) < DBL_EPSILON) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option %c: Increment is zero\n", option);
 			return GMT_PARSE_ERROR;


### PR DESCRIPTION
We had too hash **-T**_min/max/inc_ checks, as pointed out in #7856. We used _gmt_M_is_zero_ indiscriminantly (e.g., on the increment) causing small but not EPS-like increments to fail as "zero".  This PR addresses that and closes #7856.

Unrelated, I also found the issue at the end of #7855 where we checked if an argument was a remote file even though the option was actually set, in this case` -l"string"` for a legend.  Clearly, "string" should not be checked for being a remote file.
