### PR TITLE
Configure dependabot to automatically update requirements.txt for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,15 @@ updates:
     # Specify labels for pull requests
     labels:
       - "maintenance"
+
+  - package-ecosystem: "pip"
+    directory: "/doc/rst/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "weekly"
+      day: "tuesday"
+    # Allow up to 2 open pull requests at a time
+    open-pull-requests-limit: 2
+    # Specify labels for pull requests
+    labels:
+      - "maintenance"


### PR DESCRIPTION
We will be notified if any dependencies for building the GMT docs have updates.