### PR TITLE
Upgrade grd2cpt like makecpt and improve docs

### DIFF
--- a/doc/rst/source/explain_cpt_output.rst_
+++ b/doc/rst/source/explain_cpt_output.rst_
@@ -10,7 +10,7 @@
     - **r**: Output *r*/*g*/*b* codes only (even if a color name apply).
     - **x**: Output *#rrggbb* hex codes.
 
-    Optionally or alternatively, append this modifier:
+    Optionally or alternatively, append these modifiers:
 
     - **+c**: Write discrete palettes in categorical format. If *label* is appended
       then we create labels for each category to be used when the CPT is plotted.

--- a/doc/rst/source/explain_cpt_output.rst_
+++ b/doc/rst/source/explain_cpt_output.rst_
@@ -1,0 +1,30 @@
+**-F**\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*]
+    Force output CPT to be written in the desired format set by the directives, thus
+    selecting among color names, , single gray-scale values, color names, *r*/*g*/*b* only,
+    *h*-*s*-*v*, *c*/*m*/*y*/*k*, or *#rrggbb* hex codes. Choose from:
+ 
+    - **R**: Output color names if possible (and use *r*/*g*/*b* otherwise) [Default].
+    - **c**: Output color using *c*/*m*/*y*/*k* values.
+    - **g**: Output *gray* singles (will transform any colors to gray via YIQ transformation).
+    - **h**: Output *h*-*s*-*v* triplets.
+    - **r**: Output *r*/*g*/*b* codes only (even if a color name apply).
+    - **x**: Output *#rrggbb* hex codes.
+
+    Optionally or alternatively, append this modifier:
+
+    - **+c**: Write discrete palettes in categorical format. If *label* is appended
+      then we create labels for each category to be used when the CPT is plotted.
+      The *label* may be a comma-separated list of category names (you can skip a
+      category by not giving a name), or give *start*\ [-], where we automatically
+      build monotonically increasing labels from *start* (a single letter or an integer).
+      Append - to build ranges *start*\ -*start+1* instead.
+    - **+k**: Categorical CPT should have string keys instead of numerical entries.
+      Append keys, which is either a file with one key per record or a single letter
+      (e.g., D), then we build sequential letter keys (e.g., D, E, F, …) starting at that point.
+ 
+    **Notes**: (1) For comma-separated lists of keys, use |-T| instead.
+    (2) If **+cM** is given and the number of categories is 12, then we automatically create
+    a list of month names. (3) If **+cD** is given and the number of categories is 7 then we
+    make a list of weekday names.  The format of these labels will depend on the
+    :term:`FORMAT_TIME_PRIMARY_MAP`, :term:`GMT_LANGUAGE` and possibly
+    :term:`TIME_WEEK_START` settings.

--- a/doc/rst/source/explain_cpt_output.rst_
+++ b/doc/rst/source/explain_cpt_output.rst_
@@ -1,13 +1,13 @@
 **-F**\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*]
     Force output CPT to be written in the desired format set by the directives, thus
-    selecting among color names, , single gray-scale values, color names, *r*/*g*/*b* only,
+    selecting among color names, single gray-scale values, color names, *r*/*g*/*b* only,
     *h*-*s*-*v*, *c*/*m*/*y*/*k*, or *#rrggbb* hex codes. Choose from:
  
     - **R**: Output color names if possible (and use *r*/*g*/*b* otherwise) [Default].
     - **c**: Output color using *c*/*m*/*y*/*k* values.
     - **g**: Output *gray* singles (will transform any colors to gray via YIQ transformation).
     - **h**: Output *h*-*s*-*v* triplets.
-    - **r**: Output *r*/*g*/*b* codes only (even if a color name apply).
+    - **r**: Output *r*/*g*/*b* codes only (even if a color name applies).
     - **x**: Output *#rrggbb* hex codes.
 
     Optionally or alternatively, append these modifiers:

--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *cpt* ]
 [ |-D|\ [**i**\|\ **o**] ]
 [ |-E|\ [*nlevels*][**+c**][**+f**\ *file*] ]
-[ |-F|\ [**R**\|\ **r**\|\ **h**\|\ **c**\|\ **x**][**+c**\ [*label*]] ]
+[ |-F|\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]] ]
 [ |-G|\ *zlo*\ /\ *zhi* ]
 [ |-H| ]
 [ |-I|\ [**c**][**z**] ]
