### PR TITLE
Add option and list of GTHREADS to gmt-config

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,17 +284,20 @@ if (GLIB_FOUND AND GMT_USE_THREADS)
 	list (APPEND GMT_OPTIONAL_LIBRARIES ${GLIB_LIBRARIES})
 	set (GMT_CONFIG_GTHREAD_MESSAGE "enabled (${GLIB_VERSION})"
 		CACHE INTERNAL "GTHREAD config message")
+	set (GMT_CONFIG_GTHREAD_MESSAGE "enabled" CACHE INTERNAL "GLIB config message")
 endif (GLIB_FOUND AND GMT_USE_THREADS)
 if (GLIB_FOUND AND NOT GMT_USE_THREADS)
 	set (HAVE_GLIB_GTHREAD FALSE CACHE INTERNAL "User disabled threads")
 	message (STATUS "User variable GMT_USE_THREADS not set: disabling GThread.")
 	set (GMT_CONFIG_GTHREAD_MESSAGE "disabled"
 		CACHE INTERNAL "GTHREAD config message")
+	set (GMT_CONFIG_GTHREAD_MESSAGE "disabled" CACHE INTERNAL "GLIB config message")
 endif (GLIB_FOUND AND NOT GMT_USE_THREADS)
 if (GMT_USE_THREADS AND NOT GLIB_FOUND)
 	message (FATAL_ERROR "User variable GMT_USE_THREADS set but GLIB component gthread not found.")
 	set (GMT_CONFIG_GTHREAD_MESSAGE "unavailable"
 		CACHE INTERNAL "GTHREAD config message")
+	set (GMT_CONFIG_GTHREAD_MESSAGE "unavailable" CACHE INTERNAL "GLIB config message")
 endif (GMT_USE_THREADS AND NOT GLIB_FOUND)
 
 # FreeBSD uses a separate library for backtracking

--- a/src/gmt-config.in
+++ b/src/gmt-config.in
@@ -132,7 +132,7 @@ This GMT $CONFIG_VERSION has been built with the following features:
   --has-pcre    -> $CONFIG_PCRE_ENABLED
   --has-lapack  -> $CONFIG_LAPACK_ENABLED
   --has-openmp  -> $CONFIG_OPENMP_ENABLED
-  --has-gthred  -> $CONFIG_GTHREADS_ENABLED
+  --has-gthred  -> $CONFIG_GTHREAD_ENABLED
 
   --prefix      -> $CONFIG_PREFIX
   --includedir  -> $CONFIG_INCLUDEDIR

--- a/src/gmt-config.in
+++ b/src/gmt-config.in
@@ -62,6 +62,12 @@ else
   CONFIG_LAPACK_ENABLED=no
 fi
 
+if [ "@GMT_CONFIG_GTHREAD_MESSAGE@" == "enabled" ]; then
+  CONFIG_GTHREAD_ENABLED=yes
+else
+  CONFIG_GTHREAD_ENABLED=no
+fi
+
 if [ "@GMT_CONFIG_OPENMP_MESSAGE@" == "enabled" ]; then
   CONFIG_OPENMP_ENABLED=yes
 else
@@ -81,26 +87,27 @@ Usage: gmt-config [OPTIONS]
 
 Available values for OPTIONS include:
 
-  --help        display this help message and exit
-  --all         display all options
-  --bits        whether library is build 32-bit or 64-bit
-  --cc          C compiler
-  --cflags      pre-processor and compiler flags
-  --datadir     GMT's data directories
-  --dataserver  URL of the remote GMT data server
-  --dcw         location of used DCW
-  --dep-libs    dependent libraries
-  --gshhg       location of used GSHHG
-  --has-fftw    whether FFTW is used in build
-  --has-pcre    whether PCRE is used in build
-  --has-lapack  whether LAPACK is used in build
-  --has-openmp  whether GMT was built with OpenMP support
-  --includedir  include directory
-  --libdir      library directory
-  --libs        library linking information
-  --plugindir   GMT's plugin directory
-  --prefix      install prefix
-  --version     library version
+  --help         display this help message and exit
+  --all          display all options
+  --bits         whether library is build 32-bit or 64-bit
+  --cc           C compiler
+  --cflags       pre-processor and compiler flags
+  --datadir      GMT's data directories
+  --dataserver   URL of the remote GMT data server
+  --dcw          location of used DCW
+  --dep-libs     dependent libraries
+  --gshhg        location of used GSHHG
+  --has-fftw     whether FFTW is used in build
+  --has-pcre     whether PCRE is used in build
+  --has-lapack   whether LAPACK is used in build
+  --has-openmp   whether GMT was built with OpenMP support
+  --has-gthreads whether GMT was built with GTHREADS support
+  --includedir   include directory
+  --libdir       library directory
+  --libs         library linking information
+  --plugindir    GMT's plugin directory
+  --prefix       install prefix
+  --version      library version
 EOF
   exit $1
 }
@@ -125,6 +132,7 @@ This GMT $CONFIG_VERSION has been built with the following features:
   --has-pcre    -> $CONFIG_PCRE_ENABLED
   --has-lapack  -> $CONFIG_LAPACK_ENABLED
   --has-openmp  -> $CONFIG_OPENMP_ENABLED
+  --has-gthreds -> $CONFIG_GTHREADS_ENABLED
 
   --prefix      -> $CONFIG_PREFIX
   --includedir  -> $CONFIG_INCLUDEDIR
@@ -189,6 +197,10 @@ for arg in "$@"; do
 
     --has-openmp)
     echo $CONFIG_OPENMP_ENABLED
+    ;;
+
+    --has-gthreads)
+    echo $CONFIG_GTHREADS_ENABLED
     ;;
 
     --includedir)

