### PR TITLE
Update module names in docs

### DIFF
--- a/doc/rst/source/gmtbinstats.rst
+++ b/doc/rst/source/gmtbinstats.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtbinstats
 .. include:: module_core_purpose.rst_
 
-***********
-gmtbinstats
-***********
+********
+binstats
+********
 
 |gmtbinstats_purpose|
 

--- a/doc/rst/source/gmtconnect.rst
+++ b/doc/rst/source/gmtconnect.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtconnect
 .. include:: module_core_purpose.rst_
 
-**********
-gmtconnect
-**********
+*******
+connect
+*******
 
 |gmtconnect_purpose|
 

--- a/doc/rst/source/gmtconvert.rst
+++ b/doc/rst/source/gmtconvert.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtconvert
 .. include:: module_core_purpose.rst_
 
-**********
-gmtconvert
-**********
+*******
+convert
+*******
 
 |gmtconvert_purpose|
 

--- a/doc/rst/source/gmtdefaults.rst
+++ b/doc/rst/source/gmtdefaults.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtdefaults
 .. include:: module_core_purpose.rst_
 
-***********
-gmtdefaults
-***********
+********
+defaults
+********
 
 |gmtdefaults_purpose|
 

--- a/doc/rst/source/gmtget.rst
+++ b/doc/rst/source/gmtget.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtget
 .. include:: module_core_purpose.rst_
 
-******
-gmtget
-******
+***
+get
+***
 
 |gmtget_purpose|
 

--- a/doc/rst/source/gmtinfo.rst
+++ b/doc/rst/source/gmtinfo.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtinfo
 .. include:: module_core_purpose.rst_
 
-*******
-gmtinfo
-*******
+****
+info
+****
 
 |gmtinfo_purpose|
 

--- a/doc/rst/source/gmtlogo.rst
+++ b/doc/rst/source/gmtlogo.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtlogo
 .. include:: module_core_purpose.rst_
 
-*******
-gmtlogo
-*******
+****
+logo
+****
 
 |gmtlogo_purpose|
 

--- a/doc/rst/source/gmtmath.rst
+++ b/doc/rst/source/gmtmath.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtmath
 .. include:: module_core_purpose.rst_
 
-*******
-gmtmath
-*******
+****
+math
+****
 
 |gmtmath_purpose|
 

--- a/doc/rst/source/gmtregress.rst
+++ b/doc/rst/source/gmtregress.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtregress
 .. include:: module_core_purpose.rst_
 
-**********
-gmtregress
-**********
+*******
+regress
+*******
 
 |gmtregress_purpose|
 

--- a/doc/rst/source/gmtselect.rst
+++ b/doc/rst/source/gmtselect.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtselect
 .. include:: module_core_purpose.rst_
 
-*********
-gmtselect
-*********
+******
+select
+******
 
 |gmtselect_purpose|
 

--- a/doc/rst/source/gmtset.rst
+++ b/doc/rst/source/gmtset.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtset
 .. include:: module_core_purpose.rst_
 
-******
-gmtset
-******
+***
+set
+***
 
 |gmtset_purpose|
 

--- a/doc/rst/source/gmtsimplify.rst
+++ b/doc/rst/source/gmtsimplify.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtsimplify
 .. include:: module_core_purpose.rst_
 
-***********
-gmtsimplify
-***********
+********
+simplify
+********
 
 |gmtsimplify_purpose|
 

--- a/doc/rst/source/gmtspatial.rst
+++ b/doc/rst/source/gmtspatial.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtspatial
 .. include:: module_core_purpose.rst_
 
-**********
-gmtspatial
-**********
+*******
+spatial
+*******
 
 |gmtspatial_purpose|
 

--- a/doc/rst/source/gmtsplit.rst
+++ b/doc/rst/source/gmtsplit.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtsplit
 .. include:: module_core_purpose.rst_
 
-********
-gmtsplit
-********
+*****
+split
+*****
 
 |gmtsplit_purpose|
 

--- a/doc/rst/source/gmtvector.rst
+++ b/doc/rst/source/gmtvector.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtvector
 .. include:: module_core_purpose.rst_
 
-*********
-gmtvector
-*********
+******
+vector
+******
 
 |gmtvector_purpose|
 

--- a/doc/rst/source/gmtwhich.rst
+++ b/doc/rst/source/gmtwhich.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtwhich
 .. include:: module_core_purpose.rst_
 
-********
-gmtwhich
-********
+*****
+which
+*****
 
 |gmtwhich_purpose|
 

--- a/doc/rst/source/modules-classic.rst
+++ b/doc/rst/source/modules-classic.rst
@@ -205,23 +205,22 @@ Core Modules
     - :doc:`filter1d`
     - :doc:`fitcircle`
     - :doc:`gmt2kml`
