### PR TITLE
GMT_Put_Vector: Fix a bug when passing longitude/latitude strings

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -15579,9 +15579,9 @@ int GMT_Put_Vector (void *V_API, struct GMT_VECTOR *V, unsigned int col, unsigne
 		}
 		if (special_type == GMT_DATETIME || gmtlib_maybe_abstime (API->GMT, text))	/* Honor backwards compatibility for GMT_DATETIME */
 			L_type = GMT_IS_ABSTIME;
-		else if (strchr ("WE", text[L]))
+		else if (strchr ("WE", text[L-1]))
 			L_type = GMT_IS_LON;
-		else if (strchr ("SN", text[L]))
+		else if (strchr ("SN", text[L-1]))
 			L_type = GMT_IS_LAT;
 		else if (strchr (text, ':'))
 			L_type = GMT_IS_GEO;


### PR DESCRIPTION
Here is the PyGMT script to reproduce the issue. The expected output is `[-25.5, -12.5]`, but the actual output is `[334.5, 347.5]`. 
```python
In [1]: import pygmt

In [2]: pygmt.info([["12:30S"], ["25:30S"]], per_column=True)
Out[2]: array([334.5, 347.5])
```
The bug exists in the `GMT_Put_Vector` function. In this function, GMT checks if the last character of a text string is one of E, N, S, W, to determine if the strings should be parsed as longitude/latitudes.

Here, `L` is the length of the first string so `text[L-1]` should be the last character of the string, but GMT incorrectly checks `text[L]`. This PR fixes the bug, and after the fix it's correct:
```
In [1]: import pygmt

In [2]: pygmt.info([["12:30S"], ["25:30S"]], per_column=True)
Out[2]: array([-25.5, -12.5])
```