### PR TITLE
Need to reparse -o when output received from module call

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -4322,7 +4322,7 @@ GMT_LOCAL int gmtapi_export_dataset (struct GMTAPI_CTRL *API, int object_ID, uns
 	}
 	gmt_set_dataset_minmax (GMT, D_obj);	/* Update all counters and min/max arrays */
 	if (API->GMT->common.o.col.end || GMT->common.o.col.text)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
-		gmtlib_reparse_o_option (GMT, (GMT->common.o.col.text) ? 0 : D_obj->n_columns);
+		gmt_reparse_o_option (GMT, (GMT->common.o.col.text) ? 0 : D_obj->n_columns);
 	toggle = (GMT->current.setting.io_lonlat_toggle[GMT_OUT] && D_obj->n_columns >= 2);
 	GMT->current.io.data_record_number_in_tbl[GMT_OUT] = GMT->current.io.data_record_number_in_seg[GMT_OUT] = 0;
 	DH = gmt_get_DD_hidden (D_obj);
@@ -10617,7 +10617,7 @@ GMT_LOCAL int gmtapi_put_record_init (struct GMTAPI_CTRL *API, unsigned int mode
 			API->current_fp = S_obj->fp;
 			API->current_put_n_columns = S_obj->n_columns;
 			if (API->GMT->common.o.col.end || API->GMT->common.o.col.text)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
-				gmtlib_reparse_o_option (API->GMT, (API->GMT->common.o.col.text) ? 0 : S_obj->n_columns);
+				gmt_reparse_o_option (API->GMT, (API->GMT->common.o.col.text) ? 0 : S_obj->n_columns);
 			error = gmtapi_put_record_fp (API, mode, record);
 			break;
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -149,8 +149,8 @@
  *	gmtlib_putcmyk
  *	gmtlib_putfill
  *	gmtlib_puthsv
- *	gmtlib_reparse_i_option
- *	gmtlib_reparse_o_option
+ *	gmt_reparse_i_option
+ *	gmt_reparse_o_option
  *	gmtlib_report_func
  *	gmtlib_set_case_and_kind
  *	gmtlib_setparameter
@@ -20362,10 +20362,14 @@ GMT_LOCAL void gmtinit_reparse_io_option (struct GMT_CTRL *GMT, uint64_t n_colum
 	}
 	if (n_columns == 0) return;	/* Cannot update the string */
 	for (k = strlen (C->string) - 1; k && !(C->string[k] == ':' || C->string[k] == '-'); k--);	/* Find the last : or - in open-ended sequence */
-	strncpy (token, C->string, k+1);	/* Get duplicate, this ends with - or : */
-	sprintf (text, "%d", (int)n_columns-1);
-	strcat (token, text);	/* Add explicit last column to include */
-	if (C->string[k+1] == ',') strncat (token, &C->string[k+1],PATH_MAX-1);	/* Probably trailing text selections */
+	if (k == 0)
+		strcpy (token, C->string);	/* Get duplicate */
+	else {
+		strncpy (token, C->string, k+1);	/* Get duplicate, this ends with - or : */
+		sprintf (text, "%d", (int)n_columns-1);
+		strcat (token, text);	/* Add explicit last column to include */
+		if (C->string[k+1] == ',') strncat (token, &C->string[k+1],PATH_MAX-1);	/* Probably trailing text selections */
+	}
 	if (dir == GMT_IN)
 		GMT->common.i.active = false;	/* So we can parse -i again */
 	else
@@ -20376,10 +20380,10 @@ GMT_LOCAL void gmtinit_reparse_io_option (struct GMT_CTRL *GMT, uint64_t n_colum
 		GMT->current.io.trailing_text[GMT_OUT] = o_trailing;	/* Reset to what was parsed initially */
 }
 
-void gmtlib_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns) {
+void gmt_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns) {
 	gmtinit_reparse_io_option (GMT, n_columns, GMT_IN);
 }
 
-void gmtlib_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns) {
+void gmt_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns) {
 	gmtinit_reparse_io_option (GMT, n_columns, GMT_OUT);
 }

