### PR TITLE
Fix the gspline_7 test on Linux/Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@
 name: Tests
 
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@
 name: Tests
 
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master

--- a/test/greenspline/gspline_7.sh
+++ b/test/greenspline/gspline_7.sh
@@ -44,8 +44,7 @@ gmt begin gspline_7 ps
 	LEGS=-l"Solution-Slopes"
 	# Loop over gradients and place grid and labels
 	while read X S X2 Sout; do
-		pattern="^${X}\t"	# Search pattern for finding y-value at gradient
-		Y=$(grep ${pattern} oneD_out.txt | awk '{print $2}')
+		Y=$(awk -v X=$X '$1==X {print $2}' oneD_out.txt) # finding y-value at gradient
 		# Lay down grid/labels after shifting origin to tangent point
 		gmt plot -W0.25p,blue -X${X}i -Y${Y}i lines.txt
 		the_Sout=$(gmt math -Q ${Sout} NEG =)


### PR DESCRIPTION
Test `test/greenspline/gspline_7.sh` fails on Linux/Windows but passes on macOS.

On Linux/Windows, the error message are like:
```
 8/18 Test  #651: test/greenspline/gspline_7.sh ......***Failed    1.65 sec
Set GMT_SESSION_NAME = 78532
Warning: NING]:  not a valid number and may not be decoded properly.
Error:  [ERROR]: Operation "NEG" requires 1 operands
ERROR: gmtest:90
memtrack errors: 0
exit status: 1
ERROR: gspline_7.sh:59
memtrack errors: 0
exit status: 1
```

It's because the `\t` pattern in `grep` is not portable and is likely not recognized by GNU grep:
```
		pattern="^${X}\t"	# Search pattern for finding y-value at gradient
		Y=$(grep ${pattern} oneD_out.txt | awk '{print $2}')
```
This PR fixes it to:
```
Y=$(awk -v X=$X '$1==X {print $2}' oneD_out.txt) # finding y-value at gradient
```
