### PR TITLE
Improve plot3d docs

### DIFF
--- a/doc/rst/source/explain_line_draw.rst_
+++ b/doc/rst/source/explain_line_draw.rst_
@@ -1,0 +1,13 @@
+**-A**\ [**m**\|\ **p**\|\ **x**\|\ **y**\|\ **r**\|\ **t**]
+    By default, geographic line segments are drawn as great circle arcs by resampling
+    coarse input data along such arcs. To disable this sampling and draw them as
+    straight lines, use the |-A| flag.  For Cartesian data, points are simply connected.
+    To adjust these behaviors, append a directive:
+
+    - **m**: Draw the line by first following a meridian, then a parallel.
+    - **p**: Start following a parallel, then a meridian. (This can be practical
+      to draw a line along parallels, for example).
+    - **r**: For polar projections, draw stair-case curves whose first move is along *r*.
+    - **t**: Same, but first move is along *theta*.
+    - **x**: For Cartesian data, draw stair-case curves that whose first move is along *x*.
+    - **y**: Same, but first move is along *y*.

--- a/doc/rst/source/explain_line_draw.rst_
+++ b/doc/rst/source/explain_line_draw.rst_
@@ -11,3 +11,5 @@
     - **t**: Same, but first move is along *theta*.
     - **x**: For Cartesian data, draw stair-case curves that whose first move is along *x*.
     - **y**: Same, but first move is along *y*.
+
+    **Note**: In :doc:`plot3d`, the |-A| option requires constant *z*-coordinates.

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -85,7 +85,7 @@ Optional Arguments
 
 .. _-A:
 
-.. include:: explain_line_draw.rst_.rst_
+.. include:: explain_line_draw.rst_
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_

--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -17,7 +17,7 @@ Synopsis
 [ |-A|\ [**m**\|\ **p**\|\ **x**\|\ **y**\|\ **r**\|\ **t**] ]
 [ |SYN_OPT-B| ]
 [ |-C|\ *cpt* ]
