### PR TITLE
CI: Do not use remote file for the simple tests

### DIFF
--- a/ci/simple-gmt-tests.bat
+++ b/ci/simple-gmt-tests.bat
@@ -18,10 +18,11 @@ REM Check GMT modern mode, GSHHG and DCW
 gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
 
 REM Check remote file and modern one-liner
-gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
+REM gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
 
 REM Check supplemental modules
 gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
 
 REM Check OpenMP support
-gmt grdsample @earth_relief_01d -R0/20/0/20 -I30m -Gtopo_30m.nc -x2
+REM gmt grdsample @earth_relief_01d -R0/20/0/20 -I30m -Gtopo_30m.nc -x2
+gmt grdlandmask -R-60/-40/-40/-30 -I5m -N1/NaN -Gland_mask.nc -x2

--- a/ci/simple-gmt-tests.sh
+++ b/ci/simple-gmt-tests.sh
@@ -23,12 +23,13 @@ gmt begin && gmt coast -R0/10/0/10 -JM6i -Ba -Ggray -ENG+p1p,blue -Vd && gmt end
 if [ "${RUNNER_OS}" == "Windows" ]; then unset GMT_SESSION_NAME; fi
 
 # Check remote file and modern one-liner
-gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
+# gmt grdimage @earth_relief_01d -JH10c -Baf -pdf map
 
 # Check supplemental modules
 gmt earthtide -T2018-06-18T12:00:00 -Gsolid_tide_up.grd
 
 # Check OpenMP support
-gmt grdsample @earth_relief_01d -R0/20/0/20 -I30m -Gtopo_30m.nc -x2
+# gmt grdsample @earth_relief_01d -R0/20/0/20 -I30m -Gtopo_30m.nc -x2
+gmt grdlandmask -R-60/-40/-40/-30 -I5m -N1/NaN -Gland_mask.nc -x2
 
 set +x +e


### PR DESCRIPTION
Our CI jobs sometimes fail because of transient network connectivity issues when attempting to download remote files from the GMT data server. These failures are frustrating because they mask real test failures and reduce confidence in our CI pipeline. To address this, this PR modifies both simple-test-gmt.sh and simple-test-gmt.bat to avoid remote file dependencies entirely.