### PR TITLE
Fix the expected result in test/api/apiputvector.sh

### DIFF
--- a/test/api/apiputvector.sh
+++ b/test/api/apiputvector.sh
@@ -6,7 +6,7 @@
 # This file holds what is expected to be produced on output
 cat << EOF > answer.txt
 134.9	2020-06-01T14:55:33	-12.76	-16.25
--158	2020-06-01T16:00:51	19.8	29.5
+202	2020-06-01T16:00:51	19.8	29.5
 EOF
 testapi_putvector > results.txt
 diff -q --strip-trailing-cr results.txt answer.txt > fail


### PR DESCRIPTION
The test `test/api/apiputvector.sh` checks the output of the test program https://github.com/GenericMappingTools/gmt/blob/master/src/testapi_putvector.c.

As you can see in the figure, the first column the program passes is 134.9 and 202. So we also expect to see 134.9 and 202 as the first column in the output. However, the `answer.txt` file holds the incorrect answer due to a GMT bug.

The bug was fixed recently in #8600. That's why the test starts to fail recently. This PR fixes the `answer.txt` file and now the test passes again.