### PR TITLE
Require movie canvas dimensions in integer pixels when using modifiers +c|i

### DIFF
--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -13,7 +13,7 @@ Synopsis
 .. include:: common_SYN_OPTs.rst_
 
 **gmt movie** *mainscript*
-|-C|\ *canvas*
+|-C|\ *canvassize*
 |-N|\ *prefix*
 |-T|\ *nframes*\|\ *min*/*max*/*inc*\ [**+n**]\|\ *timefile*\ [**+p**\ *width*]\ [**+s**\ *first*]\ [**+w**\ [*str*]\|\ **W**]
 [ |-A|\ *audiofile*\ [**+e**] ]
@@ -73,8 +73,8 @@ Required Arguments
     you up to work with the SI or US canvas dimensions.  Instead of a named format you can
     request a custom format directly by giving *width*\ **x**\ *height*\ **x**\ *dpu*,
     where *dpu* is the dots-per-unit pixel density (pixel density is set automatically for the named formats).
-    Alternatively, give dimensions in pixels and add **+c** or **+i** to indicate that *dpu* is
-    per cm or inches.
+    Alternatively, give dimensions in pixels and append modifiers **+c** or **+i** to indicate that *dpu* is
+    per cm or per inches.
     
     .. _tbl-presets:
 

--- a/doc/rst/source/movie.rst
+++ b/doc/rst/source/movie.rst
@@ -73,6 +73,8 @@ Required Arguments
     you up to work with the SI or US canvas dimensions.  Instead of a named format you can
     request a custom format directly by giving *width*\ **x**\ *height*\ **x**\ *dpu*,
     where *dpu* is the dots-per-unit pixel density (pixel density is set automatically for the named formats).
+    Alternatively, give dimensions in pixels and add **+c** or **+i** to indicate that *dpu* is
+    per cm or inches.
     
     .. _tbl-presets:
 

--- a/src/movie.c
+++ b/src/movie.c
@@ -366,9 +366,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Note: uhd-2 and 8k can be used for 4320p, uhd and 4k for 2160p, and fhd or hd for 1080p. "
 		"Current PROJ_LENGTH_UNIT determines if you get SI or US canvas dimensions and dpu. "
 		"Alternatively, set a custom canvas with dimensions and dots-per-unit manually by "
-		"providing <width>x<height>x<dpu> (e.g., 15cx10cx50, 6ix6ix100, etc.). Alternatively, give pixel dimension and a modifier:" 
+		"providing <width>x<height>x<dpu> (e.g., 15cx10cx50, 6ix6ix100, etc. Alternatively, give pixel dimensions and a modifier:");
 	GMT_Usage (API, 3, "+c Dimensions are pixels and dpu is pixels per cm.");
-	GMT_Usage (API, 3, "+i Dimensions are pixels and dpu is pixels per imch.");
+	GMT_Usage (API, 3, "+i Dimensions are pixels and dpu is pixels per inch.");
 	GMT_Usage (API, 1, "\n-N<prefix>");
 	GMT_Usage (API, -2, "Set the <prefix> used for movie files and directory names. "
 		"The directory cannot already exist; see -Z to remove such directories at the end.");
@@ -817,7 +817,7 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				else {	/* Custom canvas dimensions -C<width>[<unit>]x<height>[<unit>]x<dpu>[+c|i] */
 					if ((c = strstr (arg, "+c")))	/* Got dimensions in dpc units */
 						c[0] = '\0';	/* Chop off modifier */
-					else if ((c = strstr (arg, "+i")))	/* 	/* Got dimensions in dpi units */
+					else if ((c = strstr (arg, "+i")))	/* Got dimensions in dpi units */
 						c[0] = '\0';	/* Chop off modifier */
 					if (c) {	/* Got modifier and sides in dpi or dpc -C<width>x<height>x<dpu>[+c|i] */
 						if ((n = sscanf (arg, "%[^x]x%[^x]x%lg", txt_a, txt_b, &Ctrl->C.dim[GMT_Z])) != 3) {

--- a/src/movie.c
+++ b/src/movie.c
@@ -168,7 +168,7 @@ struct MOVIE_CTRL {
 		double duration;	/* Original length of audio track */
 		char *file;
 	} A;
-	struct MOVIE_C {	/* -C<namedcanvas>|<canvas_and_dpu> */
+	struct MOVIE_C {	/* -C<namedcanvas>|<canvas_and_dpu>[+c|i] */
 		bool active;
 		double dim[3];
 		char unit;
@@ -824,9 +824,15 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 							GMT_Report (API, GMT_MSG_ERROR, "Option -C: Requires dimensions in pixels and either +c or +i for dots per unit\n");
 							n_errors++;
 						}
+						Ctrl->C.dim[GMT_X] = atof (txt_a);
+						Ctrl->C.dim[GMT_Y] = atof (txt_b);
+						if (fabs (Ctrl->C.dim[GMT_X] - irint (Ctrl->C.dim[GMT_X])) > 0 || fabs (Ctrl->C.dim[GMT_Y] - irint (Ctrl->C.dim[GMT_Y])) > 0) {
+							GMT_Report (API, GMT_MSG_ERROR, "Option -C: When either a +c or +i modifier is used, dimensions must be integer pixels\n");
+							n_errors++;
+						}
 						Ctrl->C.dim[GMT_X] = atof (txt_a) / Ctrl->C.dim[GMT_Z];
 						Ctrl->C.dim[GMT_Y] = atof (txt_b) / Ctrl->C.dim[GMT_Z];
-						Ctrl->C.unit = c[1];	/* Set inch or cm unit */
+						Ctrl->C.unit = c[1];	/* Save inch or cm unit */
 					}
 					else if ((n = sscanf (arg, "%[^x]x%[^x]x%lg", txt_a, txt_b, &Ctrl->C.dim[GMT_Z])) != 3) {
 						GMT_Report (API, GMT_MSG_ERROR, "Option -C: Requires name of a known format or give width x height x dpu string\n");
@@ -1227,7 +1233,7 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 	if (Ctrl->M.active && !Ctrl->F.active[MOVIE_PNG]) Ctrl->M.exit = true;	/* Only make the master frame */
 
 	n_errors += gmt_M_check_condition (GMT, n_files != 1 || Ctrl->In.file == NULL, "Must specify a main script file\n");
-	n_errors += gmt_M_check_condition (GMT, !Ctrl->C.active, "Option -C: Must specify a canvas dimension\n");
+	n_errors += gmt_M_check_condition (GMT, !Ctrl->C.active, "Option -C: Must specify canvas dimensions\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->M.exit && Ctrl->animate, "Option -F: Cannot use none with other selections\n");
 	n_errors += gmt_M_check_condition (GMT, !Ctrl->Q.active && !Ctrl->M.active && !Ctrl->F.active[MOVIE_PNG], "Must select at least one output product (-F, -M)\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Q.active && Ctrl->Z.active, "Cannot use -Z if -Q is also set\n");


### PR DESCRIPTION
If plot dimensions are given in pixels instead of cm, inches etc then use **+c**|**i** to indicate that units the _dpu_ is in since actual plot dimensions is then the pixel dimensions divided by the _dpu_ which gives either cm or inches.  This feature was implemented to avoid having to write painful things like

`-C16.5517241379cx6.03448275862cx116`

Much cleaner to allow

`-C1920x700x116+c`

This is helpful when it is simpler to specify the dimensions in integers but we will need to relate those via the dpc to physical dimensions (here 16.5517241379c).