### PR TITLE
Fix list item in grdmath.rst

### DIFF
--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -518,14 +518,16 @@ Notes On Operators
 #. The stack depth limit is hard-wired to 100.
 
 #. All functions expecting a positive radius (e.g., **LOG**, **KEI**,
-   etc.) are passed the absolute value of their argument. (9) The bitwise
-   operators (**BITAND**, **BITLEFT**, **BITNOT**, **BITOR**, **BITRIGHT**,
-   **BITTEST**, and **BITXOR**) convert a grid's single precision values to
-   unsigned 32-bit ints to perform the bitwise operations. Consequently,
-   the largest whole integer value that can be stored in a float grid is
-   2^24 or 16,777,216. Any higher result will be masked to fit in the lower
-   24 bits.  Thus, bit operations are effectively limited to 24 bit.  All
-   bitwise operators return NaN if given NaN arguments or bit-settings <= 0.
+   etc.) are passed the absolute value of their argument. 
+
+#. The bitwise operators (**BITAND**, **BITLEFT**, **BITNOT**, **BITOR**,
+   **BITRIGHT**, **BITTEST**, and **BITXOR**) convert a grid's single
+   precision values to unsigned 32-bit ints to perform the bitwise
+   operations. Consequently, the largest whole integer value that can be
+   stored in a float grid is 2^24 or 16,777,216. Any higher result will be
+   masked to fit in the lower 24 bits. Thus, bit operations are effectively
+   limited to 24 bit. All bitwise operators return NaN if given NaN
+   arguments or bit-settings <= 0.
 
 #. When OpenMP support is compiled in, a few operators will take advantage
    of the ability to spread the load onto several cores.  At present, the


### PR DESCRIPTION
Notes on "functions requiring positive inputs" and "bitwise operators" were combined in a single item of the list, and what appeared to be a legacy list number "(9)" separated the two topics in the paragraph. This change separates these topics into two separate numbered items.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes # N/A


**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] (N/A) Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] (N/A) Describe changes to function behavior and arguments in a comment below the function declaration.
- [x] (N/A) If adding new functionality, add a detailed description to the documentation and/or an example.
