### PR TITLE
Modify the projection formula, add tolerance, and add tests.

### DIFF
--- a/src/seis/utilmeca.c
+++ b/src/seis/utilmeca.c
@@ -130,9 +130,14 @@ static double utilmeca_proj_radius(double str1, double dip1, double str) {
 
 	   Genevieve Patau
 	*/
-	double dip, r;
+	double dip, r, s_dphi;
 
-	dip = atan (tand (dip1) * sind (str - str1));
+	s_dphi = sind (str - str1);
+	/* Force to lower hemisphere for numerical safety (loop 0-180) and snap to zero */
+	s_dphi = fabs (s_dphi);
+	if (s_dphi < 1.0e-10) s_dphi = 0.0;
+
+	dip = atan2 (sind (dip1) * s_dphi, cosd (dip1));
 	r = sqrt (2.) * sin (M_PI_4 - dip / 2.);
 	return (r);
 }

--- a/test/seis/psmeca_radius.sh
+++ b/test/seis/psmeca_radius.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Test for Issue #8053: nodal planes plotting incorrectly for vertical faults
+# Key test cases: dip=90° (vertical) and rake=180° trigger NaN in projection
+#
+
+gmt begin psmeca_radius png
+	gmt basemap -R0/12/0/6 -JM20c -B1 -BWSen
+
+	echo 3 4.5 0 30 75 180 5 S30 D75 R180 | gmt meca -Sa3c -N -L -T
+
+	echo 9 4.5 10 0 90 0 5 S0 D90 R0 | gmt meca -Sa3c -N -L -T
+
+	echo 3 1.5 10 80 90 -140 5 S80 D90 R-140 | gmt meca -Sa3c -N -L -T
+
+	echo 9 1.5 10 0 90 180 5 S0 D90 R180 | gmt meca -Sa3c -N -L -T
+
+gmt end


### PR DESCRIPTION
When dip=90° and rank=180°, tan(90°)×sin(180°)=Inf×0, causing an error.

Change the formula in the utilmeca_proj_radius function from atan(tand×sind) to atan2(sin×sin, cos) and add an epsilon tolerance.

Fixes #8053

Test results:
<img width="2501" height="1257" alt="image" src="https://github.com/user-attachments/assets/9b649d7f-e810-40ab-9a0e-719484072620" />
