### PR TITLE
DOC/projections: Make projection name consistent

### DIFF
--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -17,13 +17,13 @@
    * -
      - **-J** (*scale*\|\ *WIDTH*)
      -
-   * - :ref:`Lambert azimuthal equal-area <-Ja>`
+   * - :ref:`Lambert azimuthal <-Ja>`
      - **-Ja**\|\ **A**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
-   * - :ref:`Albers conic equal-area <-Jb>`
+   * - :ref:`Albers conic <-Jb>`
      - **-Jb**\|\ **B**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
-   * - :ref:`Cassini cylindrical <-Jc>`
+   * - :ref:`Cassini <-Jc>`
      - **-Jc**\|\ **C**
      - |lon0|/|lat0|/\ *scale*\|\ *width*
    * - :ref:`Cylindrical stereographic <-Jcyl_stere>`
@@ -44,25 +44,25 @@
    * - :ref:`General perspective <-Jg_pers>`
      - **-Jg**\|\ **G**
      - |lon0|/|lat0|\ */*\ *scale*\|\ *width*\ [**+a**\ *azimuth*][**+t**\ *tilt*][**+v**\ *vwidth/vheight*][**+w**\ *twist*][**+z**\ *altitude*\ [**r**\|\ **R**]\|\ **g**]
-   * - :ref:`Hammer equal-area <-Jh>`
+   * - :ref:`Hammer <-Jh>`
      - **-Jh**\|\ **H**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Sinusoidal equal-area <-Ji>`
+   * - :ref:`Sinusoidal <-Ji>`
      - **-Ji**\|\ **I**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Miller cylindrical <-Jj>`
+   * - :ref:`Miller <-Jj>`
      - **-Jj**\|\ **J**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Eckert IV equal-area <-Jk>`
+   * - :ref:`Eckert IV <-Jk>`
      - **-Jkf**\|\ **Kf**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Eckert VI equal-area <-Jk>`
+   * - :ref:`Eckert VI <-Jk>`
      - **-Jks**\|\ **Ks**
      - [|lon0|/]\ *scale*\|\ *width*
    * - :ref:`Lambert conic conformal <-Jl>`
      - **-Jl**\|\ **L**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
-   * - :ref:`Mercator cylindrical <-Jm>`
+   * - :ref:`Mercator <-Jm>`
      - **-Jm**\|\ **M**
      - [|lon0|/\ [|lat0|/]]\ *scale*\|\ *width*
    * - :ref:`Robinson <-Jn>`
@@ -90,7 +90,7 @@
    * - :ref:`Winkel Tripel <-Jr>`
      - **-Jr**\|\ **R**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`General stereographic <-Js>`
+   * - :ref:`Stereographic <-Js>`
      - **-Js**\|\ **S**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
    * - :ref:`Transverse Mercator <-Jt>`
@@ -110,6 +110,6 @@
      - **-Jx**\|\ **X**
      - *xscale*\|\ *width*\ [**l**\|\ **p**\ *power*\|\ **T**\|\ **t**]\
        [/\ *yscale*\|\ *height*\ [**l**\|\ **p**\ *power*\|\ **T**\|\ **t**]][**d**]
-   * - :ref:`Cylindrical equal-area <-Jy>`
+   * - :ref:`Cylindrical <-Jy>`
      - **-Jy**\|\ **Y**
      - |lon0|/|lat0|/\ *scale*\|\ *width*

--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -17,31 +17,31 @@
    * -
      - **-J** (*scale*\|\ *WIDTH*)
      -
-   * - :ref:`Lambert azimuthal <-Ja>`
+   * - :ref:`Lambert azimuthal projection <-Ja>`
      - **-Ja**\|\ **A**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
-   * - :ref:`Albers conic <-Jb>`
+   * - :ref:`Albers conic projection <-Jb>`
      - **-Jb**\|\ **B**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
    * - :ref:`Cassini projection <-Jc>`
      - **-Jc**\|\ **C**
      - |lon0|/|lat0|/\ *scale*\|\ *width*
-   * - :ref:`Cylindrical stereographic <-Jcyl_stere>`
+   * - :ref:`Cylindrical stereographic projection <-Jcyl_stere>`
      - **-Jcyl_stere**\|\ **Cyc_stere**
      - [|lon0|\ [/|lat0|]/]\ *scale*\|\ *width*
-   * - :ref:`Equidistant conic <-Jd>`
+   * - :ref:`Equidistant conic projection <-Jd>`
      - **-Jd**\|\ **D**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
-   * - :ref:`Azimuthal equidistant <-Je>`
+   * - :ref:`Azimuthal equidistant projection <-Je>`
      - **-Je**\|\ **E**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
-   * - :ref:`Azimuthal gnomonic <-Jf>`
+   * - :ref:`Azimuthal gnomonic projection <-Jf>`
      - **-Jf**\|\ **F**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
-   * - :ref:`Azimuthal orthographic <-Jg>`
+   * - :ref:`Azimuthal orthographic projection <-Jg>`
      - **-Jg**\|\ **G**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
-   * - :ref:`General perspective <-Jg_pers>`
+   * - :ref:`General perspective projection <-Jg_pers>`
      - **-Jg**\|\ **G**
      - |lon0|/|lat0|\ */*\ *scale*\|\ *width*\ [**+a**\ *azimuth*][**+t**\ *tilt*][**+v**\ *vwidth/vheight*][**+w**\ *twist*][**+z**\ *altitude*\ [**r**\|\ **R**]\|\ **g**]
    * - :ref:`Hammer projection <-Jh>`
