### PR TITLE
Italizisize vars

### DIFF
--- a/doc/rst/source/changes.rst
+++ b/doc/rst/source/changes.rst
@@ -1411,7 +1411,7 @@ grdraster
     found in the sph supplement.
 
 :doc:`sphtriangulate`
-    Delaunay or Voronoi construction of spherical lon,lat data.  Previously
+    Delaunay or Voronoi construction of spherical *lon,lat* data.  Previously
     found in the sph supplement.
 
 We have also added a new supplement called potential that contains these five modules:

--- a/doc/rst/source/changes.rst
+++ b/doc/rst/source/changes.rst
@@ -1411,7 +1411,7 @@ grdraster
     found in the sph supplement.
 
 :doc:`sphtriangulate`
-    Delaunay or Voronoi construction of spherical *lon, lat* data.  Previously
+    Delaunay or Voronoi construction of spherical (*lon, lat*) data.  Previously
     found in the sph supplement.
 
 We have also added a new supplement called potential that contains these five modules:

--- a/doc/rst/source/changes.rst
+++ b/doc/rst/source/changes.rst
@@ -1411,7 +1411,7 @@ grdraster
     found in the sph supplement.
 
 :doc:`sphtriangulate`
-    Delaunay or Voronoi construction of spherical *lon,lat* data.  Previously
+    Delaunay or Voronoi construction of spherical *lon, lat* data.  Previously
     found in the sph supplement.
 
 We have also added a new supplement called potential that contains these five modules:
