### PR TITLE
Add new greenspline option -K for statistics output to file or stdout

### DIFF
--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -19,6 +19,7 @@ Synopsis
 [ |SYN_OPT-D3| ]
 [ |-E|\ [*misfitfile*] ]
 [ |-I|\ *xinc*\ [/*yinc*\ [/*zinc*]] ]
+[ |-K|\ [*file*] ]
 [ |-L|\ [**t**][**r**] ]
 [ |-N|\ *nodefile* ]
 [ |-Q|\ [*az*\|\ *x/y/z*] ]
@@ -198,6 +199,14 @@ Optional Arguments
 
 **-I**\ *xinc*\ [/*yinc*\ [/*zinc*]]
     Specify equidistant sampling intervals, on for each dimension, separated by slashes.
+
+.. _-K:
+
+**-K**\ [*file*]
+    Write misfit and variance evaluation statistics to *file* (or *stdout* if no file is given).
+    Output order is *Data Model Explained(%) N Mean Std.dev RMS*; if |-W| is used we
+    add *chi^2* as a final 8th column.
+    If |-K| is not used then |-V|\ **i** will report these via two verbose messages.
 
 .. _-L:
 

--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -204,9 +204,9 @@ Optional Arguments
 
 **-K**\ [*file*]
     Write misfit and variance evaluation statistics to *file* (or *stdout* if no file is given).
-    Output order is *Data Model Explained(%) N Mean Std.dev RMS*; if |-W| is used we
-    add *chi^2* as a final 8th column.
-    If |-K| is not used then |-V|\ **i** will report these via two verbose messages.
+    Output order is *Data Model Explained(%) N Mean Std.dev RMS*. If |-W| is used we
+    add :math:`\chi^2` as a final 8th column. **Note**: If |-K| is not used then
+    |-V|\ **i** will report these via two verbose messages.
 
 .. _-L:
 


### PR DESCRIPTION
See #8158 for some background.  Rather than messing with the verbose output, this PR instead adds **-K** option that will wrote a data table with header and 7-8 values which makes it easier to access. Updated docs as well. Suggest @Esteban82 gives this a try and report back if there are any issues or request. You will see I basically write both the misfit and variance statistics to the file (variance first, then misfit) and then if **-W** is active we append one more output (chi^2) at the end.  This ensures that the first 7 columns are in a fixed order and the 8th optional column is only there if **-W** is set. @joa-quim, done merge this into master until @Esteban82 has given it a try later today.