### PR TITLE
If no input to greenspline then properly quit

### DIFF
--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -1836,6 +1836,13 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 
+	if (n == 0) {	/* Empty input file */
+		for (p = 0; p < n; p++) gmt_M_free (GMT, X[p]);
+		gmt_M_free (GMT, X);	gmt_M_free (GMT, obs);
+		GMT_Report (API, GMT_MSG_ERROR, "No data records found - aborting!\n");
+		Return (GMT_RUNTIME_ERROR);
+	}
+
 	X = gmt_M_memory (GMT, X, n, double *);
 	obs = gmt_M_memory (GMT, obs, n, double);
 	nm = n;

--- a/src/surface.c
+++ b/src/surface.c
@@ -831,6 +831,7 @@ GMT_LOCAL int surface_read_data (struct GMT_CTRL *GMT, struct SURFACE_INFO *C, s
 
 	if (C->npoints == 0) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "No datapoints inside region, aborting\n");
+		gmt_M_free (GMT, C->data);
 		return (GMT_RUNTIME_ERROR);
 	}
 


### PR DESCRIPTION
Since **$AWK** was not defined for @Esteban82, we get error message from system and an empty tmp file. Instead of detecting there was no input data we got a SEGV trail due to` n == 0`. Closes #8040.
