### PR TITLE
CMake: Set the max cmake policy to 3.31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if (${srcdir} STREQUAL ${bindir})
 endif (${srcdir} STREQUAL ${bindir})
 
 # Define minimum CMake version required
-cmake_minimum_required (VERSION 3.16)
+cmake_minimum_required (VERSION 3.16...3.31)
 message ("CMake version: ${CMAKE_VERSION}")
 
 # Use NEW behavior with newer CMake releases


### PR DESCRIPTION
Addressing https://github.com/GenericMappingTools/gmt/pull/8324#issuecomment-2834546743.

Upstream documentaton at https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html.