### PR TITLE
Replace deprecated CURLINFO_CONTENT_LENGTH_DOWNLOAD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,8 +139,9 @@ message (STATUS "Searching dependent libraries. This may take a few minutes...")
 find_package (NETCDF REQUIRED)
 include_directories (${NETCDF_INCLUDE_DIR})
 
-# libcurl is required since 5.4
-find_package (CURL REQUIRED)
+# libcurl is required since GMT 5.4
+# At least version 7.55.0 is needed for src/gmt_remote.c
+find_package (CURL 7.55.0 REQUIRED)
 include_directories (${CURL_INCLUDE_DIRS})
 list (APPEND GMT_OPTIONAL_LIBRARIES ${CURL_LIBRARIES})
 set (CURL_LIBRARY ${CURL_LIBRARIES} CACHE INTERNAL "")

--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -648,7 +648,7 @@ GMT_LOCAL size_t gmtremote_skip_large_files (struct GMT_CTRL *GMT, char * URL, s
 	/* Get the remote file's size and if too large we refuse to download */
 	CURL *curl = NULL;
 	CURLcode res;
-	double filesize = 0.0;
+	curl_off_t filesize = 0;
 	size_t action = 0;
 	char curl_useragent[GMT_LEN64];
 
@@ -677,10 +677,10 @@ GMT_LOCAL size_t gmtremote_skip_large_files (struct GMT_CTRL *GMT, char * URL, s
 		res = curl_easy_perform (curl);
 
 		if ((res = curl_easy_perform (curl)) == CURLE_OK) {
-      			res = curl_easy_getinfo (curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &filesize);
+      			res = curl_easy_getinfo (curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &filesize);
 			if ((res == CURLE_OK) && (filesize > 0.0)) {	/* Got the size */
 				GMT_Report (GMT->parent, GMT_MSG_INFORMATION, "Remote file %s: Size is %0.0f bytes\n", URL, filesize);
-				action = (filesize < (double)limit) ? 0 : (size_t)filesize;
+				action = ((size_t)filesize < limit) ? 0 : (size_t)filesize;
 			}
 		}
 		else	/* We failed */


### PR DESCRIPTION
**Description of proposed changes**

Compiling on MacOS gave this warning:
```
src/gmt_remote.c:680:41: warning: 'CURLINFO_CONTENT_LENGTH_DOWNLOAD' is deprecated: since 7.55.0. Use CURLINFO_CONTENT_LENGTH_DOWNLOAD_T [-Wdeprecated-declarations]
  680 |                         res = curl_easy_getinfo (curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &filesize);
      |                                                        ^
```

So I have replaced `CURLINFO_CONTENT_LENGTH_DOWNLOAD` by `CURLINFO_CONTENT_LENGTH_DOWNLOAD_T` and  changed the type of `filesize` from `double` to `curl_off_t`.

The addresses #8653 

**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
