### PR TITLE
cmake: Set GMT_BUILD_DATE to the current date or the last commit date

### DIFF
--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -59,9 +59,6 @@ endif (NOT CMAKE_BUILD_TYPE)
 # Here we change it to add the git commit hash for non-public releases
 set (GMT_PACKAGE_VERSION_WITH_GIT_REVISION ${GMT_PACKAGE_VERSION})
 
-# ...
-set (GMT_BUILD_DATE ${GMT_BUILD_DATE})
-
 # Check if it's a git repository or not
 if (EXISTS ${GMT_SOURCE_DIR}/.git)
 	set (HAVE_GIT_VERSION TRUE)
@@ -95,11 +92,15 @@ if (GIT_FOUND AND HAVE_GIT_VERSION AND NOT GMT_PUBLIC_RELEASE)
 	endif (GIT_RETURN_CODE)
 endif (GIT_FOUND AND HAVE_GIT_VERSION AND NOT GMT_PUBLIC_RELEASE)
 
-execute_process (COMMAND ${GIT_EXECUTABLE} log -1 --date=short --pretty=format:%cd
-	WORKING_DIRECTORY ${GMT_SOURCE_DIR}
-	OUTPUT_VARIABLE GMT_BUILD_DATE
-	OUTPUT_STRIP_TRAILING_WHITESPACE)
-string(REPLACE "-" "." GMT_BUILD_DATE "${GMT_BUILD_DATE}")
+# Set the GMT building date
+string(TIMESTAMP GMT_BUILD_DATE "%Y.%m.%d" UTC)  # Default to current year.
+if (HAVE_GIT_VERSION)
+	execute_process (COMMAND ${GIT_EXECUTABLE} log -1 --date=short --pretty=format:%cd
+		WORKING_DIRECTORY ${GMT_SOURCE_DIR}
+		OUTPUT_VARIABLE GMT_BUILD_DATE
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	string(REPLACE "-" "." GMT_BUILD_DATE "${GMT_BUILD_DATE}")
+endif (HAVE_GIT_VERSION)
 
 # apply license restrictions
 if (LICENSE_RESTRICTED) # on


### PR DESCRIPTION
When building the GMT release tarball (not a git repository), I see an error like:
```
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```
The error was introduced in #7468, because for release tarballs, there is no `.git` directory, so `git log` command doesn't work. 

This PR fixes the issue by setting the `GMT_BUILD_DATE` to the current UTC date by default, and only use the last commit date if it's a git repository.

Patches #7468.