### PR TITLE
Remove --GMT_THEME=cookbook from examples included in the docs

### DIFF
--- a/doc/scripts/GMT_-B_radians.sh
+++ b/doc/scripts/GMT_-B_radians.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt basemap -R-4/2/0/1 -Jx2.5c -Bxapi3fpi6 -BS --GMT_THEME=cookbook -view GMT_-B_radians
+gmt basemap -R-4/2/0/1 -Jx2.5c -Bxapi3fpi6 -BS -view GMT_-B_radians

--- a/doc/scripts/GMT_-B_slanted.sh
+++ b/doc/scripts/GMT_-B_slanted.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt basemap -R2000/2020/35/45 -JX12c -Bxa2f+a-30 -BS --GMT_THEME=cookbook -view GMT_-B_slanted
+gmt basemap -R2000/2020/35/45 -JX12c -Bxa2f+a-30 -BS -view GMT_-B_slanted

--- a/doc/scripts/GMT_-U.sh
+++ b/doc/scripts/GMT_-U.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt plot -R0/3/0/0.1 -Jx1i -U"optional command string or text here" -T --GMT_THEME=cookbook -view GMT_-U
+gmt plot -R0/3/0/0.1 -Jx1i -U"optional command string or text here" -T -view GMT_-U

--- a/doc/scripts/GMT_TM.sh
+++ b/doc/scripts/GMT_TM.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -R0/360/-80/80 -JT330/-45/10c -Ba30g -BWSne -Dc -A2000 -Slightblue -G0 --MAP_ANNOT_OBLIQUE=lon_horizontal --GMT_THEME=cookbook -view GMT_TM
+gmt coast -R0/360/-80/80 -JT330/-45/10c -Ba30g -BWSne -Dc -A2000 -Slightblue -G0 --MAP_ANNOT_OBLIQUE=lon_horizontal -view GMT_TM

--- a/doc/scripts/GMT_az_equidistant.sh
+++ b/doc/scripts/GMT_az_equidistant.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rg -JE-100/40/12c -Bg -Dc -A10000 -Glightgray -Wthinnest --GMT_THEME=cookbook -view GMT_az_equidistant
+gmt coast -Rg -JE-100/40/12c -Bg -Dc -A10000 -Glightgray -Wthinnest -view GMT_az_equidistant

--- a/doc/scripts/GMT_cassini.sh
+++ b/doc/scripts/GMT_cassini.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -R7:30/38:30/10:30/41:30+r -JC8.75/40/6c -Bafg -LjBR+c40+w100+f+o0.4c/0.5c -Dh -Gspringgreen -Sazure -Wthinnest -Ia/thinner --GMT_THEME=cookbook --FONT_LABEL=10p -view GMT_cassini
+gmt coast -R7:30/38:30/10:30/41:30+r -JC8.75/40/6c -Bafg -LjBR+c40+w100+f+o0.4c/0.5c -Dh -Gspringgreen -Sazure -Wthinnest -Ia/thinner --FONT_LABEL=10p -view GMT_cassini

--- a/doc/scripts/GMT_coverlogo.sh
+++ b/doc/scripts/GMT_coverlogo.sh
@@ -4,4 +4,4 @@
 #
 #	Logo is 5.458" wide and 2.729" high and origin is lower left
 #
-gmt logo -Dx0/0+w5.458i -X0 -Y0 --GMT_THEME=cookbook -view GMT_coverlogo
+gmt logo -Dx0/0+w5.458i -X0 -Y0 -view GMT_coverlogo

--- a/doc/scripts/GMT_eckert4.sh
+++ b/doc/scripts/GMT_eckert4.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rg -JKf12c -Bg -Dc -A10000 -Wthinnest -Givory -Sbisque3 --GMT_THEME=cookbook -view GMT_eckert4
+gmt coast -Rg -JKf12c -Bg -Dc -A10000 -Wthinnest -Givory -Sbisque3 -view GMT_eckert4

