### PR TITLE
Use named enums in grdinfo and improve -L layout

### DIFF
--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -127,18 +127,16 @@ Optional Arguments
 .. _-L:
 
 **-L**\ [**0**\|\ **1**\|\ **2**\|\ **p**\|\ **a**]
-    |-L|\ **0**
-        Report range of *v* after actually scanning the data, not just
-        reporting what the header says.
-    |-L|\ **1**
-        Report median and L1 scale of *v* (L1 scale = 1.4826 \* Median
-        Absolute Deviation (MAD)).
-    |-L|\ **2**
-        Report mean, standard deviation, and root-mean-square (rms) of *v*.
-    |-L|\ **p**
-        Report mode (LMS) and LMS scale of *v*.
-    |-L|\ **a**
-        All of the above.
+    Select various statistical reports of the grid values. Choose
+    from these directives:
+
+    - **0**: Report range of *v* after actually scanning the data, not just
+      reporting what the header says.
+    - **1**: Report median and L1 scale of *v* (L1 scale = 1.4826 \* Median
+      Absolute Deviation (MAD)).
+    - **2**: Report mean, standard deviation (L2 scale), and root-mean-square (rms) of *v* [Default].
+    - **p**: Report mode (LMS) and LMS scale of *v*.
+    - **a**: Report all of the above.
 
     **Note**: If the grid is geographic then each node represents a physical
     area that decreases with increasing latitude.  We therefore report

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -53,7 +53,7 @@ enum Opt_C_modes {
 enum Opt_L_modes {
 	GRDINFO_RANGE	= 0,
 	GRDINFO_MEAN	= 1,
-	GRDINFO_MEDIA	= 2,
+	GRDINFO_MEDIAN	= 2,
 	GRDINFO_MODE	= 4};
 
 enum Opt_M_modes {

--- a/src/grdinfo.c
+++ b/src/grdinfo.c
@@ -50,6 +50,12 @@ enum Opt_C_modes {
 	GRDINFO_NUMERICAL	= 1,
 	GRDINFO_TRAILING	= 2};
 
+enum Opt_L_modes {
+	GRDINFO_RANGE	= 0,
+	GRDINFO_MEAN	= 1,
+	GRDINFO_MEDIA	= 2,
+	GRDINFO_MODE	= 4};
+
 enum Opt_M_modes {
 	GRDINFO_FORCE_REPORT	= 1,
 	GRDINFO_FORCE			= 2,
@@ -314,13 +320,13 @@ static int parse (struct GMT_CTRL *GMT, struct GRDINFO_CTRL *Ctrl, struct GMT_OP
 				Ctrl->L.active = true;
 				switch (opt->arg[0]) {
 					case '\0': case '2':
-						Ctrl->L.norm |= 2; break;
+						Ctrl->L.norm |= GRDINFO_MEAN; break;
 					case '1':
-						Ctrl->L.norm |= 1; break;
+						Ctrl->L.norm |= GRDINFO_MEDIAN; break;
 					case 'p':
-						Ctrl->L.norm |= 4; break;
-					case 'a':	/* All three */
-						Ctrl->L.norm |= (1+2+4); break;
+						Ctrl->L.norm |= GRDINFO_MODE; break;
+					case 'a':	/* Select all three */
+						Ctrl->L.norm |= (GRDINFO_MEAN+GRDINFO_MEDIAN+GRDINFO_MODE); break;
 				}
 				break;
 			case 'M':	/* Global extrema and|or update missing header data range */
@@ -645,9 +651,9 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 		if (!Ctrl->I.active) {
 			n_cols += (is_cube) ? 6 : 4;				/* Add dx dy {dz} n_columns n_rows {n_layers} */
 			if (Ctrl->M.mode == GRDINFO_FORCE_REPORT) n_cols += (is_cube) ? 7 : 5;	/* Add x0 y0 {z0} x1 y1 {z1} nnan */
-			if (Ctrl->L.norm & 1) n_cols += 2;	/* Add median scale */
-			if (Ctrl->L.norm & 2) n_cols += 3;	/* Add mean stdev rms */
-			if (Ctrl->L.norm & 4) n_cols += 2;	/* Add mode lmsscale */
+			if (Ctrl->L.norm & GRDINFO_MEDIAN) n_cols += 2;	/* Add median scale */
+			if (Ctrl->L.norm & GRDINFO_MEAN)   n_cols += 3;	/* Add mean stdev rms */
+			if (Ctrl->L.norm & GRDINFO_MODE)   n_cols += 2;	/* Add mode lmsscale */
 			n_cols += 2;		/* Add registration and type */
 		}
 		if (Ctrl->C.mode == GRDINFO_NUMERICAL) cmode = GMT_COL_FIX_NO_TEXT;
@@ -857,16 +863,16 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 			gmt_get_cellarea (GMT, W);
 		}
 
-		if (Ctrl->L.norm & 1) {	/* Calculate the median and MAD */
+		if (Ctrl->L.norm & GRDINFO_MEDIAN) {	/* Calculate the median and MAD */
 			z_median = gmt_grd_median (GMT, G, W, false);
 			z_scale = gmt_grd_mad (GMT, G, W, &z_median, false);
 		}
-		if (Ctrl->L.norm & 2) {	/* Calculate the mean, standard deviation, and rms */
+		if (Ctrl->L.norm & GRDINFO_MEAN) {	/* Calculate the mean, standard deviation, and rms */
 			z_mean = gmt_grd_mean (GMT, G, W);	/* Compute the [weighted] mean */
 			z_stdev = gmt_grd_std (GMT, G, W);	/* Compute the [weighted] stdev */
 			z_rms = gmt_grd_rms (GMT, G, W);		/* Compute the [weighted] rms */
 		}
-		if (Ctrl->L.norm & 4) {	/* Calculate the mode and lmsscale */
+		if (Ctrl->L.norm & GRDINFO_MODE) {	/* Calculate the mode and lmsscale */
 			z_mode = gmt_grd_mode (GMT, G, W, false);
 			z_lmsscl = gmt_grd_lmsscl (GMT, G, W, &z_mode, false);
 		}
@@ -965,16 +971,16 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 					out[col++] = x_min;	out[col++] = y_min;	if (is_cube) out[col++] = z_min;
 					out[col++] = x_max;	out[col++] = y_max;	if (is_cube) out[col++] = z_max;
 				}
-				if (Ctrl->L.norm & 1) {
+				if (Ctrl->L.norm & GRDINFO_MEDIAN) {
 					out[col++] = z_median;	out[col++] = z_scale;
 				}
-				if (Ctrl->L.norm & 2) {
+				if (Ctrl->L.norm & GRDINFO_MEAN) {
 					out[col++] = z_mean;	out[col++] = z_stdev;	out[col++] = z_rms;
 				}
 				if (Ctrl->M.mode == GRDINFO_FORCE_REPORT) {
 					out[col++] = (double)n_nan;
 				}
-				if (Ctrl->L.norm & 4) {
+				if (Ctrl->L.norm & GRDINFO_MODE) {
 					out[col++] = z_mode;	out[col++] = z_lmsscl;
 				}
 				out[col++] = header->registration;
@@ -1031,17 +1037,17 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text, y_max, GMT_OUT, GMT_Y);	strcat (record, text);
 					if (is_cube) { strcat (record, sep);	gmt_ascii_format_col (GMT, text, z_max, GMT_OUT, GMT_Z);	strcat (record, text); }
 				}
-				if (Ctrl->L.norm & 1) {
+				if (Ctrl->L.norm & GRDINFO_MEDIAN) {
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text, z_median, GMT_OUT, GMT_Z);	strcat (record, text);
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text,  z_scale, GMT_OUT, GMT_Z);	strcat (record, text);
 				}
-				if (Ctrl->L.norm & 2) {
+				if (Ctrl->L.norm & GRDINFO_MEAN) {
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text, z_mean, GMT_OUT, GMT_Z);	strcat (record, text);
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text, z_stdev, GMT_OUT, GMT_Z);	strcat (record, text);
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text,   z_rms, GMT_OUT, GMT_Z);	strcat (record, text);
 				}
 				if (Ctrl->M.mode == GRDINFO_FORCE_REPORT) { sprintf (text, "%s%" PRIu64, sep, n_nan);	strcat (record, text); }
-				if (Ctrl->L.norm & 4) {
+				if (Ctrl->L.norm & GRDINFO_MODE) {
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text, z_mode,   GMT_OUT, GMT_Z);	strcat (record, text);
 					strcat (record, sep);	gmt_ascii_format_col (GMT, text, z_lmsscl, GMT_OUT, GMT_Z);	strcat (record, text);
 				}
@@ -1212,14 +1218,14 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 				sprintf (record, "%s: %" PRIu64 " nodes (%.1f%%) set to NaN", HH->name, n_nan, percent);
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			}
-			if (Ctrl->L.norm & 1) {
+			if (Ctrl->L.norm & GRDINFO_MEDIAN) {
 				sprintf (record, "%s: median: ", HH->name);
 				gmt_ascii_format_col (GMT, text, z_median, GMT_OUT, GMT_Z);	strcat (record, text);
 				strcat (record, " scale: ");
 				gmt_ascii_format_col (GMT, text, z_scale, GMT_OUT, GMT_Z);	strcat (record, text);
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			}
-			if (Ctrl->L.norm & 2) {
+			if (Ctrl->L.norm & GRDINFO_MEAN) {
 				sprintf (record, "%s: mean: ", HH->name);
 				gmt_ascii_format_col (GMT, text,  z_mean, GMT_OUT, GMT_Z);	strcat (record, text);
 				strcat (record, " stdev: ");
@@ -1228,7 +1234,7 @@ EXTERN_MSC int GMT_grdinfo (void *V_API, int mode, void *args) {
 				gmt_ascii_format_col (GMT, text,   z_rms, GMT_OUT, GMT_Z);	strcat (record, text);
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			}
-			if (Ctrl->L.norm & 4) {
+			if (Ctrl->L.norm & GRDINFO_MODE) {
 				sprintf (record, "%s: mode: ", HH->name);
 				gmt_ascii_format_col (GMT, text,   z_mode, GMT_OUT, GMT_Z);	strcat (record, text);
 				strcat (record, " lmsscale: ");


### PR DESCRIPTION
Use separate directives, and use named constants like **GRDINFO_MEAN** (2), **GRDINFO_MEDIAN** (1) and **GRDINFO_MODE** (2) to clarify what the tests on `Ctrl->L.mode` mean Better **-L** layout:

<img width="885" alt="L" src="https://github.com/GenericMappingTools/gmt/assets/26473567/fa489cb4-4714-41e1-ab02-ae1fa998ef61">
