### PR TITLE
Maintenance PR only for better function name

### DIFF
--- a/src/dimfilter.c
+++ b/src/dimfilter.c
@@ -374,7 +374,7 @@ static int parse (struct GMT_CTRL *GMT, struct DIMFILTER_CTRL *Ctrl, struct GMT_
 				break;
 			case 'D':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->D.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &Ctrl->D.mode);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &Ctrl->D.mode);
 				set++;
 				break;
 #ifdef OBSOLETE

--- a/src/filter1d.c
+++ b/src/filter1d.c
@@ -361,10 +361,10 @@ static int parse (struct GMT_CTRL *GMT, struct FILTER1D_CTRL *Ctrl, struct GMT_O
 						}
 					}
 					else if (!strchr (opt->arg, '/'))
-						n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &sval);
+						n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &sval);
 				}
 				else
-					n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &sval);
+					n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &sval);
 				if (gmt_M_compat_check (GMT, 5) && (strstr (opt->arg, "+a") || (opt->arg[0] == 'g' || opt->arg[0] == 'c'))) {	/* Deprecated syntax */
 					GMT_Report (API, GMT_MSG_COMPAT, "-Nc|g[+a] option is deprecated; use -T[<min>/<max>/]<int>[+a|n] instead.\n");
 					if ((c = strstr (opt->arg, "+a"))) {	/* Want to output any spatial distances computed */

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -437,9 +437,10 @@ EXTERN_MSC bool gmt_this_alloc_level (struct GMT_CTRL *GMT, unsigned int alloc_l
 EXTERN_MSC unsigned int gmt_rectangle_dimension (struct GMT_CTRL *GMT, struct GMT_SCALED_RECT_DIM *R, double def_percent_w, double def_percent_h, char *string);
 EXTERN_MSC int64_t gmt_read_triangulation (struct GMT_CTRL *GMT, char option, char *file, bool binary, uint64_t n, int **link);
 EXTERN_MSC unsigned int gmt_get_no_argument (struct GMT_CTRL *GMT, char *text, char option, char modifier);
+EXTERN_MSC unsigned int gmt_get_required_int64 (struct GMT_CTRL *GMT, char *text, char option, char modifier, int64_t *value);
 EXTERN_MSC unsigned int gmt_get_required_uint64 (struct GMT_CTRL *GMT, char *text, char option, char modifier, uint64_t *value);
 EXTERN_MSC unsigned int gmt_get_required_uint (struct GMT_CTRL *GMT, char *text, char option, char modifier, unsigned int *value);
-EXTERN_MSC unsigned int gmt_get_required_sint (struct GMT_CTRL *GMT, char *text, char option, char modifier, int *value);
+EXTERN_MSC unsigned int gmt_get_required_int (struct GMT_CTRL *GMT, char *text, char option, char modifier, int *value);
 EXTERN_MSC unsigned int gmt_get_required_float (struct GMT_CTRL *GMT, char *text, char option, char modifier, float *value);
 EXTERN_MSC unsigned int gmt_get_required_double (struct GMT_CTRL *GMT, char *text, char option, char modifier, double *value);
 EXTERN_MSC unsigned int gmt_get_required_char (struct GMT_CTRL *GMT, char *text, char option, char modifier, char *letter);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -113,7 +113,7 @@
  *	gmt_get_required_double
  *	gmt_get_required_file
  *	gmt_get_required_float
- *	gmt_get_required_sint
+ *	gmt_get_required_int
  *	gmt_get_required_string
  *	gmt_get_required_uint
  *	gmt_get_required_uint64
@@ -19420,6 +19420,14 @@ unsigned int gmt_get_no_argument (struct GMT_CTRL *GMT, char *text, char option,
 	return (error);
 }
 
+unsigned int gmt_get_required_int64 (struct GMT_CTRL *GMT, char *text, char option, char modifier, int64_t *value) {
+	/* Convert the text arg to an signed 64-bit int and if no arg given we fuss and return error */
+	unsigned int err;
+	if (!(err = gmtsupport_print_and_err (GMT, text, option, modifier)))
+		*value = (int64_t)atol (text);
+	return (err);
+}
+
 unsigned int gmt_get_required_uint64 (struct GMT_CTRL *GMT, char *text, char option, char modifier, uint64_t *value) {
 	/* Convert the text arg to an unsigned 64-bit int and if no arg given we fuss and return error */
 	unsigned int err;
@@ -19436,7 +19444,7 @@ unsigned int gmt_get_required_uint (struct GMT_CTRL *GMT, char *text, char optio
 	return (err);
 }
 
-unsigned int gmt_get_required_sint (struct GMT_CTRL *GMT, char *text, char option, char modifier, int *value) {
+unsigned int gmt_get_required_int (struct GMT_CTRL *GMT, char *text, char option, char modifier, int *value) {
 	/* Convert the text arg to a signed int and if no arg given we fuss and return error */
 	unsigned int err;
 	if (!(err = gmtsupport_print_and_err (GMT, text, option, modifier)))

--- a/src/grd2kml.c
+++ b/src/grd2kml.c
@@ -263,7 +263,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRD2KML_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'H':	/* RIP at a higher dpi, then downsample in gs */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->H.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &Ctrl->H.factor);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &Ctrl->H.factor);
 				break;
 			case 'I':	/* Here, intensity must be a grid file since we need to filter it */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->I.active);

--- a/src/grdcontour.c
+++ b/src/grdcontour.c
@@ -413,7 +413,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDCONTOUR_CTRL *Ctrl, struct GMT
 				break;
 			case 'S':	/* Smoothing of contours */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &j);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &j);
 				n_errors += gmt_M_check_condition (GMT, j < 0, "Option -S: Smooth_factor must be > 0\n");
 				Ctrl->S.value = j;
 				break;

--- a/src/grdhisteq.c
+++ b/src/grdhisteq.c
@@ -141,7 +141,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDHISTEQ_CTRL *Ctrl, struct GMT_
 
 			case 'C':	/* Get # of cells */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->C.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &sval);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &sval);
 				n_errors += gmt_M_check_condition (GMT, sval <= 0, "Option -C: n_cells must be positive\n");
 				Ctrl->C.value = (unsigned int)sval;
 				break;

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -699,7 +699,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'S':	/* Smoothing of contours */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &sval);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &sval);
 				n_errors += gmt_M_check_condition (GMT, sval <= 0, "Option -S: smooth value must be positive\n");
 				Ctrl->S.value = sval;
 				break;

