### PR TITLE
When given multiple tables, report line number of bad records in the offending file

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3914,7 +3914,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 	if (*n == GMT_MAX_COLUMNS) *n = n_ok;							/* Update the number of expected fields */
 	if (gmt_M_rec_is_error (GMT))
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Mismatch between actual (%d) and expected (%d) fields near line %" PRIu64 " in file %s\n",
-					col_no, *n, GMT->current.io.rec_no, GMT->current.io.filename[GMT_IN]);
+					col_no, *n, GMT->current.io.data_record_number_in_tbl[GMT_IN], GMT->current.io.filename[GMT_IN]);
 
 	if (GMT->current.setting.io_lonlat_toggle[GMT_IN] && col_no >= 2) {
 		gmt_M_double_swap (GMT->current.io.curr_rec[GMT_X], GMT->current.io.curr_rec[GMT_Y]);	/* Got lat/lon instead of lon/lat */


### PR DESCRIPTION
See this [post](https://forum.generic-mapping-tools.org/t/gmt-info-reporting-of-mismatch-of-actual-and-expected-fields/4567) on the Forum.  The problem was that the Warning statement used the total internal record counter (the only option if you cat may files into a table reader) but if you give individual files on the command line we have a secondary counter that gets reset to 0 for each new file. Pretty sure we just forgot.  Here is what it looks like now:

```
cat<<eof > file1
2 4
6 7
2 8
eof
cat<<eof > file2
2 4
trash
6 7
2 8
eof
gmt info file1 file2
gmtinfo [WARNING]: Mismatch between actual (1) and expected (2) fields near line 2 in file file2

```

Of course, the` cat file1 file2 | gmt info` example cannot change since it just see a combined stdin stream. The **gmt** **info** module reads record by record, while many others (e.g., **gmt** **convert**) reads file by file.  That also works now, e.g. 

```
gmt convert file1 file2
gmtconvert [WARNING]: Mismatch between actual (1) and expected (2) fields near line 2 in file file2
```