### PR TITLE
Update baseline image for grdimage/transp_mix

### DIFF
--- a/test/baseline/grdimage.dvc
+++ b/test/baseline/grdimage.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: bc4b746d04dde9df3cae5400ad1c730b.dir
+- md5: e21fa5a85cbf106cc8d027da81d49db8.dir
   nfiles: 36
   path: grdimage
   hash: md5
-  size: 19409266
+  size: 19831244


### PR DESCRIPTION
**Description of proposed changes**

In my previous try (https://github.com/GenericMappingTools/gmt/pull/8613#issuecomment-2472262108), I incorrectly used the "oceanic" data server, rather than the "static" server.


Let's wait to see if the CI jobs pass.