### PR TITLE
Relax column content check for pstext

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -8408,6 +8408,7 @@ void * GMT_Create_Session (const char *session, unsigned int pad, unsigned int m
 	API->runmode = mode & GMT_SESSION_RUNMODE;		/* If nonzero we set up modern GMT run-mode, else classic */
 	API->no_history = mode & GMT_SESSION_NOHISTORY;		/* If nonzero we disable the gmt.history mechanism (shorthands) entirely */
 	if (API->internal) API->leave_grid_scaled = 1;	/* Do NOT undo grid scaling after write since modules do not reuse grids we save some CPU */
+    API->n_numerical_columns = GMT_NOTSET;
 	if (session) {	/* Pick up a tag for this session */
 		char *tmptag = strdup (session);
 		API->session_tag = strdup (basename (tmptag));	/* Only used in reporting and error messages */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3398,11 +3398,16 @@ bool gmtlib_maybe_abstime (struct GMT_CTRL *GMT, char *txt) {
 	}
 	if ((c = strchr (txt, 'T'))) {	/* Maybe the T between date and clock */
 		size_t first = (size_t) (c - txt);	/* Position of that T must be either 0, 4, or between 9 and 12  */
-		if (first == 0 || first == 4 || (first > 8 && first < 13)) return true;	/* Absolute date detected (most likely) */
+		if (first == 0 || first == 4 || (first > 8 && first < 13)) {
+			if (txt[first+1] == '\0' || isdigit (txt[first+1]))	/* Absolute date detected (most likely), e.g. 2001T, T14:45 */
+				return true;
+			else
+				return false;
+		}
 	}
-	else if (n_colon && n_slash == 0 && n_dash == 0)	/* No 'T', got xxx..:yy...[:ss...] probably */
+	else if (n_colon && n_slash == 0 && n_dash <= 1)	/* No 'T', got [-]xxx..:yy...[:ss...] probably */
 		return false;
-	else if (txt[0] == '-' || txt[0] == '+')	/* No 'T' and start with a sign is likely non-time related */
+	else if (txt[0] == '-' || txt[0] == '+')	/* No 'T' and starts with a sign is likely non-time related */
 		return false;	/* datestring most likely do not start with a sign. */
 	/* Maybe user forgot the 'T' flag? */
 	if (start > 0 && ((n_dash + n_slash) == 2) && (n_dash == 2 || n_slash == 2))	/* Absolute date detected (most likely) */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3529,7 +3529,8 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 	 * (which is what we are handling here) a huge variety of datetime strings are possible via
 	 * the FORMAT_DATE_IN, FORMAT_CLOCK_IN settings.
 	 */
-	unsigned int ret_val = GMT_READ_DATA, pos = 0, col = 0, k, *type = NULL, n_numeric_cols = GMT->parent->n_numerical_columns;
+	unsigned int ret_val = GMT_READ_DATA, pos = 0, col = 0, k, *type = NULL;
+	unsigned int n_numeric_cols = (GMT->parent->n_numerical_columns == GMT_NOTSET) ? UINT_MAX : GMT->parent->n_numerical_columns;
 	int got;
 	enum gmt_col_enum phys_col_type;
 	bool found_text = false;

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -154,6 +154,7 @@ struct GMTAPI_CTRL {
 	unsigned int verbose;			/* Used until GMT is set up */
 	unsigned int n_tmp_headers;		/* Number of temporarily held table headers */
 	unsigned int terminal_width;	/* Width of the terminal */
+	unsigned int n_numerical_columns;	/* 0 except for pstext where there will be 2-4 numerical leading columns before text */
 	bool registered[2];			/* true if at least one source/destination has been registered (in and out) */
 	bool io_enabled[2];			/* true if access has been allowed (in and out) */
 	bool module_input;			/* true when we are about to read inputs to the module (command line) */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -18272,7 +18272,7 @@ bool gmt_no_pstext_input (struct GMTAPI_CTRL *API, char *arg) {
 	/* Determine if -F is such that there is nothing to read */
 	if (strstr (arg, "+c") == NULL) return false;	/* Without +c there will be input */
 	if (strstr (arg, "+t") == NULL) return false;	/* Without +t there will be input */
-	if ((c = strstr (arg, "+A")) && (c[2] == '+' || c[2] == '\0')) return false;	/* With +a and no arg there must be input */
+	if ((c = strstr (arg, "+A")) && (c[2] == '+' || c[2] == '\0')) return false;	/* With +A and no arg there must be input */
 	if ((c = strstr (arg, "+a")) && (c[2] == '+' || c[2] == '\0')) return false;	/* With +a and no arg there must be input */
 	if ((c = strstr (arg, "+j")) && (c[2] == '+' || c[2] == '\0')) return false;	/* With +j and no arg there must be input */
 	if ((c = strstr (arg, "+f")) && (c[2] == '+' || c[2] == '\0')) return false;	/* With +f and no arg there must be input */

--- a/src/pstext.c
+++ b/src/pstext.c
@@ -75,6 +75,7 @@ struct PSTEXT_CTRL {
 		bool get_xy_from_justify;	/* True if +c was given and we just get it from input */
 		bool word;		/* True if we are to select a single word from the trailing text as the label */
 		bool no_input;		/* True if we give a single static text and place it via +c */
+		bool no_xy_coord;	/* If -F+c given then we dont read/parse two coordinates */
 		struct GMT_FONT font;
 		double angle;
 		int justify, R_justify, nread, nread_numerics, first, w_col;
@@ -526,6 +527,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSTEXT_CTRL *Ctrl, struct GMT_OPT
 								if (!explicit_justify)	/* If not set explicitly, default to same justification as corner */
 									Ctrl->F.justify = Ctrl->F.R_justify;
 							}
+							Ctrl->F.no_xy_coord = true;	/* Not reading lon,lat or x,y in this case */
 							break;
 						case 'l':	/* Segment label request */
 							if (Ctrl->F.get_text) {
@@ -864,11 +866,11 @@ EXTERN_MSC int GMT_pstext (void *V_API, int mode, void *args) {
 	pstext_load_parameters_pstext (GMT, &T, Ctrl);	/* Pass info from Ctrl to T */
 	tcol_f = 2 + Ctrl->Z.active;	tcol_s = tcol_f + 1;
 	/* Since pstext input is complicated we need to help gmtio_examine_current_record by determining how many leading numerical columns to expect */
-	API->n_numerical_columns = 2;
+	API->n_numerical_columns = (Ctrl->F.no_xy_coord) ? 0 : 2;	/* Normally first 2 columns are x/y coordinates but not if -F+c */
 	if (Ctrl->F.get_text == GET_CMD_FORMAT) API->n_numerical_columns++;	/* Expect a 3rd column value for formatting */ 
 	if (Ctrl->Z.active) API->n_numerical_columns++;	/* Expect a 3-D z coordinate */
 	if (Ctrl->F.nread_numerics) API->n_numerical_columns++;	/* Will read angle from input file */
-
+fprintf (stderr, "ncol = %d\n", API->n_numerical_columns);
 	n_expected_cols = 2 + Ctrl->Z.active + Ctrl->F.nread + GMT->common.t.n_transparencies;	/* Normal number of columns to read, plus any text. This includes x,y */
 	if (Ctrl->M.active) n_expected_cols += 3;
 	no_in_txt = (Ctrl->F.get_text > 1);	/* No text in the input record */
@@ -1509,7 +1511,7 @@ EXTERN_MSC int GMT_pstext (void *V_API, int mode, void *args) {
 
 	GMT->current.map.is_world = old_is_world;
 	GMT->current.io.scan_separators = GMT_TOKEN_SEPARATORS;		/* Reset */
-	API->n_numerical_columns = 0;
+    API->n_numerical_columns = GMT_NOTSET;
 
 	gmt_map_basemap (GMT);
 	gmt_plane_perspective (GMT, -1, 0.0);


### PR DESCRIPTION
No need to scan **pstext** input for absolute time beyond the expected numerical columns (which may be 2-4).  Hopefully fixes John's issue.
Now it seems OK?

```
gmt text -JX11i/8.5i -R0/11/0/8.5 -F+f8,2+jBL -png txt <<- EOF
1 1 ATL03_20200626034717_00120806_006_01.h5/beam: gt3l
2 2 Test print
EOF

```
![txt](https://github.com/GenericMappingTools/gmt/assets/26473567/92f960b3-97a1-4825-bfcc-f90e4e581017)

