### PR TITLE
Enlarge longopts translation entry buffer sizes.

### DIFF
--- a/src/gmt_types.h
+++ b/src/gmt_types.h
@@ -74,9 +74,9 @@ struct GMT_KEYWORD_DICTIONARY {	/* Used for keyword-value lookup */
 	char separator;			/* Single character separating 2 or more identical specifications [0 for no repeat] */
 	char short_option;		/* Single character GMT option code */
 	char long_option[GMT_LEN256-1];		/* Name of corresponding long option */
-	char short_directives[GMT_LEN32];	/* Single character directives, comma-separated */
+	char short_directives[GMT_LEN64];	/* Single character directives, comma-separated */
 	char long_directives[GMT_LEN256];	/* Long name directives, comma-separated */
-	char short_modifiers[GMT_LEN32];	/* Single character modifiers, comma-separated */
+	char short_modifiers[GMT_LEN64];	/* Single character modifiers, comma-separated */
 	char long_modifiers[GMT_LEN256];	/* Long name modifiers, comma-separated */
 	unsigned int transproc_mask;	/* Translation processing mask indicating special
                                            behavior, e.g., multi-directive, etc., support */


### PR DESCRIPTION
**Description of proposed changes**
Doubled sizes of short directives/modifiers buffers to handle modules with numerous directives/modifiers.

There are no longoption strings changes in this PR.


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
