### PR TITLE
CI: Simplify the scripts for install GMT dependencies

### DIFF
--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -41,8 +41,7 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends --no-install-suggests $packages
 
 # Install packages via conda
-conda update -n base -c conda-forge conda --solver libmamba
-conda install ${conda_packages} -c conda-forge --solver libmamba
+conda install ${conda_packages} -c conda-forge
 echo "${CONDA}/bin" >> $GITHUB_PATH
 
 # Remove pcre-config from conda's path so cmake won't find the conda's one

--- a/ci/install-dependencies-macos.sh
+++ b/ci/install-dependencies-macos.sh
@@ -42,8 +42,7 @@ fi
 brew install ${packages}
 
 # Install packages via conda
-conda update -n base -c conda-forge conda --solver libmamba
-conda install ${conda_packages} -c conda-forge --solver libmamba
+conda install ${conda_packages} -c conda-forge
 echo "${CONDA}/bin" >> $GITHUB_PATH
 
 # Remove pcre-config from conda's path so cmake won't find the conda's one

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -48,8 +48,7 @@ if [ "$PACKAGE" = "true" ]; then
 fi
 
 # install more packages using conda
-$CONDA\\Scripts\\conda.exe update -n base -c conda-forge conda --solver libmamba
-$CONDA\\Scripts\\conda.exe install ${conda_packages} -c conda-forge --solver libmamba
+$CONDA\\Scripts\\conda.exe install ${conda_packages} -c conda-forge
 echo "$CONDA\\Library\\bin" >> $GITHUB_PATH
 echo "$CONDA\\Scripts" >> $GITHUB_PATH
 


### PR DESCRIPTION
conda started to use `libmamba` as its default solver one year ago, so we no longer need to update `conda`.