@@ -59,7 +59,7 @@
    * - :ref:`Eckert VI projection <-Jk>`
      - **-Jks**\|\ **Ks**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Lambert conic conformal <-Jl>`
+   * - :ref:`Lambert conic conformal projection <-Jl>`
      - **-Jl**\|\ **L**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
    * - :ref:`Mercator projection <-Jm>`
@@ -81,16 +81,16 @@
      - **-Jp**\|\ **P**
      - *scale*\|\ *width*\ [**+a**]\ [**+f**\ [**e**\|\ **p**\|\ *radius*]]\ [**+k**\ *kind*]\
        [**+r**\ *offset*][**+t**\ *origin*][**+z**\ [**p**\|\ *radius*]]
-   * - :ref:`(American) polyconic <-Jpoly>`
+   * - :ref:`(American) polyconic projection <-Jpoly>`
      - **-Jpoly**\|\ **Poly**
      - [|lon0|/\ [|lat0|/]]\ *scale*\|\ *width*
-   * - :ref:`Equidistant cylindrical <-Jq>`
+   * - :ref:`Equidistant cylindrical projection <-Jq>`
      - **-Jq**\|\ **Q**
      - [|lon0|/\ [|lat0|/]]\ *scale*\|\ *width*
-   * - :ref:`Winkel Tripel <-Jr>`
+   * - :ref:`Winkel Tripel projection <-Jr>`
      - **-Jr**\|\ **R**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Stereographic <-Js>`
+   * - :ref:`Stereographic projection <-Js>`
      - **-Js**\|\ **S**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
    * - :ref:`Transverse Mercator projection <-Jt>`
@@ -110,6 +110,6 @@
      - **-Jx**\|\ **X**
      - *xscale*\|\ *width*\ [**l**\|\ **p**\ *power*\|\ **T**\|\ **t**]\
        [/\ *yscale*\|\ *height*\ [**l**\|\ **p**\ *power*\|\ **T**\|\ **t**]][**d**]
-   * - :ref:`Cylindrical <-Jy>`
+   * - :ref:`Cylindrical projection <-Jy>`
      - **-Jy**\|\ **Y**
      - |lon0|/|lat0|/\ *scale*\|\ *width*

--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -77,7 +77,7 @@
    * - :ref:`Oblique Mercator projection, 3: origin and pole <-Jo>`
      - **-Jo**\|\ **O**\ **c**\|\ **C**
      - |lon0|/|lat0|/|lonp|/|latp|/\ *scale*\|\ *width*\ [**+v**]
-   * - :ref:`Polar [azimuthal] <-Jp>`  (:math:`\theta, r`) (or cylindrical)
+   * - :ref:`Polar [azimuthal] <-Jp>` (:math:`\theta, r`) (or cylindrical)
      - **-Jp**\|\ **P**
      - *scale*\|\ *width*\ [**+a**]\ [**+f**\ [**e**\|\ **p**\|\ *radius*]]\ [**+k**\ *kind*]\
        [**+r**\ *offset*][**+t**\ *origin*][**+z**\ [**p**\|\ *radius*]]

--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -99,7 +99,7 @@
    * - :ref:`Universal Transverse Mercator (UTM) projection <-Ju>`
      - **-Ju**\|\ **U**
      - *zone*/*scale*\|\ *width*
-   * - :ref:`Van der Grinten <-Jv>`
+   * - :ref:`Van der Grinten projection <-Jv>`
      - **-Jv**\|\ **V**
      - [|lon0|/]\ *scale*\|\ *width*
    * - :ref:`Mollweide projection <-Jw>`

--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -17,10 +17,10 @@
    * -
      - **-J** (*scale*\|\ *WIDTH*)
      -
-   * - :ref:`Lambert azimuthal projection <-Ja>`
+   * - :ref:`Lambert azimuthal equal-area projection <-Ja>`
      - **-Ja**\|\ **A**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
-   * - :ref:`Albers conic projection <-Jb>`
+   * - :ref:`Albers conic equal-area projection <-Jb>`
      - **-Jb**\|\ **B**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
    * - :ref:`Cassini projection <-Jc>`
@@ -44,19 +44,19 @@
    * - :ref:`General perspective projection <-Jg_pers>`
      - **-Jg**\|\ **G**
      - |lon0|/|lat0|\ */*\ *scale*\|\ *width*\ [**+a**\ *azimuth*][**+t**\ *tilt*][**+v**\ *vwidth/vheight*][**+w**\ *twist*][**+z**\ *altitude*\ [**r**\|\ **R**]\|\ **g**]
-   * - :ref:`Hammer projection <-Jh>`
+   * - :ref:`Hammer equal-area projection <-Jh>`
      - **-Jh**\|\ **H**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Sinusoidal projection <-Ji>`
+   * - :ref:`Sinusoidal equal-area projection <-Ji>`
      - **-Ji**\|\ **I**
      - [|lon0|/]\ *scale*\|\ *width*
    * - :ref:`Miller projection <-Jj>`
      - **-Jj**\|\ **J**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Eckert IV projection <-Jk>`
