### PR TITLE
Detect pole in inverse ECEF in mapproject

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9259,12 +9259,12 @@ void gmt_ECEF_forward (struct GMT_CTRL *GMT, double in[], double out[]) {
 /*! . */
 void gmt_ECEF_inverse (struct GMT_CTRL *GMT, double in[], double out[]) {
 	/* Convert ECEF coordinates to geodetic lon, lat, height given the datum parameters.
-	 * GMT->current.proj.datum.from is always the ellipsoid to use. */
+	 * GMT->current.proj.datum.from is always the ellipsoid to use */
 
 	unsigned int i;
 	double in_p[3], sin_lat, cos_lat, N, p, theta, sin_theta, cos_theta;
 
-	/* First remove the xyz shifts, us in_p to avoid changing in[] */
+	/* First remove the xyz shifts, us in_p to avoid changing in */
 	for (i = 0; i < 3; i++) in_p[i] = in[i] - GMT->current.proj.datum.from.xyz[i];
 
 	p = hypot (in_p[GMT_X], in_p[GMT_Y]);

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -9279,7 +9279,7 @@ void gmt_ECEF_inverse (struct GMT_CTRL *GMT, double in[], double out[]) {
 		N = GMT->current.proj.datum.from.a / sqrt (1.0 - GMT->current.proj.datum.from.e_squared * sin_lat * sin_lat);
 		out[GMT_Z] = (p / cos_lat) - N;
 	}
-	else {	/* S or N pole, use sign of in_p[GMT_Z] to set latitude */
+	else {	/* S or N pole, use sign of in_p[GMT_Z] to set latitude and height */
 		out[GMT_X] = 0.0;	/* Might as well pick0 since any longitude will work */
 		out[GMT_Y] = (in_p[GMT_Z] > 0.0) ? 90.0 : -90.0;	/* EIther at north or south pole, check via Z coordinate */
 		out[GMT_Z] = in_p[GMT_Z] - copysign (GMT->current.proj.datum.from.b, in_p[GMT_Z]);


### PR DESCRIPTION
See issue reported on the [forum](https://forum.generic-mapping-tools.org/t/mapproject-e-and-i/4483/2).  When x^2 + y^2 is zero we are at one of the poles so avoid dividing by 0.
