### PR TITLE
Consistently use *.txt extension for ASCII files in examples and docs

### DIFF
--- a/doc/rst/source/explain_contlabel.rst_
+++ b/doc/rst/source/explain_contlabel.rst_
@@ -12,8 +12,8 @@
         option, you can append /*fraction* which is used to place the
         very first label for each contour when the cumulative
         along-contour distance equals *fraction \* dist* [0.25].
-    **f**\ *ffile.d*
-        Reads the ASCII file *ffile.d* and places labels at locations in
+    **f**\ *ffile*
+        Reads the ASCII file *ffile* and places labels at locations in
         the file that matches locations along the quoted lines. Inexact
         matches and points outside the region are skipped.
     **l\|L**\ *line1*\ [,\ *line2*,...]
@@ -36,10 +36,10 @@
         /*min\_dist*\ [**c**\|\ **i**\|\ **p**] to enforce that a
         minimum distance separation between successive labels is
         enforced.
-    **x\|X**\ *xfile.d*
-        Reads the multisegment file *xfile.d* and places labels at the
+    **x\|X**\ *xfile*
+        Reads the multisegment file *xfile* and places labels at the
         intersections between the quoted lines and the lines in
-        *xfile.d*. **X** will resample the lines first along
+        *xfile*. **X** will resample the lines first along
         great-circle arcs.
 
     In addition, you may optionally append

--- a/doc/rst/source/gmt2kml.rst
+++ b/doc/rst/source/gmt2kml.rst
@@ -415,7 +415,7 @@ a crude example:
 
 <!--This level of folder is inserted only when using -O, -K>
 
-<Folder><name>file1.dat</name>
+<Folder><name>file1.txt</name>
 
 <!--One folder for each input file (not when standard input)>
 
@@ -423,11 +423,11 @@ a crude example:
 
 <!--One folder per line segment>
 
-<!--Points from the first line segment in file file1.dat go here>
+<!--Points from the first line segment in file file1.txt go here>
 
 <Folder><name>Point Set 1</name>
 
-<!--Points from the second line segment in file file1.dat go here>
+<!--Points from the second line segment in file file1.txt go here>
 
 </Folder>
 
@@ -435,7 +435,7 @@ a crude example:
 
 <Folder><name>Line Features</name>
 
-<Folder><name>file1.dat</name>
+<Folder><name>file1.txt</name>
 
 <!--One folder for each input file (not when standard input)>
 

--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -291,7 +291,7 @@ Examples
 
 To convert the binary file test.b (single precision) with 4 columns to ASCII::
 
-    gmt convert test.b -bi4f > test.dat
+    gmt convert test.b -bi4f > test.txt
 
 To convert the multiple segment ASCII table test.txt to a double precision binary file::
 
@@ -350,11 +350,11 @@ file like this::
 
 do::
 
-    gmt convert file.gmt -a2=ELEVATION > xyz.dat
+    gmt convert file.gmt -a2=ELEVATION > xyz.txt
 
 or just::
 
-    gmt convert file.gmt -aELEVATION > xyz.dat
+    gmt convert file.gmt -aELEVATION > xyz.txt
 
 To connect all points in the file sensors.txt with the specified origin
 at 23.5/19, try::

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -352,7 +352,7 @@ predicted bathymetry on a Mercator grid) and the Muller et al age grid
 age.3.2.nc along the lon,lat coordinates given in the file
 cruise_track.xy, try::
 
-    gmt grdtrack cruise_track.xy -Gtopo.8.2.img,1,1 -Gage.3.2.nc > depths-age.d
+    gmt grdtrack cruise_track.xy -Gtopo.8.2.img,1,1 -Gage.3.2.nc > depths-age.txt
 
 To sample the Sandwell/Smith IMG format file grav.18.1.img (1 minute
 free-air anomalies on a Mercator grid) along 100-km-long cross-profiles

--- a/doc/rst/source/grdvolume.rst
+++ b/doc/rst/source/grdvolume.rst
@@ -149,13 +149,13 @@ maximizes the ratio of volume to surface area for the file peaks.nc, use
 
 ::
 
-  gmt grdvolume peaks.nc -C100/300/10 -Th > results.d
+  gmt grdvolume peaks.nc -C100/300/10 -Th > results.txt
 
 To see the areas and volumes for all the contours in the previous example, use
 
 ::
 
-  gmt grdvolume peaks.nc -C100/300/10 > results.d
+  gmt grdvolume peaks.nc -C100/300/10 > results.txt
 
 To find the volume of water in a lake with its free surface at 0 and max depth of 300 meters, use
 

--- a/doc/rst/source/supplements/geodesy/earthtide.rst
+++ b/doc/rst/source/supplements/geodesy/earthtide.rst
@@ -130,7 +130,7 @@ To obtain a one day long time-series, starting at same date, at the -7 *W*, 37 *
 
 ::
 
-    gmt earthtide -T2018-06-18T/2018-06-19T/1m -L-7/37 > solid_tide.dat
+    gmt earthtide -T2018-06-18T/2018-06-19T/1m -L-7/37 > solid_tide.txt
 
 
 The get the Sun and Moon position in geographical coordinates at the *now* time

--- a/doc/rst/source/supplements/spotter/rotconverter.rst
+++ b/doc/rst/source/supplements/spotter/rotconverter.rst
@@ -133,7 +133,7 @@ model_total_reconstruction.APM to stage poles, run
 
 To obtain Nazca motion relative to Pacific hotspots by adding the motion
 of Nazca relative to a fixed Pacific to the Pacific-Hotspot reference
-model DC85_stages.d, and report the result as total reconstruction
+model DC85_stages.txt, and report the result as total reconstruction
 reconstruction poles in the northern hemisphere, try
 
 ::

--- a/doc/rst/source/supplements/x2sys/x2sys_put.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_put.rst
@@ -77,7 +77,7 @@ X2sys Databases
 The **x2sys_put** utility adds new information to the x2sys data bases.
 These consists of two files: The first file contains a listing of all
 the tracks that have been added to the system; it is named
-*TAG*\ \_tracks.d and is in ASCII format. The second file is named
+*TAG*\ \_tracks.txt and is in ASCII format. The second file is named
 *TAG*\ \_index.b and is in native binary format. It contains information
 on which tracks cross each of the bins, and what data sets were observed
 while crossing the bin. The bins are defined by the |-R| and |-I|


### PR DESCRIPTION
Files like output.d or output.dat does not indicate uniquely that these are ASCII tables.  Using *.txt makes that much clearer. Also fixed contour label directive arguments (.e.g., **-Gx**_xfile.d_) to not have a file name with extension but just _xfile_.
