### PR TITLE
Add longoptions support for kml2gmt.

### DIFF
--- a/src/longopt/kml2gmt_inc.h
+++ b/src/longopt/kml2gmt_inc.h
@@ -25,18 +25,12 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 		  short_directives,    long_directives,
 		  short_modifiers,     long_modifiers,
 		  transproc_mask */
-	{ 0, 'E', "",
-	          "",                  "",
-	          "",                  "",
-		  GMT_TP_STANDARD },
-	{ 0, 'F', "",
-	          "",                  "",
+	{ 0, 'E', "z_ignore|extend_data", "", "", "", "", GMT_TP_STANDARD },
+	{ 0, 'F', "feature|feature_type",
+	          "s,l,p",             "point,line,polygon",
 	          "",                  "",
 		  GMT_TP_STANDARD },
-	{ 0, 'Z', "",
-	          "",                  "",
-	          "",                  "",
-		  GMT_TP_STANDARD },
+	{ 0, 'Z', "altitudes",         "", "", "", "", GMT_TP_STANDARD },
 	{ 0, '\0', "", "", "", "", "", 0 }  /* End of list marked with empty option and strings */
 };
 #endif  /* !KML2GMT_INC_H */


### PR DESCRIPTION
**Description of proposed changes**

Python differences:

  No Python module.

Julia differences:

  Changed -F 'select' to 'feature|feature_type' to match existing reviewed
    gmt2kml -F longoption strings (as well as Julia gmt2kml).

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