-    - :doc:`gmtbinstats`
-    - :doc:`gmtconnect`
-    - :doc:`gmtconvert`
-    - :doc:`gmtdefaults`
-    - :doc:`grdgdal`
-    - :doc:`gmtget`
-    - :doc:`gmtinfo`
+    - :doc:`gmtbinstats <gmtbinstats>`
+    - :doc:`gmtconnect <gmtconnect>`
+    - :doc:`gmtconvert <gmtconvert>`
+    - :doc:`gmtdefaults <gmtdefaults>`
+    - :doc:`gmtget <gmtget>`
+    - :doc:`gmtinfo <gmtinfo>`
     - :doc:`gmtlogo-classic`
-    - :doc:`gmtmath`
-    - :doc:`gmtregress`
-    - :doc:`gmtselect`
-    - :doc:`gmtset`
-    - :doc:`gmtsimplify`
-    - :doc:`gmtspatial`
-    - :doc:`gmtsplit`
-    - :doc:`gmtvector`
-    - :doc:`gmtwhich`
+    - :doc:`gmtmath <gmtmath>`
+    - :doc:`gmtregress <gmtregress>`
+    - :doc:`gmtselect <gmtselect>`
+    - :doc:`gmtset <gmtset>`
+    - :doc:`gmtsimplify <gmtsimplify>`
+    - :doc:`gmtspatial <gmtspatial>`
+    - :doc:`gmtsplit <gmtsplit>`
+    - :doc:`gmtvector <gmtvector>`
+    - :doc:`gmtwhich <gmtwhich>`
     - :doc:`grd2cpt`
     - :doc:`grd2kml`
     - :doc:`grd2xyz`
@@ -234,6 +233,7 @@ Core Modules
     - :doc:`grdfft`
     - :doc:`grdfill`
     - :doc:`grdfilter`
+    - :doc:`grdgdal`
     - :doc:`grdgradient`
     - :doc:`grdhisteq`
     - :doc:`grdimage-classic`
@@ -315,8 +315,8 @@ Supplemental Modules
     - :doc:`/supplements/mgd77/mgd77path`
     - :doc:`/supplements/mgd77/mgd77sniffer`
     - :doc:`/supplements/mgd77/mgd77track-classic`
-    - :doc:`/supplements/potential/gmtflexure`
-    - :doc:`/supplements/potential/gmtgravmag3d`
+    - :doc:`gmtflexure </supplements/potential/gmtflexure>`
+    - :doc:`gmtgravmag3d </supplements/potential/gmtgravmag3d>`
     - :doc:`/supplements/potential/gravfft`
     - :doc:`/supplements/potential/gravprisms`
     - :doc:`/supplements/potential/grdflexure`
@@ -333,7 +333,7 @@ Supplemental Modules
     - :doc:`/supplements/seis/pspolar`
     - :doc:`/supplements/seis/pssac`
     - :doc:`/supplements/spotter/backtracker`
-    - :doc:`/supplements/spotter/gmtpmodeler`
+    - :doc:`gmtpmodeler </supplements/spotter/gmtpmodeler>`
     - :doc:`/supplements/spotter/grdpmodeler`
     - :doc:`/supplements/spotter/grdrotater`
     - :doc:`/supplements/spotter/grdspotter`
@@ -457,15 +457,15 @@ Gridding
 Sampling of 1-D and 2-D data
 ----------------------------
 
-+-----------------------+-----------------------+
-| :doc:`gmtsimplify`    | |gmtsimplify_purpose| |
-+-----------------------+-----------------------+
-| :doc:`grdsample`      | |grdsample_purpose|   |
-+-----------------------+-----------------------+
-| :doc:`grdtrack`       | |grdtrack_purpose|    |
-+-----------------------+-----------------------+
-| :doc:`sample1d`       | |sample1d_purpose|    |
-+-----------------------+-----------------------+
++----------------------------------+-----------------------+
+| :doc:`gmtsimplify <gmtsimplify>` | |gmtsimplify_purpose| |
++----------------------------------+-----------------------+
+| :doc:`grdsample`                 | |grdsample_purpose|   |
++----------------------------------+-----------------------+
+| :doc:`grdtrack`                  | |grdtrack_purpose|    |
++----------------------------------+-----------------------+
+| :doc:`sample1d`                  | |sample1d_purpose|    |
++----------------------------------+-----------------------+
 
 Projection and map-transformation
 ---------------------------------
@@ -481,84 +481,84 @@ Projection and map-transformation
 Information retrieval
 ---------------------
 
