### PR TITLE
Strengthen -Elines documentation for grdtrack and grdinterpolate

### DIFF
--- a/doc/rst/source/explain_interpolant.rst_
+++ b/doc/rst/source/explain_interpolant.rst_
@@ -1,0 +1,14 @@
+**-Fl**\|\ **a**\|\ **c**\|\ **e**\|\ **l**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**]
+    Choose the desired 1-D spline interpolant from one of these directives:
+
+    - **a**: Akima spline [Default].
+    - **e**: Step curve.
+    - **c**: Natural cubic spline.
+    - **l**: Linear interpolant.
+    - **n**: No interpolation, just select nearest point.
+    - **s**: Smoothing cubic spline; append fit parameter *p* for an approximate fit.
+
+    You may change the GMT default interpolant; see :term:`GMT_INTERPOLANT` in your :doc:`gmt.conf` file.
+    You may optionally evaluate the first or second derivative of the spline
+    by appending **+d1** or **+d2**, respectively. **Note**: If you use derivatives
+    with directives **e** or **n** then the result is always zero.

--- a/doc/rst/source/explain_lines.rst_
+++ b/doc/rst/source/explain_lines.rst_
@@ -1,33 +1,33 @@
 **-E**\ *table*\|\ *origin*\ |\ *line*\ [,\ *line*,...][**+a**\ *az*][**+c**][**+d**][**+g**][**+i**\ *inc*][**+l**\ *length*][**+n**\ *np*][**+o**\ *az*][**+p**][**+r**\ *radius*][**+x**]
-    Specify one or more profiles along which we will sample the grid (or cube)
+    Specify one or more profiles along which we will sample the grid (or cube).
+    There are several way to supply or create the profiles:
 
     - Give your custom profiles via a *table* containing *lon lat* points.
