### PR TITLE
Fix typo in PostScript comment (fram → frame)

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -3095,7 +3095,7 @@ GMT_LOCAL void gmtplot_map_boundary (struct GMT_CTRL *GMT) {
 	}
 
 	PSL_comment(PSL, "End of map frame\n");
-	if (!PSL->internal.comments) PSL_command(PSL, "\n%%End of map fram\n");
+	if (!PSL->internal.comments) PSL_command(PSL, "\n%%End of map frame\n");
 }
 
 /* gmt_map_basemap will create a basemap for the given area.


### PR DESCRIPTION
This typo was bodering me. 

This only affects the generated PS comment. While this could have been fixed directly, I preferred to submit a PR for safety.