-+-----------------------+-----------------------+
-| :doc:`gmtdefaults`    | |gmtdefaults_purpose| |
-+-----------------------+-----------------------+
-| :doc:`gmtget`         | |gmtget_purpose|      |
-+-----------------------+-----------------------+
-| :doc:`gmtinfo`        | |gmtinfo_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`gmtset`         | |gmtset_purpose|      |
-+-----------------------+-----------------------+
-| :doc:`grdinfo`        | |grdinfo_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`grdselect`      | |grdselect_purpose|   |
-+-----------------------+-----------------------+
++----------------------------------+-----------------------+
+| :doc:`gmtdefaults <gmtdefaults>` | |gmtdefaults_purpose| |
++----------------------------------+-----------------------+
+| :doc:`gmtget <gmtget>`           | |gmtget_purpose|      |
++----------------------------------+-----------------------+
+| :doc:`gmtinfo <gmtinfo>`         | |gmtinfo_purpose|     |
++----------------------------------+-----------------------+
+| :doc:`gmtset <gmtset>`           | |gmtset_purpose|      |
++----------------------------------+-----------------------+
+| :doc:`grdinfo`                   | |grdinfo_purpose|     |
++----------------------------------+-----------------------+
+| :doc:`grdselect`                 | |grdselect_purpose|   |
++----------------------------------+-----------------------+
 
 Mathematical operations on tables or grids
 ------------------------------------------
 
-+-----------------------+---------------------------+
-| :doc:`gmtmath`        | |gmtmath_purpose|         |
-+-----------------------+---------------------------+
-| :doc:`makecpt`        | |makecpt_purpose|         |
-+-----------------------+---------------------------+
-| :doc:`spectrum1d`     | |spectrum1d_purpose|      |
-+-----------------------+---------------------------+
-| :doc:`sph2grd`        | |sph2grd_purpose|         |
-+-----------------------+---------------------------+
-| :doc:`sphdistance`    | |sphdistance_purpose|     |
-+-----------------------+---------------------------+
-| :doc:`sphtriangulate` | |sphtriangulate_purpose|  |
-+-----------------------+---------------------------+
++--------------------------+---------------------------+
+| :doc:`gmtmath <gmtmath>` | |gmtmath_purpose|         |
++--------------------------+---------------------------+
+| :doc:`makecpt`           | |makecpt_purpose|         |
++--------------------------+---------------------------+
+| :doc:`spectrum1d`        | |spectrum1d_purpose|      |
++--------------------------+---------------------------+
+| :doc:`sph2grd`           | |sph2grd_purpose|         |
++--------------------------+---------------------------+
+| :doc:`sphdistance`       | |sphdistance_purpose|     |
++--------------------------+---------------------------+
+| :doc:`sphtriangulate`    | |sphtriangulate_purpose|  |
++--------------------------+---------------------------+
 
 Convert or extract subsets of data
 ----------------------------------
 
-+-----------------------+-----------------------+
-| :doc:`gmtbinstats`    | |gmtbinstats_purpose| |
-+-----------------------+-----------------------+
-| :doc:`gmtconnect`     | |gmtconnect_purpose|  |
-+-----------------------+-----------------------+
-| :doc:`gmtconvert`     | |gmtconvert_purpose|  |
-+-----------------------+-----------------------+
-| :doc:`gmtselect`      | |gmtselect_purpose|   |
-+-----------------------+-----------------------+
-| :doc:`gmtspatial`     | |gmtspatial_purpose|  |
-+-----------------------+-----------------------+
-| :doc:`gmtsplit`       | |gmtsplit_purpose|    |
-+-----------------------+-----------------------+
-| :doc:`gmtvector`      | |gmtvector_purpose|   |
-+-----------------------+-----------------------+
-| :doc:`grd2kml`        | |grd2kml_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`grd2xyz`        | |grd2xyz_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`grdblend`       | |grdblend_purpose|    |
-+-----------------------+-----------------------+
-| :doc:`grdconvert`     | |grdconvert_purpose|  |
-+-----------------------+-----------------------+
-| :doc:`grdcut`         | |grdcut_purpose|      |
-+-----------------------+-----------------------+
-| :doc:`grdpaste`       | |grdpaste_purpose|    |
-+-----------------------+-----------------------+
-| :doc:`xyz2grd`        | |xyz2grd_purpose|     |
-+-----------------------+-----------------------+
++----------------------------------+-----------------------+
+| :doc:`gmtbinstats <gmtbinstats>` | |gmtbinstats_purpose| |
++----------------------------------+-----------------------+
+| :doc:`gmtconnect <gmtconnect>`   | |gmtconnect_purpose|  |
++----------------------------------+-----------------------+
+| :doc:`gmtconvert <gmtconvert>`   | |gmtconvert_purpose|  |
++----------------------------------+-----------------------+
+| :doc:`gmtselect <gmtselect>`     | |gmtselect_purpose|   |
++----------------------------------+-----------------------+
+| :doc:`gmtspatial <gmtspatial>`   | |gmtspatial_purpose|  |
++----------------------------------+-----------------------+
+| :doc:`gmtsplit <gmtsplit>`       | |gmtsplit_purpose|    |
++----------------------------------+-----------------------+
+| :doc:`gmtvector <gmtvector>`     | |gmtvector_purpose|   |
++----------------------------------+-----------------------+
+| :doc:`grd2kml`                   | |grd2kml_purpose|     |
++----------------------------------+-----------------------+
+| :doc:`grd2xyz`                   | |grd2xyz_purpose|     |
++----------------------------------+-----------------------+
+| :doc:`grdblend`                  | |grdblend_purpose|    |
++----------------------------------+-----------------------+
+| :doc:`grdconvert`                | |grdconvert_purpose|  |
++----------------------------------+-----------------------+
+| :doc:`grdcut`                    | |grdcut_purpose|      |
++----------------------------------+-----------------------+
+| :doc:`grdpaste`                  | |grdpaste_purpose|    |
++----------------------------------+-----------------------+
+| :doc:`xyz2grd`                   | |xyz2grd_purpose|     |
++----------------------------------+-----------------------+
 
 Trends in 1-D and 2-D data
 --------------------------
 
