### PR TITLE
Missing an else in grdclip decision

### DIFF
--- a/src/grdclip.c
+++ b/src/grdclip.c
@@ -350,7 +350,7 @@ EXTERN_MSC int GMT_grdclip (void *V_API, int mode, void *args) {
 			Out->data[ij] = Ctrl->S.above;
 			n_above++;
 		}
-		if (Ctrl->S.mode & GRDCLIP_ABOVE_OR_EQUAL && G->data[ij] >= Ctrl->S.high) {
+		else if (Ctrl->S.mode & GRDCLIP_ABOVE_OR_EQUAL && G->data[ij] >= Ctrl->S.high) {
 			Out->data[ij] = Ctrl->S.above;
 			n_above++;
 		}


### PR DESCRIPTION
When we added the ABOVE|BELOW_OR_EQUAL I forgot an "else" in acut/paste step so that mean the obove setting could be reset by the last else in the loop. Works for me in pygmt now.

```
orig = pygmt.datasets.load_earth_relief(resolution="01d", registration="pixel")
grid = pygmt.grdclip(orig, above=[0.0, 0.0])
print(orig.data.min(), orig.data.max())
-8190.5 5651.5
print(grid.data.min(), grid.data.max())
-8190.5 0.0
```
