### PR TITLE
CI: Remove the workaround from the dvc-diff workflow

### DIFF
--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -45,12 +45,6 @@ jobs:
         create-args: >-
           gmt
 
-    # workaround from https://github.com/iterative/cml/issues/1377
-    - name: Setup NodeJS
-      uses: actions/setup-node@v3.8.1
-      with:
-        node-version: '16'
-
     # Produce the markdown diff report, which should look like:
     # ## Summary of changed images
     #


### PR DESCRIPTION
Closes https://github.com/GenericMappingTools/gmt/pull/7970.

PR #7970 is no longer valid after this PR is merged.