### PR TITLE
Documentation: Rename the name of the links from "See cookbook information" to "See technical reference"

### DIFF
--- a/doc/rst/source/common_SYN_OPTs.rst_
+++ b/doc/rst/source/common_SYN_OPTs.rst_
@@ -80,10 +80,10 @@
 
 .. |SYN_OPT-Area| replace:: |-A|\ *min\_area*\ [/*min\_level*/*max\_level*][**+a**\ [**g**\|\ **i**][**s**\|\ **S**]][**+l**\|\ **r**][**+p**\ *percent*]
 
-.. |Add_-B_links| replace:: :ref:`(See full description) <-B_full>` :ref:`(See cookbook information)
+.. |Add_-B_links| replace:: :ref:`(See full description) <-B_full>` :ref:`(See technical reference)
     <reference/options:Map frame and axes annotations: The **-B** option>`.
 
-.. |Add_-J_links| replace:: :ref:`(See full description) <-J_full>` :ref:`(See cookbook summary)
+.. |Add_-J_links| replace:: :ref:`(See full description) <-J_full>` :ref:`(See technical reference)
     <reference/options:Coordinate transformations and map projections: The **-J** option>`
     :ref:`(See projections table) <proj-codes>`.
 
@@ -93,16 +93,16 @@
    provided, the region will be automatically determined based on the data in *table*
    (equivalent to using **-Ra**). |Add_-R_links|
 
-.. |Add_-R_links| replace:: :ref:`(See full description) <-R_full>` :ref:`(See cookbook information)
+.. |Add_-R_links| replace:: :ref:`(See full description) <-R_full>` :ref:`(See technical reference)
     <reference/options:Data domain or map region: The **-R** option>`.
 
-.. |Add_-XY_links| replace:: :ref:`(See full description) <-XY_full>` :ref:`(See cookbook information)
+.. |Add_-XY_links| replace:: :ref:`(See full description) <-XY_full>` :ref:`(See technical reference)
     <reference/options:Plot positioning and layout: The **-X** **-Y** options>`.
 
-.. |Add_-U_links| replace:: :ref:`(See full description) <-U_full>` :ref:`(See cookbook information)
+.. |Add_-U_links| replace:: :ref:`(See full description) <-U_full>` :ref:`(See technical reference)
     <reference/options:Timestamps on plots: The **-U** option>`.
 
-.. |Add_-V_links| replace:: :ref:`(See full description) <-V_full>` :ref:`(See cookbook information)
+.. |Add_-V_links| replace:: :ref:`(See full description) <-V_full>` :ref:`(See technical reference)
     <reference/options:Verbose feedback: The **-V** option>`.
 
 .. |br| raw:: html

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -211,11 +211,11 @@ These are all the common GMT options that remain the same for all GMT
 modules. No space between the option flag and the associated arguments.
 
 .. _-B_full:
-.. |Add_-B| replace:: :ref:`(See cookbook information) <reference/options:Map frame and axes annotations: The **-B** option>`.
+.. |Add_-B| replace:: :ref:`(See technical reference) <reference/options:Map frame and axes annotations: The **-B** option>`.
 .. include:: explain_-B.rst_
 
 .. _-J_full:
-.. |Add_-J| replace:: :ref:`(See cookbook summary)
+.. |Add_-J| replace:: :ref:`(See technical reference)
     <reference/options:Coordinate transformations and map projections: The **-J** option>`
     :ref:`(See projections table) <proj-codes>`.
 .. include:: explain_-J.rst_
@@ -229,7 +229,7 @@ modules. No space between the option flag and the associated arguments.
 .. include:: explain_-Jproj_full.rst_
 
 .. _-R_full:
-.. |Add_-R| replace:: :ref:`(See cookbook information) <reference/options:Data domain or map region: The **-R** option>`.
+.. |Add_-R| replace:: :ref:`(See technical reference) <reference/options:Data domain or map region: The **-R** option>`.
 .. include:: explain_-R.rst_
 
 .. _-Rz_full:
@@ -238,15 +238,15 @@ modules. No space between the option flag and the associated arguments.
 .. include:: explain_-Rz_full.rst_
 
 .. _-U_full:
-.. |Add_-U| replace:: :ref:`(See cookbook information) <reference/options:Timestamps on plots: The **-U** option>`.
+.. |Add_-U| replace:: :ref:`(See technical reference) <reference/options:Timestamps on plots: The **-U** option>`.
 .. include:: explain_-U.rst_
 
 .. _-V_full:
-.. |Add_-V| replace:: :ref:`(See cookbook information) <reference/options:Verbose feedback: The **-V** option>`.
+.. |Add_-V| replace:: :ref:`(See technical reference) <reference/options:Verbose feedback: The **-V** option>`.
 .. include:: explain_-V.rst_
 
 .. _-XY_full:
-.. |Add_-XY| replace:: :ref:`(See cookbook information) <reference/options:Plot positioning and layout: The **-X** **-Y** options>`.
+.. |Add_-XY| replace:: :ref:`(See technical reference) <reference/options:Plot positioning and layout: The **-X** **-Y** options>`.
 .. include:: explain_-XY.rst_
 
 .. _-aspatial_full:


### PR DESCRIPTION
**Description of proposed changes**

As "cookbook" was renamed to "technical reference," I feel it makes sense to also update the name of the links in the documentation from "See cookbook information" to "See technical reference".

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
