### PR TITLE
grdview: Fix the bug for the default z-plane when only -N is set

### DIFF
--- a/src/grdview.c
+++ b/src/grdview.c
@@ -608,9 +608,9 @@ static int parse (struct GMT_CTRL *GMT, struct GRDVIEW_CTRL *Ctrl, struct GMT_OP
 					n_errors += gmt_default_option_error (GMT, opt);
 				break;
 			case 'N':	/* Facade */
+				n_errors += gmt_M_repeated_module_option (API, Ctrl->N.active);
 				if (opt->arg[0]) {
 					char colors[GMT_LEN64] = {""};
-					n_errors += gmt_M_repeated_module_option (API, Ctrl->N.active);
 					if ((c = strstr (opt->arg, "+g")) != NULL) {	/* Gave modifier +g<fill> */
 						c[0] = '\0';	/* Truncate string temporarily */
 						if (opt->arg[0])


### PR DESCRIPTION
The `grdview -N` docs say (https://docs.generic-mapping-tools.org/6.6/grdview.html#n):

> If no level is set then we default to the minimum value in the reliefgrid. However, if [-R](https://docs.generic-mapping-tools.org/6.6/grdview.html#r) was used to set zmin/zmax then we use that value if it is less than the grid minimum value.

Currently, when `-N` is set but `level` is not given, the plane is not drawn at all. It can be reproduced by the following command:
```
gmt grdview @earth_relief_01d -R-25/-13/63/66 -CSCM/oleron -JZ3c -p30/30 -Qs -N -png map
```
| Actual output | Expected output |
|---|---|
| <img width="1958" height="976" alt="map" src="https://github.com/user-attachments/assets/076e9e43-7c9d-4cf8-a4f8-96c748cd54a5" /> | <img width="1961" height="976" alt="map" src="https://github.com/user-attachments/assets/1320e82c-58e0-48d5-98e8-7139e46f0138" /> | 

The error is because we forgot to set `Ctrl->N.active` to `true` if setting `-N` alone without `level`. This PR fixes the issue.