### PR TITLE
colorbar: Add modifier +n|N to -D option for placing colorbar NaN box on the right and to skip label

### DIFF
--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -139,7 +139,7 @@ Optional Arguments
     unit that will be moved to the opposite side. Append **c** if you want to print a
     vertical label as a column of characters (does not work with special characters).
   - **+n** plots a rectangle with the NaN color (via the **N** entry in your cpt (or :term:`COLOR_NAN` if no such entry)
-    at the start of the bar, append *text* to change label from NaN.
+    at the start of the bar, append *text* to change label from NaN. To place it at the end of the bar, use **+N** instead.
   - **+r** will reverse the positive direction of the bar.
 
 .. _-F:

--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -124,6 +124,8 @@ Optional Arguments
     percentage of the bar *length*.
   - **+e** adds sidebar triangles for back- and/or foreground colors. Append **f** (foreground) or **b** 
     background) for only one sidebar triangle [Default gives both]. Optionally, append triangle height [Default is half the barwidth].
+    The back and/or foreground colors are taken from your **B** and **F** colors in your CPT.  If none then the system default
+    colors for **B** and **F** are used instead (:term:`COLOR_BACKGROUND` and :term:`COLOR_FOREGROUND`).
   - **+h** selects a horizontal scale [Default is vertical (**+v**)].
   - **+j** sets the anchor point. By default, the anchor point on the scale is assumed to be the bottom left corner (BL),
     but this can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`text`).
@@ -136,7 +138,8 @@ Optional Arguments
     the unit remains below. Append one or more of **a**, **l** or **u** to control which of the annotations, label, and
     unit that will be moved to the opposite side. Append **c** if you want to print a
     vertical label as a column of characters (does not work with special characters).
-  - **+n** plots a rectangle with the NaN color at the start of the bar, append *text* to change label from NaN.
+  - **+n** plots a rectangle with the NaN color (via the **N** entry in your cpt (or :term:`COLOR_NAN` if no such entry)
+    at the start of the bar, append *text* to change label from NaN.
   - **+r** will reverse the positive direction of the bar.
 
 .. _-F:

--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -318,7 +318,7 @@ Notes
    Use another PDF viewer if this bothers you.
 #. For cyclic (wrapping) color tables the cyclic symbol is plotted to the right
    of the color bar.  If annotations are specified there then we place the cyclic
-   symbol at the left, unless **+n** was used in which case we center of the color bar instead.
+   symbol at the left, unless **+n** or **+N** were used in which case we center of the color bar instead.
 #. Discrete CPTs may have transparency applied to all or some individual slices.
    Continuous CPTs may have transparency applied to all slices, but not just some.
 

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -172,7 +172,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [%s] [-C<cpt>] [-D%s[+w<length>[/<width>]][+e[b|f][<length>]][+h|v][+j<justify>][+ma|c|l|u][+n[<txt>]]%s[+r]] "
+	GMT_Usage (API, 0, "usage: %s [%s] [-C<cpt>] [-D%s[+w<length>[/<width>]][+e[b|f][<length>]][+h|v][+j<justify>][+ma|c|l|u][+n|N[<txt>]]%s[+r]] "
 		"[-F%s] [-G<zlo>/<zhi>] [-I[<max_intens>|<low_i>/<high_i>]] [%s] %s[-L[i|I][<gap>]] [-M] [-N[p|<dpi>]] %s%s[-Q] [%s] "
 		"[-S[+a<angle>][+c|n][+r][+s][+x<label>][+y<unit>]] [%s] [%s] [-W<scale>] [%s] [%s] [-Z<widthfile>] %s[%s] [%s] [%s]\n",
 			name, GMT_B_OPT, GMT_XYANCHOR, GMT_OFFSET, GMT_PANEL, GMT_J_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeoz_OPT,
@@ -205,7 +205,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+m Move selected annotations/labels/units on opposite side of colorscale. "
 		"Append any of a, l, or u to move the annotations, labels, or unit, respectively. "
 		"Append c to plot vertical labels as column text.");
-	GMT_Usage (API, 3, "+n Draw rectangle with NaN color and label with <txt> [NaN].");
+	GMT_Usage (API, 3, "+n Draw rectangle with NaN color and label with <txt> on the left (use +N to place on the right) [NaN].");
 	gmt_mappanel_syntax (API->GMT, 'F', "Specify a rectangular panel behind the scale.", 3);
 	GMT_Usage (API, 1, "\n-G<zlo>/<zhi>");
 	GMT_Usage (API, -2, "Truncate incoming CPT to be limited to the z-range <zlo>/<zhi>. "

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1732,6 +1732,30 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 			}
 			PSL_plotline (PSL, xp, yp, nv, p_arg);
 		}
