### PR TITLE
doc: No need to show the scripts that generate the big tables

### DIFF
--- a/doc/rst/source/reference/cpts.rst
+++ b/doc/rst/source/reference/cpts.rst
@@ -44,12 +44,6 @@ Color maps can be selected in various of the GMT tools using **-C**\ [*section*/
 
    The standard 46 CPTs supported by GMT.
 
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_M_1a.txt
-
 .. _CPT_files_b:
 
 .. figure:: /_images/GMT_App_M_1b.*
@@ -57,12 +51,6 @@ Color maps can be selected in various of the GMT tools using **-C**\ [*section*/
    :align: center
 
    The 30 scientific color maps by Fabio Crameri supported by GMT.
-
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_M_1b.txt
 
 .. _CPT_files_c:
 
@@ -75,12 +63,6 @@ Color maps can be selected in various of the GMT tools using **-C**\ [*section*/
    **Note**: Any GMT colormap can be made cyclic by running :doc:`/makecpt`
    with the **-Ww** option (wrapped = cyclic).
 
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_M_1c.txt
-
 .. _CPT_files_d:
 
 .. figure:: /_images/GMT_App_M_1d.*
@@ -88,12 +70,6 @@ Color maps can be selected in various of the GMT tools using **-C**\ [*section*/
    :align: center
 
    The 22 color maps from cmocean by Kristen M. Thyng supported by GMT.
-
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_M_1d.txt
 
 For additional color tables, visit
 `cpt-city <http://soliton.vm.bytemark.co.uk/pub/cpt-city/>`_ and
@@ -126,10 +102,3 @@ annotation code to **B**.
 .. figure:: /_images/GMT_App_M_2.*
    :width: 600 px
    :align: center
-
-
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_M_2.txt

--- a/doc/rst/source/reference/custom-symbols.rst
+++ b/doc/rst/source/reference/custom-symbols.rst
@@ -34,12 +34,6 @@ Several custom symbol definitions comes included with GMT (see Figure :ref:`Cust
    Be aware that some symbols may have a hardwired fill or no-fill component,
    while others duplicate what is already available as standard built-in symbols.
 
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_N_1.txt
-
 You may find it convenient to examine some of these and use them as a
 starting point for your own design; they can be found in GMT's
 share/custom directory.  In addition to the ones listed in Figure :ref:`Custom symbols <Custom_symbols>`

--- a/doc/rst/source/reference/octal-codes.rst
+++ b/doc/rst/source/reference/octal-codes.rst
@@ -20,12 +20,6 @@ characters (shown in the light green boxes) you need to set
 
    Octal codes and corresponding symbols for StandardEncoding (left) and ISOLatin1Encoding (right) fonts.
 
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_F_stand+_iso+.txt
-
 The chart for the Symbol character set (GMT font number 12) and Pifont
 ZapfDingbats character set (font number 34) are presented in
 Figure :ref:`Octal codes for Symbol and ZapfDingbats <Octal_codes_symbol_zap>` below. The octal code
@@ -44,12 +38,6 @@ firmware will not know about the euro).
    :align: center
 
    Octal codes and corresponding symbols for Symbol (left) and ZapfDingbats (right) fonts.
-
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_F_symbol_dingbats.txt
 
 Footnote
 --------

--- a/doc/rst/source/reference/postscript-fonts.rst
+++ b/doc/rst/source/reference/postscript-fonts.rst
@@ -12,12 +12,6 @@ usually Courier). The following is a list of the GMT fonts:
 
    The standard 35 PostScript fonts recognized by GMT.
 
-.. toggle::
-
-   Here is the source script for the figure above:
-
-   .. literalinclude:: /_verbatim/GMT_App_G.txt
-
 For the special fonts Symbol (12) and ZapfDingbats (34), see the octal
 charts in Chapter :doc:`octal-codes`. When specifying fonts in GMT, you can
 either give the entire font name *or* just the font number listed in


### PR DESCRIPTION
**Description of proposed changes**

Take this page (https://docs.generic-mapping-tools.org/dev/reference/octal-codes.html) as an example. Currently, the script that used to generate the big table is shown on this page, but the script is useless to users and no need to show them.