### PR TITLE
coast: Clarify the default resolutions in classic and modern modes

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8570,7 +8570,7 @@ void gmt_GSHHG_resolution_syntax  (struct GMT_CTRL *GMT, char option, char *stri
 	GMT_Usage (API, 3, "f: Full resolution (may be very slow for large regions).");
 	GMT_Usage (API, 3, "h: High resolution (may be slow for large regions).");
 	GMT_Usage (API, 3, "i: Intermediate resolution.");
-	GMT_Usage (API, 3, "l: Low resolution [Default].");
+	GMT_Usage (API, 3, "l: Low resolution [Default in classic mode].");
 	GMT_Usage (API, 3, "c: Crude resolution, for tasks that need crude continent outlines only.");
 	GMT_Usage (API, -2, "Append +f to use a lower resolution should the chosen one not be available [abort]. %s", string);
 }
@@ -20528,7 +20528,7 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 		c[0] = '\0';  /* Remove = */
 		n_errors += gmtlib_setparameter (GMT, opt->arg, &c[1], false);
 	}
-	if (n_errors) 
+	if (n_errors)
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "GMT parameter parsing failures for %d settings\n", n_errors);
 	gmt_M_memcpy (GMT->current.map.frame.side, sides, 5U, unsigned int);
 	GMT->current.map.frame.draw = was;

--- a/src/grdlandmask.c
+++ b/src/grdlandmask.c
@@ -122,7 +122,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	gmt_GSHHG_syntax (API->GMT, 'A');
 	gmt_GSHHG_resolution_syntax (API->GMT, 'D', "Alternatively, choose (a)uto to automatically select the best "
-		"resolution given the chosen region.");
+		"resolution given the chosen region [Default in modern mode].");
 	GMT_Usage (API, 1, "\n-E[<bordervalues>]");
 	GMT_Usage (API, -2, "Indicate that nodes exactly on a polygon boundary are outside [inside]. Optionally append "
 		"<border> or <cborder>/<lborder>/<iborder>/<pborder>. We will then trace lines through the grid and reset the "

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -216,7 +216,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, "+l Set lake fill.");
 	GMT_Usage (API, 3, "+r Set river-lake fill.");
 	gmt_GSHHG_resolution_syntax (API->GMT, 'D', "Alternatively, choose (a)uto to automatically select the best "
-		"resolution given the chosen region.");
+		"resolution given the chosen region [Default in modern mode].");
 	gmt_DCW_option (API, 'E', 1U);
 	gmt_mappanel_syntax (API->GMT, 'F', "Specify a rectangular panel behind the map scale or rose.", 3);
 	GMT_Usage (API, -2, "Note: If using both -L and -T, use -Fl and -Ft.");


### PR DESCRIPTION
The default resolution is **l** in classic mode and **a** in modern mode. The online documentation is correct but the synopsis message is incorrect.

**Old message:** 
```
  -D<resolution>[+f]
     Choose one of the following resolutions:
       f: Full resolution (may be very slow for large regions).
       h: High resolution (may be slow for large regions).
       i: Intermediate resolution.
       l: Low resolution [Default].
       c: Crude resolution, for tasks that need crude continent outlines only.
     Append +f to use a lower resolution should the chosen one not be available [abort].
     Alternatively, choose (a)uto to automatically select the best resolution given the chosen
     region.
```

**New message**
```
  -D<resolution>[+f]
     Choose one of the following resolutions:
       f: Full resolution (may be very slow for large regions).
       h: High resolution (may be slow for large regions).
       i: Intermediate resolution.
       l: Low resolution [Default in classic mode].
       c: Crude resolution, for tasks that need crude continent outlines only.
     Append +f to use a lower resolution should the chosen one not be available [abort].
     Alternatively, choose (a)uto to automatically select the best resolution given the chosen
     region [Default in modern mode].
```