+		if (Ctrl->D.emode & PSSCALE_NAN_RT) {	/* Add NaN rectangle on right (top) side */
+			nan_off += Ctrl->D.elength;
+			xp[0] = xp[1] = xright + gap;	xp[2] = xp[3] = xp[0] + MAX (width, Ctrl->D.elength);
+			for (i = 0; i < 4; i++) xp[i] += nan_off;
+			yp[0] = yp[3] = width;	yp[1] = yp[2] = 0.0;
+			if ((f = P->bfn[GMT_NAN].fill) != NULL)
+				gmt_setfill (GMT, f, 1);
+			else {
+				gmt_M_rgb_copy (rgb, P->bfn[GMT_NAN].rgb);
+				if (Ctrl->M.active) rgb[0] = rgb[1] = rgb[2] = gmt_M_yiq (rgb);
+				PSL_setfill (PSL, rgb, 1);
+			}
+			if (P->bfn[GMT_NAN].rgb[3] > 0.0) {
+				transp[GMT_FILL_TRANSP] = P->bfn[GMT_NAN].rgb[3];
+				PSL_settransparencies (PSL, transp);
+			}
+			PSL_plotpolygon (PSL, xp, yp, 4);
+			if (P->bfn[GMT_NAN].rgb[3] > 0.0) {
+				transp[GMT_FILL_TRANSP] = 0.0;	/* Reset */
+				PSL_settransparencies (PSL, transp);
+			}
+			if (Ctrl->D.etext)
+				gmt_map_text (GMT, xp[2] + fabs (GMT->current.setting.map_annot_offset[GMT_PRIMARY]), 0.5 * width, &GMT->current.setting.font_annot[GMT_PRIMARY], Ctrl->D.etext, -90.0, PSL_BC, 0);
+		}
 
 		PSL_setlinecap (PSL, PSL_SQUARE_CAP);	/* Square cap required for box of scale bar */
 
