### PR TITLE
Use named constants rater than 0-2

### DIFF
--- a/src/gmt_contour.h
+++ b/src/gmt_contour.h
@@ -37,6 +37,13 @@ enum GMT_enum_contline {
 	GMT_CONTOUR_XLINE,	/* Contour labels where crossing straight lines (via key points) */
 	GMT_CONTOUR_XCURVE};	/* Contour labels where crossing arbitrary lines (via file) */
 
+/*! Various settings for angles related to contours and decorated lines */
+enum GMT_enum_contangle {
+	GMT_ANGLE_LINE_PARALLEL = 0,	/* Angles follows the line locally */
+	GMT_ANGLE_LINE_NORMAL,	/* Angles is normal to the line locally */
+	GMT_ANGLE_LINE_FIXED};	/* Angle is fixed regardless of line direction */
+
+
 /*! Various settings for quoted line/contour label types */
 enum GMT_enum_label {
 	GMT_LABEL_IS_NONE = 0,	/* No contour/line crossing  */

--- a/src/gmt_decorate.h
+++ b/src/gmt_decorate.h
@@ -54,7 +54,7 @@ struct GMT_DECORATE {
 	unsigned int nx;		/* Number of crossovers at any time */
 	unsigned int f_n;		/* Number of such points */
 	unsigned int nudge_flag;	/* 0 if off, 1 if nudging relative to x/y axis, 2 if following local line coordinate system */
-	unsigned int angle_type;	/* 0 = line-parallel, 1 = line-normal, 2 = fixed angle */
+	unsigned int angle_type;	/* 0 = line-parallel (GMT_ANGLE_LINE_PARALLEL), 1 = line-normal (GMT_ANGLE_LINE_NORMAL), 2 = fixed angle (GMT_ANGLE_LINE_FIXED) */
 	int number_placement;		/* How the n_cont symbols are distributed [-1/0/+1]*/
 	bool isolate;			/* true if we have a limit on how close symbols may appear (see below) */
 	bool segmentize;		/* true if we should segmentize input lines before plotting */

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -1218,7 +1218,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 				cont[c].type = 'A';
 			else
 				cont[c].type = (Ctrl->contour.annot) ? 'A' : 'C';
-			cont[c].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[c].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 			cont[c].do_tick = (char)Ctrl->T.active;
 			c++;
 		}
@@ -1229,7 +1229,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 			cont[c].type = 'A';
 		else
 			cont[c].type = (Ctrl->contour.annot) ? 'A' : 'C';
-		cont[c].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+		cont[c].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 		cont[c].do_tick = (char)Ctrl->T.active;
 		n_contours = c + 1;
 	}
@@ -1251,13 +1251,13 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 			cont[c].type = 'C';
 			cont[c].val = zc[c];
 			cont[c].do_tick = Ctrl->T.active ? 1 : 0;
-			cont[c].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[c].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 		}
 		for (c = 0; c < (int)na; c++) {
 			cont[c+nc].type = 'A';
 			cont[c+nc].val = za[c];
 			cont[c+nc].do_tick = Ctrl->T.active ? 1 : 0;
-			cont[c+nc].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[c+nc].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 		}
 		if (za) gmt_M_free (GMT, za);
 		if (zc) gmt_M_free (GMT, zc);
@@ -1276,7 +1276,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 			cont[n_contours].type = 'A';
 			cont[n_contours].val = Ctrl->A.info.single_cont;
 			cont[n_contours].do_tick = Ctrl->T.active ? 1 : 0;
-			cont[n_contours].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[n_contours].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 			n_contours++;
 		}
 	}
@@ -1302,7 +1302,7 @@ EXTERN_MSC int GMT_grdcontour (void *V_API, int mode, void *args) {
 				cont[n_contours].type = 'C';
 			else
 				cont[n_contours].type = (fabs (cont[n_contours].val - aval) < noise) ? 'A' : 'C';
-			cont[n_contours].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[n_contours].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 			cont[n_contours].do_tick = (char)Ctrl->T.active;
 		}
 	}

--- a/src/pscontour.c
+++ b/src/pscontour.c
@@ -908,7 +908,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 			else
 				cont[c].type = (Ctrl->contour.annot) ? 'A' : 'C';
 			cont[c].type = (P->data[i].annot && !Ctrl->A.info.mode) ? 'A' : 'C';
-			cont[c].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[c].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 			cont[c].do_tick = Ctrl->T.active;
 			GMT_Report (API, GMT_MSG_DEBUG, "Contour slice %d: Value = %g type = %c angle = %g\n", c, cont[c].val, cont[c].type, cont[c].angle);
 			c++;
@@ -921,7 +921,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 				cont[c].type = 'A';
 			else
 				cont[c].type = (Ctrl->contour.annot) ? 'A' : 'C';
-			cont[c].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[c].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 			cont[c].do_tick = Ctrl->T.active;
 			c++;
 		}
@@ -946,13 +946,13 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 			cont[c].type = 'C';
 			cont[c].val = zc[c];
 			cont[c].do_tick = Ctrl->T.active ? 1 : 0;
-			cont[c].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[c].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 		}
 		for (c = 0; c < na; c++) {
 			cont[c+nc].type = 'A';
 			cont[c+nc].val = za[c];
 			cont[c+nc].do_tick = Ctrl->T.active ? 1 : 0;
-			cont[c+nc].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[c+nc].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 		}
 		if (za) gmt_M_free (GMT, za);
 		if (zc) gmt_M_free (GMT, zc);
@@ -971,7 +971,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 			cont[n_contours].type = 'A';
 			cont[n_contours].val = Ctrl->A.info.single_cont;
 			cont[n_contours].do_tick = Ctrl->T.active;
-			cont[n_contours].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[n_contours].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 			n_contours++;
 		}
 	}
@@ -1013,7 +1013,7 @@ EXTERN_MSC int GMT_pscontour (void *V_API, int mode, void *args) {
 			}
 			if (Ctrl->contour.annot && (cont[c].val - aval) > noise) aval += Ctrl->A.info.interval;
 			cont[c].type = (fabs (cont[c].val - aval) < noise) ? 'A' : 'C';
-			cont[c].angle = (Ctrl->contour.angle_type == 2) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
+			cont[c].angle = (Ctrl->contour.angle_type == GMT_ANGLE_LINE_FIXED) ? Ctrl->contour.label_angle : GMT->session.d_NaN;
 			cont[c].do_tick = Ctrl->T.active;
 		}
 		n_contours = c;


### PR DESCRIPTION
We have an _angle_type_ that indicates what angle we should use along a contour for label placement or decorated symbol placement. Hard to remember what 0-2 means so this PR just introduces named enums.  No change to any code or behaviour (yet).
