### PR TITLE
Fix bad effect of roundoff at boarder

### DIFF
--- a/src/gmt_constants.h
+++ b/src/gmt_constants.h
@@ -71,6 +71,7 @@
 
 #define GMT_CONV15_LIMIT 1.0e-15	/* Very tight convergence limit or "close to zero" limit */
 #define GMT_CONV12_LIMIT 1.0e-12	/* Tight limit for gaps/overlaps in CPT z-values */
+#define GMT_CONV9_LIMIT	 1.0e-9		/* Fairly tight convergence limit or "close to zero" limit */
 #define GMT_CONV8_LIMIT	 1.0e-8		/* Fairly tight convergence limit or "close to zero" limit */
 #define GMT_CONV6_LIMIT	 1.0e-6		/* 1 ppm */
 #define GMT_CONV5_LIMIT	 1.0e-5		/* 10 ppm */

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -2098,8 +2098,8 @@ GMT_LOCAL void gmtproj_imollweide (struct GMT_CTRL *GMT, double *lon, double *la
 	phi = asin (y * GMT->current.proj.w_iy);
 	*lon = x / (GMT->current.proj.w_x * cos(phi));
 	if ((fabs (*lon) - 180.0) < GMT_CONV9_LIMIT)
-        *lon = copysign (180.0, *lon);
-    if (fabs (*lon) > 180.0) {   /* Beyond Horizon */
+	*lon = copysign (180.0, *lon);
+	if (fabs (*lon) > 180.0) {   /* Beyond Horizon */
 		*lat = *lon = GMT->session.d_NaN;
 		return;
 	}

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -2054,7 +2054,7 @@ GMT_LOCAL void gmtproj_vmollweide (struct GMT_CTRL *GMT, double lon0, double sca
 
 	gmtproj_check_R_J (GMT, &lon0);
 	GMT->current.proj.central_meridian = lon0;
-	GMT->current.proj.w_x = GMT->current.proj.EQ_RAD * D2R * d_sqrt (8.0) / M_PI;
+	GMT->current.proj.w_x = GMT->current.proj.EQ_RAD * D2R * 2.0 * M_SQRT2 / M_PI;
 	GMT->current.proj.w_y = GMT->current.proj.EQ_RAD * M_SQRT2;
 	GMT->current.proj.w_iy = 1.0 / GMT->current.proj.w_y;
 	GMT->current.proj.w_r = 0.25 * (scale * GMT->current.proj.M_PR_DEG * 360.0);	/* = Half the minor axis */
@@ -2097,7 +2097,9 @@ GMT_LOCAL void gmtproj_imollweide (struct GMT_CTRL *GMT, double *lon, double *la
 
 	phi = asin (y * GMT->current.proj.w_iy);
 	*lon = x / (GMT->current.proj.w_x * cos(phi));
-	if (fabs (*lon) > 180.0) {	/* Horizon */
+	if ((fabs (*lon) - 180.0) < GMT_CONV9_LIMIT)
+        *lon = copysign (180.0, *lon);
+    if (fabs (*lon) > 180.0) {   /* Beyond Horizon */
 		*lat = *lon = GMT->session.d_NaN;
 		return;
 	}


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/mapproject-mollweide-transformation/4542) for background on **mapproject**.  Two issues:

1. Mollweide should be run on the sphere.
2. Need to allow 10e-9 slop at ±180 longitude to not exceed that limit.

WIth this we get

```
echo 180 0 | gmt mapproject -Jw0/1:1 -Fe -C --PROJ_ELLIPSOID=Sphere
18019934.021	0

echo 18019934.021 0 | gmt mapproject -Jw0/1:1 -Fe -C --PROJ_ELLIPSOID=Sphere -I
180	0

```
