### PR TITLE
Fix '!defined' to 'defined' in gmt_init.c

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -9164,7 +9164,7 @@ int gmt_default_error (struct GMT_CTRL *GMT, char option) {
 		case 's': error += GMT->common.s.active == false; break;
 		case 't': error += GMT->common.t.active == false; break;
 		case 'w': error += GMT->common.w.active == false; break;
-#if !defined(GMT_MP_ENABLED)
+#if defined(GMT_MP_ENABLED)
 		case 'x': error += GMT->common.x.active == false; break;
 #endif
 		case ':': error += GMT->common.colon.active == false; break;


### PR DESCRIPTION
It seems there is a typo in commit https://github.com/GenericMappingTools/gmt/commit/508619e404c1dd4298c6639d1a91b311fd62c6e1.

Patches https://github.com/GenericMappingTools/gmt/commit/508619e404c1dd4298c6639d1a91b311fd62c6e1.
