### PR TITLE
CI: Pin to macOS 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
           - name: Linux
             os: ubuntu-latest
           - name: macOS
-            os: macos-latest
+            os: macos-13 # macos-14 use M1 chips, which causes many failures
           - name: Windows
             os: windows-latest
 


### PR DESCRIPTION
As mentioned in https://github.com/GenericMappingTools/gmt/issues/8462#issuecomment-2084201112, GitHub Actions has upgraded its `macos-latest` to `macos-14` (with ARM M1 Chip), which causes many new failures.

We don't have time to deal with failures recently, so better to pin to macos 13 temporarily.