### PR TITLE
Example (8) A 3-D histogram: Fix argument for "S"

### DIFF
--- a/doc/examples/ex08/ex08.bat
+++ b/doc/examples/ex08/ex08.bat
@@ -6,6 +6,6 @@ REM DOS calls:	echo
 REM
 gmt begin ex08
 	gmt makecpt -Ccubhelix -T-5000/0
-	gmt grd2xyz @earth_relief_05m -R0/5/0/5 | gmt plot3d -B -Bz1000+l"Topography (m)" -BWSneZ+b+tETOPO5 -R0/5/0/5/-5000/0 -JM12c -JZ14c -p200/30 -So0.0833333ub-5000 -Wthinnest -C -i0:2,2
+	gmt grd2xyz @earth_relief_05m -R0/5/0/5 | gmt plot3d -B -Bz1000+l"Topography (m)" -BWSneZ+b+tETOPO5 -R0/5/0/5/-5000/0 -JM12c -JZ14c -p200/30 -So0.0833333u+b-5000 -Wthinnest -C -i0:2,2
 	echo 0.1 4.9 This is the surface of cube | gmt text -JZ -Z0 -F+f24p,Helvetica-Bold+jTL -p
 gmt end show

--- a/doc/examples/ex08/ex08.sh
+++ b/doc/examples/ex08/ex08.sh
@@ -8,6 +8,6 @@
 gmt begin ex08
 	gmt makecpt -Ccubhelix -T-5000/0
 	gmt grd2xyz @earth_relief_05m -R0/5/0/5 | gmt plot3d -B -Bz1000+l"Topography (m)" -BWSneZ+b+tETOPO5 \
-		-R0/5/0/5/-5000/0 -JM12c -JZ14c -p200/30 -So0.0833333ub-5000 -Wthinnest -C -i0:2,2
+		-R0/5/0/5/-5000/0 -JM12c -JZ14c -p200/30 -So0.0833333u+b-5000 -Wthinnest -C -i0:2,2
 	echo '0.1 4.9 This is the surface of cube' | gmt text -JZ -Z0 -F+f24p,Helvetica-Bold+jTL -p
 gmt end show


### PR DESCRIPTION
**Description of proposed changes**

Following the documentation at https://docs.generic-mapping-tools.org/dev/plot3d.html#s:

> -Sosize[c|i|p|q][+b|B[base]][+v|inz]

There should be a `+` before the **b** (or + **B**).

This PR updates the example "(8) A 3-D histogram".


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
