### PR TITLE
Improve the presentation of how to enter CPT or colors via -C

### DIFF
--- a/doc/rst/source/create_cpt.rst_
+++ b/doc/rst/source/create_cpt.rst_
@@ -1,4 +1,4 @@
-**-C**\ [[*section*/]\ *master\_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local\_cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]]
+**-C**\ [[*section*/]\ *master\_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local.cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]]
     Name of an input CPT file or a comma-separated list of colors from which to build a CPT.
     Generally, the input can be many things:
 

--- a/doc/rst/source/create_cpt.rst_
+++ b/doc/rst/source/create_cpt.rst_
@@ -1,4 +1,4 @@
-**-C**\ [[*section*/]\ *master\_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local\_cpt*\|\ *color1,color2*\ [,\ *color3*\ ,...]]
+**-C**\ [[*section*/]\ *master\_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local\_cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]]
     Name of an input CPT file or a comma-separated list of colors from which to build a CPT.
     Generally, the input can be many things:
 
@@ -6,11 +6,11 @@
        (see :ref:`Of Colors and Color Legends`) and can be either addressed
        by *master\_cpt* or *section*/*master\_cpt* (without the **.cpt** extension).
     #. File name of already custom-made *local.cpt* file.
-    #. Build a linear continuous CPT from *color1,color2*\ [*,color3*\ ,...] automatically,
-       where *z* starts at 0 and is incremented by one for each color. In this case,
+    #. Build a linear continuous CPT from *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]
+       automatically, where *z* starts at 0 and is incremented by one for each color. In this case,
        *color*\ :math:`_i` can be a r/g/b (e.g., 255/100/75), or h-s-v triplet (e.g., 180-0.8-1),
        a c/m/y/k quadruple (e.g., 80/50/40/30), an HTML hexadecimal color (e.g. #aabbcc),
-       or a :ref:`color name <RGBchart>`.
+       or a :ref:`color name <RGBchart>`. No spaces between commas are allowed.
 
     A few modifiers pertains to hinges and units:
 
@@ -21,4 +21,4 @@
       another distance *unit* to meter.
     - **+U**: Likewise, you may convert their *z*-values from meter to another *unit*.
 
-    **Note**: For **+u**\|\ **U**, the *unit* must be taken from **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.
+    **Note**: For **+u**\|\ **U**, a *unit* must be selected from **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.

--- a/doc/rst/source/create_cpt.rst_
+++ b/doc/rst/source/create_cpt.rst_
@@ -2,15 +2,15 @@
     Name of an input CPT file or a comma-separated list of colors from which to build a CPT.
     Generally, the input can be many things:
 
-    # A standard GMT *master\_cpt* files, e.g., *earth* 
-      (see :ref:`Of Colors and Color Legends`) and can be either addressed
-      by *master\_cpt* or *section*/*master\_cpt* (without the **.cpt** extension).
-    # File name of already custom-made *local.cpt* file.
-    # Build a linear continuous CPT from *color1,color2*\ [*,color3*\ ,...] automatically,
-      where *z* starts at 0 and is incremented by one for each color. In this case,
-      *color*\ :math:`_i` can be a r/g/b (e.g., 255/100/75), or h-s-v triplet (e.g., 180-0.8-1),
-      a c/m/y/k quadruple (e.g., 80/50/40/30), an HTML hexadecimal color (e.g. #aabbcc),
-      or a :ref:`color name <RGBchart>`.
+    #. A standard GMT *master\_cpt* file, e.g., *earth* 
+       (see :ref:`Of Colors and Color Legends`) and can be either addressed
+       by *master\_cpt* or *section*/*master\_cpt* (without the **.cpt** extension).
+    #. File name of already custom-made *local.cpt* file.
+    #. Build a linear continuous CPT from *color1,color2*\ [*,color3*\ ,...] automatically,
+       where *z* starts at 0 and is incremented by one for each color. In this case,
+       *color*\ :math:`_i` can be a r/g/b (e.g., 255/100/75), or h-s-v triplet (e.g., 180-0.8-1),
+       a c/m/y/k quadruple (e.g., 80/50/40/30), an HTML hexadecimal color (e.g. #aabbcc),
+       or a :ref:`color name <RGBchart>`.
 
     A few modifiers pertains to hinges and units:
 
@@ -21,4 +21,4 @@
       another distance *unit* to meter.
     - **+U**: Likewise, you may convert their *z*-values from meter to another *unit*.
 
-    **Note**: For **+u**\|\ **U**, the *unit* taken from **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.
+    **Note**: For **+u**\|\ **U**, the *unit* must be taken from **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.

--- a/doc/rst/source/create_cpt.rst_
+++ b/doc/rst/source/create_cpt.rst_
@@ -1,5 +1,6 @@
 **-C**\ [[*section*/]\ *master\_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local.cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]]
     Name of an input CPT file or a comma-separated list of colors from which to build a CPT.
