### PR TITLE
WIP: Let us have the Spilhaus projection accessible from pscoast.c

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -18546,7 +18546,7 @@ int gmt_parse_common_options (struct GMT_CTRL *GMT, char *list, char option, cha
 				if (GMT->current.gdal_read_in.hCT_inv) OCTDestroyCoordinateTransformation(GMT->current.gdal_read_in.hCT_inv);
 				GMT->current.gdal_read_in.hCT_fwd = gmt_OGRCoordinateTransformation (GMT, source, dest);
 				GMT->current.gdal_read_in.hCT_inv = gmt_OGRCoordinateTransformation (GMT, dest, source);
-				GMT->current.proj.projection      = GMT_PROJ4_PROJS;		/* This now make it use the proj4 lib */
+				GMT->current.proj.projection = strstr(dest, "spilhaus") ? GMT_PROJ4_SPILHAUS : GMT_PROJ4_PROJS;	/* Special case for spilhaus */
 				GMT->common.J.active = true;
 				if (GMT->current.gdal_read_in.hCT_fwd == NULL || GMT->current.gdal_read_in.hCT_inv == NULL)
 					error = 1;

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3088,6 +3088,9 @@ GMT_LOCAL void gmtplot_map_boundary (struct GMT_CTRL *GMT) {
 		case GMT_VANGRINTEN:
 			gmtplot_basic_map_boundary (GMT, PSL, w, e, s, n);
 			break;
+		case GMT_PROJ4_SPILHAUS:
+			gmtplot_basic_map_boundary (GMT, PSL, w, e, s, n);
+			break;
 	}
 	PSL_comment (PSL, "End of map frame\n");
 }

--- a/src/gmt_project.h
+++ b/src/gmt_project.h
@@ -120,7 +120,10 @@ enum gmt_enum_misc {GMT_MOLLWEIDE = 400,
 	GMT_WINKEL};
 
 /* All projections from proj.4 lib */
-enum gmt_enum_allprojs {GMT_PROJ4_PROJS = 500};
+#define gmt_M_is_proj4(C) (C->current.proj.projection / 100 == 5)
+enum gmt_enum_allprojs {GMT_PROJ4_PROJS = 500,
+	GMT_PROJ4_SPILHAUS,
+};
 
 /*! The various GMT measurement units */
 enum gmt_enum_units {GMT_IS_METER = 0,

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1518,7 +1518,7 @@ EXTERN_MSC int GMT_grdimage(void *V_API, int mode, void *args) {
 
 	/* Determine if grid/image is to be projected */
 	need_to_project = (gmt_M_is_nonlinear_graticule (GMT) || Ctrl->E.dpi > 0);
-	if (need_to_project && GMT->current.proj.projection == GMT_PROJ4_PROJS) {
+	if (need_to_project && gmt_M_is_proj4(GMT)) {
 		if (GMT->current.proj.is_proj4)
 			if (strstr(GMT->common.J.proj4string, "longlat") || strstr(GMT->common.J.proj4string, "lonlat") || strstr(GMT->common.J.proj4string, "latlon"))
 				need_to_project = false;

--- a/src/pscoast.c
+++ b/src/pscoast.c
@@ -59,7 +59,7 @@
 #define THIS_MODULE_PURPOSE	"Plot continents, countries, shorelines, rivers, and borders"
 #define THIS_MODULE_KEYS	">?},>DE-lL"
 #define THIS_MODULE_NEEDS	"JR"
-#define THIS_MODULE_OPTIONS "->BJKOPRUVXYbdptxy" GMT_OPT("Zc")
+#define THIS_MODULE_OPTIONS "->BJKOPRUVXYbdgptxy" GMT_OPT("Zc")
 
 #define LAKE	0
 #define RIVER	1


### PR DESCRIPTION
For this, it was necessary to add the -g option to pscoast and make a gap detection in `gmt_geo_to_xy_line()`.

We can not yet do the interrupted graticule nor plot a frame.

