### PR TITLE
The nc check for valid_min, valid_max of xx and yy coordinates breaks valid grids.

### DIFF
--- a/src/gmt_nc.c
+++ b/src/gmt_nc.c
@@ -682,10 +682,18 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 		if (has_vector && header->n_columns == 1) has_vector = false;	/* One coordinate does not a vector make */
 
 		/* Look for the x-coordinate range attributes */
+
+		/* 
+		   Don't understand what this was meant to do. It screwes the coordinates when xx or yy have a valid_min|max
+		   attribute set to (for example lon) [-180 180] but the vector itself contains a subset of that range,
+		   which is a perfectly valid set.
+	
 		has_range = (!nc_get_att_double (ncid, ids[HH->xy_dim[0]], "actual_range", dummy) ||
 			!nc_get_att_double (ncid, ids[HH->xy_dim[0]], "valid_range", dummy) ||
 			!(nc_get_att_double (ncid, ids[HH->xy_dim[0]], "valid_min", &dummy[0]) +
 			nc_get_att_double (ncid, ids[HH->xy_dim[0]], "valid_max", &dummy[1])));
+		*/
+		has_range = (!nc_get_att_double (ncid, ids[HH->xy_dim[0]], "actual_range", dummy));
 
 		if (has_vector && has_range) {	/* Has both so we can do a basic sanity check */
 
@@ -784,10 +792,15 @@ GMT_LOCAL int gmtnc_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *head
 			dy = fabs (xy[1] - xy[0]);	/* Grid spacing in y */
 		}
 		if (has_vector && header->n_rows == 1) has_vector = false;	/* One coordinate does not a vector make */
+
+		/*
+		// Don't understand what this was meant to do. It screwes the coordinates when yy have a valid_min|max
 		has_range = (!nc_get_att_double (ncid, ids[HH->xy_dim[1]], "actual_range", dummy) ||
 			!nc_get_att_double (ncid, ids[HH->xy_dim[1]], "valid_range", dummy) ||
 			!(nc_get_att_double (ncid, ids[HH->xy_dim[1]], "valid_min", &dummy[0]) +
 			nc_get_att_double (ncid, ids[HH->xy_dim[1]], "valid_max", &dummy[1])));
+		*/
+		has_range = (!nc_get_att_double (ncid, ids[HH->xy_dim[1]], "actual_range", dummy));
 
 		if (has_vector && has_range) {	/* Has both so we can do a basic sanity check */
 			threshold = (0.5+GMT_CONV5_LIMIT) * dy;


### PR DESCRIPTION
I don't understand what was the idea of this check but it breaks reading perfectly valid netCDF files so this PR comments it.

Example that lead me to this fix.

This gets wrong coordinates
```
gmt grdinfo 2024011000.nc
grdinfo [WARNING]: The x-coordinates and range attribute are in conflict but range is exactly 360; we rely on this range
grdinfo [WARNING]: The y-coordinates and range attribute are in conflict but range is exactly 180; we rely on this range
2024011000.nc: Title: bathymetry
2024011000.nc: Command: 2018/11/12 14:45:24 +ATLANTIC Netcdf creation
2024011000.nc: Remark:
2024011000.nc: Pixel node registration used [Geographic grid]
2024011000.nc: Grid file format: nf = GMT netCDF format (32-bit float), CF-1.7
2024011000.nc: x_min: -180 x_max: 180 x_inc: 0.645161290323 name: longitude n_columns: 558
2024011000.nc: y_min: -90 y_max: 90 y_inc: 0.656934306569 (2365 sec) name: latitude n_rows: 274
```
 but with GDAL they are correct
```
gdalinfo 2024011000.nc
Driver: netCDF/Network Common Data Format
Files: 2024011000.nc
Size is 512, 512
Metadata:
  NC_GLOBAL#bulletin_date=2018-11-12 00:00:00
  NC_GLOBAL#bulletin_type=operational
  NC_GLOBAL#comment=+ATLANTIC operational modelling product
  NC_GLOBAL#contact=francisco.campuzano@colabatlantic.com
  NC_GLOBAL#Conventions=CF-1.6
  NC_GLOBAL#date=2024
  NC_GLOBAL#field_type=mean
  NC_GLOBAL#geospatial_lat_max=46.469978
  NC_GLOBAL#geospatial_lat_min=24.549999
  NC_GLOBAL#geospatial_lon_max=8.2502604
  NC_GLOBAL#geospatial_lon_min=-36.389999
```