### PR TITLE
Fix bad movie -A parsing

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -729,19 +729,11 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 				break;
 
 			case 'A':	/* Audio track (but also backwards compatible Animated GIF [Deprecated]) */
-				if (opt->arg[0] && (c = gmt_first_modifier (GMT, opt->arg, "ls")) == NULL) {	/* New audio syntax option -A<audiofile>[+e] */
-					n_errors += gmt_M_repeated_module_option (API, Ctrl->A.active);
-					if ((c = strstr (opt->arg, "+e"))) {	/* Stretch audio to fit video length */
-						Ctrl->A.exact = true;
-						c[0] = '\0';	/* Remove modifier */
-					}
-					Ctrl->A.file = strdup (opt->arg);	/* Get audio file name */
-					if (c) c[0] = '+';	/* Restore modifier */
-				}
-				else if (gmt_M_compat_check (GMT, 6)) {	/* GMT6 compatibility allows backwards compatible -A[+l<loop>][+s<stride>] for animated GIF */
-					GMT_Report (API, GMT_MSG_COMPAT, "Option -A[+l<loop>][+s<stride>] is deprecated - use -F instead\n");
-					Ctrl->F.active[MOVIE_GIF] = Ctrl->F.active[MOVIE_PNG] = Ctrl->animate = true;	/* Old -A implies -Fpng */
-					if ((c = gmt_first_modifier (GMT, opt->arg, "ls"))) {	/* Process any modifiers */
+				n_errors += gmt_M_repeated_module_option (API, Ctrl->A.active);
+				if (gmt_M_compat_check (GMT, 6)) {	/* GMT6 compatibility allows backwards compatible -A[+l<loop>][+s<stride>] for animated GIF */
+					if ((c = strstr (opt->arg, "+e")) == NULL && (c = gmt_first_modifier (GMT, opt->arg, "ls"))) {	/* Process any deprecated modifiers */
+						GMT_Report (API, GMT_MSG_COMPAT, "Option -A[+l<loop>][+s<stride>] is deprecated - use -F instead\n");
+						Ctrl->F.active[MOVIE_GIF] = Ctrl->F.active[MOVIE_PNG] = Ctrl->animate = true;	/* Old -A implies -Fpng */
 						pos = 0;	/* Reset to start of new word */
 						while (gmt_getmodopt (GMT, 'A', c, "ls", &pos, p, &n_errors) && n_errors == 0) {
 							switch (p[0]) {
@@ -765,6 +757,16 @@ static int parse (struct GMT_CTRL *GMT, struct MOVIE_CTRL *Ctrl, struct GMT_OPTI
 						}
 						c[0] = '\0';
 					}
+					if (Ctrl->F.skip || Ctrl->F.loop) break;	/* Processed old deprecated +s or +l modifiers */
+				}
+				/* Here we process modern -A<soundfile>[+e] syntax */
+				if (opt->arg[0]) {	/* Get audio and optionally stretch to fit video length */
+					if ((c = strstr (opt->arg, "+e"))) {
+						Ctrl->A.exact = true;
+						c[0] = '\0';	/* Remove modifier */
+					}
+					Ctrl->A.file = strdup (opt->arg);	/* Get audio file name */
+					if (c) c[0] = '+';	/* Restore modifier */
 				}
 				else
 					n_errors += gmt_default_option_error (GMT, opt);


### PR DESCRIPTION
Would complain about **+e**.  Turn things around and checked for the deprecated **+l +s** first.

Sorry @Esteban82.  See if this works properly, it clearly had a problem as you pointed out.  Now I check for the deprecated **+s +l** first and if found I get out.  If not I check for **+e** and the audio file name.