### PR TITLE
Add a new modifier to -f, -fa, to permit reading files with text in the first column.

### DIFF
--- a/doc/rst/source/explain_-f_full.rst_
+++ b/doc/rst/source/explain_-f_full.rst_
@@ -23,8 +23,13 @@ all items from the given column and to the end of the record should be considere
 
 Three shorthand options for common selections are available. The shorthand **-f**\ [**i**\|\ **o**]\ **g** means
 **-f**\ [**i**\|\ **o**]0x,1y (i.e., geographic coordinates), while **-f**\ [**i**\|\ **o**]\ **c** means
-**-f**\ [**i**\|\ **o**]0:1\ **f** (i.e., Cartesian coordinates). A special use of **-f** is to select
+**-f**\ [**i**\|\ **o**]0:1\ **f** (i.e., Cartesian coordinates). A first special use of **-f** is to select
 **-fp**\ [*unit*], which *requires* **-J -R** and lets you use *projected* map coordinates (e.g., UTM meters) as data input.
 Such coordinates are automatically inverted to longitude, latitude during the data import. Optionally, append a length
-*unit* (see table :ref:`distance units <tbl-distunits>`) [default is meter]. For more information, see Sections
-:ref:`input-data-formats` and :ref:`output-data-formats`.
+*unit* (see table :ref:`distance units <tbl-distunits>`) [default is meter]. The second special case is to use **-fa**.
+We use this when reading a file whose first column is plain text (and NO date or time) followed by numeric records.
+Normally, such a file would result in a _"Selection led to no output columns"_ error because the file was interpreted
+to be made only of text (_i.,e.,_ no numbers). Or even worse, only part of the file is read. The **-fa** option
+forces the first column to be ignored (output as NaN) and the remaining records parsed normally. User may add the
+**-i1:** to fully drop that first column in reading. For more information, see Sections :ref:`input-data-formats`
+and :ref:`output-data-formats`.

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -1925,8 +1925,9 @@ GMT_LOCAL int gmtinit_parse_f_option (struct GMT_CTRL *GMT, char *arg) {
 			case 'x':	code = GMT_IS_LON;		break;		/* Longitude coordinates */
 			case 'y':	code = GMT_IS_LAT;		break;		/* Latitude coordinates */
 			case 'f':	code = GMT_IS_FLOAT;	break;		/* Plain floating point coordinates */
-			case 'd':	code = GMT_IS_DIMENSION;	break;	/* Length dimension (with possible unit) */
+			case 'd':	code = GMT_IS_DIMENSION;break;		/* Length dimension (with possible unit) */
 			case 's':	code = GMT_IS_STRING;	break;		/* This must be start of trailing text */
+			case 'a':	code = GMT_IS_FIRSTCOLSTR;	break;	/* First column is text followed by trailing numbers */
 			default:	/* No suffix, consider it an error */
 				GMT_Report (GMT->parent, GMT_MSG_ERROR, "Malformed -f argument [%s]\n", arg);
 				return 1;

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -3529,8 +3529,12 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 				got = gmt_scanf_arg (GMT, token, GMT_IS_UNKNOWN, false, &value);
 			if (got == GMT_IS_NAN) {	/* Parsing failed, which means we found our first non-number; but it could also be a valid NaN */
 				gmt_str_tolower (token);
-				if (strncmp (token, "nan", 3U))
-					found_text = true;
+				if (strncmp(token, "nan", 3U)) {
+					if (GMT->current.io.col_type[GMT_IN][0] == GMT_IS_FIRSTCOLSTR)
+						type[col++] = got = GMT_IS_FLOAT;
+					else
+						found_text = true;
+				}
 				else
 					type[col++] = got = GMT_IS_FLOAT;
 			}
@@ -3574,6 +3578,13 @@ GMT_LOCAL unsigned int gmtio_examine_current_record (struct GMT_CTRL *GMT, char 
 
 	for (k = 0; k < col; k++)	/* Check if we can utilize what we learned about each physical column */
 		gmtio_assign_col_type_if_notset (GMT, k, type[k]);
+
+	/* When -fa & -i was used here we still have a leading col_type = GMT_IS_FIRSTCOLSTR that would cause
+	   first col to always come out as NaN. Need to reset it GMT_IS_FLOAT.
+	*/
+	if (GMT->common.i.col.select && GMT->current.io.col_type[GMT_IN][0] == GMT_IS_FIRSTCOLSTR)
+		GMT->current.io.col_type[GMT_IN][0] = GMT_IS_FLOAT;
+
 	gmt_M_free (GMT, type);
 
 
@@ -7384,6 +7395,10 @@ int gmt_scanf (struct GMT_CTRL *GMT, char *s, unsigned int expectation, double *
 			return (type);
 			break;
 
+		case  GMT_IS_FIRSTCOLSTR:
+			return (GMT_IS_NAN);
+			break;
+
 		default:
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "GMT_LOGIC_BUG: gmt_scanf() called with invalid expectation.\n");
 			return (GMT_IS_NAN);
@@ -8161,7 +8176,7 @@ struct GMT_DATASET * gmtlib_create_dataset (struct GMT_CTRL *GMT, uint64_t n_tab
 }
 
 /*! . */
-struct GMT_DATATABLE * gmtlib_read_table (struct GMT_CTRL *GMT, void *source, unsigned int source_type, bool greenwich, unsigned int *geometry, unsigned int *data_type, bool use_GMT_io) {
+struct GMT_DATATABLE *gmtlib_read_table(struct GMT_CTRL *GMT, void *source, unsigned int source_type, bool greenwich, unsigned int *geometry, unsigned int *data_type, bool use_GMT_io) {
 	/* Reads an entire data set into a single table in memory with any number of segments */
 
 	bool ASCII, close_file = false, header = true, no_segments, first_seg = true, poly, this_is_poly = false;
@@ -8256,7 +8271,7 @@ struct GMT_DATATABLE * gmtlib_read_table (struct GMT_CTRL *GMT, void *source, un
 	}
 
 	if (GMT->current.io.record.data == NULL) *data_type = GMT_READ_TEXT;
-	In = GMT->current.io.input (GMT, fp, &n_expected_fields, &status);	/* Get first record */
+	In = GMT->current.io.input (GMT, fp, &n_expected_fields, &status);	/* Get first record. If == NULL means we read a header line. */
 	n_read++;
 	if (gmt_M_rec_is_eof(GMT)) {
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "File %s is empty!\n", file);
@@ -8332,7 +8347,8 @@ struct GMT_DATATABLE * gmtlib_read_table (struct GMT_CTRL *GMT, void *source, un
 			/* Segment initialization */
 			row = 0;
 			if (!no_segments) {	/* Read data if we read a segment header up front, but guard against headers which sets in = NULL */
-				while (!gmt_M_rec_is_eof (GMT) && (In = GMT->current.io.input (GMT, fp, &n_expected_fields, &status)) == NULL) n_read++;
+				while (!gmt_M_rec_is_eof (GMT) && (In = GMT->current.io.input (GMT, fp, &n_expected_fields, &status)) == NULL)
+					n_read++;
 			}
 			if (GMT->current.io.record_type[GMT_IN] == GMT_READ_TEXT)
 				S->n_columns = 0;	/* No numerical data */
@@ -8383,7 +8399,8 @@ struct GMT_DATATABLE * gmtlib_read_table (struct GMT_CTRL *GMT, void *source, un
 
 			row++;
 			In = GMT->current.io.input (GMT, fp, &n_expected_fields, &status);
-			while (gmt_M_rec_is_table_header (GMT)) In = GMT->current.io.input (GMT, fp, &n_expected_fields, &status);	/* Just wind past other comments */
+			while (gmt_M_rec_is_table_header (GMT))
+				In = GMT->current.io.input (GMT, fp, &n_expected_fields, &status);	/* Just wind past other comments */
 			n_read++;
 		}
 
@@ -8403,14 +8420,16 @@ struct GMT_DATATABLE * gmtlib_read_table (struct GMT_CTRL *GMT, void *source, un
 				double dlon = GMT->hidden.mem_coord[GMT_X][0] - GMT->hidden.mem_coord[GMT_X][row-1];
 				if (!((fabs (dlon) == 0.0 || fabs (dlon) == 360.0) && GMT->hidden.mem_coord[GMT_Y][0] == GMT->hidden.mem_coord[GMT_Y][row-1])) {
 					gmt_prep_tmp_arrays (GMT, GMT_IN, row, S->n_columns);	/* Maybe reallocate tmp read vectors */
-					for (col = 0; col < S->n_columns; col++) GMT->hidden.mem_coord[col][row] = GMT->hidden.mem_coord[col][0];
+					for (col = 0; col < S->n_columns; col++)
+						GMT->hidden.mem_coord[col][row] = GMT->hidden.mem_coord[col][0];
 					row++;	/* Explicitly close polygon */
 					GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Explicitly closed open geographic polygon in file %s, segment %" PRIu64 "\n", file, seg);
 				}
 			}
 			else if (gmt_polygon_is_open (GMT, GMT->hidden.mem_coord[GMT_X], GMT->hidden.mem_coord[GMT_Y], row)) {	/* Cartesian closure */
 				gmt_prep_tmp_arrays (GMT, GMT_IN, row, S->n_columns);	/* Init or update tmp read vectors */
-				for (col = 0; col < S->n_columns; col++) GMT->hidden.mem_coord[col][row] = GMT->hidden.mem_coord[col][0];
+				for (col = 0; col < S->n_columns; col++)
+					GMT->hidden.mem_coord[col][row] = GMT->hidden.mem_coord[col][0];
 				row++;	/* Explicitly close polygon */
 				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Explicitly closed open Cartesian polygon in file %s, segment %" PRIu64 "\n", file, seg);
 			}

--- a/src/gmt_io.h
+++ b/src/gmt_io.h
@@ -110,7 +110,8 @@ enum gmt_col_enum {
 	GMT_IS_AZIMUTH		=  512,	/* An angle to be converted via map projection to angle on map  */
 	GMT_IS_ANGLE		= 1024,	/* An angle to be used as is  */
 	GMT_IS_STRING		= 2048,	/* An text argument [internally used, not via -f]  */
-	GMT_IS_UNKNOWN		= 4096};	/* Input type is not knowable without -f */
+	GMT_IS_FIRSTCOLSTR	= 4096,	/* An text first column followed by numerics [set via -f]  */
+	GMT_IS_UNKNOWN		= 8192};/* Input type is not knowable without -f */
 
 /*! Various ways to report longitudes */
 enum GMT_lon_enum {


### PR DESCRIPTION
Reading files with text columns causes surprising problems or total failures. See these examples.

Put this in a `test.txt` file
```
blabla bla
blabla   1 10
4blablau 2 20
blabla   3 30
```
Now
```
gmt gmtconvert test.txt
gmtconvert [WARNING]: No data records provided
```
This happens because GMT can read text but only it comes after numeric records. But even this is not exactly true. Date and time columns may come in a first text column and GMT tries to parse that. So, if in the above example we replace `4blablau` by `4blablaT` the combination of a digit and the token ending with a `T` (or `t`) makes it being interpreted as a date, and now

```
gmt gmtconvert test.txt
-62040988800    2       20
NaN     3       30
```
that is, it reads second on on rows. Very disturbing.

It would be nice if we could catch all those cases automatically but my attempts to do it automatically lead to screw the automatic guessing of Date columns, so I was forced to introduce a new **-f** modifier (**a** at lack of a better letter) to force reading first column as float, even if it a text and with this we can

```
C:\v>gmtconvert ttt.dat -fa
NaN     NaN
NaN     1
NaN     2
NaN     3
```
Worked but header row is now reported as numeric too. Solvable by setting **-h1**

```
C:\v>gmtconvert test.txt -fa -h1
# blabla bla
# Command : gmt gmtconvert ttt.dat -fa -h1
NaN     1       10
NaN     2       20
NaN     3       30
```

and to get read of the header and first, garbage, column
```
C:\v>gmtconvert test.txt -fa -h1 -i1:
# blabla bla
# Command : gmt gmtconvert ttt.dat -fa -h1 -i1:
1       10
2       20
3       30
```

Not perfect but the GMT _IO_ is damn complicated.