### PR TITLE
FIX: `grdinterpolate -S` failed with `-T`

### DIFF
--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -646,7 +646,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 				GMT_Report (API, GMT_MSG_ERROR, "Unable to create virtual dataset for sampled time-series\n");
 				Return (API->error);
 			}
-			sprintf (cmd, "%s -F%s -N%d -T%s ->%s", i_file, Ctrl->F.spline, (int)(Out->n_columns - 1), Ctrl->T.string, o_file);
+			sprintf (cmd, "%s -F%s -N%d -T%s ->%s", i_file, Ctrl->F.spline, (Ctrl->S.active)? GMT_Z : (int)(Out->n_columns - 1), Ctrl->T.string, o_file);
 			if (GMT_Call_Module (API, "sample1d", GMT_MODULE_CMD, cmd) != GMT_NOERROR) {	/* Interpolate each profile per -T */
 				Return (API->error);
 			}


### PR DESCRIPTION
## bug description

`grdinterpolate -S` failed with `-T`, 
``` bash
$ gmt grdinterpolate S362ANI_kmps.nc?vs -S120/30 -T30/2890/10
sample1d [ERROR]: x-values are not monotonically increasing/decreasing (at zero-based record 5)!
sample1d [ERROR]: Failure in gmt_intpol near row 6!
```
(cube can be downloaded by `curl -s http://ds.iris.edu/spudservice/data/17996723 -o S362ANI_kmps.nc`)

but single `-S` works fine, 
``` bash
$ gmt grdinterpolate S362ANI_kmps.nc?vs -S120/30
> Location 120,30
120     30      25      4.50629997253
120     30      50      4.45459985733
120     30      75      4.41890001297
120     30      100     4.40129995346
120     30      125     4.39860010147
120     30      150     4.40659999847
... (skip)
```

## What's changed

Same logic as below. Column index passed to `sampled1d -N[col]` is changeable. 
https://github.com/GenericMappingTools/gmt/blob/5beb2bdbeb6c838fe7aba14c55c5e52c0132f741/src/grdinterpolate.c#L607-L620

The new result seems fine. 
``` bash
$ gmt grdinterpolate S362ANI_kmps.nc?vs -S120/30 -T30/2890/10
> Location 120,30
120     30      30      4.49469568981
120     30      40      4.47343079986
120     30      50      4.45459985733
120     30      60      4.43819725238
120     30      70      4.4245685905
120     30      80      4.41396319261
... (skip)
``` 