### PR TITLE
Address issues raised in #8438 and more.

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15811,9 +15811,14 @@ struct GMT_CTRL *gmt_init_module (struct GMTAPI_CTRL *API, const char *lib_name,
 	GMT->current.ps.active = is_PS;		/* true if module will produce PS */
 
 	/* Check if there is an input remote grid or memory file so we may set geographic to be true now before we must decide on auto-J */
-	if (options && (opt = GMT_Find_Option (API, GMT_OPT_INFILE, *options))) {
-		if (gmt_remote_dataset_id (API, opt->arg) != GMT_NOTSET)	/* All remote data grids/images are geographic */
-			gmt_set_geographic (GMT, GMT_IN);
+	if (options && (opt = GMT_Find_Option(API, GMT_OPT_INFILE, *options))) {
+		if (gmt_remote_dataset_id(API, opt->arg) != GMT_NOTSET) {	/* All remote data grids/images are geographic */
+			gmt_set_geographic(GMT, GMT_IN);
+			/* Above is not enough for tilled grids. That case looses this info when creating the final grid but a not
+			   consulting the units in the header of any of the tiles. Se we reinforce it with a fake -fg option.
+			*/
+			API->GMT->common.f.is_geo[0] = true;
+		}
 		else if (gmtlib_data_is_geographic (API, opt->arg))	/* This dataset, grid, image, matrix, or vector is geographic */
 			gmt_set_geographic (GMT, GMT_IN);
 	}
@@ -18255,7 +18260,7 @@ unsigned int gmt_parse_inc_option (struct GMT_CTRL *GMT, char option, char *item
 
 GMT_LOCAL int gmtinit_parse_proj4 (struct GMT_CTRL *GMT, char *item, char *dest) {
 	/* Deal with proj.4 or EPSGs passed in -J option */
-	char  *item_t1 = NULL, *item_t2 = NULL, wktext[32] = {""}, *pch;
+	char  *item_t1 = NULL, *item_t2 = NULL, epsg2proj[GMT_LEN256] = {""}, wktext[32] = {""}, *pch;
 	bool   do_free = false;
 	int    error = 0, scale_pos;
 	size_t k, len;
@@ -18287,7 +18292,7 @@ GMT_LOCAL int gmtinit_parse_proj4 (struct GMT_CTRL *GMT, char *item, char *dest)
 	/* Don't remember anymore if we still need to call gmt_importproj4(). We don't for simple
 	   mapproject usage but maybe we still need for mapping purposes. To-be-rediscovered.
 	*/
-	item_t2 = gmt_importproj4 (GMT, item_t1, &scale_pos);		/* This is GMT -J proj string */
+	item_t2 = gmt_importproj4 (GMT, item_t1, &scale_pos, epsg2proj);		/* This is the GMT -J proj string */
 	if (item_t2 && !GMT->current.ps.active && !strcmp(item_t2, "/1:1")) {
 		/* Even though it failed to do the mapping we can still use it in mapproject */
 		GMT->current.proj.projection_GMT = GMT_NO_PROJ;
@@ -18307,6 +18312,10 @@ GMT_LOCAL int gmtinit_parse_proj4 (struct GMT_CTRL *GMT, char *item, char *dest)
 		}
 		else		/* Not particularly useful yet because mapproject will fail anyway when scale != 1:1 */
 			GMT->current.proj.projection_GMT = GMT_NO_PROJ;
+		
+		/* If input was a EPSG code, save the epsg -> proj conversion string. Save also if input was a +proj string */
+		if (epsg2proj[0] != '\0')   snprintf(GMT->common.J.proj4string, GMT_LEN256-1, "%s", epsg2proj);
+		else if (item_t1[0] == '+') snprintf(GMT->common.J.proj4string, GMT_LEN256-1, "%s", item_t1);
 
 		/* Check if the scale is 1 or 1:1, and don't get fooled with, for example, 1:10 */
 		pch = &item_t2[scale_pos];

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -8014,9 +8014,11 @@ GMT_LOCAL void gmtplot_wipe_substr(char *str1, char *str2) {
 }
 #endif
 
-char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
+char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos, char *epsg2proj) {
 	/* Take a PROJ.4 projection string or EPSG code and try to find the equivalent -J syntax
 		scale_pos is position on the return string where starts the scale sub-string.
+		The pStr pointer is changed when in input it contains an EPSG code. On return it will
+		have the proj4 string corresponding to the EPSG code. That pointer can later be freed with free()
 	*/
 	unsigned int pos = 0;
 	//bool got_lonlat = false;
@@ -8031,7 +8033,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 		pch[0] = '\0';
 	}
 	else {
-		GMT->current.ps.active ? sprintf(scale_c, "14c") : sprintf(scale_c, "1:1");
+		GMT->current.ps.active ? sprintf(scale_c, "15c") : sprintf(scale_c, "1:1");
 	}
 
 	if (isdigit(szProj4[1])) {		/* A EPSG code. By looking at 2nd char instead of 1st both +epsg and epsg work */
@@ -8066,6 +8068,7 @@ char *gmt_importproj4 (struct GMT_CTRL *GMT, char *pStr, int *scale_pos) {
 			return (pStrOut);
 		}
 		snprintf(szProj4, GMT_LEN256-1, "%s", pszResult);
+		snprintf(epsg2proj, GMT_LEN256-1, "%s", pszResult);			/* This one now has the proj4 conversion of the EPSG code. */
 		if (scale_c[0] != '\0') strcat (szProj4, scale_c);		/* Add the width/scale found above */
 		CPLFree(pszResult);
 		OSRDestroySpatialReference(hSRS);

--- a/src/gmt_prototypes.h
+++ b/src/gmt_prototypes.h
@@ -280,8 +280,8 @@ EXTERN_MSC void gmt_map_text (struct GMT_CTRL *GMT, double x, double y, struct G
 EXTERN_MSC void gmt_map_title (struct GMT_CTRL *GMT, double x, double y);
 EXTERN_MSC void gmt_linearx_grid (struct GMT_CTRL *GMT, struct PSL_CTRL *P, double w, double e, double s, double n, double dval);
 EXTERN_MSC int gmt_ps_append (struct GMT_CTRL *GMT, char *source, unsigned int mode, FILE *dest);
-EXTERN_MSC char * gmt_export2proj4 (struct GMT_CTRL *GMT);
-EXTERN_MSC char * gmt_importproj4 (struct GMT_CTRL *GMT, char *szProj4, int *scale_pos);
+EXTERN_MSC char *gmt_export2proj4 (struct GMT_CTRL *GMT);
+EXTERN_MSC char *gmt_importproj4 (struct GMT_CTRL *GMT, char *szProj4, int *scale_pos, char *epsg2proj);
 EXTERN_MSC int gmt_strip_layer (struct GMTAPI_CTRL *API, int nlayers);
 EXTERN_MSC void gmt_textpath_init (struct GMT_CTRL *GMT, struct GMT_PEN *BP, double Brgb[]);
 EXTERN_MSC void gmt_draw_map_rose (struct GMT_CTRL *GMT, struct GMT_MAP_ROSE *mr);

--- a/src/grdblend.c
+++ b/src/grdblend.c
@@ -1084,8 +1084,8 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 				n_fill++;						/* One more cell filled */
 				if (z[col] < Grid->header->z_min) Grid->header->z_min = z[col];	/* Update the extrema for output grid */
 				if (z[col] > Grid->header->z_max) Grid->header->z_max = z[col];
-                if (gmt_M_is_zero (z[col]))
-                    m = 1;
+				if (gmt_M_is_zero (z[col]))
+					m = 1;
 			}
 			else			/* No grids covered this node, defaults to the no_data value */
 				z[col] = no_data_f;
@@ -1161,6 +1161,12 @@ EXTERN_MSC int GMT_grdblend (void *V_API, int mode, void *args) {
 		if (gmt_remove_file (GMT, outfile))	/* Try half-heartedly to remove the temporary file */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Failed to delete file %s\n", outfile);
 	}
+
+	/* These two were not copied back into GMT and would be lost in gmt_end_module. Needed to set the correct
+	   @PROJ parameters in PS files. See issue #8438
+	*/
+	GMT_cpy->current.io.col_type[0][0] = GMT->current.io.col_type[0][0];
+	GMT_cpy->current.io.col_type[0][1] = GMT->current.io.col_type[0][1];
 
 	Return (GMT_NOERROR);
 }

--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -2786,7 +2786,6 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 			else if (Ctrl->W.warp && !proj4_cmd)
 				GMT_Report (API, GMT_MSG_ERROR, "Could not find the Proj4 command in the PS file. No conversion performed.\n");
 		}
-
 		else if (Ctrl->W.kml) {	/* Write a basic kml file */
 			char kml_file[PATH_MAX] = "";
 			if (Ctrl->D.active)
@@ -2860,7 +2859,6 @@ EXTERN_MSC int GMT_psconvert (void *V_API, int mode, void *args) {
 				GMT_Report (API, GMT_MSG_INFORMATION, "Wrote KML file %s\n", kml_file);
 			}
 		}
-
 		else if (Ctrl->W.active && !found_proj) {
 			GMT_Report (API, GMT_MSG_ERROR, "Could not find the 'PROJ' tag in the PS file. No world file created.\n");
 			GMT_Report (API, GMT_MSG_ERROR, "This situation occurs when one of the two next cases is true:\n");


### PR DESCRIPTION
The `grdimage -A` worked but with many limitations. For example it didn't set the CRS in the output GeoTIFF file. Also, if using a EPSG or proj4 string had many hidden errors. The problem is that using ``-J+proj=...`` opens the door to awful complicated code flows. This PR fixes several of those issues, but not all. For example, this now works correctly
```
gmt grdimage @earth_relief_05m  -Alixo.tiff -J4326
```
or
```
gmt grdimage @earth_relief_05m  -Alixo.tiff -J+proj=longlat
```
or
```
gmt grdimage @earth_relief_05m  -Alixo.tiff -JW14
```
but this hangs when it fall ins a nearly infinite loop due to badly assigned scales.
```
gmt grdimage @earth_relief_06m_p  -Alixo.tiff -J+proj=robin
```

Spend 2 day debugging/relearning things but must stop here for now. Again, this PR hopefully fixes many issues, but not all.