### PR TITLE
grdclip: Fix typo in the docs of "-S"

### DIFF
--- a/doc/rst/source/grdclip.rst
+++ b/doc/rst/source/grdclip.rst
@@ -64,15 +64,15 @@ Optional Arguments
 .. _-S:
 
 **-Sa**\ *high/above*\ [**+e**]
-    Set all data[i] > *high* to *above*.  Modifier **+e** includes the equality, i.e., data[i] >= *high*.
+    Set all data[i] > *high* to *above*. Modifier **+e** includes the equality, i.e., data[i] >= *high*.
 **-Sb**\ *low/below*\ [**+e**]
-    Set all data[i] < *low* to *below*.  Modifier **+e** includes the equality, i.e., data[i] <= *low*.
+    Set all data[i] < *low* to *below*. Modifier **+e** includes the equality, i.e., data[i] <= *low*.
 **-Si**\ *low/high/between*
     Set all data[i] >= *low* and <= *high* to *between*.
     Repeat the option for as many intervals as are needed.
 **-Sr**\ *old/new*
-    Set all data[i] == *old* to *new*.  This is mostly useful when
-    your data are known to be integer values.  Repeat the option
+    Set all data[i] == *old* to *new*. This is mostly useful when
+    your data are known to be integer values. Repeat the option
     for as many replacements as are needed.
 
 .. |Add_-V| replace:: |Add_-V_links|

--- a/doc/rst/source/grdclip.rst
+++ b/doc/rst/source/grdclip.rst
@@ -64,9 +64,9 @@ Optional Arguments
 .. _-S:
 
 **-Sa**\ *high/above*\ [**+e**]
-    Set all data[i] > *high* to *above*.  Modifer **+e** includes the equality, i.e., data[i] >= *high*.
+    Set all data[i] > *high* to *above*.  Modifier **+e** includes the equality, i.e., data[i] >= *high*.
 **-Sb**\ *low/below*\ [**+e**]
-    Set all data[i] < *low* to *below*.  Modifer **+e** includes the equality, i.e., data[i] <= *low*.
+    Set all data[i] < *low* to *below*.  Modifier **+e** includes the equality, i.e., data[i] <= *low*.
 **-Si**\ *low/high/between*
     Set all data[i] >= *low* and <= *high* to *between*.
     Repeat the option for as many intervals as are needed.


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a tiny typo in the documentation of **-S** of `grdclip`.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
