### PR TITLE
doc: Fix the order for sections included in the documentation

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -29,16 +29,6 @@ it can do.
             - :ref:`Grid Format Specifications <tbl-grdformats>`
             - :doc:`theme-settings`
 
-.. Add a hidden toctree to suppress "document isn't included in any toctree" warnings
-.. toctree::
-   :hidden:
-
-   std-opts
-   gmt.conf
-   gmtcolors
-   color-picker
-   theme-settings
-
 .. grid:: 1 2 2 2
 
     .. grid-item-card::
@@ -90,3 +80,13 @@ it can do.
             GMT C API </devdocs/api>
             PostScriptLight C API </devdocs/postscriptlight>
             /devdocs/devdocs
+
+.. Add a hidden toctree to suppress "document isn't included in any toctree" warnings
+.. toctree::
+   :hidden:
+
+   std-opts
+   gmt.conf
+   gmtcolors
+   color-picker
+   theme-settings


### PR DESCRIPTION
If you visit the documentation landing page (https://docs.generic-mapping-tools.org/dev/index.html) and click the "Next" button at the end. You'll see the "Standard Options" page, then "gmt.conf" page, then "gmtcolors" page.

This is not ideal and is inconsistent with the order of sections on the left sidebar.

This PR fixes the issue by moving the hidden toctree to the end.