### PR TITLE
Fix two issues related to #8718.

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -10136,7 +10136,7 @@ unsigned int gmtlib_is_time (struct GMT_CTRL *GMT, char *text) {
 		gmt_strrepc (string, p[k], ' ');	/* Replace date separators with space */
 	if (n_colon)
 		gmt_strrepc (string, ':', ' ');	/* Replace time separators with space */
-	if ((n_dash >= 1 && n_slash == 0) || (n_dash == 0 && n_slash >= 1)) {
+	if (((n_dash >= 1 && n_slash == 0) || (n_dash == 0 && n_slash >= 1)) || (n_dash == 0 && n_slash == 0 && string[L] == 'T')) {
 		/* Apart from random junk SHIT 5 6 7:X:Hello!, Possibilities are:
 		 *	1.  yyyy mm dd[T][hh.xxx|:mm.xx|:ss.xx]  Full date and possibly time
 		 *	2.  yyyy jjj[T][hh.xxx|:mm.xx|:ss.xx]  Julian day and possibly time

--- a/src/gmt_map.c
+++ b/src/gmt_map.c
@@ -6915,6 +6915,9 @@ void gmt_auto_frame_interval (struct GMT_CTRL *GMT, unsigned int axis, unsigned 
 	}
 	f *= GMT->session.u2u[GMT_INCH][GMT_PT];	/* Change to points */
 
+	if (is_time && GMT->current.setting.time_system.scale != 1.0)	/* Because gmtmap_auto_time_increment always expects the time in seconds */
+		d *= GMT->current.setting.time_system.scale;
+
 #ifndef NO_THEMES
 	if (GMT->current.setting.run_mode == GMT_MODERN && gmt_M_axis_is_geo (GMT, axis)) {	/* Need more space for degree symbol and WESN letters not considered in the algorithm */
 		if (strchr (GMT->current.setting.format_geo_map, 'F'))	/* Need more space for degree symbol and letter */


### PR DESCRIPTION
First was that a string like "1920T" was not recognizes as an absolute time (contrary to documentation).

Automatic annotations (-Ba) were failing miserably for when -R were given in years (and probably other time units as well) because the guessing function is always expecting times in seconds.
