### PR TITLE
Enable longoptions support for grdsample.

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -244,7 +244,7 @@ enum GMT_time_period {
  * supported module documentation (e.g., manual pages) rather than these
  * non-user-facing translation entries.
  */
-#define GMT_I_INCREMENT_KW { '/', 'I', "increment|inc", "", "", "e,n", "exact,number", GMT_TP_STANDARD }
+#define GMT_I_INCREMENT_KW { '/', 'I', "increment|inc|spacing", "", "", "e,n", "exact,number", GMT_TP_STANDARD }
 #define GMT_C_CPT_KW	{ 0, 'C', "cpt|cmap", "", "", "h,i,s,u,U", "hinge,zinc,file,fromunit,tounit", GMT_TP_STANDARD }
 #define GMT_G_OUTGRID_KW { 0, 'G', "outgrid", "", "", "d,n,o,s,c,l", "divide,nan,offset,scale,gdal,list", GMT_TP_STANDARD }
 #define GMT_W_PEN_KW	{ 0, 'W', "pen", "", "", "c", "color", GMT_TP_STANDARD }

--- a/src/longopt/grdsample_inc.h
+++ b/src/longopt/grdsample_inc.h
@@ -25,18 +25,9 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 		  short_directives,    long_directives,
 		  short_modifiers,     long_modifiers,
 		  transproc_mask */
-	{ 0, 'G', "",
-	          "",                  "",
-	          "",                  "",
-		  GMT_TP_STANDARD },
-	{ 0, 'I', "",
-	          "",                  "",
-	          "",                  "",
-		  GMT_TP_STANDARD },
-	{ 0, 'T', "",
-	          "",                  "",
-	          "",                  "",
-		  GMT_TP_STANDARD },
+	GMT_G_OUTGRID_KW,
+	GMT_I_INCREMENT_KW,
+	{ 0, 'T', "toggle_registration|toggle", "", "", "", "", GMT_TP_STANDARD },
 	{ 0, '\0', "", "", "", "", "", 0 }  /* End of list marked with empty option and strings */
 };
 #endif  /* !GRDSAMPLE_INC_H */


### PR DESCRIPTION
**Description of proposed changes**

Note one-line change to gmt_constants.h def of GMT_I_INCREMENT_KW. This change was made to accommodate what seems to be the standard GMT Python use of **spacing** as an alias for **-I**.

Python differences:

  Changed -T translate to toggle_registration|toggle.

Julia differences:

  No differences.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
