### PR TITLE
Fix lack of 360 periodicity in central longitude and -R check

### DIFF
--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -384,8 +384,8 @@ GMT_LOCAL int gmtmap_cyl_validate_clon (struct GMT_CTRL *GMT, unsigned int mode)
 		}
 	}
 	else if (!GMT->common.R.oblique) {	/* For regional (<360) areas we cannot have clon > 180 away from either boundary */
-		double dw = fabs (GMT->current.proj.pars[0] - GMT->common.R.wesn[XLO]);
-		double de = fabs (GMT->current.proj.pars[0] - GMT->common.R.wesn[XHI]);
+		double dw = fabs (GMT->current.proj.pars[0] - GMT->common.R.wesn[XLO]);	if (dw >= 360) dw -= 360.0;
+		double de = fabs (GMT->current.proj.pars[0] - GMT->common.R.wesn[XHI]);	if (de >= 360) de -= 360.0;
 		if (dw > 180.0 || de > 180.0) {
 			if (mode == 2) {	/* Yield an error if fixed central longitude, range < 360, and exceed 180 to the border from central longitude */
 				static char *border[2] = {"Western", "Eastern"};


### PR DESCRIPTION
See this forum [post](https://forum.generic-mapping-tools.org/t/hammer-projection-bug/4543) for background.  It missed a check that if you exceed 360 then take out that multiple.  Now seems OK.
