### PR TITLE
CI: Bump to Ghostscript 10.03.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # Pull baseline image data from dvc remote (DAGsHub)
       - name: Pull baseline image data from dvc remote
         run: dvc pull
 
@@ -153,7 +152,6 @@ jobs:
         run: call ci/simple-gmt-tests.bat
         if: runner.os == 'Windows'
 
-      # Run full tests and rerun failed tests
       - name: Run full tests
         run: |
           set -x -e

--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -18,7 +18,7 @@ EXCLUDE_OPTIONAL=${EXCLUDE_OPTIONAL:-false}
 # packages installed via apt-get
 packages="build-essential cmake ninja-build libcurl4-gnutls-dev libnetcdf-dev curl git libgdal-dev"
 # packages installed via conda
-conda_packages="ghostscript=10.02.1"
+conda_packages="ghostscript=10.03.0"
 
 # optional packages
 if [ "$EXCLUDE_OPTIONAL" = "false" ]; then

--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -18,7 +18,7 @@ PACKAGE="${PACKAGE:-false}"
 # packages for compiling GMT
 # cmake is pre-installed on GitHub Actions
 packages="ninja curl pcre2 netcdf gdal geos fftw libomp"
-conda_packages="ghostscript=10.02.1"
+conda_packages="ghostscript=10.03.0"
 
 # packages for build documentation
 if [ "$BUILD_DOCS" = "true" ]; then

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -28,7 +28,7 @@ echo "${VCPKG_INSTALLATION_ROOT}/installed/${WIN_PLATFORM}/tools/gdal" >> $GITHU
 # list installed packages
 vcpkg list
 
-conda_packages="ninja ghostscript=10.02.1"
+conda_packages="ninja ghostscript=10.03.0"
 if [ "$BUILD_DOCS" = "true" ]; then
     conda_packages+=" sphinx dvc"
     # choco install pngquant


### PR DESCRIPTION
Bump the Ghostscript version to 10.03.0 in the CI jobs. No new failing tests, so this PR should be good to merge.