+    If no argument is given then under modern mode we select the current CPT.
     Generally, the input can be many things:
 
     #. A standard GMT *master\_cpt* file, e.g., *earth* 

--- a/doc/rst/source/create_cpt.rst_
+++ b/doc/rst/source/create_cpt.rst_
@@ -1,11 +1,11 @@
-**-C**\ [[*section*/]\ *master\_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local.cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]]
+**-C**\ [[*section*/]\ *master_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local.cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]]
     Name of an input CPT file or a comma-separated list of colors from which to build a CPT.
     If no argument is given then under modern mode we select the current CPT.
     Generally, the input can be many things:
 
-    #. A standard GMT *master\_cpt* file, e.g., *earth* 
+    #. A standard GMT *master_cpt* file, e.g., *earth* 
        (see :ref:`Of Colors and Color Legends`) and can be either addressed
-       by *master\_cpt* or *section*/*master\_cpt* (without the **.cpt** extension).
+       by *master\_cpt* or *section*/*master_cpt* (without the **.cpt** extension).
     #. File name of already custom-made *local.cpt* file.
     #. Build a linear continuous CPT from *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]
        automatically, where *z* starts at 0 and is incremented by one for each color. In this case,

--- a/doc/rst/source/create_cpt.rst_
+++ b/doc/rst/source/create_cpt.rst_
@@ -1,14 +1,24 @@
-**-C**\ [[*section*/] *master\_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local\_cpt*\|\ *color1,color2*\ [,\ *color3*\ ,...]]
-    Name of an input CPT file. Generally, the input is one of the GMT *master\_cpt* files
-    (see :ref:`Of Colors and Color Legends`) and can be either addressed by *master\_cpt* or *section*/*master\_cpt*
-    (without the **.cpt** extension). If given a master CPT with soft-hinges then
-    you can enable the hinge at data value *hinge* [0] via **+h**, whereas for hard-hinge CPTs you
-    can adjust the location of the hinge [0].  For any other *master\_cpt*, you may convert their *z*-values
-    from meter to another distance unit (append **+U**\ *unit*) or from another unit to meter (append **+u**\ *unit*),
-    with *unit* taken from **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.
-    One can also supply the file name of already custom made *local\_cpt* file.
-    Alternatively, give *color1,color2*\ [*,color3*\ ,...]
-    to build a linear continuous CPT from those colors automatically,
-    where *z* starts at 0 and is incremented by one for each color.
-    In this case *color*\ **n** can be a r/g/b triplet, a :ref:`color name <RGBchart>`,
-    or an HTML hexadecimal color (e.g. #aabbcc).
+**-C**\ [[*section*/]\ *master\_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local\_cpt*\|\ *color1,color2*\ [,\ *color3*\ ,...]]
+    Name of an input CPT file or a comma-separated list of colors from which to build a CPT.
+    Generally, the input can be many things:
+
+    # A standard GMT *master\_cpt* files, e.g., *earth* 
+      (see :ref:`Of Colors and Color Legends`) and can be either addressed
+      by *master\_cpt* or *section*/*master\_cpt* (without the **.cpt** extension).
+    # File name of already custom-made *local.cpt* file.
+    # Build a linear continuous CPT from *color1,color2*\ [*,color3*\ ,...] automatically,
+      where *z* starts at 0 and is incremented by one for each color. In this case,
+      *color*\ :math:`_i` can be a r/g/b (e.g., 255/100/75), or h-s-v triplet (e.g., 180-0.8-1),
+      a c/m/y/k quadruple (e.g., 80/50/40/30), an HTML hexadecimal color (e.g. #aabbcc),
+      or a :ref:`color name <RGBchart>`.
+
+    A few modifiers pertains to hinges and units:
+
+    - **+h**: If given a master CPT with soft hinges then you can enable the hinge at
+      data value *hinge* [0], whereas for hard-hinge CPTs you can adjust the location
+      of the hinge [0] but not disable it.
+    - **+u**: For any other *master\_cpt*, you may convert their *z*-values from 
+      another distance *unit* to meter.
+    - **+U**: Likewise, you may convert their *z*-values from meter to another *unit*.
+
+    **Note**: For **+u**\|\ **U**, the *unit* taken from **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.

--- a/doc/rst/source/use_cpt_grd.rst_
+++ b/doc/rst/source/use_cpt_grd.rst_
@@ -1,16 +1,27 @@
-**-C**\ [*cpt*\|\ *master*\ [**+h**\ [*hinge*]][**+i**\ *zinc*][**+u**\|\ **U**\ *unit*] \|\ *color1,color2*\ [,\ *color3*\ ,...][+s<fname>]]
-    Name of a CPT file. Alternatively, supply the name of a GMT color master
-    dynamic CPT [*turbo*, but we use *geo* for @earth_relief and *srtm* for @srtm_relief data] to
-    automatically determine a continuous CPT from the grid's *z*-range; you may round the range
-    to the nearest multiple of *zinc* by adding **+i**\ *zinc*. If given a GMT Master soft-hinge CPT
-    (see :ref:`Of Colors and Color Legends`) then you can enable the hinge at data value *hinge* [0] via **+h**,
-    whereas for hard-hinge CPTs you can adjust the location of the hinge [0].
-    For other CPTs, you may convert their *z*-values from meter to another distance unit (append **+U**\ *unit*)
-    or from another unit to meter (append **+u**\ *unit*), with *unit* taken from
-    **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.
-    Yet another option is to specify **-C**\ *color1*\ ,\ *color2*\ [,\ *color3*\ ,...]
-    to build a linear continuous CPT from those colors automatically. In this case *color*\ **n** can be a r/g/b triplet,
-    a color name, or an HTML hexadecimal color (e.g. #aabbcc). If no argument is given to **-C**
-    then under modern mode we select the current CPT. Append +s<fname> to save the used cpt in a disk file.
-    This is useful when the cpt was generated automatically, but so far this option is only available in *grdimage*
-    and *grdview* Attention, this option, if used, **must** be at the end of the **-C** option.
+**-C**\ [[*section*/]\ *master_cpt*\ [**+h**\ [*hinge*]][**+u**\|\ **U**\ *unit*]\|\ *local.cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]][**+s**\ *fname*]]
+    Name of an input CPT file or a comma-separated list of colors from which to build a CPT.
+    If no argument is given then under modern mode we select the current CPT.
+    Generally, the input can be many things:
+
+    #. A standard GMT *master_cpt* file, e.g., *earth* 
+       (see :ref:`Of Colors and Color Legends`) and can be either addressed
+       by *master\_cpt* or *section*/*master_cpt* (without the **.cpt** extension).
+    #. File name of already custom-made *local.cpt* file.
+    #. Build a linear continuous CPT from *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]
+       automatically, where *z* starts at 0 and is incremented by one for each color. In this case,
+       *color*\ :math:`_i` can be a r/g/b (e.g., 255/100/75), or h-s-v triplet (e.g., 180-0.8-1),
+       a c/m/y/k quadruple (e.g., 80/50/40/30), an HTML hexadecimal color (e.g. #aabbcc),
+       or a :ref:`color name <RGBchart>`. No spaces between commas are allowed.
+
+    A few modifiers pertains to hinges and units:
+
+    - **+h**: If given a master CPT with soft hinges then you can enable the hinge at
+      data value *hinge* [0], whereas for hard-hinge CPTs you can adjust the location
+      of the hinge [0] but not disable it.
+    - **+i**: Append increment *dz* to quantize the range [Default uses the exact grid range].
+    - **+s**: Append *fname* to save the finalized cpt in a disk file.
+      This is useful when the cpt was generated automatically, but if used, **must** be
+      at the end of the **-C** option.
+    - **+u**: For any other *master_cpt*, you may convert their *z*-values from 
+      another distance *unit* to meter.
+    - **+U**: Likewise, you may convert their *z*-values from meter to another *unit*.


### PR DESCRIPTION
This PR updates `create_cpt.rst_` which is used in **makecpt** and **grd2cpt**. Clearer instructions and modifiers listed separately.

<img width="909" alt="color" src="https://github.com/GenericMappingTools/gmt/assets/26473567/bd092058-708a-4235-91f8-fd30e128f36c">