@@ -1583,7 +1583,7 @@ ways, such as
 
 *  While we support the scaling of z-values in grids via the filename convention
    name[=\ *ID*\ [**+s**\ *scale*][**+o**\ *offset*][**+n**\ *nan*] mechanism, there are times
-   when we wish to scale the x,y domain as well. Users can now
+   when we wish to scale the *x, y* domain as well. Users can now
    append **+u**\ *unit* to their gridfile names, where *unit* is one of non-arc units listed
    in Table :ref:`distunits <tbl-distunits>`.  This will convert your Cartesian
    x and y coordinates *from* the given unit *to* meters.  We also support the inverse
@@ -1660,7 +1660,7 @@ Finally, here is a list of numerous enhancements to individual programs:
 *  :doc:`grd2cpt` takes **-F** to specify output color model and **-G** to
    truncate incoming CPT to be limited to a given range.
 
-*  :doc:`grd2xyz` takes **-C** to write row, col instead of x,y.  Append **f**
+*  :doc:`grd2xyz` takes **-C** to write row, col instead of *x, y*.  Append **f**
    to start at 1, else start at 0.  Alternatively, use **-Ci** to write just
    the two columns *index* and *z*, where *index*
    is the 1-D indexing that GMT uses when referring to grid nodes.

--- a/doc/rst/source/clip.rst
+++ b/doc/rst/source/clip.rst
@@ -42,7 +42,7 @@ Synopsis
 Description
 -----------
 
-Reads (x,y) file(s) [or standard input] and draws polygons
+Reads (*x, y*) file(s) [or standard input] and draws polygons
 that are activated as clipping paths. Several files may be read to
 create complex paths consisting of several non-connecting segments. Only
 marks that are subsequently drawn inside the clipping path will be

--- a/doc/rst/source/devdocs/api.rst
+++ b/doc/rst/source/devdocs/api.rst
@@ -2340,7 +2340,7 @@ you call GMT_Begin_IO_.
 
     The modes for setting various comment types.
 
-The named modes (*command*, *remark*, *title*, *name_x,y,z* and
+The named modes (*command*, *remark*, *title*, *name_x*\|\ *y*\|\ *z* and
 *colnames* are used to distinguish regular text comments from specific
 fields in the header structures of the data resources, such as
 :ref:`GMT_GRID <struct-grid>`. For the various table resources (e.g., :ref:`GMT_DATASET <struct-dataset>`)

--- a/doc/rst/source/devdocs/postscriptlight.rst
+++ b/doc/rst/source/devdocs/postscriptlight.rst
@@ -626,10 +626,10 @@ Here are functions used to plot various geometric symbols or constructs.
     of vector head, PSL_VEC_BEGIN (4) =
     place vector head at beginning of vector,
     PSL_VEC_END (8) = place vector head at end of vector,
-    PSL_VEC_JUST_B (0) = align vector beginning at (x,y),
-    PSL_VEC_JUST_C (16) = align vector center at (x,y),
-    PSL_VEC_JUST_E (32) = align vector end at (x,y),
-    PSL_VEC_JUST_S (64) = align vector center at (x,y),
+    PSL_VEC_JUST_B (0) = align vector beginning at (*x, y*),
+    PSL_VEC_JUST_C (16) = align vector center at (*x, y*),
+    PSL_VEC_JUST_E (32) = align vector end at (*x, y*),
+    PSL_VEC_JUST_S (64) = align vector center at (*x, y*),
     PSL_VEC_OUTLINE (128) = draw vector head outline using default
     pen, PSL_VEC_FILL (512) = fill vector head using default fill,
     PSL_VEC_MARC90 (2048) = if angles subtend 90, draw straight angle
@@ -868,7 +868,7 @@ and others and issue calculations with **PSL_setcommand**.
     you must pass as *arg1* the *node* array indicating at which
     node in the *xpath, ypath* array the text will be plotted; let
     *arg2* be NULL. For
-    straight baselines you must instead pass another set of x,y
+    straight baselines you must instead pass another set of *x, y*
     coordinates with the locations of the text label placements
     via *arg1, arg2*.
     Each label has its own entry in the

--- a/doc/rst/source/dimfilter.rst
+++ b/doc/rst/source/dimfilter.rst
@@ -60,20 +60,20 @@ Required Arguments
 .. _-D:
 
 **-D**\ *flag*
-    Distance *flag* (0-4) determines how grid (x,y) relates to filter *width*, as follows:
+    Distance *flag* (0-4) determines how grid (*x, y*) relates to filter *width*, as follows:
 
-    - *flag* = 0: grid (x,y) in same units as *width*, Cartesian distances.
-    - *flag* = 1: grid (x,y) in degrees, *width* in kilometers, Cartesian distances.
-    - *flag* = 2: grid (x,y) in degrees, *width* in km, dx scaled by
+    - *flag* = 0: grid (*x, y*) in same units as *width*, Cartesian distances.
+    - *flag* = 1: grid (*x, y*) in degrees, *width* in kilometers, Cartesian distances.
+    - *flag* = 2: grid (*x, y*) in degrees, *width* in km, dx scaled by
       cos(middle y), Cartesian distances.
 
     The above options are fastest because they allow weight matrix to be
     computed only once. The next two options are slower because they
     recompute weights for each latitude.
 
-    - *flag* = 3: grid (x,y) in degrees, *width* in km, dx scaled by
+    - *flag* = 3: grid (*x, y*) in degrees, *width* in km, dx scaled by
       cosine(y), Cartesian distance calculation.
-    - *flag* = 4: grid (x,y) in degrees, *width* in km, Spherical distance
+    - *flag* = 4: grid (*x, y*) in degrees, *width* in km, Spherical distance
       calculation.
 
 .. _-F:

--- a/doc/rst/source/events.rst
+++ b/doc/rst/source/events.rst
@@ -478,7 +478,7 @@ To prevent this, you can sort your file into ascending order via the :doc:`gmtco
 Drawing trajectories
 --------------------
 
-If **-Ar** is used to draw trajectories (lines with *x,y,t* coordinates) then, as stated, we will
+If **-Ar** is used to draw trajectories (lines with *x, y, t* coordinates) then, as stated, we will
 use a linear interpolation to find intermediate terminal points.  For geographic data, and especially
 if your original point spacing is large, you may wish to first interpolate such trajectories along
 great circles via :doc:`sample1d` rather than subject large gaps to linear interpolation.

--- a/doc/rst/source/explain_-aspatial_full.rst_
+++ b/doc/rst/source/explain_-aspatial_full.rst_
@@ -21,7 +21,7 @@ OGR/GMT input with **-a** option
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you need to populate GMT data columns with (constant) values specified by aspatial attributes, use **-a** and append
-any number of comma-separated *col=name* associations. For example, **-a**\ *2=depth* will read the spatial *x,y*
+any number of comma-separated *col=name* associations. For example, **-a**\ *2=depth* will read the spatial *x, y*
 columns from the file and add a third (*z*) column based on the value of the aspatial field called *depth*. You can also
 associate aspatial fields with other settings such as labels, fill colors, pens, and values (for looking-up colors) by
 letting the *col* value be one of **D** (for *distance*), **G** (for *fill*), **I** (for *ID*), **L** (for *label*),

--- a/doc/rst/source/explain_contdump.rst_
+++ b/doc/rst/source/explain_contdump.rst_
@@ -1,4 +1,4 @@
-    Dump the (*x,y,z*) coordinates of each contour to one or more output files
+    Dump the (*x, y, z*) coordinates of each contour to one or more output files
     (or standard output if *template* is not given). No plotting will take place.
     If *template* contains one or more of the C language `printf <https://en.wikipedia.org/wiki/Printf_format_string>`_
     format specifiers %d, %f, %c

--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -221,7 +221,7 @@
         to *base* [Relative to origin]. Normally, the bar requires a single input *y*-value.
         To plot multi-band bars, please append **+v**\|\ **i**\ *ny*, where *ny* indicates the
         total number of bands in the bar (and hence the number of values required to follow
-        the x,y coordinate pair in the input).  Here, **+i** means we must accumulate the
+        the *x, y* coordinate pair in the input).  Here, **+i** means we must accumulate the
         bar values from the increments *dy*, while **+v** means we get the complete
         values relative to *base* in increasing order. Normally, the bands are plotted as sections of a final single bar.
         Use **+s** to instead split the bar into *ny* side-by-side, individual and thinner bars. The
@@ -239,7 +239,7 @@
         to *base* [Relative to origin]. Normally, the bar requires a single input *x*-value.
         To plot multi-band bars, please append **+v**\|\ **i**\ *nx*, where *nx* indicates the
         total number of bands in the bar (and hence the number of values required to follow
-        the x,y coordinate pair in the input).  Here, **+i** means we must accumulate the
+        the *x, y* coordinate pair in the input).  Here, **+i** means we must accumulate the
         bar value from the increments *dx*, while **+v** means we get the complete
         values relative to *base* in increasing order. Normally, the bands are plotted as sections of a final single bar.
         Use **+s** to instead split the bar into *nx* side-by-side, individual and thinner bars. The

--- a/doc/rst/source/fitcircle.rst
+++ b/doc/rst/source/fitcircle.rst
@@ -32,7 +32,7 @@ Synopsis
 Description
 -----------
 
-**fitcircle** reads *lon,lat* [or *lat,lon*] values from the first two
+**fitcircle** reads *lon, lat* [or *lat, lon*] values from the first two
 columns on standard input [or *table*]. These are converted to
 Cartesian three-vectors on the unit sphere. Then two locations are
 found: the mean of the input positions, and the pole to the great circle
@@ -64,7 +64,7 @@ Required Arguments
 ------------------
 
 *table*
-    One or more ASCII [or binary, see **-bi**] files containing *lon,lat* [or *lat,lon*; see
+    One or more ASCII [or binary, see **-bi**] files containing *lon, lat* [or *lat, lon*; see
     **-:**\ [**i**\|\ **o**]] values in the first 2 columns. If no
     file is specified, **fitcircle** will read from standard input.
 
@@ -140,12 +140,12 @@ Examples
 
 .. include:: explain_example.rst_
 
-To find the parameters of a great circle that most closely fits the (*lon,lat*)
+To find the parameters of a great circle that most closely fits the (*lon, lat*)
 points in the remote file @sat_03.txt in a least-squares sense, try::
 
   gmt fitcircle @sat_03.txt -L2 -Fm
 
-Suppose you have *lon,lat,grav* data along a twisty ship track in the file
+Suppose you have *lon, lat, grav* data along a twisty ship track in the file
 ship.xyg. You want to project this data onto a great circle and resample
 it in distance, in order to filter it or check its spectrum. Do the
 following:

--- a/doc/rst/source/fitcircle.rst
+++ b/doc/rst/source/fitcircle.rst
@@ -32,7 +32,7 @@ Synopsis
 Description
 -----------
 
-**fitcircle** reads lon,lat [or lat,lon] values from the first two
+**fitcircle** reads *lon,lat* [or *lat,lon*] values from the first two
 columns on standard input [or *table*]. These are converted to
 Cartesian three-vectors on the unit sphere. Then two locations are
 found: the mean of the input positions, and the pole to the great circle
@@ -64,7 +64,7 @@ Required Arguments
 ------------------
 
 *table*
-    One or more ASCII [or binary, see **-bi**] files containing lon,lat [or lat,lon; see
+    One or more ASCII [or binary, see **-bi**] files containing *lon,lat* [or *lat,lon*; see
     **-:**\ [**i**\|\ **o**]] values in the first 2 columns. If no
     file is specified, **fitcircle** will read from standard input.
 
@@ -140,12 +140,12 @@ Examples
 
 .. include:: explain_example.rst_
 
-To find the parameters of a great circle that most closely fits the (lon,lat)
+To find the parameters of a great circle that most closely fits the (*lon,lat*)
 points in the remote file @sat_03.txt in a least-squares sense, try::
 
   gmt fitcircle @sat_03.txt -L2 -Fm
 
-Suppose you have lon,lat,grav data along a twisty ship track in the file
+Suppose you have *lon,lat,grav* data along a twisty ship track in the file
 ship.xyg. You want to project this data onto a great circle and resample
 it in distance, in order to filter it or check its spectrum. Do the
 following:
@@ -160,7 +160,7 @@ Here, *ox*/*oy* is the lon/lat of the mean from **fitcircle**, and
 gravity data sampled every 1 km along the great circle which best fits
 ship.xyg
 
-If you have lon, lat points in the file data.txt and wish to return the northern
+If you have *lon, lat* points in the file data.txt and wish to return the northern
 hemisphere great circle pole location using the L2 norm, try
 
 ::

--- a/doc/rst/source/fitcircle.rst
+++ b/doc/rst/source/fitcircle.rst
@@ -32,7 +32,7 @@ Synopsis
 Description
 -----------
 
-**fitcircle** reads *lon, lat* [or *lat, lon*] values from the first two
+**fitcircle** reads (*lon, lat*) [or (*lat, lon*)] values from the first two
 columns on standard input [or *table*]. These are converted to
 Cartesian three-vectors on the unit sphere. Then two locations are
 found: the mean of the input positions, and the pole to the great circle
@@ -64,7 +64,7 @@ Required Arguments
 ------------------
 
 *table*
-    One or more ASCII [or binary, see **-bi**] files containing *lon, lat* [or *lat, lon*; see
+    One or more ASCII [or binary, see **-bi**] files containing (*lon, lat*) [or (*lat, lon*); see
     **-:**\ [**i**\|\ **o**]] values in the first 2 columns. If no
     file is specified, **fitcircle** will read from standard input.
 

--- a/doc/rst/source/gallery/ex03.rst
+++ b/doc/rst/source/gallery/ex03.rst
@@ -6,9 +6,9 @@
 In this example we will show how to use the GMT programs
 :doc:`fitcircle </fitcircle>`, :doc:`project </project>`,
 :doc:`sample1d </sample1d>`, :doc:`spectrum1d </spectrum1d>`,
-and :doc:`plot </plot>`. Suppose you have (lon, lat,
-gravity) along a satellite track in a file called ``sat.xyg``, and (lon, lat,
-gravity) along a ship track in a file called ``ship.xyg``. You want to make a
+and :doc:`plot </plot>`. Suppose you have (*lon, lat,
+gravity*) along a satellite track in a file called ``sat.xyg``, and (*lon, lat,
+gravity*) along a ship track in a file called ``ship.xyg``. You want to make a
 cross-spectral analysis of these data. First, you will have to get the
 two data sets into equidistantly sampled time-series form. To do this,
 it will be convenient to project these along the great circle that best

--- a/doc/rst/source/gallery/ex49.rst
+++ b/doc/rst/source/gallery/ex49.rst
@@ -5,7 +5,7 @@
 
 In this example we show an example of data analysis using grids
 of seafloor depth and age for a region in the south Atlantic.
-Dumping separate x,y,z triplets with :doc:`grd2xyz </grd2xyz>`
+Dumping separate *x, y, z* triplets with :doc:`grd2xyz </grd2xyz>`
 lets us paste the output back via :doc:`gmtconvert </gmtconvert>`
 to make binary tables of age,depth,depth.  Here, depth is repeated in
 order to use :doc:`blockmode </blockmode>` for modal depth estimation

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -568,11 +568,11 @@ I/O Parameters
 
     **IO_LONLAT_TOGGLE**
         (**-:**) Set if the first two columns of input and output files
-        contain (latitude,longitude) or (y,x) rather than the expected
-        (longitude,latitude) or (x,y). false means we have (x,y) both on
-        input and output. **true** means both input and output should be (y,x).
-        **IN** means only input has (y,x), while **OUT** means only output should
-        be (y,x) [default is **false**].
+        contain (*latitude,longitude*) or (**y, x**) rather than the expected
+        (longitude,latitude) or (*x, y*). false means we have (*x, y*) both on
+        input and output. **true** means both input and output should be (**y, x**).
+        **IN** means only input has (**y, x**), while **OUT** means only output should
+        be (**y, x**) [default is **false**].
 
     **IO_N_HEADER_RECS**
         Specifies how many header records to expect if **-h** is used [default is **0**].

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -12,13 +12,13 @@ Introduction
 ------------
 
 GMT is a collection of freely available command-line tools under the GNU LGPL that allows you to
-manipulate x,y and x,y,z data sets (filtering, trend fitting, gridding,
+manipulate *x, y* and *x, y, z* data sets (filtering, trend fitting, gridding,
 projecting, etc.) and produce illustrations ranging from
 simple x-y plots, via contour maps, to artificially illuminated surfaces
 and 3-D perspective views in black/white or full color. Linear, :math:`\log_{10}`,
 and power scaling is supported in addition to over 30 common map
 projections. The processing and display routines within GMT are
-completely general and will handle any (x,y) or (x,y,z) data as input.
+completely general and will handle any (*x, y*) or (*x, y, z*) data as input.
 
 Synopsis
 --------

--- a/doc/rst/source/gmt2kml.rst
+++ b/doc/rst/source/gmt2kml.rst
@@ -306,14 +306,14 @@ first make the CPT and then create the KML file thus::
     gmt makecpt -Ccategorical > categories.cpt
     gmt 2kml @kml_pointsets.txt -Ccategories.cpt > points.kml
 
-To convert a file with point locations (lon, lat) into a KML file with
+To convert a file with point locations (*lon, lat*) into a KML file with
 red circle symbols, try
 
 ::
 
   gmt 2kml mypoints.txt -Gred+f -Fs > mypoints.kml
 
-To convert a multisegment file with lines (lon, lat) separated by
+To convert a multisegment file with lines (*lon, lat*) separated by
 segment headers that contain a **-L**\ labelstring with the feature
 name, selecting a thick white pen, and title the document, try
 
@@ -321,7 +321,7 @@ name, selecting a thick white pen, and title the document, try
 
   gmt 2kml mylines.txt -Wthick,white -Fl -T"Lines from here to there" > mylines.kml
 
-To convert a multisegment file with polygons (lon, lat) separated by
+To convert a multisegment file with polygons (*lon, lat*) separated by
 segment headers that contain a **-L**\ labelstring with the feature
 name, selecting a thick black pen and semi-transparent yellow fill,
 giving a title to the document, and prescribing a particular region
@@ -331,7 +331,7 @@ limit, try
 
   gmt 2kml mypolygons.txt -Gyellow@50+f -Fp -T"My polygons" -R30/90/-20/40 > mypolygons.kml
 
-To convert a file with point locations (lon, lat, time) into a KML file
+To convert a file with point locations (*lon, lat, time*) into a KML file
 with green circle symbols that will go active at the specified time and
 stay active going forward, try
 

--- a/doc/rst/source/gmtbinstats.rst
+++ b/doc/rst/source/gmtbinstats.rst
@@ -41,7 +41,7 @@ Synopsis
 Description
 -----------
 
-**binstats** reads arbitrarily located (x,y[,z][,w]) points
+**binstats** reads arbitrarily located (*x, y*\ [, *z*][, *w*]) points
 (2-4 columns) from standard input [or *table*] and for each
 node in the specified grid layout determines which points are
 within the given radius.  These points are then used in the
@@ -55,7 +55,7 @@ Required Arguments
 
 *table*
     A 2-4 column ASCII file(s) [or binary, see
-    **-bi**] holding (x,y[,z][,w]) data values. You must use |-W|
+    **-bi**] holding (*x, y*\ [, *z*][, *w*]) data values. You must use |-W|
     to indicate that you have weights.  Only |-C|\ **n** will accept 2 columns only.
     If no file is specified, **binstats** will read from standard input.
 

--- a/doc/rst/source/gmtconnect.rst
+++ b/doc/rst/source/gmtconnect.rst
@@ -170,7 +170,7 @@ the end points' digitization error could be up to 0.1 mm, run::
     gmt connect segment_*.txt -T0.1 > new_segments.txt
 
 To combine the digitized segments in the multisegment file my_lines.txt
-(whose coordinates are in lon,lat) into as few complete lines as
+(whose coordinates are in *lon,lat*) into as few complete lines as
 possible, assuming the end points digitization error could be up to 150 m, and write
 the complete segments to individual files called Map_segment_0001.txt,
 Map_segment_0002.txt, etc., run::

--- a/doc/rst/source/gmtconnect.rst
+++ b/doc/rst/source/gmtconnect.rst
@@ -170,7 +170,7 @@ the end points' digitization error could be up to 0.1 mm, run::
     gmt connect segment_*.txt -T0.1 > new_segments.txt
 
 To combine the digitized segments in the multisegment file my_lines.txt
-(whose coordinates are in *lon,lat*) into as few complete lines as
+(whose coordinates are in *lon, lat*) into as few complete lines as
 possible, assuming the end points digitization error could be up to 150 m, and write
 the complete segments to individual files called Map_segment_0001.txt,
 Map_segment_0002.txt, etc., run::

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -298,9 +298,9 @@ and output arguments.
   **KM2DEG**      1 1     Converts kilometers to spherical degrees                                                    Special Operators  
   **KN**          2 1     Modified Bessel function of A (2nd kind, order B)                                           Special Functions  
   **KURT**        1 1     Kurtosis of A                                                                               Probability        
-  **LAB2HSV**     3 3     Convert l,a,b triplets to h,s,v triplets                                                    Special Operators  
-  **LAB2RGB**     3 3     Convert l,a,b triplets to r,g,b triplets                                                    Special Operators  
-  **LAB2XYZ**     3 3     Convert l,a,b triplets to x,y,z triplets                                                    Special Operators  
+  **LAB2HSV**     3 3     Convert *l,a,b* triplets to *h,s,v* triplets                                                Special Operators  
+  **LAB2RGB**     3 3     Convert *l,a,b* triplets to *r,g,b* triplets                                                Special Operators  
+  **LAB2XYZ**     3 3     Convert *l,a,b* triplets to *x,y,z* triplets                                                Special Operators  
   **LCDF**        1 1     Laplace cumulative distribution function for z = A                                          Probability        
   **LCRIT**       1 1     Laplace distribution critical value for alpha = A                                           Probability        
   **LE**          2 1     1 if A <= (equal or smaller than) B, else 0                                                 Logic              
@@ -351,9 +351,9 @@ and output arguments.
   **RAND**        2 1     Uniform random values between A and B                                                       Probability        
   **RCDF**        1 1     Rayleigh cumulative distribution function for z = A                                         Probability        
   **RCRIT**       1 1     Rayleigh distribution critical value for alpha = A                                          Probability        
-  **RGB2HSV**     3 3     Convert r,g,b triplets to h,s,v triplets, with r = A, g = B, and b = C (in 0-255 range)     Special Operators  
-  **RGB2LAB**     3 3     Convert r,g,b triplets to l,a,b triplets, with r = A, g = B, and b = C (in 0-255 range)     Special Operators  
-  **RGB2XYZ**     3 3     Convert r,g,b triplets to x,y,x triplets, with r = A, g = B, and b = C (in 0-255 range)     Special Operators  
+  **RGB2HSV**     3 3     Convert *r,g,b* triplets to *h,s,v* triplets, with r = A, g = B, and b = C (in 0-255 range) Special Operators  
+  **RGB2LAB**     3 3     Convert *r,g,b* triplets to *l,a,b* triplets, with r = A, g = B, and b = C (in 0-255 range) Special Operators  
+  **RGB2XYZ**     3 3     Convert *r,g,b* triplets to *x,y,z* triplets, with r = A, g = B, and b = C (in 0-255 range) Special Operators  
   **RINT**        1 1     Rint (A) (round to integral value nearest to A)                                             Arithmetic         
   **RMS**         1 1     Root-mean-square of A                                                                       Arithmetic         
   **RMSW**        1 1     Weighted root-mean-square of A for weights in B                                             Arithmetic         
@@ -393,9 +393,9 @@ and output arguments.
   **WCRIT**       3 1     Weibull distribution critical value for alpha = A, scale = B, and shape = C                 Probability        
   **WPDF**        3 1     Weibull density distribution P(x,scale,shape), with x = A, scale = B, and shape = C         Probability        
   **XOR**         2 1     B if A equals NaN, else A                                                                   Logic              
-  **XYZ2HSV**     3 3     Convert x,y,z triplets to h,s,v triplets                                                    Special Operators  
-  **XYZ2LAB**     3 3     Convert x,y,z triplets to l,a,b triplets                                                    Special Operators  
-  **XYZ2RGB**     3 3     Convert x,y,z triplets to r,g,b triplets                                                    Special Operators  
+  **XYZ2HSV**     3 3     Convert *x,y,z* triplets to *h,s,v* triplets                                                Special Operators  
+  **XYZ2LAB**     3 3     Convert *x,y,z* triplets to *l,a,b* triplets                                                Special Operators  
+  **XYZ2RGB**     3 3     Convert *x,y,z* triplets to *r,g,b* triplets                                                Special Operators  
   **Y0**          1 1     Bessel function of A (2nd kind, order 0)                                                    Special Functions  
   **Y1**          1 1     Bessel function of A (2nd kind, order 1)                                                    Special Functions  
   **YN**          2 1     Bessel function of A (2nd kind, order B)                                                    Special Functions  

--- a/doc/rst/source/gmtselect.rst
+++ b/doc/rst/source/gmtselect.rst
@@ -111,7 +111,7 @@ Optional Arguments
 **-F**\ *polygonfile*
     Pass all records whose location is within one of the closed polygons
     in the multiple-segment file *polygonfile*. For spherical polygons
-    (lon, lat), make sure no consecutive points are separated by 180
+    (*lon, lat*), make sure no consecutive points are separated by 180
     degrees or more in longitude. Note that *polygonfile* must be in
     ASCII regardless of whether **-bi** is used.
 
@@ -263,7 +263,7 @@ Note On Distances
 
 If options |-C| or |-L| are selected then distances are Cartesian
 and in user units; use **-fg** to imply spherical distances in km and
-geographical (lon, lat) coordinates. Alternatively, specify |-R| and
+geographical (*lon, lat*) coordinates. Alternatively, specify |-R| and
 **-J** to measure projected Cartesian distances in map units (cm, inch,
 or points, as determined by :term:`PROJ_LENGTH_UNIT`).
 

--- a/doc/rst/source/gmtselect.rst
+++ b/doc/rst/source/gmtselect.rst
@@ -53,7 +53,7 @@ selected based on whether or not they are 1) inside a rectangular region (|-R| [
 polygons in the *polygonfile*, 5) inside geographical features (based on coastlines), 6) has z-values
 within a given range, or 7) inside bins of a grid mask whose nodes are non-zero. The sense of the tests can
 be reversed for each of these 7 criteria by using the |-I| option. See option **-:** on how to read
-(y,x) or (latitude,longitude) files (this option affects all module input data).  **Note**: If no projection
+(*y, x*) or (*lat, lon*) files (this option affects all module input data).  **Note**: If no projection
 information is used then you must supply **-fg** to tell **select** that your data are geographical.
 
 Required Arguments

--- a/doc/rst/source/gmtsplit.rst
+++ b/doc/rst/source/gmtsplit.rst
@@ -38,24 +38,24 @@ Synopsis
 Description
 -----------
 
-**split** reads a series of (*x,y[,z]*) records [or optionally
-(*x,y[,z],d,h*); see |-S| option] from standard input [or *xy[z][dh]file*]
-and splits this into separate lists of (*x,y[,z]*) series, such that each
-series has a nearly constant azimuth through the *x,y* plane. There are
+**split** reads a series of (*x, y*\ [*, z*]) records [or optionally
+(*x, y* [, *z*], *d, h*); see |-S| option] from standard input [or *xy[z][dh]file*]
+and splits this into separate lists of (*x, y*\ [, *z*]) series, such that each
+series has a nearly constant azimuth through the *x-y* plane. There are
 options to choose only those series which have a certain orientation, to
 set a minimum length for series, and to high- or low-pass filter the *z*
-values and/or the *x,y* values. **split** is a useful filter between
+values and/or the *x, y* values. **split** is a useful filter between
 data extraction and :doc:`wiggle` plotting, and can also be used to
-divide a large *x,y[,z]* dataset into segments.
+divide a large *x, y*\ [, *z*] dataset into segments.
 
 Required Arguments
 ------------------
 
 *table*
     One or more ASCII [or binary, see **-bi**]
-    files with 2, 3, or 5 columns holding (*x,y*,[*z*\ [,\ *d,h*\ ]])
-    data values. To use (*x,y,z,d,h*) input, sorted so that *d* is
-    non-decreasing, specify the |-S| option; default expects (*x,y,z*)
+    files with 2, 3, or 5 columns holding (*x, y*\ [, *z*\ [,\ *d,h*\ ]])
+    data values. To use (*x ,y, z, d, h*) input, sorted so that *d* is
+    non-decreasing, specify the |-S| option; default expects (*x, y, z*)
     only. If no files are specified, **split** will read from
     standard input.
 
@@ -85,7 +85,7 @@ Optional Arguments
 .. _-F:
 
 **-F**\ *xy\_filter*/*z\_filter*
-    Filter the z values and/or the *x,y* values, assuming these are
+    Filter the z values and/or the *x, y* values, assuming these are
     functions of *d* coordinate. *xy\_filter* and *z\_filter* are filter
     widths in distance units. If a filter width is zero, the filtering
     is not performed. The absolute value of the width is the full width
@@ -96,9 +96,9 @@ Optional Arguments
     filtered before any segmentation is performed, so that the only edge
     effects in the filtering will happen at the beginning and end of the
     complete data stream. If *xy\_filter* is non-zero, the data are first
-    divided into segments and then the *x,y* values of each segment are
+    divided into segments and then the *x, y* values of each segment are
     filtered separately. This may introduce edge effects at the ends of
-    each segment, but prevents a low-pass *x,y* filter from rounding off
+    each segment, but prevents a low-pass *x, y* filter from rounding off
     the corners of track segments. [Default = no filtering].
 
 .. _-N:
@@ -127,12 +127,12 @@ Optional Arguments
 .. _-S:
 
 **-S**
-    Both *d* and *h* are supplied. In this case, input contains *x,y,z,d,h*.
-    [Default expects (*x,y,z*) input, and *d,h* are computed from delta *x*,
-    delta *y*. Use **-fg** to indicate map data; then *x,y* are assumed to
+    Both *d* and *h* are supplied. In this case, input contains *x, y, z, d, h*.
+    [Default expects (*x, y, z*) input, and *d,h* are computed from delta *x*,
+    delta *y*. Use **-fg** to indicate map data; then *x, y* are assumed to
     be in degrees of longitude, latitude, distances are considered to be
     in kilometers, and angles are actually azimuths. Otherwise,
-    distances are Cartesian in same units as *x,y* and angles are
+    distances are Cartesian in same units as *x, y* and angles are
     counter-clockwise from horizontal].
 
 .. |Add_-V| replace:: |Add_-V_links|
@@ -177,9 +177,9 @@ Distance Calculations
 ---------------------
 
 The type of input data is dictated by the **-f** option. If **-fg** is
-given then *x,y* are in degrees of longitude, latitude, distances are in
+given then *x, y* are in degrees of longitude, latitude, distances are in
 kilometers, and angles are azimuths. Otherwise, distances are Cartesian
-in same units as *x,y* and angles are counter-clockwise from horizontal.
+in same units as *x, y* and angles are counter-clockwise from horizontal.
 
 Examples
 --------

--- a/doc/rst/source/gmtvector.rst
+++ b/doc/rst/source/gmtvector.rst
@@ -59,7 +59,7 @@ Required Arguments
 
 *table*
     One or more ASCII [or binary, see **-bi**]
-    file containing *lon, lat* [*lat, lon* if **-:**] values in the first 2
+    file containing (*lon, lat*) [or (*lat, lon*) if **-:**] values in the first 2
     columns (if **-fg** is given) or (*r, theta*), or perhaps (*x, y*\ [*, z*])
     if **-Ci** is given). If no file is specified, **vector**, will
     read from standard input.
@@ -179,7 +179,7 @@ as well as the 95% confidence ellipse around that point, try::
 
     gmt vector @ship_15.txt -Am -fg
 
-Suppose you have a file with *lon, lat* called points.txt. You want to
+Suppose you have a file with (*lon, lat*) called points.txt. You want to
 compute the spherical angle between each of these points and the
 location 133/34. Try::
 

--- a/doc/rst/source/gmtvector.rst
+++ b/doc/rst/source/gmtvector.rst
@@ -59,7 +59,7 @@ Required Arguments
 
 *table*
     One or more ASCII [or binary, see **-bi**]
-    file containing *lon,lat* [*lat,lon* if **-:**] values in the first 2
+    file containing *lon, lat* [*lat, lon* if **-:**] values in the first 2
     columns (if **-fg** is given) or (*r, theta*), or perhaps (*x, y*\ [*, z*])
     if **-Ci** is given). If no file is specified, **vector**, will
     read from standard input.

--- a/doc/rst/source/gmtvector.rst
+++ b/doc/rst/source/gmtvector.rst
@@ -39,10 +39,10 @@ Synopsis
 Description
 -----------
 
-**vector** reads either (x, y), (x, y, z), (r, theta) or (lon, lat)
-[or (lat,lon); see **-:**] coordinates from the first 2-3 columns on
+**vector** reads either (x, y), (x, y, z), (r, theta) or (*lon, lat*)
+[or (*lat, lon*); see **-:**] coordinates from the first 2-3 columns on
 standard input [or one or more tables]. If **-fg** is selected and only two items
-are read (i.e., lon, lat) then these coordinates are converted to
+are read (i.e., *lon, lat*) then these coordinates are converted to
 Cartesian three-vectors on the unit sphere. Otherwise we expect (r,
 theta) unless **-Ci** is in effect. If no file is found we expect a
 single vector to be given as argument to **-A**; this argument will also
@@ -51,16 +51,16 @@ vectors (or the one provided via |-A|) are denoted the prime
 vector(s). Several standard vector operations (angle between vectors,
 cross products, vector sums, and vector rotations) can be selected; most
 require a single second vector, provided via |-S|. The output vectors
-will be converted back to (lon, lat) or (r, theta) unless **-Co** is set
-which requests (x, y[, z]) Cartesian coordinates.
+will be converted back to (*lon, lat*) or (*r, theta*) unless **-Co** is set
+which requests (*x, y*\ [*, z*]) Cartesian coordinates.
 
 Required Arguments
 ------------------
 
 *table*
     One or more ASCII [or binary, see **-bi**]
-    file containing lon,lat [lat,lon if **-:**] values in the first 2
-    columns (if **-fg** is given) or (r, theta), or perhaps (x, y[, z])
+    file containing *lon,lat* [*lat,lon* if **-:**] values in the first 2
+    columns (if **-fg** is given) or (*r, theta*), or perhaps (*x, y*\ [*, z*])
     if **-Ci** is given). If no file is specified, **vector**, will
     read from standard input.
 
@@ -179,7 +179,7 @@ as well as the 95% confidence ellipse around that point, try::
 
     gmt vector @ship_15.txt -Am -fg
 
-Suppose you have a file with lon, lat called points.txt. You want to
+Suppose you have a file with *lon, lat* called points.txt. You want to
 compute the spherical angle between each of these points and the
 location 133/34. Try::
 

--- a/doc/rst/source/grd2xyz.rst
+++ b/doc/rst/source/grd2xyz.rst
@@ -39,7 +39,7 @@ precision of the ASCII output format by editing the
 :term:`FORMAT_FLOAT_OUT` parameter in your :doc:`gmt.conf` file or use
 **--FORMAT_FLOAT_OUT**\ =\ *format* on the command line, or choose binary
 output using single or double precision storage. As an option you may
-output z-values without the (x,y) coordinates (see |-Z| below) or you can
+output z-values without the (*x, y*) coordinates (see |-Z| below) or you can
 save the grid in the STL format for 3-D printers.
 
 Required Arguments
@@ -104,8 +104,8 @@ Optional Arguments
 .. _-W:
 
 **-W**\ [**a**\ [**+u**\ *unit*]\|\ *weight*]
-    Write out *x,y,z,w*\ , where *w* is the supplied *weight* (or 1 if not
-    supplied) [Default writes *x,y,z* only].  Choose **-Wa** to compute
+    Write out *x, y, z, w*\ , where *w* is the supplied *weight* (or 1 if not
+    supplied) [Default writes *x, y, z* only].  Choose **-Wa** to compute
     weights equal to the area each node represents.  For Cartesian grids this
     is simply the product of the *x* and *y* increments (except for
     gridline-registered grids at all sides [half] and corners [quarter]).
@@ -214,7 +214,7 @@ To edit individual values in the 2' by 2' remote AFR.nc file, dump the .nc to AS
 
   gmt grd2xyz @AFR.nc > AFR.xyz
 
-To write a single precision binary file without the x,y positions from
+To write a single precision binary file without the *x, y* positions from
 the remote file @AFR.nc file, using scanline orientation, run:
 
 ::

--- a/doc/rst/source/grdfilter.rst
+++ b/doc/rst/source/grdfilter.rst
@@ -52,26 +52,26 @@ Required Arguments
 .. _-D:
 
 **-D**\ *flag*
-    Distance *flag* tells how grid (x,y) relates to filter *width* as
+    Distance *flag* tells how grid (*x, y*) relates to filter *width* as
     follows:
 
     - *flag* = p: grid (px,py) with *width* an odd number of pixels;
       Cartesian distances.
-    - *flag* = 0: grid (x,y) same units as *width*, Cartesian distances.
-    - *flag* = 1: grid (x,y) in degrees, *width* in km, Cartesian
+    - *flag* = 0: grid (*x, y*) same units as *width*, Cartesian distances.
+    - *flag* = 1: grid (*x, y*) in degrees, *width* in km, Cartesian
       distances.
-    - *flag* = 2: grid (x,y) in degrees, *width* in km, dx scaled by
+    - *flag* = 2: grid (*x, y*) in degrees, *width* in km, dx scaled by
       cos(middle y), Cartesian distances.
 
     The above options are fastest because they allow weight matrix to be
     computed only once. The next three options are slower because they
     recompute weights for each latitude.
 
-    - *flag* = 3: grid (x,y) in degrees, *width* in km, dx scaled by
+    - *flag* = 3: grid (*x, y*) in degrees, *width* in km, dx scaled by
       cosine(y), Cartesian distance calculation.
-    - *flag* = 4: grid (x,y) in degrees, *width* in km, Spherical distance
+    - *flag* = 4: grid (*x, y*) in degrees, *width* in km, Spherical distance
       calculation.
-    - *flag* = 5: grid (x,y) in Mercator **-Jm**\ 1 img units, *width* in
+    - *flag* = 5: grid (*x, y*) in Mercator **-Jm**\ 1 img units, *width* in
       km, Spherical distance calculation.
 
 .. _-F:

--- a/doc/rst/source/grdgdal.rst
+++ b/doc/rst/source/grdgdal.rst
@@ -124,12 +124,12 @@ Optional Arguments
 Examples
 --------
 
-To interpolate the x,y,z data at 0.05 increment in a VRT file using the nearest neighbor algorithm
+To interpolate the *x, y, z* data at 0.05 increment in a VRT file using the nearest neighbor algorithm
 and saving the result as a netCDF::
 
     gmt grdgdal lixo.vrt -Agrid -R0/10/0/10 -Gjunk.nc -I0.05 -F"-a nearest" -M+r
 
-Now the same as above but saving the grid with GDAL and using the x,y,z point file directly::
+Now the same as above but saving the grid with GDAL and using the *x, y, z* point file directly::
 
     gmt grdgdal lixo.csv -Agrid -R0/10/0/10 -Gjunk.nc -I0.05 -F"-a nearest" -M+w
 

--- a/doc/rst/source/grdgradient.rst
+++ b/doc/rst/source/grdgradient.rst
@@ -56,14 +56,14 @@ Optional Arguments
 
 **-A**\ *azim*\ [/*azim2*]
     Azimuthal direction for a directional derivative; *azim* is the
-    angle in the x,y plane measured in degrees positive clockwise from
+    angle in the *x-y* plane measured in degrees positive clockwise from
     north (the +y direction) toward east (the +x direction). The
     negative of the directional derivative,
     :math:`-(\frac{dz}{dx}\sin(a) + \frac{dz}{dy}\cos(a))`
     , is found where :math:`a` is the *azimuth*; negation yields positive values
     when the slope of :math:`z(x,y)` is downhill in the :math:`a` direction, the
     correct sense for shading the illumination of an image (see
-    :doc:`grdimage` and :doc:`grdview`) by a light source above the x,y plane
+    :doc:`grdimage` and :doc:`grdview`) by a light source above the *x-y* plane
     shining from the :math:`a` direction. Optionally, supply two azimuths,
     **-A**\ *azim*/*azim2*, in which case the gradients in each of these
     directions are calculated and the one larger in magnitude is

--- a/doc/rst/source/grdhisteq.rst
+++ b/doc/rst/source/grdhisteq.rst
@@ -42,7 +42,7 @@ of gray occurring equally. Alternatively, see :doc:`grd2cpt`.
 The second common use of **grdhisteq** is in writing a grid with
 statistics based on some kind of cumulative distribution function. In
 this application, the output has relative highs and lows in the same
-(x,y) locations as the input file, but the values are changed to reflect
+(*x, y*) locations as the input file, but the values are changed to reflect
 their place in some cumulative distribution. One example would be to
 find the lowest 10% of the data: Take a grid, run **grdhisteq** and make
 a grid using *n_cells* = 10, and then contour the result to trace the 1
@@ -54,7 +54,7 @@ output from :doc:`grdgradient` and make a grid file output with the
 Gaussian option, you will have a grid whose values are distributed
 according to a Gaussian distribution with zero mean and unit variance.
 The locations of these values will correspond to the locations of the
-input; that is, the most negative output value will be in the (x,y)
+input; that is, the most negative output value will be in the (*x, y*)
 location of the most negative input value, and so on.
 
 Required Arguments

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -206,9 +206,9 @@ Operator        Args   Returns                                                  
 **BITTEST**     2 1    1 if bit B of A is set, else 0 (bitwise TEST operator)                                          Logic
 **BITXOR**      2 1    A ^ B (bitwise XOR operator)                                                                    Logic
 **BLEND**       3 1    Blend A and B using weights in C (0-1 range) as A*C + B*(1-C)                                   Special Operators
-**CAZ**         2 1    Cartesian azimuth from grid nodes to stack x,y (i.e., A, B)                                     Special Operators
-**CBAZ**        2 1    Cartesian back-azimuth from grid nodes to stack x,y (i.e., A, B)                                Special Operators
-**CDIST**       2 1    Cartesian distance between grid nodes and stack x,y (i.e., A, B)                                Special Operators
+**CAZ**         2 1    Cartesian azimuth from grid nodes to stack *x, y* (i.e., A, B)                                  Special Operators
+**CBAZ**        2 1    Cartesian back-azimuth from grid nodes to stack *x, y* (i.e., A, B)                             Special Operators
+**CDIST**       2 1    Cartesian distance between grid nodes and stack *x, y* (i.e., A, B)                             Special Operators
 **CDIST2**      2 1    As CDIST but only to nodes that are != 0                                                        Special Operators
 **CEIL**        1 1    ceil (A) (smallest integer >= A)                                                                Logic
 **CHICRIT**     2 1    Chi-squared distribution critical value for alpha = A and nu = B                                Probability
@@ -282,9 +282,9 @@ Operator        Args   Returns                                                  
 **KM2DEG**      1 1    Converts kilometers to spherical degrees                                                        Special Operators
 **KN**          2 1    Modified Bessel function of A (2nd kind, order B)                                               Special Functions
 **KURT**        1 1    Kurtosis of A                                                                                   Probability
-**LAB2HSV**     3 3    Convert l,a,b triplets to h,s,v triplets                                                        Special Operators
-**LAB2RGB**     3 3    Convert l,a,b triplets to r,g,b triplets                                                        Special Operators
-**LAB2XYZ**     3 3    Convert l,a,b triplets to x,y,z triplets                                                        Special Operators
+**LAB2HSV**     3 3    Convert *l,a,b* triplets to *h,s,v* triplets                                                    Special Operators
+**LAB2RGB**     3 3    Convert *l,a,b* triplets to *r,g,b* triplets                                                    Special Operators
+**LAB2XYZ**     3 3    Convert *l,a,b* triplets to *x,y,z* triplets                                                    Special Operators
 **LCDF**        1 1    Laplace cumulative distribution function for z = A                                              Probability
 **LCRIT**       1 1    Laplace distribution critical value for alpha = A                                               Probability
 **LDIST**       1 1    Compute minimum distance (in km if -fg) from lines in multi-segment ASCII file A                Special Operators
@@ -339,9 +339,9 @@ Operator        Args   Returns                                                  
 **RAND**        2 1    Laplace random noise with mean A and std. deviation B                                           Probability
 **RCDF**        1 1    Rayleigh cumulative distribution function for z = A                                             Probability
 **RCRIT**       1 1    Rayleigh distribution critical value for alpha = A                                              Probability
-**RGB2HSV**     3 3    Convert r,g,b triplets to h,s,v triplets, with r = A, g = B, and b = C (in 0-255 range)         Special Operators
-**RGB2LAB**     3 3    Convert r,g,b triplets to l,a,b triplets, with r = A, g = B, and b = C (in 0-255 range)         Special Operators
-**RGB2XYZ**     3 3    Convert r,g,b triplets to x,y,x triplets, with r = A, g = B, and b = C (in 0-255 range)         Special Operators
+**RGB2HSV**     3 3    Convert *r,g,b* triplets to *h,s,v* triplets, with r = A, g = B, and b = C (in 0-255 range)     Special Operators
+**RGB2LAB**     3 3    Convert *r,g,b* triplets to *l,a,b* triplets, with r = A, g = B, and b = C (in 0-255 range)     Special Operators
+**RGB2XYZ**     3 3    Convert *r,g,b* triplets to *x,y,z* triplets, with r = A, g = B, and b = C (in 0-255 range)      Special Operators
 **RINT**        1 1    rint (A) (round to integral value nearest to A)                                                 Arithmetic
 **RMS**         1 1    Root-mean-square of A                                                                           Arithmetic
 **RMSW**        1 1    Weighted root-mean-square of A for weights in B                                                 Arithmetic
@@ -389,9 +389,9 @@ Operator        Args   Returns                                                  
 **WPDF**        3 1    Weibull density distribution P(x,scale,shape), with x = A, scale = B, and shape = C             Probability
 **WRAP**        1 1    wrap A in radians onto [-pi,pi]                                                                 Special Operators
 **XOR**         2 1    A ^ B (bitwise XOR operator)                                                                    Logic
-**XYZ2HSV**     3 3    Convert x,y,z triplets to h,s,v triplets                                                        Special Operators
-**XYZ2LAB**     3 3    Convert x,y,z triplets to l,a,b triplets                                                        Special Operators
-**XYZ2RGB**     3 3    Convert x,y,z triplets to r,g,b triplets                                                        Special Operators
+**XYZ2HSV**     3 3    Convert *x,y,z* triplets to *h,s,v* triplets                                                    Special Operators
+**XYZ2LAB**     3 3    Convert *x,y,z* triplets to *l,a,b* triplets                                                    Special Operators
+**XYZ2RGB**     3 3    Convert *x,y,z* triplets to *r,g,b* triplets                                                    Special Operators
 **Y0**          1 1    Bessel function of A (2nd kind, order 0)                                                        Special Functions
 **Y1**          1 1    Bessel function of A (2nd kind, order 1)                                                        Special Functions
 **YLM**         2 2    Real and Imaginary orthonormalized spherical harmonics degree A order B                         Special Functions

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -352,8 +352,8 @@ Operator        Args   Returns                                                  
 **SADDLE**      1 1    Saddle point (±), with (local) minimum (-1) or maximum (+1) in x-direction, 0 elsewhere         Calculus
 **SDIST**       2 1    Spherical (Great circle|geodesic) distance (in km) between nodes and stack (A, B) |ex_SDIST|    Special Operators
 **SDIST2**      2 1    As SDIST but only to nodes that are != 0                                                        Special Operators
-**SAZ**         2 1    Spherical azimuth from grid nodes to stack lon, lat (i.e., A, B)                                Special Operators
-**SBAZ**        2 1    Spherical back-azimuth from grid nodes to stack lon, lat (i.e., A, B)                           Special Operators
+**SAZ**         2 1    Spherical azimuth from grid nodes to stack *lon, lat* (i.e., A, B)                              Special Operators
+**SBAZ**        2 1    Spherical back-azimuth from grid nodes to stack *lon, lat* (i.e., A, B)                         Special Operators
 **SEC**         1 1    Inverse of secant (result in radians)                                                           Calculus
 **SECD**        1 1    Inverse of secant (result in degrees)                                                           Calculus
 **SIGN**        1 1    Sign (+1 or -1) of A                                                                            Logic
@@ -465,8 +465,8 @@ Notes On Operators
    is weighted by the geographic area represented by that node.
 
 #. The operator **SDIST** calculates spherical distances in km between the
-   (lon, lat) point on the stack and all node positions in the grid. The
-   grid domain and the (lon, lat) point are expected to be in degrees.
+   (*lon, lat*) point on the stack and all node positions in the grid. The
+   grid domain and the (*lon, lat*) point are expected to be in degrees.
    Similarly, the **SAZ** and **SBAZ** operators calculate spherical
    azimuth and back-azimuths in degrees, respectively. The operators
    **LDIST** and **PDIST** compute spherical distances in km if **-fg** is

--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -352,8 +352,8 @@ Operator        Args   Returns                                                  
 **SADDLE**      1 1    Saddle point (±), with (local) minimum (-1) or maximum (+1) in x-direction, 0 elsewhere         Calculus
 **SDIST**       2 1    Spherical (Great circle|geodesic) distance (in km) between nodes and stack (A, B) |ex_SDIST|    Special Operators
 **SDIST2**      2 1    As SDIST but only to nodes that are != 0                                                        Special Operators
-**SAZ**         2 1    Spherical azimuth from grid nodes to stack *lon, lat* (i.e., A, B)                              Special Operators
-**SBAZ**        2 1    Spherical back-azimuth from grid nodes to stack *lon, lat* (i.e., A, B)                         Special Operators
+**SAZ**         2 1    Spherical azimuth from grid nodes to stack (*lon, lat*) (i.e., A, B)                            Special Operators
+**SBAZ**        2 1    Spherical back-azimuth from grid nodes to stack (*lon, lat*) (i.e., A, B)                       Special Operators
 **SEC**         1 1    Inverse of secant (result in radians)                                                           Calculus
 **SECD**        1 1    Inverse of secant (result in degrees)                                                           Calculus
 **SIGN**        1 1    Sign (+1 or -1) of A                                                                            Logic

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -49,7 +49,7 @@ Description
 
 **grdtrack** reads one or more grid files (or a Sandwell/Smith IMG
 files) and a table (from file or standard input; but see |-E| for
-exception) with (*x,y*) [or (*lon,lat*)] positions in the first two columns
+exception) with (*x, y*) [or (*lon, lat*)] positions in the first two columns
 (more columns may be present). It interpolates the grid(s) at the
 positions in the table and writes out the table with the interpolated
 values added as (one or more) new columns. Alternatively (|-C|), the
@@ -66,7 +66,7 @@ Required Arguments
 
 *table*
     This is an ASCII (or binary, see **-bi**) file where the first 2 columns
-    hold the (x,y) positions where the user wants to sample the 2-D data set.
+    hold the (*x, y*) positions where the user wants to sample the 2-D data set.
     If no tables are given then we read from standard input. If |-E| is set
     then no input table is read since we will create one from the given
     |-E| parameters.
@@ -74,7 +74,7 @@ Required Arguments
 .. _-G:
 
 **-G**\ *gridfile*
-    *gridfile* is a 2-D binary grid file with the function f(x,y). If the
+    *gridfile* is a 2-D binary grid file with the function *f*\ (*x, y*). If the
     specified grid is in Sandwell/Smith Mercator format you must append
     a comma-separated list of arguments that includes a scale to
     multiply the data (usually 1 or 0.1), the mode which stand for the
@@ -349,7 +349,7 @@ gravity, preceded by one header record)::
 
 To sample the Sandwell/Smith IMG format file topo.8.2.img (2 minute
 predicted bathymetry on a Mercator grid) and the Muller et al age grid
