### PR TITLE
CI: Install libpcre2 instead of libpcre3

### DIFF
--- a/ci/install-dependencies-linux.sh
+++ b/ci/install-dependencies-linux.sh
@@ -22,7 +22,7 @@ conda_packages="ghostscript=10.03.0"
 
 # optional packages
 if [ "$EXCLUDE_OPTIONAL" = "false" ]; then
-    packages+=" libfftw3-dev libpcre3-dev liblapack-dev libglib2.0-dev"
+    packages+=" libfftw3-dev libpcre2-dev liblapack-dev libglib2.0-dev"
 fi
 
 # packages for running GMT tests


### PR DESCRIPTION
libpcre3-dev is the old library and may not be supported in OS like Debian 13. Changing it to the new library libpcre2-dev.