-    - Given and origin (and azimuth and length via relevant modifiers below)
+    - Given an *origin* (and *azimuth* and *length* and relevant modifiers below).
     - Give one or more lines. The format of each *line* is *start*/*stop*, where
       *start* or *stop* are either *lon*/*lat* (*x*/*y* for Cartesian data) or a
-      2-character XY key that uses the :doc:`text`-style justification format to 
+      2-character key that uses the :doc:`text`-style justification format to 
       specify a point on the map as [LCR][BMT]. In addition to line coordinates,
       you can use Z-, Z+ to mean the global minimum and maximum locations in the
-      grid (only available if a single input grid is given.    
+      grid (only available if a single input grid is given) or top layer in a cube
+      (only for doc:`grdinterpolate`).
 
-    Choose among several modifiers to affect the profiles:
+    Choose among several modifiers to create profiles:
 
     - **+a**: Set the *azimuth* of a profile of given *length* (see **+l**) starting at the given *origin*.
-    - **+c**: Connect profile segments with shared joints into a single segment.
+    - **+c**: Connect multiple profile segments with shared joints into a single segment.
     - **+d**: Compute the along-track distances of the profiles.
     - **+g**: Report degrees of longitude or latitude instead of great circle distances starting at zero [Default].
     - **+i**: Append *inc* to set the sampling interval; if not given then we default to half the minimum grid interval.
-    - **+l**: Append the total length of the profile if **+a** or **+o** are used with *origin*.
+    - **+l**: Append the total *length* of the profile if **+a** or **+o** are used with an *origin*.
     - **+n**: Append the desired number of points along profile (which determines the sampling interval). 
-    - **+o**: Like **+a** but centers the profile on the given *origin* in the *azimuth* direction.
+    - **+o**: Like **+a**, but centers the profile on the given *origin* in the *azimuth* direction.
     - **+p**: Force sampling along the parallel if your *line* starts and ends at the same latitude [Great circle].
     - **+r**: Append *radius* for circular sampling along small circle of given radius centered on the *origin*.
       Requires either **+n** or **+i**.
-    - **+x**: Compute distances along a loxodrome (rhumbline) instead of along the great circle.
+    - **+x**: Compute distances along a loxodrome (i.e., rhumbline) instead of along the great circle.
 
     **Notes**: (1) Only one distance unit can be chosen.  Giving different units
     will result in an error.  If no units are specified we default to
-    great circle distances in km (if geographic).  If working with geographic
+    great circle distances in km (if geographic). (2) If working with geographic
     data you can use **-j** to control the distance calculation mode [Great Circle].
-    (2) If |-C| is set and *spacing* is given then that sampling scheme
-    overrules any modifier set in |-E|.

--- a/doc/rst/source/explain_lines.rst_
+++ b/doc/rst/source/explain_lines.rst_
@@ -1,0 +1,33 @@
+**-E**\ *table*\|\ *origin*\ |\ *line*\ [,\ *line*,...][**+a**\ *az*][**+c**][**+d**][**+g**][**+i**\ *inc*][**+l**\ *length*][**+n**\ *np*][**+o**\ *az*][**+p**][**+r**\ *radius*][**+x**]
+    Specify one or more profiles along which we will sample the grid (or cube)
+
+    - Give your custom profiles via a *table* containing *lon lat* points.
+    - Given and origin (and azimuth and length via relevant modifiers below)
+    - Give one or more lines. The format of each *line* is *start*/*stop*, where
+      *start* or *stop* are either *lon*/*lat* (*x*/*y* for Cartesian data) or a
+      2-character XY key that uses the :doc:`text`-style justification format to 
+      specify a point on the map as [LCR][BMT]. In addition to line coordinates,
+      you can use Z-, Z+ to mean the global minimum and maximum locations in the
+      grid (only available if a single input grid is given.    
+
+    Choose among several modifiers to affect the profiles:
+
+    - **+a**: Set the *azimuth* of a profile of given *length* (see **+l**) starting at the given *origin*.
+    - **+c**: Connect profile segments with shared joints into a single segment.
+    - **+d**: Compute the along-track distances of the profiles.
+    - **+g**: Report degrees of longitude or latitude instead of great circle distances starting at zero [Default].
+    - **+i**: Append *inc* to set the sampling interval; if not given then we default to half the minimum grid interval.
+    - **+l**: Append the total length of the profile if **+a** or **+o** are used with *origin*.
+    - **+n**: Append the desired number of points along profile (which determines the sampling interval). 
+    - **+o**: Like **+a** but centers the profile on the given *origin* in the *azimuth* direction.
+    - **+p**: Force sampling along the parallel if your *line* starts and ends at the same latitude [Great circle].
+    - **+r**: Append *radius* for circular sampling along small circle of given radius centered on the *origin*.
+      Requires either **+n** or **+i**.
+    - **+x**: Compute distances along a loxodrome (rhumbline) instead of along the great circle.
+
+    **Notes**: (1) Only one distance unit can be chosen.  Giving different units
+    will result in an error.  If no units are specified we default to
+    great circle distances in km (if geographic).  If working with geographic
+    data you can use **-j** to control the distance calculation mode [Great Circle].
+    (2) If |-C| is set and *spacing* is given then that sampling scheme
+    overrules any modifier set in |-E|.

--- a/doc/rst/source/grdinterpolate.rst
+++ b/doc/rst/source/grdinterpolate.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt grdinterpolate** *cube* | *grd1 grd2 ...*
 |-G|\ *outfile*
 [ |SYN_OPT-D3| ]
-[ |-E|\ *table*\|\ *line* ]
+[ |-E|\ *line* ]
 [ |-F|\ **a**\|\ **c**\|\ **e**\|\ **l**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**] ]
 [ |SYN_OPT-R| ]
 [ |-S|\ *x/y*\|\ *pointfile*\ [**+h**\ *header*] ]
