### PR TITLE
Revert "CI: Check if new DVC files are pushed to the remote (#7824)"

### DIFF
--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -71,9 +71,3 @@ jobs:
             fi
           done
           exit $error
-
-      - name: Setup DVC
-        uses: iterative/setup-dvc@v1
-
-      - name: Check if DVC files are missing from the remote
-        run: dvc data status --not-in-remote --json | grep -v not_in_remote


### PR DESCRIPTION
No need to check DVC files in the "Code Validator" workflow because we added the "DVC diff" workflow in #7832.

This reverts commit e0d4cb58fb16dc689497502503be428a9b545d77.