### PR TITLE
New pen meca and coupe -T syntax

### DIFF
--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -257,7 +257,7 @@ Optional Arguments
 
     *2*: only the second nodal plane is plotted.
 
-    Append **++p**\ *pen* to set alternative pen attributes for this feature 
+    Append **+p**\ *pen* to set alternative pen attributes for this feature 
     [Default pen is as set by |-W|].
 
     For double couple mechanisms, the |-T| option renders the beach ball transparent

--- a/doc/rst/source/supplements/seis/coupe.rst
+++ b/doc/rst/source/supplements/seis/coupe.rst
@@ -29,7 +29,7 @@ Synopsis
 [ |-L|\ [*pen*] ]
 [ |-N| ]
 [ |-Q| ]
-[ |-T|\ *nplane*\ [/*pen*] ]
+[ |-T|\ [*plane*]\ [**+p**\ *pen*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -247,18 +247,18 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [*nplane*][**/**\ *pen*]
+**-T**\ [*plane*]\ [**+p**\ *pen*]
     Plot the nodal planes and outlines the bubble which is transparent.
-    If *nplane* is
+    If *plane* is
 
-    *0*: both nodal planes are plotted;
+    *0*: both nodal planes are plotted [Default];
 
     *1*: only the first nodal plane is plotted;
 
     *2*: only the second nodal plane is plotted.
 
-    Append **/**\ *pen* to set the pen attributes for this feature.
-    Default pen is as set by |-W|. [Default: 0].
+    Append **++p**\ *pen* to set alternative pen attributes for this feature 
+    [Default pen is as set by |-W|].
 
     For double couple mechanisms, the |-T| option renders the beach ball transparent
     by drawing only the nodal planes and the circumference.

--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -27,7 +27,7 @@ Synopsis
 [ |-I|\ [*intens*] ]
 [ |-L|\ [*pen*] ]
 [ |-N| ]
-[ |-T|\ *nplane*\ [/*pen*] ]
+[ |-T|\ [*plane*]\ [**+p**\ *pen*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]
@@ -178,9 +178,9 @@ Optional Arguments
 
 .. _-T:
 
-**-T**\ [*nplane*][**/**\ *pen*]
+**-T**\ [*plane*]\ [**+p**\ *pen*]
     Plots the nodal planes and outlines the bubble which is transparent.
-    If *nplane* is
+    If *plane* is
 
     *0*: both nodal planes are plotted [Default];
 
@@ -188,8 +188,8 @@ Optional Arguments
 
     *2*: only the second nodal plane is plotted.
 
