### PR TITLE
Fix error in indexing for matrix-to-grid input

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -5522,6 +5522,10 @@ start_over_import_grid:		/* We may get here if we cannot honor a GMT_IS_REFERENC
 					else if (S_obj->wesn[XHI] < G_obj->header->wesn[XLO]) { /* Must first wrap G_obj->header->wesn east to fit the data */
 						G_obj->header->wesn[XLO] -= 360.0;	G_obj->header->wesn[XHI] -= 360.0;
 					}
+					if (S_obj->wesn[XLO] < G_obj->header->wesn[XLO]) {
+						/* Must wrap G_obj->header.wesn so the left bound in S_obj is smaller larger than that in G_obj, otherwise i0 is negative (but it's defined as unsigned int */
+						G_obj->header->wesn[XLO] -= 360.0;	G_obj->header->wesn[XHI] -= 360.0;
+					}
 				}
 				j1 = (unsigned int)gmt_M_grd_y_to_row (GMT, S_obj->wesn[YLO]+dy, G_obj->header);
 				j0 = (unsigned int)gmt_M_grd_y_to_row (GMT, S_obj->wesn[YHI]-dy, G_obj->header);
@@ -6341,7 +6345,11 @@ start_over_import_cube:		/* We may get here if we cannot honor a GMT_IS_REFERENC
 					if (S_obj->wesn[XLO] > U_obj->header->wesn[XHI]) { /* Must first wrap U_obj->header->wesn west to fit the data */
 						U_obj->header->wesn[XLO] += 360.0;	U_obj->header->wesn[XHI] += 360.0;
 					}
-					else if (S_obj->wesn[XHI] < U_obj->header->wesn[XLO]) { /* Must first wrap G_obj->header->wesn east to fit the data */
+					else if (S_obj->wesn[XHI] < U_obj->header->wesn[XLO]) { /* Must first wrap U_obj->header->wesn east to fit the data */
+						U_obj->header->wesn[XLO] -= 360.0;	U_obj->header->wesn[XHI] -= 360.0;
+					}
+					if (S_obj->wesn[XLO] < U_obj->header->wesn[XLO]) {
+						/* Must wrap U_obj->header.wesn so the left bound in S_obj is smaller larger than that in U_obj, otherwise i0 is negative (but it's defined as unsigned int */
 						U_obj->header->wesn[XLO] -= 360.0;	U_obj->header->wesn[XHI] -= 360.0;
 					}
 				}


### PR DESCRIPTION
**Description of proposed changes**

Related to #5294 and #5947 and patches #5947.

`S_obj->wesn[XLO]` can't be smaller than `G_obj->header->wesn[XLO]`, because at line below:
```
i0 = (unsigned int)gmt_M_grd_x_to_col (GMT, S_obj->wesn[XLO]+dx, G_obj->header);
```
The macro is expanded to something like:
```
(S_obj->wesn[XLO]+dx - G_obj->header->wesn[XLO]) / G_obj->header->inc[GMT_X] - G_obj->header->xy_off
```
If `S_obj->wesn[XLO] < G_obj->header->wesn[XLO]`, then the result is negative, but `i0` is defined as `unsigned int` on Linux/macOS. Then `i0` has a weird positive value, making the for loop below fail.

On Windows, it doesn't have the issue, because `openmp_int` is defined as `int` on Windows.

