### PR TITLE
Int16 tif files are more likely a grid than an image

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3523,7 +3523,7 @@ int gmt_raster_type (struct GMT_CTRL *GMT, char *file, bool extra) {
 				code = GMT_IS_GRID;
 			else if (I->type == GMT_FLOAT)		/* No doubt in this case */
 				code = GMT_IS_GRID;
-			else if (I->type == GMT_SHORT)		/* No so sure here but a Int16 is much likely a grid */
+			else if (I->type == GMT_SHORT && I->header->n_bands == 1)	/* No so sure here but a Int16 is much likely a grid */
 				code = GMT_IS_GRID;
 			else if (HH->orig_datatype == GMT_UCHAR || HH->orig_datatype == GMT_CHAR)	/* Got a gray or RGB image with or without transparency */
 				code = GMT_IS_IMAGE;

--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -3523,6 +3523,8 @@ int gmt_raster_type (struct GMT_CTRL *GMT, char *file, bool extra) {
 				code = GMT_IS_GRID;
 			else if (I->type == GMT_FLOAT)		/* No doubt in this case */
 				code = GMT_IS_GRID;
+			else if (I->type == GMT_SHORT)		/* No so sure here but a Int16 is much likely a grid */
+				code = GMT_IS_GRID;
 			else if (HH->orig_datatype == GMT_UCHAR || HH->orig_datatype == GMT_CHAR)	/* Got a gray or RGB image with or without transparency */
 				code = GMT_IS_IMAGE;
 			else if (I->header->n_bands > 1)	/* Whatever it is we must return multiband as an image */


### PR DESCRIPTION
When deciding if a .tif is a grid or image the Int16 (short int) case was not considered, which resulted in the file being tagged as image. This gave errors like

grdcut wc2.1_10m_prec_01.tif=gd:GTiff ...
...
grdcut [ERROR]: Unsupported image format. Supported formats are: BMP,GIF,JPG,PNG & TIF
grdcut [ERROR]: Alternatively, append :<driver> for a valid GDAL driver

With this PR the grdcut command succeeded.

