### PR TITLE
Fix bug in greenspline for -E -C

### DIFF
--- a/src/greenspline.c
+++ b/src/greenspline.c
@@ -2704,8 +2704,8 @@ EXTERN_MSC int GMT_greenspline (void *V_API, int mode, void *args) {
 						double dev, rms = 0.0, chi2_sum = 0.0;
 						for (j = 0; j < nm; j++) {	/* For each data constraint */
 							for (p = 0, wp = 0.0; p < nm; p++) {	/* Add contribution for each data constraint */
+								r = greenspline_get_radius (GMT, X[j], X[p], 2U);
 								if (!gmt_M_is_zero (r)) {	/* For all pairs except self-pairs */
-									r = greenspline_get_radius (GMT, X[j], X[p], 2U);
 									part = G (GMT, r, par, Lz);
 									wp += alpha[p] * part;	/* Just add this scaled Green's function */
 								}


### PR DESCRIPTION
Wherever we need to evalute the solution we compute the distance been two points and if nonzero we evaluate the Green's function.  But, in one place we placed the calculation after the zero-check and of course r was always zero and the calculation of the surface did not happen.

Hopefully not more issues but this one is obvious so we fix it in this simple PR.