### PR TITLE
Update the baseline image for psxy/urlquakes

### DIFF
--- a/test/baseline/psxy.dvc
+++ b/test/baseline/psxy.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 943fde38ba4b0d65350c58bea7313e4e.dir
+- md5: 1fc1282aacff2e7af0af2000e475c03c.dir
   nfiles: 143
   path: psxy
   hash: md5
-  size: 9374765
+  size: 9402186


### PR DESCRIPTION
Test `psxy/urlquakes.sh` fails because there are changes of the earthquake catalog from the URL.