### PR TITLE
gmt_common_sighandler.c: fix ucontext for Apple

### DIFF
--- a/src/gmt_common_sighandler.c
+++ b/src/gmt_common_sighandler.c
@@ -80,13 +80,19 @@ GMT_LOCAL void backtrace_symbols_fd(void *const *buffer, int size, int fd) {
 # if __DARWIN_UNIX03
 #  ifdef __x86_64__
 #   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__rip)
-#  elif __arm64__	/* Apple Silicon, e.g. M1 */
+#  elif defined(__arm64__)	/* Apple Silicon, e.g. M1 */
 #   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__pc)
+#  elif defined(__POWERPC__)	/* Both ppc and ppc64 */
+#   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__srr0)
 #  else
 #   define UC_IP(uc) ((void *) (uc)->uc_mcontext->__ss.__eip)
 #  endif
 # else
-#  define UC_IP(uc) ((void *) (uc)->uc_mcontext->ss.eip)
+#  ifdef __ppc__
+#   define UC_IP(uc) ((void *) (uc)->uc_mcontext->ss.srr0)
+#  else
+#   define UC_IP(uc) ((void *) (uc)->uc_mcontext->ss.eip)
+#  endif
 # endif
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 # ifdef __x86_64__


### PR DESCRIPTION
**Description of proposed changes**

Fix ucontext macros for macOS.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Current code falls back to x86 version on PowerPC, which is obviously wrong.

**Reminders**

Perhaps this is a trivial bug fix, there is no need to document it specifically.

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

P. S. I am not sure FreeBSD macro for PowerPC is correct. AFAIK, `__ppc__` is Apple-specific.
@pkubaj Could you please take a look? (I am not changing anything for FreeBSD in this PR, I mean to verify what the source has now.)