### PR TITLE
Clear up synopsis, usage and man pages

### DIFF
--- a/doc/rst/source/gmtbinstats.rst
+++ b/doc/rst/source/gmtbinstats.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt gmtbinstats** [ *table* ] |-G|\ *outgrid*
+**gmt binstats** [ *table* ] |-G|\ *outgrid*
 |SYN_OPT-I|
 |-C|\ **a**\|\ **d**\|\ **g**\|\ **i**\|\ **l**\|\ **L**\|\ **m**\|\ **n**\|\ **o**\|\ **p**\|\ **q**\ [*quant*]\|\ **r**\|\ **s**\|\ **u**\|\ **U**\|\ **z**
 |SYN_OPT-R|
@@ -41,7 +41,7 @@ Synopsis
 Description
 -----------
 
-**gmtbinstats** reads arbitrarily located (x,y[,z][,w]) points
+**binstats** reads arbitrarily located (x,y[,z][,w]) points
 (2-4 columns) from standard input [or *table*] and for each
 node in the specified grid layout determines which points are
 within the given radius.  These points are then used in the
@@ -57,7 +57,7 @@ Required Arguments
     A 2-4 column ASCII file(s) [or binary, see
     **-bi**] holding (x,y[,z][,w]) data values. You must use |-W|
     to indicate that you have weights.  Only |-C|\ **n** will accept 2 columns only.
-    If no file is specified, **gmtbinstats** will read from standard input.
+    If no file is specified, **binstats** will read from standard input.
 
 .. _-C:
 
@@ -191,14 +191,14 @@ To examine the population inside a circle of 1000 km radius for all nodes in a 5
 using the remote file @capitals.gmt, and plot the resulting grid using default projection and colors, try::
 
     gmt begin map
-      gmt gmtbinstats @capitals.gmt -a2=population -Rg -I5 -Cz -Gpop.nc -S1000k
+      gmt binstats @capitals.gmt -a2=population -Rg -I5 -Cz -Gpop.nc -S1000k
       gmt grdimage pop.nc -B
     gmt end show
 
 To do hexagonal binning of the data in the file mydata.txt and counting the number of points inside
 each hexagon, try::
 
-    gmt gmtbinstats mydata.txt -R0/5/0/3 -I1 -Th -Cn > counts.txt
+    gmt binstats mydata.txt -R0/5/0/3 -I1 -Th -Cn > counts.txt
 
 See Also
 --------

--- a/doc/rst/source/gmtdefaults.rst
+++ b/doc/rst/source/gmtdefaults.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt defaults** [ |-D|\ [**u**\|\ **s**] ]
+**gmt defaults** [ |-D|\ [**s**\|\ **u**] ]
 
 |No-spaces|
 
@@ -46,7 +46,7 @@ Optional Arguments
 
 .. _-D:
 
