### PR TITLE
Add -Ccpt option to sample colors from sample1d and grdxyz

### DIFF
--- a/doc/rst/source/dump_rgb.rst_
+++ b/doc/rst/source/dump_rgb.rst_
@@ -1,0 +1,33 @@
+**-C**\ [*section*/]\ *master*\|\ *cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]\ [**+h**\ [*hinge*]][**+i**\ *dz*][**+u**\|\ **U**\ *unit*][**+s**\ *fname*]
+    Determine the color components based on the *z* values.
+    Append name of a master CPT, an input CPT file or a comma-separated list of colors from which to build a CPT.
+    If no argument is given then under modern mode we select the current CPT, if it is available.
+    Generally, the input can be many things:
+
+    #. A standard GMT *master* CPT file, e.g., *earth* 
+       (see :ref:`Of Colors and Color Legends`) and can be either addressed
+       by *master* or *section*/*master* (without any **.cpt** extension).
+    #. File name of already custom-made *cpt* file (e.g, *my_colors.cpt*).
+    #. Build a linear continuous CPT from *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]
+       automatically, where *z* starts at 0 and is incremented by one for each color. In this case,
+       *color*\ :math:`_i` can be a *r*/*g*/*b* (e.g., 255/100/75), *h*-*s*-*v* triplet (e.g., 180-0.8-1),
+       a *c*/*m*/*y*/*k* quadruple (e.g., 80/50/40/30), an HTML hexadecimal color (e.g. *#aabbcc*),
+       or a :ref:`color name <RGBchart>`. No spaces between commas are allowed.
+
+    A few modifiers pertains to hinges and units:
+
+    - **+h** - If given a master CPT with soft hinges then you can enable the hinge at
+      data value *hinge* [0], whereas for hard-hinge CPTs you can adjust the location
+      of the hinge [0] but not disable it.
+    - **+i** - Append increment *dz* to quantize the grid range [Default uses the exact grid range].
+    - **+s** - Append *fname* to save the finalized CPT in a disk file.
+      This is useful when the CPT is generated automatically, but if used, **must** be
+      at the end of the **-C** option.
+    - **+u** - For any other *master* CPT, you may convert their *z*-values from 
+      other distance `Units`_ to meter by appending the original unit code.
+    - **+U** - Likewise, you may convert their *z*-values from meter to other `Units`_
+      by appending the desired unit code.
+
+    **Note**: We append four extra output columns at the end of the output records.  These
+    are the red, green, and blue components color components (all in 0-255 range) and the
+    transparency value (0-100% range, with 0 meaning opaque).

--- a/doc/rst/source/grd2xyz.rst
+++ b/doc/rst/source/grd2xyz.rst
@@ -13,7 +13,8 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt grd2xyz** *ingrid*
-[ |-C|\ [**f**\|\ **i**] ]
+[ |-C|\ [*section*/]\ *master*\|\ *cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]\ [**+h**\ [*hinge*]][**+i**\ *dz*][**+u**\|\ **U**\ *unit*][**+s**\ *fname*] ]
+[ |-F|\ [**f**\|\ **i**] ]
 [ |-L|\ [**c**\|\ **r**\|\ **x**\|\ **y**]\ *value* ]
 [ |SYN_OPT-R| ]
 [ |SYN_OPT-V| ]
@@ -40,7 +41,8 @@ precision of the ASCII output format by editing the
 **--FORMAT_FLOAT_OUT**\ =\ *format* on the command line, or choose binary
 output using single or double precision storage. As an option you may
 output z-values without the (*x, y*) coordinates (see |-Z| below) or you can
-save the grid in the STL format for 3-D printers.
+save the grid in the STL format for 3-D printers. Also, by giving a CPT via
+|-C| we will add *r*, *g*, *b*, *a* columns to the output based on *z* values.
 
 Required Arguments
 ------------------
@@ -55,7 +57,11 @@ Optional Arguments
 
 .. _-C:
 
-**-C**\ [**f**\|\ **i**]
+.. include:: use_cpt_grd.rst_
+
+.. _-F:
+
+**-F**\ [**f**\|\ **i**]
     Replace the x- and y-coordinates on output with the corresponding
     column and row numbers. These start at 0 (C-style counting); append
     **f** to start at 1 (FORTRAN-style counting). Alternatively, append

--- a/doc/rst/source/grd2xyz.rst
+++ b/doc/rst/source/grd2xyz.rst
@@ -57,7 +57,7 @@ Optional Arguments
 
 .. _-C:
 
-.. include:: use_cpt_grd.rst_
+.. include:: dump_rgb.rst_
 
 .. _-F:
 

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -91,7 +91,7 @@ Optional Arguments
 
 .. _-C:
 
-.. include:: use_cpt_grd.rst_
+.. include:: dump_rgb.rst_
 
 .. _-E:
 

--- a/doc/rst/source/sample1d.rst
+++ b/doc/rst/source/sample1d.rst
@@ -14,6 +14,7 @@ Synopsis
 
 **gmt sample1d** [ *table* ]
 [ |-A|\ [**f**\|\ **p**\|\ **m**\|\ **r**\|\ **R**][**+d**][**+l**] ]
+[ |-C|\ [*section*/]\ *master*\|\ *cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]\ [**+h**\ [*hinge*]][**+i**\ *dz*][**+u**\|\ **U**\ *unit*][**+s**\ *fname*] ]
 [ |-E| ]
 [ |-F|\ **a**\|\ **c**\|\ **e**\|\ **l**\|\ **n**\|\ **s**\ *p*\ [**+d1**\|\ **2**] ]
 [ |-N|\ *col* ]
