### PR TITLE
Fix bug in grdblend when setting -I that was in fact ignored and got its value from first grid.

### DIFF
--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -204,7 +204,8 @@ GMT_LOCAL bool grdblend_outside_cartesian_x_range (struct GMT_GRID_HEADER *h, do
 
 EXTERN_MSC void gmtlib_close_grd (struct GMT_CTRL *GMT, struct GMT_GRID *G);
 
-GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsigned int n_files, struct GMT_GRID_HEADER **h_ptr, struct GRDBLEND_INFO **blend, bool delayed, struct GMT_GRID *Grid) {
+GMT_LOCAL int grdblend_init_blend_job(struct GMT_CTRL *GMT, char **files, unsigned int n_files, struct GMT_GRID_HEADER **h_ptr,
+                                      struct GRDBLEND_INFO **blend, bool delayed, struct GMT_GRID *Grid) {
 	/* Returns how many blend files or a negative error value if something went wrong */
 	int type, status, not_supported = 0, t_data, k_data = GMT_NOTSET;
 	unsigned int one_or_zero, n = 0, n_scanned, do_sample, n_download = 0, down = 0, srtm_res = 0;
@@ -377,13 +378,13 @@ GMT_LOCAL int grdblend_init_blend_job (struct GMT_CTRL *GMT, char **files, unsig
 			gmt_increment_adjust (GMT, wesn, GMT->common.R.inc, (GMT->common.R.active[GSET]) ? GMT->common.R.registration : B[0].G->header->registration);	/* In case user specified incs using distance units we must call this here before adjusting wesn */
 		inc = (GMT->common.R.active[ISET]) ? GMT->common.R.inc : B[0].G->header->inc;	/* Either use -I if given else they all have the same increments */
 		pp = (uint64_t)ceil ((wesn[XHI] - wesn[XLO])/inc[GMT_X] - GMT_CONV6_LIMIT);
-		wesn[XHI] = wesn[XLO] + pp * B[0].G->header->inc[GMT_X];
+		wesn[XHI] = wesn[XLO] + pp * *inc;
 		pp = (uint64_t)ceil ((wesn[YHI] - wesn[YLO])/inc[GMT_Y] - GMT_CONV6_LIMIT);
-		wesn[YHI] = wesn[YLO] + pp * B[0].G->header->inc[GMT_Y];
+		wesn[YHI] = wesn[YLO] + pp * *inc;
 		/* Create the h structure and initialize it */
 		h = gmt_get_header (GMT);
 		gmt_M_memcpy (h->wesn, wesn, 4, double);
-		gmt_M_memcpy (h->inc, B[0].G->header->inc, 2, double);
+		gmt_M_memcpy (h->inc, inc, 2, double);
 		h->registration = (GMT->common.R.active[GSET]) ? GMT->common.R.registration : B[0].G->header->registration;	/* Either use -r if given else they all have the same registration */
 		gmt_M_grd_setpad (GMT, h, GMT->current.io.pad); /* Assign default pad */
 		gmt_set_grddim (GMT, h);	/* Update dimensions */

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -422,14 +422,14 @@ GMT_LOCAL int grdblend_init_blend_job(struct GMT_CTRL *GMT, char **files, unsign
 		Iargs[0] = Rargs[0] = '\0';
 		do_sample = 0;
 		if (not_supported) {
-			GMT_Report (GMT->parent, GMT_MSG_WARNING,
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION,
 			            "File %s not supported via row-by-row read - must reformat first\n", B[n].file);
 			do_sample |= 2;
 		}
 		if (fabs((t->inc[GMT_X] - h->inc[GMT_X]) / h->inc[GMT_X]) > 0.002 ||
 			fabs((t->inc[GMT_Y] - h->inc[GMT_Y]) / h->inc[GMT_Y]) > 0.002) {
 			sprintf (Iargs, "-I%.12g/%.12g", h->inc[GMT_X], h->inc[GMT_Y]);
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "File %s has different increments (%.12g/%.12g) than the output grid (%.12g/%.12g) - must resample\n",
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "File %s has different increments (%.12g/%.12g) than the output grid (%.12g/%.12g) - must resample\n",
 				B[n].file, t->inc[GMT_X], t->inc[GMT_Y], h->inc[GMT_X], h->inc[GMT_Y]);
 			do_sample |= 1;
 		}
@@ -452,7 +452,7 @@ GMT_LOCAL int grdblend_init_blend_job(struct GMT_CTRL *GMT, char **files, unsign
 			wesn[YHI] = h->wesn[YLO] + k * h->inc[GMT_Y];
 			while (wesn[YHI] > t->wesn[YHI]) wesn[YHI] -= t->inc[GMT_Y];	/* Make sure we are not outside this grid */
 			sprintf (Rargs, "-R%.12g/%.12g/%.12g/%.12g", wesn[XLO], wesn[XHI], wesn[YLO], wesn[YHI]);
-			GMT_Report (GMT->parent, GMT_MSG_WARNING, "File %s coordinates are phase-shifted w.r.t. the output grid - must resample\n", B[n].file);
+			GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "File %s coordinates are phase-shifted w.r.t. the output grid - must resample\n", B[n].file);
 			do_sample |= 1;
 		}
 		else if (do_sample) {	/* Set explicit -R to handle possible subsetting */


### PR DESCRIPTION
Before (result obvious wrong as it didn't respect the -I and the blended -R was wrong too)

```
grdmath -R0/10/0/10 -I2 X = G1.grd
grdmath -R5/15/0/10 -I1 X Y = G2.grd

grdblend G1.grd G2.grd -GG3.grd -I1
grdblend [WARNING]: File G1.grd has different increments (2/2) than the output grid (1/1) - must resample

grdblend G1.grd G2.grd -GG3.grd -I1
grdblend [WARNING]: File G2.grd has different increments (1/1) than the output grid (2/2) - must resample
grdblend [WARNING]: File G2.grd coordinates are phase-shifted w.r.t. the output grid - must resample
grdsample [WARNING]: Output sampling interval in x exceeds input interval and may lead to aliasing.
grdsample [WARNING]: Output sampling interval in y exceeds input interval and may lead to aliasing.

grdinfo G3.grd
G3.grd: Title:
G3.grd: Command: gmt grdblend G1.grd G2.grd -GG3.grd -I1
G3.grd: Remark:
G3.grd: Gridline node registration used [Cartesian grid]
G3.grd: Grid file format: nf = GMT netCDF format (32-bit float), CF-1.7
G3.grd: x_min: 0 x_max: 30 x_inc: 2 name: x n_columns: 16
G3.grd: y_min: 0 y_max: 20 y_inc: 2 name: y n_rows: 11
G3.grd: v_min: 0 v_max: 0 name: z
G3.grd: scale_factor: 1 add_offset: 0
G3.grd: format: classic
G3.grd: Default CPT:
```

With this PR

```
grdblend G1.grd G2.grd -GG3.grd -I1
grdblend [WARNING]: File G1.grd has different increments (2/2) than the output grid (1/1) - must resample

grdinfo G3.grd
G3.grd: Title:
G3.grd: Command: gmt grdblend G1.grd G2.grd -GG3.grd -I1
G3.grd: Remark:
G3.grd: Gridline node registration used [Cartesian grid]
G3.grd: Grid file format: nf = GMT netCDF format (32-bit float), CF-1.7
G3.grd: x_min: 0 x_max: 15 x_inc: 1 name: x n_columns: 16
G3.grd: y_min: 0 y_max: 10 y_inc: 1 name: y n_rows: 11
G3.grd: v_min: 0 v_max: 0 name: z
G3.grd: scale_factor: 1 add_offset: 0
G3.grd: format: classic
G3.grd: Default CPT:
```

Run the tests and this doesn't seem to cause any failures, but our testing system is very broken, at least for me where I can't use the `GMT_DATA_SERVER=static` and where the CI give different results in all 3 OS.

So, please test this too. 