### PR TITLE
No longer test GMT building on old Ubuntu releases (14.04, 16.04, and 18.04)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,11 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - ubuntu:14.04  # CMake 2.8.12 + GNU 4.8.4;  EOL: 2024-04-25
-          - ubuntu:16.04  # CMake 3.5.1  + GNU 5.4.0;  EOL: 2026-04-23
-          - ubuntu:18.04  # CMake 3.10.2 + GNU 7.4.0;  EOL: 2028-04-26
-          - ubuntu:20.04  # CMake 3.16.3 + GNU 9.3.0;  EOL: 2030-04-23
-          - ubuntu:22.04  # CMake 3.22.1 + GNU 11.2.0; EOL: 2032-04-21
+          - ubuntu:20.04  # CMake 3.16.3 + GNU 9.3.0;  EOL: 2025-04-23
+          - ubuntu:22.04  # CMake 3.22.1 + GNU 11.2.0; EOL: 2027-04-21
           - ubuntu:23.04  # CMake 3.24.1 + GNU 12.2.0; EOL: 2024-01-20
           - debian:10     # CMake 3.13.4 + GNU 8.3.0;  EOL: 2024-06-01
           - debian:11     # CMake 3.18.4 + GNU 10.2.1; EOL: 2026-06-01

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -192,9 +192,6 @@ You may also install other optional dependencies for more capabilities within GM
 **NOTE:** The Ubuntu/Debian official repositories may provide old GMT versions.
 If you want the latest GMT 6.x release, your best bet then is to
 [build the latest release from source](BUILDING.md).
-Keep in mind that Ubuntu 16.04 LTS for mysterious reasons does not
-include the [supplemental modules](https://docs.generic-mapping-tools.org/latest/modules.html#supplemental-modules),
-but you can obtain them by [building from source](BUILDING.md) or upgrading to Ubuntu 18.04 LTS (or newer).
 
 Install GMT via:
 


### PR DESCRIPTION
Just in case you don't know much about Ubuntu, here is some background information.

For Ubuntu LTS releases like Ubuntu 14.04, it has a 5-year standard support and another 5-year support through [Extended Security Maintenance (ESM)](https://ubuntu.com/security/esm). ESM is mainly for organizations/companies who don't want to upgrade their servers very often. It requires Ubuntu Pro subscriptions, although it's free for personal use.

Since GMT is free software with no paid support, it makes no sense to support old Ubuntu releases that don't have standard support. In this PR, we no longer test GMT building on  Ubuntu 14.04, 16.04 and 18.04, which means building GMT on these old Ubuntu releases may suddenly break in the future. Dropping support of these old Ubuntu releases also makes it possible to bump our minimum support CMake version from 2.8 (released in 2013) to 3.x.