### PR TITLE
Improve -C option in greenspline and gpsgridder

### DIFF
--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -164,23 +164,27 @@ Optional Arguments
     spline coefficients by SVD and eliminate the contribution from smaller
     eigenvalues [Default uses Gauss-Jordan elimination to solve the linear system
     and fit the data exactly (unless |-W| is used)]. Append a directive and *value*
-    to determine which eigenvalues to keep: **n** will retain only the *value* largest
-    eigenvalues [all], **r** [Default] will retain those eigenvalues whose ratio
-    to the largest eigenvalue is less than *value* [0], while **v** will retain
-    the eigenvalues needed to ensure the model prediction variance fraction is at
-    least *value*. For **n** and **v** you may append % if *value* is given as a
-    *percentage* of the total instead.  Several optional modifiers are available:
-    Append **+f**\ *file* to save the eigenvalues to the specified file for further
-    analysis. If **+n** is given then **+f**\ *file* is required and execution will
-    stop after saving the eigenvalues, i.e., no surface output is produced.  The
-    two other modifiers (**+c** and **+i**) are only available for 2-D gridding and
-    can be used to write intermediate grids, one per added eigenvalue, and thus require
-    a file name with a suitable extension to be given via |-G| (we automatically
-    insert "_cum_###" or "_inc_###" before the extension, using a fixed integer
-    format for the eigenvalue number starting at 0).  The **+i** modifier will
-    write the **i**\ ncremental contributions to the grid for each eigenvalue added,
-    while **+c** will instead produce the **c**\ umulative sum of these contributions.
-    Use both modifiers to write both types of intermediate grids.
+    to determine which eigenvalues to keep:
+
+    - **n**: Retain only the *value* numbers largest eigenvalues [all]. Optionally,
+      append % to indicate *value* is given in percentage.
+    - **r**: Retain those eigenvalues whose ratio to the largest eigenvalue is less than
+      *value* [Default, with *value* = 0].
+    - **v**: Retain the eigenvalues needed to ensure the model prediction variance fraction
+      is at least *value*. Optionally, append % to indicate *value* is given in percentage.
+
+    Several optional modifiers are available:
+
+    - **+c**: Produce the cumulative sum of these contributions, one grid per eigenvalue (2-D only).
+    - **+f**: Append *file* to save the eigenvalues to the specified file for further analysis.
+    - **+n**: If given then **+f**\ *file* is required and execution will
+      stop after saving the eigenvalues, i.e., no surface output is produced. 
+    - **+i**: Produce the incremental sum of these contributions, one grid per eigenvalue (2-D only).
+        
+    **Notes**: (1) Modifiers **++c** and **+i** require a file name with a suitable extension
+    to be given via |-G| (we automatically insert "_cum_###" or "_inc_###" before the
+    extension, using a fixed integer format for the eigenvalue number, starting at 0).
+    (2) Use both modifiers to write both types of intermediate grids.
 
 .. _-D:
 

--- a/doc/rst/source/supplements/geodesy/gpsgridder.rst
+++ b/doc/rst/source/supplements/geodesy/gpsgridder.rst
@@ -94,27 +94,31 @@ Optional Arguments
 .. _-C:
 
 **-C**\ [[**n**\|\ **r**\|\ **v**]\ *value*\ [%]][**+c**][**+f**\ *file*][**+i**][**+n**]
-    Find an approximate surface fit: Solve the linear system for the
+   Find an approximate surface fit: Solve the linear system for the
     spline coefficients by SVD and eliminate the contribution from smaller
     eigenvalues [Default uses Gauss-Jordan elimination to solve the linear system
     and fit the data exactly (unless |-W| is used)]. Append a directive and *value*
-    to determine which eigenvalues to keep: **n** will retain only the *value* largest
-    eigenvalues [all], **r** [Default] will retain those eigenvalues whose ratio
-    to the largest eigenvalue is less than *value* [0], while **v** will retain
-    the eigenvalues needed to ensure the model prediction variance fraction is at
-    least *value*. For **n** and **v** you may append % if *value* is given as a
-    *percentage* of the total instead.  Several optional modifiers are available:
-    Append **+f**\ *file* to save the eigenvalues to the specified file for further
-    analysis. If **+n** is given then **+f**\ *file* is required and execution will
-    stop after saving the eigenvalues, i.e., no surface output is produced.
-    The two other modifiers (**+c** and **+i**) can be used to
-    write intermediate grids, two (*u* and *v*) per eigenvalue, and we will
-    automatically insert "_cum_###" or "_inc_###" before the file extension,
-    using a fixed integer format for the eigenvalue number starting at 0.  The
-    **+i** modifier will write the **i**\ ncremental contributions to the grids
-    for each eigenvalue, while **+c** will instead produce the **c**\ umulative
-    sum of these contributions. Use both modifiers to write both types of
-    intermediate grids.
+    to determine which eigenvalues to keep:
+
+    - **n**: Retain only the *value* numbers largest eigenvalues [all]. Optionally,
+      append % to indicate *value* is given in percentage.
+    - **r**: Retain those eigenvalues whose ratio to the largest eigenvalue is less than
+      *value* [Default, with *value* = 0].
+    - **v**: Retain the eigenvalues needed to ensure the model prediction variance fraction
+      is at least *value*. Optionally, append % to indicate *value* is given in percentage.
+
+    Several optional modifiers are available:
+
+    - **+c**: Produce the cumulative sum of these contributions, two (*u* and *v*) grids per eigenvalue (2-D only).
+    - **+f**: Append *file* to save the eigenvalues to the specified file for further analysis.
+    - **+i**: Produce the incremental sum of these contributions, two (*u* and *v*) grids per eigenvalue (2-D only).
+    - **+n**: If given then **+f**\ *file* is required and execution will
+      stop after saving the eigenvalues, i.e., no surface output is produced. 
+    
+    **Notes**: (1) Modifiers **++c** and **+i** require a file name with a suitable extension
+    to be given via |-G| (we automatically insert "_cum_###" or "_inc_###" before the
+    extension, using a fixed integer format for the eigenvalue number, starting at 0).
+    (2) Use both modifiers to write both types of intermediate grids.
 
 .. _-E:
 


### PR DESCRIPTION
Almost the same option (gpsgridded writes tw not one grid per eigenvalue).  Updated docs:

<img width="908" alt="C2" src="https://github.com/GenericMappingTools/gmt/assets/26473567/979f0859-9816-419d-a6f1-d47ee45f845f">

<img width="915" alt="C" src="https://github.com/GenericMappingTools/gmt/assets/26473567/2b7bb9b1-85fb-46b6-8f0e-0ec588282588">