@@ -49,7 +50,8 @@ Equidistant or arbitrary sampling can be selected. All columns
 are resampled based on the new sampling interval. Several interpolation
 schemes are available, in addition to a *smoothing* spline which trades off misfit
 for curvature. Extrapolation outside the range of the input data
-is not supported.
+is not supported. By giving a CPT via |-C| we will add *r*, *g*, *b*, *a* columns to the output
+based on the last input data column.
 
 Required Arguments
 ------------------
@@ -86,6 +88,10 @@ Optional Arguments
     
     **Note**: Calculation mode for loxodromes is spherical, hence **-je**
     cannot be used in combination with **+l**.
+
+.. _-C:
+
+.. include:: use_cpt_grd.rst_
 
 .. _-E:
 

--- a/src/grd2xyz.c
+++ b/src/grd2xyz.c
@@ -539,7 +539,7 @@ EXTERN_MSC int GMT_grd2xyz (void *V_API, int mode, void *args) {
 		}
 
 		if (Ctrl->C.active) {	/* Just sample the CPT for the z value and append four columns r g b a */
-			unsigned int k, geo = gmt_M_is_geographic (GMT, GMT_IN);
+			unsigned int k, kol, geo = gmt_M_is_geographic (GMT, GMT_IN);
 			static char *coord[2] = {"x\ty\tz\tred\tgreen\tblue\ttransparency", "lon\tlat\tz\tred\tgreen\tblue\ttransparency"};
 			if (first_grd) GMT_Put_Record (API, GMT_WRITE_TABLE_HEADER, coord[geo]);
 			first_grd = false;
@@ -548,7 +548,8 @@ EXTERN_MSC int GMT_grd2xyz (void *V_API, int mode, void *args) {
 			gmt_M_grd_loop (GMT, G, row, col, ij) {
 				out[GMT_X] = x[col];	out[GMT_Y] = y[row];	out[GMT_Z] = G->data[ij];
 				gmt_get_rgb_from_z (GMT, P, G->data[ij], rgb);
-				for (k = 0; k < 4; k++) out[GMT_Z + 1 + k] = rgb[k];
+				for (k = 0, kol = GMT_Z + 1; k < 3; k++) out[kol++] = irint (255.0 * rgb[k]);	/* r/g/b in 0-255 range */
+				out[kol] = irint (100.0 * rgb[k]);	/* Transparency in 0-100% range */
 				write_error = GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 				if (write_error == GMT_NOTSET) n_suppressed++;	/* Bad value caught by -s[r] */
 			}

--- a/src/longopt/grd2xyz_inc.h
+++ b/src/longopt/grd2xyz_inc.h
@@ -25,7 +25,8 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 		  short_directives,    long_directives,
 		  short_modifiers,     long_modifiers,
 		  transproc_mask */
-	{ 0, 'C', "",
+	GMT_C_CPT_KW,
+	{ 0, 'F', "",
 	          "",                  "",
 	          "",                  "",
 		  GMT_TP_STANDARD },

--- a/src/longopt/sample1d_inc.h
+++ b/src/longopt/sample1d_inc.h
@@ -29,6 +29,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	          "",                  "",
 	          "",                  "",
 		  GMT_TP_STANDARD },
+	GMT_C_CPT_KW,
 	{ 0, 'E', "",
 	          "",                  "",
 	          "",                  "",

--- a/src/sample1d.c
+++ b/src/sample1d.c
@@ -415,8 +415,8 @@ EXTERN_MSC int GMT_sample1d (void *V_API, int mode, void *args) {
 				for (row = 0; row < S->n_rows; row++) {	/* Current point */
 					gmt_get_rgb_from_z (GMT, P, S->data[last][row], rgb);
 					for (k = 0, col = last + 1; k < 3; k++, col++)
-						S->data[col][row] = irint (255.0 * rgb[k]);
-					S->data[col][row] = irint (100.0 * rgb[k]);
+						S->data[col][row] = irint (255.0 * rgb[k]);	/* r/g/b in 0-255 range */
+					S->data[col][row] = irint (100.0 * rgb[k]);	/* Transparency in 0-100% range */
 				}
 			}
 		}


### PR DESCRIPTION
We had no simple way to determine what the colour would be for a given _z_ value (other than under the hood for the usual plotting).  This PR lets **sample1d** and **grd2xyz** optionally take **-C**_cpt_. This lets **sample1d** look up the colour based on the input records' last column (or via **-i**) while **grd2xyz** will get the colour based on the grid _z_-values.  Both modules then add 4 new columns _r_, _g_, _b_, a to their output.

Note: **grd2xyz** already used **-C**[**f**|**i**] for some formatting schemes that are rarely used.  I changed this to **-F** and made **-C** backwards compatible of, course.

```
gmt math -o1 -T0/30/5 T = | gmt sample1d  -Ct.cpt
0	0	0	127	55
5	0	42	255	55
10	0	212	255	55
15	128	255	128	55
20	255	212	0	55
25	255	42	0	55
30	127	0	0	55
```

for a random CPT that I made with **makecpt** **-A**55 to have a nonzero transparency.

PS. Joaquim and I are working some fixes to the writing of images via GDAL. The goal is to pixel-by-pixel transparency which PostScript cannot do.