### PR TITLE
Fix bad check for when using -T in mapproject

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -812,7 +812,7 @@ static int parse (struct GMT_CTRL *GMT, struct MAPPROJECT_CTRL *Ctrl, struct GMT
 	if (n_errors) return GMT_PARSE_ERROR;	/* Might as well return here since otherwise we may get some false warnings from below as well */
 
 	geodetic_calc = (Ctrl->G.mode || Ctrl->A.active || Ctrl->L.active);
-	no_JR_needed = (Ctrl->A.active || Ctrl->E.active || Ctrl->G.active || Ctrl->L.active || Ctrl->N.active || Ctrl->T.active || Ctrl->Z.active);
+	no_JR_needed = (Ctrl->A.active || Ctrl->E.active || Ctrl->G.active || Ctrl->L.active || Ctrl->N.active || Ctrl->Z.active);
 	if (GMT->common.J.width_given) will_need_RJ = true;	/* Need -R -J to convert width to scale */
 
 	/* The following lousy hack allows NOT having to specify -R */


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/mapproject-t-option/4534) for details. The parser checked that all the options that cannot work with **-T** were not set ( **-A**, **-E**, **-G**, **-L**, **-W** or **-Z**) but it also erroneously added **-T** in that list so of course we got the dumb message.  Now fixed and works.