--- a/doc/scripts/GMT_equi_cyl.sh
+++ b/doc/scripts/GMT_equi_cyl.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rg -JQ12c -B60f30g30 -Dc -A5000 -Gtan4 -Slightcyan --GMT_THEME=cookbook -view GMT_equi_cyl
+gmt coast -Rg -JQ12c -B60f30g30 -Dc -A5000 -Gtan4 -Slightcyan -view GMT_equi_cyl

--- a/doc/scripts/GMT_general_cyl.sh
+++ b/doc/scripts/GMT_general_cyl.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -R-145/215/-90/90 -JY35/30/12c -B45g45 -Dc -A10000 -Sdodgerblue -Wthinnest --GMT_THEME=cookbook --MAP_FRAME_TYPE=fancy-rounded -view GMT_general_cyl
+gmt coast -R-145/215/-90/90 -JY35/30/12c -B45g45 -Dc -A10000 -Sdodgerblue -Wthinnest --MAP_FRAME_TYPE=fancy-rounded -view GMT_general_cyl

--- a/doc/scripts/GMT_gnomonic.sh
+++ b/doc/scripts/GMT_gnomonic.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rg -JF-120/35/60/12c -B30g15 -Dc -A10000 -Gtan -Scyan -Wthinnest --GMT_THEME=cookbook -view GMT_gnomonic
+gmt coast -Rg -JF-120/35/60/12c -B30g15 -Dc -A10000 -Gtan -Scyan -Wthinnest -view GMT_gnomonic

--- a/doc/scripts/GMT_grinten.sh
+++ b/doc/scripts/GMT_grinten.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # GRAPHICSMAGICK_RMS = 0.0035
-gmt coast -Rg -JV10c -Bg -Dc -Glightgray -Scornsilk -A10000 -Wthinnest --GMT_THEME=cookbook -view GMT_grinten
+gmt coast -Rg -JV10c -Bg -Dc -Glightgray -Scornsilk -A10000 -Wthinnest -view GMT_grinten

--- a/doc/scripts/GMT_hammer.sh
+++ b/doc/scripts/GMT_hammer.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rg -JH12c -Bg -Dc -A10000 -Gblack -Scornsilk --GMT_THEME=cookbook -view GMT_hammer
+gmt coast -Rg -JH12c -Bg -Dc -A10000 -Gblack -Scornsilk -view GMT_hammer

--- a/doc/scripts/GMT_lambert_az_hemi.sh
+++ b/doc/scripts/GMT_lambert_az_hemi.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rg -JA280/30/12c -Bg -Dc -A1000 -Gnavy --GMT_THEME=cookbook -view GMT_lambert_az_hemi
+gmt coast -Rg -JA280/30/12c -Bg -Dc -A1000 -Gnavy -view GMT_lambert_az_hemi

--- a/doc/scripts/GMT_miller.sh
+++ b/doc/scripts/GMT_miller.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -R-90/270/-80/90 -Jj1:400000000 -Bx45g45 -By30g30 -Dc -A10000 -Gkhaki -Wthinnest -Sazure --GMT_THEME=cookbook -view GMT_miller
+gmt coast -R-90/270/-80/90 -Jj1:400000000 -Bx45g45 -By30g30 -Dc -A10000 -Gkhaki -Wthinnest -Sazure -view GMT_miller

--- a/doc/scripts/GMT_mollweide.sh
+++ b/doc/scripts/GMT_mollweide.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rd -JW12c -Bg -Dc -A10000 -Gtomato1 -Sskyblue --GMT_THEME=cookbook -view GMT_mollweide
+gmt coast -Rd -JW12c -Bg -Dc -A10000 -Gtomato1 -Sskyblue -view GMT_mollweide