-**-D**\ [**u**\|\ **s**]
+**-D**\ [**s**\|\ **u**]
     Print the system GMT defaults settings to standard output. Append **u**
     for US defaults or **s** for SI defaults. [|-D| alone gives the
     SI defaults; If |-D| is omitted, the user's

--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -27,7 +27,7 @@ Synopsis
 Description
 -----------
 
-Normally, **gmt get** will list the value of one or more specified GMT default parameters.
+Normally, **get** will list the value of one or more specified GMT default parameters.
 Alternatively (with |-D|), it will instead download selected sets remote data from the
 current GMT data server.
 

--- a/doc/rst/source/gmtinfo.rst
+++ b/doc/rst/source/gmtinfo.rst
@@ -55,7 +55,7 @@ supplied increments given by |-I|. Such output will be in the text form
 modules (hence only *dx* and *dy* are needed).  If |-C| is combined with
 |-I| then the output will be in column form and rounded up/down for as many
 columns as there are increments provided in |-I|. A similar option (|-T|)
-will provide a |-T|\ *zmin/zmax/dz* string for makecpt.
+will provide a |-T|\ *zmin/zmax/dz* string for :doc:`makecpt`.
 
 Required Arguments
 ------------------
@@ -160,7 +160,8 @@ Optional Arguments
 **-T**\ *dz*\ [**w**\|\ **d**\|\ **h**\|\ **m**\|\ **s**][**+c**\ *col*]
     Report the min/max of the first (0'th) column to the nearest multiple of *dz* and output this as the
     string |-T|\ *zmin/zmax/dz*. To use another column, append **+c**\ *col*. Cannot be used together with |-I|.
-    **Note**: If your column has absolute time then you may append a valid fixed time unit to *dz*, or rely
+    **Note**: If your column has absolute time then you may append a valid fixed time unit to *dz*
+    (i.e., choose from **w**\ eek, **d**\ ay, **h**\ our, **m**\ inute, or **s**\ econd), or rely
     on the current setting of :term:`TIME_UNIT` [**s**].
 
 .. |Add_-V| replace:: |Add_-V_links|

--- a/doc/rst/source/gmtregress.rst
+++ b/doc/rst/source/gmtregress.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-T|\ [*min/max*\ /]\ *inc*\ [**+i**\|\ **n**] \|\ |-T|\ *file*\|\ *list* ]
 [ |SYN_OPT-V| ]
 [ |-W|\ [**w**]\ [**x**]\ [**y**]\ [**r**] ]
-[ |-Z|\ [±]\ *limit* ]
+[ |-Z|\ [**+**\|\ **-**]\ *limit* ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-b| ]
 [ |SYN_OPT-d| ]
@@ -167,7 +167,7 @@ Optional Arguments
 
 .. _-Z:
 
-**-Z**\ [±]\ *limit*
+**-Z**\ [**+**\|\ **-**]\ *limit*
     Change the threshold for outlier detection: When **-Nw** is used, residual *z-scores* that exceed this *limit* [±2.5] will
     be flagged as outliers.  To only consider negative or positive *z-scores* as possible outliers, specify a signed *limit*.
 

--- a/doc/rst/source/gmtspatial.rst
+++ b/doc/rst/source/gmtspatial.rst
@@ -199,8 +199,8 @@ Optional Arguments
     the intersection of polygons (closed), **-Su** which returns the
     union of polygons (closed), **-Ss** which will split polygons that
     straddle the Dateline, and **-Sj** which will join polygons that
-    were split by the Dateline. **Note1**: Only **-Sb**, **-Sh** and **-Ss** have been implemented.
-    **Note2**: **-Sb** is a purely Cartesian operation so *width* must be in data units.
+    were split by the Dateline. **Notes**: (1) Only **-Sb**, **-Sh** and **-Ss** have been implemented.
+    (2) **-Sb** is a purely Cartesian operation so *width* must be in data units.
     That is, for geographical coordinates *width* must be provided in degrees or, preferably, project data into
     an equal-area projection, compute the buffer and then convert back to geographical.
 

--- a/doc/rst/source/gmtsplit.rst
+++ b/doc/rst/source/gmtsplit.rst
@@ -12,7 +12,7 @@ Synopsis
 
 .. include:: common_SYN_OPTs.rst_
 
-**gmt gmtsplit** [ *table* ]
+**gmt split** [ *table* ]
 [ |-A|\ *azimuth*/*tolerance* ]
 [ |-C|\ *course_change*]
 [ |-D|\ *minimum_distance* ]
@@ -38,13 +38,13 @@ Synopsis
 Description
 -----------
 
-**gmtsplit** reads a series of (*x,y[,z]*) records [or optionally
+**split** reads a series of (*x,y[,z]*) records [or optionally
 (*x,y[,z],d,h*); see |-S| option] from standard input [or *xy[z][dh]file*]
 and splits this into separate lists of (*x,y[,z]*) series, such that each
 series has a nearly constant azimuth through the *x,y* plane. There are
 options to choose only those series which have a certain orientation, to
 set a minimum length for series, and to high- or low-pass filter the *z*
-values and/or the *x,y* values. **gmtsplit** is a useful filter between
+values and/or the *x,y* values. **split** is a useful filter between
 data extraction and :doc:`wiggle` plotting, and can also be used to
 divide a large *x,y[,z]* dataset into segments.
 
@@ -56,7 +56,7 @@ Required Arguments
     files with 2, 3, or 5 columns holding (*x,y*,[*z*\ [,\ *d,h*\ ]])
     data values. To use (*x,y,z,d,h*) input, sorted so that *d* is
     non-decreasing, specify the |-S| option; default expects (*x,y,z*)
-    only. If no files are specified, **gmtsplit** will read from
+    only. If no files are specified, **split** will read from
     standard input.
 
 Optional Arguments
@@ -202,7 +202,7 @@ anomalies. Try this:
 
 MGD-77 users: For this application we recommend that you extract dist,azim
 from :doc:`mgd77list <supplements/mgd77/mgd77list>` rather than have
-**gmtsplit** compute them separately.
+**split** compute them separately.
 
 Suppose you have been given a binary, double-precision file containing
 lat, lon, gravity values from a survey, and you want to split it into

--- a/doc/rst/source/grd2kml.rst
+++ b/doc/rst/source/grd2kml.rst
@@ -71,8 +71,8 @@ Optional Arguments
 **-A**\ **a**\|\ **g**\|\ **s**\ [*altitude*]
     Select one of three altitude modes recognized by Google Earth that
     determines the altitude (in m) of the tile layer: **a** absolute
-    altitude, **g** altitude relative to sea surface or ground, **s**
-    altitude relative to seafloor or ground. To plot the tiles at a
+    altitude, **g** altitude relative to ground, or **s**
+    altitude relative to seafloor. To plot the tiles at a
     fixed altitude, append an altitude *altitude* (in m). Use 0 to clamp the
     features to the chosen reference surface. [By default the tiles are clamped
     to the sea surface or ground].

--- a/doc/rst/source/grdmask.rst
+++ b/doc/rst/source/grdmask.rst
@@ -18,7 +18,7 @@ Synopsis
 [ |-A|\ [**m**\|\ **p**\|\ **x**\|\ **y**\|\ **r**\|\ **t**] ]
 [ |-C|\ **f**\|\ **l**\|\ **o**\|\ **u** ]
 [ |-N|\ [**z**\|\ **Z**\|\ **p**\|\ **P**]\ *values* ]
-[ |-S|\ *search\_radius*\|\ *xlim*\ /*ylim* ] [ |SYN_OPT-V| ]
+[ |-S|\ *radius*\|\ *xlim*\ /*ylim* ] [ |SYN_OPT-V| ]
 [ |SYN_OPT-a| ]
 [ |SYN_OPT-bi| ]
 [ |SYN_OPT-di| ]
@@ -123,9 +123,9 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ *search\_radius*\|\ *xlim*\ /*ylim*
+**-S**\ *radius*\|\ *xlim*\ /*ylim*
     Set nodes to inside, on edge, or outside depending on their distance
-    to the nearest data point. Nodes within *radius* [0] from the
+    to the nearest data point. Nodes within the searsch *radius* [0] from the
     nearest data point are considered inside; append a distance unit
     (see `Units`_). If *radius* is given as **z** then we instead read
     individual radii from the 3rd input column.  Unless Cartesian data,

--- a/doc/rst/source/mask.rst
+++ b/doc/rst/source/mask.rst
@@ -53,7 +53,7 @@ Reads a (*x*,\ *y*,\ *z*) file [or standard input] and uses
 this information to find out which grid cells are reliable. Only grid
 cells which have one or more data points are considered reliable. As an
 option, you may specify a radius of influence. Then, all grid cells that
-are within *radius* of a data point are considered reliable.
+are within the search *radius* of a data point are considered reliable.
 Furthermore, an option is provided to reverse the sense of the test.
 Having found the reliable/not reliable points, the module will either
 paint tiles to mask these nodes (with the |-T| switch), or use
@@ -149,7 +149,7 @@ Optional Arguments
 .. _-S:
 
 **-S**\ *search\_radius*
-    Sets radius of influence. Grid nodes within *radius* of a data point
+    Sets search radius of influence. Grid nodes within *radius* of a data point
     are considered reliable. [Default is 0, which means that only grid
     cells with data in them are reliable]. Append the distance unit (see `Units`_).
 

--- a/doc/rst/source/psmask.rst
+++ b/doc/rst/source/psmask.rst
@@ -25,7 +25,7 @@ Synopsis
 [ |-L|\ *nodegrid*\ [**+i**\|\ **o**] ]
 [ |-N| ] [ |-O| ]
 [ |-P| ] [ |-Q|\ *cut* ]
-[ |-S|\ *search\_radius* ]
+[ |-S|\ *radius* ]
 [ |-T| ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]

--- a/doc/rst/source/supplements/potential/gmtflexure.rst
+++ b/doc/rst/source/supplements/potential/gmtflexure.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |-C|\ **p**\|\ **y**\ *value* ]
 [ |-F|\ *force* ]
 [ |-L| ]
-[ |-M|\ [**x**][**z**] ]
+[ |-M|\ [**h**][**v**] ]
 [ |-S| ]
 [ |-T|\ *wfile*]
 [ |SYN_OPT-V| ]
@@ -112,10 +112,10 @@ Optional Arguments
 
 .. _-M:
 
-**-M**\ [**x**][**z**]
-    Optionally append one or both of **x** and **z**: Use **x** to indicated that all
-    x-distances are in km [meters] and **z** to
-    indicate that all z-deflections are in km [meters].
+**-M**\ [**h**][**v**]
+    Optionally append one or both of **h** and **v**: Use **h** to indicated that all
+    horizontal distances are in km [meters] and **z** to
+    indicate that all vertical deflections are in km [meters].
 
 .. _-S:
 

--- a/doc/rst/source/supplements/potential/gravprisms.rst
+++ b/doc/rst/source/supplements/potential/gravprisms.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-H|\ *H*/*rho_l*/*rho_h*\ [**+b**\ *boost*][**+d**\ *densify*][**+p**\ *power*] ]
 [ |SYN_OPT-I| ]
 [ |-L|\ *base* ]
-[ |-M|\ [**h**]\ [**z**] ]
+[ |-M|\ [**h**]\ [**v**] ]
 [ |-N|\ *trackfile* ]
 [ |SYN_OPT-R| ]
 [ |-S|\ *shapegrid* ]
@@ -163,9 +163,9 @@ Optional Arguments
 
 .. _-M:
 
-**-M**\ [**h**]\ [**z**]
+**-M**\ [**h**]\ [**v**]
     Sets distance units used.  Append **h** to indicate that both horizontal distances are in km [m],
-    and append **z** to indicate vertical distances are in km [m].  If selected, we will internally
+    and append **v** to indicate vertical distances are in km [m].  If selected, we will internally
     convert any affected distance provided by data input or command line options to meters. **Note**:
     Any output will retain the original units.
 

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -167,10 +167,6 @@ Optional Arguments
     will be time in years, while the last trailing text word is formatted time. 
     The output records thus contain *time flexuregrid timetag*.
 
-.. _-N:
-
-.. include:: ../../explain_fft.rst_
-
 .. _-M:
 
 **-M**\ *tm*
@@ -178,6 +174,10 @@ Optional Arguments
     thickness specified via |-E|.  Append the Maxwell time *tm* for the
     viscoelastic model (in years); add **k** for kyr and **M** for Myr.
     Cannot be used in conjunctions with |-F|.
+
+.. _-N:
+
+.. include:: ../../explain_fft.rst_
 
 .. _-Q:
 

--- a/doc/rst/source/supplements/segy/pssegy.rst
+++ b/doc/rst/source/supplements/segy/pssegy.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |-C|\ *clip* ]
 [ |-E|\ *error* ] [ |-I| ] [ |-K| ] [ |-L|\ *nsamp* ]
 [ |-M|\ *ntrace* ] [ |-N| ] [ |-O| ] [ |-P| ]
-[ |-Q|\ *<mode><value>* ]
+[ |-Q|\ **b**\|\ **i**\|\ **u**\|\ **x**\|\ **y**\ *value* ]
 [ |-S|\ *header* ]
 [ |-T|\ *filename* ]
 [ |SYN_OPT-U| ]

--- a/doc/rst/source/supplements/segy/pssegyz.rst
+++ b/doc/rst/source/supplements/segy/pssegyz.rst
@@ -22,7 +22,7 @@ Synopsis
 [ |-N| ]
 [ |-O| ]
 [ |-P| ]
-[ |-Q|\ *<mode><value>* ]
+[ |-Q|\ **b**\|\ **i**\|\ **u**\|\ **x**\|\ **y**\ *value* ]
 [ |-S|\ *header_x*/*header_y* ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]

--- a/doc/rst/source/supplements/segy/segy.rst
+++ b/doc/rst/source/supplements/segy/segy.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |-C|\ *clip* ]
 [ |-E|\ *error* ] [ |-I| ] [ |-L|\ *nsamp* ]
 [ |-M|\ *ntrace* ] [ |-N| ]
