### PR TITLE
CI: Remove some Debian/Fedora versions to save CI resources

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 #
 # Build GMT source codes on different Linux distros using dockers.
 #
+# This workflow is triggered by push or pull request events.
+#
 name: Docker
 
 on:
@@ -53,17 +55,11 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          # Test the oldest and latest Ubuntu LTS releases and also unstable Debian/Fedora
           # Ubuntu: https://en.wikipedia.org/wiki/Ubuntu_version_history#Table_of_versions
           - ubuntu:20.04    # CMake 3.16.3 + GNU 9.3.0;  EOL: 2025-05-29
-          - ubuntu:22.04    # CMake 3.22.1 + GNU 11.2.0; EOL: 2027-06-01
           - ubuntu:24.04    # CMake 3.28.3 + GNU 13.2.0; EOL: 2029-05-31
-          # Debian: https://en.wikipedia.org/wiki/Debian_version_history#Release_table
-          - debian:11       # CMake 3.18.4 + GNU 10.2.1; EOL: 2026-06-01
-          - debian:12       # CMake 3.25.1 + GNU 12.2.0; EOL: 2028-06-01
           - debian:sid      # rolling release with latest versions
-          # Fedora: https://en.wikipedia.org/wiki/Fedora_Linux_release_history
-          - fedora:39       # CMake 3.27.7 + GNU 13.2.1; EOL: 2024-11-12
-          - fedora:40       # CMake 3.28.2 + GNU 14.0.1; EOL: 2025-05-13
           - fedora:rawhide  # rolling release with latest versions
 
     steps:


### PR DESCRIPTION
Only build GMT on the following Linux distros to ensure it works on the oldest and latest CMake + GNU toolchains. Other Linux distros are removed to save CI resources and also reduce our maintenance burden.

- Ubuntu 20.04
- Ubuntu 24.04
- Debian unstable
- Fedora unstable