### PR TITLE
Add admin/list_known_failures.sh to list known failures and simplify the workflow

### DIFF
--- a/.github/workflows/remind.yml
+++ b/.github/workflows/remind.yml
@@ -21,17 +21,11 @@ jobs:
 
     - name: Find and report known failures
       run: |
-        # Get the list of known failures
-        KNOWN_FAILURES=$(grep -rl 'GMT_KNOWN_FAILURE' test/**/*.sh)
+        title="Review GMT's known failures"
 
-        # If there are known failures, create an issue
-        if [ -n "$KNOWN_FAILURES" ]; then
-          title="Review GMT's known failures"
+        bash admin/list_known_failures.sh > report.md
 
-          echo "The following tests are marked as GMT_KNOWN_FAILURE and need review:" > report.md
-          echo "" >> report.md
-          while IFS= read -r line ; do echo "1. $line"; done <<< $KNOWN_FAILURES >> report.md
-
+        if [ -s "report.md" ]; then
           gh issue create --title "$title" --body-file report.md
         fi
       env:

--- a/admin/list_known_failures.sh
+++ b/admin/list_known_failures.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Report the list of known failures.
+#
+
+if [ ! -d cmake ]; then
+	echo "Must be run from top-level gmt directory"
+	exit 1
+fi
+
+known_failures=$(grep -rl "GMT_KNOWN_FAILURE" test/**/*.sh doc/**/*.sh)
+if [ -n "$known_failures" ]; then
+    echo "The following tests are marked as GMT_KNOWN_FAILURE and need review:"
+    echo ""
+    while IFS= read -r line; do
+        echo "- $line"
+    done <<< $known_failures
+fi


### PR DESCRIPTION
Add `admin/list_known_failures.sh` so that we can run the script locally at any time. It also simplifies the `remind.yml` workflow file.