### PR TITLE
Long-lasting bug with seniority finally killed in gmt_crossover function

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -3288,7 +3288,6 @@ GMT_LOCAL void gmtsupport_hold_contour_sub (struct GMT_CTRL *GMT, double **xxx, 
 			for (line_no = 0; line_no < G->X->n_segments; line_no++) {	/* For each of the crossing lines */
 				S = G->X->table[0]->segment[line_no];	/* Current segment */
 				gmt_init_track (GMT, S->data[GMT_Y], S->n_rows, &(G->ylist_XP));
-				/* Both the created lines and the contours here are in projected coordinates, so we pass geo = false */
 				G->nx = (unsigned int)gmt_crossover (GMT, S->data[GMT_X], S->data[GMT_Y], NULL, G->ylist_XP, S->n_rows, xx, yy, NULL, G->ylist, nn, false, gmt_M_x_is_lon (GMT, GMT_IN), &G->XC);
 				gmt_M_free (GMT, G->ylist_XP);
 				if (G->nx == 0) continue;
@@ -3542,7 +3541,6 @@ GMT_LOCAL void gmtsupport_decorated_line_sub (struct GMT_CTRL *GMT, double *xx, 
 		for (line_no = 0; line_no < G->X->n_segments; line_no++) {	/* For each of the crossing lines */
 			Sd = G->X->table[0]->segment[line_no];	/* Current segment */
 			gmt_init_track (GMT, Sd->data[GMT_Y], Sd->n_rows, &(G->ylist_XP));
-			/* Both the created lines and the contours here are in projected coordinates, so we pass geo = false */
 			G->nx = (unsigned int)gmt_crossover (GMT, Sd->data[GMT_X], Sd->data[GMT_Y], NULL, G->ylist_XP, Sd->n_rows, xx, yy, NULL, G->ylist, nn, false, gmt_M_x_is_lon (GMT, GMT_IN), &G->XC);
 			gmt_M_free (GMT, G->ylist_XP);
 			if (G->nx == 0) continue;
@@ -15134,8 +15132,6 @@ uint64_t gmt_crossover (struct GMT_CTRL *GMT, double xa[], double ya[], uint64_t
 
 		/* First check for internal neighboring segments which cannot cross */
 
-if (this_b == 178)
-	nx = 0;
 		if (internal && (this_a == this_b || (A[this_a].stop == B[this_b].start || A[this_a].start == B[this_b].stop) || (A[this_a].start == B[this_b].start || A[this_a].stop == B[this_b].stop))) {	/* Neighboring segments cannot cross */
 			this_b++;
 			new_b = true;
@@ -15413,13 +15409,7 @@ if (this_b == 178)
 						}
 					}
 					else {	/* Segments are not parallel */
-						//bool xc_ab_status, xc_ae_status, xc_bb_status, xc_be_status;
 						xc = (yb[xb_start] - ya[xa_start] + slp_a * xa[xa_start] - slp_b * xb[xb_start]) / (slp_a - slp_b);
-						//xc_ab_status = (xc < xa[xa_start]);	/* None of these must be true */
-						//xc_ae_status = (xc > xa[xa_stop]);
-						//xc_bb_status = (xc < xb[xb_start]);
-						//xc_be_status = (xc > xb[xb_stop]);
-						//if (!(xc_ab_status || xc_ae_status || xc_bb_status || xc_be_status)) {	/* Did cross within the segment extents */
 						if (!(xc < xa[xa_start] || xc > xa[xa_stop] || xc < xb[xb_start] || xc > xb[xb_stop])) {	/* Did cross within the segment extents */
 
 							/* Only accept xover if occurring before segment end (in time) */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -3288,6 +3288,7 @@ GMT_LOCAL void gmtsupport_hold_contour_sub (struct GMT_CTRL *GMT, double **xxx, 
 			for (line_no = 0; line_no < G->X->n_segments; line_no++) {	/* For each of the crossing lines */
 				S = G->X->table[0]->segment[line_no];	/* Current segment */
 				gmt_init_track (GMT, S->data[GMT_Y], S->n_rows, &(G->ylist_XP));
+				/* Both the created lines and the contours here are in projected coordinates, so we pass geo = false */
 				G->nx = (unsigned int)gmt_crossover (GMT, S->data[GMT_X], S->data[GMT_Y], NULL, G->ylist_XP, S->n_rows, xx, yy, NULL, G->ylist, nn, false, gmt_M_x_is_lon (GMT, GMT_IN), &G->XC);
 				gmt_M_free (GMT, G->ylist_XP);
 				if (G->nx == 0) continue;
@@ -3541,6 +3542,7 @@ GMT_LOCAL void gmtsupport_decorated_line_sub (struct GMT_CTRL *GMT, double *xx, 
 		for (line_no = 0; line_no < G->X->n_segments; line_no++) {	/* For each of the crossing lines */
 			Sd = G->X->table[0]->segment[line_no];	/* Current segment */
 			gmt_init_track (GMT, Sd->data[GMT_Y], Sd->n_rows, &(G->ylist_XP));
+			/* Both the created lines and the contours here are in projected coordinates, so we pass geo = false */
 			G->nx = (unsigned int)gmt_crossover (GMT, Sd->data[GMT_X], Sd->data[GMT_Y], NULL, G->ylist_XP, Sd->n_rows, xx, yy, NULL, G->ylist, nn, false, gmt_M_x_is_lon (GMT, GMT_IN), &G->XC);
 			gmt_M_free (GMT, G->ylist_XP);
 			if (G->nx == 0) continue;
@@ -15132,6 +15134,8 @@ uint64_t gmt_crossover (struct GMT_CTRL *GMT, double xa[], double ya[], uint64_t
 
 		/* First check for internal neighboring segments which cannot cross */
 
+if (this_b == 178)
+	nx = 0;
 		if (internal && (this_a == this_b || (A[this_a].stop == B[this_b].start || A[this_a].start == B[this_b].stop) || (A[this_a].start == B[this_b].start || A[this_a].stop == B[this_b].stop))) {	/* Neighboring segments cannot cross */
 			this_b++;
 			new_b = true;
@@ -15409,7 +15413,13 @@ uint64_t gmt_crossover (struct GMT_CTRL *GMT, double xa[], double ya[], uint64_t
 						}
 					}
 					else {	/* Segments are not parallel */
+						//bool xc_ab_status, xc_ae_status, xc_bb_status, xc_be_status;
 						xc = (yb[xb_start] - ya[xa_start] + slp_a * xa[xa_start] - slp_b * xb[xb_start]) / (slp_a - slp_b);
+						//xc_ab_status = (xc < xa[xa_start]);	/* None of these must be true */
+						//xc_ae_status = (xc > xa[xa_stop]);
+						//xc_bb_status = (xc < xb[xb_start]);
+						//xc_be_status = (xc > xb[xb_stop]);
+						//if (!(xc_ab_status || xc_ae_status || xc_bb_status || xc_be_status)) {	/* Did cross within the segment extents */
 						if (!(xc < xa[xa_start] || xc > xa[xa_stop] || xc < xb[xb_start] || xc > xb[xb_stop])) {	/* Did cross within the segment extents */
 
 							/* Only accept xover if occurring before segment end (in time) */
@@ -15436,7 +15446,7 @@ uint64_t gmt_crossover (struct GMT_CTRL *GMT, double xa[], double ya[], uint64_t
 
 							tx_a = ta_start + fabs (xc - xa[ta_start]) * i_del_xa;
 							tx_b = tb_start + fabs (xc - xb[tb_start]) * i_del_xb;
-							if (tx_a < ta_stop && tx_b < tb_stop) {
+							if (tx_a < ta_stop && tx_b <= tb_stop) {	/* Equality means the crossing occurred on the second data node */
 								X->x[nx] = xc;
 								X->y[nx] = ya[xa_start] + (xc - xa[xa_start]) * slp_a;
 								X->xnode[0][nx] = tx_a;

--- a/test/baseline/greenspline.dvc
+++ b/test/baseline/greenspline.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 346061c5e8dc2a44a7fe74e6a827c4ea.dir
-  size: 1581934
+- md5: 416c79243026ec7b60578a5bb74cf8b8.dir
   nfiles: 8
   path: greenspline
+  hash: md5


### PR DESCRIPTION
The test `spline_5.sh` has failed (at least on macOS) for the longest time.  Finally decided to debug the sucker and found that the missing contour annotations had to do with round-off.  If fact there were two missing but only one was seen as a bug.  Problem was that if the crossing was exactly on a data noted then our test to see if it was outside the segment failed because we checked along-track "time":

`tx_a < ta_stop && tx_b < tb_stop`

Clearly, if _tx_a_ or _tx_b_ equal _ta_stop_ or _tb_stop_ then we still fail (cutting at the mode). Solution is to allow one of the ends to be equal:

`if (tx_a < ta_stop && tx_b <= tb_stop)`

Now, the contour map places all the contours crossing the imaginary line set by **-Gl**:

![gspline_5](https://github.com/GenericMappingTools/gmt/assets/26473567/75140b49-9ff4-4f19-aab2-88711231de6f)

The topmost 40 label in the bottom plot was missing before, but so was the 30 contour.  Now all is well. A bug with seniority bites the dust!
