### PR TITLE
CI: Need to setup miniconda for macOS-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
 defaults:
   run:
     # default to use bash shell
-    shell: bash
+    shell: bash -el {0}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,6 +72,10 @@ jobs:
           name: vcpkg-cache
           path: C:\vcpkg\installed\
         if: runner.os == 'Windows'
+
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v3
+        if: runner.os == 'macOS'
 
       - name: Install GMT dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ on:
 defaults:
   run:
     # default to use bash shell
-    shell: bash
+    shell: bash -el {0}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -66,6 +66,10 @@ jobs:
           name: vcpkg-cache
           path: C:\vcpkg\installed\
         if: runner.os == 'Windows'
+
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v3
+        if: runner.os == 'macOS'
 
       - name: Install GMT dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ on:
 defaults:
   run:
     # default to use bash shell
-    shell: bash
+    shell: bash -el {0}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,6 +69,10 @@ jobs:
           name: vcpkg-cache
           path: C:\vcpkg\installed\
         if: runner.os == 'Windows'
+
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v3
+        if: runner.os == 'macOS'
 
       - name: Install GMT dependencies
         run: |


### PR DESCRIPTION
Our CI recently upgraded to the latest macOS image `macos-14`, which no longer provides conda, so the CI fails. We have to install conda ourselves in macOS CI.


xref: https://github.com/actions/runner-images/issues/9262. 