### PR TITLE
cmake: Do not install .dvc files in the doc directory

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -66,4 +66,5 @@ install (DIRECTORY examples
 	PATTERN "CMakeLists.txt" EXCLUDE
 	PATTERN "gmt.history" EXCLUDE
 	PATTERN ".DS_Store" EXCLUDE
+	PATTERN "*.dvc" EXCLUDE
 	REGEX "[.](cmake|in|ps)$" EXCLUDE)


### PR DESCRIPTION
`.dvc` files in the `doc` directory should not be installed when running `ninja install`.