+   * - :ref:`Eckert IV equal-area projection <-Jk>`
      - **-Jkf**\|\ **Kf**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Eckert VI projection <-Jk>`
+   * - :ref:`Eckert VI equal-area projection <-Jk>`
      - **-Jks**\|\ **Ks**
      - [|lon0|/]\ *scale*\|\ *width*
    * - :ref:`Lambert conic conformal projection <-Jl>`
@@ -110,6 +110,6 @@
      - **-Jx**\|\ **X**
      - *xscale*\|\ *width*\ [**l**\|\ **p**\ *power*\|\ **T**\|\ **t**]\
        [/\ *yscale*\|\ *height*\ [**l**\|\ **p**\ *power*\|\ **T**\|\ **t**]][**d**]
-   * - :ref:`Cylindrical projection <-Jy>`
+   * - :ref:`Cylindrical equal-area projection <-Jy>`
      - **-Jy**\|\ **Y**
      - |lon0|/|lat0|/\ *scale*\|\ *width*

--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -17,10 +17,10 @@
    * -
      - **-J** (*scale*\|\ *WIDTH*)
      -
-   * - :ref:`Lambert azimuthal equal area <-Ja>`
+   * - :ref:`Lambert azimuthal equal-area <-Ja>`
      - **-Ja**\|\ **A**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
-   * - :ref:`Albers conic equal area <-Jb>`
+   * - :ref:`Albers conic equal-area <-Jb>`
      - **-Jb**\|\ **B**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
    * - :ref:`Cassini cylindrical <-Jc>`
@@ -44,19 +44,19 @@
    * - :ref:`General perspective <-Jg_pers>`
      - **-Jg**\|\ **G**
      - |lon0|/|lat0|\ */*\ *scale*\|\ *width*\ [**+a**\ *azimuth*][**+t**\ *tilt*][**+v**\ *vwidth/vheight*][**+w**\ *twist*][**+z**\ *altitude*\ [**r**\|\ **R**]\|\ **g**]
-   * - :ref:`Hammer equal area <-Jh>`
+   * - :ref:`Hammer equal-area <-Jh>`
      - **-Jh**\|\ **H**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Sinusoidal equal area <-Ji>`
+   * - :ref:`Sinusoidal equal-area <-Ji>`
      - **-Ji**\|\ **I**
      - [|lon0|/]\ *scale*\|\ *width*
    * - :ref:`Miller cylindrical <-Jj>`
      - **-Jj**\|\ **J**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Eckert IV equal area <-Jk>`
+   * - :ref:`Eckert IV equal-area <-Jk>`
      - **-Jkf**\|\ **Kf**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Eckert VI equal area <-Jk>`
+   * - :ref:`Eckert VI equal-area <-Jk>`
      - **-Jks**\|\ **Ks**
      - [|lon0|/]\ *scale*\|\ *width*
    * - :ref:`Lambert conic conformal <-Jl>`
@@ -68,7 +68,7 @@
    * - :ref:`Robinson <-Jn>`
      - **-Jn**\|\ **N**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Oblique Mercator, 1: origin and azim <-Jo>`
+   * - :ref:`Oblique Mercator, 1: origin and azimuth <-Jo>`
      - **-Jo**\|\ **O**\ **a**\|\ **A**
      - |lon0|/|lat0|/\ *azim*/*scale*\|\ *width*\ [**+v**]
    * - :ref:`Oblique Mercator, 2: two points <-Jo>`
@@ -81,7 +81,7 @@
      - **-Jp**\|\ **P**
      - *scale*\|\ *width*\ [**+a**]\ [**+f**\ [**e**\|\ **p**\|\ *radius*]]\ [**+k**\ *kind*]\
        [**+r**\ *offset*][**+t**\ *origin*][**+z**\ [**p**\|\ *radius*]]
-   * - :ref:`(American) polyconic <-Jpoly>` 
+   * - :ref:`(American) polyconic <-Jpoly>`
      - **-Jpoly**\|\ **Poly**
      - [|lon0|/\ [|lat0|/]]\ *scale*\|\ *width*
    * - :ref:`Equidistant cylindrical <-Jq>`
@@ -110,6 +110,6 @@
      - **-Jx**\|\ **X**
      - *xscale*\|\ *width*\ [**l**\|\ **p**\ *power*\|\ **T**\|\ **t**]\
        [/\ *yscale*\|\ *height*\ [**l**\|\ **p**\ *power*\|\ **T**\|\ **t**]][**d**]
-   * - :ref:`Cylindrical equal area <-Jy>`
+   * - :ref:`Cylindrical equal-area <-Jy>`
      - **-Jy**\|\ **Y**
      - |lon0|/|lat0|/\ *scale*\|\ *width*

--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -84,7 +84,7 @@
    * - :ref:`(American) polyconic projection <-Jpoly>`
      - **-Jpoly**\|\ **Poly**
      - [|lon0|/\ [|lat0|/]]\ *scale*\|\ *width*
-   * - :ref:`Equidistant cylindrical projection <-Jq>`
+   * - :ref:`Cylindrical equidistant projection <-Jq>`
      - **-Jq**\|\ **Q**
      - [|lon0|/\ [|lat0|/]]\ *scale*\|\ *width*
    * - :ref:`Winkel Tripel projection <-Jr>`

--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -23,7 +23,7 @@
    * - :ref:`Albers conic <-Jb>`
      - **-Jb**\|\ **B**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
-   * - :ref:`Cassini <-Jc>`
+   * - :ref:`Cassini projection <-Jc>`
      - **-Jc**\|\ **C**
      - |lon0|/|lat0|/\ *scale*\|\ *width*
    * - :ref:`Cylindrical stereographic <-Jcyl_stere>`
@@ -44,37 +44,37 @@
    * - :ref:`General perspective <-Jg_pers>`
      - **-Jg**\|\ **G**
      - |lon0|/|lat0|\ */*\ *scale*\|\ *width*\ [**+a**\ *azimuth*][**+t**\ *tilt*][**+v**\ *vwidth/vheight*][**+w**\ *twist*][**+z**\ *altitude*\ [**r**\|\ **R**]\|\ **g**]
-   * - :ref:`Hammer <-Jh>`
+   * - :ref:`Hammer projection <-Jh>`
      - **-Jh**\|\ **H**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Sinusoidal <-Ji>`
