### PR TITLE
Improve the layout of coast -A

### DIFF
--- a/doc/rst/source/clear.rst
+++ b/doc/rst/source/clear.rst
@@ -96,7 +96,7 @@ To only wipe your GMT server directory for Earth data, try::
 
     gmt clear data=earth
 
-To just wipe your the earth_relief data set and leave other earth data intact, try::
+To just wipe your the earth_relief data set and leave other data intact, try::
 
     gmt clear data=earth_relief
 

--- a/doc/rst/source/explain_-A.rst_
+++ b/doc/rst/source/explain_-A.rst_
@@ -3,14 +3,19 @@
     hierarchical level that is lower than *min\_level* or higher than
     *max\_level* will not be plotted [Default is 0/0/4 (all features)].
     Level 2 (lakes) contains regular lakes and wide river bodies which
-    we normally include as lakes; append **+r** to just get river-lakes
-    or **+l** to just get regular lakes.  Append **+p**\ *percent* to
-    exclude polygons whose percentage area of the corresponding full-resolution
-    feature is less than *percent*.  Use **+a** to control special
-    aspects of the Antarctica coastline: By default (or add **i**) we
-    select the ice shelf boundary as the coastline for Antarctica; alternatively,
-    add **g** to select the ice grounding line instead.  For expert
-    users who wish to utilize their own Antarctica (with islands) coastline
-    you can add **s** to skip all GSHHG features below 60S. In contrast, you
-    can add **S** to instead skip all features *north* of 60S. See
-    :ref:`GSHHG Information <gshhg-information>` below for more details. |Add_-A|
+    we normally include as lakes. Several modifiers provide further control:
+
+    - **+r** Only select river-lakes and exclude regular lakes.
+    - **+l** Only regular lakes and exclude river-lakes.
+    - **+p** Append *percent* to exclude polygons whose percentage area of the
+      corresponding full-resolution feature is less than *percent*.
+    - **+a** Control special aspects of the Antarctica coastline.  Append one
+      of **i**\|\ **g**\|\ **s**\|\ **S**:
+
+      - **i** selects the ice shelf boundary as the coastline for Antarctica [Default].
+      - **g** selects the Antarctica ice grounding line as the coastline.
+      - **s** Skip all GSHHG features below 60S (For users who wish to utilize their
+        own Antarctica (with islands) coastline). 
+      - **S** Like **s** but skip instead all features *north* of 60S.
+
+    See :ref:`GSHHG Information <gshhg-information>` below for more details. |Add_-A|

--- a/doc/rst/source/explain_-A.rst_
+++ b/doc/rst/source/explain_-A.rst_
@@ -5,10 +5,6 @@
     Level 2 (lakes) contains regular lakes and wide river bodies which
     we normally include as lakes. Several modifiers provide further control:
 
-    - **+r** Only select river-lakes and exclude regular lakes.
-    - **+l** Only regular lakes and exclude river-lakes.
-    - **+p** Append *percent* to exclude polygons whose percentage area of the
-      corresponding full-resolution feature is less than *percent*.
     - **+a** Control special aspects of the Antarctica coastline.  Append one
       of **i**\|\ **g**\|\ **s**\|\ **S**:
 
@@ -17,5 +13,10 @@
       - **s** Skip all GSHHG features below 60S (For users who wish to utilize their
         own Antarctica (with islands) coastline). 
       - **S** Like **s** but skip instead all features *north* of 60S.
+
+    - **+l** Only regular lakes and exclude river-lakes.
+    - **+p** Append *percent* to exclude polygons whose percentage area of the
+      corresponding full-resolution feature is less than *percent*.
+    - **+r** Only select river-lakes and exclude regular lakes.
 
     See :ref:`GSHHG Information <gshhg-information>` below for more details. |Add_-A|

--- a/doc/rst/source/explain_-A.rst_
+++ b/doc/rst/source/explain_-A.rst_
@@ -6,10 +6,10 @@
     we normally include as lakes. Several modifiers provide further control:
 
     - **+a** Control special aspects of the Antarctica coastline.  Append one
-      of **i**\|\ **g**\|\ **s**\|\ **S**:
+      of **g**\|\ **s**\|\ **s**\|\ **S**:
 
-      - **i** selects the ice shelf boundary as the coastline for Antarctica [Default].
       - **g** selects the Antarctica ice grounding line as the coastline.
+      - **i** selects the ice shelf boundary as the coastline for Antarctica [Default].
       - **s** Skip all GSHHG features below 60S (For users who wish to utilize their
         own Antarctica (with islands) coastline). 
       - **S** Like **s** but skip instead all features *north* of 60S.


### PR DESCRIPTION
Separate modifiers and their args on separate bulleted sections. The -**A** option is also used in **gmtselect**, **grdlandmask**, and **grdmath**.

<img width="905" alt="coast" src="https://github.com/GenericMappingTools/gmt/assets/26473567/67bd259e-e819-4600-a6bf-bb08a6589d56">
