### PR TITLE
gmtlogo: Create the gmt_letters array dynamically to avoid MSVC compiler error

### DIFF
--- a/src/gmt_notposix.h
+++ b/src/gmt_notposix.h
@@ -331,8 +331,8 @@
 
 #ifndef NAN
 #	ifdef _MSC_VER
-		static const double _NAN = (-(float)(((float)(1e+300 * 1e+300)) * 0.0F));
-#		define NAN _NAN
+#		include <ymath.h>
+#		define NAN _Nan._Double
 #	else /* _MSC_VER */
 		static const double _NAN = (HUGE_VAL-HUGE_VAL);
 #		define NAN _NAN

--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -451,12 +451,12 @@ EXTERN_MSC int GMT_gmtlogo (void *V_API, int mode, void *args) {
 	gmt_letters[idx][1] = NAN;
 	idx += 1;
 	memcpy(gmt_letters + idx, gmt_letters_g, sizeof(gmt_letters_g));
-	idx += sizeof(gmt_letters_g);
+	idx += GMT_N_LETTERS_G;
 	gmt_letters[idx][0] = NAN;
 	gmt_letters[idx][1] = NAN;
 	idx += 1;
 	memcpy(gmt_letters + idx, gmt_letters_m, sizeof(gmt_letters_m));
-	idx += sizeof(gmt_letters_m);
+	idx += GMT_N_LETTERS_M;
 	gmt_letters[idx][0] = NAN;
 	gmt_letters[idx][1] = NAN;
 	idx += 1;

--- a/src/gmtlogo.c
+++ b/src/gmtlogo.c
@@ -33,9 +33,13 @@
 #define THIS_MODULE_NEEDS	"jr"
 #define THIS_MODULE_OPTIONS "->KJOPRUVXYtxy" GMT_OPT("c")
 
-#define GMT_N_LETTERS	116
-static float gmt_letters[GMT_N_LETTERS][2] = {	/* The G, M, T polygons */
-	{ NAN, NAN },
+
+#define GMT_N_LETTERS_G 92
+#define GMT_N_LETTERS_M 13
+#define GMT_N_LETTERS_T 8
+#define GMT_N_LETTERS (GMT_N_LETTERS_G + GMT_N_LETTERS_M + GMT_N_LETTERS_T + 3)
+
+static float gmt_letters_g[GMT_N_LETTERS_G][2] = {	/* The G polygons */
 	{ -59.5, -41.8 },
 	{ -59.5, 2.2 },
 	{ -105, 2.2 },
@@ -128,7 +132,8 @@ static float gmt_letters[GMT_N_LETTERS][2] = {	/* The G, M, T polygons */
 	{ -72.7, -32 },
 	{ -71.96, -30.8 },
 	{ -68.04, -41.8 },
-	{ NAN, NAN },
+};
+static float gmt_letters_m[GMT_N_LETTERS_M][2] = {	/* The M polygons */
 	{ -37.8, -41.8 },
 	{ -23.8, -41.8 },
 	{ -23.8, 27.39 },
@@ -142,7 +147,8 @@ static float gmt_letters[GMT_N_LETTERS][2] = {	/* The G, M, T polygons */
 	{ 12.46, -29.7 },
 	{ -17.22, 40.48 },
 	{ -37.8, 40.48 },
-	{ NAN, NAN },
+};
+static float gmt_letters_t[GMT_N_LETTERS_T][2] = {	/* The T polygons */
 	{ 124.46, -41.8 },
 	{ 124.46, 30.47 },
 	{ 160.02, 30.47 },
@@ -329,12 +335,13 @@ static int parse (struct GMT_CTRL *GMT, struct GMTLOGO_CTRL *Ctrl, struct GMT_OP
 
 EXTERN_MSC int GMT_gmtlogo (void *V_API, int mode, void *args) {
 	/* High-level function that implements the gmtlogo task */
-	int error, fmode;
+	int error, fmode, idx = 0;
 
 	uint64_t par[4] = {0, 0, 0, 0};
 
 	double wesn[4] = {0.0, 0.0, 0.0, 0.0};	/* Dimensions in inches */
 	double scale, y, dim[2];
+	float gmt_letters[GMT_N_LETTERS][2];
 
 	char cmd[GMT_LEN256] = {""}, pars[GMT_LEN128] = {""}, file[GMT_VF_LEN] = {""};
 
@@ -438,6 +445,22 @@ EXTERN_MSC int GMT_gmtlogo (void *V_API, int mode, void *args) {
 	GMT_Call_Module (API, "psclip", GMT_MODULE_CMD, cmd);
 
 	/* Plot the GMT letters as shadows, then full size, using GMT_psxy */
+
+	/* Copy the polygons into the gmt_letters array, with NAN records as segment separators */
+	gmt_letters[idx][0] = NAN;
+	gmt_letters[idx][1] = NAN;
+	idx += 1;
+	memcpy(gmt_letters + idx, gmt_letters_g, sizeof(gmt_letters_g));
+	idx += sizeof(gmt_letters_g);
+	gmt_letters[idx][0] = NAN;
+	gmt_letters[idx][1] = NAN;
+	idx += 1;
+	memcpy(gmt_letters + idx, gmt_letters_m, sizeof(gmt_letters_m));
+	idx += sizeof(gmt_letters_m);
+	gmt_letters[idx][0] = NAN;
+	gmt_letters[idx][1] = NAN;
+	idx += 1;
+	memcpy(gmt_letters + idx, gmt_letters_t, sizeof(gmt_letters_t));
 
 	/* Allocate a matrix container for holding the GMT-matrix coordinates */
 	par[0] = 2;	par[1] = GMT_N_LETTERS;


### PR DESCRIPTION
As reported in https://github.com/conda-forge/gmt-feedstock/pull/302#issuecomment-2487473474, building GMT source code with MSVC started to fail with following errors:
```
%SRC_DIR%\src\gmtlogo.c(38): error C2099: initializer is not a constant
%SRC_DIR%\src\gmtlogo.c(131): error C2099: initializer is not a constant
%SRC_DIR%\src\gmtlogo.c(145): error C2099: initializer is not a constant
```
I believe it's caused by behavior changes of new MSVC versions. In PR #8627 and #8628, we tried to improve the handling of `NAN` on Windows to avoid the error, but it seems we don't have a good solution there.

Instead, we can refactor the `gmt_letters` array in `gmtlogo.c` to avoid initializing `gmt_letters` with `NAN`. This is done by splitting the `gmt_letters` array into three separate arrays (for the letter G, M and T, respectively), and then creating the `gmt_letters` array by joining the three arrays with `NAN` records. This PR also reverts the changes in PR #8627

Now the build passes.