### PR TITLE
Clarify non-implemented options in sph2grd.rst

### DIFF
--- a/doc/rst/source/sph2grd.rst
+++ b/doc/rst/source/sph2grd.rst
@@ -71,11 +71,13 @@ Optional Arguments
     Will evaluate a derived field from a geopotential model.  Choose
     between **Dg** which will compute the gravitational field or **Dn**
     to compute the geoid [Add |-E| for anomalies on the ellipsoid].
+    Not implemented yet.
 
 .. _-E:
 
 **-E**
     Evaluate expansion on the current ellipsoid [Default is sphere].
+    Not implemented yet.
 
 .. _-F:
 


### PR DESCRIPTION
Added notes indicating that options -D and -E are not implemented yet.

https://github.com/GenericMappingTools/gmt/blob/0fbea58e0b7d403506641d9d999a14dbeee7dba3/src/sph2grd.c#L156-L165

**Description of proposed changes**



<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
