### PR TITLE
FIX: in `grdtrack`, `-Su+d+r` gives 0 result

### DIFF
--- a/doc/rst/source/grdtrack.rst
+++ b/doc/rst/source/grdtrack.rst
@@ -200,7 +200,7 @@ Optional Arguments
     values to all cross-profiles. **+d** : Append stack deviations to
     all cross-profiles. **+r** : Append data residuals (data - stack) to
     all cross-profiles. **+s**\ [*file*] : Save stacked profile to
-    *file* [grdtrack_stacked_profile.txt]. **+c**\ *fact* : Compute
+    *file* [stacked_profile.txt]. **+c**\ *fact* : Compute
     uncertainty envelope on stacked profile as ±\ *fact* \*\ *deviation* [2].
     **Notes**: (1) Deviations depend on *method* and are standard deviation (**a**), L1
     scale, i.e., 1.4826 \* median absolute deviation (MAD) (for **m** and **p**),

--- a/src/grdtrack.c
+++ b/src/grdtrack.c
@@ -1020,9 +1020,10 @@ EXTERN_MSC int GMT_grdtrack (void *V_API, int mode, void *args) {
 						M->data[2+k*n_step][row] = stacked_dev[k];	/* The stacked deviation */
 						M->data[3+k*n_step][row] = stacked_lo[k];	/* The stacked low value */
 						M->data[4+k*n_step][row] = stacked_hi[k];	/* The stacked high value */
-						if (Ctrl->S.mode >= STACK_LOWER) continue;
-						M->data[5+k*n_step][row] = stacked_val[k] - Ctrl->S.factor * stacked_dev[k];	/* The low envelope value */
-						M->data[6+k*n_step][row] = stacked_val[k] + Ctrl->S.factor * stacked_dev[k];	/* The low envelope value */
+						if (Ctrl->S.mode < STACK_LOWER) {
+							M->data[5+k*n_step][row] = stacked_val[k] - Ctrl->S.factor * stacked_dev[k];	/* The low envelope value */
+							M->data[6+k*n_step][row] = stacked_val[k] + Ctrl->S.factor * stacked_dev[k];	/* The low envelope value */
+						} 
 						if (n_added_cols == 0) continue;	/* No modification to profile outputs requested */
 						for (seg = 0; seg < T->n_segments; seg++) {	/* For each segment to append to */
 							col_s = colx;	/* Start over at this column */


### PR DESCRIPTION
## bug description

Following command gives 0 value result, 
``` bash
$ gmt grdtrack -G@earth_relief_30m -C23d/0.1/5 -E125/33/146/46+i0.1d -Su+a+d+r+s | head -n5
> Cross profile number -L0-0 at  125.000/033.000 az=-45.1
114.26416966    40.6673817899   -11.503849419   128.406893601   1235.72535495   0       0       0
114.367384391   40.6052116066   -11.403759574   128.406893601   1186.20357679   0       0       0
114.470407141   40.5429497186   -11.3036706902  128.47411274    1138.74642045   0       0       0
114.573238406   40.4805964975   -11.2035827687  128.541121917   1097.87933294   0       0       0
```

but `-Sa`(or `m` or `p`) result seems fine,
``` bash
$ gmt grdtrack -G@earth_relief_30m -C23d/0.1/5 -E125/33/146/46+i0.1d -Sa+a+d+r+s | head -n5
> Cross profile number -L0-0 at  125.000/033.000 az=-45.1
114.26416966    40.6673817899   -11.503849419   128.406893601   1235.72535495   720.292586732   470.461540049   515.43276822
114.367384391   40.6052116066   -11.403759574   128.406893601   1186.20357679   671.853133504   467.132268645   514.350443286
114.470407141   40.5429497186   -11.3036706902  128.47411274    1138.74642045   617.656836713   463.490082661   521.089583733
114.573238406   40.4805964975   -11.2035827687  128.541121917   1097.87933294   565.3276248     460.812758913   532.551708144
```

the stacked profile (*stacked_profile.txt*, generated by `+s`) wasn't influenced.

## What's Changed

The original `continue` statement here skip the value assignment, so I changed `if` to include "envolope" instead.

https://github.com/GenericMappingTools/gmt/blob/13885722ad2fbf0ca834f72657b16b62cb2f57dd/src/grdtrack.c#L1018-L1033

The new result seems fine (0 value in *residual* column is normal for this command),

``` bash
$ gmt grdtrack -G@earth_relief_30m -C23d/0.1/5 -E125/33/146/46+i0.1d -Su+a+d+r+s | head -n5
> Cross profile number -L0-0 at  125.000/033.000 az=-45.1
114.26416966    40.6673817899   -11.503849419   128.406893601   1235.72535495   1235.72535495   506.723581417   0
114.367384391   40.6052116066   -11.403759574   128.406893601   1186.20357679   1186.20357679   484.533767645   0
114.470407141   40.5429497186   -11.3036706902  128.47411274    1138.74642045   1138.74642045   461.580797293   0
114.573238406   40.4805964975   -11.2035827687  128.541121917   1097.87933294   1097.87933294   439.851354011   0
```