### PR TITLE
Reestablish CPT hinge for master tables

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8959,6 +8959,7 @@ struct GMT_PALETTE *gmt_get_palette (struct GMT_CTRL *GMT, char *file, enum GMT_
 			return (P);
 		}
 
+		master = (file && file[0]) ? file : GMT->current.setting.cpt;	/* Set master CPT prefix */
 		P = GMT_Read_Data (GMT->parent, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, GMT_READ_NORMAL|GMT_CPT_CONTINUOUS, NULL, master, NULL);
 		if (!P) return (P);		/* Error reading file. Return right away to avoid a segv in next line */
 		/* Stretch to fit the data range */

--- a/test/baseline/grdimage.dvc
+++ b/test/baseline/grdimage.dvc
@@ -1,5 +1,6 @@
 outs:
-- md5: 8219134ac2d69f2e4123365c18252cfa.dir
-  size: 8666527
-  nfiles: 30
+- md5: e0f5ec57ec18927bec8fc07d3334a8b5.dir
+  size: 8865922
+  nfiles: 31
   path: grdimage
+  hash: md5

--- a/test/grdimage/cpt_hinge.sh
+++ b/test/grdimage/cpt_hinge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Remote grid with a soft-hinge cpt with/without +h to enable and set it
+# Bottom panel: Polar CPT with activated soft-hinge at 0, so z = 0 is white
+# Middle panel: Polar CPT with activated soft-hinge at 2000, so z = 2000 is white
+# Top panel:    Polar CPT with deactivated soft-hinge, so z_mid = --1368.5 is white
+
+gmt begin cpt_hinge png
+	# Pass CPT and activate soft hinge at 0
+	gmt grdimage @earth_relief_06m -RPT -Cpolar+h -B
+	gmt coast -W0.25p
+	gmt colorbar -DJRM -Bxa1000 -By+l"Hinge = 0"
+	# Create new CPT and activate soft hinge at 2000
+	gmt makecpt -Cpolar+h2000 -T-5766/3029 -H > t.cpt
+	gmt grdimage @earth_relief_06m -RPT -Ct.cpt -B -Y8c
+	gmt coast -W0.25p
+	gmt colorbar -DJRM -Ct.cpt -Bxa1000 -By+l"Hinge = 2000"
+	# Pass CPT and do not activate any hinge
+	gmt grdimage @earth_relief_06m -RPT -Cpolar -B -Y8c
+	gmt coast -W0.25p
+	gmt colorbar -DJRM -Bxa1000 -By+l"No hinge set"
+gmt end show

--- a/test/grdimage/cpt_hinge.sh
+++ b/test/grdimage/cpt_hinge.sh
@@ -4,7 +4,7 @@
 # Middle panel: Polar CPT with activated soft-hinge at 2000, so z = 2000 is white
 # Top panel:    Polar CPT with deactivated soft-hinge, so z_mid = --1368.5 is white
 
-gmt begin cpt_hinge png
+gmt begin cpt_hinge ps
 	# Pass CPT and activate soft hinge at 0
 	gmt grdimage @earth_relief_06m -RPT -Cpolar+h -B
 	gmt coast -W0.25p


### PR DESCRIPTION
We (I) somehow lost a line or two in `gmt_support.c`.  Added a test as well so that we are warned if this tests fails again.  The CPT `polar` has a soft hinge at 0 and that is only activated via the **+h**[_hinge_] modifier at the end of the selected CPT. Output is below. Note that

1. top plot sets no hinge so the white center is at the mid-point -1368.5.
2. Middle panel uses a hinge of 2000 and creates a new cpt via **makecpt**. Now the white point is at z = 2000.
3. Bottom panel activates the soft-hinge at 0 so that is where the white point falls.

![cpt_hinge](https://github.com/GenericMappingTools/gmt/assets/26473567/bf3d475b-f494-4b48-a00c-2292f453fb6f)

All tests pass (well, that use to pass).