### PR TITLE
DOC/grdgradient.rst: Update URL link to "Hill-Shading and the Reflectance Map" by Horn (1981)

### DIFF
--- a/doc/rst/source/grdgradient.rst
+++ b/doc/rst/source/grdgradient.rst
@@ -265,7 +265,7 @@ References
 
 Horn, B.K.P., Hill-Shading and the Reflectance Map, Proceedings of the
 IEEE, Vol. 69, No. 1, January 1981, pp. 14-47.
-(http://people.csail.mit.edu/bkph/papers/Hill-Shading.pdf)
+(https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1456186)
 
 See Also
 --------

--- a/doc/rst/source/grdgradient.rst
+++ b/doc/rst/source/grdgradient.rst
@@ -264,7 +264,8 @@ References
 ----------
 
 Horn, B.K.P., Hill-Shading and the Reflectance Map, Proceedings of the
-IEEE, Vol. 69, No. 1, January 1981, pp. 14-47. (https://ieeexplore.ieee.org/document/1456186/)
+IEEE, Vol. 69, No. 1, January 1981, pp. 14-47.
+(https://www.researchgate.net/publication/2996084_Hill_shading_and_the_reflectance_map)
 
 See Also
 --------

--- a/doc/rst/source/grdgradient.rst
+++ b/doc/rst/source/grdgradient.rst
@@ -264,8 +264,7 @@ References
 ----------
 
 Horn, B.K.P., Hill-Shading and the Reflectance Map, Proceedings of the
-IEEE, Vol. 69, No. 1, January 1981, pp. 14-47.
-(https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1456186)
+IEEE, Vol. 69, No. 1, January 1981, pp. 14-47. (https://ieeexplore.ieee.org/document/1456186/)
 
 See Also
 --------


### PR DESCRIPTION
**Description of proposed changes**

This PR is a suggestion to update the URL link to the publication "Hill-Shading and the Reflectance Map" by Horn (1981) from http://people.csail.mit.edu/bkph/papers/Hill-Shading.pdf (which seem not freely available anymore 🙁) to the ResearchGate upload at https://www.researchgate.net/publication/2996084_Hill_shading_and_the_reflectance_map. There people can download a full text, but the PDF file provided at http://dx.doi.org/10.1109/PROC.1981.11918 is not freely available (I can only download it via my KIT university account).

Fixes #8582


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
