### PR TITLE
Fix lack of xyz->xy conversion for graticules in grdview -T

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -10829,7 +10829,7 @@ struct GMT_POSTSCRIPT * gmt_get_postscript (struct GMT_CTRL *GMT) {
 	return (P);
 }
 
-void gmt_plot_image_graticules (struct GMT_CTRL *GMT, struct GMT_GRID *G, struct GMT_GRID *I, struct GMT_PALETTE *P, struct GMT_PEN *pen, bool skip, double *intensity) {
+void gmt_plot_image_graticules (struct GMT_CTRL *GMT, struct GMT_GRID *G, struct GMT_GRID *I, struct GMT_PALETTE *P, struct GMT_PEN *pen, bool skip, double *intensity, bool grdview) {
 	/* Lay down an image using polygons of the graticules.  This is recoded from grdview
 	 * so it can also be used in grdimage.
 	 * G is the data grid
@@ -10874,8 +10874,19 @@ void gmt_plot_image_graticules (struct GMT_CTRL *GMT, struct GMT_GRID *G, struct
 			gmt_illuminate (GMT, *intensity, fill.rgb);
 		n = gmt_graticule_path (GMT, &xx, &yy, 1, true, G->x[col] - inc2[GMT_X], G->x[col] + inc2[GMT_X], G->y[row] - inc2[GMT_Y], G->y[row] + inc2[GMT_Y]);
 		gmt_setfill (GMT, &fill, outline);
-		S->data[GMT_X] = xx;    S->data[GMT_Y] = yy;    S->n_rows = n;
-		gmt_geo_polygons (GMT, S);
+		if (GMT->current.proj.three_D && grdview) {	/* Deal with grdview */
+			uint64_t k;
+			double xp, yp;
+			for (k = 0; k < n; k++) {
+				gmt_geoz_to_xy (GMT, xx[k], yy[k], G->data[ij], &xp, &yp);
+				xx[k] = xp;	yy[k] = yp;
+			}
+			PSL_plotpolygon (GMT->PSL, xx, yy, n);
+		}
+		else {	/* 2-D, most likely grdimage w/wo -p */
+			S->data[GMT_X] = xx;    S->data[GMT_Y] = yy;    S->n_rows = n;
+			gmt_geo_polygons (GMT, S);
+		}
 		gmt_M_free (GMT, xx);
 		gmt_M_free (GMT, yy);
 	}

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -272,7 +272,7 @@ EXTERN_MSC struct GMT_GRID * gmt_duplicate_grid (struct GMT_CTRL *GMT, struct GM
 
 EXTERN_MSC int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S1, struct GMT_DATASEGMENT *S2, struct GMT_FILL *F1, struct GMT_FILL *F2, struct GMT_PEN *P1, struct GMT_PEN *P2, struct GMT_PEN *P3, char *sec_label);
 EXTERN_MSC void gmt_plot_timex_grid (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double w, double e, double s, double n, unsigned int item);
-EXTERN_MSC void gmt_plot_image_graticules (struct GMT_CTRL *GMT, struct GMT_GRID *G, struct GMT_GRID *I, struct GMT_PALETTE *P, struct GMT_PEN *pen, bool skip, double *intensity);
+EXTERN_MSC void gmt_plot_image_graticules (struct GMT_CTRL *GMT, struct GMT_GRID *G, struct GMT_GRID *I, struct GMT_PALETTE *P, struct GMT_PEN *pen, bool skip, double *intensity, bool grdview);
 EXTERN_MSC double gmt_inch_to_degree_scale (struct GMT_CTRL *GMT, double lon0, double lat0, double azimuth);
 EXTERN_MSC bool gmt_text_is_latex (struct GMT_CTRL *GMT, const char *string);
 EXTERN_MSC void gmt_map_text (struct GMT_CTRL *GMT, double x, double y, struct GMT_FONT *font, char *label, double angle, int just, unsigned int form);

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1709,7 +1709,7 @@ EXTERN_MSC int GMT_grdimage (void *V_API, int mode, void *args) {
 
 	if (Ctrl->T.active) {	/* Plot colored graticules instead */
 		need_to_project = false;	/* Since we are not doing reprojection of the grid */
-		gmt_plot_image_graticules (GMT, Grid_orig, Intens_orig, P, (Ctrl->T.outline) ? &Ctrl->T.pen : NULL, Ctrl->T.skip, Ctrl->I.constant ? &Ctrl->I.value : NULL);
+		gmt_plot_image_graticules (GMT, Grid_orig, Intens_orig, P, (Ctrl->T.outline) ? &Ctrl->T.pen : NULL, Ctrl->T.skip, Ctrl->I.constant ? &Ctrl->I.value : NULL, false);
 		goto basemap_and_free;	/* Skip all the image projection and just overlay basemap and free memory */
 	}
 

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -1306,7 +1306,7 @@ EXTERN_MSC int GMT_grdview (void *V_API, int mode, void *args) {
 	}
 
 	if (Ctrl->T.active)	/* Plot colored graticules instead */
-		gmt_plot_image_graticules (GMT, Topo, Intens, P, (Ctrl->T.outline) ? &Ctrl->T.pen : NULL, Ctrl->T.skip, Ctrl->I.constant ? &Ctrl->I.value : NULL);
+		gmt_plot_image_graticules (GMT, Topo, Intens, P, (Ctrl->T.outline) ? &Ctrl->T.pen : NULL, Ctrl->T.skip, Ctrl->I.constant ? &Ctrl->I.value : NULL, true);
 	else if (Ctrl->Q.mode == GRDVIEW_IMAGE) {	/* Plot image */
 		int nx_i, ny_i, ip, jp, min_i, max_i, min_j, max_j, dist;
 		int done, layers, last_i, last_j;


### PR DESCRIPTION
See #8036 for background. We use _gmt_graticule_path_ to uild polygons for each grid node but in **grdview** we need to project them to 3-D coordinates (x,y,z to x', y')

Now, 

`gmt grdview  @earth_relief_10m -JB-90/21/19/23/10c -R-92/-87/19/23 -p-30/40 -Cglobe -B -BWSen -T -png map`

yields 

![t](https://github.com/GenericMappingTools/gmt/assets/26473567/28dcd8cd-fa25-4432-88bd-792f19ddb374)

`gmt grdview  @earth_relief_10m -JB-90/21/19/23/10c -R-92/-87/19/23 -p-30/40 -Cglobe -B -BWSen -Qc -png map`

still fails (below) but that is a separate branch in **grdview** that needs another fix by another PR.

![map](https://github.com/GenericMappingTools/gmt/assets/26473567/b3abe6a4-e65d-48ca-95bf-098a43f0a800)
