### PR TITLE
DOC: Fix the default resolution from 1200 to 300 for patterns

### DIFF
--- a/doc/rst/source/reference/features.rst
+++ b/doc/rst/source/reference/features.rst
@@ -519,14 +519,14 @@ URLs and remote files
 
 Three classes of files are given special treatment in GMT.
 
-#. GMT offers several remote global data grids that you can access via our remote file mechanism 
+#. GMT offers several remote global data grids that you can access via our remote file mechanism
    (e.g. **@earth_relief**). The first time you access one of these files, GMT will download
-   the file (or a subset tile) from the selected GMT server and save it to the *server* directory 
-   under your **$GMT_USERDIR** directory [~/.gmt]. Once one of these grids have been downloaded 
+   the file (or a subset tile) from the selected GMT server and save it to the *server* directory
+   under your **$GMT_USERDIR** directory [~/.gmt]. Once one of these grids have been downloaded
    any future reference will simply obtain the file from **$GMT_USERDIR** (except if explicitly
-   removed by the user). See the `Remote Datasets <https://docs.generic-mapping-tools.org/dev/datasets/remote-data.html>`_ 
+   removed by the user). See the `Remote Datasets <https://docs.generic-mapping-tools.org/dev/datasets/remote-data.html>`_
    section for a comprehensive list of available remote datasets and detailed information.
-   
+
 
 #. If a file is given as a full URL, starting with **http://**, **https://**,
    or **ftp://**, then the file will be downloaded to the current directory and subsequently
@@ -1007,7 +1007,7 @@ use **-G** for this task and some have several options specifying different fill
     customized, repeating images using image raster files.
     The optional **+r**\ *dpi* modifier sets the resolution of this image on the page;
     the area fill is thus made up of a series of these "tiles".  The
-    default resolution is 1200.  By specifying upper case **-GP**
+    default resolution is 300.  By specifying upper case **-GP**
     instead of **-Gp** the image will be bit-reversed, i.e., white and
     black areas will be interchanged (only applies to 1-bit images or
     predefined bit-image patterns). For these patterns and other 1-bit


### PR DESCRIPTION
The documentation says the default DPI for patterns is 1200, but actually it's 300 from the source code:

https://github.com/GenericMappingTools/gmt/blob/3f87eb0da19e76260cd5582e3256891dfe6a0ae2/src/postscriptlight.h#L56

I believe it's a typo which can be dated back to even GMT 5.4 (https://docs.generic-mapping-tools.org/5.4/GMT_Docs.html#specifying-area-fill-attributes).

Here is a test to verify that the dpi resolution is 300, not 1200:
```
gmt begin map
    gmt basemap -R0/10/0/10 -JX10c -Baf
    echo 2 5 | gmt plot -Sc2c -Gp10
    echo 5 5 | gmt plot -Sc2c -Gp10+r300
    echo 8 5 | gmt plot -Sc2c -Gp10+r1200
gmt end show
```
<img width="1265" height="1249" alt="map" src="https://github.com/user-attachments/assets/5cc9cb6f-8077-45f2-89bc-50a8a45b1280" />

