### PR TITLE
grdmath.rst and surface.rst: add missing power of two and show nabla …

### DIFF
--- a/doc/rst/source/grdmath.rst
+++ b/doc/rst/source/grdmath.rst
@@ -224,7 +224,7 @@ Operator        Args   Returns                                                  
 **CSC**         1 1    Cosecant of A (A in radians)                                                                    Calculus
 **CSCD**        1 1    Cosecant of A (A in degrees)                                                                    Calculus
 **CUMSUM**      2 1    Cumulative sum per row (B=±1|3) or column (B=±2|4) in A. Sign of B sets summation direction     Arithmetic
-**CURV**        1 1    Curvature of A (Laplacian)                                                                      Calculus
+**CURV**        1 1    Curvature of A (Laplacian, :math:`\nabla^2`)                                                    Calculus
 **D2DX2**       1 1    d^2(A)/dx^2 2nd derivative                                                                      Calculus
 **D2DY2**       1 1    d^2(A)/dy^2 2nd derivative                                                                      Calculus
 **D2DXY**       1 1    d^2(A)/dxdy 2nd derivative                                                                      Calculus

--- a/doc/rst/source/surface.rst
+++ b/doc/rst/source/surface.rst
@@ -54,7 +54,7 @@ solving the differential equation (away from data points)
 
     (1 - t) \nabla ^2(z) + t \nabla (z) = 0,
 
-where *t* is a tension factor between 0 and 1, and :math:`\nabla` indicates the
+where *t* is a tension factor between 0 and 1, and :math:`\nabla^2` indicates the
 2-D Cartesian Laplacian operator. Here, *t* = 0 gives the "minimum curvature" solution.
 Minimum curvature can cause undesired oscillations and false local maxima or minima
 [See *Smith and Wessel*\ , 1990], and you may wish to use *t* > 0 to suppress these


### PR DESCRIPTION
* Add $\nabla$ in grdmath-table - I dont know how this looks when rendered. Does it mess up the table?
* In surface-docs, I think the $\nabla$ is wrong - it should be $\nabla^2$. See [wikipedia](https://en.wikipedia.org/wiki/Laplace_operator) and section in docs about formats:
<img width="833" height="363" alt="2025-10-03_15-01" src="https://github.com/user-attachments/assets/69ad40c4-f19d-418a-bef2-331067c7f6ee" />
