### PR TITLE
Update link to "2008-06_netcdf4_perf_report.pdf" - 02

### DIFF
--- a/doc/rst/source/reference/file-formats.rst
+++ b/doc/rst/source/reference/file-formats.rst
@@ -235,7 +235,7 @@ Further reading:
 
 - `Unidata NetCDF Workshop: NetCDF Formats and Performance <http://www.unidata.ucar.edu/software/netcdf/workshops/most-recent/performance/index.html>`_
 - `Unidata NetCDF Workshop: What is Chunking? <http://www.unidata.ucar.edu/software/netcdf/workshops/most-recent/nc4chunking/WhatIsChunking.html>`_
-- `HDF NetCDF-4 Performance Report <https://support.hdfgroup.org/pubs/papers/2008-06_netcdf4_perf_report.pdf>`_
+- `HDF NetCDF-4 Performance Report <https://support.hdfgroup.org/archive/support/pubs/papers/2008-06_netcdf4_perf_report.pdf>`_
 
 Gridline and Pixel node registration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Description of proposed changes**

Again an update of the URL to the file "Update link to "2008-06_netcdf4_perf_report.pdf":
- First: http://www.hdfgroup.org/pubs/papers/2008-06_netcdf4_perf_report.pdf
- After PR 8556: https://support.hdfgroup.org/pubs/papers/2008-06_netcdf4_perf_report.pdf
- Currently: https://support.hdfgroup.org/archive/support/pubs/papers/2008-06_netcdf4_perf_report.pdf

At the top of the website https://support.hdfgroup.org/archive/support/pubs/papers/index.html it says 
> This web site is no longer maintained (but will remain online).
> Please see The HDF Group's new [Support Portal](https://portal.hdfgroup.org/) for the latest information.

Fixes #8572
Patches: #8556 


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.

