### PR TITLE
cmake: Use the builtin FindLATEX module to search for latex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,7 @@ if (DO_EXAMPLES OR DO_TESTS AND NOT GRAPHICSMAGICK)
 endif (DO_EXAMPLES OR DO_TESTS AND NOT GRAPHICSMAGICK)
 
 # Find latex and dvips for LaTeX integration
-find_program (LATEX latex)
-find_program (DVIPS dvips)
+find_package (LATEX COMPONENTS DVIPS)
 
 # Add subdirectories
 add_subdirectory (src)

--- a/doc/scripts/CMakeLists.txt
+++ b/doc/scripts/CMakeLists.txt
@@ -94,9 +94,9 @@ foreach (skip_test GMT_-U.sh GMT_encoding.sh gen_data_App_O.sh gen_data_dummy.sh
 endforeach()
 
 # Remove GMT_latex.sh if latex or dvips not found
-if (NOT LATEX OR NOT DVIPS)
+if (NOT LATEX_FOUND)
 	list (REMOVE_ITEM _scripts_tests doc/scripts/GMT_latex.sh doc/scripts/GMT_slope2intensity.sh doc/scripts/GMT_seamount_density.sh)
-endif (NOT LATEX OR NOT DVIPS)
+endif (NOT LATEX_FOUND)
 
 if (DO_TESTS AND BASH)
 	foreach (_job ${_scripts_tests})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,9 +40,9 @@ if (DO_TESTS)
 	endif (NOT DO_SUPPLEMENT_TESTS)
 
 	# Remove latex-specific tests if latex or dvips not found
-	if (NOT LATEX OR NOT DVIPS)
+	if (NOT LATEX_FOUND)
 		list (REMOVE_ITEM GMT_TEST_DIRS latex)
-	endif (NOT LATEX OR NOT DVIPS)
+	endif (NOT LATEX_FOUND)
 
 	# export HAVE_GMT_DEBUG_SYMBOLS
 	get_directory_property (_dir_defs COMPILE_DEFINITIONS)


### PR DESCRIPTION
**Description of proposed changes**

Use `find_package (LATEX COMPONENTS DVIPS)` instead of
```
find_program (LATEX latex)
find_program (DVIPS dvips)
```
xref: https://cmake.org/cmake/help/latest/module/FindLATEX.html