### PR TITLE
grdfilter: Clarify the syntax for the weight file when custom or operator filters are used

### DIFF
--- a/doc/rst/source/grdfilter.rst
+++ b/doc/rst/source/grdfilter.rst
@@ -94,11 +94,13 @@ Required Arguments
     - (**g**) Gaussian: Weights are given by the Gaussian function, where
       *width* is 6 times the conventional Gaussian sigma.
     - (**f**) Custom: Weights are given by the precomputed values in the
-      filter weight grid file *weight*, which must have odd dimensions;
+      filter weight grid file *weight*; append the name of the weight grid in the
+      form of **-Ff**\ *weight*. The grid must have odd dimensions;
       also requires **-D0** and output spacing must match input spacing or
       be integer multiples.
     - (**o**) Operator: Weights are given by the precomputed values in the
-      filter weight grid file *weight*, which must have odd dimensions;
+      filter weight grid file *weight*; append the name of the weight grid in the
+      form of **-Fo**\ *weight*. The grid must have odd dimensions;
       also requires **-D0** and output spacing must match input spacing or
       be integer multiples. Weights are assumed to sum to zero so no
       accumulation of weight sums and normalization will be done.


### PR DESCRIPTION
https://docs.generic-mapping-tools.org/dev/grdfilter.html

The option syntax is `-Fxwidth[/width2][+c|+h|+l|+qquantile|+u]`, but the documentation says something like:

> Weights are given by the precomputed values in the filter weight grid file *weight*, which must have odd dimensions

It's unclear how *weight* can be passed. This PR clarifies the syntax is **-Ff**_weight_.