-+-----------------------+-----------------------+
-| :doc:`fitcircle`      | |fitcircle_purpose|   |
-+-----------------------+-----------------------+
-| :doc:`gmtregress`     | |gmtregress_purpose|  |
-+-----------------------+-----------------------+
-| :doc:`grdtrend`       | |grdtrend_purpose|    |
-+-----------------------+-----------------------+
-| :doc:`trend1d`        | |trend1d_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`trend2d`        | |trend2d_purpose|     |
-+-----------------------+-----------------------+
++--------------------------------+-----------------------+
+| :doc:`fitcircle`               | |fitcircle_purpose|   |
++--------------------------------+-----------------------+
+| :doc:`gmtregress <gmtregress>` | |gmtregress_purpose|  |
++--------------------------------+-----------------------+
+| :doc:`grdtrend`                | |grdtrend_purpose|    |
++--------------------------------+-----------------------+
+| :doc:`trend1d`                 | |trend1d_purpose|     |
++--------------------------------+-----------------------+
+| :doc:`trend2d`                 | |trend2d_purpose|     |
++--------------------------------+-----------------------+
 
 Grid operations
 ---------------
@@ -592,21 +592,21 @@ Grid operations
 Miscellaneous
 -------------
 
-+-----------------------+-----------------------+
-| :doc:`batch`          | |batch_purpose|       |
-+-----------------------+-----------------------+
-| :doc:`docs`           | |docs_purpose|        |
-+-----------------------+-----------------------+
-| :doc:`gmt2kml`        | |gmt2kml_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`grdgdal`        | |grdgdal_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`gmtwhich`       | |gmtwhich_purpose|    |
-+-----------------------+-----------------------+
-| :doc:`kml2gmt`        | |kml2gmt_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`psconvert`      | |psconvert_purpose|   |
-+-----------------------+-----------------------+
++----------------------------+-----------------------+
+| :doc:`batch`               | |batch_purpose|       |
++----------------------------+-----------------------+
+| :doc:`docs`                | |docs_purpose|        |
++----------------------------+-----------------------+
+| :doc:`gmt2kml`             | |gmt2kml_purpose|     |
++----------------------------+-----------------------+
+| :doc:`grdgdal`             | |grdgdal_purpose|     |
++----------------------------+-----------------------+
+| :doc:`gmtwhich <gmtwhich>` | |gmtwhich_purpose|    |
++----------------------------+-----------------------+
+| :doc:`kml2gmt`             | |kml2gmt_purpose|     |
++----------------------------+-----------------------+
+| :doc:`psconvert`           | |psconvert_purpose|   |
++----------------------------+-----------------------+
 
 geodesy
 -------
