### PR TITLE
Explain why the FONT settings for colorbars is apparently not working.

### DIFF
--- a/doc/rst/source/colorbar.rst
+++ b/doc/rst/source/colorbar.rst
@@ -51,9 +51,12 @@ setting the option |-I|. Colors may be spaced according to a linear
 scale, all be equal size, or by providing a file with individual tile
 widths. The font used for the annotations along the scale is specified by
 :term:`FONT_ANNOT_PRIMARY` while any unit placed at the side of the
-bar is controlled by :term:`FONT_ANNOT_SECONDARY`. If a label along the bar
-is requested, it is plotted with :term:`FONT_LABEL`. For a full overview of CPTs,
-see the Technical Reference section on :ref:`Color palette tables <CPT_section>`.
+bar is controlled by :term:`FONT_ANNOT_SECONDARY`. If a label along the bar is requested, it is plotted with
+:term:`FONT_LABEL`. But mind you that the modern mode theme scales down the size of annotations and labels
+based on the colorbar length for improved legibility. So, in modern mode scripts it might look that these
+parameter settings are not working correctly. If you may want to increase font sizes to compensate the
+scaling effect the solution is to use the online ``--FONT_ANNOT_PRIMARY=...`` construct.
+For a full overview of CPTs, see the Technical Reference section on :ref:`Color palette tables <CPT_section>`.
 
 .. figure:: /_images/GMT_colorbar.*
    :width: 500 px


### PR DESCRIPTION
See this [forum post ](https://forum.generic-mapping-tools.org/t/issue-with-the-font-of-annotation-of-colorbar-using-oblique-projection/4756)