### PR TITLE
grdsample: Fix the incorrect handling of -Am and -Ap

### DIFF
--- a/src/gmt_vector.c
+++ b/src/gmt_vector.c
@@ -446,7 +446,7 @@ GMT_LOCAL uint64_t gmtvector_fix_up_path_cartesian (struct GMT_CTRL *GMT, double
 	if (step <= 0.0) step = 1.0;	/* Sanity valve; if step not given we set it to 1 */
 
 	for (i = 1; i < n; i++) {
-		if (mode == GMT_STAIRS_Y) {	/* First follow x, then y */
+		if (mode == GMT_STAIRS_X) {	/* First follow x, then y */
 			n_step = lrint (fabs (x[i] - x[i-1]) / step);
 			for (j = 1; j <= n_step; j++) {
 				c = j / (double)n_step;
@@ -465,7 +465,7 @@ GMT_LOCAL uint64_t gmtvector_fix_up_path_cartesian (struct GMT_CTRL *GMT, double
 			}
 			k = 0;
 		}
-		else if (mode == GMT_STAIRS_X) {	/* First follow y, then x */
+		else if (mode == GMT_STAIRS_Y) {	/* First follow y, then x */
 			n_step = lrint (fabs (y[i]-y[i-1]) / step);
 			for (j = 1; j <= n_step; j++) {
 				c = j / (double)n_step;
@@ -1378,7 +1378,7 @@ void gmt_matrix_matrix_mult (struct GMT_CTRL *GMT, double *A, double *B, uint64_
 #else
 	dgemm_ ("t", tr, &na, &nb, &nc, &one, A, &nd, B, &ne, &zero, C, &nf);
 #endif
-	
+
 #else
 	/* Plain matrix multiplication, no speed up; space must exist */
 	uint64_t row, col, k, a_ij, b_ij, c_ij, n_colsA = n_rowsB;

--- a/test/baseline/sample1d.dvc
+++ b/test/baseline/sample1d.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 80fefdb9f9002469c5c61275f23d5532.dir
+- md5: d40cf3c06eab98f9cd49288dc20ff315.dir
   nfiles: 5
   path: sample1d
   hash: md5


### PR DESCRIPTION
See https://github.com/GenericMappingTools/gmt/issues/8645#issuecomment-2570042505 for context.

This PR fixes the sample1d -Am|-Ap issue.