### PR TITLE
Let grdcut -E extract a vertical slice from a 3-D cube

### DIFF
--- a/doc/rst/source/grdcut.rst
+++ b/doc/rst/source/grdcut.rst
@@ -17,6 +17,7 @@ Synopsis
 |-G|\ *outgrid*
 |SYN_OPT-R|
 [ |-D|\ [**+t**] ]
+[ |-E|\ **x**\|\ **y**\ *coord* ]
 [ |-F|\ *polygonfile*\ [**+c**][**+i**] ]
 [ |-J|\ *parameters* ]
 [ |-N|\ [*nodata*] ]
@@ -79,6 +80,13 @@ Optional Arguments
     to standard output. The increments will reflect the input grid unless it is a
     remote gridded data set without implied resolution. Append **+t** to instead receive
     the information as the trailing string "-Rwest/east/south/north -Ixinc/yinc".
+
+.. _-E:
+
+**-E**\ **x**\|\ **y**\ *coord*
+    We extract a vertical slice going along the **x**\ -column *coord* or along the
+    **y**\ -row *coord*, depending on the given directive.
+    **Note**: Input file must be a 3-D netCDF cube, and |-E| can only be used with option |-G|.
 
 .. _-F:
 

--- a/doc/rst/source/grdcut.rst
+++ b/doc/rst/source/grdcut.rst
@@ -39,9 +39,10 @@ If in doubt, run :doc:`grdinfo` to check range. Alternatively, define the
 sub-region indirectly via a range check on the node values or via distances from
 a fixed point. Furthermore, you can use |-J| for oblique projections to determine
 the corresponding rectangular |-R| setting that will give a sub-region that fully
-covers the oblique domain.  Finally, use |-F| to specify a polygon and either use
+covers the oblique domain.  You can use |-F| to specify a polygon and either use
 its bounding box for sub-region or set grid nodes inside or outside the polygon
