### PR TITLE
Relax the need for -R in grdproject

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -12730,8 +12730,8 @@ int gmt_BC_init (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *h) {
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Grid is considered to have a 360-degree longitude range.\n");
 		if (GMT->parent->ignore_BC) xtest = 0.0;	/* To bypass the checks below */
 		/* xtest should be within GMT_CONV4_LIMIT of zero or of one.  */
-		if (xtest > GMT_CONV4_LIMIT && xtest < (1.0 - GMT_CONV4_LIMIT) ) {
-			/* Error.  We need it to divide into 180 so we can phase-shift at poles.  */
+		if (xtest > GMT_CONV4_LIMIT && xtest < (1.0 - GMT_CONV4_LIMIT) && GMT->current.proj.projection_GMT == 0) {
+			/* Maybe error.  We need it to divide into 180 so we can phase-shift at poles but not if we already projected the grid to Cartesian.  */
 			GMT_Report (GMT->parent, GMT_MSG_WARNING, "x_inc does not divide 180; geographic boundary condition changed to natural.\n");
 			HH->nxp = HH->nyp = 0;
 			HH->gn  = HH->gs = false;

--- a/src/grdproject.c
+++ b/src/grdproject.c
@@ -216,7 +216,6 @@ static int parse (struct GMT_CTRL *GMT, struct GRDPROJECT_CTRL *Ctrl, struct GMT
 	                                   "Can specify only one of -F and -M\n");
 	n_errors += gmt_M_check_condition (GMT, (GMT->common.R.active[ISET] + Ctrl->E.active) > 1,
 	                                   "Must specify only one of -D or -E\n");
-	n_errors += gmt_M_check_condition (GMT, GMT->common.J.width_given && !GMT->common.R.active[RSET] , "Option -J: If map width is given you must also specify a region with -R\n");
 	n_errors += gmt_M_check_condition (GMT, GMT->common.R.active[ISET] && (GMT->common.R.inc[GMT_X] <= 0.0 ||
 	                                   GMT->common.R.inc[GMT_Y] < 0.0),
 	                                   "Option -D: Must specify positive increment(s)\n");


### PR DESCRIPTION
It used to be that way but in pursuit of a bug we added the requirement to **grdproject** that **-R** be set if **-J** was given a size.  This resulted in a global grid (-180/180/-90/90) given -JH10c gave the final grid wesn as 0/10/-5/5 and no longer geographic, but that is not really our business.  I have removed that check and should no longer bother anyone. All tests pass now, including the examples posted.

`gmt grdproject @earth_relief_01d_g -JH10c -Gtmp.nc`
