### PR TITLE
-d option: Fix typo in documentation

### DIFF
--- a/doc/rst/source/explain_-d_full.rst_
+++ b/doc/rst/source/explain_-d_full.rst_
@@ -11,7 +11,7 @@ The **-d** option
 The **-d** option allows user-coded missing data values to be translated to official NaN values in GMT. Within GMT,
 any missing values are represented by the IEEE NaN value. However, user data may occasionally denote missing data with
 an unlikely value (e.g., -99999). Since GMT cannot guess this special missing data value, you can use the **-d**
-option to have such values replaced with NaNs. Similarly, the **-d** option can replace all NaNs with the chosed
+option to have such values replaced with NaNs. Similarly, the **-d** option can replace all NaNs with the chosen
 *nodata* value should the GMT output need to conform to such a requirement.
 
 For input only, use **-di**\ *nodata* to examine all input columns after the first two. If any item equals *nodata*,


### PR DESCRIPTION
**Description of proposed changes**

This PR aims to fix a typo in the documentation of the **-d** option (https://docs.generic-mapping-tools.org/dev/gmt.html#the-d-option).

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