-age.3.2.nc along the *lon,lat* coordinates given in the file
+age.3.2.nc along the *lon, lat* coordinates given in the file
 cruise_track.xy, try::
 
     gmt grdtrack cruise_track.xy -Gtopo.8.2.img,1,1 -Gage.3.2.nc > depths-age.txt

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -349,7 +349,7 @@ gravity, preceded by one header record)::
 
 To sample the Sandwell/Smith IMG format file topo.8.2.img (2 minute
 predicted bathymetry on a Mercator grid) and the Muller et al age grid
-age.3.2.nc along the *lon, lat* coordinates given in the file
+age.3.2.nc along the (*lon, lat*) coordinates given in the file
 cruise_track.xy, try::
 
     gmt grdtrack cruise_track.xy -Gtopo.8.2.img,1,1 -Gage.3.2.nc > depths-age.txt

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -49,7 +49,7 @@ Description
 
 **grdtrack** reads one or more grid files (or a Sandwell/Smith IMG
 files) and a table (from file or standard input; but see |-E| for
-exception) with (x,y) [or (lon,lat)] positions in the first two columns
+exception) with (*x,y*) [or (*lon,lat*)] positions in the first two columns
 (more columns may be present). It interpolates the grid(s) at the
 positions in the table and writes out the table with the interpolated
 values added as (one or more) new columns. Alternatively (|-C|), the
