### PR TITLE
Improve the patch for NaN with MSVC

### DIFF
--- a/src/gmt_notposix.h
+++ b/src/gmt_notposix.h
@@ -331,9 +331,16 @@
 
 #ifndef NAN
 #	ifdef _MSC_VER
-#		define NAN (-(float)(((float)(1e+300 * 1e+300)) * 0.0F));
+# 		ifndef INFINITY
+#			ifndef _HUGE_ENUF
+#				define _HUGE_ENUF 1e+300 // _HUGE_ENUF*_HUGE_ENUF must overflow
+# 			endif
+#			define INFINITY ((float)(_HUGE_ENUF * _HUGE_ENUF))
+# 		endif
+# 		define NAN (-(float)(INFINITY * 0.0F))
 #	else /* _MSC_VER */
-#		define NAN (HUGE_VAL-HUGE_VAL);
+		static const double _NAN = (HUGE_VAL-HUGE_VAL);
+#		define NAN _NAN
 #	endif /* _MSC_VER */
 #endif /* !NAN */
 

--- a/src/gmt_notposix.h
+++ b/src/gmt_notposix.h
@@ -331,11 +331,9 @@
 
 #ifndef NAN
 #	ifdef _MSC_VER
-		static const double _NAN = (-(float)(((float)(1e+300 * 1e+300)) * 0.0F));
-#		define NAN _NAN
+#		define NAN (-(float)(((float)(1e+300 * 1e+300)) * 0.0F));
 #	else /* _MSC_VER */
-		static const double _NAN = (HUGE_VAL-HUGE_VAL);
-#		define NAN _NAN
+#		define NAN (HUGE_VAL-HUGE_VAL);
 #	endif /* _MSC_VER */
 #endif /* !NAN */
 


### PR DESCRIPTION
**Description of proposed changes**

Not sure what's happening. Changes in PR #8627 passed in that PR, but failed after merging into the master branch (see https://github.com/GenericMappingTools/gmt/actions/runs/11934957233/job/33265224118).

ChatGPT told me:

> In C, a static const variable at global scope must be initialized with a constant expression that can be evaluated at compile time. However:
> 
> (1e+300 * 1e+300) * 0.0F involves floating-point arithmetic, which is not considered a compile-time constant in most C compilers.
>
> HUGE_VAL - HUGE_VAL is also not a compile-time constant for the same reason.

So, this PR improves the definition NAN without any floating-point arithmetic.

With the new patch, the conda-forge building in https://github.com/conda-forge/gmt-feedstock/pull/302 passes.