### PR TITLE
Update two baseline images for the coupe module

### DIFF
--- a/test/baseline/seis.dvc
+++ b/test/baseline/seis.dvc
@@ -1,5 +1,6 @@
 outs:
-- md5: 732b3570f6a3f9291e2f6f138cdc8d0a.dir
+- md5: 5f1f329cbe98dcf240dc57828014498a.dir
   nfiles: 15
   path: seis
   hash: md5
+  size: 924345


### PR DESCRIPTION
We have two new "failures" after PR https://github.com/GenericMappingTools/gmt/pull/8804.

This PR updates the two baseline images for seis_04.sh and seis_05.sh to match the behavior in #8804.