+   * - :ref:`Sinusoidal projection <-Ji>`
      - **-Ji**\|\ **I**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Miller <-Jj>`
+   * - :ref:`Miller projection <-Jj>`
      - **-Jj**\|\ **J**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Eckert IV <-Jk>`
+   * - :ref:`Eckert IV projection <-Jk>`
      - **-Jkf**\|\ **Kf**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Eckert VI <-Jk>`
+   * - :ref:`Eckert VI projection <-Jk>`
      - **-Jks**\|\ **Ks**
      - [|lon0|/]\ *scale*\|\ *width*
    * - :ref:`Lambert conic conformal <-Jl>`
      - **-Jl**\|\ **L**
      - |lon0|/|lat0|/|lat1|/|lat2|/\ *scale*\|\ *width*
-   * - :ref:`Mercator <-Jm>`
+   * - :ref:`Mercator projection <-Jm>`
      - **-Jm**\|\ **M**
      - [|lon0|/\ [|lat0|/]]\ *scale*\|\ *width*
-   * - :ref:`Robinson <-Jn>`
+   * - :ref:`Robinson projection <-Jn>`
      - **-Jn**\|\ **N**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Oblique Mercator, 1: origin and azim <-Jo>`
+   * - :ref:`Oblique Mercator projection, 1: origin and azim <-Jo>`
      - **-Jo**\|\ **O**\ **a**\|\ **A**
      - |lon0|/|lat0|/\ *azim*/*scale*\|\ *width*\ [**+v**]
-   * - :ref:`Oblique Mercator, 2: two points <-Jo>`
+   * - :ref:`Oblique Mercator projection, 2: two points <-Jo>`
      - **-Jo**\|\ **O**\ **b**\|\ **B**
      - |lon0|/|lat0|/|lon1|/|lat1|/\ *scale*\|\ *width*\ [**+v**]
-   * - :ref:`Oblique Mercator, 3: origin and pole <-Jo>`
+   * - :ref:`Oblique Mercator projection, 3: origin and pole <-Jo>`
      - **-Jo**\|\ **O**\ **c**\|\ **C**
      - |lon0|/|lat0|/|lonp|/|latp|/\ *scale*\|\ *width*\ [**+v**]
    * - :ref:`Polar [azimuthal] <-Jp>`  (:math:`\theta, r`) (or cylindrical)
@@ -93,16 +93,16 @@
    * - :ref:`Stereographic <-Js>`
      - **-Js**\|\ **S**
      - |lon0|/|lat0|\ [/\ *horizon*]/\ *scale*\|\ *width*
-   * - :ref:`Transverse Mercator <-Jt>`
+   * - :ref:`Transverse Mercator projection <-Jt>`
      - **-Jt**\|\ **T**
      - |lon0|/\ [|lat0|/]\ *scale*\|\ *width*
-   * - :ref:`Universal Transverse Mercator (UTM) <-Ju>`
+   * - :ref:`Universal Transverse Mercator (UTM) projection <-Ju>`
      - **-Ju**\|\ **U**
      - *zone*/*scale*\|\ *width*
    * - :ref:`Van der Grinten <-Jv>`
      - **-Jv**\|\ **V**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Mollweide <-Jw>`
+   * - :ref:`Mollweide projection <-Jw>`
      - **-Jw**\|\ **W**
      - [|lon0|/]\ *scale*\|\ *width*
    * - :ref:`Linear <-Jx_linear>`, :ref:`logarithmic <-Jx_log>`,

--- a/doc/rst/source/proj-codes.rst_
+++ b/doc/rst/source/proj-codes.rst_
@@ -68,7 +68,7 @@
    * - :ref:`Robinson <-Jn>`
      - **-Jn**\|\ **N**
      - [|lon0|/]\ *scale*\|\ *width*
-   * - :ref:`Oblique Mercator, 1: origin and azimuth <-Jo>`
+   * - :ref:`Oblique Mercator, 1: origin and azim <-Jo>`
      - **-Jo**\|\ **O**\ **a**\|\ **A**
      - |lon0|/|lat0|/\ *azim*/*scale*\|\ *width*\ [**+v**]
    * - :ref:`Oblique Mercator, 2: two points <-Jo>`

--- a/doc/rst/source/reference/coordinate-transformations.rst
+++ b/doc/rst/source/reference/coordinate-transformations.rst
@@ -20,7 +20,7 @@ Finally, note that while we will specify dimensions in inches (by appending **i*
 points (**p**) as :ref:`unit <reference/features:Dimension units>` instead.
 
 Cartesian coordinate transformations
---------------------------------------------------------------------------------
+------------------------------------
 
 GMT Cartesian coordinate transformations come in three flavors:
 
@@ -50,7 +50,7 @@ operates on or creates table data:
 .. _-Jx_linear:
 
 Linear coordinate transformation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There are in fact three different uses of the Cartesian linear transformation, each associated with specific command
 line options. The different manifestations result from specific properties of three kinds of data:
@@ -190,7 +190,7 @@ A simple plot of a school week calendar can be made as follows:
 .. _-Jx_log:
 
 Logarithmic coordinate transformation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -229,7 +229,7 @@ A plot in which the *x*-axis is logarithmic (the *y*-axis remains linear, i.e., 
 .. _-Jx_power:
 
 Power (exponential) coordinate transformation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -267,7 +267,7 @@ Since :math:`q = 1` we do not need to specify **p**\ 1 since it is identical to 
 .. _-Jp:
 
 Polar coordinate transformations
---------------------------------------------------------------------------------
+--------------------------------
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -400,8 +400,8 @@ next to its equal-area cousin in the Section `Lambert azimuthal equal-area proje
 
 .. _-Jg_pers:
 
