### PR TITLE
CI: Use 'gh run download' to download GMT caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,12 +66,10 @@ jobs:
         uses: actions/checkout@v4.1.4
 
       - name: Setup vcpkg (Windows)
-        uses: dawidd6/action-download-artifact@v3.1.4
-        with:
-          workflow: ci-caches.yml
-          name: vcpkg-cache
-          path: C:\vcpkg\installed\
+        run: gh run download -n vcpkg-cache -D C:/vcpkg/installed/
         if: runner.os == 'Windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
@@ -124,18 +122,11 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Download cached GMT remote data from GitHub Artifacts
-        uses: dawidd6/action-download-artifact@v3.1.4
-        with:
-          workflow: ci-caches.yml
-          name: gmt-cache
-          path: gmt-cache
-
-      # Move downloaded files to ~/.gmt directory and list them
-      - name: Move and list downloaded remote files
         run: |
-          mkdir -p ~/.gmt/static/
-          mv gmt-cache/* ~/.gmt/static/
+          gh run download -n gmt-cache -D ~/.gmt/static/
           ls -lRh ~/.gmt/static/
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Install GMT
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,12 +60,10 @@ jobs:
         uses: actions/checkout@v4.1.4
 
       - name: Setup vcpkg (Windows)
-        uses: dawidd6/action-download-artifact@v3.1.4
-        with:
-          workflow: ci-caches.yml
-          name: vcpkg-cache
-          path: C:\vcpkg\installed\
+        run: gh run download -n vcpkg-cache -D C:/vcpkg/installed/
         if: runner.os == 'Windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
@@ -120,18 +118,11 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Download cached GMT remote data from GitHub Artifacts
-        uses: dawidd6/action-download-artifact@v3.1.4
-        with:
-          workflow: ci-caches.yml
-          name: gmt-cache
-          path: gmt-cache
-
-      # Move downloaded files to ~/.gmt directory and list them
-      - name: Move and list downloaded remote files
         run: |
-          mkdir -p ~/.gmt/static/
-          mv gmt-cache/* ~/.gmt/static/
+          gh run download -n gmt-cache -D ~/.gmt/static/
           ls -lRh ~/.gmt/static/
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Build documentation
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,12 +63,10 @@ jobs:
         uses: actions/checkout@v4.1.4
 
       - name: Setup vcpkg (Windows)
-        uses: dawidd6/action-download-artifact@v3.1.4
-        with:
-          workflow: ci-caches.yml
-          name: vcpkg-cache
-          path: C:\vcpkg\installed\
+        run: gh run download -n vcpkg-cache -D C:/vcpkg/installed/
         if: runner.os == 'Windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
@@ -130,18 +128,11 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Download cached GMT remote data from GitHub Artifacts
-        uses: dawidd6/action-download-artifact@v3.1.4
-        with:
-          workflow: ci-caches.yml
-          name: gmt-cache
-          path: gmt-cache
-
-      # Move downloaded files to ~/.gmt directory and list them
-      - name: Move and list downloaded remote files
         run: |
-          mkdir -p ~/.gmt/static/
-          mv gmt-cache/* ~/.gmt/static/
+          gh run download -n gmt-cache -D ~/.gmt/static/
           ls -lRh ~/.gmt/static/
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote


### PR DESCRIPTION
Use `gh run download` to download GMT caches, so we don't need to use the 3rd-party `dawidd6/action-download-artifact` action in some workflows. Please note that it still needs in the docker workflow because `gh` is not available in these images.