### PR TITLE
Let psxy -N be usable with binary input.

### DIFF
--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -158,7 +158,7 @@ struct GMT_COMMON {
 		char string[GMT_LEN256];
 	} a;
 	struct b {	/* -b[i][o][s|S][d|D][#cols][cvar1/var2/...] */
-		bool active[2];		/* true if current input/output is in native binary format */
+		bool active[3];		/* true if current input/output is in native binary format */
 		bool nc[2];		/* True if netcdf i/o */
 		bool o_delay;		/* true if we don't know number of output columns until we have read at least one input record */
 		bool bin_primary;	/* true if we need to switch back to binary after reading a secondary file in ascii */

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -4835,7 +4835,7 @@ int gmtlib_process_binary_input (struct GMT_CTRL *GMT, uint64_t n_read) {
 						gmtio_adjust_periodic_lon (GMT, &GMT->current.io.curr_rec[col_no]);
 						break;
 					case GMT_IS_LAT:
-						if (GMT->current.io.curr_rec[col_no] < -90.0 || GMT->current.io.curr_rec[col_no] > +90.0) {
+						if (!GMT->common.b.active[2] && (GMT->current.io.curr_rec[col_no] < -90.0 || GMT->current.io.curr_rec[col_no] > +90.0)) {
 							GMT_Report (GMT->parent, GMT_MSG_WARNING, "Latitude (%g) at line # %" PRIu64 " exceeds -|+ 90! - set to NaN\n", GMT->current.io.curr_rec[col_no], GMT->current.io.rec_no);
 							GMT->current.io.curr_rec[col_no] = GMT->session.d_NaN;
 						}

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1403,6 +1403,8 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		Return (GMT_RUNTIME_ERROR);
 	GMT_Report (API, GMT_MSG_DEBUG, "Operation will require %d input columns [n_cols_start = %d]\n", n_needed, n_cols_start);
 
+	if (Ctrl->N.active && GMT->common.b.active[GMT_IN]) GMT->common.b.active[2] = true; /* To signal gmtlib_process_binary_input that lats may be of |90| */
+
 	if (GMT->common.R.active[RSET] && GMT->common.J.active && gmt_map_setup (GMT, GMT->common.R.wesn))
 		Return (GMT_PROJECTION_ERROR);
 	if (S.u_set) {	/* When -Sc<unit> is given we temporarily reset the system unit to these units so conversions will work */
@@ -2430,7 +2432,10 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 				gmt_M_rgb_copy (current_pen.rgb, save_pen.rgb);
 			if (Ctrl->H.active) current_pen = nominal_pen;
 		} while (true);
-		if (GMT->common.t.variable) {	/* Reset the transparencies */
+
+		GMT->common.b.active[2] = false;	/* Reset this because externals have long memory and -N may not be used in a future call */
+
+		if (GMT->common.t.variable) {		/* Reset the transparencies */
 			double transp[2] = {0.0, 0.0};	/* None selected */
 			PSL_settransparencies (PSL, transp);
 		}

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -929,8 +929,10 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 		}
 	}
 
-	if (gmt_check_binary_io (GMT, n_needed))
+	if (gmt_check_binary_io(GMT, n_needed))
 		Return (GMT_RUNTIME_ERROR);
+
+	if (Ctrl->N.active && GMT->common.b.active[GMT_IN]) GMT->common.b.active[2] = true; /* Signal gmtlib_process_binary_input that lats may be of |90| */
 
 	if (S.symbol == GMT_SYMBOL_QUOTED_LINE) {
 		if (gmt_contlabel_prep (GMT, &S.G, NULL))
@@ -1705,6 +1707,8 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 					gmt_M_rgb_copy (current_pen.rgb, save_pen.rgb);
 			}
 		} while (true);
+
+		GMT->common.b.active[2] = false;	/* Reset this because externals have long memory and -N may not be used in a future call */
 
 		if (GMT_End_IO (API, GMT_IN, 0) != GMT_NOERROR) {	/* Disables further data input */
 			Return (API->error);


### PR DESCRIPTION
Fix issue #8606

But solution isn't perfect. For longitudes the 360-wrapping code does not let to plot outside and there is nothing we can do about it without risking to break the general longitudes wrapping.

```
echo 190 110 | gmtconvert -bo | gmt plot -bi -Rd -JQ10i -Baf -BWSen -N -Gred -Sc12p -png lixo
```
![lixo](https://github.com/user-attachments/assets/4336cd99-e90f-4606-93a4-45874a00a065)
