### PR TITLE
Support reading GeoJSON files by converting to OGR_GMT format

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -5217,8 +5217,9 @@ FILE * gmt_fopen (struct GMT_CTRL *GMT, const char *filename, const char *mode) 
 		if (!fd) {	/* No, was not a netCDF file */
 			if ((c = gmt_getdatapath (GMT, &filename[first], path, R_OK)) != NULL) {	/* Got the file path */
 				char *ext = gmt_get_ext (c);	/* Get pointer to extension (or NULL if no extension) */
-				if (ext && mode[0] == 'r' && !strncmp (ext, "shp", 3U)) {	/* Got a shapefile for reading */
-					/* We will do a system call to ogr2ogr in order to read the shapefile */
+				if (ext && mode[0] == 'r' && (!strncasecmp (ext, "shp", 3U) || !strncasecmp(ext, "geojson", 7U) || !strncasecmp(ext, "json", 4U) )) {
+					/* Got a shapefile or geojson file for reading */
+					/* We will do a system call to ogr2ogr to convert it to OGR_GMT format */
 					char cmd[GMT_BUFSIZ+GMT_LEN256] = {""};
 					int error = 0;
 					if (GMT->parent->tmp_dir)	/* Make unique file in temp dir */


### PR DESCRIPTION
If files have suffixes like `.json`/`.geojson` (case insensitive), they will be converted to OGR_GMT format internally before reading.

Closes https://github.com/GenericMappingTools/gmt/issues/4599.

