### PR TITLE
Fix a bunch of clang compiler warnings

### DIFF
--- a/src/batch.c
+++ b/src/batch.c
@@ -653,7 +653,6 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 
 	if (Ctrl->S[BATCH_PREFLIGHT].active) {	/* Create the preflight script from the user's -Sf script */
 		/* The preflight script must be modern mode */
-		unsigned int rec = 0;
 		sprintf (pre_file, "batch_preflight.%s", extension[Ctrl->In.mode]);
 		is_classic = gmt_script_is_classic (GMT, Ctrl->S[BATCH_PREFLIGHT].fp);
 		if (is_classic) {
@@ -685,7 +684,6 @@ EXTERN_MSC int GMT_batch (void *V_API, int mode, void *args) {
 				if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 				fprintf (fp, "%s", line);	/* Just copy the line as is */
 			}
-			rec++;
 		}
 		fclose (Ctrl->S[BATCH_PREFLIGHT].fp);	/* Done reading the preflight script */
 		fclose (fp);	/* Done writing the temporary preflight script */

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -615,7 +615,7 @@ GMT_LOCAL char * gmtinit_colon_digexcl (char *string) {
 	return NULL;
 }
 
-#if 0/* Not in use yet, Roger, or this is my old stuff?
+#if 0	/* Not in use yet, Roger, or this is my old abandoned stuff? */
 /*! . */
 GMT_LOCAL char * gmtinit_strchr_predexcl (char *string, char target, char predexcl) {
 	/* Version of strchr() that will ignore any instance of target

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -615,6 +615,7 @@ GMT_LOCAL char * gmtinit_colon_digexcl (char *string) {
 	return NULL;
 }
 
+#if 0/* Not in use yet, Roger, or this is my old stuff?
 /*! . */
 GMT_LOCAL char * gmtinit_strchr_predexcl (char *string, char target, char predexcl) {
 	/* Version of strchr() that will ignore any instance of target
@@ -626,6 +627,7 @@ GMT_LOCAL char * gmtinit_strchr_predexcl (char *string, char target, char predex
 		if ((*c == target) && ((c == string) || (*(c-1) != predexcl))) return c;
 	return NULL;
 }
+#endif
 
 /*! . */
 GMT_LOCAL struct GMT_KEYWORD_DICTIONARY * gmtinit_find_kw (struct GMTAPI_CTRL *API, struct GMT_KEYWORD_DICTIONARY *kw1, struct GMT_KEYWORD_DICTIONARY *kw2, char *arg, int *k) {

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -3204,7 +3204,7 @@ GMT_LOCAL void gmtinit_parse_format_float_out (struct GMT_CTRL *GMT, char *value
 	char fmt[GMT_LEN64] = {""};
 	strncpy (GMT->current.setting.format_float_out_orig, value, GMT_LEN256-1);
 	if (strchr (value, ',')) {
-		unsigned int start = 0, stop = 0, error = 0;
+		unsigned int start = 0, stop = 0;
 		char *p = NULL;
 		/* Look for multiple comma-separated format statements of type [<cols>:]<format>.
 		 * Last format also becomes the default for unspecified columns */
@@ -3216,7 +3216,7 @@ GMT_LOCAL void gmtinit_parse_format_float_out (struct GMT_CTRL *GMT, char *value
 				else if (isdigit ((int)fmt[0]))	/* Just a single column, e.g., 3 */
 					start = stop = atoi (fmt);
 				else				/* Something bad */
-					error++;
+					GMT_Report (GMT->parent, GMT_MSG_ERROR, "Bad column specification: %s - expect trouble\n", fmt);
 				p++;	/* Move to format */
 				for (k = start; k <= stop; k++)
 					GMT->current.io.o_format[k] = strdup (p);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -9908,6 +9908,7 @@ GMT_LOCAL unsigned int gmtio_count_special (struct GMT_CTRL *GMT, char *string) 
 	char *p = NULL;
 	int code;
 	unsigned int L = strlen (string), start = 0, n_special = 0, k;
+	gmt_M_unused (GMT);
 
 	if (string[start] == '-' || string[start] == '+') start++;	/* Skip any leading signs */
 	p = &string[start];	/* Start of arg after skipping potential signs */
@@ -9945,6 +9946,7 @@ GMT_LOCAL bool gmtio_is_float (struct GMT_CTRL *GMT, char *string, bool allow_ex
 	 * Note: string has no leading sign. */
 
 	unsigned int L = strlen (string), k = 0, n_exp = 0, n_sep = 0;
+	gmt_M_unused (GMT);
 	for (k = 0; k < L; k++) {
 		if (string[k] == 'e' || string[k] == 'd') {	/* Allow junk FORTRAN output using d for double precision exponential format */
 			if (!allow_exp) return (false);

--- a/src/gmt_memory.c
+++ b/src/gmt_memory.c
@@ -143,7 +143,7 @@ int gmt_memtrack_init (struct GMT_CTRL *GMT) {
 	M->active = ( env && strcasecmp (env, "off") != 0 ); /* Track if GMT_TRACK_MEMORY is set and is not OFF */
 	M->do_log = ( env && strcasecmp (env, "log") == 0 ); /* Write a log if GMT_TRACK_MEMORY is LOG */
 	if (M->active && isdigit (env[0]))	/* Got a specific ID to track; see gmtmemory_memtrack_add */
-		 M->find = atoi (env);
+		 M->find = atol (env);
 	M->search = true;
 	if (M->active) M->fp = stderr;
 	if (!M->do_log) /* Logging not requested */ {
@@ -317,6 +317,7 @@ static inline void gmtmemory_memtrack_add (struct GMT_CTRL *GMT, const char *whe
 		/* The item you are looking for is being allocated now */
 		int found = 1;	/* Add a debug stop point here and then examine where you are */
 		found ++;	/* Just to keep compiler happy */
+		if (found) GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Memory tracker found ID = %" PRIu64 "\n", M->find);
 	}
 	entry->ID = M->n_ID++;
 

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -11053,7 +11053,7 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 					X[np].y0 = S0->data[col_y0][row];	/* Critical point's y0 coordinate */
 					X[np].s0_i0 = row;	/* Set S0 first index inside this section */
 					/* Must interpolate to get the corresponding value at x along S1 */
-					result = gmt_intpol (GMT, S1->data[GMT_X], S1->data[col_y1], NULL, S1->n_rows, 1, &(X[np].x), &(X[np].y1), 0.0, GMT_SPLINE_AKIMA);
+					if ((result = gmt_intpol (GMT, S1->data[GMT_X], S1->data[col_y1], NULL, S1->n_rows, 1, &(X[np].x), &(X[np].y1), 0.0, GMT_SPLINE_AKIMA))) return (result);
 					kk = 0;
 					while (S1->data[GMT_X][kk] < X[np].x) kk++;	/* Wind to first x point beyond the NaN gap */
 					X[np].s1_i0 = kk;	/* Set first S1 index inside this section */
@@ -11062,7 +11062,7 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 					X[np].y1 = S0->data[col_y0][row];	/* Critical point's y1 coordinate */
 					X[np].s1_i0 = row;	/* Set S1 first index inside this section */
 					/* Must interpolate to get the corresponding value at x along S0 */
-					result = gmt_intpol (GMT, S0->data[GMT_X], S0->data[col_y0], NULL, S0->n_rows, 1, &(X[np].x), &(X[np].y0), 0.0, GMT_SPLINE_AKIMA);
+					if ((result = gmt_intpol (GMT, S0->data[GMT_X], S0->data[col_y0], NULL, S0->n_rows, 1, &(X[np].x), &(X[np].y0), 0.0, GMT_SPLINE_AKIMA))) return (result);
 					kk = 0;
 					while (S0->data[GMT_X][kk] < X[np].x) kk++;	/* Wind to first point beyond the NaN gap */
 					X[np].s0_i0 = kk;	/* Set first S0 index inside this section */
@@ -11080,7 +11080,7 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 						X[np].y0 = S0->data[col_y0][row];	/* Critical point's y0 coordinate */
 						X[np].s0_i0 = row;	/* Set S0 first index inside this section */
 						/* Must interpolate to get the corresponding value at x along S1 */
-						result = gmt_intpol (GMT, S1->data[GMT_X], S1->data[col_y1], NULL, S1->n_rows, 1, &(X[np].x), &(X[np].y1), 0.0, GMT_SPLINE_AKIMA);
+						if ((result = gmt_intpol (GMT, S1->data[GMT_X], S1->data[col_y1], NULL, S1->n_rows, 1, &(X[np].x), &(X[np].y1), 0.0, GMT_SPLINE_AKIMA))) return (result);
 						kk = 0;
 						while (S1->data[GMT_X][kk] < X[np].x) kk++;	/* Wind to first point beyond gap */
 						X[np].s1_i0 = kk;	/* Set S1 first index inside this section */
@@ -11088,7 +11088,7 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 					else {	/* Working on S1 */
 						X[np].y1 = S1->data[col_y1][row];	/* Critical point's y1 coordinate */
 						X[np].s1_i0 = row;	/* Set S1 first index inside this section */
-						result = gmt_intpol (GMT, S0->data[GMT_X], S0->data[col_y0], NULL, S0->n_rows, 1, &(X[np].x), &(X[np].y0), 0.0, GMT_SPLINE_AKIMA);
+						if ((result = gmt_intpol (GMT, S0->data[GMT_X], S0->data[col_y0], NULL, S0->n_rows, 1, &(X[np].x), &(X[np].y0), 0.0, GMT_SPLINE_AKIMA))) return (result);
 						kk = 0;
 						while (S0->data[GMT_X][kk] < X[np].x) kk++;	/* Wind to first point beyond gap */
 						X[np].s0_i0 = kk;	/* Set first S0 index inside this section */
@@ -11119,7 +11119,7 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 		X[np].type = GMT_CURVE_CUT;	/* CUT type at start of common x-domain */
 		X[np].s0_i1 = X[np].s1_i1 = -1;	/* Not set yet */
 		/* Must interpolate to get the corresponding value at x along S1 (y1) */
-		result = gmt_intpol (GMT, S1->data[GMT_X], S1->data[col_y1], NULL, S1->n_rows, 1, &(X[np].x), &(X[np].y1), 0.0, GMT_SPLINE_AKIMA);
+		if ((result = gmt_intpol (GMT, S1->data[GMT_X], S1->data[col_y1], NULL, S1->n_rows, 1, &(X[np].x), &(X[np].y1), 0.0, GMT_SPLINE_AKIMA))) return (result);
 		np++;
 	}
 	else if (S1->data[GMT_X][0] >= S0->data[GMT_X][0]) {	/* S0 has the minimum x */
@@ -11136,7 +11136,7 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 		X[np].type = GMT_CURVE_CUT;	/* CUT type at start of common x-domain */
 		X[np].s0_i1 = X[np].s1_i1 = -1;	/* Not set yet */
 		/* Must interpolate to get the corresponding value at x along S0 (y0) */
-		result = gmt_intpol (GMT, S0->data[GMT_X], S0->data[col_y0], NULL, S0->n_rows, 1, &(X[np].x), &(X[np].y0), 0.0, GMT_SPLINE_AKIMA);
+		if ((result = gmt_intpol (GMT, S0->data[GMT_X], S0->data[col_y0], NULL, S0->n_rows, 1, &(X[np].x), &(X[np].y0), 0.0, GMT_SPLINE_AKIMA))) return (result);
 		np++;
 	}
 	/* If S0 ends before S1 or the other way around we must get the y-value at the smallest end point */
@@ -11154,7 +11154,7 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 		X[np].s1_i0 = stop[1];	/* S1 has been wound back to stop[1] */
 		X[np].type = GMT_CURVE_CUT;	/* CUT type at end of common x-domain */
 		X[np].s0_i1 = X[np].s1_i1 = -1;	/* Not set yet */
-		result = gmt_intpol (GMT, S1->data[GMT_X], S1->data[col_y1], NULL, S1->n_rows, 1, &(X[np].x), &(X[np].y1), 0.0, GMT_SPLINE_AKIMA);
+		if ((result = gmt_intpol (GMT, S1->data[GMT_X], S1->data[col_y1], NULL, S1->n_rows, 1, &(X[np].x), &(X[np].y1), 0.0, GMT_SPLINE_AKIMA))) return (result);
 		np++;
 	}
 	else if (S1->data[GMT_X][last[1]] <= S0->data[GMT_X][last[0]]) {
@@ -11170,7 +11170,7 @@ int gmt_two_curve_fill (struct GMT_CTRL *GMT, struct GMT_DATASEGMENT *S0, struct
 		X[np].s0_i0 = stop[0];	/* S0 has been wound back to stop[0] */
 		X[np].s1_i0 = last[1];	/* Last S1 in overlap is its last point */
 		X[np].s0_i1 = X[np].s1_i1 = -1;	/* Not set yet */
-		result = gmt_intpol (GMT, S0->data[GMT_X], S0->data[col_y0], NULL, S0->n_rows, 1, &(X[np].x), &(X[np].y0), 0.0, GMT_SPLINE_AKIMA);
+		if ((result = gmt_intpol (GMT, S0->data[GMT_X], S0->data[col_y0], NULL, S0->n_rows, 1, &(X[np].x), &(X[np].y0), 0.0, GMT_SPLINE_AKIMA))) return (result);
 		X[np].type = GMT_CURVE_CUT;	/* CUT type at end of common x-domain */
 		np++;
 	}

--- a/src/gmt_private.h
+++ b/src/gmt_private.h
@@ -154,7 +154,7 @@ struct GMTAPI_CTRL {
 	unsigned int verbose;			/* Used until GMT is set up */
 	unsigned int n_tmp_headers;		/* Number of temporarily held table headers */
 	unsigned int terminal_width;	/* Width of the terminal */
-	unsigned int n_numerical_columns;	/* 0 except for pstext where there will be 2-4 numerical leading columns before text */
+	int n_numerical_columns;		/* 0 except for pstext where there will be 2-4 numerical leading columns before text */
 	bool registered[2];			/* true if at least one source/destination has been registered (in and out) */
 	bool io_enabled[2];			/* true if access has been allowed (in and out) */
 	bool module_input;			/* true when we are about to read inputs to the module (command line) */

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -487,7 +487,7 @@ GMT_LOCAL void gmtproj_genper_setup (struct GMT_CTRL *GMT, double h0, double alt
 			phig = lat - asind(N1*e2*sphi1*cphi1/(P*a));
 			GMT_Report (GMT->parent, GMT_MSG_DEBUG, "genper: %2d P %12.7f phig %12.7f\n", niter, P, phig);
 		}
-		while (fabs (phig - phig_last) > 1e-9);
+		while (fabs (phig - phig_last) > GMT_PROJ_CONV_LIMIT);
 		sincosd (phig, &sphig, &cphig);
 		P = (cphi1/cphig)*(H + N1 + h0)/a;
 	}

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -15702,10 +15702,10 @@ unsigned int gmtlib_load_custom_annot (struct GMT_CTRL *GMT, struct GMT_PLOT_AXI
 	 * an array with coordinates and labels, and set interval to true if applicable.
 	 */
 	int nc, error;
-	unsigned int save_coltype, save_max_cols_to_read;
+	unsigned int k = 0, save_coltype, save_max_cols_to_read;
 	uint64_t row;
 	bool text, found, save_trailing;
-	unsigned int k = 0, n_annot = 0, n_int = 0;
+	//unsigned int n_annot = 0, n_int = 0;
 	double *x = NULL, limit[2] = {-DBL_MAX, +DBL_MAX};
 	char **L = NULL, type[GMT_LEN8] = {""}, txt[GMT_BUFSIZ] = {""};
 	struct GMT_DATASET *D = NULL;
@@ -15749,8 +15749,10 @@ unsigned int gmtlib_load_custom_annot (struct GMT_CTRL *GMT, struct GMT_PLOT_AXI
 			}
 		}
 		else if (S->data[GMT_X][row] < limit[0] || S->data[GMT_X][row] > limit[1]) continue;	/* Cartesian check */
+#if 0	/* Old degguging things left commented */
 		if (strchr (type, 'i')) n_int++;
 		if (strchr (type, 'a')) n_annot++;
+#endif
 		x[k] = S->data[GMT_X][row];
 		if (text && nc == 2) {
 			gmtlib_enforce_rgb_triplets (GMT, txt, GMT_BUFSIZ);	/* If @; is used, make sure the color information passed on to ps_text is in r/b/g format */

--- a/src/gmtconnect.c
+++ b/src/gmtconnect.c
@@ -923,6 +923,7 @@ EXTERN_MSC int GMT_gmtconnect (void *V_API, int mode, void *args) {
 	GMT_Report (API, GMT_MSG_INFORMATION, "%" PRIu64 " new closed segments\n", n_closed);
 	GMT_Report (API, GMT_MSG_INFORMATION, "%" PRIu64 " segments were already closed\n", n_closed_orig);
 	if (n_trouble) GMT_Report (API, GMT_MSG_INFORMATION, "%" PRIu64 " trouble spots\n", n_trouble);
+	if (chain) GMT_Report (API, GMT_MSG_DEBUG, "%" PRIu64 " composite line segments (closed or open) processed via connecting\n", chain);
 
 	gmt_M_free (GMT, buffer);
 

--- a/src/gmtinfo.c
+++ b/src/gmtinfo.c
@@ -409,7 +409,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTINFO_CTRL *Ctrl, struct GMT_OP
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_M_free (GMT, xyzmin); gmt_M_free (GMT, xyzmax); gmt_M_free (GMT, xyzminL); gmt_M_free (GMT, lonmin);  gmt_M_free (GMT, lonmax); gmt_M_free (GMT, xyzmaxL); gmt_M_free (GMT, Q); gmt_M_free (GMT, Z); gmt_M_free (GMT, Out); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
 EXTERN_MSC int GMT_gmtinfo (void *V_API, int mode, void *args) {
-	bool got_stuff = false, first_data_record, give_r_string = false, save_t, first_time = true;;
+	bool got_stuff = false, first_data_record, give_r_string = false, save_t, first_time = true;
 	bool brackets = false, work_on_abs_value, do_report, done, full_range = false;
 	int i, j, error = 0, col_type[GMT_MAX_COLUMNS];
 	unsigned int fixed_phase[2] = {1, 1}, min_cols, save_range, n_items = 0;

--- a/src/gmtsplit.c
+++ b/src/gmtsplit.c
@@ -199,7 +199,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTSPLIT_CTRL *Ctrl, struct GMT_O
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int j, n_errors = 0, n_outputs = 0;
+	unsigned int j, n_errors = 0;
 	char txt_a[GMT_LEN256] = {""};
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
@@ -281,7 +281,6 @@ static int parse (struct GMT_CTRL *GMT, struct GMTSPLIT_CTRL *Ctrl, struct GMT_O
 							n_errors++;
 						}
 						if (opt->arg[j] == 'z') Ctrl->Q.z_selected = true;
-						n_outputs++;
 					}
 					else {
 						GMT_Report (API, GMT_MSG_ERROR, "Option -Q: Too many output columns selected: Choose from -Qxyzdg\n");

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1022,7 +1022,7 @@ GMT_LOCAL void grdimage_img_byte_index (struct GMT_CTRL *GMT, struct GRDIMAGE_CT
 		for (scol = 0; scol < Conf->n_columns; scol++) {	/* Compute rgb for each pixel along this scanline */
 			node_s = kk_s + Conf->actual_col[scol];	/* Start of current pixel node */
 			index = (int)Conf->Image->data[node_s];
-			if (index < start) {	/* E.g., data is 0 for Nodata */
+			if (index < (int64_t)start) {	/* E.g., data is 0 for Nodata */
 				for (k = 0; k < 3; k++)
 					image[byte++] = (unsigned char)gmt_M_s255 (Conf->P->bfn[GMT_NAN].rgb[k]);
 			}

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -705,7 +705,7 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 	/* High-level function that implements the grdtrack task */
 
 	int status, error, ks;
-	uint64_t n_points = 0, n_read = 0;
+	uint64_t n_points = 0;
 	unsigned int g, k, xy_mode, dtype, pad_mode = 0;
 	bool img_conv_needed = false, some_outside = false;
 
@@ -1278,8 +1278,6 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 				Out = gmt_new_record (GMT, out, NULL);
 				Out->text = (GMT->current.io.trailing_text[GMT_OUT]) ? In->text : NULL;
 			}
-
-			n_read++;
 
 			status = grdtrack_sample_all_grids (GMT, GC, Ctrl->G.n_grids, xy_mode, in[GMT_X], in[GMT_Y], value);
 			if (status == -1) {	/* Point is outside the region of all grids */

--- a/src/gsfml/fzblender.c
+++ b/src/gsfml/fzblender.c
@@ -361,8 +361,8 @@ struct TREND {	/* Holds slope and intercept for each segment column we need to d
 
 EXTERN_MSC int GMT_fzblender (void *V_API, int mode, void *args) {
 	unsigned int fz, row;
-	int error = 0, n_d, n_g, k, n, item, status, ndig;
-	int col[N_BLEND_COLS][N_BLENDS] =	/* Columns in the analyzis file for b,d,e,t,u trace parameters */
+	int error = 0, n_d, n_g, k, n, item, status;
+	int col[N_BLEND_COLS][N_BLENDS] =	/* Columns in the analysis file for b,d,e,t,u trace parameters */
 	{
 		{POS_XB0, POS_XD0, POS_XE0, POS_XT0, POS_XR},	/* FZ longitudes */
 		{POS_YB0, POS_YD0, POS_YE0, POS_YT0, POS_YR},	/* FZ latitudes */
@@ -572,7 +572,7 @@ EXTERN_MSC int GMT_fzblender (void *V_API, int mode, void *args) {
 			continue;
 		}
 	
-		ndig = irint (floor (log10 ((double)Tin->segment[fz]->n_rows))) + 1;	/* Determine how many decimals are needed for largest FZ id */
+		//ndig = irint (floor (log10 ((double)Tin->segment[fz]->n_rows))) + 1;	/* Determine how many decimals are needed for largest FZ id */
 		
 		for (row = 0; row < Tin->segment[fz]->n_rows; row++) {	/* Process each point along digitized FZ trace */
 			

--- a/src/gsfml/mlconverter.c
+++ b/src/gsfml/mlconverter.c
@@ -111,14 +111,13 @@ static int parse (struct GMTAPI_CTRL *API, struct MLCONVERTER_CTRL *Ctrl, struct
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_files = 0, n_errors = 0;
+	unsigned int n_errors = 0;
 	struct GMT_OPTION *opt = NULL;
 
 	for (opt = options; opt; opt = opt->next) {
 		switch (opt->option) {
 
 			case '<':	/* Skip input files */
-				n_files++;
 				break;
 
 			/* Processes program-specific parameters */

--- a/src/mgd77/mgd77header.c
+++ b/src/mgd77/mgd77header.c
@@ -121,7 +121,7 @@ static int parse (struct GMT_CTRL *GMT, struct MGD77HEADER_CTRL *Ctrl, struct GM
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, n_opts = 0;
+	unsigned int n_errors = 0;
 	int sval;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
@@ -163,9 +163,6 @@ static int parse (struct GMT_CTRL *GMT, struct MGD77HEADER_CTRL *Ctrl, struct GM
 				break;
 		}
 	}
-	if (Ctrl->M.mode == RAW_HEADER) n_opts++;
-	if (Ctrl->M.mode == M77T_HEADER) n_opts++;
-	if (Ctrl->M.mode == FORMATTED_HEADER) n_opts++;
 
 	return (n_errors ? GMT_PARSE_ERROR : GMT_NOERROR);
 }

--- a/src/mgd77/mgd77manage.c
+++ b/src/mgd77/mgd77manage.c
@@ -333,7 +333,7 @@ static int parse (struct GMT_CTRL *GMT, struct MGD77MANAGE_CTRL *Ctrl, struct GM
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, k, n_cruises = 0;
+	unsigned int n_errors = 0, k;
 	bool got_table, got_grid, strings;
 	nc_type c_nc_type;
 	char file[PATH_MAX] = {""}, *c = NULL;
@@ -345,7 +345,6 @@ static int parse (struct GMT_CTRL *GMT, struct MGD77MANAGE_CTRL *Ctrl, struct GM
 
 			case '<':	/* Input files */
 			case '#':	/* Skip input files confused as numbers (e.g. 123456) */
-				n_cruises++;
 				break;
 
 			/* Processes program-specific parameters */

--- a/src/movie.c
+++ b/src/movie.c
@@ -1667,7 +1667,6 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 
 	if (Ctrl->S[MOVIE_PREFLIGHT].active) {	/* Create the preflight script from the user's background script */
 		/* The background script must be modern mode */
-		unsigned int rec = 0;
 		if (Ctrl->S[MOVIE_PREFLIGHT].PS)	/* Just got a PS file, nothing to do */
 			fclose (Ctrl->S[MOVIE_PREFLIGHT].fp);
 		else {	/* Run the preflight script */
@@ -1710,7 +1709,6 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 					else if (strchr (line, '\n') == NULL) strcat (line, "\n");	/* In case the last line misses a newline */
 					fprintf (fp, "%s", line);	/* Just copy the line as is */
 				}
-				rec++;
 			}
 			fclose (Ctrl->S[MOVIE_PREFLIGHT].fp);	/* Done reading the foreground script */
 			fclose (fp);	/* Done writing the preflight script */

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -2153,12 +2153,19 @@ static int psl_paragraphprocess (struct PSL_CTRL *PSL, double y, double fontsize
 							if (n_scan == 1) {	/* Got gray shade */
 								rgb[0] /= 255.0;	/* Normalize to 0-1 range */
 								rgb[1] = rgb[2] = rgb[0];
-								if (rgb[0] < 0.0 || rgb[0] > 1.0) error++;
+								if (rgb[0] < 0.0 || rgb[0] > 1.0) {
+									PSL_message (PSL, PSL_MSG_ERROR, "Error: Normalized gray value < 0 or > 1\n");
+									error++;
+								}
 							}
 							else if (n_scan == 3) {	/* Got r/g/b */
+								static *color[3] = {"red", "gree", "blue"};
 								for (p = 0; p < 3; p++) {
 									rgb[p] /= 255.0;	/* Normalize to 0-1 range */
-									if (rgb[p] < 0.0 || rgb[p] > 1.0) error++;
+									if (rgb[p] < 0.0 || rgb[p] > 1.0) {
+										error++;
+										PSL_message (PSL, PSL_MSG_ERROR, "Error: Normalized %s value < 0 or > 1\n", color[p]);
+									}
 								}
 							}
 							else	/* Got crap */
@@ -2344,7 +2351,7 @@ static int psl_paragraphprocess (struct PSL_CTRL *PSL, double y, double fontsize
 
 	psl_freewords (word, n_alloc_txt);
 	PSL_free (word);
-	return (sub_on|super_on|scaps_on|symbol_on|font_on|size_on|color_on|under_on);
+	return (error + sub_on|super_on|scaps_on|symbol_on|font_on|size_on|color_on|under_on);
 }
 
 static void psl_get_origin (double xt, double yt, double xr, double yr, double r, double *xo, double *yo, double *b1, double *b2) {

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -2159,7 +2159,7 @@ static int psl_paragraphprocess (struct PSL_CTRL *PSL, double y, double fontsize
 								}
 							}
 							else if (n_scan == 3) {	/* Got r/g/b */
-								static *color[3] = {"red", "gree", "blue"};
+								static char *color[3] = {"red", "green", "blue"};
 								for (p = 0; p < 3; p++) {
 									rgb[p] /= 255.0;	/* Normalize to 0-1 range */
 									if (rgb[p] < 0.0 || rgb[p] > 1.0) {

--- a/src/potential/gmtgravmag3d.c
+++ b/src/potential/gmtgravmag3d.c
@@ -261,7 +261,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTGRAVMAG3D_CTRL *Ctrl, struct G
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int pos = 0, n_errors = 0, n_files = 0;
+	unsigned int pos = 0, n_errors = 0;
 	int n_par, err_npar = 0, nBELL = 0, nCIL = 0, nPRI = 0, nCONE = 0, nELL = 0, nPIR = 0, nSPHERE = 0;
 	char p[GMT_LEN256] = {""}, p2[GMT_LEN256] = {""};
 	struct GMT_OPTION *opt = NULL;
@@ -273,7 +273,6 @@ static int parse (struct GMT_CTRL *GMT, struct GMTGRAVMAG3D_CTRL *Ctrl, struct G
 			case '<':	/* Input files */
 				if (GMT_Get_FilePath (API, GMT_IS_DATASET, GMT_IN, GMT_FILE_REMOTE, &(opt->arg))) n_errors++;
 				Ctrl->T.xyz_file = strdup(opt->arg);
-				n_files++;
 				break;
 
 			/* Processes program-specific parameters */

--- a/src/potential/grdseamount.c
+++ b/src/potential/grdseamount.c
@@ -829,7 +829,6 @@ GMT_LOCAL double grdseamount_para_solver (struct SEAMOUNT *S, double f, double v
 
 GMT_LOCAL double grdseamount_gauss_solver (struct SEAMOUNT *S, double f, double v, bool elliptical) {
 	/* Return effective phi given volume fraction for a Gaussian seamount */
-	int n = 0;
 	double A, B, V0, phi, phi0, r02, h0;
 	r02 = (elliptical) ? S->major * S->minor : S->radius * S->radius;
 	h0  = S->height;

--- a/src/potential/grdseamount.c
+++ b/src/potential/grdseamount.c
@@ -839,8 +839,7 @@ GMT_LOCAL double grdseamount_gauss_solver (struct SEAMOUNT *S, double f, double 
 	do {
 		phi0 = phi;
 		phi = M_SQRT2 * sqrt (-log (B/(1 + 4.5 * phi0*phi0))) / 3.0;
-		n++;
-	} while (fabs (phi-phi0) > 1e-6);
+	} while (fabs (phi-phi0) > GMT_CONV6_LIMIT);
 	return (phi);
 }
 

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -291,6 +291,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 GMT_LOCAL unsigned int psevents_parse_ramp_type (struct GMT_CTRL *GMT, char *string, unsigned int *start) {
 	/* Detect optional ramp codes c, l, q[Default] and start of parsing text for value */
 	unsigned int type = PSEVENTS_RAMP_QUAD;	/* Default ramp (except for fade which was linear) */
+	gmt_M_unused (GMT);
 
 	switch (string[1]) {
 		case 'c':	type = PSEVENTS_RAMP_COSINE;	*start = 2;	break;
@@ -914,7 +915,7 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 
 	enum gmt_col_enum time_type, end_type;
 
-	unsigned int n_cols_needed, n_copy_to_out, col, s_in = 2, t_in = 2, d_in = 3, x_col = 2, i_col = 3, t_col = 4;
+	unsigned int n_cols_needed, n_copy_to_out, col, t_in = 2, d_in = 3, x_col = 2, i_col = 3, t_col = 4;
 	unsigned int x_type, y_type, geometry;
 
 	uint64_t tbl, seg, row, n_symbols_plotted = 0, n_labels_plotted = 0;
@@ -1168,7 +1169,7 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 	}
 
 	if (!Ctrl->Z.active) {
-		if (Ctrl->C.active) s_in++, t_in++, d_in++, x_col++, i_col++, t_col++;	/* Must allow for z-value in input/output before size, time, length */
+		if (Ctrl->C.active) t_in++, d_in++, x_col++, i_col++, t_col++;	/* Must allow for z-value in input/output before size, time, length */
 		if (Ctrl->S.mode) t_in++, d_in++, x_col++, i_col++, t_col++;	/* Must allow for size in input/output before time and length */
 	}
 	/* Determine if there is a coda phase where symbols remain visible after the event ends: */

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -796,6 +796,7 @@ GMT_LOCAL double psevents_ramp (struct GMT_CTRL *GMT, struct PSEVENTS_CTRL *Ctrl
 	 */
 	unsigned int direction = (section == PSEVENTS_RISE) ? PSEVENTS_RAMP_UP : PSEVENTS_RAMP_DOWN;
 	double t_norm = 1.0 + (t_now - t[section])/Ctrl->E.dt[kind][section], ramp = 0.0;
+	gmt_M_unused (GMT);
 	if (section == PSEVENTS_FADE) t_norm -= 1.0;
 
 	t_norm = fabs (t_norm);

--- a/src/seis/grdvs30.c
+++ b/src/seis/grdvs30.c
@@ -223,6 +223,7 @@ static int check_grid_compat (struct GMTAPI_CTRL *API, struct GMT_GRID *A, struc
 	   return 1		if any of the corners differ more than 1/5 of the grid spacing
 	   return 3		if registrations are not equal
 	*/
+	gmt_M_unused (API);
 	if (fabs((A->header->inc[GMT_X] - B->header->inc[GMT_X]) / A->header->inc[GMT_X]) > 0.002 ||
 		fabs((A->header->inc[GMT_Y] - B->header->inc[GMT_Y]) / A->header->inc[GMT_Y]) > 0.002)
 		return 1;

--- a/src/spotter/originater.c
+++ b/src/spotter/originater.c
@@ -697,6 +697,8 @@ EXTERN_MSC int GMT_originater (void *V_API, int mode, void *args) {
 		smt++;
 	} while (true);
 
+	if (n_skipped) GMT_Report (API, GMT_MSG_INFORMATION, "%u seamount skipped as flagged by negative ages\n", n_skipped);
+
 	if (GMT_End_IO (API, GMT_IN,  0) != GMT_NOERROR) {	/* Disables further data input */
 		Return (API->error);
 	}

--- a/src/surface.c
+++ b/src/surface.c
@@ -1728,7 +1728,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		GMT_h_OPT, GMT_i_OPT, GMT_qi_OPT, GMT_r_OPT, GMT_w_OPT, GMT_x_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
-	ppm = urint (SURFACE_CONV_LIMIT / 1e-6);	/* Default convergence criteria */
+	ppm = urint (SURFACE_CONV_LIMIT / GMT_CONV6_LIMIT);	/* Default convergence criteria */
 
 	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
 	GMT_Option (API, "<");

--- a/src/surface_experimental.c
+++ b/src/surface_experimental.c
@@ -1933,7 +1933,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_r_OPT, GMT_s_OPT, GMT_x_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
-	ppm = urint (SURFACE_CONV_LIMIT / 1e-6);	/* Default convergence criteria */
+	ppm = urint (SURFACE_CONV_LIMIT / GMT_CONV6_LIMIT);	/* Default convergence criteria */
 
 	GMT_Message (API, GMT_TIME_NONE, "\t-G sets output grid file name.\n");
 	GMT_Option (API, "I,R");

--- a/src/surface_old.c
+++ b/src/surface_old.c
@@ -1534,7 +1534,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 		GMT_V_OPT, GMT_bi_OPT, GMT_di_OPT, GMT_e_OPT, GMT_f_OPT, GMT_h_OPT, GMT_i_OPT, GMT_r_OPT, GMT_s_OPT, GMT_colon_OPT, GMT_PAR_OPT);
 
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
-	ppm = urint (SURFACE_CONV_LIMIT / 1e-6);
+	ppm = urint (SURFACE_CONV_LIMIT / GMT_CONV6_LIMIT);
 
 	GMT_Message (API, GMT_TIME_NONE, "\t-G sets output grid file name.\n");
 	GMT_Option (API, "I,R");

--- a/src/windbarbs/psbarb.c
+++ b/src/windbarbs/psbarb.c
@@ -294,9 +294,9 @@ EXTERN_MSC int GMT_psbarb (void *V_API, int mode, void *args) {
 	bool penset_OK = true, old_is_world;
 	bool get_rgb, clip_set = false, fill_active;
 	bool default_outline, outline_active;
-	unsigned int k, j, geometry, pos2x, pos2y, set_type;
+	unsigned int k, j, geometry, pos2y, set_type;
 	unsigned int n_cols_start = 3, justify;
-	unsigned int ex1, ex2, ex3, n_needed, read_mode;
+	unsigned int ex1, ex2, n_needed, read_mode;
 	int error = GMT_NOERROR;
 
 	uint64_t i, n, n_total_read = 0;
@@ -363,12 +363,11 @@ EXTERN_MSC int GMT_psbarb (void *V_API, int mode, void *args) {
 	/* Extra columns 1, 2, and 3 */
 	ex1 = (get_rgb) ? 4 : 3;
 	ex2 = (get_rgb) ? 5 : 4;
-	ex3 = (get_rgb) ? 6 : 5;
 	if (!GMT->common.J.zactive) {			/* PSBARB */
-		ex1--; ex2--; ex3--; n_cols_start--;
+		ex1--; ex2--; n_cols_start--;
 		for (j = 0; j < S.n_nondim; j++) S.nondim_col[j]--;
 	}
-	pos2x = ex1 + GMT->current.setting.io_lonlat_toggle[GMT_IN];	/* Column with a 2nd longitude (for VECTORS with two sets of coordinates) */
+	// pos2x = ex1 + GMT->current.setting.io_lonlat_toggle[GMT_IN];	/* Column with a 2nd longitude (for VECTORS with two sets of coordinates) */
 	pos2y = ex2 - GMT->current.setting.io_lonlat_toggle[GMT_IN];	/* Column with a 2nd latitude (for VECTORS with two sets of coordinates) */
 	n_needed = n_cols_start + S.n_required;
 


### PR DESCRIPTION
Mostly harmless variables set but not used, but we had one test of an unsigned int against -1, which cannot be good.  Changed to signed int variable.  Turned a bunch of other places where we set and incremented error if something odd happened, but no action was taken.  Fixed most of those. Removed many unused counters probably from some debugging operation.  Added return further up if _gmt_intpol_ returned an error (new code now fixed).