-to NaN. **Note**: If the input grid is actually an image (gray-scale,
+to NaN. Finally, if the input is a 3-D netCDF cube then you can make a vertical
+slice through existing nodes. **Note**: If the input grid is actually an image (gray-scale,
 RGB, or RGBA), then options |-N| and |-Z| are unavailable, while for multi-layer
 Geotiff files only options |-R|, |-S| and |-G| are supported, i.e., you can cut out
 a sub-region only (which we do via *gdal_translate* if you have multiple bands).
@@ -86,7 +87,9 @@ Optional Arguments
 **-E**\ **x**\|\ **y**\ *coord*
     We extract a vertical slice going along the **x**\ -column *coord* or along the
     **y**\ -row *coord*, depending on the given directive.
-    **Note**: Input file must be a 3-D netCDF cube, and |-E| can only be used with option |-G|.
+    **Note**: (1) Input file must be a 3-D netCDF cube, and |-E| can only be used with
+    option |-G|. (2) *coord* must exactly match the coordinates given by th cube. We are
+    not interpolating between nodes and only do a clean slice through existing cube nodes.
 
 .. _-F:
 

--- a/doc/rst/source/grdcut.rst
+++ b/doc/rst/source/grdcut.rst
@@ -192,6 +192,11 @@ that is using an oblique projection to display the remote Earth Relief data grid
 
     gmt grdcut @earth_relief -R270/20/305/25+r -JOc280/25.5/22/69/24c -D+t -V
 
+To extract a vertical grid slice at *x = 35* and parallel to the *y-z* plane
+from the 3-D model seis3D.nc, try::
+
+    gmt grdcut seis3D.nc -Gslice_x35.nc -Ex35 -V
+
 Notes
 -----
 

--- a/doc/rst/source/module_core_purpose.rst_
+++ b/doc/rst/source/module_core_purpose.rst_
@@ -70,7 +70,7 @@
 
 .. |grdblend_purpose| replace:: Blend several partially overlapping grids into one larger grid
 
-.. |grdclip_purpose| replace:: 
+.. |grdclip_purpose| replace:: Clip the range of grid values
 
 .. |grdcontour_purpose| replace:: Make contour map using a grid
 

--- a/doc/rst/source/module_core_purpose.rst_
+++ b/doc/rst/source/module_core_purpose.rst_
@@ -70,13 +70,13 @@
 
 .. |grdblend_purpose| replace:: Blend several partially overlapping grids into one larger grid
 
-.. |grdclip_purpose| replace:: Clip the range of grid values
+.. |grdclip_purpose| replace:: 
 
 .. |grdcontour_purpose| replace:: Make contour map using a grid
 
 .. |grdconvert_purpose| replace:: Convert between different grid formats
 
-.. |grdcut_purpose| replace:: Extract subregion from a grid or image
+.. |grdcut_purpose| replace:: Extract subregion from a grid or image or a slice from a cube
 
 .. |grdedit_purpose| replace:: Modify header or content of a grid
 

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -6149,6 +6149,8 @@ start_over_import_cube:		/* We may get here if we cannot honor a GMT_IS_REFERENC
 					z_min = U_obj->header->z_min;	/* Initialize cube min/max values based on this first layer */
 					z_max = U_obj->header->z_max;
 					here = 0;	/* Initialize offset into k'th layer */
+					UH = gmt_get_U_hidden (U_obj);
+					UH->alloc_mode = GMT_ALLOC_INTERNALLY;
 				}
 				else {	/* Here we update min/max for subsequent layers read */
 					if (G->header->z_min < z_min) z_min = G->header->z_min;

--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -13421,11 +13421,14 @@ struct GMT_RESOURCE * GMT_Encode_Options (void *V_API, const char *module_name, 
 	else if (!strncmp (module, "pscoupe", 7U)) {
 		type = ((opt = GMT_Find_Option (API, 'A', *head)) && strstr (opt->arg, "+c")) ? 'D' : 'X';
 	}
-	/* 1x. Check if grdcut is just getting information and if input is a grid or image */
+	/* 1x. Check if grdcut is just getting information and if input is a grid, image or cube */
 	else if (!strncmp (module, "grdcut", 6U)) {
 		if (GMT_Find_Option (API, 'D', *head))
 			deactivate_output = true;   /* Turn off implicit output since none is in effect, only secondary -D output */
-		type = (GMT_Find_Option (API, 'I', *head)) ? 'I' : 'G'; /* Giving -I means we are reading an image */
+		else if (GMT_Find_Option (API, 'E', *head))
+			type = 'U'; /* Giving -E means we are reading a 3-D cube */
+		else
+			type = 'G'; /* Default is a grid */
 	}
 	/* 1y. Check if this is the gravprisms module, where primary dataset input should be turned off if -C is used */
 	else if (!strncmp (module, "gravprisms", 10U) && (opt = GMT_Find_Option (API, 'C', *head))) {

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3960,7 +3960,14 @@ bool gmt_grd_domains_match (struct GMT_CTRL *GMT, struct GMT_GRID *A, struct GMT
 
 struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *C, unsigned int dim, double coord) {
 	uint64_t row, col, xrow, xcol, layer, ijg, ijc;
-	struct GMT_GRID *G = gmt_create_grid (GMT);
+	struct GMT_GRID *G = NULL;
+
+	if (gmtlib_var_inc (C->z, C->header->n_bands)) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cube has non-equidistant spacing in the third dimension\n");
+		GMT->parent->error = GMT_RUNTIME_ERROR;
+		return (NULL);
+	}
+	G = gmt_create_grid (GMT);
 	G->header->n_columns = C->header->n_bands;	/* Vertical dimension */
 	G->header->n_rows = (dim == GMT_X) ? C->header->n_rows : C->header->n_columns;
 	G->header->wesn[XLO] = (dim == GMT_X) ? C->header->wesn[YLO] : C->header->wesn[XLO];

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3969,6 +3969,7 @@ struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *
 	uint64_t row, col, xrow, xcol, layer, ijg, ijc;
 	double pos = 0.0;
 	struct GMT_GRID *G = NULL;
+	struct GMT_GRID_HIDDEN *GH = NULL;
 
 	if (gmtlib_var_inc (C->z, C->header->n_bands)) {	/* Check if equidistant in z direction */
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cube has non-equidistant spacing in the third dimension (consider grdinterpolate instead)\n");
@@ -3993,7 +3994,7 @@ struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *
 	}
 	else {	/* Received an y-coordinate, find corresponding row */
 		xrow = gmt_M_grd_y_to_row (GMT, coord, C->header);
-		pos = gmt_M_grd_row_to_y (GMT, xcol, C->header);
+		pos = gmt_M_grd_row_to_y (GMT, xrow, C->header);
 	}
 	if (!doubleAlmostEqualZero (coord, pos)) {	/* Not aligned with cube nodes */
 		static char *axis = "xy";
@@ -4006,6 +4007,8 @@ struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *
 	/* Checks passed, time to do the work */
 
 	G->data = gmt_M_memory_aligned (GMT, NULL, G->header->size, gmt_grdfloat);	/* Allocate grid and padding */
+	GH = gmt_get_G_hidden (G);
+	GH->alloc_mode = GMT_ALLOC_INTERNALLY;
 
 	/* Loop over the output grids rows and columns and match to nodes in the cube */
 	for (layer = 0; layer < G->header->n_rows; layer++) {	/* This is the loop over the rows in the output grid */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -4012,7 +4012,7 @@ struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *
 
 	/* Loop over the output grids rows and columns and match to nodes in the cube */
 	for (layer = 0; layer < G->header->n_rows; layer++) {	/* This is the loop over the rows in the output grid */
-		ijg = gmt_M_ijp (G->header, layer, 0);	/* TL node in output grid */
+		ijg = gmt_M_ijp (G->header, G->header->n_rows-1-layer, 0);	/* TL node in output grid */
 		if (dim == GMT_X) {	/* Must loop over the cube's y-dimension */
 			ijc = gmt_M_ijp (C->header, 0, xcol) + layer * C->header->size;	/* Corresponding point in the cube */
 			/* col loops over the columns in the 2-D grid which are rows in the cube */

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3959,45 +3959,69 @@ bool gmt_grd_domains_match (struct GMT_CTRL *GMT, struct GMT_GRID *A, struct GMT
 }
 
 struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *C, unsigned int dim, double coord) {
+	/* Special case of slicing a cube vertically and along the cube's node structure.  For
+	 * oblique cuts and resampling and for grids with variable spacing/time in the third
+	 * dimension, see grdinterpolate instead.
+	 * Here, dim is either GMT_X or GMT_Y which informs us whether coord is an x-
+	 * or y-coordinate and that defines the vertical plan to be at that constant
+	 * coordinate and parallel to the z-axis and the other axis (y or x).
+	 */
 	uint64_t row, col, xrow, xcol, layer, ijg, ijc;
+	double pos = 0.0;
 	struct GMT_GRID *G = NULL;
 
-	if (gmtlib_var_inc (C->z, C->header->n_bands)) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cube has non-equidistant spacing in the third dimension\n");
+	if (gmtlib_var_inc (C->z, C->header->n_bands)) {	/* Check if equidistant in z direction */
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Cube has non-equidistant spacing in the third dimension (consider grdinterpolate instead)\n");
 		GMT->parent->error = GMT_RUNTIME_ERROR;
 		return (NULL);
 	}
-	G = gmt_create_grid (GMT);
-	G->header->n_columns = C->header->n_bands;	/* Vertical dimension */
-	G->header->n_rows = (dim == GMT_X) ? C->header->n_rows : C->header->n_columns;
-	G->header->wesn[XLO] = (dim == GMT_X) ? C->header->wesn[YLO] : C->header->wesn[XLO];
-	G->header->wesn[XHI] = (dim == GMT_X) ? C->header->wesn[YHI] : C->header->wesn[XHI];
+	G = gmt_create_grid (GMT);	/* Create empty grid structure */
+	/* The number of columns in the output grid depends which of the two planes we selected */
+	G->header->n_columns  = (dim == GMT_X) ? C->header->n_rows     : C->header->n_columns;
+	G->header->wesn[XLO]  = (dim == GMT_X) ? C->header->wesn[YLO]  : C->header->wesn[XLO];
+	G->header->wesn[XHI]  = (dim == GMT_X) ? C->header->wesn[YHI]  : C->header->wesn[XHI];
 	G->header->inc[GMT_X] = (dim == GMT_X) ? C->header->inc[GMT_Y] : C->header->inc[GMT_X];
-	G->header->wesn[YLO] = C->z_range[0];
-	G->header->wesn[YHI] = C->z_range[1];
+	/* The number of rows in the output grid is always the third dimension in the cube and independent of dim */
+	G->header->n_rows     = C->header->n_bands;	
+	G->header->wesn[YLO]  = C->z_range[0];
+	G->header->wesn[YHI]  = C->z_range[1];
 	G->header->inc[GMT_Y] = C->z_inc;
-	gmt_set_grddim (GMT, G->header);
-	if (dim == GMT_X)
+	gmt_set_grddim (GMT, G->header);	/* Determine dimensions, mx, pad etc */
+	if (dim == GMT_X) {	/* Received an x-coordinate, find corresponding column */
 		xcol = gmt_M_grd_x_to_col (GMT, coord, C->header);
-	else
+		pos = gmt_M_grd_col_to_x (GMT, xcol, C->header);
+	}
+	else {	/* Received an y-coordinate, find corresponding row */
 		xrow = gmt_M_grd_y_to_row (GMT, coord, C->header);
-	G->data = gmt_M_memory_aligned (GMT, NULL, G->header->size, gmt_grdfloat);
+		pos = gmt_M_grd_row_to_y (GMT, xcol, C->header);
+	}
+	if (!doubleAlmostEqualZero (coord, pos)) {	/* Not aligned with cube nodes */
+		static char *axis = "xy";
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -E%c: Your %c-coordinate is not aligned with the cube %c-nodes (%lg vs %lg).\n", axis[dim], axis[dim], axis[dim], coord, pos);
+		GMT->parent->error = GMT_RUNTIME_ERROR;
+		gmt_free_grid (GMT, &G, true);
+		return (NULL);
+	}
 
-	for (layer = 0; layer < C->header->n_bands; layer++) {
-		ijg = gmt_M_ijp (G->header, layer, 0);
-		if (dim == GMT_X) {
-			ijc = gmt_M_ijp (C->header, 0, xcol) + layer * C->header->size;
-			/* row here is basically the column in the 2-D grid */
-			for (row = 0; row < C->header->n_rows; row++, ijg++)
+	/* Checks passed, time to do the work */
+
+	G->data = gmt_M_memory_aligned (GMT, NULL, G->header->size, gmt_grdfloat);	/* Allocate grid and padding */
+
+	/* Loop over the output grids rows and columns and match to nodes in the cube */
+	for (layer = 0; layer < G->header->n_rows; layer++) {	/* This is the loop over the rows in the output grid */
+		ijg = gmt_M_ijp (G->header, layer, 0);	/* TL node in output grid */
+		if (dim == GMT_X) {	/* Must loop over the cube's y-dimension */
+			ijc = gmt_M_ijp (C->header, 0, xcol) + layer * C->header->size;	/* Corresponding point in the cube */
+			/* col loops over the columns in the 2-D grid which are rows in the cube */
+			for (col = 0; col < G->header->n_columns; col++, ijg++, ijc += G->header->mx)
 				G->data[ijg] = C->data[ijc];
 		}
-		else {
-			ijc = gmt_M_ijp (C->header, xrow, 0) + layer * C->header->size;
-			/* col here is the column in the 2-D grid */
-			ijc = gmt_M_ijp (C->header, xrow, 0) + layer * C->header->size;
-			for (col = 0; col < C->header->n_columns; col++, ijg++)
+		else {	/* Must loop over the cube's x-dimension */
+			ijc = gmt_M_ijp (C->header, xrow, 0) + layer * C->header->size;/* Corresponding point in the cube */
+			/* col here is the column in the 2-D grid which are also cols in the cube */
+			for (col = 0; col < C->header->n_columns; col++, ijg++, ijc++)
 				G->data[ijg] = C->data[ijc];
 		}
 	}
-	return (G);
+	return (G);	/* Return the fully allocated local grid */
 }

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3957,3 +3957,13 @@ bool gmt_grd_domains_match (struct GMT_CTRL *GMT, struct GMT_GRID *A, struct GMT
 	}
 	return (true);
 }
+
+struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *C, unsigned int dim, double coord) {
+	struct GMT_GRID *G = gmt_get_grid (GMT);
+	G->header->n_columns = C->header->n_bands;	/* Vertical dimension */
+	G->header->n_rows = (dim == GMT_X) ? C->header->n_rows : C->header->n_columns;
+	G->header->wesn[XLO] = (dim == GMT_X) ? C->header->wesn[YLO] : C->header->wesn[XLO];
+	G->header->wesn[XHI] = (dim == GMT_X) ? C->header->wesn[YHI] : C->header->wesn[XHI];
+	G->header->wesn[YLO] = C->z_range[0];
+	G->header->wesn[YHI] = C->z_range[1];
+}

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -218,6 +218,7 @@ EXTERN_MSC bool gmt_file_is_cache (struct GMTAPI_CTRL *API, const char *file);
 
 /* gmt_grdio.c: */
 
+EXTERN_MSC struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *C, unsigned int dim, double coord);
 EXTERN_MSC bool gmt_grd_domains_match (struct GMT_CTRL *GMT, struct GMT_GRID *A, struct GMT_GRID *B, char *comment);
 EXTERN_MSC unsigned int gmt_grid_perimeter (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h, double **x, double **y);
 EXTERN_MSC void gmt_change_grid_history (struct GMTAPI_CTRL *API, unsigned int mode, struct GMT_GRID_HEADER *h, char *command);

--- a/src/grdclip.c
+++ b/src/grdclip.c
@@ -33,11 +33,11 @@
 
 #define THIS_MODULE_CLASSIC_NAME	"grdclip"
 #define THIS_MODULE_MODERN_NAME		"grdclip"
-#define THIS_MODULE_LIB			"core"
-#define THIS_MODULE_PURPOSE		"Clip the range of grid values"
-#define THIS_MODULE_KEYS		"<G{,GG}"
-#define THIS_MODULE_NEEDS		""
-#define THIS_MODULE_OPTIONS 		"-RV"
+#define THIS_MODULE_LIB		"core"
+#define THIS_MODULE_PURPOSE	"Clip the range of grid values"
+#define THIS_MODULE_KEYS	"<G{,GG}"
+#define THIS_MODULE_NEEDS	""
+#define THIS_MODULE_OPTIONS 	"-RV"
 
 enum Grdclip_cases {
 	GRDCLIP_BELOW	= 1,

--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -501,7 +501,7 @@ EXTERN_MSC int GMT_grdcut (void *V_API, int mode, void *args) {
 		if (GMT_Write_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_AND_DATA, NULL, Ctrl->G.file, G) != GMT_NOERROR) {
 			Return (API->error);
 		}
-		GMT_Destroy_Data (API, &C);
+		gmt_free_grid (GMT, &G, true);
 		Return (GMT_NOERROR);
 	}
 

--- a/src/grdcut.c
+++ b/src/grdcut.c
@@ -136,7 +136,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Dry-run mode. No grid is written but its domain and increment will be "
 		"written to standard output in w e s n dx dy numerical format.  Append +t to instead receive text strings -Rw/e/s/n -Idx/dy.");
 	GMT_Usage (API, 1, "\n-Ex|y<coord>");
-	GMT_Usage (API, -2, "Cut a vertical grid from the input cube along x = <coord> or y == <coord>.\n");
+	GMT_Usage (API, -2, "Cut a vertical grid from an input cube along x = <coord> or y == <coord>.\n");
 	GMT_Usage (API, 1, "\n-F<polygontable>[+c][+i]");
 	GMT_Usage (API, -2, "Specify a multi-segment closed polygon table that describes the grid subset "
 		"to be extracted (nodes between grid boundary and polygons will be set to NaN).");

--- a/test/baseline/grdcut.dvc
+++ b/test/baseline/grdcut.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 9b894ca37d8aebb68012a7076f065cae.dir
-  size: 566243
-  nfiles: 5
+- md5: c767dbffab4f48485beaaea5a36f250d.dir
+  size: 732380
+  nfiles: 6
   path: grdcut

--- a/test/baseline/grdcut.dvc
+++ b/test/baseline/grdcut.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: c767dbffab4f48485beaaea5a36f250d.dir
-  size: 732380
+- md5: d0bfce2251b06e3137263b75eaacf6c0.dir
+  size: 736923
   nfiles: 6
   path: grdcut

--- a/test/grdcut/vert_cube_cuts.sh
+++ b/test/grdcut/vert_cube_cuts.sh
@@ -14,8 +14,8 @@ gmt begin vert_cube_cuts
 	# Compute the yx and xz vertical grids directly using -R with x|y and z
 	gmt grdmath -R-10/10/1/8 -I1 X Y 0.25 MUL HYPOT Y DIV 4 POW -0.5 MUL EXP 5 MUL 8 Y SUB ADD = orig_y.grd
 	gmt grdmath -R-10/10/1/8 -I1 X 6 HYPOT Y 0.25 MUL HYPOT Y DIV 4 POW -0.5 MUL EXP 5 MUL 8 Y SUB ADD = orig_x.grd
+	gmt makecpt -T0/12
 	gmt subplot begin 2x2 -Fs8c -Sct+tc -Srl -Blrbt -A1+gwhite -R-10/10/1/8 -JX10c/-5c -M0.5c -T"Cuts of @[5 e^{\left [-\frac{1}{2}\left( \frac{r}{z}\right)^4\right]} + 8 - z@["
-		gmt makecpt -T0/12
 		gmt grdimage orig_x.grd -c -B+t"y-z cut x = 0"
 		gmt grdimage orig_y.grd -c -B+t"x-z cut y = 6"
 		gmt grdimage x.grd -c

--- a/test/grdcut/vertial_cube_cuts.sh
+++ b/test/grdcut/vertial_cube_cuts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Testing vertical cuts of a cube via grdcut
+#
+gmt begin vert_cube_cuts
+	# Create the 3-D cube from w = 5 * exp (-0.5*(r/z)^4) + 8 - z
+	gmt math -T1/8/1 -o0 --FORMAT_FLOAT_OUT=%01.0f T = z.txt
+	while read z; do
+		gmt grdmath -R-10/10/-10/10 -I1 0 0 CDIST $z 0.25 MUL HYPOT $z DIV 4 POW -0.5 MUL EXP 5 MUL 8 $z SUB ADD = tmp_$z.grd
+	done < z.txt
+	gmt grdinterpolate -Zz.txt tmp_?.grd -Gfake_xyz_cube.nc
+	# Cut slices at x = 0 and y = 6
+	gmt grdcut fake_xyz_cube.nc -Ex0 -Gy.grd
+	gmt grdcut fake_xyz_cube.nc -Ey6 -Gx.grd
+	# Compute the yx and xz vertical grids directly using -R with x|y and z
+	gmt grdmath -R-10/10/1/8 -I1 X Y 0.25 MUL HYPOT Y DIV 4 POW -0.5 MUL EXP 5 MUL 8 Y SUB ADD = orig_y.grd
+	gmt grdmath -R-10/10/1/8 -I1 X 6 HYPOT Y 0.25 MUL HYPOT Y DIV 4 POW -0.5 MUL EXP 5 MUL 8 Y SUB ADD = orig_x.grd
+	gmt subplot begin 2x2 -Fs8c -Sct+tc -Srl -Blrbt -A1+gwhite -R-10/10/1/8 -JX10c/-5c -M0.5c -T"Cuts of @[5 e^{\left [-\frac{1}{2}\left( \frac{r}{z}\right)^4\right]} + 8 - z@["
+		gmt makecpt -T0/12
+		gmt grdimage orig_x.grd -c -B+t"y-z cut x = 0"
+		gmt grdimage orig_y.grd -c -B+t"x-z cut y = 6"
+		gmt grdimage x.grd -c
+		gmt grdimage y.grd -c
+	gmt subplot end
+	gmt colorbar -DJBC -B
+gmt end show


### PR DESCRIPTION
**grdcut** **-Ex**|**y**_coord_ lets users extract a vertical slice grid that is either parallel to the x or y direction and goes through the specified coordinate. For example, `gmt grdcut my cube.nc -Gslice.nc -Ey33` will cut along the row corresponding to y = 33. For **grdcut** we require the cube be equidistant in the 3rd dimension, and that _coord_ is a node coordinate so there is no resampling here, just picking the nodes along that slice.  Once tested I will add this to **grdinterpolate** where, if **-T** is set and *coord* does not necessarily fall on a node,. we will resample by providing the coordinates for the output grid.
