### PR TITLE
Add support for loongarch

### DIFF
--- a/src/gmt_common_sighandler.c
+++ b/src/gmt_common_sighandler.c
@@ -111,6 +111,8 @@ GMT_LOCAL void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.arm_pc)
 # elif defined( __hppa__)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.sc_iaoq[0])
+# elif defined( __loongarch__)
+#  define UC_IP(uc) ((void *) (uc)->uc_mcontext.__pc)
 # elif defined(__m68k__)
 #  define UC_IP(uc) ((void *) (uc)->uc_mcontext.gregs[R_PC])
 # elif defined(__riscv)


### PR DESCRIPTION
Fix the compilation error in loongarch architecture, the detailed error link is as follows: [https://buildd.debian.org/status/fetch.php?pkg=gmt&arch=loong64&ver=6.5.0%2Bdfsg-3&stamp=1709414765&raw=0](url)