### PR TITLE
More careful with Mollweide

### DIFF
--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -2105,9 +2105,9 @@ GMT_LOCAL void gmtproj_imollweide (struct GMT_CTRL *GMT, double *lon, double *la
 	*lon += GMT->current.proj.central_meridian;
 	phi2 = 2.0 * phi;
 	*lat = asind ((phi2 + sin (phi2)) / M_PI);
-	if (fabs (*lat) > 90.0)
+	if (fabs (*lat) > 90.0)	/* Sanity check */
 		*lat = copysign (90.0, *lat);
-	if (GMT->current.proj.GMT_convert_latitudes) *lat = gmt_M_lata_to_latg (GMT, *lat);
+	else if (GMT->current.proj.GMT_convert_latitudes) *lat = gmt_M_lata_to_latg (GMT, *lat);
 }
 
 /* -JH HAMMER-AITOFF EQUAL AREA PROJECTION */

--- a/src/gmt_proj.c
+++ b/src/gmt_proj.c
@@ -2097,15 +2097,16 @@ GMT_LOCAL void gmtproj_imollweide (struct GMT_CTRL *GMT, double *lon, double *la
 
 	phi = asin (y * GMT->current.proj.w_iy);
 	*lon = x / (GMT->current.proj.w_x * cos(phi));
-	if ((fabs (*lon) - 180.0) < GMT_CONV9_LIMIT)
-	*lon = copysign (180.0, *lon);
-	if (fabs (*lon) > 180.0) {   /* Beyond Horizon */
-		*lat = *lon = GMT->session.d_NaN;
+	if (fabs (*lon) > 180.0) {   /* Beyond horizon by a whisker so set to 180/0 depending on signs */
+		*lat = 0.0;
+		*lon = copysign (180.0, *lon) + GMT->current.proj.central_meridian;
 		return;
 	}
 	*lon += GMT->current.proj.central_meridian;
 	phi2 = 2.0 * phi;
 	*lat = asind ((phi2 + sin (phi2)) / M_PI);
+	if (fabs (*lat) > 90.0)
+		*lat = copysign (90.0, *lat);
 	if (GMT->current.proj.GMT_convert_latitudes) *lat = gmt_M_lata_to_latg (GMT, *lat);
 }
 


### PR DESCRIPTION
While the fix yesterday (#8238) handled the bad **mapproject** results, it caused a failure in several Mollweide maps and images.  This revised fix simply checks that if longitude (which is actually delta longitude relative to the central longitude) is > 180 then we set it to ±180 and add back the central longitude and the same with latitude (0).  No more failures and the **mapproject** issue remains fixed as well.
