### PR TITLE
Use --metric (and aliases) for -j

### DIFF
--- a/src/gmt_common_longoptions.h
+++ b/src/gmt_common_longoptions.h
@@ -107,7 +107,7 @@
     { ',', 'i', "incols",
                 "",                      "",
                 "l,d,o,s",               "log10,divide,offset,scale" },
-    {   0, 'j', "distance",
+    {   0, 'j', "metric|spherical|distcalc",
                 "e,f,g",                 "ellipsoidal,flatearth,spherical",
                 "",                      "" },
     {   0, 'l', "legend",


### PR DESCRIPTION
I had selected **--distnce** for **-j** but not used in PyJu which also differ.  But since **-D** is **--distance** in the two grid filter functions we want to preserve that so **-j** changes instead.
