### PR TITLE
Handle remote tiled grids in option arguments

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15402,7 +15402,7 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 				gmt_parse_common_options (API->GMT, "V", opt->option, opt->arg);
 		}
 		for (opt = *options; opt; opt = opt->next) {	/* Loop over all options */
-			if (opt->option != GMT_OPT_INFILE) continue;	/* Only check command line input files */
+			if (strchr (opt->arg, '@') == NULL) continue;/* Cannot be a remote file */
 			if ((err_code = gmtinit_might_be_remotefile (opt->arg)) == 0) continue;
 			if (err_code == 2) {
 				GMT_Report (API, GMT_MSG_ERROR, "File %s is not a file and looks like pstext strings.\n", opt->arg);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1243,6 +1243,7 @@ int gmt_set_remote_and_local_filenames (struct GMT_CTRL *GMT, const char * file,
 	}
 
 	if (file[0] == '@') {	/* Either a cache file or a remote data set */
+		gmt_refresh_server (GMT->parent);
 		if ((k_data = gmt_remote_dataset_id (API, file)) != GMT_NOTSET) {
 			/* Got a valid remote server data filename and we know the local path to those */
 			if (GMT->session.USERDIR == NULL) {


### PR DESCRIPTION
While commands like

`gmt grdimage @earth_relief_05m -B -png map`

works, commands like

`gmt grdtrack  -G@earth_relief_05m  -R0/20/0/20 -n+a -o3,2 -EBL/TR+d`

do not, since _gmt_init_module_ never processed options with remote files.  It was foolishly assumed that only command line files might be remote files, but many GMT modules pass input grids via an option.  This PR now checks all option arguments for remote files and solves the reported problem, thus re-closing #7859.
