### PR TITLE
gmtlogo/psbasemap: Ensure the long options for -D are consistent with other modules

### DIFF
--- a/src/longopt/gmtlogo_inc.h
+++ b/src/longopt/gmtlogo_inc.h
@@ -27,7 +27,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 		  transproc_mask */
 	{ 0, 'D', "position",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "w,h,j,o",           "width,height,janchor,offset",
+	          "w,h,j,o",           "width,height,anchor,offset",
 		  GMT_TP_STANDARD },
 	{ 0, 'F', "border|box",
 	          "",                  "",

--- a/src/longopt/inset_inc.h
+++ b/src/longopt/inset_inc.h
@@ -28,7 +28,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	{ 0, 'C', "clearance",         "", "", "", "", GMT_TP_STANDARD },
 	{ 0, 'D', "rectangle|inset_box|position",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "r,u,w,j,o",         "corners,units,width,janchor,offset",
+	          "r,u,w,j,o",         "corners,units,width,anchor,offset",
 		  GMT_TP_STANDARD },
 	{ 0, 'F', "inset_frame|box",
 	          "",                  "",

--- a/src/longopt/psbasemap_inc.h
+++ b/src/longopt/psbasemap_inc.h
@@ -28,7 +28,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	{ 0, 'A', "polygon",           "", "", "", "", GMT_TP_STANDARD },
 	{ 0, 'D', "inset|inset_box",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "r,s,t,u,w,j,o",     "corners,outfile,translate,units,width,janchor,offset",
+	          "r,s,t,u,w,j,o",     "corners,outfile,translate,units,width,anchor,offset",
 		  GMT_TP_STANDARD },
 	{ 0, 'F', "box",
 	          "d,l,t",             "inset,scale,rose",
@@ -36,7 +36,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 		  GMT_TP_STANDARD },
 	{ 0, 'L', "mapscale|map_scale",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "w,a,c,f,j,l,o,u,v", "length,align,loc,fancy,janchor,label,offset,units,vertical",
+	          "w,a,c,f,j,l,o,u,v", "length,align,loc,fancy,anchor,label,offset,units,vertical",
 		  GMT_TP_STANDARD },
 	/* -Td and -Tm not doable because they have inconsistent short modifiers? */
 	{ 0, '\0', "", "", "", "", "", 0 }  /* End of list marked with empty option and strings */

--- a/src/longopt/pscoast_inc.h
+++ b/src/longopt/pscoast_inc.h
@@ -50,7 +50,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = { /* Local options for this m
 		  GMT_TP_STANDARD },
 	{ 0, 'L', "mapscale",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "w,a,c,f,j,l,o,u,v", "length,align,loc,fancy,janchor,label,offset,units,vertical",
+	          "w,a,c,f,j,l,o,u,v", "length,align,loc,fancy,anchor,label,offset,units,vertical",
 		  GMT_TP_STANDARD },
 	{ 0, 'M', "dump",              "", "", "", "", GMT_TP_STANDARD },
 	{ 0, 'N', "borders",           "", "", "", "", GMT_TP_STANDARD },

--- a/src/longopt/psimage_inc.h
+++ b/src/longopt/psimage_inc.h
@@ -27,7 +27,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 		  transproc_mask */
 	{ 0, 'D', "position",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "r,w,j,n,o",         "dpi,width,janchor,replicate,offset",
+	          "r,w,j,n,o",         "dpi,width,anchor,replicate,offset",
 		  GMT_TP_STANDARD },
 	{ 0, 'F', "box",
 	          "",                  "",

--- a/src/longopt/pslegend_inc.h
+++ b/src/longopt/pslegend_inc.h
@@ -28,7 +28,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	{ 0, 'C', "clearance",         "", "", "", "", GMT_TP_STANDARD },
 	{ 0, 'D', "position",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "w,j,l,o",           "width,janchor,spacing,offset",
+	          "w,j,l,o",           "width,anchor,spacing,offset",
 		  GMT_TP_STANDARD },
 	{ 0, 'F', "box",
 	          "",                  "",

--- a/src/longopt/psscale_inc.h
+++ b/src/longopt/psscale_inc.h
@@ -28,7 +28,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = {
 	GMT_C_CPT_KW,
 	{ 0, 'D', "position",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "w,e,h,v,j,m,n,o,r", "size,triangles,horizontal,vertical,janchor,move_annot,nan,offset,reverse",
+	          "w,e,h,v,j,m,n,o,r", "size,triangles,horizontal,vertical,anchor,move_annot,nan,offset,reverse",
 		  GMT_TP_STANDARD },
 	{ 0, 'F', "box",
 	          "",                  "",

--- a/src/longopt/pswiggle_inc.h
+++ b/src/longopt/pswiggle_inc.h
@@ -29,7 +29,7 @@ static struct GMT_KEYWORD_DICTIONARY module_kw[] = { /* Local options for this m
 	{ 0, 'C', "center",            "", "", "", "", GMT_TP_STANDARD },
 	{ 0, 'D', "scalebar",
 	          "g,j,J,n,x",         "mapcoords,inside,outside,boxcoords,plotcoords",
-	          "w,j,a,o,l",         "length,janchor,side,offset,label",
+	          "w,j,a,o,l",         "length,anchor,side,offset,label",
 		  GMT_TP_STANDARD },
 	{ 0, 'F', "panel",
 	          "",                  "",

--- a/test/gmtlogo/gmtlogo-l2s.sh
+++ b/test/gmtlogo/gmtlogo-l2s.sh
@@ -19,10 +19,10 @@ cat << EOF > $a
 EOF
 
 # module-specific longopts
-gmt $m $l2s --position=user:10/20+width:5 --position=map:1/2+height:2 >> $b
-gmt $m $l2s --position=justify:TR+justify:BL --position=mirror:TR >> $b
-gmt $m $l2s --position=normalize:0.5/0.4+offset:1/2 >> $b
-gmt $m $l2s --position=plot:3/4+justify:BL >> $b
+gmt $m $l2s --position=mapcoords:10/20+width:5 --position=mapcoords:1/2+height:2 >> $b
+gmt $m $l2s --position=inside:TR+anchor:BL --position=outside:TR >> $b
+gmt $m $l2s --position=boxcoords:0.5/0.4+offset:1/2 >> $b
+gmt $m $l2s --position=plotcoords:3/4+anchor:BL >> $b
 gmt $m $l2s --border+clearance:0.1 --box+fill:red --box+inner:1 >> $b
 gmt $m $l2s --border+pen:2p --border+radius:0.5 --box+shade:1/1/green >> $b
 gmt $m $l2s --label=standard --style=none --style=url >> $b

--- a/test/inset/inset-l2s.sh
+++ b/test/inset/inset-l2s.sh
@@ -26,8 +26,8 @@ gmt begin
 gmt $m $l2s --clearance=w25 >> $b
 gmt $m $l2s --rectangle=10/20/2/3+corners+units:i >> $b
 gmt $m $l2s --inset_box=mapcoords:1/-0.5+width:7 >> $b
-gmt $m $l2s --position=inside:BR+janchor:LT >> $b
-gmt $m $l2s --rectangle=outside:BR+anchoroffset:1/2 >> $b
+gmt $m $l2s --position=inside:BR+anchor:LT >> $b
+gmt $m $l2s --rectangle=outside:BR+offset:1/2 >> $b
 gmt $m $l2s --rectangle=boxcoords:0/0 --rectangle=plotcoords:5/5 >> $b
 gmt $m $l2s --inset_frame+clearance:10+fill:red+inner:4p/black >> $b
 gmt $m $l2s --box+pen:2p+radius:1p+shade:1/2/gray >> $b

--- a/test/psbasemap/psbasemap-l2s.sh
+++ b/test/psbasemap/psbasemap-l2s.sh
@@ -30,7 +30,7 @@ EOF
 gmt $m $l2s --polygon >> $b
 gmt $m $l2s --inset=10/20/2/3+corners+units:i >> $b
 gmt $m $l2s --inset_box=mapcoords:1/-0.5+width:7 >> $b
-gmt $m $l2s --inset=inside:BR+janchor:LT+outfile:file >> $b
+gmt $m $l2s --inset=inside:BR+anchor:LT+outfile:file >> $b
 gmt $m $l2s --inset=outside:BR+offset:1/2+translate >> $b
 gmt $m $l2s --inset=boxcoords:0/0 --inset=plotcoords:5/5 >> $b
 gmt $m $l2s --box=inset+clearance:0.1/0.2+fill:OldLace >> $b
@@ -38,9 +38,9 @@ gmt $m $l2s --box=scale+inner:0.1c/3p,red,.- >> $b
 gmt $m $l2s --box=rose+pen:1p,yellow,4_8_5_8:2p --box=rose+radius:3p >> $b
 gmt $m $l2s --box=rose+shade:2p/6p/gray >> $b
 gmt $m $l2s --mapscale=10/20/2/3+length:7+align:l+loc:10/20 >> $b
-gmt $m $l2s --map_scale=mapcoords:1/-0.5+fancy+janchor:LT >> $b
+gmt $m $l2s --map_scale=mapcoords:1/-0.5+fancy+anchor:LT >> $b
 gmt $m $l2s --mapscale=inside:BR+label:"My Label"+units >> $b
-gmt $m $l2s --mapscale=outside:BR+anchoroffset:1/2+vertical >> $b
+gmt $m $l2s --mapscale=outside:BR+offset:1/2+vertical >> $b
 gmt $m $l2s --mapscale=boxcoords:0/0 --mapscale=plotcoords:5/5 >> $b
 
 diff $a $b --strip-trailing-cr > fail

--- a/test/pscoast/pscoast-l2s.sh
+++ b/test/pscoast/pscoast-l2s.sh
@@ -39,8 +39,8 @@ gmt $m $l2s --land=#00fafa >> $b
 gmt $m $l2s --rivers=0/0.3p,red >> $b
 gmt $m $l2s --zaxis=scale:20 --zaxis=width:8 >> $b
 gmt $m $l2s --mapscale=mapcoords:1/-0.5+length:7n --mapscale=inside:6+align:l >> $b
-gmt $m $l2s --mapscale=outside:4/2+loc:3/4+fancy --mapscale=outside:40+janchor:LT >> $b
-gmt $m $l2s --mapscale=boxcoords:0/0+label:MyLbl --mapscale=boxcoords:10/1+anchoroffset:1/2 >> $b
+gmt $m $l2s --mapscale=outside:4/2+loc:3/4+fancy --mapscale=outside:40+anchor:LT >> $b
+gmt $m $l2s --mapscale=boxcoords:0/0+label:MyLbl --mapscale=boxcoords:10/1+offset:1/2 >> $b
 gmt $m $l2s --mapscale=plotcoords:5/5+units --mapscale=plotcoords:2+vertical >> $b
 gmt $m $l2s --dump >> $b
 #gmt $m $l2s --borders=national:3p,red --borders=state:1p,yellow >> $b

--- a/test/psimage/psimage-l2s.sh
+++ b/test/psimage/psimage-l2s.sh
@@ -27,8 +27,8 @@ EOF
 # module-specific longopts
 gmt $m $l2s --position=10/20/2/3+dpi:1200 >> $b
 gmt $m $l2s --position=mapcoords:1/-0.5+width:7 >> $b
-gmt $m $l2s --position=inside:BR+janchor:LT+replicate:2/2 >> $b
-gmt $m $l2s --position=outside:BR+anchoroffset:1/2 >> $b
+gmt $m $l2s --position=inside:BR+anchor:LT+replicate:2/2 >> $b
+gmt $m $l2s --position=outside:BR+offset:1/2 >> $b
 gmt $m $l2s --position=boxcoords:0/0 --position=plotcoords:5/5 >> $b
 gmt $m $l2s --box+clearance:10+fill:red+inner:4p/black >> $b
 gmt $m $l2s --box+pen:2p+radius:1p+shade:1/2/gray >> $b

--- a/test/pslegend/pslegend-l2s.sh
+++ b/test/pslegend/pslegend-l2s.sh
@@ -24,8 +24,8 @@ EOF
 # module-specific longopts
 gmt $m $l2s --clearance=1/2 >> $b
 gmt $m $l2s --position=10/20/2/3 --position=mapcoords:1/-0.5+width:7 >> $b
-gmt $m $l2s --position=inside:BR+janchor:LT+spacing:2 >> $b
-gmt $m $l2s --position=outside:BR+anchoroffset:1/2 >> $b
+gmt $m $l2s --position=inside:BR+anchor:LT+spacing:2 >> $b
+gmt $m $l2s --position=outside:BR+offset:1/2 >> $b
 gmt $m $l2s --position=boxcoords:0/0 --position=plotcoords:5/5 >> $b
 gmt $m $l2s --box+clearance:10+fill:red+inner:4p/black >> $b
 gmt $m $l2s --box+pen:2p+radius:1p+shade:1/2/gray >> $b

--- a/test/psscale/psscale-l2s.sh
+++ b/test/psscale/psscale-l2s.sh
@@ -33,8 +33,8 @@ EOF
 gmt $m $l2s --cpt=file --cmap=other/file >> $b
 gmt $m $l2s --position=10/20/2/3+size:200/100+triangles:b6+horizontal >> $b
 gmt $m $l2s --position=mapcoords:1/-0.5+vertical+nan+reverse >> $b
-gmt $m $l2s --position=inside:BR+janchor:LT+move_annot:aclu >> $b
-gmt $m $l2s --position=outside:BR+anchoroffset:1/2 >> $b
+gmt $m $l2s --position=inside:BR+anchor:LT+move_annot:aclu >> $b
+gmt $m $l2s --position=outside:BR+offset:1/2 >> $b
 gmt $m $l2s --position=boxcoords:0/0 --position=plotcoords:5/5 >> $b
 gmt $m $l2s --box+clearance:10+fill:red+inner:4p/black >> $b
 gmt $m $l2s --box+pen:2p+radius:1p+shade:1/2/gray >> $b

--- a/test/pswiggle/pswiggle-l2s.sh
+++ b/test/pswiggle/pswiggle-l2s.sh
@@ -24,8 +24,8 @@ EOF
 # module-specific longopts
 gmt $m $l2s --azimuth=30 >> $b
 gmt $m $l2s --center=6 >> $b
-gmt $m $l2s --scalebar=mapcoords:-10/-10+length:12 --scalebar=inside:RM+janchor:CB >> $b
-gmt $m $l2s --scalebar=outside:CB+side:l --scalebar=boxcoords:0.2/0.5+anchoroffset:5/10 >> $b
+gmt $m $l2s --scalebar=mapcoords:-10/-10+length:12 --scalebar=inside:RM+anchor:CB >> $b
+gmt $m $l2s --scalebar=outside:CB+side:l --scalebar=boxcoords:0.2/0.5+offset:5/10 >> $b
 gmt $m $l2s --scalebar=plotcoords:3/3+label:YourLbl >> $b
 #gmt $m $l2s --panel+clearance:0.1/0.2+fill:OldLace --panel+inner:0.1c/3p,red,.- >> $b
 #gmt $m $l2s --panel+pen:1p,yellow,4_8_5_8:2p --panel+radius:3p >> $b


### PR DESCRIPTION
Some GMT modules like `image`/`logo`/`legend`/`colorbar` can add embellishments. These modules have similar syntax for placing these embellishments. For example, `logo`'s `-D` option has the following syntax:
```
-D[g|j|J|n|x]refpoint[+hheight|+wwidth][+jjustify][+odx[/dy]]
```
in which `[g|j|J|n|x]refpoint[+jjustify][+odx[/dy]]` are common to all embellishments and determine the location of embellishments on maps. 

The long option names are `g|j|J|n|x` for `mapcoords,inside,outside,boxcoords,plotcoords`, `janchor` for `+j`, and `anchoroffset` for `+o`. 

This PR fixes the inconsistences in a few modules.