-[ |-Q|\ *<mode><value>* ]
+[ |-Q|\ **b**\|\ **i**\|\ **u**\|\ **x**\|\ **y**\ *value* ]
 [ |-S|\ *header* ]
 [ |-T|\ *filename* ]
 [ |SYN_OPT-U| ]
@@ -140,9 +140,9 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ *<mode><value>*
-    Can be used to change 5 different settings depending on *mode*:
-       **-Qb**\ *bias* to bias scaled traces (-Qb-0.1 subtracts 0.1 from values).
+**-Q**\ **b**\|\ **i**\|\ **u**\|\ **x**\|\ **y**\ *value*
+    Can be used to change 5 different settings depending on the directive (repeatable):
+       **-Qb**\ *bias* to bias scaled traces (-**Qb**\ -0.1 subtracts 0.1 from values).
 
        **-Qi**\ *dpi* sets the dots-per-inch resolution of the image [300].
 

--- a/doc/rst/source/supplements/segy/segy2grd.rst
+++ b/doc/rst/source/supplements/segy/segy2grd.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-D|\ |SYN_OPT-D2| ]
 [ |-L|\ [*nsamp*] ]
 [ |-M|\ [*ntraces*] ]
-[ |-Q|\ *<mode><value>* ]
+[ |-Q|\ **x**\|\ **y**\ *value* ]
 [ |-S|\ [*header*] ]
 [ |SYN_OPT-V| ]
 [ |SYN_OPT-bi| ]