-[ |-D|\ *dx*/*dy* ]
+[ |-D|\ *dx*\ [/*dy*] ]
 [ |-E|\ [**x**\|\ **y**\|\ **X**\|\ **Y**][**+a**\|\ **A**][**+cl**\|\ **f**][**+n**][**+w**\ *width*\ [/*cap*]][**+p**\ *pen*] ]
 [ |-F|\ [**c**\|\ **n**\|\ **p**][**a**\|\ **s**\|\ **t**\|\ **r**\|\ *refpoint*] ]
 [ |-G|\ *fill*\|\ **+z** ]
@@ -85,19 +85,7 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**m**\|\ **p**\|\ **x**\|\ **y**\|\ **r**\|\ **t**]
-    By default, geographic line segments are drawn as great circle arcs by resampling
-    coarse input data along such arcs. To disable this sampling and draw them as
-    straight lines, use the |-A| flag.  For Cartesian data, points are simply connected.
-    To adjust these behaviors, append a directive:
-
-    - **m**: Draw the line by first following a meridian, then a parallel.
-    - **p**: Start following a parallel, then a meridian. (This can be practical
-      to draw a line along parallels, for example).
-    - **r**: For polar projections, draw stair-case curves whose first move is along *r*.
-    - **t**: Same, but first move is along *theta*.
-    - **x**: For Cartesian data, draw stair-case curves that whose first move is along *x*.
-    - **y**: Same, but first move is along *y*.
+.. include:: explain_line_draw.rst_.rst_
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_
@@ -125,8 +113,8 @@ Optional Arguments
 
 .. _-D:
 
-**-D**\ *dx*/*dy*
-    Offset the plot symbol or line locations by the given amounts *dx/dy*
+**-D**\ *dx*\ [/*dy*]
+    Offset the plot symbol or line locations by the given amounts
     [Default is no offset]. If *dy* is not given it is set equal to *dx*.
     You may append dimensional units from **c**\ \|\ **i**\ \|\ **p** to each value.
 

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -94,8 +94,7 @@ Optional Arguments
 
 .. _-A:
 
-.. include:: explain_line_draw.rst_.rst_
-    **Note**: The |-A| option requires constant *z*-coordinates.
+.. include:: explain_line_draw.rst_
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -94,18 +94,8 @@ Optional Arguments
 
 .. _-A:
 
-**-A**\ [**m**\|\ **p**\|\ **x**\|\ **y**\|\ **r**\|\ **t**]
-    By default, geographic line segments are drawn as great circle arcs by resampling
-    coarse input data along such arcs. To disable this sampling and draw them as
-    straight lines, use the |-A| flag.  Alternatively, add **m** to draw
-    the line by first following a meridian, then a parallel. Or append **p**
-    to start following a parallel, then a meridian. (This can be practical
-    to draw a line along parallels, for example).  For Cartesian data, points
-    are simply connected, unless you append **x** or **y** to draw stair-case
-    curves that whose first move is along *x* or *y*, respectively. For polar
-    projection, append **r** or **t** to draw stair-case curves that whose first
-    move is along *r* or *theta*, respectively. **Note**:
-    The |-A| option requires constant *z*-coordinates.
+.. include:: explain_line_draw.rst_.rst_
+    **Note**: The |-A| option requires constant *z*-coordinates.
 
 .. |Add_-B| replace:: |Add_-B_links|
 .. include:: explain_-B.rst_
@@ -167,17 +157,18 @@ Optional Arguments
 
 .. _-L:
 
-**-L**\ [**+b**\|\ **d**\|\ **D**][**+xl**\|\ **r**\|\ *x0*][**+yl**\|\ **r**\|\ *y0*][**+p**\ *pen*]
-    Force closed polygons.  Alternatively, append modifiers to build a polygon from a line segment.
-    Append **+d** to build symmetrical envelope around y(x) using deviations dy(x) given in extra column 4.
-    Append **+D** to build asymmetrical envelope around y(x) using deviations dy1(x) and dy2(x) from extra columns 4-5.
-    Append **+b** to build asymmetrical envelope around y(x) using bounds yl(x) and yh(x) from extra columns 4-5.
-    Append **+xl**\|\ **r**\|\ *x0* to connect first and last point to anchor points at either *xmin*, *xmax*, or *x0*, or
-    append **+yb**\|\ **t**\|\ *y0* to connect first and last point to anchor points at either *ymin*, *ymax*, or *y0*.
-    Polygon may be painted (|-G|) and optionally outlined by adding **+p**\ *pen* [no outline].
-    All constructed polygons are assumed to have a constant *z* value.
+**-L**\ [**+b**\|\ **d**\|\ **D**][**+xl**\|\ **r**\|\ *x0*][**+yb**\|\ **t**\|\ *y0*][**+p**\ *pen*]
+    Force closed polygons.  Alternatively, append modifiers to build a polygon from a line segment:
+
+    - **+d**: Build a symmetrical envelope around *y*\ (*x*) using deviations *dy*(\ *x*) given in extra column 3.
+    - **+D**: Build an asymmetrical envelope around *y*\ (*x*) using deviations *dy1*\ (*x*) and *dy2*\ (*x)* from extra columns 3-4.
+    - **+b**: Build an asymmetrical envelope around *y*\ (*x*) using bounds *yl*\ (*x*) and *yh*(*x*) from extra columns 3-4.
+    - **+x**: Connect first and last point to anchor points at either *xmin* (append **l**), *xmax* (append **r**), or *x0* (append it).
+    - **+y**: Connect first and last point to anchor points at either *ymin* (append **b**), *xmax* (append **t**), or *y0* (append it).
+
+    Such polygons may be painted (|-G|) and optionally outlined by adding modifier **+p**\ *pen* [no outline].
     **Note**: When option |-Z| is passed via segment headers you will need |-L| to ensure
-    your segments are interpreted as polygons, else they are seen as lines.
+    your segments are interpreted as polygons, else they will be seen as lines.
 
 .. _-N:
 
@@ -218,14 +209,27 @@ Optional Arguments
 
 **-W**\ [*pen*][*attr*] :ref:`(more ...) <-Wpen_attrib>`
     Set pen attributes for lines or the outline of symbols [Defaults:
-    width = 0.25p, color = black, style = solid]. If the modifier **+cl**
-    is appended then the color of the line are taken from the CPT (see
-    |-C|). If instead modifier **+cf** is appended then the color from the cpt
-    file is applied to symbol fill.  Use just **+c** for both effects.
-    If |-Z| is set, then append **+z** to |-W| to assign pen color via **-C**\ *cpt* and the
-    *z*-values obtained.  Finally, if pen *color* = *auto*\ [*-segment*] or *auto-table* then
-    we will cycle through the pen colors implied by :term:`COLOR_SET` and change on a per-segment
-    or per-table basis.  The *width*, *style*, or *transparency* settings are unchanged.
+    *width* = 0.25p, *color* = black, *style* = solid]. Modifiers can be used to change the
+    appearance of the line:
+
+    - **+c**: Determine how the color from the cpt file lookup is applied to symbol 
+      and|or fill.  Append **l** to have the color of the line to be taken from the CPT (see
+      |-C|). If instead **f** is appended then the color from the cpt file is applied
+      to symbol fill.  If no argument is given the we use the color for both pen and fill.
+    - **+o**: Append *offset*\ [*unit*] and we will start and stop drawing the line at the
+      given distance *offset* from the end point. Append a *unit* from **c**\|\ **i**\|\ **p** to
+      indicate plot distance offsets on the map or append map distance units instead (see Units below)
+      [Cartesian distances]. Give *offset* as *b_offset*/*e_offset* if the beginning and end of the
+      line should have different offsets.
+    - **+s**: Draw the line using a Bezier spline [linear spline].
+    - **+v**: Given [**b**\|\ **e**]\ *vspecs*, we place a vector head at the ends of the lines. Prepend
+      **b** (beginning) or **e** (end) to add a vector at only one end [Default is shared specs for both end of the line].
+      **Note**: Because **+v** may take additional modifiers it must necessarily be given
+      at the end of the pen specification. See the `Vector Attributes`_ for more information or such modifiers.
+    - **+z**: If |-Z| is set, assign pen color via **-C**\ *cpt* and the *z*-values obtained
+      (same if transparency is set via |-Z|).  Finally, if pen *color* = *auto*\ [*-segment*] or *auto-table* then
+      we will cycle through the pen colors implied by :term:`COLOR_SET` and change on a per-segment
+      or per-table basis.  The *width*, *style*, or *transparency* settings are unchanged.
 
 .. |Add_-XY| replace:: |Add_-XY_links|
 .. include:: explain_-XY.rst_
@@ -235,15 +239,25 @@ Optional Arguments
 .. _-Z:
 
 **-Z**\ *value*\|\ *file*\ [**+t**\|\ **T**]
+    Control the color and|or transparency of line and polygons.
     Instead of specifying a line or polygon fill and outline color via |-G| and |-W|,
-    give both a *value* via |-Z| and a color lookup table via |-C|.  Alternatively,
-    give the name of a *file* with one z-value (read from the last column) for each polygon
-    or line in the input data. To apply the color obtained to a fill, use **-G+z**; to
-    apply it to the pen color, append **+z** to |-W|.
-    To just modulate the transparency of the polygon or line instead, append **+t** and the
-    *z*-value will be assumed to be transparency in the 0-100 % range.  Finally, append **+T**
-    and supply two columns via *file*: The last column must be the *z*-value while the next
-    to last column must have transparencies (in 0-100 % range).
+    pass a color lookup table via |-C|. Then, select one of two modes:
+
+    1. Append a *value* and the color is looked-up via the CPT.
+    2. Give the name of a *file* with one z-value (read from the last column) for each polygon
+       or line in the input data.
+
+    To apply the color we must use the |-G| or |-W| options in conjunction with |-Z|:
+
+    - **-G+z**: Apply the color to the polygon fill.
+    - **-W+z**: Apply the color to the pen instead.
+
+    Two modifiers is used to also handle transparency and|or color:
+
+    - **+t**: Modulate the transparency of the polygon or line instead; the
+      *z*-value will be assumed to be transparency in the 0-100 % range.
+    - **+T**: Supply two columns via *file*: The last column must be the *z*-value
+      while the penultimate column must have transparencies (in 0-100 % range).
 
 .. include:: explain_-aspatial.rst_
 


### PR DESCRIPTION
Introduce new RST include file `explain_line_draw.rst_` to handle the identical **-A** option in **plot** and **plot3d**. Update the **-L -W -Z** descriptions based on the updated ones in **plot**.
