### PR TITLE
Improve the layout of gmtinfo's -I option in usage and docs

### DIFF
--- a/doc/rst/source/gmtinfo.rst
+++ b/doc/rst/source/gmtinfo.rst
@@ -112,29 +112,36 @@ Optional Arguments
 **-I**\ [**b**\|\ **e**\|\ **f**\|\ **p**\|\ **s**]\ *dx*\ [/*dy*\ [/*dz*...][**+e**\|\ **r**\|\ **R**\ *incs*]
     Compute the *min*\ /*max* values of the first *n* columns to the nearest multiple
     of the provided increments (separate the *n* increments by slashes) [default is 2 columns].
-    By default, output results in the form |-R|\ *w/e/s/n*, unless |-C| is
-    set in which case we output each *min* and *max* value in separate output columns.
-    If only one increment is given we also use it for the second
-    column (for backwards compatibility). To override this behavior, use
-    |-I|\ **p**\ *dx*. If the input *x*- and *y*-coordinates all have the
+    By default, output results in the string |-R|\ *w/e/s/n* or |-R|\ *xmin/xmax/ymin/ymax*,
+    unless |-C| is set in which case we output each *min* and *max* value in separate
+    output columns. If only one increment is given we also use it for the second
+    column. Several directives are available:
+
+    - **b**: Write the bounding box of the data table or segments (see |-A|)
+      as a closed polygon segment. 
+    - **e**: The exact *min*\ /*max* of the input is given in the **-R** string.
+      If you only want either the *x-* or *y-*\ range to be exact and the other
+      range rounded, give one of the increments as zero.
+    - **f**: Append *dx*\ [/*dy*] to report an extended region optimized
+      to give grid dimensions for fastest results in programs using FFTs.
+    - **p**: Append *dx*. This directive overrides use of a single *dx* for two columns.
+    - **s**: Append *dx*\ [/*dy*] to report an extended region optimized to
+      give grid dimensions for fastest results in programs like :doc:`surface`.
+
+    A few modifiers can adjust the determined region further:
+
+    - **+e**: Similar to **+r**, but ensures that the bounding box extends by at
+      least 0.25 times the increment(s) [no extension].
+    - **+r**: Modify the *min*\ /*max* of the first *n* columns further:
+      Append *inc*, *xinc*/*yinc*, or *winc*/*einc*/*sinc*/*ninc* to adjust the
+      region to be a multiple of these steps [no adjustment].
+    - **+R**: Extend the region outward by adding and subtracting these increments instead.
+
+    **Note**: If the input *x*- and *y*-coordinates all have the
     same phase shift relative to the *dx* and *dy* increments then we
     use those phase shifts in determining the region, and you may use
     |SYN_OPT-r| to switch from gridline-registration to pixel-registration.
     For irregular data both phase shifts are set to 0 and the |SYN_OPT-r| is ignored.
-    Use |-I|\ **f**\ *dx*\ [/*dy*] to report an extended region optimized
-    to give grid dimensions for fastest results in programs using FFTs.
-    Use |-I|\ **s**\ *dx*\ [/*dy*] to report an extended region optimized to
-    give grid dimensions for fastest results in programs like surface.
-    Use |-I|\ **b** to write the bounding box of the data table or segments (see |-A|)
-    as a closed polygon segment. **Note**: For oblique projections you should
-    use the **-Ap** option in :doc:`plot` to draw the box properly.
-    If |-I|\ **e** is given then the exact min/max of the input is given in the **-R** string.
-    If you only want either the *x-* or *y-* range to be exact and the other range rounded, give one of the increments as zero.
-    Append **+r** to modify the min/max of the first *n* columns further:
-    Append *inc*, *xinc*/*yinc*, or *winc*/*einc*/*sinc*/*ninc* to adjust the
-    region to be a multiple of these steps [no adjustment]. Alternatively, use **+R** to extend the region
-    outward by adding these increments instead, or **+e** which is like **+r** but
-    it ensures that the bounding box extends by at least 0.25 times the increment [no extension].
 
 .. _-L:
 

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -153,20 +153,23 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "d: Dataset: One record per segment with tbl_no, seg_no, nrows, start_rec, stop_rec.");
 	GMT_Usage (API, 3, "t: Tables:  Same as D but the counts resets per table.");
 	GMT_Usage (API, 1, "\n-I[b|e|f|p|s]<dx>[/<dy>[/<dz>..]][+e|r|R<incs>]");
-	GMT_Usage (API, -2, "Return textstring -Rw/e/s/n to nearest multiple of <dx>/<dy> (assumes at least two columns). "
-		"Give -Ie to just report the min/max extent in the -Rw/e/s/n string (no multiples). Give -I<dx>/0 or -I0/<dy> for mixed exact and rounded result. "
-		"If -C is set then no -R string is issued.  Instead, the number of increments "
-		"given determines how many columns are rounded off to the nearest multiple. "
-		"If only one increment is given we also use it for the second column (for backwards compatibility). "
-		"To override this behavior, use -Ip<dx>. "
-		"If input data are regularly distributed we use observed phase shifts in determining -R [no phase shift] "
-		"and allow -r to change from gridline-registration to pixel-registration. "
-		"Use -Ib to report the bounding box polygon for the data files (or segments; see -A). "
-		"Use -If<dx>[/<dy>] to report an extended region optimized for fastest results in FFTs. "
-		"Use -Is<dx>[/<dy>] to report an extended region optimized for fastest results in surface. "
-		"Append +r to modify the region further: Append <inc>, <xinc>/<yinc>, or <winc>/<einc>/<sinc>/<ninc> "
-		"to round region to these multiples; use +R to extend region by those increments instead, "
-		"or use +e which is like +r but makes sure the region extends at least by %g x <inc>.\n", GMT_REGION_INCFACTOR);
+	GMT_Usage (API, -2, "Return textstring -Rw/e/s/n to nearest multiple of <dx>/<dy> (assumes input has at least two columns). "
+		"Several directives affect the result: ");
+	GMT_Usage (API, 3, "%s b: Report the bounding box polygon for the data files (or segments; see -A).", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s e: Report the exact min/max extent in the -Rw/e/s/n string (no multiples). Give -I<dx>/0 or -I0/<dy> for mixed exact and rounded result.", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s f: Append <dx>[/<dy>] to report an extended region optimized for fastest results in FFTs.", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s p: If only one increment is given we also use it for the second column (for backwards compatibility). "
+		"To override this behavior, use -Ip<dx>.", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s s: Append <dx>[/<dy>] to report an extended region optimized for fastest results in surface.", GMT_LINE_BULLET);
+	GMT_Usage (API, -2, "Three modifiers can adjust the determined region further:");
+	GMT_Usage (API, 3, "+r: Modify the region further: Append <inc>, <xinc>/<yinc>, or <winc>/<einc>/<sinc>/<ninc> "
+		"to round region to these multiples.");
+	GMT_Usage (API, 3, "+e: Like +r, but makes sure the region extends at least by %g x <inc>.", GMT_REGION_INCFACTOR);
+	GMT_Usage (API, 3, "+R: Like +r but adds and subtracts the given increments to extend the region outwards.");
+	GMT_Usage (API, -2, "Notes: (1) If -C is set then no -R string is issued.  Instead, the number of increments "
+		"given determines how many columns are rounded off to the nearest multiple.");
+	GMT_Usage (API, -2, "Notes: (2) If input data are regularly distributed we use observed phase shifts in determining "
+		"-R [no phase shift] and allow -r to change from gridline-registration to pixel-registration.");
 	GMT_Usage (API, 1, "\n-L Determine limiting region. With -I it rounds inward so bounds are within data range. "
 		"Use -A to find the limiting common bounds of all segments or tables.");
 	GMT_Usage (API, 1, "\n-T<dz>[%s][+c<col>]", GMT_TIME_FIX_UNITS_DISPLAY);


### PR DESCRIPTION
Again, spread meaning of directives and modifiers over several lines.
