### PR TITLE
Fix important comment typo in gmt_common_longoptions.h.

### DIFF
--- a/src/gmt_common_longoptions.h
+++ b/src/gmt_common_longoptions.h
@@ -33,7 +33,7 @@
      * long_modifiers:   Comma-separated list of the corresponding modifier words
      * transproc_mask:   Indicates via bitwise-OR of various GMT_TP_???? bitflags any unusual
      *                   translation processing used by the particular GMT_KEYWORD_DICTIONARY
-     *                   entry, e.g., GMT_TP_MULTDIR indicates multi-directive support. Specify
+     *                   entry, e.g., GMT_TP_MULTIDIR indicates multi-directive support. Specify
      *                   GMT_TP_STANDARD to indicate standard translation processing with
      *                   no unusual attributes.
      *


### PR DESCRIPTION
**Description of proposed changes**

**_There are no longoption string changes in this PR._**


<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