@@ -78,29 +78,8 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *table*\|\ *line*\ [,\ *line*,...][**+a**\ *az*][**+g**][**+i**\ *inc*][**+l**\ *length*][**+n**\ *np*][**+o**\ *az*][**+p**][**+r**\ *radius*][**+x**]
-    Specify a crossectinonal profile via a *file* or from specified *line* coordinates and modifiers.
-    If a *file*, it must be contain a single segment with either *lon lat* or *lon lat dist* records.
-    These must be equidistant.  Alternatively, the format of each *line* is
-    *start*/*stop*, where *start* or *stop* are *lon*/*lat* (*x*/*y* for
-    Cartesian data). You may append **+i**\ *inc* to set the sampling interval;
-    if not given then we default to half the minimum grid interval.  If your *line* starts and
-    ends at the same latitude you can force sampling along the parallel with **+p** [great circle].
-    For a *line* along parallels or meridians you can add **+g** to report degrees of longitude or latitude
-    instead of great circle distances starting at zero.  Append **+x** to compute distances
-    along a loxodrome (rhumbline) instead of great circle. Instead of two coordinates
-    you can specify an origin and one of **+a**, **+o**, or **+r**.
-    The **+a** sets the azimuth of a profile of given
-    length starting at the given origin, while **+o** centers the profile
-    on the origin; both require **+l**. For circular sampling specify
-    **+r** to define a circle of given radius centered on the origin;
-    this option requires either **+n** or **+i**.  The **+n**\ *np* modifier sets
-    the desired number of points, while **+l**\ *length* gives the
-    total length of the profile.
-    Also note that only one distance unit can be chosen.  Giving different units
-    will result in an error.  If no units are specified we default to
-    great circle distances in km (if geographic).  If working with geographic
-    data you can use **-j** to control distance calculation mode [Great Circle].
+.. include:: explain_lines.rst_
+
     Use |-G| to set the output grid file name.
 
 .. _-F:

--- a/doc/rst/source/grdinterpolate.rst
+++ b/doc/rst/source/grdinterpolate.rst
@@ -16,7 +16,7 @@ Synopsis
 |-G|\ *outfile*
 [ |SYN_OPT-D3| ]
 [ |-E|\ *table*\|\ *line* ]
-[ |-F|\ **l**\|\ **a**\|\ **c**\|\ **n**\ [**+d**\ 1\|\ 2] ]
+[ |-F|\ **a**\|\ **c**\|\ **e**\|\ **l**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**] ]
 [ |SYN_OPT-R| ]
 [ |-S|\ *x/y*\|\ *pointfile*\ [**+h**\ *header*] ]
 [ |-T|\ [*min/max*\ /]\ *inc*\ [**+i**\|\ **n**] \|\ |-T|\ *file*\|\ *list* ]
@@ -105,13 +105,7 @@ Optional Arguments
 
 .. _-F:
 
-**-Fl**\|\ **a**\|\ **c**\|\ **n**\ [**+d**\ 1\|\ 2]
-    Choose from **l** (Linear), **a** (Akima spline), **c** (natural
-    cubic spline), and **n** (no interpolation: nearest point) [Default
-    is **-Fa**]. You may change the default interpolant; see
-    :term:`GMT_INTERPOLANT` in your :doc:`gmt.conf` file.
-    You may optionally evaluate the first or second derivative of the spline
-    by appending **+d** and specify 1 or 2, respectively.
+.. include:: explain_interpolant.rst_
 
 .. |Add_-R| replace:: Using the |-R| option will select a subsection of the grid. If this subsection exceeds the
     boundaries of the grid, only the common region will be output. |Add_-R_links|

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -146,7 +146,7 @@ Optional Arguments
     In concert with |-C| we can save the (possibly resampled) original
     lines to the file *dfile* [Default only saves the cross-profiles].
     The columns will be *lon*, *lat*, *dist*, *azimuth*, *z1*, *z2*, ...
-    (sampled value for each grid)
+    (sampled value for each grid).
 
 .. _-E:
 

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -150,35 +150,9 @@ Optional Arguments
 
 .. _-E:
 
-**-E**\ *line*\ [,\ *line*,...][**+a**\ *az*][**+c**][**+d**][**+g**][**+i**\ *inc*][**+l**\ *length*][**+n**\ *np*][**+o**\ *az*][**+r**\ *radius*]
-    Instead of reading input track coordinates, specify profiles via
-    coordinates and modifiers. The format of each *line* is
-    *start*/*stop*, where *start* or *stop* are either *lon*/*lat* (*x*/*y* for
-    Cartesian data) or a 2-character XY key that uses the :doc:`text`-style
-    justification format to specify a point on the map as
-    [LCR][BMT]. Each line will be a separate segment unless **+c** is used
-    which will connect segments with shared joints into a single segment.
-    In addition to line coordinates, you can use Z-, Z+ to mean the global
-    minimum and maximum locations in the grid (only available if a
-    single grid is given via |-G|). You may append
-    **+i**\ *inc* to set the sampling interval; if not given then
-    we default to half the minimum grid interval.  For a *line* along parallels
-    or meridians you can add **+g** to report degrees of longitude or latitude
-    instead of great circle distances starting at zero.  Instead of two coordinates
-    you can specify an origin and one of **+a**, **+o**, or **+r**.
-    The **+a** sets the azimuth of a profile of given
-    length starting at the given origin, while **+o** centers the profile
-    on the origin; both require **+l**. For circular sampling specify
-    **+r** to define a circle of given radius centered on the origin;
-    this option requires either **+n** or **+i**.  The **+n**\ *np* modifier sets
-    the desired number of points, while **+l**\ *length* gives the
-    total length of the profile. Append **+d** to output the along-track
-    distances after the coordinates.  **Notes**: (1) No track file will be read.
-    Also note that only one distance unit can be chosen.  Giving different units
-    will result in an error.  If no units are specified we default to
-    great circle distances in km (if geographic).  If working with geographic
-    data you can use **-j** to control distance calculation mode [Great Circle].
-    (2) If |-C| is set and *spacing* is given the that sampling scheme
+.. include:: explain_lines.rst_
+
+    (3) If |-C| is set and *spacing* is given then that sampling scheme
     overrules any modifier set in |-E|.
 
 .. _-F:

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -137,7 +137,8 @@ Optional Arguments
     *deviation* [0]. Looking in the direction of the line, a positive *deviation*
     will rotate the crosslines clockwise and a negative one will rotate them
     counter-clockwise.  Finally, you can use **+f** to set a fixed azimuth
