### PR TITLE
Stress that IO_COL_SEPARATOR is for output formatting only

### DIFF
--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -524,9 +524,12 @@ I/O Parameters
 .. glossary::
 
     **IO_COL_SEPARATOR**
-        This setting determines what character will separate ASCII output
-        data columns written by GMT. Choose from **tab**, **space**, **comma**, and
-        **none** [default is **tab**].
+        This setting determines what character will separate ASCII *output*
+        data columns written by GMT. Choose from **tab**, **space**, **comma**,
+        **semicolon** and **none** [default is **tab**]. You may also just give
+        any character or string (e.g., "--|--"). **Note**: When reading input
+        data GMT automatically skips white-space, commas, and semi-colons; you
+        cannot select an individual input column separator.
 
     **IO_FIRST_HEADER**
         This setting determines if the first segment header is written when

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -11736,6 +11736,10 @@ unsigned int gmtlib_setparameter (struct GMT_CTRL *GMT, const char *keyword, cha
 				strncpy (GMT->current.setting.io_col_separator, " ", 8U);
 			else if (!strcmp (lower_value, "comma"))
 				strncpy (GMT->current.setting.io_col_separator, ",", 8U);
+			else if (!strcmp (lower_value, "semicolon"))
+				strncpy (GMT->current.setting.io_col_separator, ";", 8U);
+			else if (!strcmp (lower_value, "semi-colon"))
+				strncpy (GMT->current.setting.io_col_separator, ";", 8U);
 			else if (!strcmp (lower_value, "none"))
 				GMT->current.setting.io_col_separator[0] = 0;
 #ifdef WIN32


### PR DESCRIPTION
Also added semi-colon (which is also skipped on input) and pointed out this setting applies to output only.
