### PR TITLE
correct formula in greenspline.rst

### DIFF
--- a/doc/rst/source/greenspline.rst
+++ b/doc/rst/source/greenspline.rst
@@ -81,7 +81,7 @@ the *m* extra constraints:
 
 .. math::
 
-    s(\mathbf{x}_k) = \nabla w(\mathbf{x}_k) = \sum_{j=1}^{n} \alpha_j \nabla g(\mathbf{x}_k; \mathbf{x}_j) \mathbf{n}_k, \quad k = 1,m
+    s(\mathbf{x}_k) = \nabla w(\mathbf{x}_k) \mathbf{n}_k = \sum_{j=1}^{m} \alpha_{j+n} \nabla g(\mathbf{x}_k; \mathbf{x}_j) \mathbf{n}_k, \quad k = 1,m
 
 where the gradient of the Green's functions is dotted with the unit vector of the observed gradient.
 


### PR DESCRIPTION
**Before**

<img width="424" height="60" alt="image" src="https://github.com/user-attachments/assets/3c3b92e0-7861-4f1d-a440-348557b31b32" />


**After**

<img width="457" height="62" alt="image" src="https://github.com/user-attachments/assets/360de1cd-74b8-47e9-89b4-aba4a163dffc" />


Based on the description after equation (6) in [Wessel and Bercovici (1998)](https://doi.org/10.1023/A:1021713421882), 

> In mixed situations where N0 data points and N1 slopes constrain the interpolation (4) is used to evaluate the first N0 equations and (6) to evaluate the last N1 equations in the total (N0 + N1) by (N0 + N1) square linear system. Once c has been determined, the complete solution w(x) is evaluated using (3).

Also the correct formula satisfies the description *"we must add additional m unknown coefficients"* in [greenspline doc](https://docs.generic-mapping-tools.org/dev/greenspline.htm)