### PR TITLE
coast.rst: -E argument, improve description of +l and +L

### DIFF
--- a/doc/rst/source/coast.rst
+++ b/doc/rst/source/coast.rst
@@ -128,7 +128,7 @@ Optional Arguments
 
     - **+l** to just list the countries and their codes (no data extraction or plotting takes place).
     - **+L** to see states/territories for Argentina, Australia, Brazil, Canada, China, India, Norway, Russia and the US.
-    - **+l**\|\ **+L** to **-E**\ =\ *continent* or **-E**\ *code* to only list countries in that continent or country;
+    - **+l**\|\ **+L** to **-E**\ =\ *continent* or **-E**\ *code* to only list countries or states in that continent or country, respectively;
       repeat if more than one continent or country is requested.
     - **+n** to list the named :ref:`DCW collections <dcw-collections>` or regions (**-E**\ *code*\ **+n** will list
       collections that contains the listed codes). All names are case-insensitive.


### PR DESCRIPTION
Make it clear(er) that ``-E<code>+L`` will list states for the given code.