@@ -121,20 +121,30 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**R**\|\ **r**\|\ **h**\|\ **c**\|\ **x**][**+c**\ [*label*]]
-    Force output CPT to written with r/g/b codes, gray-scale values
-    or color name (**R**, default) or r/g/b codes only (**r**), or h-s-v
-    codes (**h**), or c/m/y/k codes (**c**), or #rrggbb hex codes (**x**).
-    Optionally or alternatively,
-    append **+c** to write discrete palettes in categorical format.
-    If *label* is appended then we create labels for each category to be used
-    when the CPT is plotted. The *label* may be a comma-separated list of
-    category names (you can skip a category by not giving a name), or give
-    *start*\ [-], where we automatically build monotonically increasing labels
-    from *start* (a single letter or an integer). Append - to build ranges
-    *start*-*start+1* instead.  **Note**: If **+cM** is given and the number
-    of categories is 12, then we automatically create a list of month names.
-    Likewise, if **+cD** is given and the number of categories is 7 then we
+**-F**\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]]
+    Force output CPT to be written in the desired format set by the directives, thus
+    selecting among color names, , single gray-scale values, color names, *r*/*g*/*b* only,
+    *h*-*s*-*v*, *c*/*m*/*y*/*k*, or *#rrggbb* hex codes. Choose from:
+ 
+    - **R**: Output color names if possible (and use *r*/*g*/*b* otherwise) [Default].
+    - **c**: Output color using *c*/*m*/*y*/*k* values.
+    - **g**: Output *gray* singles (will transform any colors to gray via YIQ transformation).
+    - **h**: Output *h*-*s*-*v* triplets.
+    - **r**: Output *r*/*g*/*b* codes only (even if a color name apply).
+    - **x**: Output *#rrggbb* hex codes.
+
+    Optionally or alternatively, append this modifier:
+
+    - **+c**: Write discrete palettes in categorical format. If *label* is appended
+      then we create labels for each category to be used when the CPT is plotted.
+      The *label* may be a comma-separated list of category names (you can skip a
+      category by not giving a name), or give *start*\ [-], where we automatically
+      build monotonically increasing labels from *start* (a single letter or an integer).
+      Append - to build ranges *start*\ -*start+1* instead.
+
+    **Notes**: (1) For comma-separated lists of keys, use |-T| instead.
+    (2) If **+cM** is given and the number of categories is 12, then we automatically create
+    a list of month names. (3) If **+cD** is given and the number of categories is 7 then we
     make a list of weekday names.  The format of these labels will depend on the
     :term:`FORMAT_TIME_PRIMARY_MAP`, :term:`GMT_LANGUAGE` and possibly
     :term:`TIME_WEEK_START` settings.

--- a/doc/rst/source/grd2cpt.rst
+++ b/doc/rst/source/grd2cpt.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *cpt* ]
 [ |-D|\ [**i**\|\ **o**] ]
 [ |-E|\ [*nlevels*][**+c**][**+f**\ *file*] ]
-[ |-F|\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]] ]
+[ |-F|\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*] ]
 [ |-G|\ *zlo*\ /\ *zhi* ]
 [ |-H| ]
 [ |-I|\ [**c**][**z**] ]
@@ -121,33 +121,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]]
-    Force output CPT to be written in the desired format set by the directives, thus
-    selecting among color names, , single gray-scale values, color names, *r*/*g*/*b* only,
-    *h*-*s*-*v*, *c*/*m*/*y*/*k*, or *#rrggbb* hex codes. Choose from:
- 
-    - **R**: Output color names if possible (and use *r*/*g*/*b* otherwise) [Default].
-    - **c**: Output color using *c*/*m*/*y*/*k* values.
-    - **g**: Output *gray* singles (will transform any colors to gray via YIQ transformation).
-    - **h**: Output *h*-*s*-*v* triplets.
-    - **r**: Output *r*/*g*/*b* codes only (even if a color name apply).
-    - **x**: Output *#rrggbb* hex codes.
-
-    Optionally or alternatively, append this modifier:
-
-    - **+c**: Write discrete palettes in categorical format. If *label* is appended
-      then we create labels for each category to be used when the CPT is plotted.
-      The *label* may be a comma-separated list of category names (you can skip a
-      category by not giving a name), or give *start*\ [-], where we automatically
-      build monotonically increasing labels from *start* (a single letter or an integer).
-      Append - to build ranges *start*\ -*start+1* instead.
-
-    **Notes**: (1) For comma-separated lists of keys, use |-T| instead.
-    (2) If **+cM** is given and the number of categories is 12, then we automatically create
-    a list of month names. (3) If **+cD** is given and the number of categories is 7 then we
-    make a list of weekday names.  The format of these labels will depend on the
-    :term:`FORMAT_TIME_PRIMARY_MAP`, :term:`GMT_LANGUAGE` and possibly
-    :term:`TIME_WEEK_START` settings.
+.. include:: explain_cpt_output.rst_
 
 .. _-G:
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *cpt* ]
 [ |-D|\ [**i**\|\ **o**] ]
 [ |-E|\ [*nlevels*] ]
-[ |-F|\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*]
+[ |-F|\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*]]
 [ |-G|\ *zlo*\ /\ *zhi* ]
 [ |-H| ]
 [ |-I|\ [**c**][**z**] ]
