### PR TITLE
Fix grdcut tif grids

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3517,6 +3517,8 @@ int gmt_raster_type (struct GMT_CTRL *GMT, char *file, bool extra) {
 			struct GMT_GRID_HEADER_HIDDEN *HH = gmt_get_H_hidden (I->header);	/* Get pointer to hidden structure */
 			if (HH->pocket && strchr (HH->pocket, ',') == NULL)	/* Got a single band request which we return as a grid */
 				code = GMT_IS_GRID;
+			else if (I->type == GMT_FLOAT)		/* No doubt in this case */
+				code = GMT_IS_GRID;
 			else if (HH->orig_datatype == GMT_UCHAR || HH->orig_datatype == GMT_CHAR)	/* Got a gray or RGB image with or without transparency */
 				code = GMT_IS_IMAGE;
 			else if (I->header->n_bands > 1)	/* Whatever it is we must return multiband as an image */

--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -299,13 +299,15 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCUT_CTRL *Ctrl, struct GMT_OPT
 			if (ftype == GMT_IS_IMAGE)	/* Must read file as an image */
 				Ctrl->In.type = GMT_IS_IMAGE;
 			else if (ftype == GMT_IS_GRID) {	/* Check extension in case of special case */
-				if (strstr (Ctrl->G.file, ".tif"))	/* Want to write a single band (normally written as a grid) to geotiff instead */
-					Ctrl->In.type = GMT_IS_IMAGE;
-				else
-					Ctrl->In.type = GMT_IS_GRID;
+				Ctrl->In.type = GMT_IS_GRID;
+				//if (strstr (Ctrl->G.file, ".tif"))	/* Want to write a single band (normally written as a grid) to geotiff instead */
+					//Ctrl->In.type = GMT_IS_IMAGE;
+				//else
+					//Ctrl->In.type = GMT_IS_GRID;
 			}
 			else	/* Just have to assume it is a grid */
 				Ctrl->In.type = GMT_IS_GRID;
+
 			if (Ctrl->In.type == GMT_IS_IMAGE) {
 				n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active, "Option -N: Cannot be used with an image\n");
 				n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active, "Option -Z: Cannot be used with an image\n");


### PR DESCRIPTION
Cutting geotiff float files was failing because the .tif extension was forcing trying to save as images when input is clearly a grid (determined by data type).

I still left non-working commented lines to see if brings some memory of what was meant in that line.