### PR TITLE
Projection table: Remove unclear semicolon

### DIFF
--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -15,7 +15,7 @@
      - GMT CODES
      - Parameters
    * -
-     - **-J** (*scale*\|\ *WIDTH*);
+     - **-J** (*scale*\|\ *WIDTH*)
      -
    * - :ref:`Lambert azimuthal equal area <-Ja>`
      - **-Ja**\|\ **A**


### PR DESCRIPTION
**Description of proposed changes**

This PR removes a (unclear) semicolon from the projection table (https://docs.generic-mapping-tools.org/dev/reference/map-projections.html#gmt-map-projections):
![projection_table_semicolon](https://github.com/user-attachments/assets/c04c8115-5b09-4e1e-a16a-c47030e066a9)

(or is this semicolon required for a correct rst table syntax ?)

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
