### PR TITLE
DOC: Fix typo in docs for plot -E 

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -135,7 +135,7 @@ Optional Arguments
       using |-G|. These quantities must be stored in the columns after the (*x, y*)
       pair [or (*x, y, z*) triplet].
     - **Y** - Draw a box-and-whisker symbol (i.e., stem-and-leaf) in *y* direction.
-      Same layount as for **X**.
+      Same layout as for **X**.
 
     Several modifiers can affect the appearance of the symbols:
 


### PR DESCRIPTION
**Description of proposed changes**

Just a typo fix in the docs for **-E** of plot.

**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
