### PR TITLE
Set slightly higher RMS values for tests grdvector/bothg.sh and pscontour/thickness.sh

### DIFF
--- a/test/grdvector/bothg.sh
+++ b/test/grdvector/bothg.sh
@@ -4,6 +4,8 @@
 # Due to hairline differences due to arcm64 macOS and Intel we need a
 # higher rms threshold for this test to pass
 #
+# GRAPHICSMAGICK_RMS = 0.005
+#
 ps=bothg.ps
 gmt pscoast -R-180/180/-70/70 -JM18c -Dc -Sblue -Glightgray -W0.01p,black -Baf -P --FONT_ANNOT_PRIMARY=9p,Helvetica,black -K -Xc > $ps
 gmt grdvector -O -K wx_grd000.nc wy_grd000.nc -R-180/180/-70/70 -J -Q4p+e+jc+gwhite -Si50k -W0.75p,white -I10 >> $ps

--- a/test/pscontour/thickness.sh
+++ b/test/pscontour/thickness.sh
@@ -3,7 +3,7 @@
 # Comes from forum message http://gmt.soest.hawaii.edu/boards/1/topics/5532?r=5548
 # Due to hairline differences in many gridlines between Linux and macOS we need a
 # higher rms threshold for this test to pass
-# GRAPHICSMAGICK_RMS = 0.02
+# GRAPHICSMAGICK_RMS = 0.021
 ps=thickness.ps
 cat << EOF > t.cpt
 0 255 247 236   500 255 247 236


### PR DESCRIPTION
Increase GM rms value so that these two tests can pass.
