### PR TITLE
Improve layout of gmtvector docs

### DIFF
--- a/doc/rst/source/gmtvector.rst
+++ b/doc/rst/source/gmtvector.rst
@@ -110,7 +110,7 @@ Optional Arguments
 .. _-T:
 
 **-T**\ **a**\|\ **d**\|\ **D**\|\ **p**\ *azim*\|\ **s**\|\ **r**\ [*arg*]\|\ **R**\|\ **s**\|\ **t**\ [*arg*]\|\ **x**
-    Specify the vector transformation of interest:
+    Specify the vector transformation of interest via these directives:
 
     - **a**: Compute the vector average.
     - **b**: Determines the pole of the two points bisector.
@@ -120,11 +120,11 @@ Optional Arguments
     - **s**: Evaluate the vector sum.
     - **r**: Perform vector rotation (here, *par* is a single
       angle for 2-D Cartesian data and *lon/lat/angle* for a 3-D rotation pole and angle)
-    - **R** Similar to **r** but will instead rotate the fixed secondary vector
+    - **R**: Similar to **r** but will instead rotate the fixed secondary vector
       by the rotations implied by the input records.
     - **t**: Translate the input point by a *distance* in the *azimuth* direction
       (append *azimuth*/*distance*\ [*unit*] for the same translation for all input points,
-      or just append*unit* to read *azimuth* and *distance* (in specified *unit* [**e**])
+      or just append *unit* to read *azimuth* and *distance* (in specified *unit* [**e**])
       from the third and fourth data column in the file.
     - **x**: Compute the vectors or cross-product.
 

--- a/doc/rst/source/gmtvector.rst
+++ b/doc/rst/source/gmtvector.rst
@@ -51,7 +51,7 @@ vectors (or the one provided via |-A|) are denoted the prime
 vector(s). Several standard vector operations (angle between vectors,
 cross products, vector sums, and vector rotations) can be selected; most
 require a single second vector, provided via |-S|. The output vectors
-will be converted back to (*lon, lat*) or (*r, theta*) unless **-Co** is set
+will be converted back to (*lon, lat*) or (*r, theta*) unless **-Co** is set,
 which requests (*x, y*\ [*, z*]) Cartesian coordinates.
 
 Required Arguments
@@ -129,9 +129,9 @@ Optional Arguments
     - **x**: Compute the vectors or cross-product.
 
     If |-T| is not given then no transformation takes place; the
-    output is determined by other options, such as |-A|, |-C|,
-    |-E|, and |-N|. **Notes**: (1) For **-Tt** and geographic coordinates we will
-    perform a great circle calculation unless **-je** or **-jf** is selected;
+    output is determined by other options, such as |-A|, |-C|, |-E|, and |-N|.
+    **Notes** for directive **t** : (1) If geographic coordinates we will perform
+    a great circle calculation unless **-je** or **-jf** is selected;
     (2) if a distance is negative then we remove the sign and add 180 degrees to the azimuth.
 
 .. |Add_-V| replace:: |Add_-V_links|

--- a/doc/rst/source/gmtvector.rst
+++ b/doc/rst/source/gmtvector.rst
@@ -110,24 +110,29 @@ Optional Arguments
 .. _-T:
 
 **-T**\ **a**\|\ **d**\|\ **D**\|\ **p**\ *azim*\|\ **s**\|\ **r**\ [*arg*]\|\ **R**\|\ **s**\|\ **t**\ [*arg*]\|\ **x**
-    Specify the vector transformation of interest. Append **a** for
-    average, **b** for the pole of the two points bisector, **d** for
-    dot product (use **D** to get angle in degrees between the two
-    vectors), **p**\ *azim* for the pole to the great circle specified by
-    input vector and the circle's *azim* (no second vector used), **s** for vector sum,
-    **r**\ *par* for vector rotation (here, *par* is a single
-    angle for 2-D Cartesian data and *lon/lat/angle* for a 3-D rotation
-    pole and angle), **R** will instead rotate the fixed secondary vector
-    by the rotations implied by the input records, **t** to translate
-    the input point by a *distance* in the *azimuth* direction (append *azimuth*/*distance*\ [*unit*]
-    for the same translation for all input points, or just append
-    *unit* to read *azimuth* and *distance* (in specified *unit* [**e**])
-    from the third and fourth data column in the file, and **x** for cross-product.
+    Specify the vector transformation of interest:
+
+    - **a**: Compute the vector average.
+    - **b**: Determines the pole of the two points bisector.
+    - **d**: Compute dot product  of the two vectors.
+    - **D**: Same as **+d** but returns the angle in degrees between the two vectors.
+    - **p**: The pole to the great circle specified by input vector and the circle's *azim* (no second vector used).
+    - **s**: Evaluate the vector sum.
+    - **r**: Perform vector rotation (here, *par* is a single
+      angle for 2-D Cartesian data and *lon/lat/angle* for a 3-D rotation pole and angle)
+    - **R** Similar to **r** but will instead rotate the fixed secondary vector
+      by the rotations implied by the input records.
+    - **t**: Translate the input point by a *distance* in the *azimuth* direction
+      (append *azimuth*/*distance*\ [*unit*] for the same translation for all input points,
+      or just append*unit* to read *azimuth* and *distance* (in specified *unit* [**e**])
+      from the third and fourth data column in the file.
+    - **x**: Compute the vectors or cross-product.
+
     If |-T| is not given then no transformation takes place; the
-    output is determined by other options such as |-A|, |-C|,
+    output is determined by other options, such as |-A|, |-C|,
     |-E|, and |-N|. **Notes**: (1) For **-Tt** and geographic coordinates we will
-    perform a great circle calculation unless **-je** or **-jf** is selected; (2) if a distance
-    is negative then we remove the sign and add 180 degrees to the azimuth.
+    perform a great circle calculation unless **-je** or **-jf** is selected;
+    (2) if a distance is negative then we remove the sign and add 180 degrees to the azimuth.
 
 .. |Add_-V| replace:: |Add_-V_links|
 .. include:: explain_-V.rst_

--- a/src/gmtvector.c
+++ b/src/gmtvector.c
@@ -127,8 +127,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"If no file(s) is given, standard input is read.");
 	GMT_Usage (API, 1, "\n-A[m][<conf>]|<vector>");
 	GMT_Usage (API, -2, "Single primary vector, given as lon/lat, r/theta, or x/y[/z].  No tables will be read. "
-		"Alternatively, give -Am to compute a single primary vector as the mean of the input vectors. "
-		"The confidence ellipse for the mean vector is determined (95%% level); "
+		"Alternatively, give -Am to compute the single primary vector as the mean of the input vectors. "
+		"The confidence ellipse for the mean vector will be determined (95%% level); "
 		"optionally append a different confidence level in percent.");
 	GMT_Usage (API, 1, "\n-C[i|o]");
 	GMT_Usage (API, -2, "Indicate Cartesian coordinates on input/output instead of lon,lat or r/theta. "
@@ -153,7 +153,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "t: Translate input vectors to points a distance <dist> away in the azimuth <azim>. "
 		"Append <azim>/<dist> for a fixed set of azimuth and distance for all points, "
 		"otherwise we expect to read <azim>, <dist> from the input file; append a unit [e]. "
-		"A negative distance implies a flip of 180 degrees.;");
+		"A negative distance implies a flip of 180 degrees.");
 	GMT_Usage (API, 3, "x: Compute cross-product(s) with secondary vector (see -S).");
 	GMT_Option (API, "V,bi0");
 	if (gmt_M_showusage (API)) GMT_Usage (API, -2, "Default is 2 [or 3; see -C, -fg] input columns.");


### PR DESCRIPTION
The usual: Rearrange documentation for **-T** so that each directive has its one paragraph. And a few typos in the C.

<img width="916" alt="vector" src="https://github.com/GenericMappingTools/gmt/assets/26473567/b42f9b62-c450-4a0a-840e-0b34e11a90f1">
