### PR TITLE
DOC: plot / plot3d: Fix typos in description (-G and -W) 

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -59,7 +59,7 @@ If a symbol is selected and no symbol size given, then it will interpret the thi
 Symbols whose *size* is <= 0 are skipped. If no symbols are specified then the symbol code (see |-S| below) must be present as
 last column in the input. If |-S| is not used, a line connecting the data points will be drawn instead. To explicitly close
 polygons, use |-L|. Select a fill with |-G|. If |-G| is set, |-W| will control whether the polygon outline is drawn or not.
-If a symbol is selected, |-G| and |-W| determines the fill and outline/no outline, respectively.
+If a symbol is selected, |-G| and |-W| determine the fill and outline/no outline, respectively.
 
 Required Arguments
 ------------------

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -63,7 +63,7 @@ last column in the input. If |-S| is not used, a line connecting the
 data points will be drawn instead. To explicitly close polygons, use
 |-L|. Select a fill with |-G|. If |-G| is set, |-W| will control
 whether the polygon outline is drawn or not. If a symbol is selected,
-**-G** and |-W| determine the fill and outline/no outline,
+|-G| and |-W| determine the fill and outline/no outline,
 respectively.
 
 Required Arguments

--- a/doc/rst/source/plot3d.rst
+++ b/doc/rst/source/plot3d.rst
@@ -63,7 +63,7 @@ last column in the input. If |-S| is not used, a line connecting the
 data points will be drawn instead. To explicitly close polygons, use
 |-L|. Select a fill with |-G|. If |-G| is set, |-W| will control
 whether the polygon outline is drawn or not. If a symbol is selected,
-**-G** and |-W| determines the fill and outline/no outline,
+**-G** and |-W| determine the fill and outline/no outline,
 respectively.
 
 Required Arguments


### PR DESCRIPTION
**Description of proposed changes**

Fix a few small typos in the description of `plot` and `plot3d` for **-G** and **-W**.

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
