### PR TITLE
Update two PS file following bug fix

### DIFF
--- a/test/baseline/gmtbinstats.dvc
+++ b/test/baseline/gmtbinstats.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 79631ee331b20e2d503f893cdd0a4aa3.dir
-  size: 718273
+- md5: 78f0346f337427ffed15a93753374d68.dir
   nfiles: 5
   path: gmtbinstats
+  hash: md5


### PR DESCRIPTION
The bugfix in #8243 for **gmtbinstats** meant the plots change a big, now with correct values for median and q95, etc.
