### PR TITLE
Improve man page for gmt logo

### DIFF
--- a/doc/rst/source/gmtlogo.rst
+++ b/doc/rst/source/gmtlogo.rst
@@ -70,9 +70,9 @@ Optional Arguments
     - **+o**: Offset the GMT logo by *dx*/*dy* away from the *refpoint* point in
       the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
    
-   **Note**: (1) If **-Dj** is used then *justify* defaults to the same as *refpoint*, while
-   if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-   (2) Since the aspect ratio is fixed, only one of **+h** and **+w** can be specified.
+    **Note**: (1) If **-Dj** is used then *justify* defaults to the same as *refpoint*, while
+    if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
+    (2) Since the aspect ratio is fixed, only one of **+h** and **+w** can be specified.
  
 .. _-F:
 

--- a/doc/rst/source/gmtlogo.rst
+++ b/doc/rst/source/gmtlogo.rst
@@ -51,21 +51,29 @@ Optional Arguments
 .. _-D:
 
 **-D**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ [**+h**\ *height*\|\ **+w**\ *width*\ ][**+j**\ *justify*]\ [**+o**\ *dx*\ [/*dy*]]
-    Sets reference point on the map for the image using one of four coordinate systems:
-    (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
-    a 2-char justification code that refers to the (invisible) map domain rectangle,
-    (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
-    (inches, cm, etc.).  All but **-Dx** requires both |-R| and |-J| to be specified.
-    Use **+w**\ *width* to set the width of the GMT logo in plot coordinates
-    (inches, cm, etc.). Alternatively, use **+h**\ *height* to instead specify the logo height.
-    **Note**: Since the aspect ratio is fixed, only one of height and width can be specified.
-    By default, the anchor point on the GMT logo is assumed to be the bottom left corner (BL), but this
-    can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`text`).
-    **Note**: If **-Dj** is used then *justify* defaults to the same as *refpoint*,
-    if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
-    Add **+o** to offset the GMT logo by *dx*/*dy* away from the *refpoint* point in
-    the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
 
+    Sets reference point on the map for the image using one of four coordinate systems:
+
+    - **g**: Set *refpoint* in map (user) coordinates.
+    - **j**: Set *refpoint* via a 2-char justification code that refers to the (invisible) map domain rectangle (see :doc:`text`).
+      The logo is justified to fit on the inside of the map domain rectangle.
+    - **J**: Same as **j**, but instead justifies the logo on the outside of the map domain rectangle.
+    - **n**: Set *refpoint* using normalized (0-1) coordinates.
+    - **x**: Set *refpoint* using plot coordinates (inches, cm, etc.).
+
+    All but **-Dx** requires both |-R| and |-J| to be specified. Modifiers control size and adjustments:
+
+    - **+w**: Append *width* to set the width of the GMT logo in plot coordinates (inches, cm, etc.).
+    - **+h**: Append *height* to instead specify the logo height.
+    - **+j**: By default, the anchor point on the GMT logo is assumed to be the bottom left corner (BL), but this
+      can be changed by appending the 2-char justification code *justify* (see :doc:`text`).
+    - **+o**: Offset the GMT logo by *dx*/*dy* away from the *refpoint* point in
+      the direction implied by *justify* (or the direction implied by **-Dj** or **-DJ**).
+   
+   **Note**: (1) If **-Dj** is used then *justify* defaults to the same as *refpoint*, while
+   if **-DJ** is used then *justify* defaults to the mirror opposite of *refpoint*.
+   (2) Since the aspect ratio is fixed, only one of **+h** and **+w** can be specified.
+ 
 .. _-F:
 
 **-F**\ [**+c**\ *clearances*][**+g**\ *fill*][**+i**\ [[*gap*/]\ *pen*]][**+p**\ [*pen*]][**+r**\ [*radius*]]\

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8871,7 +8871,7 @@ void gmt_refpoint_syntax (struct GMT_CTRL *GMT, char *option, char *string, unsi
 			"or the mirror opposite of <refpoint> (with -J), or %s (otherwise).", type[kind], just[kind]);
 		GMT_Usage (API, 3+shift, "+o Offset %s from <refpoint> by <dx>[/<dy>] in direction implied by <justify> [0/0].", type[kind]);
 	}
-	else
+	else if ((part & 5) == 0)
 		GMT_Usage (API, -(2+shift), "All systems except x require the -R and -J options to be set. ");
 }
 

--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -217,7 +217,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	GMT_Message (API, GMT_TIME_NONE, "  OPTIONAL ARGUMENTS:\n");
-	gmt_refpoint_syntax (API->GMT, "\n-D", "Specify position of the GMT logo [0/0].", GMT_ANCHOR_LOGO, 1);
+	gmt_refpoint_syntax (API->GMT, "\n-D", "Specify position of the GMT logo [0/0].", GMT_ANCHOR_LOGO, 5);
 	gmt_refpoint_syntax (API->GMT, "D", NULL, GMT_ANCHOR_LOGO, 2);
 	GMT_Usage (API, 3, "+h Set the <height> of the GMT logo [72p], or");
 	GMT_Usage (API, 3, "+w Set the <width> of the GMT logo [144p]");


### PR DESCRIPTION
Also avoid repeat of "needs both **-R -J**" in -D docs.  However, the stuff beneath **-D** is tabbed one to many to the right.  I cannot see why as it looks exactly as **-F** which does the right indentation.  Anyone? See difference in alignment for **-D** and **-F** below:

<img width="899" alt="logo" src="https://github.com/GenericMappingTools/gmt/assets/26473567/fcfe2ebc-08d0-4be7-8f11-b29bbc928204">
