### PR TITLE
cmake: Set CMP0153 policy to NEW to silent the warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ foreach (p
 		CMP0058 # CMake 3.3: Ninja requires custom command byproducts to be explicit
 		CMP0074	# CMake 3.12: find_package uses PackageName_ROOT variables
 		CMP0115 # CMake 3.20: Source file extensions must be explicit.
+		CMP0153 # CMake 3.28: The exec_program() command should not be called.
 		)
 	if (POLICY ${p})
 		cmake_policy (SET ${p} NEW)

--- a/cmake/modules/FindGEOS.cmake
+++ b/cmake/modules/FindGEOS.cmake
@@ -78,9 +78,7 @@ ELSE(WIN32)
 
       IF (GEOS_CONFIG)
 
-        EXEC_PROGRAM(${GEOS_CONFIG}
-            ARGS --version
-            OUTPUT_VARIABLE GEOS_VERSION)
+        EXECUTE_PROCESS(COMMAND ${GEOS_CONFIG} --version OUTPUT_VARIABLE GEOS_VERSION)
         STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" GEOS_VERSION_MAJOR "${GEOS_VERSION}")
         STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" GEOS_VERSION_MINOR "${GEOS_VERSION}")
 
@@ -89,9 +87,7 @@ ELSE(WIN32)
         ENDIF (GEOS_VERSION_MAJOR LESS 3 OR (GEOS_VERSION_MAJOR EQUAL 3 AND GEOS_VERSION_MINOR LESS 3) )
 
         # set INCLUDE_DIR to prefix+include
-        EXEC_PROGRAM(${GEOS_CONFIG}
-            ARGS --prefix
-            OUTPUT_VARIABLE GEOS_PREFIX)
+        EXECUTE_PROCESS(COMMAND ${GEOS_CONFIG} --prefix OUTPUT_VARIABLE GEOS_PREFIX)
 
         FIND_PATH(GEOS_INCLUDE_DIR
             geos_c.h
@@ -101,9 +97,7 @@ ELSE(WIN32)
             )
 
         ## extract link dirs for rpath
-        EXEC_PROGRAM(${GEOS_CONFIG}
-            ARGS --libs
-            OUTPUT_VARIABLE GEOS_CONFIG_LIBS )
+        EXECUTE_PROCESS(COMMAND ${GEOS_CONFIG} --libs OUTPUT_VARIABLE GEOS_CONFIG_LIBS )
 
         ## split off the link dirs (for rpath)
         ## use regular expression to match wildcard equivalent "-L*<endchar>"


### PR DESCRIPTION
[CMP0153](https://cmake.org/cmake/help/latest/policy/CMP0153.html) says:

> The [exec_program()](https://cmake.org/cmake/help/latest/command/exec_program.html#command:exec_program) command should not be called.
> 
> This command has long been superseded by the [execute_process()](https://cmake.org/cmake/help/latest/command/execute_process.html#command:execute_process) command and has been deprecated since CMake 3.0.
> 
> CMake >= 3.28 prefer that this command never be called. The OLD behavior for this policy is to allow the command to be called. The NEW behavior for this policy is to issue a FATAL_ERROR when the command is called.
> 
> This policy was introduced in CMake version 3.28. CMake version 3.28.1 warns when the policy is not set and uses OLD behavior. Use the [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) command to set it to OLD or NEW explicitly.

This PR explicitly set the policy to `NEW` and update `exec_program` to `execute_process` in `FindGEOS.cmake`.