### PR TITLE
FIX: check whether -C and -E use different unit in `grdtrack`

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -139,7 +139,8 @@ Optional Arguments
     counter-clockwise.  Finally, you can use **+f** to set a fixed azimuth
     for all profiles. **Note**: If |-C| is set and *spacing* is given then
     that sampling scheme overrules any modifier set in |-E|.
-    Currently, there is a bug when |-C| and |-E| use different units.
+    Currently, there is a bug when |-C| and |-E| use different units 
+    (see PR `#8728 <https://github.com/GenericMappingTools/gmt/pull/8728>`_ ).
     If you use both, please manually specify the same unit for each.
 
 .. _-D:

--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -139,6 +139,8 @@ Optional Arguments
     counter-clockwise.  Finally, you can use **+f** to set a fixed azimuth
     for all profiles. **Note**: If |-C| is set and *spacing* is given then
     that sampling scheme overrules any modifier set in |-E|.
+    Currently, there is a bug when |-C| and |-E| use different units.
+    If you use both, please manually specify the same unit for each.
 
 .. _-D:
 

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -815,7 +815,9 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 		}
 		if (gmt_init_distaz (GMT, Ctrl->E.unit, Ctrl->E.mode, GMT_MAP_DIST) == GMT_NOT_A_VALID_TYPE)	/* Initialize the distance unit and scaling */
 			Return (GMT_NOT_A_VALID_TYPE);
-
+			
+		/* !!! TEMPORARY METHOD !!! */
+		/* Currently we cannot use different units in -C and -E, we have to prevent this bug first. See PR #8728 */
 		/* Check whether -C and -E use different unit */
 		if (Ctrl->C.active && Ctrl->C.unit != Ctrl->E.unit){
 			GMT_Report (API, GMT_MSG_ERROR, 

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -816,6 +816,14 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 		if (gmt_init_distaz (GMT, Ctrl->E.unit, Ctrl->E.mode, GMT_MAP_DIST) == GMT_NOT_A_VALID_TYPE)	/* Initialize the distance unit and scaling */
 			Return (GMT_NOT_A_VALID_TYPE);
 
+		/* Check whether -C and -E use different unit */
+		if (Ctrl->C.active && Ctrl->C.unit != Ctrl->E.unit){
+			GMT_Report (API, GMT_MSG_ERROR, 
+				"Option -C and -E shoule take the same unit, but received %c (-C) and %c (-E). "
+				"Recommend you explicitly set the same unit for -C and -E.\n", Ctrl->C.unit, Ctrl->E.unit);
+			Return (GMT_RUNTIME_ERROR);
+		}
+
 		/* Set default spacing to half the min grid spacing: */
 		Ctrl->E.step = 0.5 * MIN (GC[0].G->header->inc[GMT_X], GC[0].G->header->inc[GMT_Y]);
 		if (gmt_M_is_geographic (GMT, GMT_IN)) {	/* Convert to km if geographic or degrees if arc-units */


### PR DESCRIPTION
## bug description

1. In `grdtrack` module, `-C` and `-E` use different default units for geographic grids (*meter* for `-C`, *kilometer* for `-E`). Users might comfused about the result if they did't explicitly set units. 

2. Also, it seems that `-C` and `-E` cannot use different units, even if I explicity set them. For example, 

   ``` bash
    $ gmt grdtrack -G@earth_relief_30m -C10d/0.1/5 -E125/33/146/46+i10k | head -n5
    > Cross profile number -L0-000 at  125.000/033.000 az=-45.1
    152.120545696   2.11440582896   -555983.596548  143.502762578   -4493.94584719
    -104.038158968  -52.8958698548  -544862.587853  143.502762578   -4172.34066777
    -15.7830363619  13.8917296377   -533750.674146  80.1535161628   25.4353068519
    104.739638124   45.5743008564   -522618.396532  37.7551090445   1373.92989473
   ```
   while the result seems fine if I set the same unit, 

   ``` bash
    $ gmt grdtrack -G@earth_relief_30m -C10d/0.1/5 -E125/33/146/46+i0.1d | head -n5
    > Cross profile number -L0-0 at  125.000/033.000 az=-45.1
    120.595820698   36.4509628442   -5.00004763636  132.358684312   36.0413484424
    120.687607339   36.3835507254   -4.90002198049  132.358684312   24.5587581626
    120.779234893   36.3160685085   -4.79999733063  132.413174504   11.9851527852
    120.870703862   36.2485164875   -4.69997368705  132.467483417   -0.153214879891
   ```
  
## What's changed

Not perfect solution, I just add an `if` statement to check whether they are the different unit. After recompiling, same command above will return error, 

``` bash
$ gmt grdtrack -G@earth_relief_30m -C10d/0.1/5 -E125/33/146/46+i10k | head -n5
grdtrack [ERROR]: Option -C and -E shoule take the same unit, but received d (-C) and k (-E). Recommend you explicitly set the same unit for -C and -E.
```