### PR TITLE
Move the annoying warning about the sloppy w/e/s/n one level up (GMT_MSG_INFORMATION)

### DIFF
--- a/src/gmt_grdio.c
+++ b/src/gmt_grdio.c
@@ -2572,8 +2572,11 @@ GMT_LOCAL int gmtlib_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], str
 }
 
 int gmt_adjust_loose_wesn (struct GMT_CTRL *GMT, double wesn[], struct GMT_GRID_HEADER *header) {
-	/* Most places we wish to warn if w/e/s/n is sloppy except when via DCW that must be rounded */
-	return gmtlib_adjust_loose_wesn (GMT, wesn, header, GMT->common.R.via_polygon ? GMT_MSG_INFORMATION : GMT_MSG_WARNING);
+	/* Most places we wish to warn if w/e/s/n is sloppy except when via DCW that must be rounded
+	   JL: Changed to default to GMT_MSG_INFORMATION. This warning is just too annoying and most
+	   users don't understand it. It also results often from computed code inside wrappers.
+	*/
+	return gmtlib_adjust_loose_wesn (GMT, wesn, header, GMT_MSG_INFORMATION);
 }
 
 void gmt_scale_and_offset_f (struct GMT_CTRL *GMT, gmt_grdfloat *data, size_t length, double scale, double offset) {


### PR DESCRIPTION
I propose to move the warning about the sloppy w/e/s/n one level up (require -Ii).

This warning shows up like 
```
gmtread [WARNING]: (w - x_min) must equal (NX + eps) * x_inc), where NX is an integer and |eps| <= 0.0001.
gmtread [WARNING]: w reset from 5.96701 to 5.93333333333
...
```
and I bet a large majority of users don't understand what we are talking about. On the other side, at least to me, that occurs with codes generated inside a wrapper where user has really no control on the exact w/e/s/n being asked, which will be modified anyway. So, for a bit sanity (perhaps mostly mine) let's move it up one level of verbosity.