--- a/src/gshhg/gshhg.c
+++ b/src/gshhg/gshhg.c
@@ -177,7 +177,7 @@ static int parse (struct GMT_CTRL *GMT, struct GSHHG_CTRL *Ctrl, struct GMT_OPTI
 				break;
 			case 'N':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->N.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &sval);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &sval);
 				n_errors += gmt_M_check_condition (GMT, sval < 0, "Option -N: Level cannot be negative!\n");
 				Ctrl->N.level = sval;
 				break;

--- a/src/img/img2grd.c
+++ b/src/img/img2grd.c
@@ -310,7 +310,7 @@ static int parse (struct GMT_CTRL *GMT, struct IMG2GRD_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'N':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->N.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &Ctrl->N.value);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &Ctrl->N.value);
 				break;
 			case 'S':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->S.active);
@@ -318,7 +318,7 @@ static int parse (struct GMT_CTRL *GMT, struct IMG2GRD_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'T':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
-				if (gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &Ctrl->T.value)) {
+				if (gmt_get_required_int (GMT, opt->arg, opt->option, 0, &Ctrl->T.value)) {
 					n_errors++;
 					GMT_Report (API, GMT_MSG_ERROR, "Option -T requires an output type 0-3.\n");
 				}

--- a/src/movie.c
+++ b/src/movie.c
@@ -974,7 +974,7 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 
 			case 'H':	/* RIP at a higher dpu, then downsample in gs to improve sub-pixeling */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->H.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &Ctrl->H.factor);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &Ctrl->H.factor);
 				break;
 
 			case 'I':	/* Include file with settings used by all scripts */

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -875,7 +875,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSCONVERT_CTRL *Ctrl, struct GMT_
 				break;
 			case 'H':	/* RIP at a higher dpi, then downsample in gs */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->H.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &Ctrl->H.factor);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &Ctrl->H.factor);
 				break;
 			case 'I':	/* Set margins/scale modifiers [Deprecated -I: Do not use the ICC profile when converting gray shades] */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->I.active);

--- a/src/segy/pssegyz.c
+++ b/src/segy/pssegyz.c
@@ -246,11 +246,11 @@ static int parse (struct GMT_CTRL *GMT, struct PSSEGYZ_CTRL *Ctrl, struct GMT_OP
 				break;
 			case 'L':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->L.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &Ctrl->L.value);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &Ctrl->L.value);
 				break;
 			case 'M':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active);
-				n_errors += gmt_get_required_sint (GMT, opt->arg, opt->option, 0, &Ctrl->M.value);
+				n_errors += gmt_get_required_int (GMT, opt->arg, opt->option, 0, &Ctrl->M.value);
 				break;
 			case 'N':	/* trace norm. */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->N.active);

--- a/src/segy/segy2grd.c
+++ b/src/segy/segy2grd.c
@@ -198,7 +198,7 @@ static int parse (struct GMT_CTRL *GMT, struct SEGY2GRD_CTRL *Ctrl, struct GMT_O
 				break;
 			case 'L':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->L.active);
-				n_errors += gmt_get_required_sint (GMT, &opt->arg[1], opt->option, 0, &Ctrl->L.value);
+				n_errors += gmt_get_required_int (GMT, &opt->arg[1], opt->option, 0, &Ctrl->L.value);
 				break;
 			case 'M':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->M.active);


### PR DESCRIPTION
Se have functions like _gmt_get_required_sint_ and _gmt_get_required_uint_, but we did not have one for signed _int64_t_ and we never use "s" as a prefix anyway; there is only _u_ or no _u_ up front..  So this PR simply removes the _sint_ and calls it _int_, and adds _int64_t_ to match the _uint64_t_ function.  No effect on anything except ensuring we have the various flavours as needed.
