### PR TITLE
Using -e with -bi is an error

### DIFF
--- a/doc/rst/source/explain_-e_full.rst_
+++ b/doc/rst/source/explain_-e_full.rst_
@@ -15,4 +15,5 @@ The test can also be inverted to only pass data records that *do not* match the 
 character with a backslash [Default accepts all data records]. For matching data records against extended `regular
 expressions <https://en.wikipedia.org/wiki/Regular_expression>`_, please enclose the expression in slashes. Append
 **i** for case-insensitive matching. To supply a list of such patterns, give **+f**\ *file* with one pattern per line.
-To give a single pattern starting with **+f**, escape it with a backslash.
+To give a single pattern starting with **+f**, escape it with a backslash. **Note**: Option **-e** is not allowed if
+**-b** selects binary input.

--- a/src/gmt_parse.c
+++ b/src/gmt_parse.c
@@ -1164,5 +1164,11 @@ int GMT_Parse_Common (void *V_API, const char *given_options, struct GMT_OPTION 
 				break;
 		}
 	}
+	/* Ensure that -e is not used with binary input */
+	if (API->GMT->common.e.active && API->GMT->common.b.active[GMT_IN]) {
+		GMT_Report (API, GMT_MSG_ERROR, "Option -e: Cannot be used if binary input is selected.\n");
+		return_error (API, GMT_PARSE_ERROR);
+	}
+
 	return (GMT_OK);
 }


### PR DESCRIPTION
In _GMT_Parse_Common_ we need to check for conflicts, such as setting **-e** and -bi.
