### PR TITLE
Use GDALGetDataTypeSizeBytes since GDALGetDataTypeSize is deprecated

### DIFF
--- a/src/gmt_gdalcall.c
+++ b/src/gmt_gdalcall.c
@@ -184,7 +184,7 @@ GMT_LOCAL int save_grid_with_GMT(struct GMT_CTRL *GMT, GDALDatasetH hDstDS, stru
 	GDALRasterBandH	hBand;
 
 	hBand = GDALGetRasterBand(hDstDS, 1);
-	nPixelSize = GDALGetDataTypeSize(GDALGetRasterDataType(hBand)) / 8;	/* /8 because return value is in BITS */
+	nPixelSize = GDALGetDataTypeSizeBytes(GDALGetRasterDataType(hBand));
 	nXSize = GDALGetRasterXSize(hDstDS);
 	nYSize = GDALGetRasterYSize(hDstDS);
 

--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -1041,7 +1041,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 
 	/* The following assumes that all bands have the same PixelSize, data type. Otherwise ... */
 	hBand = GDALGetRasterBand(hDataset, first_layer);
-	nPixelSize = GDALGetDataTypeSize(GDALGetRasterDataType(hBand)) / 8;	/* /8 because return value is in BITS */
+	nPixelSize = GDALGetDataTypeSizeBytes(GDALGetRasterDataType(hBand));
 
 	if (jump) {
 		nBufXSize[0] = XDim / jump;


### PR DESCRIPTION
**Description of proposed changes**

This is to replace
```GDALGetDataTypeSize(GDALGetRasterDataType(hBand)) / 8```
by 
```GDALGetDataTypeSizeBytes(GDALGetRasterDataType(hBand))```
since
`GDALGetDataTypeSize` (which was in bits) is marked as deprecated since GDAL v3.12.

This does not change any of the functionality.

**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
