### PR TITLE
Add the -t option for psevents

### DIFF
--- a/src/psevents.c
+++ b/src/psevents.c
@@ -32,7 +32,7 @@
 #define THIS_MODULE_PURPOSE	"Plot event symbols, lines, polygons and labels for one moment in time"
 #define THIS_MODULE_KEYS	"<D{,CC(,>?}"
 #define THIS_MODULE_NEEDS	"JR"
-#define THIS_MODULE_OPTIONS	"-:>BJKOPRUVXYabdefhilpqw"
+#define THIS_MODULE_OPTIONS	"-:>BJKOPRUVXYabdefhilpqtw"
 
 enum Psevent {	/* Misc. named array indices */
 	PSEVENTS_SYMBOL = 0,


### PR DESCRIPTION
In this option I add the `-t` option for psevents module. This PR refers to the first issue in #8775.

I try it with this commands:
```
gmt makecpt -Cred,green,blue -T0,70,300,10000 > q.cpt
gmt events -Rg -JG200/5/6i -Baf @quakes_2018.txt -SE- -Cq.cpt  --TIME_UNIT=d -T2018-06-01T  -t50 -png prueba
```
I got this figure
<img width="1807" height="1806" alt="prueba" src="https://github.com/user-attachments/assets/1e23699b-54dc-4890-9c5f-832390b63470" />


If it is ok, later I will modify the docs. 