### PR TITLE
The psl_patch() function is intended for small polygons but it doesn't fill them.

### DIFF
--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -1744,6 +1744,7 @@ static int psl_patch (struct PSL_CTRL *PSL, double *x, double *y, int np) {
 	n1 = --n;
 	for (i = n - 1; i >= 0; i--, n--) PSL_command (PSL, "%d %d ", ix[n] - ix[i], iy[n] - iy[i]);
 	PSL_command (PSL, "%d %d %d SP\n", n1, ix[0], iy[0]);
+	PSL_command(PSL, "FO\n");		/* Close polygon and stroke/fill as set by PSL_setfill */
 	return (PSL_NO_ERROR);
 }
 


### PR DESCRIPTION
This PR fixes it.

This is what we get. Note that the -G+z is ignored but the segment headers have -Z<val> info  
```
makecpt -T-500/0/20 > cpt.cpt
gmt plot3d D.dat -p217.5/30 -JX15c/10c -Baf -Bza -R253/278/7.6/21.6/-400/-0 -JZ3c -Ccpt.cpt -W+z -G+z -png tri_1.png
```

![tri_1 png](https://github.com/user-attachments/assets/6360db0e-224c-4fb9-ae08-8c54df7e5ae3)

With this PR we get the triangles filled, though we still have to set -L even though the triangles are closed.
```
gmt plot3d D.dat -p217.5/30 -JX15c/10c -Baf -Bza -R253/278/7.6/21.6/-400/-0 -JZ3c -Ccpt.cpt -G+z -L -png tri_2.png
```
![tri_2 png](https://github.com/user-attachments/assets/8b77b0fd-c068-466d-97ea-aad6dc9900d1)




[D.zip](https://github.com/user-attachments/files/16923926/D.zip)
