### PR TITLE
Warn that Latex cannot be used in panel tags

### DIFF
--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -109,8 +109,8 @@ Optional Arguments (begin mode)
     shift relative to the tag box [default is **2p**\ /**-2p**] and *shade* sets the
     fill style to use for shading [default is **gray50**].
     Append **+v** to increase tag numbers vertically down columns [horizontally across rows].
-    **Note**: Currently you cannot use Latex expressions in the panel tag. The workaround is
-    to place such tags separately via :doc:text.
+    **Note**: Currently you cannot use LaTeX expressions in the panel tag. The workaround is
+    to place such tags separately via :doc:`text`.
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_

--- a/doc/rst/source/subplot.rst
+++ b/doc/rst/source/subplot.rst
@@ -109,6 +109,8 @@ Optional Arguments (begin mode)
     shift relative to the tag box [default is **2p**\ /**-2p**] and *shade* sets the
     fill style to use for shading [default is **gray50**].
     Append **+v** to increase tag numbers vertically down columns [horizontally across rows].
+    **Note**: Currently you cannot use Latex expressions in the panel tag. The workaround is
+    to place such tags separately via :doc:text.
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_


### PR DESCRIPTION
See #7958 for background.  This updates the documentation until we have a better solution.