-General perspective projection (**-Jg** **-JG**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Perspective projection (**-Jg** **-JG**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -450,8 +450,8 @@ following :doc:`/coast` command (*lon0*\ =4; *lat0*\ =52; *altitude*\ =230 km; *
 
 .. _-Jg:
 
-Azimuthal orthographic projection (**-Jg** **-JG**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Orthographic projection (**-Jg** **-JG**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -528,8 +528,8 @@ perimeter:
 
 .. _-Jf:
 
-Azimuthal gnomonic projection (**-Jf** **-JF**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gnomonic projection (**-Jf** **-JF**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -887,7 +887,7 @@ As with the previous projections, the user can choose between a rectangular boun
 
 .. _-Jq:
 
-Equidistant cylindrical projection (**-Jq** **-JQ**)
+Cylindrical equidistant projection (**-Jq** **-JQ**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -218,7 +218,7 @@ Azimuthal projections
 
 .. _-Ja:
 
-Lambert Azimuthal Equal-Area (**-Ja** **-JA**)
+Lambert azimuthal equal-area (**-Ja** **-JA**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
@@ -308,8 +308,8 @@ stereonet can be obtained by using the stereographic projection
 
 .. _-Js:
 
-Stereographic Equal-Angle (**-Js** **-JS**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Stereographic equal-angle (**-Js** **-JS**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -340,8 +340,8 @@ We will look at two different types of maps.
 Multiple types of maps can be made with this projection depending on how the region is specified. We will give
 examples in the next three subsections.
 
-Polar Stereographic Map
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Polar stereographic map
+^^^^^^^^^^^^^^^^^^^^^^^
 
 In our first example we will let the projection center be at the north
 pole. This means we have a polar stereographic projection and the map
@@ -400,8 +400,8 @@ next to its equal-area cousin in the Section `Lambert Azimuthal Equal-Area (-Ja 
 
 .. _-Jg_pers:
 
-Perspective projection (**-Jg** **-JG**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+General perspective (**-Jg** **-JG**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -450,8 +450,8 @@ following :doc:`/coast` command (*lon0*\ =4; *lat0*\ =52; *altitude*\ =230 km; *
 
 .. _-Jg:
 
-Orthographic projection (**-Jg** **-JG**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Azimuthal orthographic (**-Jg** **-JG**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -489,8 +489,8 @@ command:
 
 .. _-Je:
 
-Azimuthal Equidistant projection (**-Je** **-JE**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Azimuthal equidistant (**-Je** **-JE**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -528,8 +528,8 @@ perimeter:
 
 .. _-Jf:
 
-Gnomonic projection (**-Jf** **-JF**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Azimuthal gnomonic (**-Jf** **-JF**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -577,8 +577,8 @@ Each have a different way of spacing the meridians and parallels to obtain certa
 
 .. _-Jm:
 
-Mercator projection (**-Jm** **-JM**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Mercator cylindrical (**-Jm** **-JM**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -627,8 +627,8 @@ example, specify the region with **-R**-180/180/-70/70 to obtain a map centered 
 
 .. _-Jt:
 
-Transverse Mercator projection (**-Jt** **-JT**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Transverse Mercator (**-Jt** **-JT**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -685,8 +685,8 @@ latitudes in the regular Mercator projection and must therefore be less than 90Â
 
 .. _-Ju:
 
-Universal Transverse Mercator (UTM) projection (**-Ju** **-JU**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Universal Transverse Mercator (UTM) (**-Ju** **-JU**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -730,8 +730,8 @@ formulae instead.
 
 .. _-Jo:
 
-Oblique Mercator projection (**-Jo** **-JO**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Oblique Mercator (**-Jo** **-JO**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Option 1 Syntax**
 
@@ -846,8 +846,8 @@ to align the oblique Equator with the vertical, positive *y*-axis instead.  This
 
 .. _-Jc:
 
-Cassini cylindrical projection (**-Jc** **-JC**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cassini cylindrical (**-Jc** **-JC**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -887,8 +887,8 @@ As with the previous projections, the user can choose between a rectangular boun
 
 .. _-Jq:
 
-Cylindrical equidistant projection (**-Jq** **-JQ**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Equidistant cylindrical (**-Jq** **-JQ**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -941,8 +941,8 @@ A world map centered on the dateline using this projection can be obtained as fo
 
 .. _-Jy:
 
-Cylindrical equal-area projections (**-Jy** **-JY**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cylindrical equal-area (**-Jy** **-JY**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1002,8 +1002,8 @@ As one can see there is considerable distortion at high latitudes since the pole
 
 .. _-Jj:
 
-Miller Cylindrical projection (**-Jj** **-JJ**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Miller cylindrical (**-Jj** **-JJ**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1041,8 +1041,8 @@ can be obtained as follows:
 
 .. _-Jcyl_stere:
 
-Cylindrical stereographic projections (**-Jcyl_stere** **-JCyl_stere**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cylindrical stereographic (**-Jcyl_stere** **-JCyl_stere**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1110,8 +1110,8 @@ range of the plot, specified by the (**-R**) option.
 
 .. _-Jh:
 
-Hammer projection (**-Jh** **-JH**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Hammer equal-area (**-Jh** **-JH**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1143,8 +1143,8 @@ A view of the Pacific ocean using the Dateline as central meridian can be genera
 
 .. _-Jw:
 
-Mollweide projection (**-Jw** **-JW**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Mollweide (**-Jw** **-JW**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1177,8 +1177,8 @@ An example centered on Greenwich can be generated thus:
 
 .. _-Jr:
 
-Winkel Tripel projection (**-Jr** **-JR**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Winkel Tripel (**-Jr** **-JR**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1219,8 +1219,8 @@ Centered on Greenwich, the example in Figure :ref:`Winkel Tripel projection <GMT
 
 .. _-Jn:
 
-Robinson projection (**-Jn** **-JN**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Robinson (**-Jn** **-JN**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1254,8 +1254,8 @@ Again centered on Greenwich, the example below was created by this command:
 
 .. _-Jk:
 
-Eckert IV and VI projection (**-Jk** **-JK**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Eckert IV and VI equal-area (**-Jk** **-JK**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1305,8 +1305,8 @@ The same script, with **s** instead of **f**, yields the Eckert VI map:
 
 .. _-Ji:
 
-Sinusoidal projection (**-Ji** **-JI**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sinusoidal equal-area (**-Ji** **-JI**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1358,8 +1358,8 @@ distributions like hydrocarbon and mineral resources, etc.
 
 .. _-Jv:
 
-Van der Grinten projection (**-Jv** **-JV**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Van der Grinten (**-Jv** **-JV**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -50,7 +50,7 @@ Conic projections
 .. _-Jb:
 
 Albers conic equal-area projection (**-Jb** **-JB**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -219,7 +219,7 @@ Azimuthal projections
 .. _-Ja:
 
 Lambert azimuthal equal-area projection (**-Ja** **-JA**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -309,7 +309,7 @@ stereonet can be obtained by using the stereographic projection
 .. _-Js:
 
 Stereographic equal-angle projection (**-Js** **-JS**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -942,7 +942,7 @@ A world map centered on the dateline using this projection can be obtained as fo
 .. _-Jy:
 
 Cylindrical equal-area projection (**-Jy** **-JY**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1111,7 +1111,7 @@ range of the plot, specified by the (**-R**) option.
 .. _-Jh:
 
 Hammer equal-area projection (**-Jh** **-JH**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -1002,8 +1002,8 @@ As one can see there is considerable distortion at high latitudes since the pole
 
 .. _-Jj:
 
-Miller (**-Jj** **-JJ**)
-~~~~~~~~~~~~~~~~~~~~~~~~
+Miller projection (**-Jj** **-JJ**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -396,7 +396,7 @@ hemispheric maps. Our example shows Australia using a projection pole at
 
 
 By choosing 0/0 as the pole, we obtain the conformal stereonet presented
-next to its equal-area cousin in the Section `Lambert azimuthal (-Ja -JA)`_ on the Lambert azimuthal projection (Figure :ref:`Stereonets <GMT_stereonets>`).
+next to its equal-area cousin in the Section `Lambert azimuthal equal-area projection (-Ja -JA)`_ on the Lambert azimuthal projection (Figure :ref:`Stereonets <GMT_stereonets>`).
 
 .. _-Jg_pers:
 
@@ -846,8 +846,8 @@ to align the oblique Equator with the vertical, positive *y*-axis instead.  This
 
 .. _-Jc:
 
-Cassini projection (**-Jc** **-JC**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cassini cylindrical projection (**-Jc** **-JC**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1002,8 +1002,8 @@ As one can see there is considerable distortion at high latitudes since the pole
 
 .. _-Jj:
 
-Miller projection (**-Jj** **-JJ**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Miller cylindrical projection (**-Jj** **-JJ**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -577,8 +577,8 @@ Each have a different way of spacing the meridians and parallels to obtain certa
 
 .. _-Jm:
 
-Mercator cylindrical (**-Jm** **-JM**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Mercator (**-Jm** **-JM**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -49,8 +49,8 @@ Conic projections
 
 .. _-Jb:
 
-Albers conic (**-Jb** **-JB**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Albers conic projection (**-Jb** **-JB**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -92,8 +92,8 @@ generate the map below is therefore given by:
 
 .. _-Jd:
 
-Equidistant conic (**-Jd** **-JD**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Equidistant conic projection (**-Jd** **-JD**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -127,8 +127,8 @@ map of Cuba:
 
 .. _-Jl:
 
-Lambert conic conformal (**-Jl** **-JL**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lambert conic conformal projection (**-Jl** **-JL**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -172,8 +172,8 @@ latitudes 30.5°N and 47.5°N of 0.5–1%. Some areas, like Florida, experience 
 
 .. _-Jpoly:
 
-(American) polyconic (**-Jpoly** **-JPoly**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(American) polyconic projection (**-Jpoly** **-JPoly**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -218,8 +218,8 @@ Azimuthal projections
 
 .. _-Ja:
 
-Lambert azimuthal (**-Ja** **-JA**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lambert azimuthal projection (**-Ja** **-JA**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -308,8 +308,8 @@ stereonet can be obtained by using the stereographic projection
 
 .. _-Js:
 
-Stereographic (**-Js** **-JS**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Stereographic projection (**-Js** **-JS**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -400,8 +400,8 @@ next to its equal-area cousin in the Section `Lambert azimuthal (-Ja -JA)`_ on t
 
 .. _-Jg_pers:
 
-General perspective (**-Jg** **-JG**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+General perspective projection (**-Jg** **-JG**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -450,8 +450,8 @@ following :doc:`/coast` command (*lon0*\ =4; *lat0*\ =52; *altitude*\ =230 km; *
 
 .. _-Jg:
 
-Azimuthal orthographic (**-Jg** **-JG**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Azimuthal orthographic projection (**-Jg** **-JG**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -489,8 +489,8 @@ command:
 
 .. _-Je:
 
-Azimuthal equidistant (**-Je** **-JE**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Azimuthal equidistant projection (**-Je** **-JE**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -528,8 +528,8 @@ perimeter:
 
 .. _-Jf:
 
-Azimuthal gnomonic (**-Jf** **-JF**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Azimuthal gnomonic projection (**-Jf** **-JF**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -686,7 +686,7 @@ latitudes in the regular Mercator projection and must therefore be less than 90�
 .. _-Ju:
 
 Universal Transverse Mercator (UTM) projection (**-Ju** **-JU**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -887,8 +887,8 @@ As with the previous projections, the user can choose between a rectangular boun
 
 .. _-Jq:
 
-Equidistant cylindrical (**-Jq** **-JQ**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Equidistant cylindrical projection (**-Jq** **-JQ**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -941,8 +941,8 @@ A world map centered on the dateline using this projection can be obtained as fo
 
 .. _-Jy:
 
-Cylindrical (**-Jy** **-JY**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cylindrical projection (**-Jy** **-JY**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1041,8 +1041,8 @@ can be obtained as follows:
 
 .. _-Jcyl_stere:
 
-Cylindrical stereographic (**-Jcyl_stere** **-JCyl_stere**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cylindrical stereographic projection (**-Jcyl_stere** **-JCyl_stere**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -49,7 +49,7 @@ Conic projections
 
 .. _-Jb:
 
-Albers conic projection (**-Jb** **-JB**)
+Albers conic equal-area projection (**-Jb** **-JB**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
@@ -218,7 +218,7 @@ Azimuthal projections
 
 .. _-Ja:
 
-Lambert azimuthal projection (**-Ja** **-JA**)
+Lambert azimuthal equal-area projection (**-Ja** **-JA**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
@@ -308,7 +308,7 @@ stereonet can be obtained by using the stereographic projection
 
 .. _-Js:
 
-Stereographic projection (**-Js** **-JS**)
+Stereographic equal-angle projection (**-Js** **-JS**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
@@ -941,7 +941,7 @@ A world map centered on the dateline using this projection can be obtained as fo
 
 .. _-Jy:
 
-Cylindrical projection (**-Jy** **-JY**)
+Cylindrical equal-area projection (**-Jy** **-JY**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
@@ -1110,7 +1110,7 @@ range of the plot, specified by the (**-R**) option.
 
 .. _-Jh:
 
-Hammer projection (**-Jh** **-JH**)
+Hammer equal-area projection (**-Jh** **-JH**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -1254,8 +1254,8 @@ Again centered on Greenwich, the example below was created by this command:
 
 .. _-Jk:
 
-Eckert IV and VI projections (**-Jk** **-JK**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Eckert IV and VI equal-area projections (**-Jk** **-JK**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -1110,8 +1110,8 @@ range of the plot, specified by the (**-R**) option.
 
 .. _-Jh:
 
-Hammer equal-area projection (**-Jh** **-JH**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Hammer projection (**-Jh** **-JH**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -577,8 +577,8 @@ Each have a different way of spacing the meridians and parallels to obtain certa
 
 .. _-Jm:
 
-Mercator (**-Jm** **-JM**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Mercator projection (**-Jm** **-JM**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -627,8 +627,8 @@ example, specify the region with **-R**-180/180/-70/70 to obtain a map centered 
 
 .. _-Jt:
 
-Transverse Mercator (**-Jt** **-JT**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Transverse Mercator projection (**-Jt** **-JT**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -685,8 +685,8 @@ latitudes in the regular Mercator projection and must therefore be less than 90Â
 
 .. _-Ju:
 
-Universal Transverse Mercator (UTM) (**-Ju** **-JU**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Universal Transverse Mercator (UTM) projection (**-Ju** **-JU**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -730,8 +730,8 @@ formulae instead.
 
 .. _-Jo:
 
-Oblique Mercator (**-Jo** **-JO**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Oblique Mercator projection (**-Jo** **-JO**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Option 1 Syntax**
 
@@ -1110,8 +1110,8 @@ range of the plot, specified by the (**-R**) option.
 
 .. _-Jh:
 
-Hammer (**-Jh** **-JH**)
-~~~~~~~~~~~~~~~~~~~~~~~~
+Hammer projection (**-Jh** **-JH**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1143,8 +1143,8 @@ A view of the Pacific ocean using the Dateline as central meridian can be genera
 
 .. _-Jw:
 
-Mollweide (**-Jw** **-JW**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Mollweide projection (**-Jw** **-JW**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1177,8 +1177,8 @@ An example centered on Greenwich can be generated thus:
 
 .. _-Jr:
 
-Winkel Tripel (**-Jr** **-JR**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Winkel Tripel projection (**-Jr** **-JR**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1219,8 +1219,8 @@ Centered on Greenwich, the example in Figure :ref:`Winkel Tripel projection <GMT
 
 .. _-Jn:
 
-Robinson (**-Jn** **-JN**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Robinson projection (**-Jn** **-JN**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1254,8 +1254,8 @@ Again centered on Greenwich, the example below was created by this command:
 
 .. _-Jk:
 
-Eckert IV and VI (**-Jk** **-JK**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Eckert IV and VI projection (**-Jk** **-JK**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1305,8 +1305,8 @@ The same script, with **s** instead of **f**, yields the Eckert VI map:
 
 .. _-Ji:
 
-Sinusoidal (**-Ji** **-JI**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sinusoidal projection (**-Ji** **-JI**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1358,8 +1358,8 @@ distributions like hydrocarbon and mineral resources, etc.
 
 .. _-Jv:
 
-Van der Grinten (**-Jv** **-JV**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Van der Grinten projection (**-Jv** **-JV**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -49,8 +49,8 @@ Conic projections
 
 .. _-Jb:
 
-Albers conic equal-area projection (**-Jb** **-JB**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Albers conic (**-Jb** **-JB**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -92,8 +92,8 @@ generate the map below is therefore given by:
 
 .. _-Jd:
 
-Equidistant conic projection (**-Jd** **-JD**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Equidistant conic (**-Jd** **-JD**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -127,8 +127,8 @@ map of Cuba:
 
 .. _-Jl:
 
-Lambert conic conformal projection (**-Jl** **-JL**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lambert conic conformal (**-Jl** **-JL**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -172,8 +172,8 @@ latitudes 30.5°N and 47.5°N of 0.5–1%. Some areas, like Florida, experience 
 
 .. _-Jpoly:
 
-(American) polyconic projection (**-Jpoly** **-JPoly**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(American) polyconic (**-Jpoly** **-JPoly**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -218,8 +218,8 @@ Azimuthal projections
 
 .. _-Ja:
 
-Lambert azimuthal equal-area (**-Ja** **-JA**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lambert azimuthal (**-Ja** **-JA**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -308,7 +308,7 @@ stereonet can be obtained by using the stereographic projection
 
 .. _-Js:
 
-Stereographic equal-angle (**-Js** **-JS**)
+Stereographic (**-Js** **-JS**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
@@ -396,7 +396,7 @@ hemispheric maps. Our example shows Australia using a projection pole at
 
 
 By choosing 0/0 as the pole, we obtain the conformal stereonet presented
-next to its equal-area cousin in the Section `Lambert Azimuthal Equal-Area (-Ja -JA)`_ on the Lambert azimuthal equal-area projection (Figure :ref:`Stereonets <GMT_stereonets>`).
+next to its equal-area cousin in the Section `Lambert azimuthal (-Ja -JA)`_ on the Lambert azimuthal projection (Figure :ref:`Stereonets <GMT_stereonets>`).
 
 .. _-Jg_pers:
 
@@ -846,8 +846,8 @@ to align the oblique Equator with the vertical, positive *y*-axis instead.  This
 
 .. _-Jc:
 
-Cassini cylindrical (**-Jc** **-JC**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cassini (**-Jc** **-JC**)
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -941,8 +941,8 @@ A world map centered on the dateline using this projection can be obtained as fo
 
 .. _-Jy:
 
-Cylindrical equal-area (**-Jy** **-JY**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cylindrical (**-Jy** **-JY**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -959,7 +959,7 @@ Cylindrical equal-area (**-Jy** **-JY**)
 **Description**
 
 This cylindrical projection is actually several projections, depending on what latitude is selected as the standard
-parallel. However, they are all equal area and hence non-conformal. All meridians and parallels are straight lines.
+parallel. However, they are all equal-area and hence non-conformal. All meridians and parallels are straight lines.
 
 While you may choose any value for the standard parallel and obtain your own personal projection, there are seven
 choices of standard parallels that result in known (or named) projections. These are listed in Table :ref:`JY <tbl-JY>`.
@@ -1002,8 +1002,8 @@ As one can see there is considerable distortion at high latitudes since the pole
 
 .. _-Jj:
 
-Miller cylindrical (**-Jj** **-JJ**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Miller (**-Jj** **-JJ**)
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1110,8 +1110,8 @@ range of the plot, specified by the (**-R**) option.
 
 .. _-Jh:
 
-Hammer equal-area (**-Jh** **-JH**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Hammer (**-Jh** **-JH**)
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1254,8 +1254,8 @@ Again centered on Greenwich, the example below was created by this command:
 
 .. _-Jk:
 
-Eckert IV and VI equal-area (**-Jk** **-JK**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Eckert IV and VI (**-Jk** **-JK**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1305,8 +1305,8 @@ The same script, with **s** instead of **f**, yields the Eckert VI map:
 
 .. _-Ji:
 
-Sinusoidal equal-area (**-Ji** **-JI**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sinusoidal (**-Ji** **-JI**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 

--- a/doc/rst/source/reference/map-projections.rst
+++ b/doc/rst/source/reference/map-projections.rst
@@ -846,8 +846,8 @@ to align the oblique Equator with the vertical, positive *y*-axis instead.  This
 
 .. _-Jc:
 
-Cassini (**-Jc** **-JC**)
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Cassini projection (**-Jc** **-JC**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 
@@ -1254,8 +1254,8 @@ Again centered on Greenwich, the example below was created by this command:
 
 .. _-Jk:
 
-Eckert IV and VI projection (**-Jk** **-JK**)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Eckert IV and VI projections (**-Jk** **-JK**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Syntax**
 


### PR DESCRIPTION
**Description of proposed changes**

Related to the points 3. and 4. of https://github.com/GenericMappingTools/pygmt/issues/3405#issue-2476920122.

Currently the projection names are adjusted based on the name used in the projection table.

Related PyGMT PR at https://github.com/GenericMappingTools/pygmt/pull/3407.


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
