### PR TITLE
Ensure the point symbol is filled with -Gcolor when in a legend

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -19947,6 +19947,19 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 			fprintf (fp, "S - L %s %s %s - %s\n", size_string, gmtlib_putfill (API->GMT, fill), (cpen) ? gmt_putpen (API->GMT, cpen) : "-", label);
 			fprintf (fp, "S - - %s - %s - %s\n", size_string, gmt_putpen (API->GMT, pen), "");
 		}
+		else if (symbol == PSL_DOT) {	/* Only fill so if -G not set but -W we steal the fill color */
+			if (do_fill)	/* Gave a fill so use it */
+				fprintf (fp, "S - %c %s %s %s - %s\n", symbol, size_string, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+			else {	/* Pick either pen color or default pen color if neither fill nor pen was set */
+				struct GMT_FILL *F = gmt_M_memory (API->GMT, NULL, 1, struct GMT_FILL);
+				if (do_line)	/* Probably gave a pen instead of a fill so take its color */
+					gmt_M_rgb_copy(F->rgb, pen->rgb);
+				else	/* Got nuthin, use default pen color (which could have changed so not assuming black) */
+					gmt_M_rgb_copy(F->rgb, API->GMT->current.setting.map_default_pen.rgb);
+				fprintf (fp, "S - %c %s %s %s - %s\n", symbol, size_string, gmtlib_putfill (API->GMT, F), "-", label);
+				gmt_M_free (API->GMT, F);
+			}
+		}
 		else
 			fprintf (fp, "S - %c %s %s %s - %s\n", symbol, size_string, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 	}

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1733,7 +1733,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 							last_spiderpen = current_pen;
 					}
 				}
-				else if (S.symbol == PSL_DOT && !Ctrl->G.active)	/* Must switch on default black fill */
+				else if (S.symbol == PSL_DOT && !fill_active)	/* No -G, must switch on default black fill */
 					current_fill = black;
 				if (Ctrl->E.active) {	/* Must update decision on where error bars go since symbol has changed */
 					E_bar_above = (S.symbol == GMT_SYMBOL_BARX || S.symbol == GMT_SYMBOL_BARY);
@@ -1888,7 +1888,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 			}
 			else if (!may_intrude_inside) {
 				gmt_setfill (GMT, &current_fill, outline_setting);
-				gmt_setpen (GMT, &current_pen);
+				if (outline_setting) gmt_setpen (GMT, &current_pen);
 			}
 
 			if (S.base_set & GMT_BASE_READ) {

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1258,7 +1258,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 							last_spiderpen = current_pen;
 					}
 				}
-				else if (S.symbol == PSL_DOT && !Ctrl->G.active) {	/* Must switch on default black fill */
+				else if (S.symbol == PSL_DOT && !fill_active) {	/* Must switch on default black fill */
 					current_fill = black;
 				}
 			}
@@ -1729,7 +1729,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 			}
 			if (!geovector) {
 				gmt_setfill (GMT, &data[i].f, data[i].outline);
-				gmt_setpen (GMT, &data[i].p);
+				if (data[i].outline) gmt_setpen (GMT, &data[i].p);
 			}
 			if (QR_symbol) {
 				if (Ctrl->G.active)	/* Change color of QR code */


### PR DESCRIPTION
See #8006 for details. Problem was that we checked `Ctrl->G.active` instead of `fill_active` and if the former was false we set dot symbol color to black.  But, for legends the **-G**_fill_ is passed via the segment header and that is correctly parsed to set `fill_active` to true.  But the we change it to black... Same issue in **plot3d**.  Now it all works.

`gmt plot t.txt -R-2/2/-2/2 -JX5c -Baf -Sp0.2c -Gseagreen -lpoint_Gseagreen -png t`

![t](https://github.com/GenericMappingTools/gmt/assets/26473567/0368029c-ccce-479b-8707-354cb0c9cdb8)

Also added new code to ensure the point symbol has fill when being placed in the legend info file.
Closes #8006.