@@ -110,36 +110,7 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*]
-    Force output CPT to be written in the desired format set by the directives, thus
-    selecting among color names, , single gray-scale values, color names, *r*/*g*/*b* only,
-    *h*-*s*-*v*, *c*/*m*/*y*/*k*, or *#rrggbb* hex codes. Choose from:
- 
-    - **R**: Output color names if possible (and use *r*/*g*/*b* otherwise) [Default].
-    - **c**: Output color using *c*/*m*/*y*/*k* values.
-    - **g**: Output *gray* singles (will transform any colors to gray via YIQ transformation).
-    - **h**: Output *h*-*s*-*v* triplets.
-    - **r**: Output *r*/*g*/*b* codes only (even if a color name apply).
-    - **x**: Output *#rrggbb* hex codes.
-
-    Optionally or alternatively, select from these modifiers:
-
-    - **+c**: Write discrete palettes in categorical format. If *label* is appended
-      then we create labels for each category to be used when the CPT is plotted.
-      The *label* may be a comma-separated list of category names (you can skip a
-      category by not giving a name), or give *start*\ [-], where we automatically
-      build monotonically increasing labels from *start* (a single letter or an integer).
-      Append - to build ranges *start*\ -*start+1* instead.
-    - **+k**: Categorical CPT should have string keys instead of numerical entries. Append
-      *keys*, which is either a file with one key per record or a single letter (e.g., D),
-      then we build sequential letter keys (e.g., D, E, F, ...) starting at that point.
-
-    **Notes**: (1) For comma-separated lists of keys, use |-T| instead.
-    (2) If **+cM** is given and the number of categories is 12, then we automatically create
-    a list of month names. (3) If **+cD** is given and the number of categories is 7 then we
-    make a list of weekday names.  The format of these labels will depend on the
-    :term:`FORMAT_TIME_PRIMARY_MAP`, :term:`GMT_LANGUAGE` and possibly
-    :term:`TIME_WEEK_START` settings.
+.. include:: explain_cpt_output.rst_
 
 .. _-G:
 

--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-C|\ *cpt* ]
 [ |-D|\ [**i**\|\ **o**] ]
 [ |-E|\ [*nlevels*] ]
-[ |-F|\ [**R**\|\ **r**\|\ **h**\|\ **c**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*] ]
+[ |-F|\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*]
 [ |-G|\ *zlo*\ /\ *zhi* ]
 [ |-H| ]
 [ |-I|\ [**c**][**z**] ]
@@ -62,7 +62,7 @@ and :term:`COLOR_NAN` from
 the :doc:`gmt.conf` file or the command line will be used. This default
 behavior can be overruled using the options |-D|, |-M| or |-N|.
 
-The color model (RGB, HSV or CMYK) of the palette created by **makecpt**
+The color model (GRAY, RGB, HSV or CMYK) of the palette created by **makecpt**
 will be the same as specified in the header of the master CPT. When
 there is no :term:`COLOR_MODEL` entry in the master CPT, the
 :term:`COLOR_MODEL` specified in the :doc:`gmt.conf` file or on the command
@@ -110,24 +110,33 @@ Optional Arguments
 
 .. _-F:
 
-**-F**\ [**R**\|\ **r**\|\ **h**\|\ **c**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*]
-    Force output CPT to be written with r/g/b codes, gray-scale values
-    or color name (**R**, default) or r/g/b codes only (**r**), or h-s-v
-    codes (**h**), or c/m/y/k codes (**c**), or #rrggbb hex codes (**x**).
-    Optionally or alternatively,
-    append **+c** to write discrete palettes in categorical format.
-    If *label* is appended then we create labels for each category to be used
-    when the CPT is plotted. The *label* may be a comma-separated list of
-    category names (you can skip a category by not giving a name), or give
-    *start*\ [-], where we automatically build monotonically increasing labels
-    from *start* (a single letter or an integer). Append - to build ranges
-    *start*\ -*start+1* instead.  If the categorical CPT should have string
-    keys instead of numerical entries then append **+k**\ *keys*, where
-    *keys* is either a file with one key per record or a single letter (e.g., D),
-    then we build sequential letter keys (e.g., D, E, F, ...) starting at that point.
-    For comma-separated lists of keys, use |-T| instead.  **Note**: If **+cM** is given and the number
-    of categories is 12, then we automatically create a list of month names.
-    Likewise, if **+cD** is given and the number of categories is 7 then we
+**-F**\ [**R**\|\ **c**\|\ **g**\|\ **h**\|\ **r**\|\ **x**][**+c**\ [*label*]][**+k**\ *keys*]
+    Force output CPT to be written in the desired format set by the directives, thus
+    selecting among color names, , single gray-scale values, color names, *r*/*g*/*b* only,
+    *h*-*s*-*v*, *c*/*m*/*y*/*k*, or *#rrggbb* hex codes. Choose from:
+ 
+    - **R**: Output color names if possible (and use *r*/*g*/*b* otherwise) [Default].
+    - **c**: Output color using *c*/*m*/*y*/*k* values.
+    - **g**: Output *gray* singles (will transform any colors to gray via YIQ transformation).
+    - **h**: Output *h*-*s*-*v* triplets.
+    - **r**: Output *r*/*g*/*b* codes only (even if a color name apply).
+    - **x**: Output *#rrggbb* hex codes.
+
+    Optionally or alternatively, select from these modifiers:
+
+    - **+c**: Write discrete palettes in categorical format. If *label* is appended
+      then we create labels for each category to be used when the CPT is plotted.
+      The *label* may be a comma-separated list of category names (you can skip a
+      category by not giving a name), or give *start*\ [-], where we automatically
+      build monotonically increasing labels from *start* (a single letter or an integer).
+      Append - to build ranges *start*\ -*start+1* instead.
+    - **+k**: Categorical CPT should have string keys instead of numerical entries. Append
+      *keys*, which is either a file with one key per record or a single letter (e.g., D),
+      then we build sequential letter keys (e.g., D, E, F, ...) starting at that point.
+
+    **Notes**: (1) For comma-separated lists of keys, use |-T| instead.
+    (2) If **+cM** is given and the number of categories is 12, then we automatically create
+    a list of month names. (3) If **+cD** is given and the number of categories is 7 then we
     make a list of weekday names.  The format of these labels will depend on the
     :term:`FORMAT_TIME_PRIMARY_MAP`, :term:`GMT_LANGUAGE` and possibly
     :term:`TIME_WEEK_START` settings.

