### PR TITLE
cmake: Simplify the linking of OpenMP library in CMake and set OpenMP_ROOT for macOS CI

### DIFF
--- a/ci/config-gmt-unix.sh
+++ b/ci/config-gmt-unix.sh
@@ -21,6 +21,11 @@ set (CMAKE_C_FLAGS "-Wall -Wdeclaration-after-statement ${CMAKE_C_FLAGS}")
 set (CMAKE_C_FLAGS "-Wextra ${CMAKE_C_FLAGS}")
 EOF
 
+# Set OpenMP_ROOT so that CMake can find the libomp header and library on macOS
+if [[ "$RUNNER_OS" == "macOS" ]]; then
+    echo "set (OpenMP_ROOT $(brew --prefix)/opt/libomp/)" >> cmake/ConfigUser.cmake
+fi
+
 if [[ "$RUN_TESTS" == "true" ]]; then
     cat >> cmake/ConfigUser.cmake << 'EOF'
 set (CMAKE_BUILD_TYPE Debug)

--- a/ci/simple-gmt-tests.bat
+++ b/ci/simple-gmt-tests.bat
@@ -2,8 +2,8 @@ REM
 REM Run some simple GMT commands
 REM
 
-REM Check GMT version
-gmt --version
+REM Check GMT splash screen
+gmt
 
 REM Check GMT configuration
 bash %INSTALLDIR%/bin/gmt-config --all
@@ -22,3 +22,6 @@ gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
 
 REM Check supplemental modules
 gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
+
+REM Check OpenMP support
+gmt grdsample @earth_relief_01d -R0/20/0/20 -I30m -Gtopo_30m.nc -x2

--- a/ci/simple-gmt-tests.sh
+++ b/ci/simple-gmt-tests.sh
@@ -5,8 +5,8 @@
 
 set -x -e
 
-# Check GMT version
-gmt --version
+# Check GMT splash screen
+gmt
 
 # Check GMT configuration
 gmt-config --all
@@ -27,5 +27,8 @@ gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
 
 # Check supplemental modules
 gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
+
+# Check OpenMP support
+gmt grdsample @earth_relief_01d -R0/20/0/20 -I30m -Gtopo_30m.nc -x2
 
 set +x +e

--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -127,6 +127,10 @@
 # Set location of CURL (can be root directory or path to header file) [auto]:
 #set (CURL_ROOT "curl_install_prefix")
 
+# Set location of OpenMP (can be root directory or path to header file) [auto]:
+# CMake sometimes may fail to find the OpenMP library (libomp) on macOS.
+#set (OpenMP_ROOT $(brew --prefix)/opt/libomp/)
+
 # Set location of GLIB component gthread [auto].  This is an optional (and
 # experimental) option which you need to enable or disable:
 set (GMT_USE_THREADS TRUE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -224,7 +224,7 @@ endif (LAPACK_FOUND)
 
 # Need to know if macOS and kernel is >= 22.4.0 for newLapack syntax
 if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
-	execute_process (COMMAND bash "-c" "echo ${CMAKE_HOST_SYSTEM_VERSION} | awk -F. '{if ($1 > 22 || ($1 == 22 && $2 > 3)) {print 1} else {print 0}}'" 
+	execute_process (COMMAND bash "-c" "echo ${CMAKE_HOST_SYSTEM_VERSION} | awk -F. '{if ($1 > 22 || ($1 == 22 && $2 > 3)) {print 1} else {print 0}}'"
 		OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE ACCELERATE_NEW_LAPACK)
 else (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
 	set (ACCELERATE_NEW_LAPACK 0)
@@ -272,15 +272,14 @@ if (APPLE)
 	list (APPEND GMT_OPTIONAL_LIBRARIES ${ACCELERATE_FRAMEWORK})
 endif (APPLE)
 
-find_package (OpenMP)
+find_package (OpenMP COMPONENTS C)
 if (GMT_OPENMP)
 	set (GMT_ENABLE_OPENMP TRUE)
 	message (WARNING "CMake variable GMT_OPENMP is deprecated and will be removed in the future releases. Use GMT_ENABLE_OPENMP instead.")
 endif (GMT_OPENMP)
 if (OPENMP_FOUND AND GMT_ENABLE_OPENMP)
+	list (APPEND GMT_OPTIONAL_LIBRARIES OpenMP::OpenMP_C)
 	set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-	set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-	set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${OpenMP_SHARED_LINKER_FLAGS}")
 	set (HAVE_OPENMP TRUE CACHE INTERNAL "OpenMP enabled." FORCE)
 	set (GMT_CONFIG_OPENMP_MESSAGE "enabled" CACHE INTERNAL "OPENMP config message")
 elseif (OPENMP_FOUND AND NOT GMT_ENABLE_OPENMP)


### PR DESCRIPTION
This PR fixes the issue linking the OpenMP library on macOS, especially when using the macOS default C compiler: AppleClang. This is done by linking the library using the syntax like `target_link_libraries(hello OpenMP::OpenMP_C)`, instead of manually updating the `CMAKE_EXE_LINKER_FLAGS`/`CMAKE_SHARED_LINKER_FLAGS` cmake variables.

xref: https://gist.github.com/scivision/16c2ca1dc250f54d34f1a1a35596f4a0

In our macOS CI, we also need to define `OpenMP_ROOT` so that cmake can find the OpenMP header and library correctly.

A new test is also added to make sure that OpenMP is enabled in our CI:
```
gmt grdsample @earth_relief_01d -R0/20/0/20 -I30m -Gtopo_30m.nc -x2
```

Closes #1926.