### PR TITLE
Catch lack of increment before calling next step in filter1d

### DIFF
--- a/doc/rst/source/filter1d.rst
+++ b/doc/rst/source/filter1d.rst
@@ -226,11 +226,11 @@ v3312.txt, checking for gaps of 10 km and asymmetry of 0.3:
   gmt filter1d v3312.txt -FM50 -T0/100000/25 -L10 -S0.3 > v3312_filt.txt
 
 To smooth a noisy geospatial track using a Gaussian filter of full-width 100 km
-and not shorten the track, and add the distances to the file, use
+and not shorten the track, and add the distances every 2km to the file, use
 
 ::
 
-  gmt filter1d track.txt -Tk+a -E -Fg200 > smooth_track.txt
+  gmt filter1d track.txt -T2k+a -E -Fg200 > smooth_track.txt
 
 See Also
 --------

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7723,7 +7723,11 @@ int gmt_get_distance (struct GMT_CTRL *GMT, char *line, double *dist, char *unit
 	}
 
 	/* Get the specified length */
-	if ((sscanf (&copy[start], "%lf", dist)) != 1) {
+	if (strlen (&copy[start]) == 0) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No distance argument given, only unit.\n");
+		return (-2);
+	}
+	else if ((sscanf (&copy[start], "%lf", dist)) != 1) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unable to decode %s as a floating point number.\n", &copy[start]);
 		return (-2);
 	}
@@ -17978,6 +17982,8 @@ unsigned int gmt_parse_array (struct GMT_CTRL *GMT, char option, char *argument,
 		}
 		else
 			T->distmode = gmt_get_distance (GMT, txt[ns], &(T->inc), &(T->unit));
+		if (T->distmode < 0)
+			return GMT_PARSE_ERROR;
 		if (gmt_init_distaz (GMT, T->unit, T->distmode, GMT_MAP_DIST) == GMT_NOT_A_VALID_TYPE)
 			return GMT_PARSE_ERROR;
 		T->spatial = (T->unit == 'X') ? 1 : 2;


### PR DESCRIPTION
See #8029 for some background.  Problem was our example left out an actual increment and also did not catch the error, leading to many meaningless error message.  Now, with **-Tk+a** (no increment) we get the clean error:

```
filter1d [ERROR]: No distance argument given, only unit.
gmt [ERROR]: Error parsing filter1d options
```
