### PR TITLE
Fix the bug for plotting stroke symbols

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1331,7 +1331,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 	Ctrl->E.width *= 0.5;	/* Since we draw half-way in either direction */
 	Ctrl->E.cap   *= 0.5;	/* Since we draw half-way in either direction */
 
-	current_pen = default_pen = Ctrl->W.pen;
+	current_pen = save_pen = default_pen = Ctrl->W.pen;
 	current_fill = default_fill = (S.symbol == PSL_DOT && !Ctrl->G.active) ? black : Ctrl->G.fill;
 	default_outline = Ctrl->W.active;
 	if (Ctrl->I.active && Ctrl->I.mode == 0) {

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -880,7 +880,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 	polygon = (S.symbol == GMT_SYMBOL_LINE && (Ctrl->G.active || Ctrl->L.polygon) && !Ctrl->L.anchor);
 	if (Ctrl->W.cpt_effect && Ctrl->W.pen.cptmode & 2) polygon = true;
 	if (Ctrl->G.set_color) polygon = true;
-	default_pen = current_pen = Ctrl->W.pen;
+	default_pen = current_pen = save_pen = Ctrl->W.pen;
 	current_fill = default_fill = (S.symbol == PSL_DOT && !Ctrl->G.active) ? black : Ctrl->G.fill;
 	default_outline = Ctrl->W.active;
 	if (Ctrl->I.active && Ctrl->I.mode == 0) {
@@ -2420,7 +2420,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 	gmt_map_basemap (GMT);	/* Plot basemap last if not 3-D */
 	if (GMT->current.proj.three_D)
 		gmt_vertical_axis (GMT, 2);	/* Draw foreground axis */
-		
+
 	gmt_plane_perspective (GMT, -1, 0.0);
 
 	if (Ctrl->D.active) PSL_setorigin (PSL, -DX, -DY, 0.0, PSL_FWD);	/* Shift plot a bit */


### PR DESCRIPTION
The bug was initially reported in https://github.com/GenericMappingTools/pygmt/issues/3038.

Here is a minimal example to reproduce the issue:
```
gmt begin
gmt basemap -JX10c/5c -R2010-01-01/2014-12-01/0/6 -BWSen -Bafg
gmt plot -Sx0.3c -W1p << EOF
2010-06-01	1
2011-06-01	2
2012-06-01	3
2013-06-01	5
EOF
gmt end show
```
The script crashes with following error messages:
```
Error: /limitcheck in /----nostringval----
Operand stack:   0
Execution stack:   %interp_exit   .runexec2   --nostringval--   --nostringval--   --nostringval--   2   %stopped_push   --nostringval--   --nostringval--   --nostringval--   false   1   %stopped_push   1928   1   3   %oparray_pop   1927   1   3   %oparray_pop   1912   1   3   %oparray_pop   1785   1   3   %oparray_pop   --nostringval--   %errorexec_pop   .runexec2   --nostringval--   --nostringval--   --nostringval--   2   %stopped_push
Dictionary stack:   --dict:750/1123(ro)(G)--   --dict:0/20(G)--   --dict:85/200(L)--   --dict:173/250(L)--
Current allocation mode is local
Last OS error: No such file or directorypsconvert [ERROR]: System call [gs -q -dNOSAFER -dNOPAUSE -dBATCH -sDEVICE=bbox -DPSL_no_pagefill -dMaxBitmap=2147483647 -dUseFastColor=true '/home/seisman/.gmt/sessions/gmt_session.62272/gmt_0.ps-' 2> '/home/seisman/.gmt/sessions/gmt_session.62272/psconvert_62277c.bb'] returned error 256.
end [ERROR]: Failed to call psconvert
end [ERROR]: gmtinit_process_figures returned error 79
```
It's because the produced PS file has an extra weird line compared to a normal PS file:
```
1.68e-22 2.04e-153 5.47e+160 C
```
The line was added because `save_pen` was not correctly initialized, so the actual behavior is compiler-dependent.

This PR fixes the bug by initialize `save_pen` to `default_pen` and now no crashes.