--- a/src/gmt-config.in
+++ b/src/gmt-config.in
@@ -200,7 +200,7 @@ for arg in "$@"; do
     ;;
 
     --has-gthread)
-    echo $CONFIG_GTHREADS_ENABLED
+    echo $CONFIG_GTHREAD_ENABLED
     ;;
 
     --includedir)

--- a/src/gmt-config.in
+++ b/src/gmt-config.in
@@ -101,7 +101,7 @@ Available values for OPTIONS include:
   --has-pcre     whether PCRE is used in build
   --has-lapack   whether LAPACK is used in build
   --has-openmp   whether GMT was built with OpenMP support
-  --has-gthreads whether GMT was built with GTHREADS support
+  --has-gthread  whether GMT was built with GTHREAD support
   --includedir   include directory
   --libdir       library directory
   --libs         library linking information
@@ -132,7 +132,7 @@ This GMT $CONFIG_VERSION has been built with the following features:
   --has-pcre    -> $CONFIG_PCRE_ENABLED
   --has-lapack  -> $CONFIG_LAPACK_ENABLED
   --has-openmp  -> $CONFIG_OPENMP_ENABLED
-  --has-gthreds -> $CONFIG_GTHREADS_ENABLED
+  --has-gthred  -> $CONFIG_GTHREADS_ENABLED
 
   --prefix      -> $CONFIG_PREFIX
   --includedir  -> $CONFIG_INCLUDEDIR
@@ -199,7 +199,7 @@ for arg in "$@"; do
     echo $CONFIG_OPENMP_ENABLED
     ;;
 
-    --has-gthreads)
+    --has-gthread)
     echo $CONFIG_GTHREADS_ENABLED
     ;;
 

--- a/test/baseline/grdfilter.dvc
+++ b/test/baseline/grdfilter.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: eac7eb998192f3d7bee7c00d367d7b51.dir
-  size: 4160465
-  nfiles: 6
+- md5: bc1d12935b63c0b9af730837de41c4ea.dir
+  size: 6428161
+  nfiles: 7
   path: grdfilter

--- a/test/grdfilter/openmp.sh
+++ b/test/grdfilter/openmp.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Testing gmt grdfilter if openmp is used.
+# Testing gmt grdfilter if openmp is used [implemented in libs but not grdfilter.c].
 
 ps=openmp.ps
 
-if ! [[ ${HAVE_OPENMP} =~ TRUE|ON ]]; then
+if [ "X$(gmt-config --has-openmp)" = "Xyes" ]; then
   # Since a PS-producing test is judge by comparison to original PS
   # and since no PS is produced without OpenMP, we simply duplicate
   # the original so they both exist and are identical.
@@ -11,13 +11,13 @@ if ! [[ ${HAVE_OPENMP} =~ TRUE|ON ]]; then
   cp $baseline/${psref:-$ps} .
   exit 0
 fi
-FILT=g			# Gaussian filter
-INC=1			# 1x1 degree output
-D=1000			# 1000 km filter width
+FILT=g	# Gaussian filter
+INC=1	# 1x1 degree output
+D=1000	# 1000 km filter width
 
 # Run gmt grdfilter as specified
 gmt grdfilter -D4 -F${FILT}$D -I$INC @earth_relief_10m_p -Gt.nc -fg
 gmt makecpt -Cglobe > t.cpt
 gmt grdimage t.nc -JQ0/7i -Ba -BWSne+t"$D km Gaussian filter" -Ct.cpt -P -K -Xc -Y1.5i > $ps
-gmt psscale -Ct.cpt -D3.5i/-0.5i+w6i/0.1i+h+jTC -O -K -Bxa -By+l"m" >> $ps
+gmt psscale -Ct.cpt -Dx3.5i/-0.5i+w6i/0.1i+h+jTC -O -K -Bxa -By+l"m" >> $ps
 gmt grdimage @earth_relief_10m -JQ0/7i -Ba -BWSne+t"Original data" -Ct.cpt -O -Y4.75i >> $ps

--- a/test/grdfilter/threads.sh
+++ b/test/grdfilter/threads.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Testing gmt grdfilter if gthreads is enabled.
-ps=threads.ps # Basically same as test openmp.sh but using GTHREADS
+ps=threads.ps # Basically same as test openmp.sh but using GTHREAD
 
 if [ "X$(gmt-config --has-gthreads)" = "Xyes" ]; then
 	_thread_opt=-x+a

--- a/test/grdfilter/threads.sh
+++ b/test/grdfilter/threads.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Testing gmt grdfilter if openmp is used.
-ps=openmp.ps # same as test: openmp.sh
+# Testing gmt grdfilter if gthreads is enabled.
+ps=threads.ps # Basically same as test openmp.sh but using GTHREADS
 
-if [[ ${HAVE_GLIB_GTHREAD} =~ TRUE|ON ]]; then
-  _thread_opt=-x+a
+if [ "X$(gmt-config --has-gthreads)" = "Xyes" ]; then
+	_thread_opt=-x+a
 fi
 
-FILT=g			# Gaussian filter
-INC=1			# 1x1 degree output
-D=1000			# 1000 km filter width
+FILT=g				# Gaussian filter
+INC=1				# 1x1 degree output
+D=1000				# 1000 km filter width
 DATA=@earth_relief_10m_p	# Test on ETOP10 data
 
 # Run gmt grdfilter as specified


### PR DESCRIPTION
While it is a configuration setting it did not let us probe via _gmt-config_. Also let _openmp.sh_ write to _openmp.ps_ and _threads.sh_ to _threads.ps_ (they weirdly shared the same output file name _openmp.ps_). Added the missing PS files and updated DVC.

However, while cmake says GTHREADS is enabled, 

`gmt-config --has-gthreads`

does not return anything so I am missing something.  `gmt-config --had-openmp` correctly says "no"