--- a/doc/scripts/GMT_orthographic.sh
+++ b/doc/scripts/GMT_orthographic.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rg -JG-75/41/12c -Bg -Dc -A5000 -Gpink -Sthistle --GMT_THEME=cookbook -view GMT_orthographic
+gmt coast -Rg -JG-75/41/12c -Bg -Dc -A5000 -Gpink -Sthistle -view GMT_orthographic

--- a/doc/scripts/GMT_perspective.sh
+++ b/doc/scripts/GMT_perspective.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rg -JG4/52/12c+z230+a90+t60+w180+v60 -Bx2g2 -By1g1 -Ia -Di -Glightbrown -Wthinnest -Slightblue --GMT_THEME=cookbook --MAP_ANNOT_MIN_SPACING=0.6c -view GMT_perspective
+gmt coast -Rg -JG4/52/12c+z230+a90+t60+w180+v60 -Bx2g2 -By1g1 -Ia -Di -Glightbrown -Wthinnest -Slightblue --MAP_ANNOT_MIN_SPACING=0.6c -view GMT_perspective

--- a/doc/scripts/GMT_polyconic.sh
+++ b/doc/scripts/GMT_polyconic.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -R-180/-20/0/90 -JPoly/10c -Bx30g10 -By10g10 -Dc -A1000 -Glightgray -Wthinnest --GMT_THEME=cookbook -view GMT_polyconic
+gmt coast -R-180/-20/0/90 -JPoly/10c -Bx30g10 -By10g10 -Dc -A1000 -Glightgray -Wthinnest -view GMT_polyconic

--- a/doc/scripts/GMT_robinson.sh
+++ b/doc/scripts/GMT_robinson.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rd -JN12c -Bg -Dc -A10000 -Ggoldenrod -Ssnow2 --GMT_THEME=cookbook -view GMT_robinson
+gmt coast -Rd -JN12c -Bg -Dc -A10000 -Ggoldenrod -Ssnow2 -view GMT_robinson

--- a/doc/scripts/GMT_sinusoidal.sh
+++ b/doc/scripts/GMT_sinusoidal.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rd -JI12c -Bg -Dc -A10000 -Gcoral4 -Sazure3 --GMT_THEME=cookbook -view GMT_sinusoidal
+gmt coast -Rd -JI12c -Bg -Dc -A10000 -Gcoral4 -Sazure3 -view GMT_sinusoidal

--- a/doc/scripts/GMT_stereographic_polar.sh
+++ b/doc/scripts/GMT_stereographic_polar.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -R-30/30/60/72 -Js0/90/12c/60 -B10g -Dl -A250 -Groyalblue -Sseashell --GMT_THEME=cookbook -view GMT_stereographic_polar
+gmt coast -R-30/30/60/72 -Js0/90/12c/60 -B10g -Dl -A250 -Groyalblue -Sseashell -view GMT_stereographic_polar

--- a/doc/scripts/GMT_transverse_merc.sh
+++ b/doc/scripts/GMT_transverse_merc.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -R20/30/50/45+r -Jt35/0.5c -Bag -Dl -A250 -Glightbrown -Wthinnest -Sseashell --GMT_THEME=cookbook -view GMT_transverse_merc
+gmt coast -R20/30/50/45+r -Jt35/0.5c -Bag -Dl -A250 -Glightbrown -Wthinnest -Sseashell -view GMT_transverse_merc

--- a/doc/scripts/GMT_winkel.sh
+++ b/doc/scripts/GMT_winkel.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-gmt coast -Rd -JR12c -Bg -Dc -A10000 -Gburlywood4 -Swheat1 --GMT_THEME=cookbook -view GMT_winkel
+gmt coast -Rd -JR12c -Bg -Dc -A10000 -Gburlywood4 -Swheat1 -view GMT_winkel


### PR DESCRIPTION
Remove `--GMT_THEME=cookbook` from scripts that are included in the docs. No new tests fail, so these changes don't affect our tests.

Partially address #6649.