@@ -349,7 +349,7 @@ gravity, preceded by one header record)::
 
 To sample the Sandwell/Smith IMG format file topo.8.2.img (2 minute
 predicted bathymetry on a Mercator grid) and the Muller et al age grid
-age.3.2.nc along the lon,lat coordinates given in the file
+age.3.2.nc along the *lon,lat* coordinates given in the file
 cruise_track.xy, try::
 
     gmt grdtrack cruise_track.xy -Gtopo.8.2.img,1,1 -Gage.3.2.nc > depths-age.txt

--- a/doc/rst/source/histogram.rst
+++ b/doc/rst/source/histogram.rst
@@ -143,8 +143,8 @@ Optional Arguments
 **-I**\ [**o**\|\ **O**]
     Inquire about min/max *x* and *y* after binning. The *xmin xmax ymin
     ymax* is output; no plotting is done. Append directive **o** to output an
-    ASCII table of the resulting *x,y* data instead. Upper case directive **O** will
-    output all *x,y* bin data even when *y* == 0. **Note**: You may use **-o**
+    ASCII table of the resulting *x, y* data instead. Upper case directive **O** will
+    output all *x, y* bin data even when *y* == 0. **Note**: You may use **-o**
     to select a subset from this record.
 
 .. _-Jz:

--- a/doc/rst/source/kml2gmt.rst
+++ b/doc/rst/source/kml2gmt.rst
@@ -99,7 +99,7 @@ Examples
 
 .. include:: explain_example.rst_
 
