### PR TITLE
Fix the DOI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Documentation (development version)](https://img.shields.io/badge/docs-development-green.svg)](http://docs.generic-mapping-tools.org/dev/)
 [![GitHub release](https://img.shields.io/github/release/GenericMappingTools/gmt)](https://github.com/GenericMappingTools/gmt/releases)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5708769.svg)](https://doi.org/10.5281/zenodo.5708769)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3407865.svg)](https://zenodo.org/doi/10.5281/zenodo.3407865)
 
 ## What is GMT?
 


### PR DESCRIPTION
The old DOI (https://doi.org/10.5281/zenodo.5708769) is linked to GMT v6.3.0, so it's outdated.

This PR replace the old link with the permanent DOI link (https://zenodo.org/doi/10.5281/zenodo.3407865), which is always resolved to the latest version.