@@ -1901,10 +1925,10 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 				gmt_map_text (GMT, xright + GMT->current.setting.map_annot_offset[GMT_SECONDARY] + elength[XHI], 0.5 * width, &GMT->current.setting.font_annot[GMT_SECONDARY], unit, -90.0, PSL_BC, form);
 		}
 		if (P->is_wrapping) {	/* Add cyclic glyph */
-			if ((flip & PSSCALE_FLIP_UNIT) || unit[0] == 0)	/* The y-label is on the left or not used so place cyclic glyph on right */
-				x0 = xright + GMT->current.setting.map_annot_offset[GMT_PRIMARY] + 0.45 * width;
+			if ((flip & PSSCALE_FLIP_UNIT) || unit[0] == 0 && (Ctrl->D.emode & PSSCALE_NAN_RT) == 0)	/* The y-label is on the left or not used so place cyclic glyph on right */
+				x0 = xright + 2 * GMT->current.setting.map_annot_offset[GMT_PRIMARY] + 0.45 * width;
 			else if ((Ctrl->D.emode & PSSCALE_NAN_LB) == 0)	/* TNo nan so place on left */
-				x0 = xleft - GMT->current.setting.map_annot_offset[GMT_PRIMARY] - 0.45 * width;
+				x0 = xleft - 2 * GMT->current.setting.map_annot_offset[GMT_PRIMARY] - 0.45 * width;
 			else	/* Give up and place at center */
 				x0 = 0.5 * (xleft + xright);
 			psscale_plot_cycle (GMT, x0, 0.5 * width, PSSCALE_CYCLE_DIM * width);

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -1516,7 +1516,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 			if ((flip & PSSCALE_FLIP_UNIT) || unit[0] == 0 && (Ctrl->D.emode & PSSCALE_NAN_RT) == 0)	/* The y-label is on the left or not used so place cyclic glyph on right */
 				x0 = xright + GMT->current.setting.map_annot_offset[GMT_PRIMARY] + 0.45 * width;
 			else if ((Ctrl->D.emode & PSSCALE_NAN_LB) == 0)	/* No nan so place on left */
-				x0 = xleft - 2*GMT->current.setting.map_annot_offset[GMT_PRIMARY] - 0.45 * width;
+				x0 = xleft - 2 * GMT->current.setting.map_annot_offset[GMT_PRIMARY] - 0.45 * width;
 			else	/* Give up and place in center */
 				x0 = 0.5 * (xleft + xright);
 			psscale_plot_cycle (GMT, x0, 0.5 * width, PSSCALE_CYCLE_DIM * width);
@@ -1926,7 +1926,7 @@ GMT_LOCAL void psscale_draw_colorbar (struct GMT_CTRL *GMT, struct PSSCALE_CTRL 
 		}
 		if (P->is_wrapping) {	/* Add cyclic glyph */
 			if ((flip & PSSCALE_FLIP_UNIT) || unit[0] == 0 && (Ctrl->D.emode & PSSCALE_NAN_RT) == 0)	/* The y-label is on the left or not used so place cyclic glyph on right */
-				x0 = xright + 2 * GMT->current.setting.map_annot_offset[GMT_PRIMARY] + 0.45 * width;
+				x0 = xright + GMT->current.setting.map_annot_offset[GMT_PRIMARY] + 0.45 * width;
 			else if ((Ctrl->D.emode & PSSCALE_NAN_LB) == 0)	/* TNo nan so place on left */
 				x0 = xleft - 2 * GMT->current.setting.map_annot_offset[GMT_PRIMARY] - 0.45 * width;
 			else	/* Give up and place at center */

--- a/src/psscale.c
+++ b/src/psscale.c
@@ -172,8 +172,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [%s] [-C<cpt>] [-D%s[+w<length>[/<width>]][+e[b|f][<length>]][+h|v][+j<justify>][+ma|c|l|u][+n|N[<txt>]]%s[+r]] "
-		"[-F%s] [-G<zlo>/<zhi>] [-I[<max_intens>|<low_i>/<high_i>]] [%s] %s[-L[i|I][<gap>]] [-M] [-N[p|<dpi>]] %s%s[-Q] [%s] "
+	GMT_Usage (API, 0, "usage: %s [%s] [-C<cpt>] [-D%s[+w<len'D'h_i>]] [%s] %s[-L[i|I][<gap>]] [-M] [-N[p|<dpi>]] %s%s[-Q] [%s] "
 		"[-S[+a<angle>][+c|n][+r][+s][+x<label>][+y<unit>]] [%s] [%s] [-W<scale>] [%s] [%s] [-Z<widthfile>] %s[%s] [%s] [%s]\n",
 			name, GMT_B_OPT, GMT_XYANCHOR, GMT_OFFSET, GMT_PANEL, GMT_J_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeoz_OPT,
 			GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_p_OPT, GMT_t_OPT, GMT_PAR_OPT);
@@ -304,7 +303,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'D':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->D.active);
-				if (opt->arg[0] == '+' && (gmt_found_modifier (GMT, opt->arg, "en")) && strstr (opt->arg, "w") == NULL) {
+				if (opt->arg[0] == '+' && (gmt_found_modifier (GMT, opt->arg, "enN")) && strstr (opt->arg, "w") == NULL) {
 					/* Only want +e or +n to be added to defaults */
 					sprintf (string, "%s%s", Ctrl->D.opt, opt->arg);
 					gmt_M_str_free (Ctrl->D.opt);
@@ -518,7 +517,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT_OP
 					break;
 			}
 		}
-		if (gmt_validate_modifiers (GMT, Ctrl->D.refpoint->args, 'D', "ehjmnorvw", GMT_MSG_ERROR)) n_errors++;
+		if (gmt_validate_modifiers (GMT, Ctrl->D.refpoint->args, 'D', "ehjmnNorvw", GMT_MSG_ERROR)) n_errors++;
 		if (gmt_get_modifier (Ctrl->D.refpoint->args, 'r', string))
 			Ctrl->D.reverse = true;
 		/* Required modifier +w */
@@ -531,7 +530,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSSCALE_CTRL *Ctrl, struct GMT_OP
 				n_errors++;
 			if (Ctrl->D.reverse) Ctrl->D.R.dim[GMT_X] = -fabs(Ctrl->D.R.dim[GMT_X]);
 		}
