### PR TITLE
Hide legend -C but leave it under the hood

### DIFF
--- a/doc/rst/source/explain_-F_box.rst_
+++ b/doc/rst/source/explain_-F_box.rst_
@@ -1,6 +1,6 @@
 - **+c** - Set *clearance* where *clearance* is either *gap*, *xgap*\ /\ *ygap*, or *lgap*\ /\ *rgap*\ /\ *bgap*\ /\
-  *tgap* and *gap* gives a uniform :ref:`clearance <plt-units>`, *xgap*\ /\ *ygap* gives separate
-  :ref:`clearances <plt-units>` in the *x*- and *y*- directions, and *lgap*\ /\ *rgap*\ /\ *bgap*\ /\ *tgap* gives
+  *tgap*. Here, *gap* gives a uniform :ref:`clearance <plt-units>`, *xgap*\ /\ *ygap* give separate
+  :ref:`clearances <plt-units>` in the *x*- and *y*- directions, and *lgap*\ /\ *rgap*\ /\ *bgap*\ /\ *tgap* give
   individual :ref:`clearances <plt-units>` between the map embellishment and the border for each side.
 - **+g** - Give *fill* to fill the box with a color specified by :doc:`fill <gmtcolors>` [default is no fill].
 - **+i** - Draw a secondary, inner border border outline [[*gap*/]\ *pen*]. Optionally, append the

--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -15,7 +15,6 @@ Synopsis
 **gmt legend** [ *specfile* ]
 |-D|\ *refpoint*
 [ |SYN_OPT-B| ]
-[ |-C|\ *dx*/*dy* ]
 [ |-F|\ *box* ]
 [ |-J|\ *parameters* ]
 [ |-M|\ [**h**\|\ **e**] ]
@@ -89,11 +88,6 @@ Optional Arguments
 .. include:: explain_-B.rst_
     :start-after: **Syntax**
     :end-before: **Description**
-
-.. _-C:
-
-**-C**\ *dx*/*dy*
-    Sets the clearance between the legend frame and the internal items [4\ **p**/4\ **p**].
 
 .. _-F:
 
@@ -373,7 +367,7 @@ specifications, use::
     gmt begin legend
     gmt makecpt -Cpanoply -T-8/8 -H > tt.cpt
     gmt set FONT_ANNOT_PRIMARY 12p
-    gmt legend -R0/10/0/10 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.2 -C0.1i/0.1i -F+p+gazure1+r -B5f1 << EOF
+    gmt legend -R0/10/0/10 -JM6i -Dx0.5i/0.5i+w5i+jBL+l1.2 -F+p+gazure1+r+c0.1i -B5f1 << EOF
     # Legend test for gmt pslegend
     # G is vertical gap, V is vertical line, N sets # of columns, D draws horizontal line,
     # H is ps=legend.ps

--- a/src/pslegend.c
+++ b/src/pslegend.c
@@ -129,7 +129,7 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 
 	const char *name = gmt_show_name_and_purpose (API, THIS_MODULE_LIB, THIS_MODULE_CLASSIC_NAME, THIS_MODULE_PURPOSE);
 	if (level == GMT_MODULE_PURPOSE) return (GMT_NOERROR);
-	GMT_Usage (API, 0, "usage: %s [<specfile>] -D%s[+w<width>[/<height>]][+l<spacing>]%s [%s] [-C<dx>[/<dy>]] [-F%s] "
+	GMT_Usage (API, 0, "usage: %s [<specfile>] -D%s[+w<width>[/<height>]][+l<spacing>]%s [%s] [-F%s] "
 		"[%s] [-M[<items>]] %s%s%s[%s] [-S<scale>] [-T<file>] [%s] [%s] [%s] [%s] %s[%s] [%s] [%s] [%s]\n",
 		name, GMT_XYANCHOR, GMT_OFFSET, GMT_B_OPT, GMT_PANEL, GMT_J_OPT, API->K_OPT, API->O_OPT, API->P_OPT, GMT_Rgeo_OPT,
 		GMT_U_OPT, GMT_V_OPT, GMT_X_OPT, GMT_Y_OPT, API->c_OPT, GMT_p_OPT, GMT_qi_OPT, GMT_t_OPT, GMT_PAR_OPT);
@@ -148,8 +148,8 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	GMT_Usage (API, 3, " +l sets the line <spacing> factor in units of the current annotation font size [1.1].");
 	GMT_Message (API, GMT_TIME_NONE, "\n  OPTIONAL ARGUMENTS:\n");
 	GMT_Option (API, "B-");
-	GMT_Usage (API, 1, "\n-C<dx>[/<dy>]");
-	GMT_Usage (API, -2, "Set the clearance between legend frame and internal items [%gp].", GMT_FRAME_CLEARANCE);
+	//GMT_Usage (API, 1, "\n-C<dx>[/<dy>]");
+	//GMT_Usage (API, -2, "Set the clearance between legend frame and internal items [%gp].", GMT_FRAME_CLEARANCE);
 	gmt_mappanel_syntax (API->GMT, 'F', "Specify a rectangular panel behind the legend", 2);
 	GMT_Option (API, "J-,K");
 	GMT_Usage (API, 1, "\n-M[<items>]");


### PR DESCRIPTION
See #8303 for background.  Recommend using **legend** **-F+c** instead.  This PR comments out the **-C** documentation but code is there to process any **-C** given.  So, all tests still pass but **-C** no longer advertised since **-F+c** is more flexible anyway.

Let me know if this is an acceptable solution.  Removing the internal C struct etc. is more work and this way we are backwards compatible.
