### PR TITLE
Add a +n option to -S to prevent saving node numbers in headers.

### DIFF
--- a/doc/rst/source/triangulate.rst
+++ b/doc/rst/source/triangulate.rst
@@ -25,7 +25,7 @@ Synopsis
 [ |-N| ]
 [ |-Q|\ [**n**] ]
 [ |SYN_OPT-R| ]
-[ |-S|\ [*first*][**+z**\ [**a**\|\ **l**\|\ **m**\|\ **p**\|\ **u**]] ]
+[ |-S|\ [*first*][**+z**\ [**a**\|\ **l**\|\ **m**\|\ **p**\|\ **u**]][**+n**]]
 [ |-T| ]
 [ |SYN_OPT-V| ]
 [ |-Z| ]
@@ -167,9 +167,10 @@ Optional Arguments
 
 .. _-S:
 
-**-S**\ [*first*][**+z**\ [**a**\|\ **l**\|\ **m**\|\ **p**\|\ **u**]]
+**-S**\ [*first*][**+z**\ [**a**\|\ **l**\|\ **m**\|\ **p**\|\ **u**]][**+n**]
     Output triangles as polygon segments separated by a segment header
     record which contains node numbers *a-b-c* and **-Z**\ *polynumber*.
+    However, if the **+n** flag is used, we skip writing the *polynumber* and the node numbers.
     Optionally, append *first*, where *first* is an integer, to report
     the polygon numbers by counting from *first* [Default starts at zero].
     Incompatible with |-Q|. Optionally, add modifier

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -7272,7 +7272,8 @@ GMT_LOCAL void gmtinit_conf_modern_override (struct GMT_CTRL *GMT) {
 	GMT->current.setting.map_grid_pen[GMT_SECONDARY].width = GMT->session.d_NaN;	/* 0.5p (thinner) */
 
 	if (error)
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unrecognized value during gmtdefaults modern initialization.\n");}
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Unrecognized value during gmtdefaults modern initialization.\n");
+}
 
 /*! . */
 void gmtinit_conf_modern_US (struct GMT_CTRL *GMT) {
@@ -20541,16 +20542,18 @@ void gmt_auto_offsets_for_colorbar (struct GMT_CTRL *GMT, double offset[], int j
 		GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Adding label space\n");
 		offset[GMT_OUT] += (GMT_LETTER_HEIGHT * GMT->current.setting.font_label.size / PSL_POINTS_PER_INCH) + MAX (0.0, GMT->current.setting.map_label_offset[GMT_Y]);
 	}
-	/* Because the next call will reset frame sides i will make a copy and override the override here */
+	/* Because the next call will reset frame sides I will make a copy and override the override here */
 	gmt_M_memcpy (sides, GMT->current.map.frame.side, 5U, unsigned int);
 	was = GMT->current.map.frame.draw;
 	gmtinit_conf_modern_override (GMT);	/* Reset */
 	(void)gmt_getdefaults (GMT, NULL);
-	for (opt = options; opt; opt = opt->next) {
-		if (opt->option != '-') continue;   /* Not a parameter setting */
-		if ((c = strchr (opt->arg, '=')) == NULL) continue;
-		c[0] = '\0';  /* Remove = */
-		n_errors += gmtlib_setparameter (GMT, opt->arg, &c[1], false);
+	if (!GMT->parent->external || options->option) {	/* So that externals can send a NULL ptr for options. 'Internal' is not affected */
+		for (opt = options; opt; opt = opt->next) {
+			if (opt->option != '-') continue;   /* Not a parameter setting */
+			if ((c = strchr(opt->arg, '=')) == NULL) continue;
+			c[0] = '\0';  /* Remove = */
+			n_errors += gmtlib_setparameter(GMT, opt->arg, &c[1], false);
+		}
 	}
 	if (n_errors)
 		GMT_Report (GMT->parent, GMT_MSG_WARNING, "GMT parameter parsing failures for %d settings\n", n_errors);

--- a/src/gsfml/fzanalyzer.c
+++ b/src/gsfml/fzanalyzer.c
@@ -308,8 +308,7 @@ GMT_LOCAL void FZ_trend (double *x, double *y, int n, double *intercept, double 
 	}
 }
 
-GMT_LOCAL int FZ_fit_model (struct GMT_CTRL *GMT, double *d, double *vgg, int n, double corridor, double *width, int n_widths, double *asym, int n_asym, double *comp, int n_comp, double *results, PFV *FZshape)
-{
+GMT_LOCAL int FZ_fit_model(struct GMT_CTRL *GMT, double *d, double *vgg, int n, double corridor, double *width, int n_widths, double *asym, int n_asym, double *comp, int n_comp, double *results, PFV *FZshape) {
 	/* d	   = distance along crossing profile in km, with d = 0 the nominal FZ location given by digitized line.
 	 * vgg	   = observed (resampled) VGG along crossing profile, possibly with NaNs at end.
 	 * n	   = number of points in the profile (including any NaNs)
@@ -327,7 +326,7 @@ GMT_LOCAL int FZ_fit_model (struct GMT_CTRL *GMT, double *d, double *vgg, int n,
 	
 	int col0, w, m, ic, row, way, n_sing = 0, n_fits = 0, got_trough;
 	double *d_vgg = NULL, *res = NULL, *predicted_vgg = NULL, *vgg_comp[N_SHAPES] = {NULL, NULL, NULL};
-	double min_var_b, min_var_t, var_model, intercept, slope, var_data, F, par[3];
+	double min_var_b, min_var_t, var_model, intercept = 0.0, slope, var_data, F, par[3];
 	
 	/* The algorithms used below anticipate that vgg may have NaNs and thus skip those */
 	
@@ -338,7 +337,7 @@ GMT_LOCAL int FZ_fit_model (struct GMT_CTRL *GMT, double *d, double *vgg, int n,
 	for (m = 0; m < N_SHAPES; m++) vgg_comp[m] = gmt_M_memory (GMT, NULL, n, double);
 	predicted_vgg = gmt_M_memory (GMT, NULL, n, double);
 	gmt_M_memcpy (d_vgg, vgg, n, double);	/* Make copy of vgg */
-	FZ_trend (d, d_vgg, n, &intercept, &slope, 1);		/* Find and remove linear trend just for data variance calculation */
+	FZ_trend(d, d_vgg, n, &intercept, &slope, 1);		/* Find and remove linear trend just for data variance calculation */
 	/* So trend = d * slope + intercept; the shift of FZ location does not change this calculation (i.e. d is original d) */
 	
 	var_data = FZ_get_variance (d_vgg, n);	/* Compute sum of squares for the detrended data */
@@ -352,8 +351,8 @@ GMT_LOCAL int FZ_fit_model (struct GMT_CTRL *GMT, double *d, double *vgg, int n,
 				for (ic = 0; ic < n_comp; ic++) {	/* Search for best compression factor */
 					for (row = 0; row < n_asym; row++) {	/* Search for optimal asymmetry parameter asym */
 						n_fits++;
-						FZ_blendmodel (vgg_comp[FZ_G0], vgg_comp[FZ_G1], vgg_comp[FZ_G2], predicted_vgg, n, asym[row], comp[ic], 1.0);	/* a blend, with unit amplitude */
-						if (FZ_solution  (GMT, d, vgg, d[col0], predicted_vgg, n, par)) {	/* LS solution for trend + scaled shape */
+						FZ_blendmodel(vgg_comp[FZ_G0], vgg_comp[FZ_G1], vgg_comp[FZ_G2], predicted_vgg, n, asym[row], comp[ic], 1.0);	/* a blend, with unit amplitude */
+						if (FZ_solution(GMT, d, vgg, d[col0], predicted_vgg, n, par)) {	/* LS solution for trend + scaled shape */
 							n_sing++;
 							continue;		/* Return 1 if singular */
 						}


### PR DESCRIPTION
The reason for this is that information is normally useless but takes up needless space when the dataset is exported to the wrappers.

Also initialized some variables to please link checker.