### PR TITLE
FIX: `grdinterpolate -E` can't set correct unit

### DIFF
--- a/src/grdinterpolate.c
+++ b/src/grdinterpolate.c
@@ -456,6 +456,16 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 			}
 		}
 		else {	/* Create profile */
+			/* Need to get dx,dy from one grid */
+			if (Ctrl->Z.active)	/* Get the first file */
+				sprintf (file, "%s", Ctrl->In.file[0]);
+			else	/* Get the first layer from 3-D cube possibly via a selected variable */
+				sprintf (file, "%s?%s[0]", Ctrl->In.file[0], cube_layer);
+			if ((Grid = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, file, NULL)) == NULL) {
+				GMT_Report (API, GMT_MSG_ERROR, "Unable to read header from file %s.\n", file);
+				Return (API->error);
+			}
+
 			char prof_args[GMT_LEN128] = {""};
 			if (!(equi_levels || Ctrl->T.active)) {
 				GMT_Report (API, GMT_MSG_ERROR, "Option -E requires either equidistant levels or resampling via -T\n");
@@ -467,16 +477,7 @@ EXTERN_MSC int GMT_grdinterpolate (void *V_API, int mode, void *args) {
 			}
 			if (gmt_init_distaz (GMT, Ctrl->E.unit, Ctrl->E.mode, GMT_MAP_DIST) == GMT_NOT_A_VALID_TYPE)	/* Initialize the distance unit and scaling */
 				Return (GMT_NOT_A_VALID_TYPE);
-
-			/* Need to get dx,dy from one grid */
-			if (Ctrl->Z.active)	/* Get the first file */
-				sprintf (file, "%s", Ctrl->In.file[0]);
-			else	/* Get the first layer from 3-D cube possibly via a selected variable */
-				sprintf (file, "%s?%s[0]", Ctrl->In.file[0], cube_layer);
-			if ((Grid = GMT_Read_Data (API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_CONTAINER_ONLY, NULL, file, NULL)) == NULL) {
-				GMT_Report (API, GMT_MSG_ERROR, "Unable to read header from file %s.\n", file);
-				Return (API->error);
-			}
+			
 			/* Set default spacing to half the min grid spacing: */
 			Ctrl->E.step = 0.5 * MIN (Grid->header->inc[GMT_X], Grid->header->inc[GMT_Y]);
 			if (GMT_Destroy_Data (API, &Grid)) {


### PR DESCRIPTION
## bug description

`grdinterpolate -E` can't set correct unit,
``` bash
$ gmt grdinterpolate S362ANI_kmps.nc?vs -E0/60/110/60+i1d -T30/2890/10 -Gtest.nc  && gmt grd2xyz test.nc | head -n5
grdinterpolate [WARNING]: Your filename 0/60/110/60+i1d has what appears as valid GMT modifiers (from list +Udhinosu) but they are embedded rather than appended to the filename - modifiers ignored
0       2890    7.28660011292
112421.290721   2890    7.2931098938
224842.581442   2890    7.30029201508
337263.872163   2890    7.30822467804
449685.162883   2890    7.31660509109
```
(cube can be downloaded by `curl -s http://ds.iris.edu/spudservice/data/17996723 -o S362ANI_kmps.nc`)

## Whats' changed

This part (`-E`) should be similar to that of `grdtrack`. In `grdtrack`, `E.unit` and projection scale are determined **after** the grid data reading, but this is opposite in `grdinterpolate`, see code below,
https://github.com/GenericMappingTools/gmt/blob/5beb2bdbeb6c838fe7aba14c55c5e52c0132f741/src/grdinterpolate.c#L464-L479

I use `printf()` to check the `GMT->current.map.dist[GMT_MAP_DIST].scale` before and after the `GMT_Read_Data()`, `scale` is redetermined. `Grid` here is just used to determined the default interval. So I just change the position of the calling function `GMT_Read_Data()` part, move upward a little bit.

The new result seems fine,
``` bash
$ gmt grdinterpolate S362ANI_kmps.nc?vs -E0/60/110/60+i10k -T30/2890/10 -Gtest.nc  && gmt grd2xyz test.nc | head -n5
grdinterpolate [WARNING]: Your filename 0/60/110/60+i10k has what appears as valid GMT modifiers (from list +Udhinosu) but they are embedded rather than appended to the filename - modifiers ignored
0       2890    7.28660011292
10.030152332    2890    7.28715085983
20.0603046639   2890    7.2877073288
30.0904569959   2890    7.28826999664
40.1206093279   2890    7.28883838654
```
``` bash
$ gmt grdinterpolate S362ANI_kmps.nc?vs -E0/60/110/60+i1.5d -T30/2890/10 -Gtest.nc  && gmt grd2xyz test.nc | head -n5
grdinterpolate [WARNING]: Your filename 0/60/110/60+i1.5d has what appears as valid GMT modifiers (from list +Udhinosu) but they are embedded rather than appended to the filename - modifiers ignored
0       2890    7.28660011292
1.51654172632   2890    7.29662418365
3.03308345265   2890    7.30822467804
4.54962517897   2890    7.3208527565
6.0661669053    2890    7.33400297165
```
``` bash
$ gmt grdinterpolate S362ANI_kmps.nc?vs -E0/60/110/60+i30m -T30/2890/10 -Gtest.nc  && gmt grd2xyz test.nc | head -n5
grdinterpolate [WARNING]: Your filename 0/60/110/60+i30m has what appears as valid GMT modifiers (from list +Udhinosu) but they are embedded rather than appended to the filename - modifiers ignored
0       2890    7.28660011292
30.0181455108   2890    7.28972959518
60.0362910215   2890    7.29303884506
90.0544365323   2890    7.2965130806
120.072582043   2890    7.300137043
```