-    for all profiles.
+    for all profiles. **Note**: If |-C| is set and *spacing* is given then
+    that sampling scheme overrules any modifier set in |-E|.
 
 .. _-D:
 

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -92,19 +92,13 @@ Optional Arguments
 
 .. _-F:
 
-**-Fl**\|\ **a**\|\ **c**\|\ **e**\|\ **l**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**]
-    Choose from **a** (Akima spline), **e** (step curve), **c** (natural cubic spline),
-    **l** (Linear), **n** (no interpolation: nearest point), or **s** (smoothing cubic
-    spline; append fit parameter *p*) [Default is **-Fa**]. You may change the default interpolant; see :term:`GMT_INTERPOLANT` in your :doc:`gmt.conf` file.
-    You may optionally evaluate the first or second derivative of the spline
-    by appending **+d1** or **+d2**, respectively. **Note**: If you use the derivatives
-    with directives **e** or **n** then the result is always zero.
+.. include:: explain_interpolant.rst_
 
 .. figure:: /_images/GMT_splines.*
    :width: 500 px
    :align: center
 
-   The |-F| option lets you choose among several interpolators, including
+   The |-F| option lets you choose among several interpolants, including
    one that is approximate (the smoothing spline).  You can also specify
    that you actually need a derivative of the solution instead of the value.
 

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -367,6 +367,9 @@ enum GMT_time_period {
 /* Modifiers for contour -A option */
 #define GMT_CONTSPEC_MODS "acdefghijklLnNoprstuvwxX="
 
+/* Directives and modifiers for -F interpolant option */
+#define GMT_INTERPOLANT_OPT "a|c|e|l|n|s<p>[+d1|2]"
+
 /* Valid modifiers for various input files */
 
 /* Valid modifiers for -Tmin/max/inc array creator */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -543,6 +543,7 @@ EXTERN_MSC void gmt_set_refpoint (struct GMT_CTRL *GMT, struct GMT_REFPOINT *A);
 EXTERN_MSC void gmt_free_refpoint (struct GMT_CTRL *GMT, struct GMT_REFPOINT **Ap);
 EXTERN_MSC void gmt_flip_azim_d (struct GMT_CTRL *GMT, double *azim);
 EXTERN_MSC void gmt_flip_angle_d (struct GMT_CTRL *GMT, double *angle);
+EXTERN_MSC void gmt_explain_lines (struct GMTAPI_CTRL *API, unsigned mode);
 EXTERN_MSC struct GMT_DATASET * gmt_make_profiles (struct GMT_CTRL *GMT, char option, char *args, bool resample, bool project, bool get_distances, double step, enum GMT_enum_track mode, double xyz[2][3], unsigned int *dtype);
 EXTERN_MSC unsigned int gmt_split_poly_at_dateline (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S, struct GMT_DATASEGMENT ***Lout);
 EXTERN_MSC bool gmt_x_is_outside (struct GMT_CTRL *GMT, double *x, double left, double right);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -490,7 +490,9 @@ EXTERN_MSC struct GMT_CONTOUR_INFO * gmt_get_contours_from_table (struct GMT_CTR
 EXTERN_MSC int gmt_signum (double x);
 EXTERN_MSC void gmt_get_rgb_lookup (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, int index, double value, double *rgb);
 EXTERN_MSC int gmt_locate_custom_symbol (struct GMT_CTRL *GMT, const char *in_name, char *name, char *path, unsigned int *pos);
+EXTERN_MSC unsigned gmt_parse_interpolant (struct GMTAPI_CTRL *API, char *arg, unsigned int *mode, unsigned int *type, double *fit);
 EXTERN_MSC unsigned int gmt_set_interpolate_mode (struct GMT_CTRL *GMT, unsigned int mode, unsigned int type);
+EXTERN_MSC void gmt_explain_interpolate_mode (struct GMTAPI_CTRL *API);
 EXTERN_MSC unsigned int gmt_get_dist_units (struct GMT_CTRL *GMT, char *args, char *unit, unsigned int *mode);
 EXTERN_MSC unsigned int gmt_validate_cpt_parameters (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, char *file, bool *interpolate, bool *force_continuous);
 EXTERN_MSC void gmt_extend_region (struct GMT_CTRL *GMT, double wesn[], unsigned int mode, double inc[]);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -1622,6 +1622,7 @@ unsigned gmt_parse_interpolant (struct GMTAPI_CTRL *API, char *arg, unsigned int
 	else if (strstr (&arg[1], "+2")) *type = 2;	/* Want second derivative (backwards compatibility) */
 	return (n_errors);
 }
+
 void gmt_explain_interpolate_mode (struct GMTAPI_CTRL *API) {
 	/* Display usage synopsis for -F interpolant option */
 	char type[3] = {'l', 'a', 'c'};
@@ -11159,6 +11160,32 @@ unsigned int gmt_get_dist_units (struct GMT_CTRL *GMT, char *args, char *unit, u
 	return (error);
 }
 
+void gmt_explain_lines (struct GMTAPI_CTRL *API, unsigned mode) {
+	/* mode is 0 for gratrack and 1for grdinterpolate */
+	static char *item[2] = {"grid", "top layer in the cube"};
+	GMT_Usage (API, 1, "\n-E<table|<origin>|<line1>[,<line2>,...][+a<az>][+c][+d][+g][+i<step>][+l<length>][+n<np>][+o<az>][+p][+r<radius>][+x]");
+	GMT_Usage (API, -2, "Read profiles from <table> or create them on the fly. Choose on of these choices:");
+	GMT_Usage (API, 3, "%s Read one or more profiles from <table>", GMT_LINE_BULLET);
+	GMT_Usage (API, 3, "%s Create quick paths based on <line1>[,<line2>,...]. Each <line> is given by <start>/<stop>, where <start> or <stop> "
+		"are <lon/lat> or a 2-character key that uses the \"pstext\"-style justification format "
+		"to specify a point on the map as [LCR][BMT].  In addition, you can use Z-, Z+ to mean "
+		"the global minimum and maximum locations in the %s.", GMT_LINE_BULLET, item[mode]);
+	GMT_Usage (API, 3, "%s Set an origin, provide azimuth and length and more via modifiers and create a profile.", GMT_LINE_BULLET);
+	GMT_Usage (API, -2, "Several modifiers are available to create the profiles:");
+	GMT_Usage (API, 3, "+a Define a profile from <origin> in the <az> direction; requires +l.");
+	GMT_Usage (API, 3, "+c Create a continuous segment if two end points are identical [separate segments].");
+	GMT_Usage (API, 3, "+d Insert an extra output column with distances following the coordinates.");
+	GMT_Usage (API, 3, "+g Use gridline coordinates (degree longitude or latitude) if <line> is so aligned [great circle].");
+	GMT_Usage (API, 3, "+i Set the sampling increment <step> [Default is 0.5 x min of (x_inc, y_inc)].");
+	GMT_Usage (API, 3, "+l Set the length of the profile.");
+	GMT_Usage (API, 3, "+o Like +a but centers profile on <origin>; requires +l.");
+	GMT_Usage (API, 3, "+p Sample along the parallel if <line> has constant latitude.");
+	GMT_Usage (API, 3, "+n Set <np>, the number of output points and compute <inc> from <length>, so +l is required.");
+	GMT_Usage (API, 3, "+r Set <radius> of circle about <origin>; requires +i or +n.");
+	GMT_Usage (API, 3, "+x Follow a loxodrome (rhumbline) [great circle].");
+	GMT_Usage (API, -2, "Note:  A unit is optional.  Only ONE unit type from %s can be used throughout this option, "
+		"so mixing of units is not allowed [Default unit is km, if geographic].", GMT_LEN_UNITS2_DISPLAY);
+}
 
 /*! . */
 struct GMT_DATASET *gmt_make_profiles (struct GMT_CTRL *GMT, char option, char *args, bool resample, bool project, bool get_distances, double step, enum GMT_enum_track mode, double xyz[2][3], unsigned int *dtype) {

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -57,10 +57,11 @@ struct GRDINTERPOLATE_CTRL {
 		double step;
 		char unit;
 	} E;
-	struct GRDINTERPOLATE_F {	/* -Fl|a|c[+d1|2] */
+	struct GRDINTERPOLATE_F {	/* -Fl|a|c|e|n|s<p>[+d1|2] */
 		bool active;
 		unsigned int mode;
 		unsigned int type;
+		double fit;
 		char spline[GMT_LEN8];
 	} F;
 	struct GRDINTERPOLATE_G {	/* -G<output_grdfile>  */
@@ -120,9 +121,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s <cube> | <grd1> <grd2> <grd3> ... -G<outfile> [%s] "
 		"[-E<file>|<line1>[,<line2>,...][+a<az>][+g][+i<step>][+l<length>][+n<np>][+o<az>][+p][+r<radius>][+x]] "
-		"[-Fl|a|c|n[+d1|2]] [%s] [-S<x>/<y>|<table>[+h<header>]] [-T[<min>/<max>/]<inc>[+i|n]] [%s] "
+		"[-F%s [%s] [-S<x>/<y>|<table>[+h<header>]] [-T[<min>/<max>/]<inc>[+i|n]] [%s] "
 		"[-Z[<levels>]] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s] [%s]\n",
-			name,  GMT_GRDEDIT3D, GMT_Rgeo_OPT, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT,
+			name,  GMT_GRDEDIT3D, GMT_INTERPOLANT_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_b_OPT, GMT_d_OPT, GMT_e_OPT, GMT_f_OPT, GMT_g_OPT,
 			GMT_h_OPT, GMT_i_OPT, GMT_n_OPT, GMT_o_OPT, GMT_q_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
@@ -152,14 +153,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -3, "+x Follow a loxodrome (rhumbline) [great circle].");
 	GMT_Usage (API, -2, "Note:  A unit is optional.  Only ONE unit type from %s can be used throughout this option, so "
 		"mixing of units is not allowed [Default unit is km, if grid is geographic].");
-	GMT_Usage (API, 1, "\n-Fl|a|c|n[+d1|2]");
-	GMT_Usage (API, -2, "Set the grid interpolation mode.  Choose from:");
-	GMT_Usage (API, -3, "l: Linear interpolation.");
-	GMT_Usage (API, -3, "a: Akima spline interpolation.");
-	GMT_Usage (API, -3, "c: Cubic spline interpolation.");
-	GMT_Usage (API, -3, "n: No interpolation (nearest point).");
-	GMT_Usage (API, -2, "Optionally, request a spline derivative via a modifier:");
-	GMT_Usage (API, 3, "+d Append 1 for 1st derivative or 2 for 2nd derivative.");
+	gmt_explain_interpolate_mode (API);
 	GMT_Option (API, "R");
 	GMT_Usage (API, 1, "\n-S<x>/<y>|<table>[+h<header>]");
 	GMT_Usage (API, -2, "Give a fixed point for across-stack sampling [Default] or interpolation [with -T]. For "
@@ -223,20 +217,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDINTERPOLATE_CTRL *Ctrl, struct
 				break;
 			case 'F':	/* Set the spline type */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->F.active);
-				switch (opt->arg[0]) {
-					case 'l':	Ctrl->F.mode = GMT_SPLINE_LINEAR;	break;
-					case 'a':	Ctrl->F.mode = GMT_SPLINE_AKIMA;	break;
-					case 'c':	Ctrl->F.mode = GMT_SPLINE_CUBIC;	break;
-					case 'n':	Ctrl->F.mode = GMT_SPLINE_NN;		break;
-					default:
-						GMT_Report (API, GMT_MSG_ERROR, "Option -F: Bad spline selector %c\n", opt->arg[0]);
-						n_errors++;
-						break;
-				}
-				if (strstr (&opt->arg[1], "+d1")) Ctrl->F.type = 1;	/* Want first derivative */
-				else if (strstr (&opt->arg[1], "+d2")) Ctrl->F.type = 2;	/* Want second derivative */
-				else if (strstr (&opt->arg[1], "+1")) Ctrl->F.type = 1;	/* Want first derivative (backwards compatibility) */
-				else if (strstr (&opt->arg[1], "+2")) Ctrl->F.type = 2;	/* Want second derivative (backwards compatibility) */
+				n_errors += gmt_parse_interpolant (API, opt->arg, &(Ctrl->F.mode), &(Ctrl->F.type), &(Ctrl->F.fit));
 				strncpy (Ctrl->F.spline, opt->arg, GMT_LEN8-1);	/* Keep track of what was given since it may need to be passed verbatim to other modules */
 				break;
 			case 'G':	/* Output file or name template */

--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -138,21 +138,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"-G for embedding the level in the file name.");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	gmt_cube_info_syntax (API->GMT, 'D');
-	GMT_Usage (API, 1, "\n-E<file>|<line1>[,<line2>,...][+a<az>][+g][+i<step>][+l<length>][+n<np>][+o<az>][+p][+r<radius>][+x]");
-	GMT_Usage (API, -2, "Set up a single cross-section based on <file> or on the given <line1>[,<line2>,...]. Give "
-		"start and stop coordinates for each line segment.  The format of each <line> is <start>/<stop>, where "
-		"<start> or <stop> are coordinate pairs, e.g., <lon1/lat1>/<lon2>/<lat2>. Append +i<inc> to set the "
-		"sampling increment [Default is 0.5 x min of grid's (x_inc, y_inc)] Instead of <start/stop>, give <origin> "
-		"and append +a|o|l|n|r as required:");
-	GMT_Usage (API, -3, "+a Define a profiles from <origin> in <az> direction. Add +l<length>.");
-	GMT_Usage (API, -3, "+g Use gridline coordinates (degree longitude or latitude) if <line> is so aligned [great circle].");
-	GMT_Usage (API, -3, "+o Define a profile centered on <origin> in <az> direction. Add +l<length>.");
-	GMT_Usage (API, -3, "+p Sample along the parallel if <line> has constant latitude.");
-	GMT_Usage (API, -3, "+r Define a circle about <origin> with given <radius>. Add +i<inc> or +n<np>.");
-	GMT_Usage (API, -3, "+n Set the number of output points as <np> and computes <inc> from <length>.");
-	GMT_Usage (API, -3, "+x Follow a loxodrome (rhumbline) [great circle].");
-	GMT_Usage (API, -2, "Note:  A unit is optional.  Only ONE unit type from %s can be used throughout this option, so "
-		"mixing of units is not allowed [Default unit is km, if grid is geographic].");
+	gmt_explain_lines (API, 1);
 	gmt_explain_interpolate_mode (API);
 	GMT_Option (API, "R");
 	GMT_Usage (API, 1, "\n-S<x>/<y>|<table>[+h<header>]");

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -212,23 +212,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 1, "\n-D<dfile>");
 	GMT_Usage (API, -2, "Save [resampled] input lines to a separate file <dfile>.  Requires -C. "
 		"Output columns are lon, lat, dist, az, z1, z2, ..., zn.");
-	GMT_Usage (API, 1, "\n-E<line1>[,<line2>,...][+a<az>][+c][+d][+g][+i<step>][+l<length>][+n<np>][+o<az>][+r<radius>]");
-	GMT_Usage (API, -2, "Create quick paths based on <line1>[,<line2>,...].  Each <line> is given by <start>/<stop>, where <start> or <stop> "
-		"are <lon/lat> or a 2-character key that uses the \"pstext\"-style justification format "
-		"to specify a point on the map as [LCR][BMT].  In addition, you can use Z-, Z+ to mean "
-		"the global minimum and maximum locations in the grid.  Note: No input <table> is read.");
-	GMT_Usage (API, 3, "+i Set the sampling increment <step> [Default is 0.5 x min of (x_inc, y_inc)].");
-	GMT_Usage (API, 3, "+d Insert an extra output column with distances following the coordinates.");
-	GMT_Usage (API, -2, "Instead of <start/stop>, give <origin> and append +a|o|, +l|r, and others as required:");
-	GMT_Usage (API, 3, "+a Define a profile from <origin> in the <az> direction; requires +l.");
-	GMT_Usage (API, 3, "+c Create a continuous segment if two end points are identical [separate segments].");
-	GMT_Usage (API, 3, "+g Use gridline coordinates (degree longitude or latitude) if <line> is so aligned [great circle].");
-	GMT_Usage (API, 3, "+l Set the length of the profile.");
-	GMT_Usage (API, 3, "+o Like +a but centers profile on <origin>; requires +l.");
-	GMT_Usage (API, 3, "+r Set <radius> of circle about <origin>; requires +i or +n.");
-	GMT_Usage (API, 3, "+n Set <np>, the number of output points and compute <inc> from <length>, so +l is required.");
-	GMT_Usage (API, -2, "Note:  A unit is optional.  Only ONE unit type from %s can be used throughout this option, "
-		"so mixing of units is not allowed [Default unit is km, if geographic].", GMT_LEN_UNITS2_DISPLAY);
+	gmt_explain_lines (API, 0);
 	GMT_Usage (API, 1, "\n-F[+b][+n][+r][+z<z0>]");
 	GMT_Usage (API, -2, "Report center, left, and right point per cross-track; requires -C and a single input grid. ");
 	GMT_Usage (API, 3, "+b Compute the balance point and standard deviation of the profile instead.");


### PR DESCRIPTION
This PR deals with two separate improvements:

1. The **grdtrack** and **grdinterpolate** modules both use the very rich **-E** option for creating profiles on the fly.  The repetitive documentation for the two had some issues and missing modifiers, so this PR adds a shared `explain_interpolant.rst_` file. 
2. Also, the parsing and synopsis and usage of **-F** for the interpolant differed between the **sample1d** and **grdinterpolate** modules so I have introduced some library functions that both can call to avoid duplicate and missing directives in the code.  Likewise, for the documentation I added a shared `explain_interpolant.rst`.

Unfortunately, the docs for **-E** is not showing up in the HTML and I cannot see any difference between the include stuff for **-E** and **-F**, so I will need help to find probably an obvious issue, hence WIP.