### PR TITLE
Shut up lots of new warnings issued by MSC compiler after some update.

### DIFF
--- a/src/gmt.h
+++ b/src/gmt.h
@@ -37,6 +37,11 @@
 extern "C" {
 #endif
 
+/* Disable warning: operands are different enum types */
+#ifdef _MSC_VER
+#pragma warning( disable : 5287 )
+#endif
+
 /*
  * We only include the basic include files needed by the API. Users may
  * need to include additional files, such as <math.h>, etc. In order to


### PR DESCRIPTION
Example warning:
warning C5287: operands are different enum types 'GMT_enum_std' and 'GMT_enum_method'; use an explicit cast to silence this warning
