### PR TITLE
Avoid warnings compiling seis

### DIFF
--- a/src/seis/gmtisf.c
+++ b/src/seis/gmtisf.c
@@ -101,10 +101,7 @@ static int parse(struct GMT_CTRL *GMT, struct READISF_CTRL *Ctrl, struct GMT_OPT
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, n_files = 0, pos = 0;
-	int i, j, k;
-	size_t n_alloc = 0, len;
-	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, p[GMT_BUFSIZ] = {""};
+	unsigned int n_errors = 0, n_files = 0;
 	char  *pch = NULL;
 	double t;
 	struct GMT_OPTION *opt = NULL;
@@ -175,8 +172,7 @@ EXTERN_MSC int GMT_gmtisf(void *V_API, int mode, void *args) {	/* High-level fun
 	char   f_type[6], f_plane[6];
     bool   got_event = false, event_end, tensor_end, got_region = false;
 	int    error = GMT_NOERROR;
-	int	   i, in, mag_c = 0, event_c, idx_min_rms, np, ns, n_out_cols;
-	int	   export_aki = false, export_cmt = false, export_tensor = false;
+	int	   i, mag_c = 0, event_c, idx_min_rms, np, ns, n_out_cols;
 	int	   yyyy,mm,dd,hh,mi,ss,msec,strike,ndef,nsta,gap;
 	int   *years, *months, *days, *hours, *minutes;
 	float  stime,sdobs,lat,lon,depth,smaj,smin,sdepth,mindist,maxdist;
@@ -317,8 +313,9 @@ L1:
 			else if (!read_axes_head(line)) {
 				if (fgets(line, ISF_LINE_LEN, fp) != NULL) 
 					if (!read_axes(line, &scale_factor, &t_val, &t_azim, &t_pl, &b_val, &b_azim,
-					               &b_pl, &p_val, &p_azim, &p_pl,author));
-						tensor_end = true;
+					               &b_pl, &p_val, &p_azim, &p_pl,author))
+						;
+				tensor_end = true;
 			}
 			else if (tensor_end && !read_netmag_head(line)) {
 				mag_c = read_mags(fp,line,magtype,&magind,&mag,&magerr,&nsta,author,origid,mag_t,mags);

--- a/src/seis/read_isf.c
+++ b/src/seis/read_isf.c
@@ -14,7 +14,7 @@ int read_event_data(FILE *fp, char *line, int *yyyy, int *mm, int *dd, int *hh, 
 		int *months, int *days, int *hours, int *minutes, int *idx_min_rms) {
 
 	int	done = false, event_c = 0; 
-	float	rms_min = 1e9, gap_min = 360;
+	float	gap_min = 360;
 	*idx_min_rms = 0; 	/* I'm currently using GAP instead of RMS */
 
 	while (!done && (fgets (line, ISF_LINE_LEN, fp) != NULL)) {


### PR DESCRIPTION
**Description of proposed changes**

This is the squelch warnings when compiling the `seis` package. @seisman and @joa-quim, please take note!

I have doubts about the lines with the new line numbers 313-319. I did not change the program flow, just avoided the warning about the (second) empty if by moving the semicolon to a new line. But I really wonder if those two ifs are correct, as well as where `tensor_end = true;` belongs, particularly given the original indentation. Maybe some `{}` where missing?

Addresses #8653 

**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [x] If adding new functionality, add a detailed description to the documentation and/or an example.
