### PR TITLE
Update in the docs to netcdf 1.7

### DIFF
--- a/doc/rst/source/reference/features.rst
+++ b/doc/rst/source/reference/features.rst
@@ -2336,15 +2336,15 @@ approach should contact the GMT team for guidance.
 +==========+===============================================================+
 |          | *GMT 4 netCDF standard formats*                               |
 +----------+---------------------------------------------------------------+
-| nb       | GMT netCDF format (8-bit integer, COARDS, CF-1.5)             |
+| nb       | GMT netCDF format (8-bit integer, COARDS, CF-1.7)             |
 +----------+---------------------------------------------------------------+
-| ns       | GMT netCDF format (16-bit integer, COARDS, CF-1.5)            |
+| ns       | GMT netCDF format (16-bit integer, COARDS, CF-1.7)            |
 +----------+---------------------------------------------------------------+
-| ni       | GMT netCDF format (32-bit integer, COARDS, CF-1.5)            |
+| ni       | GMT netCDF format (32-bit integer, COARDS, CF-1.7)            |
 +----------+---------------------------------------------------------------+
-| nf       | GMT netCDF format (32-bit float, COARDS, CF-1.5)              |
+| nf       | GMT netCDF format (32-bit float, COARDS, CF-1.7)              |
 +----------+---------------------------------------------------------------+
-| nd       | GMT netCDF format (64-bit float, COARDS, CF-1.5)              |
+| nd       | GMT netCDF format (64-bit float, COARDS, CF-1.7)              |
 +----------+---------------------------------------------------------------+
 |          | *GMT 3 netCDF legacy formats*                                 |
 +----------+---------------------------------------------------------------+

--- a/doc/rst/source/reference/file-formats.rst
+++ b/doc/rst/source/reference/file-formats.rst
@@ -132,10 +132,10 @@ for ocean and atmosphere research. Sticking to this convention allows
 GMT to read gridded data provided by other institutes and other
 programs. Conversely, other general domain programs will be able to read
 grids created by GMT. COARDS is a subset of a more extensive
-convention for netCDF data called CF-1.5 (Climate and Forecast, version
-1.5). Hence, GMT grids are also automatically CF-1.5-compliant.
-However, since CF-1.5 has more general application than COARDS, not all
-CF-1.5 compliant netCDF files can be read by GMT.
+convention for netCDF data called CF-1.7 (Climate and Forecast, version
+1.7). Hence, GMT grids are also automatically CF-1.7-compliant.
+However, since CF-1.7 has more general application than COARDS, not all
+CF-1.7 compliant netCDF files can be read by GMT.
 
 The netCDF grid file in GMT has several attributes (See Table
 :ref:`netcdf-format <tbl-netcdf-format>`) to describe the content. The routine
@@ -149,7 +149,7 @@ slightly deviating from the standards used by GMT can also be read.
 +======================+====================================================================+
 |                      | *Global attributes*                                                |
 +----------------------+--------------------------------------------------------------------+
-| Conventions          | COARDS, CF-1.5 (optional)                                          |
+| Conventions          | COARDS, CF-1.7 (optional)                                          |
 +----------------------+--------------------------------------------------------------------+
 | title                | Title (optional)                                                   |
 +----------------------+--------------------------------------------------------------------+


### PR DESCRIPTION
I create a grid and I saw with grdinfo that the files formats are CF-1.7 (not CF-1.5).

I made this PR to update this.

Approve ONLY if it is correct