### PR TITLE
Isolate the -I intensity option in one include file

### DIFF
--- a/doc/rst/source/explain_intense.rst_
+++ b/doc/rst/source/explain_intense.rst_
@@ -1,4 +1,4 @@
-**-I**\ [*ifile*\|\ *intens*\|\ **+a**\ *azimuth**][**+d**][**+m**\ *ambient*][**+n**\ *args*]
+**-I**\ [*ifile*\|\ *intens*\|\ **+a**\ *azimuth*][**+d**][**+m**\ *ambient*][**+n**\ *args*]
     Gives the name of a grid file with intensities in the ±1 range,
     or a constant *intens* to apply everywhere (affects the ambient light).
     Alternatively, derive intensities from the main data grid via a call
@@ -7,7 +7,7 @@
     give **+d** to select the default (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0).
     For more specific intensity scenarios then run :doc:`grdgradient`
     separately first. If we should derive intensities from another file
-    than the main grid, specify that file with suitable modifiers [Default is no
+    than the main grid, specify that file as *ifile* and add suitable modifiers [Default is no
     illumination]. **Note**: If the input grid actually is an image then
-    an *ifile* or constant *intens* must be provided since derivatives are
+    *ifile* or constant *intens* must be provided since derivatives are
     not available.

--- a/doc/rst/source/explain_intense.rst_
+++ b/doc/rst/source/explain_intense.rst_
@@ -1,0 +1,13 @@
+**-I**\ [*ifile*\|\ *intens*\|\ **+a**\ *azimuth**][**+d**][**+m**\ *ambient*][**+n**\ *args*]
+    Gives the name of a grid file with intensities in the ±1 range,
+    or a constant *intens* to apply everywhere (affects the ambient light).
+    Alternatively, derive intensities from the main data grid via a call
+    to :doc:`grdgradient` by appending **+a**\ *azimuth*, **+n**\ *args*
+    and **+m**\ *ambient* for the arguments needed by that module, or just
+    give **+d** to select the default (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0).
+    For more specific intensity scenarios then run :doc:`grdgradient`
+    separately first. If we should derive intensities from another file
+    than the main grid, specify that file with suitable modifiers [Default is no
+    illumination]. **Note**: If the input grid actually is an image then
+    an *ifile* or constant *intens* must be provided since derivatives are
+    not available.

--- a/doc/rst/source/grd2kml.rst
+++ b/doc/rst/source/grd2kml.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |-E|\ *URL* ]
 [ |-F|\ *filtercode* ]
 [ |-H|\ *scale* ]
-[ |-I|\ [*intensfile*\|\ *intensity*\|\ *modifiers*] ]
+[ |-I|\ [*ifile*\|\ *intens*\|\ **+a**\ *azimuth**][**+d**][**+m**\ *ambient*][**+n**\ *args*] ]
 [ |-L|\ *tilesize* ]
 [ |-S|\ [*extra*] ]
 [ |-T|\ *title* ]
@@ -67,7 +67,6 @@ Optional Arguments
 
 .. _-A:
 
-
 **-A**\ **a**\|\ **g**\|\ **s**\ [*altitude*]
     Select one of three altitude modes recognized by Google Earth that
     determines the altitude (in m) of the tile layer: **a** absolute
@@ -109,16 +108,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ [*intensfile*\|\ *intensity*\|\ *modifiers*]
-    Gives the name of a grid file with intensities in the ±1 range,
-    or a constant intensity to apply everywhere (affects the ambient light).
-    Alternatively, derive an intensity grid from the input data grid *grid*
-    via a call to :doc:`grdgradient`; append **+a**\ *azimuth* and **+n**\ *args*
-    to specify azimuth and intensity arguments for that module or just give **+d**
-    to select the default arguments (**+a**\ -45\ **+nt**\ 1). If you want a more
-    specific intensity scenario then run :doc:`grdgradient` separately first.
-    [Default is no illumination].
-
+.. include:: explain_intense.rst_
 
 .. _-L:
 
