### PR TITLE
Remove deprecated doc and usage language from grdview

### DIFF
--- a/doc/rst/source/grdview.rst
+++ b/doc/rst/source/grdview.rst
@@ -15,7 +15,7 @@ Synopsis
 **gmt grdview** *reliefgrid* |-J|\ *parameters*
 [ |SYN_OPT-B| ]
 [ |-C|\ [*section*/]\ *master*\|\ *cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]\ [**+h**\ [*hinge*]][**+i**\ *dz*][**+u**\|\ **U**\ *unit*][**+s**\ *fname*] ]
-[ |-G|\ *drapegrid* \| |-G|\ *grd_r* |-G|\ *grd_g* |-G|\ *grd_b* ]
+[ |-G|\ *drapegrid*\|*drapeimage* ]
 [ |-I|\ [*file*\|\ *intens*\|\ **+a**\ *azimuth*][**+d**][**+m**\ *ambient*][**+n**\ *args*] ]
 [ |-Jz|\ \|\ **Z**\ *parameters* ]
 [ |-N|\ [*level*]\ [**+g**\ *fill*] ]
@@ -72,17 +72,13 @@ Optional Arguments
 
 .. _-G:
 
-|-G|\ *drapegrid* \| |-G|\ *grd_r* |-G|\ *grd_g* |-G|\ *grd_b*
-    Drape the image in *drapegrid* on top of the relief provided by
+|-G|\ *drapegrid*\ |*drapeimage*
+    Drape the surface in *drapegrid* on top of the relief provided by
     *reliefgrid*. [Default determines colors from *reliefgrid*]. Note that **-Jz** and
     |-N| always refers to the *reliefgrid*. The *drapegrid* only
     provides the information pertaining to colors, which (if *drapegrid* is a grid) will be looked-up
-    via the CPT (see |-C|). Instead, you may give three grid files
-    via separate |-G| options in the specified order. These files must contain the red, green, and
-    blue colors directly (in 0-255 range) and no CPT is needed. The
-    *drapegrid* may be of a different resolution than the *reliefgrid*.
-    Finally, *drapegrid* may be an image to be draped over the surface, in which
-    case the |-C| option is not required.
+    via the CPT (see |-C|). Instead, you may give a *drapeimage* to be draped over the surface, in which
+    case the |-C| option is not expected.
 
 .. _-I:
 

--- a/doc/rst/source/grdview.rst
+++ b/doc/rst/source/grdview.rst
@@ -19,7 +19,7 @@ Synopsis
 [ |-I|\ [*file*\|\ *intens*\|\ **+a**\ *azimuth*][**+d**][**+m**\ *ambient*][**+n**\ *args*] ]
 [ |-Jz|\ \|\ **Z**\ *parameters* ]
 [ |-N|\ [*level*]\ [**+g**\ *fill*] ]
-[ |-Q|\ *args*\ [**+m**] ]
+[ |-Q|\ **c**\ |**i**\ **m**\ [**x**\ |**y**]\ |**s**\[**m**]\ [*color*][**+m**] ]
 [ |SYN_OPT-Rz| ]
 [ |-S|\ *smooth* ]
 [ |-T|\ [**+o**\ [*pen*]][**+s**] ]
@@ -101,17 +101,22 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ *args*\ [**+m**]
-    Select one of following settings. For any of these choices, you may force
-    a monochrome image by appending the modifier **+m**. Colors are then
-    converted to shades of gray using the (monochrome television) YIQ transformation
+**-Q**\ \ **c**\ |**i**\ **m**\ [**x**\ |**y**]\ |**s**\[**m**]\ [*color*][**+m**]
+    Select one of following directives. For any of these choices:
 
-    #. Specify **m** for mesh plot [Default], and optionally append *color* for a different mesh paint [white].
-    #. Specify **mx** or **my** for waterfall plots (row or column profiles). Specify color as for plain **m**
-    #. Specify **s** for surface plot, and optionally append **m** to have mesh lines drawn on top of surface.
-    #. Specify **i** for image plot, and optionally append the effective dots-per-unit resolution for the rasterization [Default is :term:`GMT_GRAPHICS_DPU`].
-    #. Specify **c**. Same as **-Qi** but will make nodes with z = NaN transparent, using the colormasking
-       feature in PostScript Level 3 (the PS device must support PS Level 3).
+    **c** - Image plot, but will make nodes with *z* = NaN transparent, using the color-masking
+       feature in PostScript Level 3. Optionally append the effective dots-per-unit resolution
+       for the rasterization [Default is :term:`GMT_GRAPHICS_DPU`].
+    **i** - Image plot. Optionally append the effective dots-per-unit resolution for the
+       rasterization [Default is :term:`GMT_GRAPHICS_DPU`].
+    **m** - Mesh plot [Default]. Optionally append *color* for a different mesh paint [white].
+       For waterfall plots, append **x** for row or **y** for column profiles). Specify color as for plain **m**.
+    **s** - Surface plot. Optionally append **m** to have mesh lines drawn on top of surface. See **-Wm** for
+       setting a specific mesh *pen*.
+
+    A modifier can adjust the color further:
+
+    - **+m** - Colors are converted to shades of gray using the (monochrome television) YIQ transformation.
 
     **Note**: If the CPT is categorical then only **-Qm** is available (but see |-T|).
 

