### PR TITLE
Fix conflicts with common longoption strings.

### DIFF
--- a/src/longopt/dimfilter_inc.h
+++ b/src/longopt/dimfilter_inc.h
@@ -24,7 +24,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	/* separator, short_option, long_option,
 	          short_directives,    long_directives,
 	          short_modifiers,     long_modifiers */
-	{ 0, 'D', "distance",     "", "", "", "" },
+	{ 0, 'D', "disttype",     "", "", "", "" },
 	{ 0, 'F', "filter",
 	          "b,c,g,m,p",    "boxcar,cosarch,gaussian,median,maxprob",
 	          "l,u",          "lower,upper" },
@@ -32,7 +32,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	          "",             "",
 	          "d,n,o,s",      "divide,nan,offset,scale" },
 	GMT_INCREMENT_KW,         /* quasi-common -I option from gmt_constants.h */
-	{ 0, 'L', "script", "", "", "", "" },
+	{ 0, 'L', "script",       "", "", "", "" },
 	{ 0, 'N', "sector_filter|secfilter",
 	          "l,u,a,m,p",    "min,max,average,median,mode",
 	          "l,u",          "lower,upper" },

--- a/src/longopt/grdfilter_inc.h
+++ b/src/longopt/grdfilter_inc.h
@@ -24,13 +24,13 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	/* separator, short_option, long_option,
 	          short_directives,    long_directives,
 	          short_modifiers,     long_modifiers */
-	{ 0, 'D', "distance",     "", "", "", "" },
+	{ 0, 'D', "disttype",          "", "", "", "" },
 	{ 0, 'F', "filter",
 	          "b,c,g,f,o,m,p,h,l,L,u,U",
  				       "boxcar,cosarch,gaussian,custom,operator,median,mlprob,histogram,minall,minpos,maxall,maxneg",
 	          "c,h,l,q,u",         "center,highpass,lower,quantile,upper" },
 	{ 0, 'G', "outgrid",
-	          "",             "",
+	          "",                  "",
 	          "d,n,o,s,c",         "divide,nan,offset,scale,gdal" },
 	GMT_INCREMENT_KW,              /* quasi-common -I option from gmt_constants.h */
 	{ 0, 'N', "nans",


### PR DESCRIPTION
**Description of proposed changes**

The review of the grdfilter and dimfilter longoptions resulted in the selection of an unfortunate **--distance** choice  for the **-D** options of those modules. **--distance** is already in use as a common-option longoption string for the **-j** option:

```
/* from src/gmt_common_longoptions.h */
    {   0, 'j', "distance",
                "e,f,g",                 "ellipsoidal,flatearth,spherical",
                "",                      "" },

```

I am restoring my original **--disttype** longoption string for now and submitting this as a new PR for further group review. Please check the gmt_common_longoptions.h file for potential conflicts when making future changes, thanks!
<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #7919


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
