### PR TITLE
Fix grdview Qt backend behavior with -Qt in 3-D views

### DIFF
--- a/src/grdview.c
+++ b/src/grdview.c
@@ -1073,7 +1073,7 @@ EXTERN_MSC int GMT_grdview(void *V_API, int mode, void *args) {
 			Return (API->error);
 		}
 		if (P->is_bw) Ctrl->Q.monochrome = true;
-		if (P->categorical && !(Ctrl->Q.mode == GRDVIEW_MESH || Ctrl->Q.special || Ctrl->T.active )) {
+		if (P->categorical && !(Ctrl->Q.mode == GRDVIEW_MESH || Ctrl->Q.special || Ctrl->T.active)) {
 			GMT_Report (API, GMT_MSG_ERROR, "Categorical data (as implied by CPT) cannot be interpolated and require -T or just -Qm.\n");
 			Return (GMT_RUNTIME_ERROR);
 		}


### PR DESCRIPTION
## Description

When running the script below, the following error is triggered:

`grdview [ERROR]: Categorical data (as implied by CPT) cannot be interpolated and require -T or just -Qm.
`
This PR adds an exception that allows using -Qt with categorical CPTs when grdview is run with a 3-D projection (-JZ).

## Full script:
```
gmt begin ex05_3d png
 	gmt makecpt -Ccategorical -T0/4/1 -F+cOceanic,Land,Lakes,Islands,Ponds
	gmt grdview @earth_relief -G@earth_mask -JM15c -JZ5c -B -Bza -BSEwnZ -N-500+gwhite -R-58/-54/-36/-32/-500/500 -p120/30 -C -Qt100i
gmt end
```

See details and the expected output figure in https://github.com/GenericMappingTools/gmt/issues/8855#issuecomment-3712324621