-		/* Optional modifiers +e, +h, +j, +m, +n, +o, +v */
+		/* Optional modifiers +e, +h, +j, +m, +n, +N, +o, +v */
 		if (gmt_get_modifier (Ctrl->D.refpoint->args, 'e', string)) {
 			Ctrl->D.extend = true;
 			if (strchr (string, 'b')) Ctrl->D.emode |= PSSCALE_BACK_B;

--- a/test/baseline/psscale.dvc
+++ b/test/baseline/psscale.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 6e77da8a8cb4a2816e41162fe275360d.dir
-  size: 1431120
-  nfiles: 26
+- md5: bcfdbcb917f31d1c0e3b11261c5e7069.dir
+  size: 1557220
+  nfiles: 28
   path: psscale
   hash: md5

--- a/test/psscale/colorbar-nans-h.sh
+++ b/test/psscale/colorbar-nans-h.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Show various placements of NaN rectangle on either side of bar
+# and with default, none, or user-supplied label.  This tests the
+# new +n|N[-|<string>] syntax where +n places it on the left side
+# (bottom for vertical bars), +N places NaN box on the right side
+# (or top for vertical bars), the - sign means no label, and <string>
+# is the user-supplied label [Default is NaN].  So backwards support
+# where +n gives a left-side NaN label box.  This relates to PR
+#
+# Horizontal colorbar tests
+
+
+gmt begin colorbar-nans-h
+	gmt basemap -R0/21/0/24 -Jx1c -B0 -B+t"Horizontal colorbar NaN placement and annotation(s)"+s"Mixed with back- and foreground colors and cyclicity sign" -X2c
+	gmt makecpt -Cjet -Ww -H > w.cpt
+	gmt colorbar -Cjet -Dx10c/0+jBC+w15c+e+h+n -B -Y1.5c -X1c
+	gmt colorbar -Cjet -Dx10c/0+jBC+w15c+e+h+nBAD -B -Y2.5c
+	gmt colorbar -Cjet -Dx10c/0+jBC+w15c+e+h+n-+r -B -Y2.5c
+	gmt colorbar -Cjet -Dx10c/0+jBC+w15c+e+h+nMissing+r -B -Y2.5c
+	gmt colorbar -Cw.cpt -Dx10c/0+jBC+w15c+h+n-+r -B -Y2.5c
+	gmt colorbar -Cjet -Dx10c/0+jBC+w15c+e+h+N -B -Y2.5c
+	gmt colorbar -Cjet -Dx10c/0+jBC+w15c+e+h+NBAD -B -Y2.5c
+	gmt colorbar -Cjet -Dx10c/0+jBC+w15c+e+h+N-+r -B -Y2.5c
+	gmt colorbar -Cw.cpt -Dx10c/0+jBC+w15c+h+N!!!+r -B -Y2.5c
+gmt end show

--- a/test/psscale/colorbar-nans-v.sh
+++ b/test/psscale/colorbar-nans-v.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Show various placements of NaN rectangle on either side of bar
+# and with default, none, or user-supplied label.  This tests the
+# new +n|N[-|<string>] syntax where +n places it on the left side
+# (bottom for vertical bars), +N places NaN box on the right side
+# (or top for vertical bars), the - sign means no label, and <string>
+# is the user-supplied label [Default is NaN].  So backwards support
+# where +n gives a left-side NaN label box.  This relates to PR
+# 
+# Vertical colorbar tests
+
+gmt begin colorbar-nans-v
+	gmt basemap -R0/20/0/21 -Jx1c -B0 -B+t"Vertical Colorbar NaN placement and annotation(s)"+s"Mixed with back- and foreground colors and cyclicity sign" -X2c
+	gmt makecpt -Cjet -Ww -H > w.cpt
+	gmt colorbar -Cjet -Dx0c/0+jBC+w15c+e+v+n -B -X1.5c -Y3c
+	gmt colorbar -Cjet -Dx0c/0+jBC+w15c+e+v+nBAD -B -X2c
+	gmt colorbar -Cjet -Dx0c/0+jBC+w15c+e+v+n-+r -B -X2c
+	gmt colorbar -Cjet -Dx0c/0+jBC+w15c+e+v+nMissing+r -B -X2c
+	gmt colorbar -Cw.cpt -Dx0c/0+jBC+w15c+v+n-+r -B -X2c
+	gmt colorbar -Cjet -Dx0c/0+jBC+w15c+e+v+N -B -X2c
+	gmt colorbar -Cjet -Dx0c/0+jBC+w15c+e+v+NBAD -B -X2c
+	gmt colorbar -Cjet -Dx0c/0+jBC+w15c+e+v+N-+r -B -X2c
+	gmt colorbar -Cw.cpt -Dx0c/0+jBC+w15c+v+N!!!+r -B -X2c
+gmt end show


### PR DESCRIPTION
The new modifier for placing a NaN-color box and NAN label at the end of the color bar is now extended to

**+n**|**N**[**-**|_label_]

where the new **+N** means place it on the right side of the bar (top for vertical bars) and if the label is **-** we do not place any _label_.  Default is still NaN unless you append an alternative label.

Added two new test scripts `psscale/colorbar-nans-h.sh` and `psscale/colorbar-nans-v.sh` to ensure it works for both horizontal and vertical bars.
