### PR TITLE
Fix auto-legend for custom symbols

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -20214,6 +20214,9 @@ void gmt_add_legend_item (struct GMTAPI_CTRL *API, struct GMT_SYMBOL *S, bool do
 				gmt_M_free (API->GMT, F);
 			}
 		}
+		else if (symbol == GMT_SYMBOL_CUSTOM) { /* Custom symbol */
+			fprintf (fp, "S - %c%s %s %s %s - %s\n", GMT_SYMBOL_CUSTOM, S->custom->name, size_string, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
+		}
 		else
 			fprintf (fp, "S - %c %s %s %s - %s\n", symbol, size_string, (do_fill) ? gmtlib_putfill (API->GMT, fill) : "-", (do_line) ? gmt_putpen (API->GMT, pen) : "-", label);
 	}


### PR DESCRIPTION
The issue was originally reported in https://github.com/GenericMappingTools/pygmt/issues/1860.

Here is the CLI version to reproduce the issue:
```
gmt begin map -V
echo 1 1 | gmt plot -R0/3/0/3 -Skflash/1c -lFlash
echo 2 1 | gmt plot -SkQR/1c -lQR
echo 2 2 | gmt plot -Sc1c -lCircle
# gmt end show
```
The script fails with the following error:
```
plot [ERROR]: Could not find either custom symbol or EPS macro
```
The content of the hidden legend file is:
```
# Auto-generated legend information file
# LEGEND_JUSTIFICATION: RT
# LEGEND_SCALING: 1
# LEGEND_FRAME:  1p white 0.2c
S - k 0.393701i - default,black - Flash
S - k 0.393701i - default,black - QR
S - c 0.393701i - default,black - Circle
```
Apparently, the `S - k` records are incorrect, and they should be `S - kflash` and `S - kQR` instead.

This PR fixes the issue.

The output is:
![map](https://github.com/user-attachments/assets/b0c710f1-59db-4991-abb3-bf2bcda8ddbc)

The sizes of the symbols are a little too large in this case, but they are consistent with the sizes specified in the `-S` option. To have smaller sizes, users should add something like `+S0.2c` to the `-l` option. 


Closes https://github.com/GenericMappingTools/pygmt/issues/1860