@@ -94,12 +94,13 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ *<mode><value>*
-    Can be used to change two different settings depending on *mode*:
+**-Q**\ **x**\|\ **y**\ *value*
+    Can be used to change two different settings depending on the directive:
        **-Qx**\ *x-scale* applies scalar *x-scale* to coordinates in trace
        header to match the coordinates specified in |-R|.
 
        **-Qy**\ *s_int* specifies sample interval as *s_int* if incorrect in the SEGY file.
+       Repeatable.
 
 .. _-S:
 

--- a/doc/rst/source/supplements/segy/segyz.rst
+++ b/doc/rst/source/supplements/segy/segyz.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |-I| ] [ |-L|\ *nsamp* ]
 [ |-M|\ *ntrace* ]
 [ |-N| ]
-[ |-Q|\ *<mode><value>* ]
+[ |-Q|\ **b**\|\ **i**\|\ **u**\|\ **x**\|\ **y**\ *value* ]
 [ |-S|\ *header_x*/*header_y* ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
@@ -136,9 +136,9 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ *<mode><value>*
-    Can be used to change 5 different settings depending on *mode*:
-       **-Qb**\ *bias* to bias scaled traces (-Qb-0.1 subtracts 0.1 from values).
+**-Q**\ **b**\|\ **i**\|\ **u**\|\ **x**\|\ **y**\ *value*
+    Can be used to change 5 different settings depending on the directive (repeatable):
+       **-Qb**\ *bias* to bias scaled traces (**-Qb**\ -0.1 subtracts 0.1 from values).
 
        **-Qi**\ *dpi* sets the dots-per-inch resolution of the image [300].
 

--- a/doc/rst/source/supplements/seis/polar.rst
+++ b/doc/rst/source/supplements/seis/polar.rst
@@ -18,7 +18,7 @@ Synopsis
 |-J|\ *parameters*
 |SYN_OPT-R|
 |-M|\ *size*\ [**+m**\ *mag*]
-|-S|\ *<symbol><size>*
+|-S|\ **a**\|\ **c**\|\ **d**\|\ **h**\|\ **i**\|\ **p**\|\ **s**\|\ **t**\|\ **x**\ *size*
 [ |SYN_OPT-B| ]
 [ |-E|\ *fill* ]
 [ |-F|\ *fill* ]
@@ -95,8 +95,8 @@ Required Arguments
 
 .. _-S:
 
-**-S**\ *<symbol_type><size>*
-    Selects *symbol_type* and symbol *size*. Size is in default units (unless
+**-S**\ **a**\|\ **c**\|\ **d**\|\ **h**\|\ **i**\|\ **p**\|\ **s**\|\ **t**\|\ **x**\ *size*
+    Sets the symbol type directive and the symbol *size*. Size is in default units (unless
     **c**, **i**, or **p** is appended). Choose symbol type from
     st(*a*)r, (*c*)ircle, (*d*)iamond, (*h*)exagon, (*i*)nverted
     triangle, (*p*)oint, (*s*)quare, (*t*)riangle, (*x*)cross.

--- a/doc/rst/source/supplements/seis/pspolar.rst
+++ b/doc/rst/source/supplements/seis/pspolar.rst
@@ -18,7 +18,7 @@ Synopsis
 |-J|\ *parameters*
 |SYN_OPT-R|
 |-M|\ *size*\ [**+m**\ *mag*]
-|-S|\ *<symbol><size>*
+|-S|\ **a**\|\ **c**\|\ **d**\|\ **h**\|\ **i**\|\ **p**\|\ **s**\|\ **t**\|\ **x**\ *size*
 [ |SYN_OPT-B| ]
 [ |-E|\ *fill* ]
 [ |-F|\ *fill* ]

--- a/doc/rst/source/supplements/seis/pssac.rst
+++ b/doc/rst/source/supplements/seis/pssac.rst
@@ -26,7 +26,7 @@ Synopsis
 [ |-P| ]
 [ |-Q| ]
 [ |-S|\ [**i**]\ *scale* ]
-[ |-T|\ [**+t**\ *n*][**+r**\ *reduce_vel*][**+s**\ *shift*] ]
+[ |-T|\ [**+r**\ *reduce_vel*][**+s**\ *shift*]\ [**+t**\ *n*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/seis/sac.rst
+++ b/doc/rst/source/supplements/seis/sac.rst
@@ -23,7 +23,7 @@ Synopsis
 [ |-M|\ *size*\ [*u*][/*alpha*] ]
 [ |-Q| ]
 [ |-S|\ [**i**]\ *scale* ]
-[ |-T|\ [**+t**\ *n*][**+r**\ *reduce_vel*][**+s**\ *shift*] ]
+[ |-T|\ [**+r**\ *reduce_vel*][**+s**\ *shift*]\ [**+t**\ *n*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -172,15 +172,15 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [**+t**\ *n*][**+r**\ *reduce_vel*][**+s**\ *shift*]
+**-T**\ [**+r**\ *reduce_vel*][**+s**\ *shift*]\ [**+t**\ *n*]
     Time alignment and shift.
-
-        **+t**\ *tmark*: align all trace along time mark. *tmark* are -5(b), -4(e), -3(o), -2(a), 0-9(t0-t9).
 
         **+r**\ *reduce_vel*: reduce velocity in km/s.
 
         **+s**\ *shift*: shift all traces by *shift* seconds.
 
+        **+t**\ *tmark*: align all trace along time mark. *tmark* are -5(b), -4(e), -3(o), -2(a), 0-9(t0-t9).
+ 
 .. |Add_-U| replace:: |Add_-U_links|
 .. include:: ../../explain_-U.rst_
     :start-after: **Syntax**

--- a/doc/rst/source/supplements/spotter/originater.rst
+++ b/doc/rst/source/supplements/spotter/originater.rst
@@ -16,7 +16,7 @@ Synopsis
 |-E|\ *rot_file*\|\ *ID1-ID2*\|\ *lon*/*lat*/*angle*\ [**+i**]
 |-F|\ *hs_file*\ [**+d**]
 [ |-D|\ *d_km* ]
-[ |-L|\ [*flag*] ]
+[ |-L|\ [**l**\|\ **t**\|\ **w**\| **L**\|\ **T**\|\ **W**] ]
 [ |-N|\ *upper_age* ]
 [ |-Q|\ *r/t* ]
 [ |-S|\ [*n_hs*] ]
@@ -101,7 +101,7 @@ Optional Arguments
 
 .. _-L:
 
-**-L**\ [*flag*]
+**-L**\ [**l**\|\ **t**\|\ **w**\| **L**\|\ **T**\|\ **W**]
     Output closest approach for nearest hotspot only (ignores |-S|).
     Choose **-Lt** for (*time*, *dist*, *z*) [Default], **-Lw** for
     (*omega*, *dist*, *z*), and **-Ll** for (lon, lat, time, dist, z).

--- a/doc/rst/source/supplements/x2sys/x2sys_cross.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_cross.rst
@@ -16,7 +16,7 @@ Synopsis
 [ |-C|\ [*runtimes*] ]
 [ |-D|\ [**S**\|\ **N**] ]
 [ |-E|\ *limit* ]
-[ |-I|\ **l**\|\ **a**\|\ **c** ]
+[ |-I|\ **a**\|\ **c**\|\ **l**\|\ **n** ]
 [ |-Q|\ **e**\|\ **i** ]
 [ |SYN_OPT-R| ]
 [ |-S|\ **l**\|\ **u**\|\ **h**\ *speed* ]
@@ -88,14 +88,16 @@ Optional Arguments
 
 .. _-I:
 
-**-Il**\|\ **a**\|\ **c**
+**-I**\ **a**\|\ **c**\|\ **l**\|\ **n**
     Sets the interpolation mode for estimating values at the crossover. Choose among:
-
-    **l** Linear interpolation [Default].
 
     **a** Akima spline interpolation.
 
     **c** Cubic spline interpolation.
+
+    **l** Linear interpolation [Default].
+
+    **n** Nearest neighbor interpolation.
 
 .. _-Q:
 

--- a/src/potential/gmtflexure.c
+++ b/src/potential/gmtflexure.c
@@ -88,7 +88,7 @@ struct GMTFLEXURE_CTRL {
 	struct GMTFLEXURE_L {	/* Use variable restoring force [constant] */
 		bool active;
 	} L;
