### PR TITLE
Check for error if CPT has non-zero hinge

### DIFF
--- a/doc/rst/source/reference/features.rst
+++ b/doc/rst/source/reference/features.rst
@@ -1386,7 +1386,7 @@ are identified as such via the special comment
 
 | ``# HARD_HINGE``
 
-and all hard hinges occur at data value *z = 0* (but you can change this value by
+and all hard hinges must occur at data value *z = 0* (but you can change this value by
 adding **+h**\ *value* to the name of the CPT).
 Other CPTs may instead have a *soft* hinge which indicates a natural hinge or transition
 point in the CPT itself, unrelated to any natural data set *per se*. These CPTs
@@ -1397,6 +1397,7 @@ are flagged by the special comment
 CPTs with soft hinges behave as regular (non-hinge) CPTs *unless* the user activates then by
 appending **+h**\ [*hinge*] to the CPT name.  This modifier will convert the soft
 hinge into a hard hinge at the user-specified data value *hinge* [which defaults to 0].
+As for hard hinges, soft hinges must occur at data value *z = 0* in the CPT.
 Note that if your specified data range *excludes* an activated soft or hard hinge then we
 only perform color sampling from the *half* of the CPT that pertains to the data range.
 All dynamic CPTs will need to be stretched to the user's preferred range, and there

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -577,7 +577,7 @@ EXTERN_MSC bool gmt_x_out_of_bounds (struct GMT_CTRL *GMT, int *i, struct GMT_GR
 EXTERN_MSC bool gmt_row_col_out_of_bounds (struct GMT_CTRL *GMT, double *in, struct GMT_GRID_HEADER *h, openmp_int *row, openmp_int *col);
 EXTERN_MSC int gmt_list_cpt (struct GMT_CTRL *GMT, char option);
 EXTERN_MSC void gmt_scale_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double scale);
-EXTERN_MSC void gmt_stretch_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double z_low, double z_high);
+EXTERN_MSC unsigned int gmt_stretch_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P, double z_low, double z_high);
 EXTERN_MSC struct GMT_PALETTE * gmt_sample_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *Pin, double z[], int nz, bool continuous, bool reverse, bool log_mode, bool no_inter);
 EXTERN_MSC void gmt_invert_cpt (struct GMT_CTRL *GMT, struct GMT_PALETTE *P);
 EXTERN_MSC void gmt_undo_log10 (struct GMT_CTRL *GMT, struct GMT_PALETTE *P);

--- a/src/grd2cpt.c
+++ b/src/grd2cpt.c
@@ -710,7 +710,8 @@ EXTERN_MSC int GMT_grd2cpt (void *V_API, int mode, void *args) {
 
 	if (Ctrl->E.active && Ctrl->E.levels == 0) {	/* Use existing CPT structure, just linearly change z */
 		if ((Pout = GMT_Duplicate_Data (API, GMT_IS_PALETTE, GMT_DUPLICATE_ALLOC, Pin)) == NULL) return (API->error);
-		gmt_stretch_cpt (GMT, Pout, Ctrl->L.min, Ctrl->L.max);
+		if ((gmt_stretch_cpt (GMT, Pout, Ctrl->L.min, Ctrl->L.max)) == GMT_PARSE_ERROR)
+			Return (GMT_RUNTIME_ERROR);
 		if (Ctrl->I.mode & GMT_CPT_C_REVERSE)
 			gmt_invert_cpt (GMT, Pout);	/* Also flip the colors */
 		cpt_flags = 0;

--- a/src/makecpt.c
+++ b/src/makecpt.c
@@ -630,7 +630,9 @@ EXTERN_MSC int GMT_makecpt (void *V_API, int mode, void *args) {
 	}
 	if (!Ctrl->T.interpolate) {	/* Just copy what was in the CPT but stretch to given range min/max */
 		if ((Pout = GMT_Duplicate_Data (API, GMT_IS_PALETTE, GMT_DUPLICATE_ALLOC, Pin)) == NULL) return (API->error);
-		gmt_stretch_cpt (GMT, Pout, Ctrl->T.T.min, Ctrl->T.T.max);	/* Stretch to given range or use natural range if 0/0 */
+		/* Stretch to given range or use natural range if 0/0 */
+		if ((gmt_stretch_cpt (GMT, Pout, Ctrl->T.T.min, Ctrl->T.T.max)) == GMT_PARSE_ERROR)
+			Return (GMT_RUNTIME_ERROR);
 		if (Ctrl->I.mode & GMT_CPT_C_REVERSE)	/* Also flip the colors */
 			gmt_invert_cpt (GMT, Pout);
 		if (Ctrl->Q.mode == 1)

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1922,8 +1922,10 @@ EXTERN_MSC int GMT_psscale (void *V_API, int mode, void *args) {
 		Ctrl->D.emode &= 4;	/* This removes any 1,2,3 of selected but leaves 4 for nan */
 	}
 
-	if (P->has_range)	/* Convert from normalized to default CPT z-range */
-		gmt_stretch_cpt (GMT, P, 0.0, 0.0);
+	if (P->has_range) {	/* Convert from normalized to default CPT z-range */
+		if ((gmt_stretch_cpt (GMT, P, 0.0, 0.0)) == GMT_PARSE_ERROR)
+			Return (GMT_RUNTIME_ERROR);
+	}
 
 	if (P->categorical && (Ctrl->D.emode & 1 || Ctrl->D.emode & 2)) {
 			GMT_Report (API, GMT_MSG_WARNING, "Option -D: Cannot select back/fore-ground extender for categorical CPT\n");


### PR DESCRIPTION
Since a hinge in a CPT must internally be at z = 0, we now yield an error if it is not zero since the stretching makes that assumption and otherwise gives the wrong result.  The **+h**_hinge_ modifier can be anything but it is required that the CPT has the hinge at z = 0.
