### PR TITLE
Subplot did not process axis modifiers +p and +u

### DIFF
--- a/src/subplot.c
+++ b/src/subplot.c
@@ -687,9 +687,9 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 				}
 			}
 			if (Bx) {	/* Did get separate x-axis annotation settings */
-				if ((c = gmt_first_modifier (GMT, Bx->arg, "ls"))) {	/* Gave valid axes modifiers for custom labels */
+				if ((c = gmt_first_modifier (GMT, Bx->arg, "lpsu"))) {	/* Gave valid axes modifiers for custom labels */
 					pos = error = 0;
-					while (gmt_getmodopt (GMT, 'B', c, "ls", &pos, p, &error) && error == 0) {
+					while (gmt_getmodopt (GMT, 'B', c, "lpsu", &pos, p, &error) && error == 0) {
 						switch (p[0]) {
 							case 'l':	/* Regular x-axis label */
 								Ctrl->S[GMT_X].label[GMT_PRIMARY] = strdup (&p[1]);	break;
@@ -708,9 +708,9 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 			else if (Bxy)	/* Did common x and y-axes annotation settings */
 				Ctrl->S[GMT_X].b = strdup (Bxy->arg);
 			if (By) {	/* Did get y-axis annotation settings */
-				if ((c = gmt_first_modifier (GMT, By->arg, "ls"))) {	/* Gave valid axes modifiers for custom labels */
+				if ((c = gmt_first_modifier (GMT, By->arg, "lpsu"))) {	/* Gave valid axes modifiers for custom labels */
 					pos = 0;
-					while (gmt_getmodopt (GMT, 'B', c, "ls", &pos, p, &error) && error == 0) {
+					while (gmt_getmodopt (GMT, 'B', c, "lpsu", &pos, p, &error) && error == 0) {
 						switch (p[0]) {
 							case 'l':	/* Regular y-axis label */
 								Ctrl->S[GMT_Y].label[GMT_PRIMARY] = strdup (&p[1]);	break;

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -141,7 +141,7 @@ struct SUBPLOT_CTRL {
 		char axes[4];		/* W|e|w|e|l|r for -Sr,  S|s|N|n|b|t for -Sc [Default is MAP_FRAME_AXES] */
 		char *b;		/* Any hardwired choice for afg settings for this axis [af] */
 		char *label[2];		/* The constant primary [and alternate] y labels */
-		char *prefix[2];	/* Any prefix units for x or y axes */
+		char *prefix[2];	/* Any prefix for x or y axes */
 		char *unit[2];		/* Any annotation units for x or y axes */
 		char *extra;		/* Special -B frame args, such as fill */
 		unsigned int ptitle;	/* 0 = no subplot titles, 1 = column titles, 2 = all subplot titles */


### PR DESCRIPTION
From #7855 we learned of warnings about **+u** in **subplot** not being accepted. Because it was not coded up in subplot which does a pre**-B** parsing since it may need to replicate across many panels.  This PR

Allows parsing of **+p** for a prefix to annotations
Allows parsing of **+u** for a suffix to annotations (usually unit)

As a 1x1 **subplot** example:

```
#!/usr/bin/env bash
gmt begin transfer png
	gmt subplot begin 1x1 -Fs15c/8c -R0/5000/0/1.1 -Bxaf+u" km" -Byaf+p'$'+uM
	gmt basemap
	gmt subplot end
gmt end show

```
![transfer](https://github.com/GenericMappingTools/gmt/assets/26473567/846faf0d-445a-42cf-ad31-dc02d176c045)