--- a/doc/rst/source/grdview.rst
+++ b/doc/rst/source/grdview.rst
@@ -15,11 +15,11 @@ Synopsis
 **gmt grdview** *reliefgrid* |-J|\ *parameters*
 [ |SYN_OPT-B| ]
 [ |-C|\ [*section*/]\ *master*\|\ *cpt*\|\ *color*\ :math:`_1`,\ *color*\ :math:`_2`\ [,\ *color*\ :math:`_3`\ ,...]\ [**+h**\ [*hinge*]][**+i**\ *dz*][**+u**\|\ **U**\ *unit*][**+s**\ *fname*] ]
-[ |-G|\ *drapegrid*\|*drapeimage* ]
+[ |-G|\ *drapegrid*\|\ *drapeimage* ]
 [ |-I|\ [*file*\|\ *intens*\|\ **+a**\ *azimuth*][**+d**][**+m**\ *ambient*][**+n**\ *args*] ]
 [ |-Jz|\ \|\ **Z**\ *parameters* ]
 [ |-N|\ [*level*]\ [**+g**\ *fill*] ]
-[ |-Q|\ **c**\ |**i**\ **m**\ [**x**\ |**y**]\ |**s**\[**m**]\ [*color*][**+m**] ]
+[ |-Q|\ **c**\|\ **i**\|\ **m**\ [**x**\|\ **y**]\|\ **s**\ [**m**]\ [*color*][**+m**] ]
 [ |SYN_OPT-Rz| ]
 [ |-S|\ *smooth* ]
 [ |-T|\ [**+o**\ [*pen*]][**+s**] ]
@@ -72,7 +72,7 @@ Optional Arguments
 
 .. _-G:
 
-|-G|\ *drapegrid*\ |*drapeimage*
+|-G|\ *drapegrid*\|\ *drapeimage*
     Drape the surface in *drapegrid* on top of the relief provided by
     *reliefgrid*. [Default determines colors from *reliefgrid*]. Note that **-Jz** and
     |-N| always refers to the *reliefgrid*. The *drapegrid* only
@@ -101,18 +101,18 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ \ **c**\ |**i**\ **m**\ [**x**\ |**y**]\ |**s**\[**m**]\ [*color*][**+m**]
+**-Q**\ **c**\|\ **i**\|\ **m**\ [**x**\|\ **y**]\|\ **s**\ [**m**]\ [*color*][**+m**]
     Select one of following directives. For any of these choices:
 
-    **c** - Image plot, but will make nodes with *z* = NaN transparent, using the color-masking
-       feature in PostScript Level 3. Optionally append the effective dots-per-unit resolution
-       for the rasterization [Default is :term:`GMT_GRAPHICS_DPU`].
-    **i** - Image plot. Optionally append the effective dots-per-unit resolution for the
-       rasterization [Default is :term:`GMT_GRAPHICS_DPU`].
-    **m** - Mesh plot [Default]. Optionally append *color* for a different mesh paint [white].
-       For waterfall plots, append **x** for row or **y** for column profiles). Specify color as for plain **m**.
-    **s** - Surface plot. Optionally append **m** to have mesh lines drawn on top of surface. See **-Wm** for
-       setting a specific mesh *pen*.
+    - **c** - Image plot, but will make nodes with *z* = NaN transparent, using the color-masking
+      feature in PostScript Level 3. Optionally append the effective dots-per-unit resolution
+      for the rasterization [Default is :term:`GMT_GRAPHICS_DPU`].
+    - **i** - Image plot. Optionally append the effective dots-per-unit resolution for the
+      rasterization [Default is :term:`GMT_GRAPHICS_DPU`].
+    - **m** - Mesh plot [Default]. Optionally append *color* for a different mesh paint [white].
+      For waterfall plots, append **x** for row or **y** for column profiles). Specify color as for plain **m**.
+    - **s** - Surface plot. Optionally append **m** to have mesh lines drawn on top of surface. See **-Wm** for
+      setting a specific mesh *pen*.
 
     A modifier can adjust the color further:
 

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -43,7 +43,7 @@
 #define THIS_MODULE_MODERN_NAME	"grdview"
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Create 3-D perspective image or surface mesh from a grid"
-#define THIS_MODULE_KEYS	"<G{,CC(,GG(,zI(,IG(,>X}"
+#define THIS_MODULE_KEYS	"<G{,CC(,GG(,GI(,IG(,>X}"
 #define THIS_MODULE_NEEDS	"Jg"
 #define THIS_MODULE_OPTIONS "->BJKOPRUVXYfnptxy" GMT_OPT("Ec")
 