-To extract the *lon,lat* values from the KML file google.kml, try
+To extract the *lon, lat* values from the KML file google.kml, try
 
 ::
 

--- a/doc/rst/source/kml2gmt.rst
+++ b/doc/rst/source/kml2gmt.rst
@@ -99,7 +99,7 @@ Examples
 
 .. include:: explain_example.rst_
 
-To extract the lon,lat values from the KML file google.kml, try
+To extract the *lon,lat* values from the KML file google.kml, try
 
 ::
 

--- a/doc/rst/source/kml2gmt.rst
+++ b/doc/rst/source/kml2gmt.rst
@@ -99,7 +99,7 @@ Examples
 
 .. include:: explain_example.rst_
 
-To extract the *lon, lat* values from the KML file google.kml, try
+To extract the (*lon, lat*) values from the KML file google.kml, try
 
 ::
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -290,7 +290,7 @@ To use the GEBCO look-alike CPT with its default range for bathymetry, run::
 
 or simply use -Cgebco directly in the application that needs the color table.
 To create a 24-level color table suitable for plotting the depths in
-the remote data table v3206_06.txt (with lon, lat, depths), run
+the remote data table v3206_06.txt (with *lon, lat, depth*), run
 
 ::
 

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -50,16 +50,16 @@ Description
 -----------
 
 **mapproject** reads (longitude, latitude) positions from *tables* [or
-standard input] and computes (x,y) coordinates using the specified map
-projection and scales. Optionally, it can read (x,y) positions and
+standard input] and computes (*x, y*) coordinates using the specified map
+projection and scales. Optionally, it can read (*x, y*) positions and
 compute (longitude, latitude) values doing the inverse transformation.
-This can be used to transform linear (x,y) points obtained by digitizing
+This can be used to transform linear (*x, y*) points obtained by digitizing
 a map of known projection to geographical coordinates. May also
 calculate distances along track, to a fixed point, or closest approach
 to a line.
 Alternatively, can be used to perform various datum conversions.
 Additional data fields are permitted after the first 2 columns which
-must have (longitude,latitude) or (x,y). See option **-:** on how to
+must have (longitude,latitude) or (*x, y*). See option **-:** on how to
 read (latitude,longitude) files.
 Finally, **mapproject** can compute a variety of auxiliary output
 data from input coordinates that make up a track.  Items like
@@ -157,7 +157,7 @@ Optional Arguments
 .. _-I:
 
 **-I**
-    Do the Inverse transformation, i.e., get (longitude,latitude) from (x,y) data.
+    Do the Inverse transformation, i.e., get (longitude,latitude) from (*x, y*) data.
 
 .. |Add_-J| replace:: |Add_-J_links|
 .. include:: explain_-J.rst_
@@ -331,7 +331,7 @@ Examples
 
 .. include:: explain_example.rst_
 
-To transform a remote file with (latitude,longitude) into (x,y) positions in cm
+To transform a remote file with (latitude,longitude) into (*x, y*) positions in cm
 on a Mercator grid for a given scale of 0.5 cm per degree and selected region, run::
 
   gmt mapproject @waypoints.txt -R-180/180/-72/72 -Jm0.5c -: > xyfile
@@ -343,7 +343,7 @@ a file utm.txt and knowing the UTM zone (and zone or hemisphere), try::
 
 
 To transform several 2-column, binary, double precision files with
-(latitude,longitude) into (x,y) positions in inch on a Transverse
+(latitude,longitude) into (*x, y*) positions in inch on a Transverse
 Mercator grid (central longitude 75W) for scale = 1:500000 and suppress
 those points that would fall outside the map area, run::
 
@@ -406,10 +406,10 @@ The rectangular input region set with |-R| will in general be mapped
 into a non-rectangular grid. Unless |-C| is set, the leftmost point on
 this grid has xvalue = 0.0, and the lowermost point will have yvalue =
 0.0. Thus, before you digitize a map, run the extreme map coordinates
-through **mapproject** using the appropriate scale and see what (x,y)
+through **mapproject** using the appropriate scale and see what (*x, y*)
 values they are mapped onto. Use these values when setting up for
 digitizing in order to have the inverse transformation work correctly,
-or alternatively, use **gmt math** to scale and shift the (x,y) values
+or alternatively, use **gmt math** to scale and shift the (*x, y*) values
 before transforming.
 
 .. include:: explain_ellipsoidal.rst_

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -119,7 +119,7 @@ Optional Arguments
 .. _-E:
 
 **-E**\ [*datum*]
-    Convert from geodetic (lon, lat, height) to Earth Centered Earth Fixed (ECEF) (x,y,z) coordinates
+    Convert from geodetic (*lon, lat, height*) to Earth Centered Earth Fixed (ECEF) (*x, y, z*) coordinates
     (add |-I| for the inverse conversion). Append datum ID (see |-Q|\ **d**) or give
     *ellipsoid*:*dx*,\ *dy*,\ *dz* where *ellipsoid* may be an ellipsoid
     ID (see |-Q|\ **e**) or given as *a*\ [,\ *inv_f*], where *a* is the
@@ -349,7 +349,7 @@ those points that would fall outside the map area, run::
 
   gmt mapproject tracks.* -R-80/-70/20/40 -Jt-75/1:500000 -: -S -Di -bo -bi2 > tmfile.b
 
-To convert the geodetic coordinates (lon, lat, height) in the file
+To convert the geodetic coordinates (*lon, lat, height*) in the file
 old.txt from the NAD27 CONUS datum (Datum ID 131 which uses the
 Clarke-1866 ellipsoid) to WGS 84, run::
 

--- a/doc/rst/source/mapproject.rst
+++ b/doc/rst/source/mapproject.rst
@@ -49,10 +49,10 @@ Synopsis
 Description
 -----------
 
-**mapproject** reads (longitude, latitude) positions from *tables* [or
+**mapproject** reads (*lon*, *lat*) positions from *tables* [or
 standard input] and computes (*x, y*) coordinates using the specified map
 projection and scales. Optionally, it can read (*x, y*) positions and
-compute (longitude, latitude) values doing the inverse transformation.
+compute (*lon, lat*) values doing the inverse transformation.
 This can be used to transform linear (*x, y*) points obtained by digitizing
 a map of known projection to geographical coordinates. May also
 calculate distances along track, to a fixed point, or closest approach

--- a/doc/rst/source/mask.rst
+++ b/doc/rst/source/mask.rst
@@ -102,7 +102,7 @@ Optional Arguments
 .. _-D:
 
 **-D**\ *dumpfile*
-    Dump the (x,y) coordinates of each clipping polygon to one or more
+    Dump the (*x, y*) coordinates of each clipping polygon to one or more
     output files (or standard output if *template* is not given). No plotting
     will take place. If *template* contains the C-format specifier %d
     (including modifications like %05d) then polygons will be written to

--- a/doc/rst/source/nearneighbor.rst
+++ b/doc/rst/source/nearneighbor.rst
@@ -39,7 +39,7 @@ Synopsis
 Description
 -----------
 
-**nearneighbor** reads arbitrarily located (*x,y,z*\ [,\ *w*]) triplets
+**nearneighbor** reads arbitrarily located (*x, y, z*\ [, *w*]) triplets
 [quadruplets] from standard input [or *table*] and uses a nearest
 neighbor algorithm to assign a weighted average value to each node that
 has one or more data points within a search radius (*R*, see |-S|) centered on the
@@ -71,7 +71,7 @@ Required Arguments
 
 *table*
     3 [or 4, see |-W|] column ASCII file(s) [or binary, see
-    **-bi**] holding (*x,y,z*\ [,\ *w*]) data values. If
+    **-bi**] holding (*x, y, z*\ [, *w*]) data values. If
     no file is specified, **nearneighbor** will read from standard input.
 
 .. _-G:

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -421,7 +421,7 @@ a circle at the start location and an arrow head at the end::
     EOF
 
 To plot vectors (red vector heads, solid stem) from the file data.txt that contains
