### PR TITLE
Fix the color depth returned when reading the gray.cpt master CPT.

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8788,7 +8788,7 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 	if (n < n_alloc) X->data = gmt_M_memory (GMT, X->data, n, struct GMT_LUT);
 	X->n_colors = n;
 
-	/* The master gray.cpt has only one slice and hence it comes aout as both gray & bw, but it can only be one of them. */
+	/* The master gray.cpt has only one slice and hence it comes out as both gray & bw, but it can only be one of them. */
 	if (X->n_colors == 1 && X->is_gray && X->is_bw) X->is_bw = false;	/* Prefer gray over bw (would crash grdimage with externals). */
 
 	if (X->categorical) {	/* Set up fake ranges so CPT is continuous */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -8788,6 +8788,9 @@ struct GMT_PALETTE * gmtlib_read_cpt (struct GMT_CTRL *GMT, void *source, unsign
 	if (n < n_alloc) X->data = gmt_M_memory (GMT, X->data, n, struct GMT_LUT);
 	X->n_colors = n;
 
+	/* The master gray.cpt has only one slice and hence it comes aout as both gray & bw, but it can only be one of them. */
+	if (X->n_colors == 1 && X->is_gray && X->is_bw) X->is_bw = false;	/* Prefer gray over bw (would crash grdimage with externals). */
+
 	if (X->categorical) {	/* Set up fake ranges so CPT is continuous */
 		dz = 1.0;	/* This will presumably get reset in the loop */
 		for (i = 0; i < X->n_colors; i++) {


### PR DESCRIPTION
The master CPT gray.cpt has only one slice that fits both the `is_gray` and `is_bw` tests and hence returns with both as true, which is obviously wrong and cause that when passed to grdimage together with a grid from Julia the image_8 container was not initialized and a crash followed (see https://github.com/GenericMappingTools/GMT.jl/issues/1472).