-    Append **/**\ *pen* to set the pen attributes for this feature.
-    Default pen is as set by |-W|.
+    Append **++p**\ *pen* to set alternative pen attributes for this feature 
+    [Default pen is as set by |-W|].
 
     For double couple mechanisms, the |-T| option renders the beach ball transparent
     by drawing only the nodal planes and the circumference.

--- a/doc/rst/source/supplements/seis/meca.rst
+++ b/doc/rst/source/supplements/seis/meca.rst
@@ -188,7 +188,7 @@ Optional Arguments
 
     *2*: only the second nodal plane is plotted.
 
-    Append **++p**\ *pen* to set alternative pen attributes for this feature 
+    Append **+p**\ *pen* to set alternative pen attributes for this feature 
     [Default pen is as set by |-W|].
 
     For double couple mechanisms, the |-T| option renders the beach ball transparent

--- a/doc/rst/source/supplements/seis/pscoupe.rst
+++ b/doc/rst/source/supplements/seis/pscoupe.rst
@@ -31,7 +31,7 @@ Synopsis
 [ |-N| ]
 [ |-O| ]
 [ |-Q| ]
-[ |-T|\ *nplane*\ [/*pen*] ]
+[ |-T|\ [*plane*]\ [**+p**\ *pen*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/doc/rst/source/supplements/seis/psmeca.rst
+++ b/doc/rst/source/supplements/seis/psmeca.rst
@@ -30,7 +30,7 @@ Synopsis
 [ |-N| ]
 [ |-O| ]
 [ |-P| ]
-[ |-T|\ *nplane*\ [*pen*] ]
+[ |-T|\ [*plane*]\ [**+p**\ *pen*] ]
 [ |SYN_OPT-U| ]
 [ |SYN_OPT-V| ]
 [ |-W|\ *pen* ]

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -102,7 +102,7 @@ struct PSCOUPE_CTRL {
 		bool zerotrace;
 		int symbol;
 	} S;
-	struct PSCOUPE_T {	/* -T<nplane>[/<pen>] */
+	struct PSCOUPE_T {	/* -T[<plane>][+p<pen>] */
 		bool active;
 		unsigned int n_plane;
 		struct GMT_PEN pen;
@@ -441,7 +441,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"%s %s %s -S<format>[<scale>][+a<angle>][+f<font>][+j<justify>][+l][+m][+o<dx>[/<dy>]][+s<ref>] "
 		"[-C<cpt>] [-D[+c]%s] [-E<fill>] [-Fa[<size>[/<Psymbol>[<Tsymbol>]]]] [-Fe<fill>] [-Fg<fill>] [-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]] "
 		"[-Fs<symbol><size>] [-G<fill>] [-H[<scale>]] [-I[<intens>]] %s[-L<pen>] [-N] %s%s "
-		"[-Q] [-T<nplane>[/<pen>]] [%s] [%s] [-W<pen>] [%s] [%s] %s[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+		"[-Q] [-T[<nplane>][+p<pen>]] [%s] [%s] [-W<pen>] [%s] [%s] %s[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_J_OPT, GMT_Rgeo_OPT, GMT_B_OPT, SEIS_LINE_SYNTAX, API->K_OPT, API->O_OPT, API->P_OPT, GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT,
 		API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_tv_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -532,9 +532,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-T<plane>[/<pen>]");
 	GMT_Usage (API, -2, "Draw specified nodal <plane>(s) and circumference only to provide a transparent beach ball "
 		"using the current pen (see -W; or append alternative pen):");
+	GMT_Usage (API, 3, "0: Both nodal planes are plotted [Default].");
 	GMT_Usage (API, 3, "1: Only the first nodal plane is plotted.");
 	GMT_Usage (API, 3, "2: Only the second nodal plane is plotted.");
-	GMT_Usage (API, 3, "0: Both nodal planes are plotted.");
 	GMT_Usage (API, -2, "Note: If moment tensor is required, nodal planes overlay moment tensor.");
 	GMT_Option (API, "U,V");
 	GMT_Usage (API, 1, "\n-W<pen>");
@@ -989,11 +989,16 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 
 			case 'T':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
-				sscanf (opt->arg, "%d", &Ctrl->T.n_plane);
-				if (strlen (opt->arg) > 2 && gmt_getpen (GMT, &opt->arg[2], &Ctrl->T.pen)) {	/* Set transparent attributes */
+				if (opt->arg[0] == '\0') continue;	/* Default plane and pen implied; move on */
+				if ((c = strstr (opt->arg, "+p")) && gmt_getpen (GMT, &c[2], &Ctrl->T.pen)) {	/* Modern modifier for pen but failed parsing the pen */
 					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
 					n_errors++;
 				}
+				else if ((c = strchr (opt->arg, '/')) && gmt_getpen (GMT, &c[1], &Ctrl->T.pen)) {
+					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
+					n_errors++;
+				}
+				if (strchr ("012", opt->arg[0])) Ctrl->T.n_plane = opt->arg[0] - '0';
 				break;
 			case 'W':	/* Set line attributes */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -990,11 +990,11 @@ static int parse (struct GMT_CTRL *GMT, struct PSCOUPE_CTRL *Ctrl, struct GMT_OP
 			case 'T':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
 				if (opt->arg[0] == '\0') continue;	/* Default plane and pen implied; move on */
-				if ((c = strstr (opt->arg, "+p")) && gmt_getpen (GMT, &c[2], &Ctrl->T.pen)) {	/* Modern modifier for pen but failed parsing the pen */
+				if ((p = strstr (opt->arg, "+p")) && gmt_getpen (GMT, &p[2], &Ctrl->T.pen)) {	/* Modern modifier for pen but failed parsing the pen */
 					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
 					n_errors++;
 				}
-				else if ((c = strchr (opt->arg, '/')) && gmt_getpen (GMT, &c[1], &Ctrl->T.pen)) {
+				else if ((p = strchr (opt->arg, '/')) && gmt_getpen (GMT, &p[1], &Ctrl->T.pen)) {
 					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
 					n_errors++;
 				}

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -519,11 +519,11 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 			case 'T':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
 				if (opt->arg[0] == '\0') continue;	/* Default plane and pen implied; move on */
-				if ((c = strstr (opt->arg, "+p")) && gmt_getpen (GMT, &c[2], &Ctrl->T.pen)) {	/* Modern modifier for pen but failed parsing the pen */
+				if ((p = strstr (opt->arg, "+p")) && gmt_getpen (GMT, &p[2], &Ctrl->T.pen)) {	/* Modern modifier for pen but failed parsing the pen */
 					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
 					n_errors++;
 				}
-				else if ((c = strchr (opt->arg, '/')) && gmt_getpen (GMT, &c[1], &Ctrl->T.pen)) {
+				else if ((p = strchr (opt->arg, '/')) && gmt_getpen (GMT, &p[1], &Ctrl->T.pen)) {
 					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
 					n_errors++;
 				}

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -86,7 +86,7 @@ struct PSMECA_CTRL {
 	struct PSMECA_S {	/* -S<format>[<scale>][+a<angle>][+f<font>][+j<justify>][+l][+m][+o<dx>[/<dy>]][+s<ref>] */
 #include "meca_symbol.h"
 	} S;
-	struct PSMECA_T {	/* -T<nplane>[/<pen>] */
+	struct PSMECA_T {	/* -T[<plane>][+p<pen>] */
 		bool active;
 		unsigned int n_plane;
 		struct GMT_PEN pen;
@@ -171,7 +171,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"-S<format>[<scale>][+a<angle>][+f<font>][+j<justify>][+l][+m][+o<dx>[/<dy>]][+s<ref>] [-A%s] [%s] "
 		"[-C<cpt>] [-D<depmin>/<depmax>] [-E<fill>] [-Fa[<size>[/<Psymbol>[<Tsymbol>]]]] [-Fe<fill>] [-Fg<fill>] "
 		"[-Fr<fill>] [-Fp[<pen>]] [-Ft[<pen>]] [-Fz[<pen>]] [-G<fill>] [-H[<scale>]] [-I[<intens>]] %s[-L<pen>] "
-		"[-N] %s%s[-T[<nplane>[/<pen>]]] [%s] [%s] [-W<pen>] [%s] [%s] %s[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
+		"[-N] %s%s[-T[<nplane>][+p<pen>]] [%s] [%s] [-W<pen>] [%s] [%s] %s[%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_J_OPT, GMT_Rgeo_OPT, SEIS_LINE_SYNTAX, GMT_B_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_U_OPT, GMT_V_OPT, GMT_X_OPT,
 		GMT_Y_OPT, API->c_OPT, GMT_di_OPT, GMT_e_OPT, GMT_h_OPT, GMT_i_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_tv_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
@@ -243,12 +243,12 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Sets pen attribute for outline other than the default set by -W.");
 	GMT_Usage (API, 1, "\n-N Do Not skip/clip symbols that fall outside map border [Default will ignore those outside].");
 	GMT_Option (API, "O,P");
-	GMT_Usage (API, 1, "\n-T[<plane>[/<pen>]]");
+	GMT_Usage (API, 1, "\n-T[<plane>][+p<pen>]");
 	GMT_Usage (API, -2, "Draw specified nodal <plane>(s) and circumference only to provide a transparent beach ball "
-		"using the current pen (see -W; or append alternative pen):");
+		"using the current pen (see -W; or append an alternative pen via modifier +p):");
+	GMT_Usage (API, 3, "0: Both nodal planes are plotted [Default].");
 	GMT_Usage (API, 3, "1: Only the first nodal plane is plotted.");
 	GMT_Usage (API, 3, "2: Only the second nodal plane is plotted.");
-	GMT_Usage (API, 3, "0: Both nodal planes are plotted [Default].");
 	GMT_Usage (API, -2, "Note: If moment tensor is required, nodal planes overlay moment tensor.");
 	GMT_Option (API, "U,V");
 	GMT_Usage (API, 1, "\n-W<pen>");
@@ -518,11 +518,16 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 				break;
 			case 'T':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
-				if (opt->arg[0]) sscanf (opt->arg, "%d", &Ctrl->T.n_plane);
-				if (strlen (opt->arg) > 2 && gmt_getpen (GMT, &opt->arg[2], &Ctrl->T.pen)) {	/* Set transparent attributes */
+				if (opt->arg[0] == '\0') continue;	/* Default plane and pen implied; move on */
+				if ((c = strstr (opt->arg, "+p")) && gmt_getpen (GMT, &c[2], &Ctrl->T.pen)) {	/* Modern modifier for pen but failed parsing the pen */
 					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
 					n_errors++;
 				}
+				else if ((c = strchr (opt->arg, '/')) && gmt_getpen (GMT, &c[1], &Ctrl->T.pen)) {
+					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
+					n_errors++;
+				}
+				if (strchr ("012", opt->arg[0])) Ctrl->T.n_plane = opt->arg[0] - '0';
 				break;
 			case 'W':	/* Set line attributes */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->W.active);


### PR DESCRIPTION
Clean up **meca** and **coupe** syntax and their  parsing of **-T**[_plane_][**+p**_pen_] as well as quiet backwards parsing of the deprecated **-T**_plane_[/_pen_]. Docs look good and the tests pass but not sure if we have many tests are involving **-T**.

Closes #8057.