### PR TITLE
doc: Move the classic module list into the Reference Documentation

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -58,6 +58,7 @@ Quick links
         modules
         reference
         datasets
+        modules-classic
 
     ---
 
@@ -71,14 +72,6 @@ Quick links
         deprecated-defaults
         switching
         migrating
-
-    ---
-
-    .. toctree::
-        :maxdepth: 1
-        :caption: Classic Mode
-
-        modules-classic
 
     ---
 


### PR DESCRIPTION
**Preview**: 

![Screenshot from 2023-10-10 09-36-55](https://github.com/GenericMappingTools/gmt/assets/3974108/66c559b3-41bc-4f14-880e-6c4fc2bad9ea)

xref https://github.com/GenericMappingTools/gmt/issues/6687