-	struct GMTFLEXURE_M {	/* -Mx|z  */
+	struct GMTFLEXURE_M {	/* -Mh|v  */
 		bool active[2];	/* True if km, else m */
 	} M;
 	struct GMTFLEXURE_Q {	/* Load specifier -Qn|q|t[/args] */
@@ -248,8 +248,8 @@ static int parse (struct GMT_CTRL *GMT, struct GMTFLEXURE_CTRL *Ctrl, struct GMT
 			case 'M':	/* Length units */
 				both = false;	side = 0;
 				switch (opt->arg[0]) {
-					case 'x': side = 0; break;
-					case 'z': side = 1; break;
+					case 'h':	case 'x': side = 0; break;	/* Deprecated x and z */
+					case 'v':	case 'z': side = 1; break;
 					default:  both = true; break;
 				}
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active[side]);
@@ -308,7 +308,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s -D<rhom>/<rhol>[/<rhoi>]/<rhow> -E<Te>[k]|<D>|<file> -Qn|q|t[<args>] [-A[l|r]<bc>[/<args>]] "
-		"[-Cp|y<value>] [-F<force>] [-L] [-M[x][z]] [-S] [-T<wpre>] [%s] [-W<w0>[k]] [-Z<zm>[k]] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+		"[-Cp|y<value>] [-F<force>] [-L] [-M[h][v]] [-S] [-T<wpre>] [%s] [-W<w0>[k]] [-Z<zm>[k]] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -344,10 +344,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-F<force>");
 	GMT_Usage (API, -2, "Specify the uniform, horizontal stress in the plate in Pa m [0].");
 	GMT_Usage (API, 1, "\n-L Use variable restoring force k(x) that depends on w(x).");
-	GMT_Usage (API, 1, "\n-M[x][z]");
+	GMT_Usage (API, 1, "\n-M[h][v]");
 	GMT_Usage (API, -2, "Set units used; append one or both of these directives:");
-	GMT_Usage (API, 3, "x: Indicates all x-distances are in km [meters].");
-	GMT_Usage (API, 3, "z: Indicates all z-deflections are in km [meters].");
+	GMT_Usage (API, 3, "h: Indicates all horizontal distances are in km [meters].");
+	GMT_Usage (API, 3, "v: Indicates all vertical deflections are in km [meters].");
 	GMT_Usage (API, 1, "\n-S Also compute second derivatives (curvatures) on output.");
 	GMT_Usage (API, 1, "\n-T<wpre>");
 	GMT_Usage (API, -2, "Use file <wpre> with pre-existing deflections [none].");

--- a/src/potential/gravprisms.c
+++ b/src/potential/gravprisms.c
@@ -370,7 +370,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <prismfile> [-A] [-C[+q][+w<file>][+z<dz>]] [-D<density>[+c]] [-E<dx>[/<dy>]] [-Ff|n[<lat>]|v] "
-		"[-G<outfile>] [-H<H>/<rho_l>/<rho_h>[+b<boost>][+d<densify>][+p<power>]] [%s] [-L<base>] [-M[hz]] [-N<trktable>] [%s] "
+		"[-G<outfile>] [-H<H>/<rho_l>/<rho_h>[+b<boost>][+d<densify>][+p<power>]] [%s] [-L<base>] [-M[h][v]] [-N<trktable>] [%s] "
 		"[-S<shapegrd>] [-T<top>] [%s] [-W<avedens>] [-Z<level>] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]%s [%s]\n",
 		name, GMT_I_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT,
 		GMT_i_OPT, GMT_o_OPT, GMT_r_OPT, GMT_x_OPT, GMT_PAR_OPT);
@@ -412,10 +412,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Option (API, "I");
 	GMT_Usage (API, 1, "\n-L<base>");
 	GMT_Usage (API, -2, "Set the lower (base) surface grid or constant of a layer to create prisms for; requires -C and -T [0]");
-	GMT_Usage (API, 1, "\n-M[hz]");
+	GMT_Usage (API, 1, "\n-M[h][v]");
 	GMT_Usage (API, -2, "Change distance units used, via one or two directives:");
-	GMT_Usage (API, 3, "h: All x- and y-distances are given in km [meters].");
-	GMT_Usage (API, 3, "z: All z-distances are given in km [meters].");
+	GMT_Usage (API, 3, "h: All horizontal distances are given in km [meters].");
+	GMT_Usage (API, 3, "v: All vertical distances are given in km [meters].");
 	GMT_Usage (API, -2, "Note: All horizontal and/or vertical quantities will be affected by a factor of 1000");
 	GMT_Usage (API, 1, "\n-N<trktable>");
 	GMT_Usage (API, -2, "File with output locations (x,y) where a calculation is requested.  Optionally, z may be read as well if -Z not set. No grid "

--- a/src/potential/talwani2d.c
+++ b/src/potential/talwani2d.c
@@ -171,7 +171,7 @@ static int parse (struct GMT_CTRL *GMT, struct TALWANI2D_CTRL *Ctrl, struct GMT_
 						case 'h':
 							n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active[TALWANI2D_HOR]);
 							break;
-						case 'z':
+						case 'v':	case 'z':	/* Deprecated z */
 							n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active[TALWANI2D_VER]);
 							break;
 						default:
@@ -218,7 +218,7 @@ static int parse (struct GMT_CTRL *GMT, struct TALWANI2D_CTRL *Ctrl, struct GMT_
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <modelfile> [-A] [-D<density>] [-Ff|n[<lat>]|v] [-M[hz]] "
+	GMT_Usage (API, 0, "usage: %s <modelfile> [-A] [-D<density>] [-Ff|n[<lat>]|v] [-M[h][v]] "
 		"[-N<trktable>] [-T<xmin>/<xmax>/<xinc>[+i|n]|<file>|<list>] [%s] [-Z[<level>][/<ymin>/<ymax>]] "
 		"[%s] [%s] [%s] [%s] [%s] [%s]%s [%s]\n",
 		name, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_o_OPT,
@@ -240,10 +240,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "f: Free-air anomalies (mGal) [Default].");
 	GMT_Usage (API, 3, "n: Geoid anomalies (meter).  Optionally append latitude for evaluation of normal gravity [45].");
 	GMT_Usage (API, 3, "v: Vertical Gravity Gradient anomalies (Eotvos = 0.1 mGal/km).");
-	GMT_Usage (API, 1, "\n-M[hz]");
+	GMT_Usage (API, 1, "\n-M[h][v]");
 	GMT_Usage (API, -2, "Change distance units used, via one or two directives:");
 	GMT_Usage (API, 3, "h: All x-distances are given in km [meters].");
-	GMT_Usage (API, 3, "z: All z-distances are given in km [meters].");
+	GMT_Usage (API, 3, "v: All z-distances are given in km [meters].");
 	GMT_Usage (API, 1, "\n-N<trktable>");
 	GMT_Usage (API, -2, "File with output locations x[,z].  If there are "
 		"z-coordinates then these are used as observation levels. "

--- a/src/potential/talwani3d.c
+++ b/src/potential/talwani3d.c
@@ -192,7 +192,7 @@ static int parse (struct GMT_CTRL *GMT, struct TALWANI3D_CTRL *Ctrl, struct GMT_
 						case 'h':
 							n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active[TALWANI3D_HOR]);
 							break;
-						case 'z':
+						case 'v':	case 'z':	/* Deprecated z */
 							n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active[TALWANI3D_VER]);
 							break;
 						default:
@@ -241,7 +241,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <modelfile> [-A] [-D<density>] [-Ff|n[<lat>]|v] [-G<outfile>] [%s] "
-		"[-M[hz]] [-N<trktable>] [%s] [%s] [-Z<level>] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]%s [%s]\n",
+		"[-M[h][v]] [-N<trktable>] [%s] [%s] [-Z<level>] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]%s [%s]\n",
 		name, GMT_I_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT,
 		GMT_i_OPT, GMT_o_OPT, GMT_r_OPT, GMT_x_OPT, GMT_PAR_OPT);
 
@@ -264,10 +264,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-G<outfile>");
 	GMT_Usage (API, -2, "Set name of output file. Grid file name is requires unless -N is used.");
 	GMT_Option (API, "I");
-	GMT_Usage (API, 1, "\n-M[hz]");
+	GMT_Usage (API, 1, "\n-M[h][v]");
 	GMT_Usage (API, -2, "Change distance units used, via one or two directives:");
 	GMT_Usage (API, 3, "h: All x- and y-distances are given in km [meters].");
-	GMT_Usage (API, 3, "z: All z-distances are given in km [meters].");
+	GMT_Usage (API, 3, "v: All z-distances are given in km [meters].");
 	GMT_Usage (API, 1, "\n-N<trktable>");
 	GMT_Usage (API, -2, "File with output locations where a calculation is requested.  No grid "
 		"is produced and output (x,y,z,g|n|v) is written to standard output (see -bo for binary output).");

--- a/src/x2sys/x2sys_cross.c
+++ b/src/x2sys/x2sys_cross.c
@@ -74,7 +74,7 @@ struct X2SYS_CROSS_CTRL {
 		bool active;
 		double limit;
 	} E;
-	struct X2SYS_CROSS_I {	/* -I */
+	struct X2SYS_CROSS_I {	/* -Ia|c|l|n */
 		bool active;
 		int mode;
 	} I;
@@ -126,7 +126,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct X2SYS_CROSS_CTRL *C) {	/* De
 static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <files> -T<TAG> [-A<pairs>] [-C[<fname>]] [-D[S|N]] [-E<limit>] [-Il|a|c] [-Qe|i] "
+	GMT_Usage (API, 0, "usage: %s <files> -T<TAG> [-A<pairs>] [-C[<fname>]] [-D[S|N]] [-E<limit>] [-Ia|c|l|n] [-Qe|i] "
 		"[%s] [-Sl|h|u<speed>] [%s] [-W<size>] [-Z] [%s] [%s] [%s]\n",
 		name, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_do_OPT, GMT_PAR_OPT);
 
@@ -151,9 +151,10 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-E<limit>");
 	GMT_Usage (API, -2, "Exclude crossovers from lines with orientation differences less than <limit> [0].");
 	GMT_Usage (API, -2, "Select an interpolation mode:");
-	GMT_Usage (API, 3, "l: Linear interpolation [Default].");
 	GMT_Usage (API, 3, "a: Akima spline interpolation.");
 	GMT_Usage (API, 3, "c: Cubic spline interpolation.");
+	GMT_Usage (API, 3, "l: Linear interpolation [Default].");
+	GMT_Usage (API, 3, "n: Nearest neighbor interpolation.");
 	GMT_Usage (API, 1, "\n-Qe|i");
 	GMT_Usage (API, -2, "Select a sub-group of crossovers [Default is both]:");
 	GMT_Usage (API, 3, "e: Find external crossovers.");
@@ -229,16 +230,16 @@ static int parse (struct GMT_CTRL *GMT, struct X2SYS_CROSS_CTRL *Ctrl, struct GM
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->I.active);
 				switch (opt->arg[0]) {
 					case 'l':
-						Ctrl->I.mode = 0;
+						Ctrl->I.mode = GMT_SPLINE_LINEAR;
 						break;
 					case 'a':
-						Ctrl->I.mode = 1;
+						Ctrl->I.mode = GMT_SPLINE_AKIMA;
 						break;
 					case 'c':
-						Ctrl->I.mode = 2;
+						Ctrl->I.mode = GMT_SPLINE_CUBIC;
 						break;
 					case 'n':
-						Ctrl->I.mode = 3;
+						Ctrl->I.mode = GMT_SPLINE_NN;
 						break;
 					default:
 						n_errors++;


### PR DESCRIPTION
Effort to streamline the use of options and add missing modifiers, getting them into alphabetical order, use the same **-M** directives for the 4 potential modules that use it, etc.  No change in behavior but x2sys_cross now has the missing **-I n** directive.