### PR TITLE
CI: Run workflows based on changed files to save CI resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,17 +4,23 @@
 name: Build
 
 on:
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-      - '!doc/**/CMakeLists.txt'
   push:
     branches:
       - master
       - 6.[0-9]+
-    paths-ignore:
-      - 'doc/**'
-      - '!doc/**/CMakeLists.txt'
+    paths:
+      - 'ci/**'
+      - 'cmake/**'
+      - 'src/**'
+      - '**/CMakeLists.txt'
+      - '.github/workflows/build.yml'
+  pull_request:
+    paths:
+      - 'ci/**'
+      - 'cmake/**'
+      - 'src/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/build.yml'
 
 defaults:
   run:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -4,6 +4,7 @@ name: Check Links
 on:
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
   # pull_request:
+  workflow_dispatch:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -5,10 +5,17 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+'
+    paths:
+      - 'src/**'
+      - 'cmake/**'
+      - '**/*.sh'
+      - '.github/workflows/code-validator.yml'
   pull_request:
-    paths-ignore:
-      - 'doc/**'
-      - '!doc/**/CMakeLists.txt'
+    paths:
+      - 'src/**'
+      - 'cmake/**'
+      - '**/*.sh'
+      - '.github/workflows/code-validator.yml'
 
 name: Code Validator
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,12 +9,17 @@ on:
       - master
       - 6.[0-9]+
     paths:
-      - 'src/**'
+      - 'ci/**'
       - 'cmake/**'
+      - 'src/**'
       - '**/CMakeLists.txt'
       - '.github/workflows/docker.yml'
   pull_request:
     paths:
+      - 'ci/**'
+      - 'cmake/**'
+      - 'src/**'
+      - '**/CMakeLists.txt'
       - '.github/workflows/docker.yml'
 
 defaults:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,10 @@ on:
       - master
       - 6.[0-9]+
     paths:
-      - 'doc/**'
-      - '.github/workflows/**'
       - 'ci/**'
+      - 'doc/**'
+      - '**/CMakeLists.txt'
+      - '.github/workflows/docs.yml'
   release:
     types:
       - published

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -3,6 +3,7 @@
 on:
   # enable pull request for debugging
   # pull_request:
+  workflow_dispatch:
   # Schedule runs daily
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/remind.yml
+++ b/.github/workflows/remind.yml
@@ -1,6 +1,7 @@
 name: Reminders
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 1 */6 *' # Runs at midnight on the 1st day every 6th month
 

--- a/.github/workflows/scm-check.yml
+++ b/.github/workflows/scm-check.yml
@@ -8,6 +8,7 @@ name: SCM Check
 on:
   # uncomment the 'pull_request' line to test the workflow in PRs
   # pull_request:
+  workflow_dispatch:
   schedule:
     # weekly cron job
     - cron: '0 0 * * 0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@
 name: Tests
 
 on:
-  pull_request:
   push:
     branches:
       - master
@@ -12,11 +11,16 @@ on:
     paths:
       - 'src/**'
       - 'test/**'
-      - 'share/**'
       - 'doc/examples/**'
       - 'doc/scripts/**'
-      - '.github/workflows/**'
-      - 'ci/**'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'doc/examples/**'
+      - 'doc/scripts/**'
+      - '.github/workflows/tests.yml'
 
 defaults:
   run:


### PR DESCRIPTION
**Description of proposed changes**

It makes no sense to run the full tests in PR if a PR only contains doc changes (e.g., #8443). This PR improves the CI workflows so that workflows only run when specific files are changed.