### PR TITLE
Add -s to build-release to allow signing with default no signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ doc/examples/**/*.mp4
 doc/examples/**/*.png
 doc/examples/**/*.gif
 .vscode
+cmake/ConfigUser.cmake.orig
+cmake/ConfigUserAdvanced.cmake.orig

--- a/admin/ConfigReleaseBuildSigning.cmake
+++ b/admin/ConfigReleaseBuildSigning.cmake
@@ -25,5 +25,10 @@ set (CMAKE_C_FLAGS "-Wextra ${CMAKE_C_FLAGS}")
 # Include all the external executables and shared libraries
 # The add_macOS_cpack.txt is created by build-release.sh and placed in build
 if (APPLE)
+	# Try to codesign the Apple Bundle application if Paul or Max is building it
+	if (($ENV{USER} STREQUAL "pwessel") OR ($ENV{USER} STREQUAL "mjones") AND GMT_PUBLIC_RELEASE)
+		set (CPACK_BUNDLE_APPLE_CERT_APP "Developer ID Application: University of Hawaii (B8Y298FMLQ)")
+		set (CPACK_BUNDLE_APPLE_CODESIGN_PARAMETER "--deep -f --options runtime")
+	endif ()
 	set (EXTRA_INCLUDE_EXES "${CMAKE_BINARY_DIR}/add_macOS_cpack.txt")
 endif (APPLE)

--- a/admin/build-release.sh
+++ b/admin/build-release.sh
@@ -51,7 +51,7 @@ if [ "X${1}" = "X-p" ]; then
 elif [ "X${1}" = "X-m" ]; then
 	do_ftp=2
 elif [ "X${1}" = "X-s" ]; then
-	signing=0
+	signing=1
 elif [ "X${1}" = "X-t" ]; then
 	release=0
 elif [ $# -gt 0 ]; then
@@ -125,13 +125,13 @@ if [ "X${GMT_DCW_SOURCE}" = "X" ]; then
 	exit 1
 fi
 
-if [ $release -eq 1 ] && [ $(egrep -c '^set \(GMT_PUBLIC_RELEASE TRUE\)' cmake/ConfigDefault.cmake) -eq 0 ]; then
+if [ ${release} -eq 1 ] && [ $(egrep -c '^set \(GMT_PUBLIC_RELEASE TRUE\)' cmake/ConfigDefault.cmake) -eq 0 ]; then
 	echo "build-release.sh: Need to set GMT_PUBLIC_RELEASE to TRUE in cmake/ConfigDefault.cmake" >&2
 	exit 1
 fi
 
 G_ver=$(gs --version)
-echo "build-release.sh: You will be including Ghostscript version $G_ver"
+echo "build-release.sh: You will be including Ghostscript version ${G_ver}"
 echo "build-release.sh: Running admin/gs-check.sh to ensure it passes our transparency test" >&2
 err=$(admin/gs_check.sh | grep Total | awk '{print $3}')
 if [ "X${err}" = "X0.0" ]; then
@@ -152,7 +152,8 @@ fi
 if [ -f cmake/ConfigUserAdvanced.cmake ]; then
 	cp cmake/ConfigUserAdvanced.cmake cmake/ConfigUserAdvanced.cmake.orig
 fi
-if [ $signing -eq 1 ]; then
+if [ ${signing} -eq 1 ]; then
+	echo "build-release.sh: User ${USER} will try to sign the bundle" >&2
 	cp -f admin/ConfigReleaseBuildSigning.cmake cmake/ConfigUser.cmake
 else
 	cp -f admin/ConfigReleaseBuild.cmake cmake/ConfigUser.cmake
@@ -202,7 +203,7 @@ shasum -a 256 gmt-${Version}-*
 reset_config
 
 # 10. Paul or Meghan may place the candidate products on the pwessel/release ftp site
-if [ $do_ftp -eq 1 ]; then	# Place file in pwessel SOEST ftp release directory and set permissions
+if [ ${do_ftp} -eq 1 ]; then	# Place file in pwessel SOEST ftp release directory and set permissions
 	type=$(uname -m)
 	echo "build-release.sh: Placing gmt-${Version}-src.tar.* on the ftp site" >&2
 	scp gmt-${Version}-src.tar.* ${GMT_FTP_URL}:${GMT_FTP_DIR}
@@ -212,7 +213,7 @@ if [ $do_ftp -eq 1 ]; then	# Place file in pwessel SOEST ftp release directory a
 	fi
 	ssh ${USER}@${GMT_FTP_URL} "chmod o+r,g+rw ${GMT_FTP_DIR}/gmt-*"
 fi
-if [ $do_ftp -eq 2 ]; then	# Place M1 bundle file on ftp
+if [ ${do_ftp} -eq 2 ]; then	# Place M1 bundle file on ftp
 	type=$(uname -m)
 	if [ -f gmt-${Version}-darwin-${type}.dmg ]; then
 		echo "build-release.sh: Placing gmt-${Version}-darwin-${type}.dmg on the ftp site" >&2


### PR DESCRIPTION
We now need to pass option **-s** to admin/build-relesae if Paul or Max is to sign the bundle.  Default is no signing.

Max, please check UH account name in `ConfigReleaseBuildSigning.cmake`.