### PR TITLE
Update makecpt.rst -H

### DIFF
--- a/doc/rst/source/makecpt.rst
+++ b/doc/rst/source/makecpt.rst
@@ -123,7 +123,7 @@ Optional Arguments
 .. _-H:
 
 **-H**\
-    Modern mode only: Write the CPT to standard output as well [Default saves
+    Modern mode only: Write the CPT to standard output instead [Default saves
     the CPT as the session current CPT]. Required for scripts used to make
     animations via :doc:`movie` and :doc:`batch` where we must pass named CPT files.
 


### PR DESCRIPTION
I understand that when the `-H` option is used, the CPT is only written to standard output, not to a file. So the documentation should say "instead" rather than "as well".

Here is the relevant line in the source code for reference: https://github.com/GenericMappingTools/gmt/blob/b244cfd57683cf096c03b193ed83c51a48bbf5a8/src/makecpt.c#L668

Please approve this change only if my understanding is correct.
