### PR TITLE
CI: Fix the script to install dependencies on Windows

### DIFF
--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -48,8 +48,8 @@ if [ "$PACKAGE" = "true" ]; then
 fi
 
 # install more packages using conda
-$CONDA\\condabin\\conda.bat update -n base -c conda-forge conda --solver libmamba
-$CONDA\\condabin\\conda.bat install ${conda_packages} -c conda-forge --solver libmamba
+$CONDA\\Scripts\\conda.exe update -n base -c conda-forge conda --solver libmamba
+$CONDA\\Scripts\\conda.exe install ${conda_packages} -c conda-forge --solver libmamba
 echo "$CONDA\\Library\\bin" >> $GITHUB_PATH
 echo "$CONDA\\Scripts" >> $GITHUB_PATH
 


### PR DESCRIPTION
The CI workflow suddenly started to fail. The error message is:
```
D:\a\gmt\gmt>L "C:\Miniconda\condabin\..\Scripts\conda.exe"   update -n base -c conda-forge conda --solver libmamba 
'L' is not recognized as an internal or external command,
operable program or batch file.
```
but we are actually running 
```
'C:\Miniconda\condabin\conda.bat' update -n base -c conda-forge conda --solver libmamba
```
in the script. 

So, there must be something wrong in the `conda.bat` script.  This is likely a bug in GitHub-hosted agent and we can do nothing.

This PR fixes it by calling the `conda.exe` command directly.