### PR TITLE
Update gmt_support.c

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1818,7 +1818,7 @@ GMT_LOCAL int gmtsupport_intpol_sub (struct GMT_CTRL *GMT, double *x, double *y,
 				else if (j == 0)	/* Start at the beginning */
 					v[i] = y[0];
 				else	/* Pick the smallest before the step happens */
-					v[i] = MIN (y[j], y[j+1]);
+					v[i] = (y[j+1] >= y[j]) ? MIN (y[j], y[j+1]) : MAX (y[j], y[j+1]);
 				break;
 			case GMT_SPLINE_LINEAR+GMT_SPLINE_SLOPE:	/* Linear spline v'(u) */
 				v[i] = (y[j+1]-y[j])/(x[j+1]-x[j]);


### PR DESCRIPTION
The **sample1d -Fe** interpolator could only go up but now it can go down as well.  Please check, @federico if this is what you expected:

![GMT_splines](https://github.com/GenericMappingTools/gmt/assets/26473567/fb8015ff-7566-480e-90f7-14d0faf35685)

Related to #7490.  If you agree please update the script and plot (dvc if you have tried that before).