### PR TITLE
Fix the variable transparency case that was broken by the #8255 commit.

### DIFF
--- a/doc/rst/source/grdimage.rst
+++ b/doc/rst/source/grdimage.rst
@@ -23,7 +23,7 @@ Synopsis
 [ |-I|\ [*file*\|\ *intens*\|\ **+a**\ *azimuth*][**+d**][**+m**\ *ambient*][**+n**\ *args*] ]
 [ |-M| ]
 [ |-N| ]
-[ |-Q|\ [*color*][**+i**][**+z**\ *value*] ]
+[ |-Q|\ [*color*][**+i**][**+t**][**+z**\ *value*] ]
 [ |SYN_OPT-Rz| ]
 [ |-T|\ [**+o**\ [*pen*]][**+s**] ]
 [ |SYN_OPT-U| ]
@@ -158,7 +158,7 @@ Optional Arguments
 
 .. _-Q:
 
-**-Q**\ [*color*][**+i**][**+z**\ *value*]
+**-Q**\ [*color*][**+i**][**+t**][**+z**\ *value*]
     Handle transparency or opacity for grids or images. There are four general schemes:
 
     - Grid - Plain |-Q| will turn grid nodes with NaN values transparent in the image, using
@@ -173,10 +173,13 @@ Optional Arguments
       transparency between 0 and 255 on a per pixel basis then the *PostScript* image operator
       cannot create true variable pixel transparency *t*. Instead, each *r*, *g*, and *b* pixel
       values are converted by :math:`r' = t R + (1-t) r`, where *R* (and *G*, *B*) is the
-      transparent color at full transparency [Default is white]. If *color* is given
-      then it becomes the *R*, *B*, *G*  at full transparency. Such RGBA images will
-      be approximated by *n_columns* times *n_rows* of tiny squares with variable color and
-      transparency.  If *A* reflects opacity instead of transparency then you can use modifier
+      transparent color at full transparency [Default is white]. If *color* is given then it
+      becomes the *R*, *B*, *G*  at full transparency. This (opaque) transformation is
+      actually done by default (_i.e._, no need to set **-Q**). If, however, a true transparency
+      is wished, then use the **+i** modifier. Such RGBA images will be approximated by *n_columns*
+      times *n_rows* of tiny squares with variable color and transparency. Given this schema, the
+      PositScript created file is much larger than if **+t** is not used and that is why this is
+      not the default behavior. If *A* reflects opacity instead of transparency then you can use modifier
       **+i** to invert these numbers first. See `Limitations on transparency`_ for more discussion.
       **Note**: The **+i** modifier is not available for grids.
 


### PR DESCRIPTION
The fix in the #8255 was actually very incomplete and left the working array still pointing to a zero filled array and hence this type of transparency was totally broken. This PR fixes that. But this PR also addressees other situations.

- For the variable transparency case, and given that it implies cresting a **much** bigger _ps_ that considerably slows down the image rasterization, a new modifier **+t** is added to **-Q** to select true transparency. Otherwise, and by default, a blended transparency, that is an opaque combination of colors and alpha's, is computed.
- The single transparency value case was not working at all. This PR now does also the blended composition by default.
- The **-Q** docs are modified but I don't think they are telling the full truth. Debugging the code I don't see where a 2-values transparency layer is creating a true transparent figure. I always see the code path falling into the `grdimage_img_set_transparency` function that either copies a color or blends it. I don't know enough postscript to follow this matter any further.

If someone wants to play with a variable transparency file, here is one.
![stefan_rgba](https://github.com/user-attachments/assets/ed6d3630-720e-4ddb-9871-aab8c150a196)

EDIT: The SC bellow sows a cut of the original of the `transp_mix` test. The top left image (that in fact is the second row, first col of the full image) shows the same grid pattern as the lower left. This grid pattern in PS is what we see when using the true variable transparency that works by drawing a rectangle for each pixel (that is why those PS are huge). So, at a given point the single value transparency (obtained for example with `grdmix -A`) must have been working, but as I said above, I have no idea how. I think we should replace that orig PS by the one produced now by the `transp_mix.sh` script and remove the  `GMT_KNOWN_FAILURE`. @seisman Coul you do it after this RR is merged? I am not able to update original PS's.

![image](https://github.com/user-attachments/assets/519f1d32-d6c0-41b3-91c8-256695424afe)