@@ -129,7 +119,6 @@ Optional Arguments
     *tilesize* of 360 if |-L| is not specified.
 
 .. _-S:
-
 
 **-S**\ [*extra*]
     Add extra layers beyond that necessary to capture the full resolution of the data [none].

--- a/doc/rst/source/grdimage.rst
+++ b/doc/rst/source/grdimage.rst
@@ -20,7 +20,7 @@ Synopsis
 [ |-D|\ [**r**] ]
 [ |-E|\ [**i**\|\ *dpi*] ]
 [ |-G|\ *color*\ [**+b**\|\ **f**] ]
-[ |-I|\ [*intensfile*\|\ *intensity*\|\ *modifiers*] ]
+[ |-I|\ [*ifile*\|\ *intens*\|\ **+a**\ *azimuth**][**+d**][**+m**\ *ambient*][**+n**\ *args*] ]
 [ |-M| ]
 [ |-N| ]
 [ |-Q|\ [*color*][**+z**\ *value*] ]
@@ -142,19 +142,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ [*intensfile*\|\ *intensity*\|\ *modifiers*]
-    Gives the name of a grid file with intensities in the ±1 range,
-    or a constant intensity to apply everywhere (affects the ambient light).
-    Alternatively, derive an intensity grid from the input data grid *grid*
-    via a call to :doc:`grdgradient`; append **+a**\ *azimuth*, **+n**\ *args*,
-    and **+m**\ *ambient* to specify azimuth, intensity, and ambient arguments
-    for that module, or just give **+d** to select the
-    default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
-    specific intensity scenario then run :doc:`grdgradient` separately first.
-    If we should derive intensities from another file than *grid*, specify the
-    file with suitable modifiers [Default is no illumination].  **Note**: If
-    the input data represent an *image* then an *intensfile* or constant *intensity*
-    must be provided.
+.. include:: explain_intense.rst_
 
 .. _-M:
 

--- a/doc/rst/source/grdview.rst
+++ b/doc/rst/source/grdview.rst
@@ -16,7 +16,7 @@ Synopsis
 [ |SYN_OPT-B| ]
 [ |-C|\ [*cpt*]]
 [ |-G|\ *drapegrid* \| |-G|\ *grd_r* |-G|\ *grd_g* |-G|\ *grd_b* ]
-[ |-I|\ [*intensgrid*\|\ *intensity*\|\ *modifiers*] ]
+[ |-I|\ [*ifile*\|\ *intens*\|\ **+a**\ *azimuth**][**+d**][**+m**\ *ambient*][**+n**\ *args*] ]
 [ |-Jz|\ \|\ **Z**\ *parameters* ]
 [ |-N|\ [*level*]\ [**+g**\ *fill*] ]
 [ |-Q|\ *args*\ [**+m**] ]
@@ -86,17 +86,7 @@ Optional Arguments
 
 .. _-I:
 
-**-I**\ [*intensgrid*\|\ *intensity*\|\ *modifiers*]
-    Gives the name of a grid file with intensities in the ±1 range,
-    or a constant intensity to apply everywhere (affects the ambient light).
-    Alternatively, derive an intensity grid from the input data grid *reliefgrid*
-    via a call to :doc:`grdgradient`; append **+a**\ *azimuth*, **+n**\ *args*,
-    and **+m**\ *ambient* to specify azimuth, intensity, and ambient arguments
-    for that module, or just give **+d** to select the
-    default arguments (**+a**\ -45\ **+nt**\ 1\ **+m**\ 0). If you want a more
-    specific intensity scenario then run :doc:`grdgradient` separately first.
-    If we should derive intensities from another file than *reliefgrid*, specify the file
-    [Default is no illumination].
+.. include:: explain_intense.rst_
 
 .. _-Jz:
 


### PR DESCRIPTION
New include file `explain_intense.rst_` is added that streamlines the description on how to make or provide intensities, and is used by the **grdimage**, **grdview**, and **grd2kml** documentation:

<img width="907" alt="I" src="https://github.com/GenericMappingTools/gmt/assets/26473567/d67968cc-4556-4776-a9af-c3a4257042cb">
