### PR TITLE
Remove unused variables and other code cleaning

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3970,7 +3970,7 @@ struct GMT_GRID * gmt_vertical_cube_cut (struct GMT_CTRL *GMT, struct GMT_CUBE *
 	 * or y-coordinate and that defines the vertical plan to be at that constant
 	 * coordinate and parallel to the z-axis and the other axis (y or x).
 	 */
-	uint64_t row, col, xrow, xcol, layer, ijg, ijc;
+	uint64_t col, xrow, xcol, layer, ijg, ijc;
 	double pos = 0.0;
 	struct GMT_GRID *G = NULL;
 	struct GMT_GRID_HIDDEN *GH = NULL;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -10104,7 +10104,7 @@ unsigned int gmtlib_is_time (struct GMT_CTRL *GMT, char *text) {
 		gmt_strrepc (string, p[k], ' ');	/* Replace date separators with space */
 	if (n_colon)
 		gmt_strrepc (string, ':', ' ');	/* Replace time separators with space */
-	if ((n_dash >= 1 && n_slash == 0) || n_dash == 0 && n_slash >= 1) {
+	if ((n_dash >= 1 && n_slash == 0) || (n_dash == 0 && n_slash >= 1)) {
 		/* Apart from random junk SHIT 5 6 7:X:Hello!, Possibilities are:
 		 *	1.  yyyy mm dd[T][hh.xxx|:mm.xx|:ss.xx]  Full date and possibly time
 		 *	2.  yyyy jjj[T][hh.xxx|:mm.xx|:ss.xx]  Julian day and possibly time
@@ -10197,8 +10197,7 @@ unsigned int gmtlib_is_time (struct GMT_CTRL *GMT, char *text) {
 unsigned int gmtlib_is_string (struct GMT_CTRL *GMT, char *string) {
 	/* Apply basic checking for stuff that cannot be coordinates */
 	char *p = NULL;
-	int code;
-	unsigned int L = strlen (string), start = 0, k;
+	unsigned int L = strlen (string), start = 0;
 	unsigned int n_text = 0, n_colons = 0, n_digits = 0, n_dashes = 0, n_slashes = 0, n_specials = 0, n_periods = 0;
 
 	if (L > 24U) return (GMT_IS_STRING);	/* Too long to be an absolute time string */
@@ -10248,7 +10247,6 @@ void gmtlib_string_parser (struct GMT_CTRL *GMT, char *file)
 	unsigned int kind;
 	FILE *fp = fopen (file, "r");
 	char line[GMT_LEN256] = {""};
-	unsigned int type = GMT_X;
 	if (fp == NULL) {	/* Not good, wrong filename? */
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -/: File %s not found\n", file);
 		return;

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -10968,7 +10968,9 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 	uint64_t k, k0, k1, kk, row, nx, n, n_add, np, first[2] = {0, 0}, last[2] = {0, 0}, start[2] = {0, 0}, stop[2] = {0, 0}, n_alloc;
 	int64_t r;
 	double min_S0, min_S1, max_S0, max_S1, *xp = NULL, *yp = NULL;
+#ifdef FILL_DEBUG
 	char *debug_code = "GCX";
+#endif
 	struct GMT_CURVES_CROSS *X = NULL;
 	struct GMT_XOVER XC;
 	struct GMT_XSEGMENT *ylist1 = NULL, *ylist2 = NULL;

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -1247,7 +1247,7 @@ GMT_LOCAL void gmtproj_tm (struct GMT_CTRL *P, double lon, double lat, double *x
 
 GMT_LOCAL void gmtproj_itm (struct GMT_CTRL *GMT, double *lon, double *lat, double x, double y) {
 	/* Convert TM x/y to lon/lat */
-	double M, mu, s, c, s2, c2, s4, s6, s8, phi1, C1, C12, T1, T12, tmp, tmp2, N1, R_1, D, D2, D3, D4, D5, D6, tan_phi1, cp2;
+	double M, mu, s, c, s2, c2, s4, s6, s8, phi1, C1, C12, T1, T12, tmp, tmp2, N1, R_1, D, D2, D3, D4, D5, D6, tan_phi1;
 
 	M = y / GMT->current.setting.proj_scale_factor + GMT->current.proj.t_M0;
 	mu = M * GMT->current.proj.t_i1;

--- a/src/gmtspatial.c
+++ b/src/gmtspatial.c
@@ -1990,7 +1990,7 @@ EXTERN_MSC int GMT_gmtspatial (void *V_API, int mode, void *args) {
 
 	if (Ctrl->N.active) {	/* Report the polygons that contain the given features */
 		bool check_next;
-		uint64_t tbl, row, col, n, p, np, seg, seg2, n_inside;
+		uint64_t tbl, row, col, n, p, seg, seg2, n_inside;
 		int64_t kk;
 		unsigned int *count = NULL, nmode;
 		int ID = -1;

--- a/src/longopt/gmtregress_inc.h
+++ b/src/longopt/gmtregress_inc.h
@@ -31,7 +31,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 		  GMT_TP_STANDARD },
 	{ 0, 'C', "confidence|confidence_level", "", "", "", "", GMT_TP_STANDARD },
 	{ 0, 'E', "regression|regression_type",
-	          "x,y,o,r",           "x_on_y,y_on_x,ortho|orthogonal,reduced"
+	          "x,y,o,r",           "x_on_y,y_on_x,ortho|orthogonal,reduced",
 	          "",                  "",
 		  GMT_TP_STANDARD },
 	{ 0, 'F', "columns|column_combination", "", "", "", "", GMT_TP_STANDARD },

--- a/src/mgd77/mgd77.c
+++ b/src/mgd77/mgd77.c
@@ -475,7 +475,7 @@ bool MGD77_txt_are_constant (struct GMT_CTRL *GMT, char *txt, uint64_t n, size_t
 	return (true);
 }
 
-bool MGD77_dbl_are_constant (struct GMT_CTRL *GMT, double x[], uint64_t n, double limits[2]) {
+bool MGD77_dbl_are_constant (struct GMT_CTRL *GMT, double x[], uint64_t n, double limits[]) {
 	/* Determine if the values in x[] are all the same, and sets actual range limits */
 	uint64_t i;
 	bool constant = true;

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -807,7 +807,7 @@ GMT_LOCAL unsigned int psxy_old_E_parser (struct GMTAPI_CTRL *API, struct PSXY_C
 			n_errors++;
 		}
 	}
-	return (n_errors);
+	return  (n_errors);
 }
 
 static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTION *options, struct GMT_SYMBOL *S) {
@@ -818,7 +818,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, ztype, k, n_files = 0;
+	unsigned int n_errors = 0, ztype, n_files = 0;
 	int j;
 	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;

--- a/src/triangulate.c
+++ b/src/triangulate.c
@@ -959,7 +959,7 @@ EXTERN_MSC int GMT_triangulate (void *V_API, int mode, void *args) {
 				for (i = ij = 0; i < np; i++, ij += 3) {
 					sprintf (record, "Polygon %d-%d-%d ", link[ij], link[ij+1], link[ij+2]);
 					if (Ctrl->S.mode > TRI_POLY) {
-						double z_triangle, z_node[3];
+						double z_triangle = 0.0, z_node[3];
 						for (k = 0; k < 3; k++) z_node[k] = zz[link[ij+k]];	/* Get the three vertices' z-values */
 						switch (Ctrl->S.mode) {
 							case TRI_LOWER:	/* Set z to the lowest of the three nodes */

--- a/src/windbarbs/grdbarb.c
+++ b/src/windbarbs/grdbarb.c
@@ -147,7 +147,6 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDBARB_CTRL *Ctrl, struct GMT
 	 */
 
 	unsigned int n_errors = 0, n_files = 0;
-	size_t len;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -237,12 +236,12 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct GRDBARB_CTRL *Ctrl, struct GMT
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
 EXTERN_MSC int GMT_grdbarb (void *V_API, int mode, void *args) {
-	unsigned int justify, row, col, col_0, row_0, d_col, d_row, k, n_warn[1] = {0}, warn;
+	unsigned int justify, row, col, col_0, row_0, d_col, d_row, k, n_warn[1] = {0};
 	int error = 0;
 	
 	uint64_t ij;
 
-	double tmp, x, y, plot_x, plot_y, x_off, y_off, f;
+	double tmp, x, y, plot_x, plot_y, x_off, y_off;
 	double x2, y2, wesn[4], value, vec_length, vec_azim, c, s;
 
 	struct GMT_GRID *Grid[2] = {NULL, NULL};

--- a/src/windbarbs/psbarb.c
+++ b/src/windbarbs/psbarb.c
@@ -183,7 +183,7 @@ GMT_LOCAL int parse (struct GMT_CTRL *GMT, struct PSBARB_CTRL *Ctrl, struct GMT_
 
 	unsigned int n_errors = 0;
 	int n;
-	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, *c = NULL;
+	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""};
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
 
@@ -293,28 +293,26 @@ EXTERN_MSC int GMT_psbarb (void *V_API, int mode, void *args) {
 	/* High-level function that implements the psbarb task */
 	bool penset_OK = true, old_is_world;
 	bool get_rgb, clip_set = false, fill_active;
-	bool default_outline, outline_active, save_u = false;
-	unsigned int k, j, geometry, tbl, pos2x, pos2y, set_type;
-	unsigned int n_cols_start = 3, justify, v4_outline = 0, v4_status = 0;
-	unsigned int bcol, ex1, ex2, ex3, change, n_needed, read_mode;
+	bool default_outline, outline_active;
+	unsigned int k, j, geometry, pos2x, pos2y, set_type;
+	unsigned int n_cols_start = 3, justify;
+	unsigned int ex1, ex2, ex3, n_needed, read_mode;
 	int error = GMT_NOERROR;
 
 	uint64_t i, n, n_total_read = 0;
 	size_t n_alloc = 0;
 
-	char *text_rec = NULL, s_args[GMT_BUFSIZ] = {""};
+	char s_args[GMT_BUFSIZ] = {""};
 
 	void *record = NULL;	/* Opaque pointer to either a text or double record */
 
-	double dim[PSL_MAX_DIMS], rgb[3][4] = {{-1.0, -1.0, -1.0, 0.0}, {-1.0, -1.0, -1.0, 0.0}, {-1.0, -1.0, -1.0, 0.0}};
-	double DX = 0, DY = 0, *xp = NULL, *yp = NULL, *in = NULL, *v4_rgb = NULL;
-	double lux[3] = {0.0, 0.0, 0.0}, tmp, x_1, x_2, y_1, y_2, dx, dy, s, c, length;
+	double DX = 0, DY = 0, *in = NULL;
+	double lux[3] = {0.0, 0.0, 0.0}, tmp, x_2, y_2, dx, dy, s, c;
 
 	struct GMT_PEN default_pen, current_pen;
 	struct GMT_FILL default_fill, current_fill, black, no_fill;
 	struct GMT_SYMBOL S;
 	struct GMT_PALETTE *P = NULL;
-	struct GMT_DATASEGMENT *L = NULL;
 	struct PSBARB_DATA *data = NULL;
 	struct PSBARB_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;		/* General GMT internal parameters */
@@ -446,8 +444,7 @@ EXTERN_MSC int GMT_psbarb (void *V_API, int mode, void *args) {
 
 	{	/* symbol part */
 		bool periodic = false;
-		unsigned int n_warn[3] = {0, 0, 0}, warn, item, n_times;
-		double in2[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, *p_in = GMT->current.io.curr_rec;
+		unsigned int item, n_times;
 		double xpos[2], width, d;
 		double z;	/* PSBARB */
 		


### PR DESCRIPTION
**Description of proposed changes**

This is to do some code cleaning
- Removed unused variables (this causes warnings)
- Initialised one variable in triangulate.c (caused warning without)
- Added () in gmt_io.c in if statement with many || and && (caused warning without)
- Added one missing comma in longopt/gmtregress_inc.h (caused warning without)

**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
