### PR TITLE
CI: Fix the ci-caches workflow and always use the "static" data server in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,14 +118,14 @@ jobs:
         with:
           workflow: ci-caches.yml
           name: gmt-cache
-          path: .gmt
+          path: gmt-cache
 
       # Move downloaded files to ~/.gmt directory and list them
       - name: Move and list downloaded remote files
         run: |
-          mkdir -p ~/.gmt
-          mv .gmt/* ~/.gmt
-          ls -lRh ~/.gmt
+          mkdir -p ~/.gmt/static/
+          mv gmt-cache/* ~/.gmt/static/
+          ls -lRh ~/.gmt/static/
 
       - name: Install GMT
         run: |

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -23,12 +23,19 @@ concurrency:
 jobs:
   data_cache:
     name: Cache GMT data
-    # We have to use macOS, because Linux/Windows agents may fail to download
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
       - name: Install GMT
-        run: brew install gmt
+        uses: mamba-org/setup-micromamba@v1.8.1
+        with:
+          environment-name: gmt
+          condarc: |
+            channels:
+              - conda-forge
+              - nodefaults
+          create-args: >-
+            gmt=6.5.0
 
       - name: Download remote data
         run: |

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -7,10 +7,11 @@
 name: GMT CI Caches
 
 on:
-  # Uncomment the "push:" line to manually re-cache data artifacts in pushes
-  #push:
-  # Uncomment the 'pull_request:' line to manually re-cache data artifacts in PRs
-  # pull_request:
+  pull_request:
+    # Make any changes to the following files to refresh the cache in PRs
+    paths:
+      - '.github/workflows/ci-caches.yml'
+  workflow_dispatch:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'
@@ -79,8 +80,14 @@ jobs:
           gmt get -Dcache
           gmt get -Dcache
           gmt get -Dcache
+          # Workaround for the GMT_DATA_SERVER issue
+          mkdir ~/.gmt/static/
+          mv ~/.gmt/server ~/.gmt/static/
+          mv ~/.gmt/cache ~/.gmt/static/
+          mv ~/.gmt/gmt_data_server.txt ~/.gmt/static/
+          mv ~/.gmt/gmt_hash_server.txt ~/.gmt/static/
           # check files
-          ls -R ~/.gmt
+          ls -lR ~/.gmt
 
       # Upload the downloaded files as artifacts to GitHub
       - name: Upload artifacts to GitHub
@@ -88,8 +95,7 @@ jobs:
         with:
           name: gmt-cache
           path: |
-            ~/.gmt/cache
-            ~/.gmt/server
+            ~/.gmt/static
 
   vcpkg_cache:
     name: Cache vcpkg libraries

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -24,6 +24,9 @@ jobs:
   data_cache:
     name: Cache GMT data
     runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       - name: Install GMT

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -87,15 +87,16 @@ jobs:
           gmt which -Ga $data
           gmt which -Ga $data
           # Download cache files multiple times to make sure all are downloaded
+          # Workaroud for https://github.com/GenericMappingTools/gmt/issues/8437.
+          mv ~/.gmt/gmt_data_server.txt ~/.gmt/server/
+          mv ~/.gmt/gmt_hash_server.txt ~/.gmt/server/
           gmt get -Dcache
           gmt get -Dcache
           gmt get -Dcache
-          # Workaround for the GMT_DATA_SERVER issue
+          # Workaroud for https://github.com/GenericMappingTools/gmt/issues/8437.
           mkdir ~/.gmt/static/
           mv ~/.gmt/server ~/.gmt/static/
           mv ~/.gmt/cache ~/.gmt/static/
-          mv ~/.gmt/gmt_data_server.txt ~/.gmt/static/
-          mv ~/.gmt/gmt_hash_server.txt ~/.gmt/static/
           # check files
           ls -lR ~/.gmt
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -113,14 +113,14 @@ jobs:
         with:
           workflow: ci-caches.yml
           name: gmt-cache
-          path: .gmt
+          path: gmt-cache
 
       # Move downloaded files to ~/.gmt directory and list them
       - name: Move and list downloaded remote files
         run: |
-          mkdir -p ~/.gmt
-          mv .gmt/* ~/.gmt
-          ls -lRh ~/.gmt
+          mkdir -p ~/.gmt/static/
+          mv gmt-cache/* ~/.gmt/static/
+          ls -lRh ~/.gmt/static/
 
       - name: Check a few simple commands
         run: bash ci/simple-gmt-tests.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,14 +119,14 @@ jobs:
         with:
           workflow: ci-caches.yml
           name: gmt-cache
-          path: .gmt
+          path: gmt-cache
 
       # Move downloaded files to ~/.gmt directory and list them
       - name: Move and list downloaded remote files
         run: |
-          mkdir -p ~/.gmt
-          mv .gmt/* ~/.gmt
-          ls -lRh ~/.gmt
+          mkdir -p ~/.gmt/static/
+          mv gmt-cache/* ~/.gmt/static/
+          ls -lRh ~/.gmt/static/
 
       - name: Build documentation
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,16 +128,16 @@ jobs:
           name: gmt-cache
           path: .gmt
 
-      # Pull baseline image data from dvc remote (DAGsHub)
-      - name: Pull baseline image data from dvc remote
-        run: dvc pull
-
       # Move downloaded files to ~/.gmt directory and list them
       - name: Move and list downloaded remote files
         run: |
-          mkdir -p ~/.gmt
-          mv .gmt/* ~/.gmt
-          ls -lRh ~/.gmt
+          mkdir -p ~/.gmt/static
+          mv .gmt/* ~/.gmt/static
+          ls -lRh ~/.gmt/static
+
+      # Pull baseline image data from dvc remote (DAGsHub)
+      - name: Pull baseline image data from dvc remote
+        run: dvc pull
 
       - name: Install GMT
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,14 +126,14 @@ jobs:
         with:
           workflow: ci-caches.yml
           name: gmt-cache
-          path: .gmt
+          path: gmt-cache
 
       # Move downloaded files to ~/.gmt directory and list them
       - name: Move and list downloaded remote files
         run: |
-          mkdir -p ~/.gmt/static
-          mv .gmt/* ~/.gmt/static
-          ls -lRh ~/.gmt/static
+          mkdir -p ~/.gmt/static/
+          mv gmt-cache/* ~/.gmt/static/
+          ls -lRh ~/.gmt/static/
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote

--- a/ci/config-gmt-unix.sh
+++ b/ci/config-gmt-unix.sh
@@ -12,6 +12,9 @@ set (DCW_ROOT "$ENV{COASTLINEDIR}/dcw")
 set (GMT_USE_THREADS TRUE)
 set (GMT_ENABLE_OPENMP TRUE)
 
+# Always use the 'static' data server in CI.
+set (GMT_DATA_SERVER static)
+
 # recommended even for release build
 set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")
 # extra warnings
@@ -23,7 +26,6 @@ if [[ "$RUN_TESTS" == "true" ]]; then
 set (CMAKE_BUILD_TYPE Debug)
 
 enable_testing()
-set (GMT_DATA_SERVER static)
 set (DO_EXAMPLES TRUE)
 set (DO_TESTS TRUE)
 set (DO_API_TESTS ON)

--- a/ci/config-gmt-windows.sh
+++ b/ci/config-gmt-windows.sh
@@ -10,12 +10,14 @@ set (GSHHG_ROOT "$ENV{COASTLINEDIR}/gshhg")
 set (DCW_ROOT "$ENV{COASTLINEDIR}/dcw")
 
 set (GMT_ENABLE_OPENMP TRUE)
+
+# Always use the 'static' data server in CI.
+set (GMT_DATA_SERVER static)
 EOF
 
 if [[ "$RUN_TESTS" == "true" ]]; then
     cat >> cmake/ConfigUser.cmake << 'EOF'
 enable_testing()
-set (GMT_DATA_SERVER static)
 set (DO_EXAMPLES TRUE)
 set (DO_TESTS TRUE)
 set (DO_API_TESTS ON)


### PR DESCRIPTION
**Description of proposed changes**

- Add a workaround for issue #8437 in the "CI Caches" workflow
- Update `ci/config-gmt-*` scripts to always use the "static" data server in CI
- Update other workflows to use the "static" data 