### PR TITLE
Forgot to handle Euro dates dd.mm.yyyy in the first-record exam

### DIFF
--- a/src/gmt_internals.h
+++ b/src/gmt_internals.h
@@ -57,7 +57,7 @@ EXTERN_MSC unsigned int gmtlib_is_coordinate (struct GMT_CTRL *GMT, unsigned int
 EXTERN_MSC unsigned int gmtlib_is_time (struct GMT_CTRL *GMT, char *text);
 EXTERN_MSC unsigned int gmtlib_is_string (struct GMT_CTRL *GMT, char *string);
 EXTERN_MSC unsigned int gmtlib_determine_datatype (struct GMT_CTRL *GMT, char *text);
-EXTERN_MSC void gmtlib_string_parser (struct GMT_CTRL *GMT, char *file);
+EXTERN_MSC unsigned int gmtlib_string_parser (struct GMT_CTRL *GMT, char *file);
 EXTERN_MSC int gmtlib_adjust_we_if_central_lon_set (struct GMT_CTRL *GMT, double *west, double *east);
 EXTERN_MSC int gmtlib_colon_pos (struct GMT_CTRL *GMT, char *text);
 EXTERN_MSC bool gmtlib_invalid_symbolname (struct GMT_CTRL *GMT, char *name);

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -10215,8 +10215,19 @@ unsigned int gmtlib_is_string (struct GMT_CTRL *GMT, char *string) {
 	if (n_specials) return (GMT_IS_STRING);			/* Cannot be coordinates */
 	n_periods = gmt_count_char (GMT, p, '.');		/* How many periods. No valid coordinate has more than one */
 	if (n_periods == 2 && n_digits) {	/* Might be dd.mm.yyyy section */
-		if (n_text == 0 || (n_text == 1 && strchr (string, 'T')))	/* Valid dd.mm.yyyy[T][hh:mm:ss.xxx...] string */
+		if (n_text == 0 || (n_text == 1 && strchr (string, 'T'))) {	/* Valid dd.mm.yyyy[T][hh:mm:ss.xxx...] string */
+			char *text = strdup (string), *c = NULL;
+			int d, m, y, k = 0;
+			if ((c = strchr (text, 'T'))) c[0] = '\0';	/* Truncate at the possible T, so no must be dd.mm.yyyy */
+			gmt_strrepc (text, '.', ' ');	/* Replace the 2 periods with spaces */
+			if (sscanf (text, "%d %d %d", &d, &m, &y) != 3) {
+				gmt_M_str_free (text);
+				return (GMT_IS_STRING);
+			}
+			gmt_M_str_free (text);
+			if ((d < 1 || d > 31) || (m < 1 || m > 12)) return (GMT_IS_STRING);
 			return (GMT_IS_ABSTIME);
+		}
 		else
 			return (GMT_IS_STRING);
 	}

--- a/src/gmtconvert.c
+++ b/src/gmtconvert.c
@@ -234,7 +234,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTCONVERT_CTRL *Ctrl, struct GMT
 	char p[GMT_BUFSIZ] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
 	struct GMTAPI_CTRL *API = GMT->parent;
-	EXTERN_MSC void gmtlib_string_parser (struct GMT_CTRL *GMT, char *file);	/* For debug only */
+	EXTERN_MSC unsigned int gmtlib_string_parser (struct GMT_CTRL *GMT, char *file);	/* For debug only */
 
 	for (opt = options; opt; opt = opt->next) {
 		switch (opt->option) {
@@ -243,7 +243,7 @@ static int parse (struct GMT_CTRL *GMT, struct GMTCONVERT_CTRL *Ctrl, struct GMT
 				if (GMT_Get_FilePath (API, GMT_IS_DATASET, GMT_IN, GMT_FILE_REMOTE, &(opt->arg))) n_errors++;
 				/* Hidden test of string parsing for developers */
 				if (Ctrl->debug.active) {
-					gmtlib_string_parser (API->GMT, opt->arg);
+					if (gmtlib_string_parser (API->GMT, opt->arg)) return (GMT_RUNTIME_ERROR);
 					return (NOT_REALLY_AN_ERROR);
 				}
 				break;


### PR DESCRIPTION
See Forum [post](https://forum.generic-mapping-tools.org/t/regression-in-filter1d/4535) for background. We had a major upgrade for examining what a column might contain a month or two ago but while we did check for multiple periods as possible European-style non-ISO8601 dates, we called another function first that thought it was a string...Now fixed. 

```
cat <<eof | awk '{print $1"T",$2}' | gmt filter1d  -Fm14 --TIME_UNIT=d -V -E --FORMAT_DATE_IN=dd.mm.yyyy
29.01.2015      75.1
30.01.2015      76
31.01.2015      75
01.02.2015      75.7
eof
filter1d [INFORMATION]: Processing input table data
filter1d [INFORMATION]: Reading Data Table from Stream 1e021c3d8
filter1d [INFORMATION]: Writing Data Table to Standard Output stream
filter1d [INFORMATION]: Filter the data columns
filter1d [INFORMATION]: Read 4 records from table 0, segment 0
filter1d [INFORMATION]: F width: 14 Resolution: 1 Start: 16464 Stop: 16467
2015-01-29T00:00:00	75.4
2015-01-30T00:00:00	75.4
2015-01-31T00:00:00	75.4
2015-02-01T00:00:00	75.4
```

It is always possible to pick odd formats for scientific times but always good to stick with the ISO.