### PR TITLE
The -R string from three coutries crossing 180 was bad

### DIFF
--- a/src/gmt_dcw.c
+++ b/src/gmt_dcw.c
@@ -900,6 +900,9 @@ struct GMT_DATASET * gmt_DCW_operation (struct GMT_CTRL *GMT, struct GMT_DCW_SEL
 			wesn[XLO] = 0.0;
 			wesn[XHI] = 360.0;
 		}
+		if (wesn[XHI] < wesn[XLO]) {	/* Cannot tolerate that west larger than east */
+			wesn[XLO] -= 360.0;
+		}
 		GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Region implied by DCW polygons is %g/%g/%g/%g\n", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
 	}
 	gmt_M_free (GMT, order);

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -1513,7 +1513,7 @@ int gmt_download_file (struct GMT_CTRL *GMT, const char *name, char *url, char *
 		if (be_fussy || !(curl_err == CURLE_REMOTE_FILE_NOT_FOUND || curl_err == CURLE_HTTP_RETURNED_ERROR)) {	/* Unexpected failure - want to bitch about it */
 			GMT_Report (API, GMT_MSG_ERROR, "Libcurl Error: %s\n", curl_easy_strerror (curl_err));
 			if (curl_err == CURLE_HTTP_RETURNED_ERROR)
-				GMT_Report (API, GMT_MSG_ERROR, "Probably means %s does not exist on the remote server\n", name);
+				GMT_Report (API, GMT_MSG_ERROR, "Probably means %s does not exist on the remote server [%s]\n", name, GMT->session.DATASERVER == NULL ? "not set" : GMT->session.DATASERVER);
 			error = curl_err;
 			if (urlfile.fp != NULL) {
 				fclose (urlfile.fp);


### PR DESCRIPTION
The USA, Russia, and Fiji are the only country polygons that cross lon = 180.  That gave us odd **-R**_w/e/s/n_ strings such as 172.436/-66.9489/18.9099/71.3907 for the US. With west > east we run into trouble when building the list of remote file tiles (e.g., the @earth_relief ******_p.jp2 that needs to be downloaded).  The result was a blank map. I verified this was the same with GMT 6.4 so it is not a new bug; it has probably been there since Day 1 of remote data set implementation but nobody used **-RUS**, **-RRU** or **-RFJ** before. This PR simply does the sanity check that if if `east < west` we subtract 360 from west, since it is _assumed_ all global files are on the **-Rd** layout.  With this fix the plots for the three countries now works, as shown below (these were all blank frames before):

`gmt grdimage @earth_relief_05m -B -RUS -png USA`
![USA](https://github.com/GenericMappingTools/gmt/assets/26473567/ae076d47-1359-4bfe-9eb4-c65505c72601)

`gmt grdimage @earth_relief_05m -B -RRU -png RU`
![RU](https://github.com/GenericMappingTools/gmt/assets/26473567/9663a71b-2d1e-43cf-8856-05ae1ac212c5)

`gmt grdimage @earth_relief_05m -B -RFJ -png FJ`
![FJ](https://github.com/GenericMappingTools/gmt/assets/26473567/6216d9c8-79c7-484e-ac12-65c47cc97a79)

Since this is a long-standing bug we can choose what to do:

1. It is Sunday, so we could in a hurry build new GMT6.5 installers and the problem has been dealt with
2. Shit, horse is out of the barn and we simply should do 6.5.1 in a few days.
3. If we have lived with this since 2016 then perhaps we can live with it until 6.6?

Please opine.  Note @joa-quim this particular PR has nothing to do with code freeze concern since it was there so long.