### PR TITLE
Disallow -B when grdimage -A is used

### DIFF
--- a/doc/rst/source/grdimage.rst
+++ b/doc/rst/source/grdimage.rst
@@ -68,7 +68,9 @@ pixel, their average will dominate in the calculation of the pixel
 value. Interpolation and aliasing is controlled with the **-n** option.
 
 The |-R| option can be used to select a map region larger or smaller
-than that implied by the extent of the grid.
+than that implied by the extent of the grid. Finally, |-A| allows the
+creation of a direct output to a raster file instead of plotting via
+PostScript.
 
 Required Arguments
 ------------------
@@ -96,7 +98,8 @@ Optional Arguments
     one or more concatenated number of GDAL **-co** options. For example, to write a GeoPDF with the
     TerraGo format use *=PDF+cGEO_ENCODING=OGC_BP*. Notes: (1) If a tiff file (.tif) is selected
     then we will write a GeoTiff image if the GMT projection syntax translates into a PROJ syntax,
-    otherwise a plain tiff file is produced. (2) Any vector elements will be lost.
+    otherwise a plain tiff file is produced. (2) Any vector elements will be lost. **Note**: The **-B**
+    option is not compatible with |-A| since no PostScript output is allowed.
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -512,6 +512,8 @@ static int parse (struct GMT_CTRL *GMT, struct GRDIMAGE_CTRL *Ctrl, struct GMT_O
 	                                   "Option -A: Must provide an output filename for image\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->A.file && Ctrl->Out.file,
 								       "Option -A, -> options: Cannot provide two output files\n");
+	n_errors += gmt_M_check_condition (GMT, Ctrl->A.active && GMT->common.B.active[GMT_PRIMARY] || GMT->common.B.active[GMT_SECONDARY],
+								       "Option -A: Cannot draw base frame (-B) when creating just a raster image\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.transp_color && Ctrl->Q.z_given,
 								       "Option Q: Cannot both specify a r/g/b and a z-value\n");
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);


### PR DESCRIPTION
See pyGMT [issue](https://github.com/GenericMappingTools/pygmt/issues/2599) for background.  This PR checks that **-A** and **-B** are not both used..