--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -370,6 +370,9 @@ enum GMT_time_period {
 /* Directives and modifiers for -F interpolant option */
 #define GMT_INTERPOLANT_OPT "a|c|e|l|n|s<p>[+d1|2]"
 
+/* Directives and modifiers for -F cpt output option in makecpt/gdr2cpt */
+#define GMT_COLORMODES_OPT "[R|c|g|h|r|x]][+c[<label>]][+k<keys>]"
+
 /* Valid modifiers for various input files */
 
 /* Valid modifiers for -Tmin/max/inc array creator */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -13977,7 +13977,7 @@ char *gmtlib_putfill (struct GMT_CTRL *GMT, struct GMT_FILL *F) {
 			strcat (text, add_mods);
 		}
 	}
-	else if (F->rgb[0] < -0.5)
+	else if (F->rgb[0] < -0.5)	/* Skip it */
 		strcpy (text, "-");
 	else if ((i = gmtlib_getrgb_index (GMT, F->rgb)) >= 0)
 		snprintf (text, PATH_MAX+GMT_LEN256, "%s", gmt_M_color_name[i]);
@@ -13997,7 +13997,7 @@ char *gmt_putcolor (struct GMT_CTRL *GMT, double *rgb) {
 	static char text[GMT_LEN256] = {""};
 	int i;
 
-	if (rgb[0] < -0.5)
+	if (rgb[0] < -0.5)	/* Skip it */
 		strcpy (text, "-");
 	else if ((i = gmtlib_getrgb_index (GMT, rgb)) >= 0)
 		snprintf (text, GMT_LEN256, "%s", gmt_M_color_name[i]);
@@ -14015,10 +14015,28 @@ char *gmt_putrgb (struct GMT_CTRL *GMT, double *rgb) {
 	static char text[GMT_LEN256] = {""};
 	gmt_M_unused(GMT);
 
-	if (rgb[0] < -0.5)
+	if (rgb[0] < -0.5)	/* Skip it */
 		strcpy (text, "-");
 	else
 		snprintf (text, GMT_LEN256, "%.5g/%.5g/%.5g", gmt_M_t255(rgb,0), gmt_M_t255(rgb,1), gmt_M_t255(rgb,2));
+	gmtinit_append_trans (text, rgb[3]);
+	return (text);
+}
+
+/*! Creates t the string shade corresponding to the RGB triplet */
+char *gmt_putgray (struct GMT_CTRL *GMT, double *rgb) {
+
+	static char text[GMT_LEN256] = {""};
+	gmt_M_unused(GMT);
+
+	if (rgb[0] < -0.5)	/* Skip it */
+		strcpy (text, "-");
+	else if (gmt_M_is_gray(rgb))
+		snprintf (text, GMT_LEN256, "%.5g", gmt_M_t255(rgb,0));
+	else {	/* Must convert to gray */
+		double gray = gmt_M_yiq (rgb);
+		snprintf (text, GMT_LEN256, "%.5g", gray);
+	}
 	gmtinit_append_trans (text, rgb[3]);
 	return (text);
 }
@@ -14029,7 +14047,7 @@ char *gmt_puthex (struct GMT_CTRL *GMT, double *rgb) {
 	static char text[GMT_LEN256] = {""};
 	gmt_M_unused(GMT);
 
-	if (rgb[0] < -0.5)
+	if (rgb[0] < -0.5)	/* Skip it */
 		strcpy (text, "-");
 	else
 		snprintf (text, GMT_LEN256, "#%02x%02x%02x", urint (gmt_M_t255(rgb,0)), urint (gmt_M_t255(rgb,1)), urint (gmt_M_t255(rgb,2)));
@@ -14043,7 +14061,7 @@ char *gmtlib_putcmyk (struct GMT_CTRL *GMT, double *cmyk) {
 	static char text[GMT_LEN256] = {""};
 	gmt_M_unused(GMT);
 
-	if (cmyk[0] < -0.5)
+	if (cmyk[0] < -0.5)	/* Skip it */
 		strcpy (text, "-");
 	else
 		snprintf (text, GMT_LEN256, "%.5g/%.5g/%.5g/%.5g", 100.0*gmt_M_q(cmyk[0]), 100.0*gmt_M_q(cmyk[1]), 100.0*gmt_M_q(cmyk[2]), 100.0*gmt_M_q(cmyk[3]));
@@ -14057,7 +14075,7 @@ char *gmtlib_puthsv (struct GMT_CTRL *GMT, double *hsv) {
 	static char text[GMT_LEN256] = {""};
 	gmt_M_unused(GMT);
 
-	if (hsv[0] < -0.5)
+	if (hsv[0] < -0.5)	/* Skip it */
 		strcpy (text, "-");
 	else
 		snprintf (text, GMT_LEN256, "%.5g-%.5g-%.5g", gmt_M_q(hsv[0]), gmt_M_q(hsv[1]), gmt_M_q(hsv[2]));

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -114,6 +114,7 @@ EXTERN_MSC int gmt_set_measure_unit (struct GMT_CTRL *GMT, char unit);
 EXTERN_MSC char * gmt_putcolor (struct GMT_CTRL *GMT, double *rgb);
 EXTERN_MSC char * gmt_putrgb (struct GMT_CTRL *GMT, double *rgb);
 EXTERN_MSC char * gmt_puthex (struct GMT_CTRL *GMT, double *rgb);
+EXTERN_MSC char * gmt_putgray (struct GMT_CTRL *GMT, double *rgb);
 EXTERN_MSC double gmt_convert_units (struct GMT_CTRL *GMT, char *value, unsigned int from_default, unsigned int target_unit);
 EXTERN_MSC unsigned int gmt_check_scalingopt (struct GMT_CTRL *GMT, char option, char unit, char *unit_name);
 EXTERN_MSC int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, char *item);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -554,6 +554,8 @@ EXTERN_MSC int gmt_grd_BC_set (struct GMT_CTRL *GMT, struct GMT_GRID *G, unsigne
 EXTERN_MSC int gmt_cube_BC_set (struct GMT_CTRL *GMT, struct GMT_CUBE *U, unsigned int direction);
 EXTERN_MSC unsigned int gmt_parse_inv_cpt (struct GMT_CTRL *GMT, char *arg);
 EXTERN_MSC struct GMT_PALETTE * gmt_truncate_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double z_low, double z_high);
+EXTERN_MSC void gmt_explain_cpt_output (struct GMTAPI_CTRL *API, char option);
+EXTERN_MSC int gmt_prepare_categorical_cpt (struct GMT_CTRL *GMT, char *label, char *key, struct GMT_PALETTE *Pout);
 EXTERN_MSC void gmt_free_int_selection (struct GMT_CTRL *GMT, struct GMT_INT_SELECTION **S);
 EXTERN_MSC struct GMT_INT_SELECTION * gmt_set_int_selection (struct GMT_CTRL *GMT, char *item);
 EXTERN_MSC bool gmt_get_int_selection (struct GMT_CTRL *GMT, struct GMT_INT_SELECTION *S, uint64_t this);

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -576,7 +576,8 @@ enum GMT_enum_color {
 	GMT_HSV			= 2,
 	GMT_COLORINT		= 4,
 	GMT_NO_COLORNAMES	= 8,
-	GMT_HEX_COLOR	= 16
+	GMT_HEX_COLOR		= 16,
+	GMT_GRAY		= 32,
 };
 
 enum GMT_enum_bfn {
@@ -597,6 +598,7 @@ enum GMT_enum_cptflags {
 	GMT_CPT_SOFT_HINGE = 8,
 	GMT_CPT_TIME       = 16,
 	GMT_CPT_COLORLIST  = 32,
+	GMT_CPT_GRAY_SET   = 64,
 	GMT_CPT_HINGED     = 4	/* Backwards compatibility with 6.0 API */
 };
 

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -73,11 +73,12 @@ struct GRD2CPT_CTRL {
 		char *file;
 		unsigned int levels;
 	} E;
-	struct GRD2CPT_F {	 /* -F[R|c|g|h|r|x][+c[<label>]] */
+	struct GRD2CPT_F {	 /* -F[R|c|g|h|r|x][+c[<label>]][+k<keys>] */
 		bool active;
 		bool cat;
 		unsigned int model;
 		char *label;
+		char *key;
 	} F;
 	struct GRD2CPT_G {	/* -Glow/high for input CPT truncation */
 		bool active;
@@ -151,9 +152,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *H_OPT = (API->GMT->current.setting.run_mode == GMT_MODERN) ? " [-H]" : "";
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s %s [-A<transparency>[+a]] [-C<cpt>] [-D[i|o]] [-E[<nlevels>][+c][+f<file>]] "
-		"[-F[R|c|g|h|r|x][+c[<label>]]] [-G<zlo>/<zhi>]%s [-I[c][z]] [-L<min_limit>/<max_limit>] [-M] [-N] [-Q[i|o]] "
+		"[-F%s] [-G<zlo>/<zhi>]%s [-I[c][z]] [-L<min_limit>/<max_limit>] [-M] [-N] [-Q[i|o]] "
 		"[%s] [-Sh|l|m|u] [-T<start>/<stop>/<inc>|<n>] [%s] [-W[w]] [-Z] [%s] [%s] [%s] [%s]\n",
-		name, GMT_INGRID, H_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_ho_OPT, GMT_o_OPT, GMT_PAR_OPT);
+		name, GMT_INGRID, GMT_COLORMODES_OPT, H_OPT, GMT_Rgeo_OPT, GMT_V_OPT, GMT_bo_OPT, GMT_ho_OPT, GMT_o_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -172,19 +173,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"Alternatively, append <nlevels> to sample equidistant color levels from zmin to zmax. "
 		"Instead, append +c to use the cumulative density function (cdf) to set color bounds. "
 		"Append +f<file> to save the CDF table to a file.");
-	GMT_Usage (API, 1, "\n-F[R|r|h|c][+c[<label>]]");
-	GMT_Usage (API, -2, "Select the color model for output [Default uses the input model]:");
-	GMT_Usage (API, 3, "R: Output r/g/b or colornames.");
-	GMT_Usage (API, 3, "c: Output c/m/y/k.");
-	GMT_Usage (API, 3, "g: Output gray value (Will apply the YIQ if not a gray value).");
-	GMT_Usage (API, 3, "h: Output h-s-v.");
-	GMT_Usage (API, 3, "r: Output r/g/b only.");
-	GMT_Usage (API, 3, "x: Output hex #rrggbb only.");
-	GMT_Usage (API, -2, "One modifier controls generation of categorical labels:");
-	GMT_Usage (API, 3, "+c Output a discrete CPT in categorical CPT format. "
-		"The <label>, if appended, sets the labels for each category. It may be a "
-		"comma-separated list of category names, or <start>[-] where we automatically build "
-		"labels from <start> (a letter or an integer). Append - to build range labels <start>-<start+1>.");
+	gmt_explain_cpt_output (API, 'F');
 	GMT_Usage (API, 1, "\n-G<zlo>/<zhi>");
 	GMT_Usage (API, -2, "Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>. "
 		"To accept one of the incoming limits, set that limit to NaN.");
@@ -306,13 +295,17 @@ static int parse (struct GMT_CTRL *GMT, struct GRD2CPT_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'F':	/* Set color model for output */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->F.active);
-				if (gmt_validate_modifiers (GMT, opt->arg, 'F', "c", GMT_MSG_ERROR)) n_errors++;
+				if (gmt_validate_modifiers (GMT, opt->arg, 'F', "ck", GMT_MSG_ERROR)) n_errors++;
 				if (gmt_get_modifier (opt->arg, 'c', txt_a)) {
 					Ctrl->F.cat = true;
 					if (txt_a[0]) Ctrl->F.label = strdup (txt_a);
 				}
+				if (gmt_get_modifier (opt->arg, 'k', txt_a)) {
+					Ctrl->F.cat = true;
+					if (txt_a[0]) Ctrl->F.key = strdup (txt_a);
+				}
 				switch (opt->arg[0]) {
-					case '\0': case 'R': Ctrl->F.model = GMT_RGB; break;
+					case '\0': case '+': case 'R': Ctrl->F.model = GMT_RGB; break;
 					case 'r': Ctrl->F.model = GMT_RGB + GMT_NO_COLORNAMES; break;
 					case 'g': Ctrl->F.model = GMT_GRAY; break;
 					case 'h': Ctrl->F.model = GMT_HSV; break;
@@ -882,21 +875,14 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 	if (Ctrl->N.active) cpt_flags |= GMT_CPT_NO_BNF;	/* bit 0 controls if BFN will be written out */
 	if (Ctrl->D.mode == 1) cpt_flags |= GMT_CPT_EXTEND_BNF;	/* bit 1 controls if BF will be set to equal bottom/top rgb value */
 	if (Ctrl->F.active) Pout->model = Ctrl->F.model;
-	if (Ctrl->F.cat) {	/* Flag as a categorical CPT */
-		Pout->categorical = GMT_CPT_CATEGORICAL_VAL;
-		if (Ctrl->F.label) {	/* Want categorical labels */
-			unsigned int ns = 0;
-			char **label = gmt_cat_cpt_strings (GMT, Ctrl->F.label, Pout->n_colors, &ns);
-			for (unsigned int k = 0; k < MIN (Pout->n_colors, ns); k++) {
-				if (Pout->data[k].label) gmt_M_str_free (Pout->data[k].label);
-				Pout->data[k].label = label[k];	/* Now the job of the CPT to free these strings */
-			}
-			gmt_M_free (GMT, label);
-		}
-	}
 
 	if (Ctrl->A.active) gmt_cpt_transparency (GMT, Pout, Ctrl->A.value, Ctrl->A.mode);	/* Set transparency */
 	if (Ctrl->F.model & GMT_GRAY) cpt_flags = GMT_CPT_GRAY_SET;	/* Controls if final CPT should be converted to gray via YIQ */
+
+	if (Ctrl->F.cat) {	/* Flag as a categorical CPT */
+		if ((API->error = gmt_prepare_categorical_cpt (GMT, Ctrl->F.label, Ctrl->F.key, Pout)))
+			Return (API->error);
+	}
 
 	if (write && GMT_Write_Data (API, GMT_IS_PALETTE, GMT_IS_FILE, GMT_IS_NONE, cpt_flags, NULL, Ctrl->Out.file, Pout) != GMT_NOERROR)
 		error = API->error;

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -146,9 +146,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	const char *H_OPT = (API->GMT->current.setting.run_mode == GMT_MODERN) ? " [-H]" : "";
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
 	GMT_Usage (API, 0, "usage: %s [-A<transparency>[+a]] [-C<cpt>|colors] [-D[i|o]] [-E[<nlevels>]] "
-		"[-F[R|c|g|h|r|x]][+c[<label>]][+k<keys>]] [-G<zlo>/<zhi>]%s [-I[c][z]] [-M] [-N] [-Q] [-S<mode>] "
+		"[-F%s] [-G<zlo>/<zhi>]%s [-I[c][z]] [-M] [-N] [-Q] [-S<mode>] "
 		"[-T<min>/<max>[/<inc>[+b|i|l|n]] | -T<table> | -T<z1,z2,...zn>] [%s] [-W[w]] [-Z] [%s] [%s] [%s] [%s] [%s]\n",
-		name, H_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_ho_OPT, GMT_i_OPT, GMT_PAR_OPT);
+		name, GMT_COLORMODES_OPT, H_OPT, GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_ho_OPT, GMT_i_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
@@ -165,24 +165,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		"This option implies we read data from given command-line files [or standard input] to "
 		"determine data range (use -i to select a data column, else last column is used). "
 		"If <nlevels> is not set we use the number of color slices in the chosen CPT.");
-	GMT_Usage (API, 1, "\n-F[R|r|h|c][+c[<label>]][+k<keys>]");
-	GMT_Usage (API, -2, "Select the color model for output [Default uses the input model]:");
-	GMT_Usage (API, 3, "R: Output r/g/b or colornames.");
-	GMT_Usage (API, 3, "c: Output c/m/y/k.");
-	GMT_Usage (API, 3, "g: Output gray value (Will apply the YIQ if not a gray value).");
-	GMT_Usage (API, 3, "h: Output h-s-v.");
-	GMT_Usage (API, 3, "r: Output r/g/b only.");
-	GMT_Usage (API, 3, "x: Output hex #rrggbb only.");
-	GMT_Usage (API, -2, "Two modifiers control generation of categorical labels:");
-	GMT_Usage (API, 3, "+c Output a discrete CPT in categorical CPT format. "
-		"The <label>, if appended, sets the labels for each category. It may be a "
-		"comma-separated list of category names, or <start>[-] where we automatically build "
-		"labels from <start> (a letter or an integer). Append - to build range labels <start>-<start+1>.");
-	GMT_Usage (API, 3, "+k Set categorical keys rather than numerical values. "
-		"<keys> may be a file with one key per line or a comma-separated list of keys. "
-		"If <keys> is a single letter then we build sequential alphabetical keys from that letter. "
-		"If number of categories is 12 and label is M then we auto-create month name labels, and "
-		"if it is 7 and label is D then we auto-create weekday name labels.");
+	gmt_explain_cpt_output (API, 'F');
 	GMT_Usage (API, 1, "\n-G<zlo>/<zhi>");
 	GMT_Usage (API, -2, "Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>. "
 		"To accept one of the incoming limits, set that limit to NaN.");
@@ -302,7 +285,7 @@ static int parse (struct GMT_CTRL *GMT, struct MAKECPT_CTRL *Ctrl, struct GMT_OP
 					if (txt_a[0]) Ctrl->F.key = strdup (txt_a);
 				}
 				switch (opt->arg[0]) {
-					case '\0': case 'R': Ctrl->F.model = GMT_RGB; break;
+					case '\0': case '+': case 'R': Ctrl->F.model = GMT_RGB; break;
 					case 'c': Ctrl->F.model = GMT_CMYK; break;
 					case 'r': Ctrl->F.model = GMT_RGB + GMT_NO_COLORNAMES; break;
 					case 'g': Ctrl->F.model = GMT_GRAY; break;
@@ -674,42 +657,10 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 	if (Ctrl->N.active) cpt_flags |= GMT_CPT_NO_BNF;	/* bit 0 controls if BFN will be written out */
 	if (Ctrl->D.mode == 1) cpt_flags |= GMT_CPT_EXTEND_BNF;	/* bit 1 controls if BF will be set to equal bottom/top rgb value */
 	if (Ctrl->F.active) Pout->model = Ctrl->F.model;
+
 	if (Ctrl->F.cat) {	/* Flag as a categorical CPT */
-		bool got_key_file= (Ctrl->F.key && !gmt_access (GMT, Ctrl->F.key, R_OK));	/* Want categorical labels read from file */
-		unsigned int ns = 0;
-		Pout->categorical = GMT_CPT_CATEGORICAL_VAL;
-		if (Ctrl->F.label || (Ctrl->F.key && !got_key_file)) {	/* Want auto-categorical labels appended to each CPT record */
-			char **label = gmt_cat_cpt_strings (GMT, (Ctrl->F.label) ? Ctrl->F.label : Ctrl->F.key, Pout->n_colors, &ns);
-			for (unsigned int k = 0; k < MIN (Pout->n_colors, ns); k++) {
-				if (Pout->data[k].label) gmt_M_str_free (Pout->data[k].label);
-				if (label[k]) Pout->data[k].label = label[k];	/* Now the job of the CPT to free these strings */
-			}
-			gmt_M_free (GMT, label);	/* But the master array can go */
-		}
-		if (Ctrl->F.key) {	/* Want categorical labels */
-			char **keys = NULL;
-			if (got_key_file) {	/* Got a file with category keys */
-				ns = gmt_read_list (GMT, Ctrl->F.key, &keys);
-				if (ns < Pout->n_colors) {
-					GMT_Report (API, GMT_MSG_ERROR, "The categorical keys file %s had %d entries but CPT has %d categories\n", Ctrl->F.key, ns, Pout->n_colors);
-					Return (GMT_RUNTIME_ERROR);
-				}
-				else if (ns > Pout->n_colors)
-					GMT_Report (API, GMT_MSG_WARNING, "The categorical keys file %s had %d entries but only %d are needed - skipping the extra keys\n", Ctrl->F.key, ns, Pout->n_colors);
-			}
-			else	/* Got comma-separated keys */
-				keys = gmt_cat_cpt_strings (GMT, Ctrl->F.key, Pout->n_colors, &ns);
-			for (unsigned int k = 0; k < MIN (Pout->n_colors, ns); k++) {
-				if (Pout->data[k].key) gmt_M_str_free (Pout->data[k].key);
-				if (k < ns && keys[k]) {
-					Pout->data[k].key = keys[k];	/* Now the job of the CPT to free these strings */
-					if (Pout->data[k].label) gmt_M_str_free (Pout->data[k].label);
-					Pout->data[k].label = strdup (keys[k]);
-				}
-			}
-			gmt_M_free (GMT, keys);	/* But the master array can go */
-			Pout->categorical = GMT_CPT_CATEGORICAL_KEY;
-		}
+		if ((API->error = gmt_prepare_categorical_cpt (GMT, Ctrl->F.label, Ctrl->F.key, Pout)))
+			Return (API->error);
 	}
 
 	write = (GMT->current.setting.run_mode == GMT_CLASSIC || Ctrl->H.active);	/* Only output to stdout in classic mode and with -H in modern mode */


### PR DESCRIPTION
This PR does several things:

1. It adds **-F** directive **g** for grayscale. While a couple of GMT modules (e.g., **grdimage**, **grdview**) has a **-M** option (for converting colors to black and white television via the YIQ transformation), we cannot actually make sure CPT output.  With **-Fg** we now get a single grayscale column wether it was originally gray or had to be YIQ converted..
2. While **makecpt** had the **+k**_keys_ modifier, **grd2cpt** did not.  No good reason other than obviously a keyed categorical CPT cannot be used with a grid since the look-up values are always numbers.  But users may still want to make a categorical CPT with keys via **gd2cpt** that can then be used for non-grid plotting. Thus I duplicated the **+k** stuff from **makecpt** to **grd2cpt**.
3. Because they now have identical synopsis and usage I made helper functions that are called by both instead of maintaining duplicate usage messages.  The **-F**_arg_ string is now also a constant in `gmt_constants.h`
4. Same deal with the docs: Introduced an include file (`explain_cpt_output.rst_`) to ensure we say the same thing in the two modules.  The updated **-F** docs now look like this:

<img width="914" alt="F" src="https://github.com/GenericMappingTools/gmt/assets/26473567/82504e8e-0eef-4735-ab92-1bc9cbaa9525">
