### PR TITLE
Bump the minimum required CMake version to 3.16

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,6 @@ jobs:
           - ubuntu:22.04    # CMake 3.22.1 + GNU 11.2.0; EOL: 2027-06-01
           - ubuntu:23.10    # CMake 3.27.4 + GNU 11.2.0; EOL: 2024-07-01
           # Debian: https://en.wikipedia.org/wiki/Debian_version_history#Release_table
-          - debian:10       # CMake 3.13.4 + GNU 8.3.0;  EOL: 2024-06-01
           - debian:11       # CMake 3.18.4 + GNU 10.2.1; EOL: 2026-06-01
           - debian:12       # CMake 3.25.1 + GNU 12.2.0; EOL: 2028-06-01
           - debian:sid      # rolling release with latest versions

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,7 +23,7 @@ for instructions to install these dependencies on various operation systems.
 
 To build GMT, you have to install:
 
-- [CMake](https://cmake.org/) (>=2.8.12)
+- [CMake](https://cmake.org/) (>=3.16)
 - [netCDF](https://www.unidata.ucar.edu/software/netcdf/) (>=4.0, netCDF-4/HDF5 support mandatory)
 - [curl](https://curl.haxx.se/)
 - [GDAL](https://www.gdal.org/) (Ability to read and write numerous grid and image formats)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if (${srcdir} STREQUAL ${bindir})
 endif (${srcdir} STREQUAL ${bindir})
 
 # Define minimum CMake version required
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.16)
 message ("CMake version: ${CMAKE_VERSION}")
 
 # Use NEW behavior with newer CMake releases


### PR DESCRIPTION
**Description of proposed changes**

CMake [2.8.12](https://github.com/Kitware/CMake/releases/tag/v2.8.12) was released in 2013, which is more than 10 years ago. Most Linux distros no longer provide CMake 2.8, the only exception is CentOS 7, but CentOS 7 itself will be EOL on Jun 30th, 2024. So now it's safe for us to drop support of CMake 2.8.

This PR bumps the minimum required CMake version to 3.16, which was released in 2019 (https://github.com/Kitware/CMake/releases/tag/v3.16.0). This is also the CMake version provided by Ubuntu 20.04.