### PR TITLE
Fix proj4string check in pscoast.c

### DIFF
--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -821,7 +821,7 @@ EXTERN_MSC int GMT_pscoast(void *V_API, int mode, void *args) {
 
 	/* Check and interpret the command line arguments */
 
-	if (!Ctrl->M.active && !Ctrl->Q.active && GMT->current.proj.is_proj4 && GMT->common.J.proj4string)
+	if (!Ctrl->M.active && !Ctrl->Q.active && GMT->current.proj.is_proj4 && GMT->common.J.proj4string[0])
 		reset_CT_transformers = pscoast_proj4_no_x0y0(GMT);	/* x_0, y_0 in proj4 string, screw the map coords */
 
 


### PR DESCRIPTION
**Description of proposed changes**

In pscoast.c `if (GMT->common.J.proj4string)` should be replaced by `if (GMT->common.J.proj4string[0])` because the former always evaluates to `true`, the second only when not an empty string.

**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