@@ -678,27 +678,27 @@ MGD77
 potential
 ---------
 
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/gmtflexure`   | |gmtflexure_purpose|     |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/gmtgravmag3d` | |gmtgravmag3d_purpose|   |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/gravfft`      | |gravfft_purpose|        |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/gravprisms`   | |gravprisms_purpose|     |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/grdflexure`   | |grdflexure_purpose|     |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/grdgravmag3d` | |grdgravmag3d_purpose|   |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/grdredpol`    | |grdredpol_purpose|      |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/grdseamount`  | |grdseamount_purpose|    |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/talwani2d`    | |talwani2d_purpose|      |
-+--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/talwani3d`    | |talwani3d_purpose|      |
-+--------------------------------------------+--------------------------+
++-----------------------------------------------------------+--------------------------+
+| :doc:`gmtflexure </supplements/potential/gmtflexure>`     | |gmtflexure_purpose|     |
++-----------------------------------------------------------+--------------------------+
+| :doc:`gmtgravmag3d </supplements/potential/gmtgravmag3d>` | |gmtgravmag3d_purpose|   |
++-----------------------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/gravfft`                     | |gravfft_purpose|        |
++-----------------------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/gravprisms`                  | |gravprisms_purpose|     |
++-----------------------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/grdflexure`                  | |grdflexure_purpose|     |
++-----------------------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/grdgravmag3d`                | |grdgravmag3d_purpose|   |
++-----------------------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/grdredpol`                   | |grdredpol_purpose|      |
++-----------------------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/grdseamount`                 | |grdseamount_purpose|    |
++-----------------------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/talwani2d`                   | |talwani2d_purpose|      |
++-----------------------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/talwani3d`                   | |talwani3d_purpose|      |
++-----------------------------------------------------------+--------------------------+
 
 SEGY
 ----
@@ -724,34 +724,34 @@ seis
 | :doc:`/supplements/seis/pssac`    | |pssac_purpose|    |
 +-----------------------------------+--------------------+
 | :doc:`/supplements/seis/grdshake` | |grdshake_purpose| |
-+---------------------------------+----------------------+
++-----------------------------------+--------------------+
 | :doc:`/supplements/seis/grdvs30`  | |grdvs30_purpose|  |
