### PR TITLE
gmtwhich: Rename the long names for arguments of the -G option

### DIFF
--- a/src/longopt/gmtwhich_inc.h
+++ b/src/longopt/gmtwhich_inc.h
@@ -29,7 +29,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	{ 0, 'C', "confirm",           "", "", "", "", GMT_TP_STANDARD },
 	{ 0, 'D', "directories|report_dir", "", "", "", "", GMT_TP_STANDARD },
 	{ 0, 'G', "download",
-	          "a,c,l,u",           "user,cache,current,data",
+	          "a,c,l,u",           "auto,cache,local,user",
 	          "",                  "",
 		  GMT_TP_STANDARD },
 	{ 0, '\0', "", "", "", "", "", 0 }  /* End of list marked with empty option and strings */

--- a/test/gmtwhich/gmtwhich-l2s.sh
+++ b/test/gmtwhich/gmtwhich-l2s.sh
@@ -20,7 +20,7 @@ EOF
 gmt $m $l2s --readable >> $b
 gmt $m $l2s --confirm >> $b
 gmt $m $l2s --directories --report_dir >> $b
-gmt $m $l2s --download=user --download=cache >> $b
-gmt $m $l2s --download=current --download=data >> $b
+gmt $m $l2s --download=auto --download=cache >> $b
+gmt $m $l2s --download=local --download=user >> $b
 
 diff $a $b --strip-trailing-cr > fail


### PR DESCRIPTION
**Description of proposed changes**

`gmt which -G` take four different values:

> **a** - Place files in the appropriate folder under the user directory (this is where GMT normally places downloaded files).
> **c** - Download to the user cache directory.
> **l** - Download to the current directory [Default].
> **u** - Download to the user data directory (i.e., ignoring any subdirectory structure).

Currently, their long names are ``"user,cache,current,data"``, but I feel `"auto,cache,local,user"` makes more sense. 