### PR TITLE
DOC: basemape/coast - fix typo in docs for directional rose (-T)

### DIFF
--- a/doc/rst/source/explain_-T_rose.rst_
+++ b/doc/rst/source/explain_-T_rose.rst_
@@ -13,7 +13,7 @@
 
     - **+f**\ [*level*] to get a "fancy" rose, and optionally specify the *level* of fanciness. Level **1** draws
       the two principal E-W, N-S orientations, **2** adds the two intermediate NW-SE and NE-SW orientations, while **3**
-      adds the eight minor orientations WNW-ESE, NNW-SSE, NNE-SSW, and ENE-WSW [default is **1**].  Use **+F** to
+      adds the four minor orientations WNW-ESE, NNW-SSE, NNE-SSW, and ENE-WSW [default is **1**]. Use **+F** to
       force the labels to be readable from the south if the projection has extensive rotation of the directions.
     - **+j**\ *justify* to set the justification :ref:`anchor point <Anchor_Point_j>`, where *justify* is a 2-character
       :ref:`justification code <Reference_Points>` that is a combination of a horizontal (**L**, **C**, or **R**) and a


### PR DESCRIPTION
**Description of proposed changes**

Maybe I am confused by myself, but if we say **two** principal orientations and **two** intermediate orientations then it should be **four** (not eight) minor orientations, or?


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
