### PR TITLE
doc: Add a single introduction page

### DIFF
--- a/doc/rst/source/index.rst
+++ b/doc/rst/source/index.rst
@@ -37,6 +37,7 @@ it can do.
             :maxdepth: 1
             :caption: Getting started
 
+            intro
             install
             gallery
             animations

--- a/doc/rst/source/intro.rst
+++ b/doc/rst/source/intro.rst
@@ -35,15 +35,3 @@ maximize flexibility.  We standardized early on to use PostScript output
 instead of other graphics formats.  Apart from the built-in support for
 coastlines, GMT completely decouples data retrieval from the main
 GMT modules.  GMT uses architecture-independent file formats.
-
-GMT installation considerations
--------------------------------
-
-See the :doc:`install guide </install>`
-for instructions and to make sure you have all required dependencies installed.
-Alternatively, you can build GMT from source by following the
-`building guide <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`_.
-
-In addition, we recommend access to any flavor of the UNIX operating system
-(UNIX, Linux, macOS, Cygwin, MinGW, etc.).
-We do not recommend using the DOS command window under Windows.

--- a/doc/rst/source/tutorial/bash/index.rst
+++ b/doc/rst/source/tutorial/bash/index.rst
@@ -33,6 +33,15 @@ sufficient detail.  Nevertheless, it is hoped that the exposure
 will prompt the users to improve their GMT and UNIX skills
 after completion of this short tutorial.
 
+See the :doc:`install guide </install>`
+for instructions and to make sure you have all required dependencies installed.
+Alternatively, you can build GMT from source by following the
+`building guide <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`_.
+
+In addition, we recommend access to any flavor of the UNIX operating system
+(UNIX, Linux, macOS, Cygwin, MinGW, etc.).
+We do not recommend using the DOS command window under Windows.
+
 .. note::
    This tutorial is for GMT 6 modern mode only. Looking for the classic mode tutorial?
    Since classic mode commands haven't changed since GMT 5, please visit
@@ -41,7 +50,6 @@ after completion of this short tutorial.
 .. toctree::
     :maxdepth: 1
 
-    intro
     session-1
     session-2
     session-3

--- a/doc/rst/source/tutorial/julia/index.rst
+++ b/doc/rst/source/tutorial/julia/index.rst
@@ -25,10 +25,18 @@ still redirect to the hard-core GMT man pages, whilst others direct users to Jul
 the translated GMT manuals. A *lost case* is the GMT Technical Reference that is so big/complete that it
 will take long time to see a Julia version of it.
 
+See the :doc:`install guide </install>`
+for instructions and to make sure you have all required dependencies installed.
+Alternatively, you can build GMT from source by following the
+`building guide <https://github.com/GenericMappingTools/gmt/blob/master/BUILDING.md>`_.
+
+In addition, we recommend access to any flavor of the UNIX operating system
+(UNIX, Linux, macOS, Cygwin, MinGW, etc.).
+We do not recommend using the DOS command window under Windows.
+
 .. toctree::
     :maxdepth: 1
 
-    intro
     session-1
     session-2
     session-3


### PR DESCRIPTION
Address #8513.

Remove the two introduction pages in the bash and Julia tutorials and add a new one at the start of the documentation.