### PR TITLE
Add headings to symbols

### DIFF
--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -91,7 +91,7 @@
     diameter *size*, while the *size* of the corresponding lowercase symbols
     refers to the diameter of a circumscribed circle. (2) The stroke-only symbols
     **x**, **y**, **+** and **-** will derive their pen widths from the symbol size
-    and their pen color from |-G| or |-C|. In that sense they beha~ve as the other
+    and their pen color from |-G| or |-C|. In that sense they behave as the other
     symbols (but no outline).  You can override this behavior by specifying |-W|,
     modify it by adjusting :term:`MAP_SYMBOL_PEN_SCALE` [15%], or set it to zero to
     rely on pen defaults (and |-W|).

--- a/doc/rst/source/explain_symbols.rst_
+++ b/doc/rst/source/explain_symbols.rst_
@@ -28,6 +28,9 @@
     You can also change symbols by adding the required |-S| option to any of
     your multi-segment headers.
 
+    Basic Geometries
+    ~~~~~~~~~~~~~~~~
+    
     We will first outline the 14 basic geometric symbols that only require
     a *single* parameter: *size*.
 
@@ -88,10 +91,13 @@
     diameter *size*, while the *size* of the corresponding lowercase symbols
     refers to the diameter of a circumscribed circle. (2) The stroke-only symbols
     **x**, **y**, **+** and **-** will derive their pen widths from the symbol size
-    and their pen color from |-G| or |-C|. In that sense they behave as the other
+    and their pen color from |-G| or |-C|. In that sense they beha~ve as the other
     symbols (but no outline).  You can override this behavior by specifying |-W|,
     modify it by adjusting :term:`MAP_SYMBOL_PEN_SCALE` [15%], or set it to zero to
     rely on pen defaults (and |-W|).
+
+    Complex Geometries
+    ~~~~~~~~~~~~~~~~~~
 
     The next collection shows five symbols that require two or more parameters, and
     some have optional modifiers to enhance the symbol appearance.
@@ -180,6 +186,9 @@
         if *da* is appended then we draw all radial lines separated angularly by *da*.
         These spider-web lines are drawn using the current pen unless **+p**\ *pen* is added.
 
+    Text
+    ~~~~
+
     Text is normally placed with :doc:`text` but there are times we wish to treat a character
     of even a string as a symbol to be plotted:
 
@@ -199,6 +208,9 @@
         angle with the horiontal [0] or use **+A** to indicate map azimuth instead, **+f**\ *font*
         to select a particular font [Default is :term:`FONT_ANNOT_PRIMARY`] and
         **+j**\ *justify* to change justification [CM].
+    
+    Bars
+    ~~~~
 
     The next type of symbol is the horizontal or vertical bar:
 
@@ -247,6 +259,9 @@
         where *size* is the combined width of all the individual, thinner bars plus the gaps.
         Multi-band bars require |-C| with one color per band (CPT z-values must be 0, 1, ..., *nx* - 1).
         Thus, input records are either (*x1 y x2 ... xn*) or (*dx1 y dx2 ... dxn*).
+
+    Vectors
+    ~~~~~~~
 
     The next family of symbols are all different types of *vectors*. Apart from requiring parameters
     such as *length* and *direction* (or optionally the coordinates of the end point), we also
@@ -300,6 +315,9 @@
         If your *length* is not in distance units but in arbitrary user units (e.g., a rate in
         mm/yr) then you can use the **-i** option to scale the corresponding column via the **+s**\ *scale* modifier.
 
+    Customs
+    ~~~~~~~
+
     The next symbol is the programmable *custom* symbol:
 
     .. figure:: /_images/GMT_base_symbols6.*
@@ -325,6 +343,9 @@
         symbol via the input, the trailing text must start with the symbol name which must
         include the leading **k**. The *size* must either be given as a numerical column
         (as for all other symbols) or be added to the name with the required slash.
+
+    Lines with embellishments
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
 
     The last group of symbols are all special *lines* with embellishments along them.
     The first symbol is called a *front* and has specific


### PR DESCRIPTION
I found the documentation of types of symbols a bit hard to read. So I add some headings to split between the types of symbols. 
