### PR TITLE
Allow colorbar -LI as well as -Li

### DIFF
--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-I|\ [*max\_intens*\|\ *low_i*/*high_i*] ]
 [ |-J|\ *parameters* ]
 [ |-J|\ **z**\|\ **Z**\ *parameters* ]
-[ |-L|\ [**i**][*gap*] ]
+[ |-L|\ [**i**\|\ **I**][*gap*] ]
 [ |-M| ]
 [ |-N|\ [**p**\|\ *dpi* ]]
 [ |-Q| ]
@@ -171,18 +171,20 @@ Optional Arguments
 
 .. _-L:
 
-**-L**\ [**i**][*gap*]
+**-L**\ [**i**\|\ **I**][*gap*]
 
     Gives equal-sized color rectangles. Default scales rectangles
     according to the z-range in the CPT (Also see |-Z|). If
     *gap* is appended and the CPT is discrete we will center each
     annotation on each rectangle, using the lower boundary z-value for
     the annotation. If **i** is prepended we annotate the interval range
-    instead. If |-I| is used then each rectangle will have its
-    constant color modified by the specified intensity.  **Note**: For
-    categorical CPTs we default to activating |-L| with a *gap* such
-    that the sum of all the gaps equal 15% of the bar width.  You may
-    chose no gaps by giving |-L| only or explicitly set *gap = 0*.
+    instead, and if **I** is used instead then we include the background
+    and foreground values in the label (e.g, "< 12"). If |-I| is used
+    then each rectangle will have its constant color modified by the
+    specified intensity.  **Note**: For categorical CPTs we default to
+    activating |-L| with a *gap* such that the sum of all the gaps equal
+    15% of the bar width.  You may chose no gaps by giving |-L| only or
+    explicitly set *gap = 0*.
 
 .. _-M:
 

--- a/doc/rst/source/psscale.rst
+++ b/doc/rst/source/psscale.rst
@@ -21,7 +21,7 @@ Synopsis
 [ |-I|\ [*max\_intens*\|\ *low_i*/*high_i*] ]
 [ |-J|\ *parameters* ]
 [ |-K| ]
-[ |-L|\ [**i**][*gap*] ]
+[ |-L|\ [**i**\|\ **I**][*gap*] ]
 [ |-M| ]
 [ |-N|\ [**p**\|\ *dpi* ]]
 [ |-O| ]


### PR DESCRIPTION
If a CPT goes from 0 to 100 in steps of 10 then **-Li** normally labels the first color 0-10 and the last 90-100. With upper case **I** those two are labelled < 10 and > 90 instead, thus includes values outside the CPT range.  In addition, the PR attempts to adjust the default panel size to the longer AAA-BBB annotations.  See this form [post](https://forum.generic-mapping-tools.org/t/colorbar-box-and-annotation/4548) for the issue.  Here is what **-Li** and **-LI** look like.  Unlike the poster in the forum, I don't think we want <= since the previous is 10-20 so <= 10 seems wrong to me.

![bars](https://github.com/GenericMappingTools/gmt/assets/26473567/4e078fed-c450-424c-9227-fd813a664c6c)

Do you think this is a useful directive, @joa-quim ?