### PR TITLE
Change free to free_aligned in gmtlib_free_vector_ptr

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -9209,7 +9209,7 @@ void gmtlib_free_vector_ptr (struct GMT_CTRL *GMT, struct GMT_VECTOR *V, bool fr
 		for (unsigned int k = 0; k < V->n_headers; k++) gmt_M_str_free (V->header[k]);
 		gmt_M_free (GMT, V->header);
 	}
-	gmt_M_free (GMT, V->data);	/* Sometimes we free a V that has nothing allocated so must check */
+	gmt_M_free_aligned (GMT, V->data);	/* Sometimes we free a V that has nothing allocated so must check */
 	gmt_M_free (GMT, V->type);
 	gmt_M_free (GMT, VH->alloc_mode);
 	gmt_M_free (GMT, V->hidden);


### PR DESCRIPTION
 Change call of `gmt_M_free` to `gmt_M_free_aligned` in `gmtlib_free_vector_ptr` to match `gmt_M_memory_aligned` in `gmt_create_vector`.

At least for me, it was segfaulting because it would allocate with fftw and then try to deallocate with free.