--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -112,8 +112,6 @@ EXTERN_MSC int gmtlib_polar_prepare_label (struct GMT_CTRL *GMT, double angle, u
 EXTERN_MSC bool gmtlib_B_is_frame (struct GMT_CTRL *GMT, char *in);
 EXTERN_MSC int64_t gmtlib_parse_index_range (struct GMT_CTRL *GMT, char *p, int64_t *start, int64_t *stop);
 EXTERN_MSC int gmtlib_ascii_output_trailing_text (struct GMT_CTRL *GMT, FILE *fp, uint64_t n, double *ptr, char *txt);
-EXTERN_MSC void gmtlib_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns);
-EXTERN_MSC void gmtlib_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns);
 EXTERN_MSC void gmtlib_get_graphics_item (struct GMTAPI_CTRL *API, int *fig, int *subplot, char *panel, int *inset);
 EXTERN_MSC void gmtlib_set_KOP_strings (struct GMTAPI_CTRL *API);
 EXTERN_MSC bool gmtlib_is_modern_name (struct GMTAPI_CTRL *API, const char *module);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3556,7 +3556,7 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 	}
 	*n_columns = col;	/* Pass back the numerical column count */
 	if (GMT->common.i.col.end)	/* Asked for unspecified last column on input (e.g., -i3,2,5:), supply the missing last column number */
-		gmtlib_reparse_i_option (GMT, col);
+		gmt_reparse_i_option (GMT, col);
 
 	if (found_text) {	/* Determine record type */
 		ret_val = (*n_columns) ? GMT_READ_MIXED : GMT_READ_TEXT;	/* Possibly update record type */
@@ -6072,9 +6072,9 @@ void gmtlib_io_init (struct GMT_CTRL *GMT) {
 	GMT->current.io.cycle_col = GMT_NOTSET;
 }
 
-/*! Routine will temporarily suspend any -b, -i, -g, h selections for secondary inputs */
+/*! Routine will temporarily suspend any -b, -g, -h, -i, -o selections for secondary inputs */
 void gmt_disable_bghio_opts (struct GMT_CTRL *GMT) {
-	/* Temporarily turn off any -b, -i, -g, h selections */
+	/* Temporarily turn off any -b, -g, -h, -i, -o selections */
 	GMT->common.i.col.select = false;
 	GMT->common.o.col.select = false;
 	GMT->current.setting.io_header_orig = GMT->current.setting.io_header[GMT_IN];
@@ -6088,9 +6088,9 @@ void gmt_disable_bghio_opts (struct GMT_CTRL *GMT) {
 	}
 }
 
-/*! Routine will re-enable any suspended -b, -i, -g, -h selections */
+/*! Routine will re-enable any suspended -b, -g, -h, -i, -o selections */
 void gmt_reenable_bghio_opts (struct GMT_CTRL *GMT) {
-	/* Turn on again any -b, -i, -g, -h selections */
+	/* Turn on again any -b, -g, -h, -i, -o selections */
 	GMT->common.i.col.select = GMT->common.i.col.orig;
 	GMT->common.o.col.select = GMT->common.o.col.orig;
 	GMT->current.setting.io_header[GMT_IN] = GMT->current.setting.io_header_orig;

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -58,6 +58,8 @@ EXTERN_MSC int gmt_nc_create (struct GMT_CTRL *GMT, char *path, int mode, int *i
 
 /* gmt_init.c: */
 
+EXTERN_MSC void gmt_reparse_i_option (struct GMT_CTRL *GMT, uint64_t n_columns);
+EXTERN_MSC void gmt_reparse_o_option (struct GMT_CTRL *GMT, uint64_t n_columns);
 EXTERN_MSC void gmt_update_keys (struct GMT_CTRL *GMT, bool arg);
 EXTERN_MSC void gmt_detect_oblique_region (struct GMT_CTRL *GMT, char *file);
 EXTERN_MSC unsigned int gmt_subplot_status (struct GMTAPI_CTRL *API, int fig);

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -567,7 +567,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 			Si = In->table[0]->segment[0];	/* Short hand to the first and only segment */
 			Si->data[GMT_X][0] = Ctrl->S.x;
 			Si->data[GMT_Y][0] = Ctrl->S.y;
-			if (Ctrl->S.header)	/* Set the fixed header here via training text */
+			if (Ctrl->S.header)	/* Set the fixed header here via trailing text */
 				Si->text[0] = strdup (Ctrl->S.header);
 			Si->n_rows = 1;
 			gmt_set_dataset_minmax (GMT, In);
@@ -695,6 +695,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 		}
 
 		gmt_reenable_bghio_opts (GMT);	/* Recover settings provided by user (if -b -g -h -i were used at all) */
+		if (GMT->common.o.active) gmt_reparse_o_option (GMT, Out->n_columns);
 
 		if (Ctrl->S.active) {	/* Write the table(s) */
 			if (Ctrl->G.file && strchr (Ctrl->G.file, '%')) {	/* Want separate files per series, so change mode and build file names per segment */


### PR DESCRIPTION
See #7934 for background.  This PR checks if **-o** was set and reparses the **-o** option since it may get mangled by intermediate _GMT_Call_Module_ calculations and returns.
