### PR TITLE
FIX: `project -G` use angular unit

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -844,8 +844,14 @@ EXTERN_MSC int GMT_project (void *V_API, int mode, void *args) {
 		gmt_set_column_type (GMT, GMT_OUT, GMT_X, (Ctrl->N.active) ? GMT_IS_FLOAT : GMT_IS_LON);
 		gmt_set_column_type (GMT, GMT_OUT, GMT_Y, (Ctrl->N.active) ? GMT_IS_FLOAT : GMT_IS_LAT);
 		gmt_set_column_type (GMT, GMT_OUT, GMT_Z, GMT_IS_FLOAT);
-		if (Ctrl->Q.active && Ctrl->G.unit != 'k' && !Ctrl->G.number)
-			Ctrl->G.inc *= 0.001 / GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in km */
+		if (Ctrl->Q.active && Ctrl->G.unit != 'k' && !Ctrl->G.number){
+			if (GMT->current.map.dist[GMT_MAP_DIST].arc) {
+				Ctrl->G.inc *= (GMT->current.proj.KM_PR_DEG / GMT->current.map.dist[GMT_MAP_DIST].scale); /* Now in km */
+			}
+			else {
+				Ctrl->G.inc /= METERS_IN_A_KM * GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in km */
+			}
+		}
 	}
 	else if (!Ctrl->N.active) {	/* Decode and set the various output column types in the geographic case */
 		for (col = 0; col < P.n_outputs; col++) {


### PR DESCRIPTION
Hi, GMT!

I found that `gmt project -G<dist>`  uses wrong interval when `<dist>` appending angular unit `d|m|e`. For example, 
``` bash
$ gmt project -C125/33 -E146/46 -G1d -Q | head -n3
125     33      0
125.000007565   33.0000063736   0.001
125.00001513    33.0000127473   0.002
```
looks like there's a strange 1e-3 scale. I checked `project.c`, and I guess maybe we need to add an `if` statement here, to check whether `-G` use angular unit. 

https://github.com/GenericMappingTools/gmt/blob/640f1e68c6cdb6a056bd76807b4a1cb03669764c/src/project.c#L847-L848

So I imitate some lines for `-Z`, 

https://github.com/GenericMappingTools/gmt/blob/640f1e68c6cdb6a056bd76807b4a1cb03669764c/src/project.c#L783-L793

I add an `if` statement for `-G`,

``` C
if (Ctrl->Q.active && Ctrl->G.unit != 'k' && !Ctrl->G.number){
	if (GMT->current.map.dist[GMT_MAP_DIST].arc) {
		Ctrl->G.inc *= (GMT->current.proj.KM_PR_DEG / GMT->current.map.dist[GMT_MAP_DIST].scale); /* Now in km */
	}
	else {
		Ctrl->G.inc /= METERS_IN_A_KM * GMT->current.map.dist[GMT_MAP_DIST].scale;	/* Now in km */
	}
}
```

After recompiling, I test it with same command, the result seems fine.

``` bash
$ gmt project -C125/33 -E146/46 -G1d -Q | head -n3
125     33      0
125.848042113   33.705854159    111.195051975
126.710079013   34.4058180505   222.39010395
``` 

