### PR TITLE
remove -K in grdbarb.rst

### DIFF
--- a/doc/rst/source/supplements/windbarbs/grdbarb.rst
+++ b/doc/rst/source/supplements/windbarbs/grdbarb.rst
@@ -103,8 +103,6 @@ Optional Arguments
     **s** for arc seconds.  Alternatively, use **-Ix** to specify the
     multiples *multx*\ [/*multy*] directly [Default plots every node].
 
-.. include:: ../../explain_-K.rst_
-
 .. _-N:
 
 **-N**


### PR DESCRIPTION
-K only exists in Classic mode, maybe this is a legacy typo.