### PR TITLE
"movie": Fix typo

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -477,7 +477,7 @@ Using |-A|\ [**+e**], you can include an audio track, such as narrating the anim
 whatever you have on tap. The final movie will have a length matching the longest of the audio or animation,
 so you probably will want to process you audio file to fit your animation.  Since the animation length
 is known to be *n_frames / displayrate* you can preprocess the audio track to have the matching length.
-Alternatively, if the audio track is approximately the same length as the video (withing ±50% of animation
+Alternatively, if the audio track is approximately the same length as the video (within ±50% of animation
 length), append **+e** to scale the audio track to have the exact same length as the animation.
 
 Technical Details


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a tiny typo in the section "Adding an Audio Track" of the documentation for `movie`

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
