### PR TITLE
Fix seis/utilmeca

### DIFF
--- a/src/seis/utilmeca.c
+++ b/src/seis/utilmeca.c
@@ -913,7 +913,7 @@ void meca_axe2dc (struct SEIS_AXIS T, struct SEIS_AXIS P, struct SEIS_NODAL_PLAN
     NP1->dip = d1; NP1->str = p1;
     NP2->dip = d2; NP2->str = p2;
 
-    /* Epsilon-aware tie-break: avoid quadrant swap when P.dip ≈ T.dip */
+    /* Epsilon-aware tie-break: avoid quadrant swap when P.dip is almost equal T.dip */
     if (P.dip > T.dip + SEIS_EPSILON) {
         im = -1;
     } else if (P.dip < T.dip - SEIS_EPSILON) {


### PR DESCRIPTION
Fixes a numerical instability in `meca_axe2dc` when `P.dip ≈ T.dip`.

This issue caused the `im` flag (fault type) to flip unpredictably between `1` and `-1`, which in turn shifted the rake by 180 degrees. This resulted in swapped P/T quadrants for `psmeca -Sy`.

This patch introduces an `SEIS_EPSILON` tolerance. When `|P.dip - T.dip|` is within this tolerance, a deterministic `im` value (-1) is assigned, eliminating the instability.

Issues: #8009