### PR TITLE
grdcontour.rst: refer to constant contour interval

### DIFF
--- a/doc/rst/source/grdcontour.rst
+++ b/doc/rst/source/grdcontour.rst
@@ -110,7 +110,8 @@ Optional Arguments
 
     (3) If *contours* is a string with comma-separated values it is interpreted
         as those specific contours only.  To indicate a single specific contour
-        you must append a trailing comma to separate it from a contour interval.
+        you must append a trailing comma to separate it from a constant contour
+        interval.
         The |-A| option offers the same list choice so they may be used together
         to plot only specific annotated and non-annotated contours.
 


### PR DESCRIPTION
Had to read up on **grdcontour** again, after ``-C+<contour>`` didn't work.

Hopefully makes it a tiny bit clearer.