### PR TITLE
fix a bug in coupe ( -A+wwidth is useless when using -N  )

### DIFF
--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -1329,7 +1329,7 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 				depth = in[GMT_Z];
 
 				if (!pscoupe_dans_coupe (in[GMT_X], in[GMT_Y], depth, Ctrl->A.xlonref, Ctrl->A.ylatref, Ctrl->A.fuseau, Ctrl->A.PREF.str,
-					Ctrl->A.PREF.dip, Ctrl->A.p_length, Ctrl->A.p_width, &distance, &n_dep) && !Ctrl->N.active)
+					Ctrl->A.PREF.dip, Ctrl->A.p_length, Ctrl->A.p_width, &distance, &n_dep) )
 					continue;
 
 				xy[GMT_X] = distance;


### PR DESCRIPTION
https://github.com/GenericMappingTools/gmt/blob/58850df4f841da24240147432e28b5322cfb1ccc/src/seis/pscoupe.c#L1331-L1333

if `-N`  is used, `!Ctrl->N.active` is always 0, so the whole condition is always 0 too. 

However, if user wants to use **-A+w***width* to choose data points only in the range of the 

> width in km of the cross-section on each side of a vertical plane or above and under an oblique plane 
> https://docs.generic-mapping-tools.org/6.6/supplements/seis/coupe.html#a

, although the data points outside the range let `pscoupe_dans_coupe` returns 0 and `!pscoupe_dans_coupe` equal to 1:

https://github.com/GenericMappingTools/gmt/blob/58850df4f841da24240147432e28b5322cfb1ccc/src/seis/pscoupe.c#L353-L371

these data points will not be skipped because `!Ctrl->N.active` is always 0. 

Actually, in docs: https://docs.generic-mapping-tools.org/6.6/supplements/seis/coupe.html#n , **-N** means 

> Does not skip symbols that fall outside map border [Default plots points inside border only].

it is well done in lines:
https://github.com/GenericMappingTools/gmt/blob/58850df4f841da24240147432e28b5322cfb1ccc/src/seis/pscoupe.c#L1259
https://github.com/GenericMappingTools/gmt/blob/58850df4f841da24240147432e28b5322cfb1ccc/src/seis/pscoupe.c#L1265
https://github.com/GenericMappingTools/gmt/blob/58850df4f841da24240147432e28b5322cfb1ccc/src/seis/pscoupe.c#L1338-L1341
https://github.com/GenericMappingTools/gmt/blob/58850df4f841da24240147432e28b5322cfb1ccc/src/seis/pscoupe.c#L1684

It makes no sense to use `!Ctrl->N.active` in 
```
if (!pscoupe_dans_coupe (in[GMT_X], in[GMT_Y], depth, Ctrl->A.xlonref, Ctrl->A.ylatref, Ctrl->A.fuseau, Ctrl->A.PREF.str,
     Ctrl->A.PREF.dip, Ctrl->A.p_length, Ctrl->A.p_width, &distance, &n_dep) && !Ctrl->N.active)
     continue;
```