-+---------------------------------+----------------------+
++-----------------------------------+--------------------+
 
 spotter
 -------
 
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/backtracker`  | |backtracker_purpose|  |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/gmtpmodeler`  | |gmtpmodeler_purpose|  |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/grdpmodeler`  | |grdpmodeler_purpose|  |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/grdrotater`   | |grdrotater_purpose|   |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/grdspotter`   | |grdspotter_purpose|   |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/hotspotter`   | |hotspotter_purpose|   |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/originater`   | |originater_purpose|   |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/polespotter`  | |polespotter_purpose|  |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/rotconverter` | |rotconverter_purpose| |
-+------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/rotsmoother`  | |rotsmoother_purpose|  |
-+------------------------------------------+------------------------+
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/backtracker`               | |backtracker_purpose|  |
++-------------------------------------------------------+------------------------+
+| :doc:`gmtpmodeler </supplements/spotter/gmtpmodeler>` | |gmtpmodeler_purpose|  |
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/grdpmodeler`               | |grdpmodeler_purpose|  |
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/grdrotater`                | |grdrotater_purpose|   |
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/grdspotter`                | |grdspotter_purpose|   |
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/hotspotter`                | |hotspotter_purpose|   |
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/originater`                | |originater_purpose|   |
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/polespotter`               | |polespotter_purpose|  |
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/rotconverter`              | |rotconverter_purpose| |
++-------------------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/rotsmoother`               | |rotsmoother_purpose|  |
++-------------------------------------------------------+------------------------+
 
 windbarbs
 ---------

--- a/doc/rst/source/modules.rst
+++ b/doc/rst/source/modules.rst
@@ -199,6 +199,7 @@ Core Modules
     - :doc:`basemap`
     - :doc:`batch`
     - :doc:`begin`
+    - :doc:`gmtbinstats`
     - :doc:`blockmean`
     - :doc:`blockmedian`
     - :doc:`blockmode`
@@ -206,7 +207,10 @@ Core Modules
     - :doc:`clip`
     - :doc:`coast`
     - :doc:`colorbar`
+    - :doc:`gmtconnect`
     - :doc:`contour`
+    - :doc:`gmtconvert`
+    - :doc:`gmtdefaults`
     - :doc:`dimfilter`
     - :doc:`docs`
     - :doc:`end`
@@ -214,23 +218,8 @@ Core Modules
     - :doc:`figure`
     - :doc:`filter1d`
     - :doc:`fitcircle`
-    - :doc:`gmt2kml`
-    - :doc:`gmtbinstats`
-    - :doc:`gmtconnect`
-    - :doc:`gmtconvert`
-    - :doc:`gmtdefaults`
     - :doc:`gmtget`
-    - :doc:`gmtinfo`
-    - :doc:`gmtlogo`
-    - :doc:`gmtmath`
-    - :doc:`gmtregress`
-    - :doc:`gmtselect`
-    - :doc:`gmtset`
-    - :doc:`gmtsimplify`
-    - :doc:`gmtspatial`
-    - :doc:`gmtsplit`
-    - :doc:`gmtvector`
-    - :doc:`gmtwhich`
+    - :doc:`gmt2kml`
     - :doc:`grd2cpt`
     - :doc:`grd2kml`
     - :doc:`grd2xyz`
@@ -265,26 +254,35 @@ Core Modules
     - :doc:`greenspline`
     - :doc:`histogram`
     - :doc:`image`
+    - :doc:`gmtinfo`
     - :doc:`inset`
     - :doc:`kml2gmt`
     - :doc:`legend`
+    - :doc:`gmtlogo`
     - :doc:`makecpt`
     - :doc:`mapproject`
     - :doc:`mask`
+    - :doc:`gmtmath`
     - :doc:`movie`
     - :doc:`nearneighbor`
     - :doc:`plot`
     - :doc:`plot3d`
     - :doc:`project`
     - :doc:`psconvert`
+    - :doc:`gmtregress`
     - :doc:`rose`
     - :doc:`sample1d`
+    - :doc:`gmtselect`
+    - :doc:`gmtset`
+    - :doc:`gmtsimplify`
     - :doc:`solar`
+    - :doc:`gmtspatial`
     - :doc:`spectrum1d`
     - :doc:`sph2grd`
     - :doc:`sphdistance`
     - :doc:`sphinterpolate`
     - :doc:`sphtriangulate`
+    - :doc:`gmtsplit`
     - :doc:`subplot`
     - :doc:`surface`
     - :doc:`ternary`
@@ -292,6 +290,8 @@ Core Modules
     - :doc:`trend1d`
     - :doc:`trend2d`
     - :doc:`triangulate`
+    - :doc:`gmtvector`
+    - :doc:`gmtwhich`
     - :doc:`wiggle`
     - :doc:`xyz2grd`
 
@@ -323,8 +323,8 @@ Supplemental Modules
     - :doc:`/supplements/mgd77/mgd77sniffer`
     - :doc:`/supplements/mgd77/mgd77track`
     - :doc:`/supplements/potential/gmtflexure`
-    - :doc:`/supplements/potential/gmtgravmag3d`
     - :doc:`/supplements/potential/gravfft`
+    - :doc:`/supplements/potential/gmtgravmag3d`
     - :doc:`/supplements/potential/gravprisms`
     - :doc:`/supplements/potential/grdflexure`
     - :doc:`/supplements/potential/grdgravmag3d`
@@ -340,12 +340,12 @@ Supplemental Modules
     - :doc:`/supplements/seis/polar`
     - :doc:`/supplements/seis/sac`
     - :doc:`/supplements/spotter/backtracker`
-    - :doc:`/supplements/spotter/gmtpmodeler`
     - :doc:`/supplements/spotter/grdpmodeler`
     - :doc:`/supplements/spotter/grdrotater`
     - :doc:`/supplements/spotter/grdspotter`
     - :doc:`/supplements/spotter/hotspotter`
     - :doc:`/supplements/spotter/originater`
+    - :doc:`/supplements/spotter/gmtpmodeler`
     - :doc:`/supplements/spotter/polespotter`
     - :doc:`/supplements/spotter/rotconverter`
     - :doc:`/supplements/spotter/rotsmoother`
@@ -413,8 +413,6 @@ Plotting
 +-----------------------+-----------------------+
 | :doc:`events`         | |events_purpose|      |
 +-----------------------+-----------------------+
-| :doc:`gmtlogo`        | |gmtlogo_purpose|     |
-+-----------------------+-----------------------+
 | :doc:`grdcontour`     | |grdcontour_purpose|  |
 +-----------------------+-----------------------+
 | :doc:`grdimage`       | |grdimage_purpose|    |
@@ -428,6 +426,8 @@ Plotting
 | :doc:`image`          | |image_purpose|       |
 +-----------------------+-----------------------+
 | :doc:`legend`         | |legend_purpose|      |
++-----------------------+-----------------------+
+| :doc:`gmtlogo`        | |gmtlogo_purpose|     |
 +-----------------------+-----------------------+
 | :doc:`mask`           | |mask_purpose|        |
 +-----------------------+-----------------------+
@@ -484,13 +484,13 @@ Sampling of 1-D and 2-D data
 ----------------------------
 
 +-----------------------+-----------------------+
-| :doc:`gmtsimplify`    | |gmtsimplify_purpose| |
-+-----------------------+-----------------------+
 | :doc:`grdsample`      | |grdsample_purpose|   |
 +-----------------------+-----------------------+
 | :doc:`grdtrack`       | |grdtrack_purpose|    |
 +-----------------------+-----------------------+
 | :doc:`sample1d`       | |sample1d_purpose|    |
++-----------------------+-----------------------+
+| :doc:`gmtsimplify`    | |gmtsimplify_purpose| |
 +-----------------------+-----------------------+
 
 Projection and map-transformation
@@ -512,22 +512,22 @@ Information retrieval
 +-----------------------+-----------------------+
 | :doc:`gmtget`         | |gmtget_purpose|      |
 +-----------------------+-----------------------+
-| :doc:`gmtinfo`        | |gmtinfo_purpose|     |
-+-----------------------+-----------------------+
-| :doc:`gmtset`         | |gmtset_purpose|      |
-+-----------------------+-----------------------+
 | :doc:`grdinfo`        | |grdinfo_purpose|     |
 +-----------------------+-----------------------+
 | :doc:`grdselect`      | |grdselect_purpose|   |
++-----------------------+-----------------------+
+| :doc:`gmtinfo`        | |gmtinfo_purpose|     |
++-----------------------+-----------------------+
+| :doc:`gmtset`         | |gmtset_purpose|      |
 +-----------------------+-----------------------+
 
 Mathematical operations on tables or grids
 ------------------------------------------
 
 +-----------------------+---------------------------+
-| :doc:`gmtmath`        | |gmtmath_purpose|         |
-+-----------------------+---------------------------+
 | :doc:`makecpt`        | |makecpt_purpose|         |
++-----------------------+---------------------------+
+| :doc:`gmtmath`        | |gmtmath_purpose|         |
 +-----------------------+---------------------------+
 | :doc:`spectrum1d`     | |spectrum1d_purpose|      |
 +-----------------------+---------------------------+
@@ -548,14 +548,6 @@ Convert or extract subsets of data
 +-----------------------+-----------------------+
 | :doc:`gmtconvert`     | |gmtconvert_purpose|  |
 +-----------------------+-----------------------+
-| :doc:`gmtselect`      | |gmtselect_purpose|   |
-+-----------------------+-----------------------+
-| :doc:`gmtspatial`     | |gmtspatial_purpose|  |
-+-----------------------+-----------------------+
-| :doc:`gmtsplit`       | |gmtsplit_purpose|    |
-+-----------------------+-----------------------+
-| :doc:`gmtvector`      | |gmtvector_purpose|   |
-+-----------------------+-----------------------+
 | :doc:`grd2kml`        | |grd2kml_purpose|     |
 +-----------------------+-----------------------+
 | :doc:`grd2xyz`        | |grd2xyz_purpose|     |
@@ -568,6 +560,14 @@ Convert or extract subsets of data
 +-----------------------+-----------------------+
 | :doc:`grdpaste`       | |grdpaste_purpose|    |
 +-----------------------+-----------------------+
+| :doc:`gmtselect`      | |gmtselect_purpose|   |
++-----------------------+-----------------------+
+| :doc:`gmtspatial`     | |gmtspatial_purpose|  |
++-----------------------+-----------------------+
+| :doc:`gmtsplit`       | |gmtsplit_purpose|    |
++-----------------------+-----------------------+
+| :doc:`gmtvector`      | |gmtvector_purpose|   |
++-----------------------+-----------------------+
 | :doc:`xyz2grd`        | |xyz2grd_purpose|     |
 +-----------------------+-----------------------+
 
@@ -577,9 +577,9 @@ Trends in 1-D and 2-D data
 +-----------------------+-----------------------+
 | :doc:`fitcircle`      | |fitcircle_purpose|   |
 +-----------------------+-----------------------+
-| :doc:`gmtregress`     | |gmtregress_purpose|  |
-+-----------------------+-----------------------+
 | :doc:`grdtrend`       | |grdtrend_purpose|    |
++-----------------------+-----------------------+
+| :doc:`gmtregress`     | |gmtregress_purpose|  |
 +-----------------------+-----------------------+
 | :doc:`trend1d`        | |trend1d_purpose|     |
 +-----------------------+-----------------------+
@@ -625,13 +625,13 @@ Miscellaneous
 +-----------------------+-----------------------+
 | :doc:`grdgdal`        | |grdgdal_purpose|     |
 +-----------------------+-----------------------+
-| :doc:`gmtwhich`       | |gmtwhich_purpose|    |
-+-----------------------+-----------------------+
 | :doc:`kml2gmt`        | |kml2gmt_purpose|     |
 +-----------------------+-----------------------+
 | :doc:`movie`          | |movie_purpose|       |
 +-----------------------+-----------------------+
 | :doc:`psconvert`      | |psconvert_purpose|   |
++-----------------------+-----------------------+
+| :doc:`gmtwhich`       | |gmtwhich_purpose|    |
 +-----------------------+-----------------------+
 
 geodesy
@@ -707,9 +707,9 @@ potential
 +--------------------------------------------+--------------------------+
 | :doc:`/supplements/potential/gmtflexure`   | |gmtflexure_purpose|     |
 +--------------------------------------------+--------------------------+
-| :doc:`/supplements/potential/gmtgravmag3d` | |gmtgravmag3d_purpose|   |
-+--------------------------------------------+--------------------------+
 | :doc:`/supplements/potential/gravfft`      | |gravfft_purpose|        |
++--------------------------------------------+--------------------------+
+| :doc:`/supplements/potential/gmtgravmag3d` | |gmtgravmag3d_purpose|   |
 +--------------------------------------------+--------------------------+
 | :doc:`/supplements/potential/gravprisms`   | |gravprisms_purpose|     |
 +--------------------------------------------+--------------------------+
@@ -760,8 +760,6 @@ spotter
 +------------------------------------------+------------------------+
 | :doc:`/supplements/spotter/backtracker`  | |backtracker_purpose|  |
 +------------------------------------------+------------------------+
-| :doc:`/supplements/spotter/gmtpmodeler`  | |gmtpmodeler_purpose|  |
-+------------------------------------------+------------------------+
 | :doc:`/supplements/spotter/grdpmodeler`  | |grdpmodeler_purpose|  |
 +------------------------------------------+------------------------+
 | :doc:`/supplements/spotter/grdrotater`   | |grdrotater_purpose|   |
@@ -771,6 +769,8 @@ spotter
 | :doc:`/supplements/spotter/hotspotter`   | |hotspotter_purpose|   |
 +------------------------------------------+------------------------+
 | :doc:`/supplements/spotter/originater`   | |originater_purpose|   |
++------------------------------------------+------------------------+
+| :doc:`/supplements/spotter/gmtpmodeler`  | |gmtpmodeler_purpose|  |
 +------------------------------------------+------------------------+
 | :doc:`/supplements/spotter/polespotter`  | |polespotter_purpose|  |
 +------------------------------------------+------------------------+

--- a/doc/rst/source/supplements/potential/gmtflexure.rst
+++ b/doc/rst/source/supplements/potential/gmtflexure.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtflexure
 .. include:: ../module_supplements_purpose.rst_
 
-**********
-gmtflexure
-**********
+*******
+flexure
+*******
 
 |gmtflexure_purpose|
 

--- a/doc/rst/source/supplements/potential/gmtgravmag3d.rst
+++ b/doc/rst/source/supplements/potential/gmtgravmag3d.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtgravmag3d
 .. include:: ../module_supplements_purpose.rst_
 
-************
-gmtgravmag3d
-************
+*********
+gravmag3d
+*********
 
 |gmtgravmag3d_purpose|
 

--- a/doc/rst/source/supplements/spotter/gmtpmodeler.rst
+++ b/doc/rst/source/supplements/spotter/gmtpmodeler.rst
@@ -1,9 +1,9 @@
 .. index:: ! gmtpmodeler
 .. include:: ../module_supplements_purpose.rst_
 
-***********
-gmtpmodeler
-***********
+********
+pmodeler
+********
 
 |gmtpmodeler_purpose|
 


### PR DESCRIPTION
**Description of proposed changes**

A bunch of modules still appear with their old names in the indices in the documentation.
For example, in `modules.rst` we still have `gmtwhich` instead of `which`, while in `gmtwhich.rst` the synopsis does start with **gmt which**, though it has **gmtwhich** in the header.

One way to deal with this is similar to `psxy` and `plot`: we create near duplicate files `gmtwhich.rst` and `which.rst`, where the former will still appear in the list of classic modules, whereas the later will appear in the modern (default) list. 

I was concerned though that people will forget to update the proper documentation files, i.e. `gmtwhich.rst` **and** `which.rst` with any change. Given the number of modules involved (see below) that would be serious work.

Thus I choose to simply change the top section header of `gmtwhich.rst` (etc.) and write there `which` instead of `gmtwhich`, and of course change the alphabetical order in `modules.rst`.  This writes `which` in the index, without any further changes.

To avoid that `which` would show as well in the classical module list, I used, e.g.:
```
:doc:`gmtwhich <gmtwhich>`
```
which would then show the word `gmtwhich` again.

I identified the following modules that would need this treatment:

- [x] binstats <- gmtbinstats
- [x] connect <- gmtconnect
- [x] convert <- gmtconvert
- [x] defaults <- gmtdefaults
- [x] get <- gmtget
- [x] info <- gmtinfo
- [x] logo <- gmtlogo
- [x] math <- gmtmath
- [x] regress <- gmtregress
- [x] select <- gmtselect
- [x] set <- gmtset
- [x] simplify <- gmtsimplify
- [x] spatial <- gmtspatial
- [x] split <- gmtsplit
- [x] vector <- gmtvector
- [x] which <- gmtwhich

And in the supplemental modules

- [x] flexure <- gmtflexure
- [x] gravmag3d <- gmtgravmag3d
- [x] pmodeler <- gmtpmodeler