@@ -535,7 +535,6 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 				}
 				gmt_cpt_interval_modifier (GMT, &(Ctrl->C.file), &(Ctrl->C.dz));
 				break;
-			case 'z':	/* GMT.jl single image? */
 			case 'G':	/* One grid or image or three separate r,g,b grids */
 				Ctrl->G.active = true;
 				for (k = 0, n_commas = 0; opt->arg[k]; k++) if (opt->arg[k] == ',') n_commas++;

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -535,7 +535,6 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 				}
 				gmt_cpt_interval_modifier (GMT, &(Ctrl->C.file), &(Ctrl->C.dz));
 				break;
-			case 'z':	/* One image. This is an undocumented fake option but one that lets externals pass both images and grids for draping. */
 			case 'G':	/* One grid or image or three separate r,g,b grids */
 				Ctrl->G.active = true;
 				for (k = 0, n_commas = 0; opt->arg[k]; k++) if (opt->arg[k] == ',') n_commas++;

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -535,6 +535,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 				}
 				gmt_cpt_interval_modifier (GMT, &(Ctrl->C.file), &(Ctrl->C.dz));
 				break;
+			case 'z':	/* GMT.jl single image? */
 			case 'G':	/* One grid or image or three separate r,g,b grids */
 				Ctrl->G.active = true;
 				for (k = 0, n_commas = 0; opt->arg[k]; k++) if (opt->arg[k] == ',') n_commas++;

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -411,7 +411,7 @@ static void Free_Ctrl (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *C) {	/* Deallo
 	gmt_M_str_free (C->In.file);
 	gmt_M_str_free (C->C.file);
 	gmt_M_str_free (C->C.savecpt);
-	for (i = 0; i < 3; i++) gmt_M_str_free (C->G.file[i]);
+	for (i = 0; i < C->G.n; i++) gmt_M_str_free (C->G.file[i]);
 	gmt_M_str_free (C->I.file);
 	gmt_M_str_free (C->I.azimuth);
 	gmt_M_str_free (C->I.method);
@@ -423,8 +423,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s <topogrid> %s [%s] [-C%s] [-G<drapegrid>|<drapeimage> "
-		"[-I[<intensgrid>|<value>|<modifiers>]] [%s] %s[-N[<level>][+g<fill>]] %s%s[-Q<args>[+m]] [%s] [-S<smooth>] "
+	GMT_Usage (API, 0, "usage: %s <topogrid> %s [%s] [-C%s] [-G<drapegrid>|<drapeimage>] "
+		"[-I[<intensgrid>|<value>|<modifiers>]] [%s] %s[-N[<level>][+g<fill>]] %s%s[-Qc|i|m[x|y]|s[<color>][+m]] [%s] [-S<smooth>] "
 		"[-T[+o[<pen>]][+s]] [%s] [%s] [-W<type><pen>] [%s] [%s] %s[%s] [%s] [%s] [%s] [%s]\n",
 		name, GMT_J_OPT, GMT_B_OPT, CPT_OPT_ARGS, GMT_Jz_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeoz_OPT, GMT_U_OPT, GMT_V_OPT,
 		GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_f_OPT, GMT_n_OPT, GMT_p_OPT, GMT_t_OPT, GMT_PAR_OPT);
@@ -432,7 +432,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	if (level == GMT_SYNOPSIS) return (GMT_MODULE_SYNOPSIS);
 
 	GMT_Message (API, GMT_TIME_NONE, "  REQUIRED ARGUMENTS:\n");
-	GMT_Usage (API, 1, "\n<topogrid> is the grid surface to be plotted.");
+	GMT_Usage (API, 1, "\n<topogrid> is the grid surface shape to be plotted.");
 	GMT_Option (API, "J-Z");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Option (API, "B-");
@@ -442,7 +442,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "%s Provide a grid (<drapegrid>) and colors will be determined from it and the cpt.", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s Provide an image (<drapeimage>) and it will be draped over the surface.", GMT_LINE_BULLET);
 	GMT_Usage (API, -2, "Notes: 1) -JZ|z and -N always refer to the data in the <topogrid>. "
-		"2) The -G option requires the -Qi[<dpi>] option.");
+		"2) The -G option requires the -Qc|i[<dpu>] option.");
 	GMT_Usage (API, 1, "\n-I[<intensgrid>|<value>|<modifiers>]");
 	GMT_Usage (API, -2, "Apply directional illumination. Append name of an intensity grid, or "
 		"for a constant intensity (i.e., change the ambient light), just give a scalar. "
@@ -457,17 +457,19 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, -2, "Draw a horizontal plane at z = <level> [minimum grid (or -R) value]. For rectangular projections, append +g<fill> "
 		"to paint the facade between the plane and the data perimeter.");
 	GMT_Option (API, "O,P");
-	GMT_Usage (API, 1, "\n-Q<args>[+m]");
-	GMT_Usage (API, -2, "Set plot type request. Choose one of the following directives:");
+	GMT_Usage (API, 1, "\n-Qc|i|m[x|y]|s[<color>][+m]");
+	GMT_Usage (API, -2, "Set plot type request via on of the following directives:");
+	GMT_Usage (API, 3, "c: Transform polygons to raster-image via scanline conversion. Append effective <dpu> [%lg%c]. "
+		"Set PS Level 3 color-masking for nodes with z = NaN.",
+		API->GMT->current.setting.graphics_dpu, API->GMT->current.setting.graphics_dpu_unit);
+	GMT_Usage (API, 3, "i: As c but no color-masking. Append effective <dpu> [%lg%c].",
+		API->GMT->current.setting.graphics_dpu, API->GMT->current.setting.graphics_dpu_unit);
 	GMT_Usage (API, 3, "m: Mesh plot [Default]. Append <color> for mesh paint [%s]. "
-		"Alternatively, append x or -y for row or column \"waterfall\" profiles.",
+		"Alternatively, append x or y for row or column \"waterfall\" profiles.",
 		gmt_putcolor (API->GMT, API->GMT->PSL->init.page_rgb));
-	GMT_Usage (API, 3, "s: Colored or shaded Surface. Append m to draw mesh-lines on the surface.");
-	GMT_Usage (API, 3, "i: Transform polygons to raster-image via scanline conversion.  Append effective dpu [%lg%c].",
-		API->GMT->current.setting.graphics_dpu, API->GMT->current.setting.graphics_dpu_unit);
-	GMT_Usage (API, 3, "c: As i, but use PS Level 3 color-masking for nodes with z = NaN.  Append effective dpu [%lg%c].",
-		API->GMT->current.setting.graphics_dpu, API->GMT->current.setting.graphics_dpu_unit);
-	GMT_Usage (API, -2, "To force a monochrome image using the YIQ transformation, append +m.");
+	GMT_Usage (API, 3, "s: Colored or shaded surface. Optionally, append m to draw mesh-lines on the surface.");
+	GMT_Usage (API, -2, "Color may be further adjusted by a modifier:");
+	GMT_Usage (API, 3, "+m Force a monochrome image using the YIQ transformation.");
 	GMT_Option (API, "R");
 	GMT_Usage (API, 1, "\n-S<smooth>");
 	GMT_Usage (API, -2, "Smooth contours first (see grdcontour for <smooth> value info) [no smoothing].");


### PR DESCRIPTION
There is no need to explain about the deprecated way of specifying 3 grids to drap (red, green blue) since we stopped doing that for **grdimage** a long time ago.  **grdview** will still check if given 3 but we don't have to talk about it.  The usage and docs now deal with **-G**_drapegrid_|_drapeimage_ only. We have a script that exercises the deprecated forms `-Gr.nc,g.nc,b.nc` and `-Gr.nc -Gg.nc -Gb.nc` and that works fine under the hood without any advertisement.

I left the special option **-z** for passing a single image from GMT.jl. Suggest @joa-quim play with removing that.  Since the KEY need **G** or **I** perhaps some work needs to be done in `GMT_Encode_Options`?

Improved the doc layout for **-G** and **-Q** as well as their synopsis.

Here is -G:

<img width="896" alt="G" src="https://github.com/GenericMappingTools/gmt/assets/26473567/ae09cc0c-e07d-4e96-bdee-88666af505da">

Here is -Q:

<img width="903" alt="Q" src="https://github.com/GenericMappingTools/gmt/assets/26473567/ede2bdc3-2e7c-4ce0-bdd5-fdbedfbe1e32">

All tests pass so I think this is mostly a documentation PR.