-record of the form lon, lat, dx, dy, where dx, dy are the Cartesian
+record of the form *lon, lat, dx, dy*, where *dx, dy* are the Cartesian
 vector components given in user units, and these user units should be converted
 to cm given the scale 3.60::
 

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -133,7 +133,7 @@ Optional Arguments
 **-E**\ [**x**\|\ **y**\|\ **X**\|\ **Y**][**+a**\|\ **A**][**+cl**\|\ **f**][**+n**][**+w**\ *width*\ [/*cap*]][**+p**\ *pen*]
     Draw error bars. Append **x** and/or **y** to indicate which bars you
     want to draw [Default is both x and y]. The x and/or y errors must be
-    stored in the columns after the (x,y) pair [or (x,y,z) triplet]. If
+    stored in the columns after the (*x, y*) pair [or (*x, y, z*) triplet]. If
     **+a** is appended then we will draw asymmetrical error bars [Default
     is symmetrical error bars]; these requires
     two rather than one extra data column, with the two signed deviations.

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -53,7 +53,7 @@ Synopsis
 Description
 -----------
 
-Reads (x,y,z) triplets from *files* [or standard input] and
+Reads (*x, y, z*) triplets from *files* [or standard input] and
 will plot lines, polygons, or symbols
 at those locations in 3-D. If a symbol is selected and no symbol size
 given, then we will interpret the fourth column of the input data

--- a/doc/rst/source/plot3d_notes.rst_
+++ b/doc/rst/source/plot3d_notes.rst_
@@ -87,7 +87,7 @@ Bugs
 No hidden line removal is employed for polygons and lines. Symbols,
 however, are first sorted according to their distance from the viewpoint
 so that nearby symbols will overprint more distant ones should they
-project to the same x,y position.
+project to the same *x, y* position.
 
 The module cannot handle filling of polygons that contain the south or
 north pole. For such a polygon, make a copy and split it into two and

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -267,7 +267,7 @@ Examples
 
 .. include:: explain_example.rst_
 
-To project the remote data sets ship_03.txt (lon,lat,depth) onto a great circle specified by
+To project the remote data sets ship_03.txt (*lon,lat,depth*) onto a great circle specified by
 the center (330,-18) and rotation pole (53,21) and sort the records on the projected distances along
 that circle and only output the distance and the depths, try::
 

--- a/doc/rst/source/project.rst
+++ b/doc/rst/source/project.rst
@@ -267,7 +267,7 @@ Examples
 
 .. include:: explain_example.rst_
 
-To project the remote data sets ship_03.txt (*lon,lat,depth*) onto a great circle specified by
+To project the remote data sets ship_03.txt (*lon, lat, depth*) onto a great circle specified by
 the center (330,-18) and rotation pole (53,21) and sort the records on the projected distances along
 that circle and only output the distance and the depths, try::
 

--- a/doc/rst/source/pswiggle.rst
+++ b/doc/rst/source/pswiggle.rst
@@ -82,7 +82,7 @@ and obtain
 Bugs
 ----
 
-Sometimes the (*x,y*) coordinates are not printed with enough significant
+Sometimes the (*x, y*) coordinates are not printed with enough significant
 digits, so the local perpendicular to the track swings around a lot. To
 see if this is the problem, you should do this:
 

--- a/doc/rst/source/psxy.rst
+++ b/doc/rst/source/psxy.rst
@@ -114,7 +114,7 @@ a circle at the start location and an arrow head at the end, try
     EOF
 
 To plot vectors (red vector heads, solid stem) from the file data.txt that contains
-record of the form lon, lat, dx, dy, where dx, dy are the Cartesian
+record of the form *lon, lat, dx, dy*, where *dx, dy* are the Cartesian
 vector components given in user units, and these user units should be converted
 to cm given the scale 3.60, try
 

--- a/doc/rst/source/reference/contour-annotations.rst
+++ b/doc/rst/source/reference/contour-annotations.rst
@@ -3,10 +3,10 @@ Annotation of Contours and "Quoted Lines"
 
 The GMT programs :doc:`/grdcontour` (for
 data given as 2-dimensional grids) and
-:doc:`/contour` (for *x,y,z* tables) allow
+:doc:`/contour` (for *x, y, z* tables) allow
 for contouring of data sets, while :doc:`/plot`
-and :doc:`/plot3d` can plot lines based on *x,y*-
-and *x,y,z*-tables, respectively. In both cases it may be necessary to
+and :doc:`/plot3d` can plot lines based on *x, y*
+and *x, y, z* tables, respectively. In both cases it may be necessary to
 attach labels to these lines. Clever or optimal placements of labels is
 a very difficult topic, and GMT provides several algorithms for this
 placement as well as complete freedom in specifying the attributes of

--- a/doc/rst/source/reference/file-formats.rst
+++ b/doc/rst/source/reference/file-formats.rst
@@ -46,7 +46,7 @@ given by the parameter :term:`IO_COL_SEPARATOR`, which by default is a TAB.
 Optional segment header records
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When dealing with time- or (*x,y*)-series it is usually convenient to
+When dealing with time- or (*x, y*)-series it is usually convenient to
 have each profile in separate files. However, this may sometimes prove
 impractical due to large numbers of profiles. An example is files of
 digitized lineations where the number of individual features may range

--- a/doc/rst/source/reference/introduction.rst
+++ b/doc/rst/source/reference/introduction.rst
@@ -90,16 +90,16 @@ synopsis of the valid arguments. All the documentation is available for
 web browsing and may be installed at the user's site.
 
 The processing and display routines within GMT are completely general
-and will handle any (*x,y*) or (*x,y,z*) data as input. For many
-purposes the (*x,y*) coordinates will be (longitude, latitude) but in
+and will handle any (*x, y*) or (*x, y, z*) data as input. For many
+purposes the (*x, y*) coordinates will be (longitude, latitude) but in
 most cases they could equally well be any other variables (e.g.,
 wavelength, power spectral density). Since the GMT plot tools will
-map these (*x,y*) coordinates to positions on a plot or map using a
+map these (*x, y*) coordinates to positions on a plot or map using a
 variety of transformations (linear, log-log, and several map
 projections), they can be used with any data that are given by two or
 three coordinates. In order to simplify and standardize input and
-output, by default GMT uses two file formats only. Arbitrary sequences of (*x,y*)
-or (*x,y,z*) data are read from multi-column ASCII tables, i.e., each
+output, by default GMT uses two file formats only. Arbitrary sequences of (*x, y*)
+or (*x, y, z*) data are read from multi-column ASCII tables, i.e., each
 file consists of several records, in which each coordinate is confined
 to a separate column [5]_. This format is straightforward and allows the
 user to perform almost any simple (or complicated) reformatting or
@@ -112,7 +112,7 @@ from UCAR, the University Corporation of Atmospheric Research [*Treinish
 and Gough*, 1987]). This XDR (External Data Representation) based format
 is architecture independent, which allows the user to transfer the
 binary data files from one computer system to another [6]_.
-GMT contains programs that will read ASCII (*x,y,z*) files and produce
+GMT contains programs that will read ASCII (*x, y, z*) files and produce
 grid files. One such program, :doc:`/surface`,
 includes new modifications to the gridding algorithm developed by *Smith
 and Wessel* [1990] using continuous splines in tension. Optionally, GMT
@@ -123,12 +123,12 @@ Most of the programs will produce some form of output, which falls into
 four categories. Several of the programs may produce more than one of
 these types of output:
 
-*  1-D ASCII Tables — For example, a (*x,y*) series may be
+*  1-D ASCII Tables — For example, a (*x, y*) series may be
    filtered and the filtered values output. ASCII output is written to
    the standard output stream.
 
 *  2-D binary (netCDF or user-defined) grid files – Programs that grid
-   ASCII (*x,y,z*) data or operate on existing grid files produce
+   ASCII (*x, y, z*) data or operate on existing grid files produce
    this type of output.
 
 *  PostScript – The plotting programs all use the PostScript page

--- a/doc/rst/source/reference/options.rst
+++ b/doc/rst/source/reference/options.rst
@@ -68,7 +68,7 @@ importance (some are used a lot more than others).
 +--------------------------------+--------------------------------------------------------------------+
 | :ref:`-x <option_-x_core>`     | Set number of cores to be used in multi-threaded applications      |
 +--------------------------------+--------------------------------------------------------------------+
-| :ref:`-: <option_colon>`       | Assume input geographic data are (*lat,lon*) and not (*lon,lat*)   |
+| :ref:`-: <option_colon>`       | Assume input geographic data are (*lat, lon*) and not (*lon, lat*) |
 +--------------------------------+--------------------------------------------------------------------+
 
 .. _option_-R:
@@ -722,7 +722,7 @@ Input columns selection: The **-i** option
 
 **Examples**
 
-For example, to use the 4th, 7th, and 3rd data column as the required *x,y,z*
+For example, to use the 4th, 7th, and 3rd data column as the required *x, y, z*
 to :doc:`/blockmean` you would specify **-i**\ 3,6,2 (since 0 is the first
 column). The chosen data columns will be used as given.
 

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -120,7 +120,7 @@ Optional Arguments
     Make evenly spaced time-steps from *min* to *max* by *inc* [Default uses input times].
     The form **-T**\ *list* means a online list of *time* coordinates like for example: **-T**\ *13,15,16,22.5*.
     For details on array creation, see `Generate 1-D Array`_. **Note**: For resampling of spatial
-    (*x,y* or *lon,lat*) series you must give an increment with a valid distance unit;
+    (*x, y* or *lon, lat*) series you must give an increment with a valid distance unit;
     see `Units`_ for map units or use **c** if plain Cartesian coordinates. The first two
     columns must contain the spatial coordinates. From these we calculate distances in the
     chosen units and interpolate using this parametric series.

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -224,7 +224,7 @@ interpolation, but output the first derivative instead (the slope), try::
 
     gmt sample1d points.txt -T0/6/0.01 -Fc+d1 > slopes.txt
 
-To resample the file track.txt which contains lon, lat, depth every 2
+To resample the file track.txt which contains *lon, lat, depth* every 2
 nautical miles, use::
 
     gmt sample1d track.txt -T2n -AR > new_track.txt

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -120,7 +120,7 @@ Optional Arguments
     Make evenly spaced time-steps from *min* to *max* by *inc* [Default uses input times].
     The form **-T**\ *list* means a online list of *time* coordinates like for example: **-T**\ *13,15,16,22.5*.
     For details on array creation, see `Generate 1-D Array`_. **Note**: For resampling of spatial
-    (*x, y* or *lon, lat*) series you must give an increment with a valid distance unit;
+    (*x, y*) or (*lon, lat*) series you must give an increment with a valid distance unit;
     see `Units`_ for map units or use **c** if plain Cartesian coordinates. The first two
     columns must contain the spatial coordinates. From these we calculate distances in the
     chosen units and interpolate using this parametric series.

--- a/doc/rst/source/sphdistance.rst
+++ b/doc/rst/source/sphdistance.rst
@@ -40,7 +40,7 @@ Description
 -----------
 
 **sphdistance** reads one or more ASCII [or binary] files (or standard
-input) containing *lon, lat* and performs the construction of Voronoi
+input) containing (*lon, lat*) and performs the construction of Voronoi
 polygons. These polygons are then processed to calculate the nearest
 distance to each node of the lattice and written to the specified grid.
 The Voronoi algorithm used is STRIPACK [*Renka*\ , 1997]. As an option,
@@ -110,7 +110,7 @@ Optional Arguments
 
 **-N**\ *nodetable*
     Read the information pertaining to each Voronoi
-    polygon (the unique node *lon, lat* and polygon area) from a separate
+    polygon (the unique node (*lon, lat*) and polygon area) from a separate
     file [Default acquires this information from the ASCII segment
     headers of the output file]. Required if binary input via |-Q| is used.
 

--- a/doc/rst/source/sphdistance.rst
+++ b/doc/rst/source/sphdistance.rst
@@ -40,7 +40,7 @@ Description
 -----------
 
 **sphdistance** reads one or more ASCII [or binary] files (or standard
-input) containing lon, lat and performs the construction of Voronoi
+input) containing *lon, lat* and performs the construction of Voronoi
 polygons. These polygons are then processed to calculate the nearest
 distance to each node of the lattice and written to the specified grid.
 The Voronoi algorithm used is STRIPACK [*Renka*\ , 1997]. As an option,
@@ -110,7 +110,7 @@ Optional Arguments
 
 **-N**\ *nodetable*
     Read the information pertaining to each Voronoi
-    polygon (the unique node lon, lat and polygon area) from a separate
+    polygon (the unique node *lon, lat* and polygon area) from a separate
     file [Default acquires this information from the ASCII segment
     headers of the output file]. Required if binary input via |-Q| is used.
 

--- a/doc/rst/source/sphtriangulate.rst
+++ b/doc/rst/source/sphtriangulate.rst
@@ -40,7 +40,7 @@ Description
 -----------
 
 **sphtriangulate** reads one or more ASCII [or binary] files (or
-standard input) containing *lon, lat* and performs a spherical Delaunay
+standard input) containing (*lon, lat*) and performs a spherical Delaunay
 triangulation, i.e., it determines how the points should be connected to give
 the most equilateral triangulation possible on the sphere. Optionally,
 you may choose **-Qv** which will do further processing to obtain the
@@ -96,7 +96,7 @@ Optional Arguments
 **-N**\ *file*
     Write the information pertaining to each polygon. For Delaunay: the
     three node number and the triangle area (if |-A| was set); for
-    Voronoi the unique node *lon, lat* and polygon area (if |-A| was
+    Voronoi the unique node (*lon, lat*) and polygon area (if |-A| was
     set)) to a separate file. This information is also encoded in the
     segment headers of ASCII output files. Required if binary output is needed.
 

--- a/doc/rst/source/sphtriangulate.rst
+++ b/doc/rst/source/sphtriangulate.rst
@@ -40,7 +40,7 @@ Description
 -----------
 
 **sphtriangulate** reads one or more ASCII [or binary] files (or
-standard input) containing lon, lat and performs a spherical Delaunay
+standard input) containing *lon, lat* and performs a spherical Delaunay
 triangulation, i.e., it determines how the points should be connected to give
 the most equilateral triangulation possible on the sphere. Optionally,
 you may choose **-Qv** which will do further processing to obtain the
@@ -96,7 +96,7 @@ Optional Arguments
 **-N**\ *file*
     Write the information pertaining to each polygon. For Delaunay: the
     three node number and the triangle area (if |-A| was set); for
-    Voronoi the unique node lon, lat and polygon area (if |-A| was
+    Voronoi the unique node *lon, lat* and polygon area (if |-A| was
     set)) to a separate file. This information is also encoded in the
     segment headers of ASCII output files. Required if binary output is needed.
 

--- a/doc/rst/source/supplements/geodesy/earthtide.rst
+++ b/doc/rst/source/supplements/geodesy/earthtide.rst
@@ -29,7 +29,7 @@ Synopsis
 Description
 -----------
 
-Compute the three components of solid Earth tides as time-series or grids. Optionally compute also Sun and Moon position in *lon, lat*.
+Compute the three components of solid Earth tides as time-series or grids. Optionally compute also Sun and Moon position in (*lon, lat*).
 The output can be either in the form of a grid or as a table printed to standard output. The format of the table data is:
 *time north east vertical* in units of meters.
 

--- a/doc/rst/source/supplements/geodesy/earthtide.rst
+++ b/doc/rst/source/supplements/geodesy/earthtide.rst
@@ -29,7 +29,7 @@ Synopsis
 Description
 -----------
 
-Compute the three components of solid Earth tides as time-series or grids. Optionally compute also Sun and Moon position in lon,lat.
+Compute the three components of solid Earth tides as time-series or grids. Optionally compute also Sun and Moon position in *lon,lat*.
 The output can be either in the form of a grid or as a table printed to standard output. The format of the table data is:
 *time north east vertical* in units of meters.
 

--- a/doc/rst/source/supplements/geodesy/earthtide.rst
+++ b/doc/rst/source/supplements/geodesy/earthtide.rst
@@ -29,7 +29,7 @@ Synopsis
 Description
 -----------
 
-Compute the three components of solid Earth tides as time-series or grids. Optionally compute also Sun and Moon position in *lon,lat*.
+Compute the three components of solid Earth tides as time-series or grids. Optionally compute also Sun and Moon position in *lon, lat*.
 The output can be either in the form of a grid or as a table printed to standard output. The format of the table data is:
 *time north east vertical* in units of meters.
 

--- a/doc/rst/source/supplements/img/img2grd.rst
+++ b/doc/rst/source/supplements/img/img2grd.rst
@@ -224,10 +224,10 @@ ship.lonlatgrav and use it to sample the merc_grav.nc, we can do this:
 It is recommended to use the above method of projecting and unprojecting
 the data in such an application, because then there is only one
 interpolation step (in :doc:`grdtrack </grdtrack>`). If one first tries to convert the
-grid file to *lon, lat* and then sample it, there are two interpolation
+grid file to (*lon, lat*) and then sample it, there are two interpolation
 steps (in conversion and in sampling).
 
-To make a *lon, lat* grid from the above grid we can use
+To make a (*lon, lat*) grid from the above grid we can use
 
 ::
 
@@ -249,7 +249,7 @@ file is projected with **-Jm**\ 1i it is 80 inches wide. We can make a
 map 8 inches wide by using **-Jx**\ 0.1i on any map programs applied to
 this grid (e.g., :doc:`grdcontour </grdcontour>`,
 :doc:`grdimage </grdimage>`, :doc:`grdview </grdview>`), and then
-for overlays which work in *lon, lat* (e.g., :doc:`plot </plot>`, :doc:`coast </coast>`) we can
+for overlays which work in (*lon, lat*) (e.g., :doc:`plot </plot>`, :doc:`coast </coast>`) we can
 use the above adjusted |-R| and **-Jm**\ 0.1 to get the two systems to
 match up.
 

--- a/doc/rst/source/supplements/img/img2grd.rst
+++ b/doc/rst/source/supplements/img/img2grd.rst
@@ -224,10 +224,10 @@ ship.lonlatgrav and use it to sample the merc_grav.nc, we can do this:
 It is recommended to use the above method of projecting and unprojecting
 the data in such an application, because then there is only one
 interpolation step (in :doc:`grdtrack </grdtrack>`). If one first tries to convert the
-grid file to lon,lat and then sample it, there are two interpolation
+grid file to *lon,lat* and then sample it, there are two interpolation
 steps (in conversion and in sampling).
 
-To make a lon,lat grid from the above grid we can use
+To make a *lon,lat* grid from the above grid we can use
 
 ::
 
@@ -249,7 +249,7 @@ file is projected with **-Jm**\ 1i it is 80 inches wide. We can make a
 map 8 inches wide by using **-Jx**\ 0.1i on any map programs applied to
 this grid (e.g., :doc:`grdcontour </grdcontour>`,
 :doc:`grdimage </grdimage>`, :doc:`grdview </grdview>`), and then
-for overlays which work in lon,lat (e.g., :doc:`plot </plot>`, :doc:`coast </coast>`) we can
+for overlays which work in *lon,lat* (e.g., :doc:`plot </plot>`, :doc:`coast </coast>`) we can
 use the above adjusted |-R| and **-Jm**\ 0.1 to get the two systems to
 match up.
 

--- a/doc/rst/source/supplements/img/img2grd.rst
+++ b/doc/rst/source/supplements/img/img2grd.rst
@@ -208,7 +208,7 @@ Note that the |-V| option tells us that the range was adjusted to
 can extract this original region string using :doc:`grdinfo </grdinfo>` **-Ii**.
 Furthermore, we can also use :doc:`grdinfo </grdinfo>`
 to find that the grid file header shows its region to be
-**-R**\ -40/40/-99.4333333333/-31.4666666667. This is the range of x,y we will get from a
+**-R**\ -40/40/-99.4333333333/-31.4666666667. This is the range of *x, y* we will get from a
 Spherical Mercator projection using
 **-R**-40/40/-70.0004681551/-29.9945810754 and **-Jm**\ 1. Thus, to take
 ship.lonlatgrav and use it to sample the merc_grav.nc, we can do this:
@@ -224,10 +224,10 @@ ship.lonlatgrav and use it to sample the merc_grav.nc, we can do this:
 It is recommended to use the above method of projecting and unprojecting
 the data in such an application, because then there is only one
 interpolation step (in :doc:`grdtrack </grdtrack>`). If one first tries to convert the
-grid file to *lon,lat* and then sample it, there are two interpolation
+grid file to *lon, lat* and then sample it, there are two interpolation
 steps (in conversion and in sampling).
 
-To make a *lon,lat* grid from the above grid we can use
+To make a *lon, lat* grid from the above grid we can use
 
 ::
 
@@ -249,7 +249,7 @@ file is projected with **-Jm**\ 1i it is 80 inches wide. We can make a
 map 8 inches wide by using **-Jx**\ 0.1i on any map programs applied to
 this grid (e.g., :doc:`grdcontour </grdcontour>`,
 :doc:`grdimage </grdimage>`, :doc:`grdview </grdview>`), and then
-for overlays which work in *lon,lat* (e.g., :doc:`plot </plot>`, :doc:`coast </coast>`) we can
+for overlays which work in *lon, lat* (e.g., :doc:`plot </plot>`, :doc:`coast </coast>`) we can
 use the above adjusted |-R| and **-Jm**\ 0.1 to get the two systems to
 match up.
 

--- a/doc/rst/source/supplements/mgd77/mgd77list.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77list.rst
@@ -527,7 +527,7 @@ records whose bitflag for faa indicates BAD values, we try
 
   gmt mgd77list $(cat cruises.lis) -E -Ia -F"dist,faa,grav12_2:+faa" > bad_grav.txt
 
-To output lon, lat, mag, and faa from all the cruises listed in the file
+To output *lon, lat, mag*, and *faa* from all the cruises listed in the file
 cruises.lis, but recalculate the two residuals based on the latest
 reference fields, try:
 

--- a/doc/rst/source/supplements/mgd77/mgd77manage.rst
+++ b/doc/rst/source/supplements/mgd77/mgd77manage.rst
@@ -118,7 +118,7 @@ Optional Arguments
     E77 file has not been verified. Use **-AE** to ignore the
     verification status.
 
-    **g** Sample a GMT geographic (lon, lat) grid along the track given
+    **g** Sample a GMT geographic (*lon, lat*) grid along the track given
     by the MGD77+ file using bicubic interpolation (however, see
     **-n**). Append name of a GMT grid file.
 

--- a/doc/rst/source/supplements/potential/gmtgravmag3d.rst
+++ b/doc/rst/source/supplements/potential/gmtgravmag3d.rst
@@ -104,7 +104,7 @@ Required Arguments (not all)
     assumed constant (controlled by |-C| or |-H|). Following cases are: 4 columns -> 4rth col magnetization intensity;
     5 columns: mag, mag dip; 6 columns: mag, mag dec, mag dip; 8 columns: field dec, field dip, mag, mag dec, mag dip.
     When n columns > 3 the third argument of the |-H| option is ignored. A *raw* format (selected by the **-Tr** option)
-    is a file with N rows (one per triangle) and 9 columns corresponding to the x,y,x coordinates of each of the three
+    is a file with N rows (one per triangle) and 9 columns corresponding to the *x, y, z* coordinates of each of the three
     vertex of each triangle. Alternatively, the **-Ts** option indicates that the surface file is in the ASCII STL
     (Stereo Lithographic) format. These two type of files are used to provide a closed surface.
 

--- a/doc/rst/source/supplements/potential/grdflexure.rst
+++ b/doc/rst/source/supplements/potential/grdflexure.rst
@@ -257,7 +257,7 @@ Grid Distance Units
 
 If a Cartesian grid does not have meter as the horizontal unit, append **+u**\ *unit*
 to the input file name to convert from the specified unit to meter.  E.g., appending
-**+uk** to the load file name will scale the grid x,y coordinates from km to meter.  If your
+**+uk** to the load file name will scale the grid *x, y* coordinates from km to meter.  If your
 grid is geographic, convert distances to meters by supplying |SYN_OPT-f| instead.
 netCDF COARDS geographic grids will automatically be recognized as geographic.
 

--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -140,7 +140,7 @@ Optional Arguments
 
 **-E**
     Set :ref:`elliptical <SMT_map>` data file format. We expect input records to contain
-    *lon, lat, azimuth, semi-major, semi-minor, height* (with  the latter in meter)
+    (*lon, lat, azimuth, semi-major, semi-minor, height*) (with  the latter in meter)
     for each seamount [Default is Circular data format, expecting *lon, lat, radius, height*].
     To mix circular and elliptical seamounts you must use |-E| and provide the circular
     parameters as elliptical ones via *azimuth = 0* and *semi-major = semi-minor = radius*.
@@ -152,7 +152,7 @@ Optional Arguments
    :align: center
 
    Use |-E| to select elliptical rather than circular shapes in map view.  Both shapes require
-   *lon, lat*. Circular shapes only require the radius :math:`r_0`, while elliptical ones require the
+   (*lon, lat*). Circular shapes only require the radius :math:`r_0`, while elliptical ones require the
    azimuth :math:`\alpha` of the major axis as well as the major and minor semi-axes .
 
 .. _-F:

--- a/doc/rst/source/supplements/potential/grdseamount.rst
+++ b/doc/rst/source/supplements/potential/grdseamount.rst
@@ -152,7 +152,7 @@ Optional Arguments
    :align: center
 
    Use |-E| to select elliptical rather than circular shapes in map view.  Both shapes require
-   lon, lat. Circular shapes only require the radius :math:`r_0`, while elliptical ones require the
+   *lon, lat*. Circular shapes only require the radius :math:`r_0`, while elliptical ones require the
    azimuth :math:`\alpha` of the major axis as well as the major and minor semi-axes .
 
 .. _-F:

--- a/doc/rst/source/supplements/spotter/backtracker.rst
+++ b/doc/rst/source/supplements/spotter/backtracker.rst
@@ -42,8 +42,8 @@ Synopsis
 Description
 -----------
 
-**backtracker** reads (longitude, latitude, age) positions from
-*infiles* [or standard input] and computes rotated (x,y,t) coordinates
+**backtracker** reads (*longitude, latitude, age*) positions from
+*infiles* [or standard input] and computes rotated (*x, y, t*) coordinates
 using the specified rotation parameters. It can either calculate final
 positions [Default] or create a sampled track (flowline or hotspot track)
 between the initial and final positions [*Wessel*, 1999]. The former mode allows
@@ -84,7 +84,7 @@ Optional Arguments
 .. _-F:
 
 **-F**\ *driftfile*
-    Supply a file with (lon, lat, age) records that describe the history
+    Supply a file with (*lon, lat, age*) records that describe the history
     of hotspot motion for the current hotspot. The reconstructions will
     use the 3rd data input column (i.e., the age) to obtain the
     location of the hotspot at that time, via an interpolation of the
@@ -120,7 +120,7 @@ Optional Arguments
 .. _-Q:
 
 **-Q**\ *fixed_age*
-    Assign a fixed age to all positions. Only lon, lat input is expected
+    Assign a fixed age to all positions. Only *lon, lat* input is expected
     [Default expects longitude, latitude, age]. Useful when the input
     are points defining isochrons.
 
@@ -145,12 +145,12 @@ Optional Arguments
 .. _-W:
 
 **-W**\ [**a**\|\ **t**]
-    Rotates the given input (lon,lat,t) and calculates the confidence
+    Rotates the given input (*lon,lat,time*) and calculates the confidence
     ellipse for the projected point. The input point *must* have a time
     coordinate that exactly matches a particular total reconstruction
     rotation time, otherwise the point will be skipped. Append **t** or
     **a** to output time or angle, respectively, after the projected
-    lon, lat. After these 2-3 items, we write azimuth, major, minor (in
+    *lon, lat*. After these 2-3 items, we write azimuth, major, minor (in
     km) for the 95% confidence ellipse. See |-D| for the direction of
     rotation.
 

--- a/doc/rst/source/supplements/spotter/backtracker.rst
+++ b/doc/rst/source/supplements/spotter/backtracker.rst
@@ -120,7 +120,7 @@ Optional Arguments
 .. _-Q:
 
 **-Q**\ *fixed_age*
-    Assign a fixed age to all positions. Only *lon, lat* input is expected
+    Assign a fixed age to all positions. Only (*lon, lat*) input is expected
     [Default expects longitude, latitude, age]. Useful when the input
     are points defining isochrons.
 
@@ -150,7 +150,7 @@ Optional Arguments
     coordinate that exactly matches a particular total reconstruction
     rotation time, otherwise the point will be skipped. Append **t** or
     **a** to output time or angle, respectively, after the projected
-    *lon, lat*. After these 2-3 items, we write azimuth, major, minor (in
+    (*lon, lat*). After these 2-3 items, we write azimuth, major, minor (in
     km) for the 95% confidence ellipse. See |-D| for the direction of
     rotation.
 

--- a/doc/rst/source/supplements/spotter/backtracker.rst
+++ b/doc/rst/source/supplements/spotter/backtracker.rst
@@ -145,7 +145,7 @@ Optional Arguments
 .. _-W:
 
 **-W**\ [**a**\|\ **t**]
-    Rotates the given input (*lon,lat,time*) and calculates the confidence
+    Rotates the given input (*lon, lat, time*) and calculates the confidence
     ellipse for the projected point. The input point *must* have a time
     coordinate that exactly matches a particular total reconstruction
     rotation time, otherwise the point will be skipped. Append **t** or
@@ -184,14 +184,14 @@ Optional Arguments
 Examples
 --------
 
-To backtrack the (x,y,t) points in the file seamounts.txt to their origin
+To backtrack the (*x, y, t*) points in the file seamounts.txt to their origin
 (presumably the hotspot), using the DC85.txt Euler poles, run
 
 ::
 
   gmt backtracker seamounts.txt -Db -EDC85.txt > newpos.txt
 
-To project flowlines forward from the (x,y,t) points stored in several
+To project flowlines forward from the (*x, y, t*) points stored in several
 3-column, binary, double precision files, run
 
 ::

--- a/doc/rst/source/supplements/spotter/gmtpmodeler.rst
+++ b/doc/rst/source/supplements/spotter/gmtpmodeler.rst
@@ -47,7 +47,7 @@ Required Arguments
 ------------------
 
 *table*
-    Name of one or more tables with geographical (lon, lat) coordinates and optionally
+    Name of one or more tables with geographical (*lon, lat*) coordinates and optionally
     a third column with ages in Myr.  If no file is given then we read from standard input.
 
 .. include:: explain_rots.rst_

--- a/doc/rst/source/supplements/spotter/grdpmodeler.rst
+++ b/doc/rst/source/supplements/spotter/grdpmodeler.rst
@@ -79,7 +79,7 @@ Optional Arguments
     given the specified rotations. **Note**: If you specified more than one
     model prediction in |-S| then the filename *must* be a template
     that contains the format %s; this will be replaced with the corresponding
-    tags az, dist, stage, vel, omega, dlon, dlat, lon, lat.
+    tags *az, dist, stage, vel, omega, dlon, dlat, lon, lat*.
     If the |-G| option is not used then we create no grids and instead
     write *lon, lat, age, predictions* records to standard output.
 .. include:: /explain_grd_inout.rst_

--- a/doc/rst/source/supplements/spotter/grdpmodeler.rst
+++ b/doc/rst/source/supplements/spotter/grdpmodeler.rst
@@ -170,7 +170,7 @@ To save the coordinates of the crust's formation to separate grids, try
   gmt grdpmodeler pac_age.nc -EPac_APM.txt -V -Fpac_clip_path.txt \
                   -Gpac_origin_%s.nc -SXY
 
-To repeat the same exercise but save output *lon,lat,age,xorigin,yorigin* to a table, use
+To repeat the same exercise but save output *lon, lat, age, xorigin, yorigin* to a table, use
 
 ::
 

--- a/doc/rst/source/supplements/spotter/grdpmodeler.rst
+++ b/doc/rst/source/supplements/spotter/grdpmodeler.rst
@@ -63,7 +63,7 @@ Optional Arguments
 ------------------
 
 *ingrid*
-    Name of a grid file in geographical (lon, lat) coordinates with ages in Myr.
+    Name of a grid file in geographical (*lon, lat*) coordinates with ages in Myr.
     If no grid is provided then you may define the domain via |-R|, |-I|, and optionally **-r**.
 
 .. _-F:

--- a/doc/rst/source/supplements/spotter/grdrotater.rst
+++ b/doc/rst/source/supplements/spotter/grdrotater.rst
@@ -48,7 +48,7 @@ rotated region is not the entire globe.
 Required Arguments
 ------------------
 
-.. |Add_ingrid| replace:: Name of a grid file in geographical (lon, lat) coordinates.
+.. |Add_ingrid| replace:: Name of a grid file in geographical (*lon, lat*) coordinates.
 .. include:: /explain_grd_inout.rst_
     :start-after: ingrid-syntax-begins
     :end-before: ingrid-syntax-ends

--- a/doc/rst/source/supplements/spotter/hotspotter.rst
+++ b/doc/rst/source/supplements/spotter/hotspotter.rst
@@ -128,7 +128,7 @@ Optional Arguments
 Examples
 --------
 
-To create a CVA image from the Pacific (x,y,z,r,t) data in the file
+To create a CVA image from the Pacific (*x, y, z, r, t*) data in the file
 seamounts.txt, using the DC85.txt Euler poles, run
 
 ::

--- a/doc/rst/source/supplements/spotter/originater.rst
+++ b/doc/rst/source/supplements/spotter/originater.rst
@@ -169,7 +169,7 @@ Examples
 --------
 
 To find the likely (hotspot) origins of the seamounts represented by the
-(x,y,z,r,tc) points in the file seamounts.txt, using the DC85.txt Euler
+(*x, y, z, r, tc*) points in the file seamounts.txt, using the DC85.txt Euler
 poles and the pac_hs.txt list of possible hotspots, and report the 2 most
 likely hotspot candidates for each seamount, run
 

--- a/doc/rst/source/supplements/spotter/originater.rst
+++ b/doc/rst/source/supplements/spotter/originater.rst
@@ -104,7 +104,7 @@ Optional Arguments
 **-L**\ [**l**\|\ **t**\|\ **w**\| **L**\|\ **T**\|\ **W**]
     Output closest approach for nearest hotspot only (ignores |-S|).
     Choose **-Lt** for (*time*, *dist*, *z*) [Default], **-Lw** for
-    (*omega*, *dist*, *z*), and **-Ll** for (lon, lat, time, dist, z).
+    (*omega*, *dist*, *z*), and **-Ll** for (*lon, lat, time, dist, z*).
     Normally, *dist* is in km; use upper case modifiers **TWL** to get
     *dist* in spherical degrees.
 

--- a/doc/rst/source/supplements/spotter/polespotter.rst
+++ b/doc/rst/source/supplements/spotter/polespotter.rst
@@ -190,7 +190,7 @@ Examples
 --------
 
 To create a polespotting image from the abyssal hill and fracture zone fabric
-(*lon,lat*) data in the files hills.txt and fractures.txt, on a 1x1 degree grid
+(*lon, lat*) data in the files hills.txt and fractures.txt, on a 1x1 degree grid
 for the northern hemisphere, sampling the great circles every 10 km, and also
 dump the great circles to standard output, try
 

--- a/doc/rst/source/supplements/spotter/polespotter.rst
+++ b/doc/rst/source/supplements/spotter/polespotter.rst
@@ -190,7 +190,7 @@ Examples
 --------
 
 To create a polespotting image from the abyssal hill and fracture zone fabric
-(lon,lat) data in the files hills.txt and fractures.txt, on a 1x1 degree grid
+(*lon,lat*) data in the files hills.txt and fractures.txt, on a 1x1 degree grid
 for the northern hemisphere, sampling the great circles every 10 km, and also
 dump the great circles to standard output, try
 

--- a/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
@@ -123,7 +123,7 @@ recognized by the tag GMT:
 
   gmt x2sys_datalist c2104.gmt -TGMT > myfile
 
-To make lon,lat, and depth input for :doc:`blockmean </blockmean>` and :doc:`surface </surface>` using
+To make *lon,lat*, and *depth* input for :doc:`blockmean </blockmean>` and :doc:`surface </surface>` using
 all the files listed in the file tracks.lis and defined by the tag TRK,
 but only the data that are inside the specified area, and make output
 binary, run::

--- a/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
@@ -123,7 +123,7 @@ recognized by the tag GMT:
 
   gmt x2sys_datalist c2104.gmt -TGMT > myfile
 
-To make *lon,lat*, and *depth* input for :doc:`blockmean </blockmean>` and :doc:`surface </surface>` using
+To make *lon, lat*, and *depth* input for :doc:`blockmean </blockmean>` and :doc:`surface </surface>` using
 all the files listed in the file tracks.lis and defined by the tag TRK,
 but only the data that are inside the specified area, and make output
 binary, run::

--- a/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_datalist.rst
@@ -123,7 +123,7 @@ recognized by the tag GMT:
 
   gmt x2sys_datalist c2104.gmt -TGMT > myfile
 
-To make *lon, lat*, and *depth* input for :doc:`blockmean </blockmean>` and :doc:`surface </surface>` using
+To make (*lon, lat*), and *depth* input for :doc:`blockmean </blockmean>` and :doc:`surface </surface>` using
 all the files listed in the file tracks.lis and defined by the tag TRK,
 but only the data that are inside the specified area, and make output
 binary, run::

--- a/doc/rst/source/supplements/x2sys/x2sys_init.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_init.rst
@@ -287,8 +287,8 @@ to find it.
     and enhanced netCDF-based MGD77+ files) and the old \*.gmt files
     manipulated by the mgg supplements; for these data sets the **-j**
     and |-N| will default to great circle distance calculation in km
-    and speed in m/s. There are also format definition files for plain x,y[,z]
-    and lon,lat[,z] tracks. To initiate new track databases to be used
+    and speed in m/s. There are also format definition files for plain *x,y*\ [*,z*]
+    and *lon,lat*\ [*,z*] tracks. To initiate new track databases to be used
     with MGD77 data from NCEI, try
 
       ::

--- a/doc/rst/source/supplements/x2sys/x2sys_init.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_init.rst
@@ -287,8 +287,8 @@ to find it.
     and enhanced netCDF-based MGD77+ files) and the old \*.gmt files
     manipulated by the mgg supplements; for these data sets the **-j**
     and |-N| will default to great circle distance calculation in km
-    and speed in m/s. There are also format definition files for plain *x, y*\ [*, z*]
-    and *lon, lat*\ [*, z*] tracks. To initiate new track databases to be used
+    and speed in m/s. There are also format definition files for plain (*x, y*\ [*, z*])
+    and (*lon, lat*\ [*, z*]) tracks. To initiate new track databases to be used
     with MGD77 data from NCEI, try
 
       ::

--- a/doc/rst/source/supplements/x2sys/x2sys_init.rst
+++ b/doc/rst/source/supplements/x2sys/x2sys_init.rst
@@ -287,8 +287,8 @@ to find it.
     and enhanced netCDF-based MGD77+ files) and the old \*.gmt files
     manipulated by the mgg supplements; for these data sets the **-j**
     and |-N| will default to great circle distance calculation in km
-    and speed in m/s. There are also format definition files for plain *x,y*\ [*,z*]
-    and *lon,lat*\ [*,z*] tracks. To initiate new track databases to be used
+    and speed in m/s. There are also format definition files for plain *x, y*\ [*, z*]
+    and *lon, lat*\ [*, z*] tracks. To initiate new track databases to be used
     with MGD77 data from NCEI, try
 
       ::

--- a/doc/rst/source/surface.rst
+++ b/doc/rst/source/surface.rst
@@ -46,8 +46,8 @@ Synopsis
 Description
 -----------
 
-**surface** reads randomly-spaced (x,y,z) triplets from standard input
-[or *table*] and produces a binary file of gridded values z(x,y) by
+**surface** reads randomly-spaced (*x, y, z*) triplets from standard input
+[or *table*] and produces a binary file of gridded values *z*(*x, y*) by
 solving the differential equation (away from data points)
 
 .. math::
@@ -187,7 +187,7 @@ Optional Arguments
 .. _-S:
 
 **-S**\ *search_radius*\ [**m**\|\ **s**]
-    Search radius. Enter *search\_radius* in same units as x,y data;
+    Search radius. Enter *search\_radius* in same units as *x, y* data;
     append **m** to indicate arc minutes or **s** for arc seconds. This
     is used to initialize the grid before the first iteration; it is not
     worth the time unless the grid lattice is prime and cannot have

--- a/doc/rst/source/surface.rst
+++ b/doc/rst/source/surface.rst
@@ -308,7 +308,7 @@ project your data using a stereographic projection and grid the projected Cartes
 Gridding Geographic Data: Setting Increments
 --------------------------------------------
 
-Specifying grid increments in distance units (meters, km, etc.) for geographic (lon, lat)
+Specifying grid increments in distance units (meters, km, etc.) for geographic (*lon, lat*)
 grids triggers a conversion from the given increment to the equivalent increment in degrees.
 This is done differently for longitude and latitude and also depends on chosen ellipsoid,
 but ultimately is a great-circle approximation. For latitude we divide your *y*-increment

--- a/doc/rst/source/text.rst
+++ b/doc/rst/source/text.rst
@@ -191,7 +191,7 @@ Optional Arguments
     **-F**\ **+f**\ 12p,Helvetica-Bold,red\ **+j+a** selects a 12p red
     Helvetica-Bold font and expects to read the justification and angle
     from the file, in that order, after *x* *y* and before *text*.
-    In addition, the **+c**\ *justification* lets us use *x,y* coordinates extracted from the
+    In addition, the **+c**\ *justification* lets us use *x, y* coordinates extracted from the
     |-R| string instead of providing them in the input file. For example **-F+c**\ TL
     gets the *x_min*, *y_max* from the |-R| string and plots the text
     at the Upper Left corner of the map.  Normally, the text to be plotted

--- a/doc/rst/source/trend2d.rst
+++ b/doc/rst/source/trend2d.rst
@@ -155,10 +155,10 @@ The domain of *x* and *y* will be shifted and scaled to [-1, 1] and the
 basis functions are built from Chebyshev polynomials. These have a
 numerical advantage in the form of the matrix which must be inverted and
 allow more accurate solutions. In many applications of **trend2d** the
-user has data located approximately along a line in the x,y plane which
+user has data located approximately along a line in the *x-y* plane which
 makes an angle with the *x*-axis (such as data collected along a road or
 ship track). In this case the accuracy could be improved by a rotation
-of the *x,y* axes. **trend2d** does not search for such a rotation;
+of the *x-y* axes. **trend2d** does not search for such a rotation;
 instead, it may find that the matrix problem has deficient rank.
 However, the solution is computed using the generalized inverse and
 should still work out OK. The user should check the results graphically

--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -194,8 +194,8 @@ Optional Arguments
 .. _-Z:
 
 **-Z**
-    Controls whether we read (*x,y*) or (*x,y,z*) data and if *z* should be
-    output when |-M| or |-S| (without **+z**) are used [Read (*x,y*) only].
+    Controls whether we read (*x, y*) or (*x, y, z*) data and if *z* should be
+    output when |-M| or |-S| (without **+z**) are used [Read (*x, y*) only].
 
 .. |Add_-bi| replace:: [Default is 2 input columns].
 .. include:: explain_-bi.rst_

--- a/doc/rst/source/tutorial/bash/session-2.rst
+++ b/doc/rst/source/tutorial/bash/session-2.rst
@@ -20,7 +20,7 @@ basemap                  Create an empty basemap frame with optional scale
 coast                    Plot coastlines, filled continents, rivers, and political borders
 legend                   Create legend overlay
 **POINTS AND LINES**
-wiggle                   Draw spatial time-series along their (*x,y*)-tracks
+wiggle                   Draw spatial time-series along their (*x, y*)-tracks
 plot                     Plot symbols, polygons, and lines in 2-D
 plot3d                   Plot symbols, polygons, and lines in 3-D
 **HISTOGRAMS**
@@ -28,7 +28,7 @@ histogram                Plot a rectangular histogram
 rose                     Plot a polar histogram(sector/rose diagram)
 **CONTOURS**
 grdcontour               Contouring of grids
-contour                  Direct contouring/imaging of (*x,y,z*) data by optimal triangulation
+contour                  Direct contouring/imaging of (*x, y, z*) data by optimal triangulation
 **SURFACES**
 grdimage                 Project and plot grids or images
 grdvector                Plot vector fields from grids

--- a/doc/rst/source/tutorial/julia/session-2.rst
+++ b/doc/rst/source/tutorial/julia/session-2.rst
@@ -17,7 +17,7 @@ basemap                  Create an empty basemap frame with optional scale
 coast                    Plot coastlines, filled continents, rivers, and political borders
 legend                   Create legend overlay
 **POINTS AND LINES**
-wiggle                   Draw spatial time-series along their (*x,y*)-tracks
+wiggle                   Draw spatial time-series along their (*x, y*)-tracks
 plot                     Plot symbols, polygons, and lines in 2-D
 plot3d                   Plot symbols, polygons, and lines in 3-D
 **HISTOGRAMS**
@@ -25,7 +25,7 @@ histogram                Plot a rectangular histogram
 rose                     Plot a polar histogram(sector/rose diagram)
 **CONTOURS**
 grdcontour               Contouring of grids
-contour                  Direct contouring/imaging of (*x,y,z*) data by optimal triangulation
+contour                  Direct contouring/imaging of (*x, y, z*) data by optimal triangulation
 **SURFACES**
 grdimage                 Project and plot grids or images
 grdvector                Plot vector fields from grids

--- a/doc/rst/source/users-contrib-symbols/geology/Geology.rst
+++ b/doc/rst/source/users-contrib-symbols/geology/Geology.rst
@@ -32,7 +32,7 @@ the line with the horizontal.
 In order to use the symbols in GMT you need to use the program :doc:`plot </plot>`, using the custom
 symbol type **-Sk**\ [*symbolname*]/\ *size*\ ; where symbolname is one of the short
 names of the geological symbols shown in the table below. In addition to the location of the
-symbol (x,y) given on the first two columns of the input file, you will need additional
+symbol (*x, y*) given on the first two columns of the input file, you will need additional
 parameters for some of the symbols. You can also use as variables the size and color of
 the symbol as in any symbol plotted with :doc:`plot </plot>`. The table lists the parameters needed for
 each symbol; see the gallery for visual representation.

--- a/doc/rst/source/wiggle.rst
+++ b/doc/rst/source/wiggle.rst
@@ -249,7 +249,7 @@ and obtain
 Bugs
 ----
 
-Sometimes the (*x,y*) coordinates are not printed with enough significant
+Sometimes the (*x, y*) coordinates are not printed with enough significant
 digits, so the local perpendicular to the track swings around a lot. To
 see if this is the problem, you should do this:
 


### PR DESCRIPTION
Italicise variables in the docs and consistently use space after comma in variable lists and add () around lon, lat. I think I got most of them but a few might have expected - we can fix them when we find them.