### PR TITLE
Let pslegend -D+w accept a percentage relative to map width

### DIFF
--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -58,7 +58,10 @@ Required Arguments
     .. include:: explain_refpoint.rst_
 
     Append **+w**\ *width*\ [/*height*] to set the width (and height) of the legend box
-    in plot coordinates (inches, cm, etc.). **Note**: If **+w** is not given then we compute
+    in plot coordinates (inches, cm, etc.). If unit is % (percentage) then *width* as
+    computed as that fraction of the map width. If *height* is given as percentage then
+    then *height* is recomputed as that fraction of the legend *width* (not map height).
+    **Note**: If **+w** is not given then we compute
     the width within the *Postscript* code.  Currently, this is only possible if just
     legend codes **D**, **H**, **L**, **S**, or **V** are used and that the number of symbol
     columns (**N**) is 1. If *height* is zero or not given then we estimate *height* based

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -427,6 +427,7 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 
 /* gmt_support.c: */
 
+EXTERN_MSC unsigned int gmt_rectangle_dimension (struct GMT_CTRL *GMT, struct GMT_SCALED_RECT_DIM *R, double def_percent_w, double def_percent_h, char *string);
 EXTERN_MSC int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, bool binary, uint64_t n, int **link);
 EXTERN_MSC unsigned int gmt_get_no_argument (struct GMT_CTRL *GMT, char *text, char option, char modifier);
 EXTERN_MSC unsigned int gmt_get_required_uint64 (struct GMT_CTRL *GMT, char *text, char option, char modifier, uint64_t *value);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -19121,6 +19121,7 @@ unsigned int gmt_rectangle_dimension (struct GMT_CTRL *GMT, struct GMT_SCALED_RE
 			}
 		}
 		else {	/* Only gave width in percentage */
+			R->fraction[GMT_X] = true;
 			R->scl[GMT_X] = atof (string) * 0.01;	/* Convert to fraction */
 			R->dim[GMT_X] = 0.0;	/* Wipe back to zero */
 		}

--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -36,6 +36,13 @@
  * GMT TYPE DEFINITIONS
  *--------------------------------------------------------------------*/
 
+/*! Definition of GMT_SCALED_RECT_DIM used to handle embellishments dimensions given by default or percentages of map width */
+struct GMT_SCALED_RECT_DIM {
+	bool fraction[2];	/* True if dimensions in dim are given as fraction of map width and rectangle height */
+	double dim[2];		/* Dimensions in inches, if set; */
+	double scl[2];		/* Scales set to give dim once map width is known (scl[GMT_Y] is relative to rectangle width, not map width) */
+};
+
 /*! Definition of CONTOUR_ARGS used by grdcontour and pscontour */
 struct CONTOUR_ARGS {
 	bool cpt;		/* true of we were given a CPT file */


### PR DESCRIPTION
Similar to **psscale**, allow processing of things like **+w**80%.  This PR implements this via a new gmt function 						_gmt_rectangle_dimension_ that does the parsing, hence the PR involves psscale as well as some library and include files.

@Esteban82, All tests pass as before, but I have not tested this specifically with legend.  Please give it a try. +w90% will set width to 90% of map width, while +w90%/30% will fix height at 30% of the legend width (not map width).