### PR TITLE
Add link for boundary conditions in -n

### DIFF
--- a/doc/rst/source/explain_-n_full.rst_
+++ b/doc/rst/source/explain_-n_full.rst_
@@ -22,7 +22,7 @@ The following modifiers are supported:
 - **+a** - Switch off antialiasing (where supported) [default uses antialiasing].
 - **+b** - Override boundary conditions used, by appending *g* for geographic, *p* for periodic, or *n* for
   natural boundary conditions. For the latter two you may append **x** or **y** to specify just one direction, otherwise
-  both are assumed. For more information see :ref:<reference/file-formats:boundary-conditions-for-operations-on-grids>`.
+  both are assumed. For more information see :ref:`grid-boundary-conditions`.
 
 - **+c** - Clip the interpolated grid to input z-min/z-max [default may exceed limits].
 - **+t** - Control how close to nodes with NaNs the interpolation will go based on *threshold*. A *threshold* of 1.0

--- a/doc/rst/source/explain_-n_full.rst_
+++ b/doc/rst/source/explain_-n_full.rst_
@@ -22,7 +22,8 @@ The following modifiers are supported:
 - **+a** - Switch off antialiasing (where supported) [default uses antialiasing].
 - **+b** - Override boundary conditions used, by appending *g* for geographic, *p* for periodic, or *n* for
   natural boundary conditions. For the latter two you may append **x** or **y** to specify just one direction, otherwise
-  both are assumed.
+  both are assumed. For more information see :ref:<reference/file-formats:boundary-conditions-for-operations-on-grids>`.
+
 - **+c** - Clip the interpolated grid to input z-min/z-max [default may exceed limits].
 - **+t** - Control how close to nodes with NaNs the interpolation will go based on *threshold*. A *threshold* of 1.0
   requires all (4 or 16) nodes involved in interpolation to be non-NaN. For example, 0.5 will interpolate about half

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -307,7 +307,6 @@ modules. No space between the option flag and the associated arguments.
 .. include:: explain_-l_full.rst_
 
 .. _-n_full:
-.. |Add_-n| replace:: :ref:`(See technical reference) <reference/options:Grid interpolation parameters: The -n option>`.
 .. include:: explain_-n_full.rst_
 
 .. _-ocols_full:

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -307,7 +307,7 @@ modules. No space between the option flag and the associated arguments.
 .. include:: explain_-l_full.rst_
 
 .. _-n_full:
-
+.. |Add_-n| replace:: :ref:`(See technical reference) <reference/options:Grid interpolation parameters: The -n option>`.
 .. include:: explain_-n_full.rst_
 
 .. _-ocols_full:

--- a/doc/rst/source/gmt.rst
+++ b/doc/rst/source/gmt.rst
@@ -307,6 +307,7 @@ modules. No space between the option flag and the associated arguments.
 .. include:: explain_-l_full.rst_
 
 .. _-n_full:
+
 .. include:: explain_-n_full.rst_
 
 .. _-ocols_full:

--- a/doc/rst/source/reference/file-formats.rst
+++ b/doc/rst/source/reference/file-formats.rst
@@ -263,6 +263,8 @@ option (see Section :ref:`option_nodereg`). **Note**: The smallest
 pixel-registered grid can be 1x1 (storing a single value), while a
 gridline-registered grid cannot be smaller than 2x2.
 
+.. _grid-boundary-conditions
+
 Boundary Conditions for operations on grids
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/rst/source/reference/file-formats.rst
+++ b/doc/rst/source/reference/file-formats.rst
@@ -263,7 +263,7 @@ option (see Section :ref:`option_nodereg`). **Note**: The smallest
 pixel-registered grid can be 1x1 (storing a single value), while a
 gridline-registered grid cannot be smaller than 2x2.
 
-.. _grid-boundary-conditions
+.. _grid-boundary-conditions:
 
 Boundary Conditions for operations on grids
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/rst/source/reference/file-formats.rst
+++ b/doc/rst/source/reference/file-formats.rst
@@ -270,7 +270,7 @@ GMT has the option to specify boundary conditions in some programs
 that operate on grids (e.g.,
 :doc:`/grdsample`, :doc:`/grdgradient`,
 :doc:`/grdtrack`, :doc:`/nearneighbor`, and
-:doc:`/grdview`, to name a few. The desired
+:doc:`/grdview`, to name a few). The desired
 condition can be set with the common GMT option **-n**; see Section
 :ref:`option_-n`. The boundary conditions come into play when
 interpolating or computing derivatives near the limits of the region


### PR DESCRIPTION
This PR is to add a link for [boundary-conditions-for-operations-on-grids](https://docs.generic-mapping-tools.org/dev/reference/file-formats.html#boundary-conditions-for-operations-on-grids) on the [full explain of the -n option](https://docs.generic-mapping-tools.org/dev/reference/options.html#grid-interpolation-parameters-the-n-option).

I am not sure if I did it right. 





