### PR TITLE
CI: Cache the baselines tracked by DVC

### DIFF
--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -4,10 +4,19 @@
 # 1. GMT remote data for building documentation and running tests
 # 2. GMT GSHHG and DCW datasets
 # 3. vcpkg libraries on Windows
+# 4. DVC-tracked baseline images for tests and docs
 #
 name: GMT CI Caches
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'test/baseline/*.dvc'
+      - 'doc/examples/images/*.dvc'
+      - 'doc/scripts/images/*.dvc'
+      - '.github/workflows/ci-caches.yml'
   pull_request:
     # Make any changes to the following files to refresh the cache in PRs
     paths:
@@ -25,6 +34,7 @@ jobs:
   data_cache:
     name: Cache GMT data
     runs-on: macos-latest
+    if: github.event_name != 'push'
     defaults:
       run:
         shell: bash -l {0}
@@ -111,6 +121,7 @@ jobs:
   coastline_cache:
     name: Cache GSHHG and DCW datasets
     runs-on: ubuntu-latest
+    if: github.event_name != 'push'
     env:
       COASTLINEDIR: ${{ github.workspace }}/coastline
 
@@ -132,6 +143,7 @@ jobs:
   vcpkg_cache:
     name: Cache vcpkg libraries
     runs-on: windows-latest
+    if: github.event_name != 'push'
 
     steps:
       - name: Checkout
@@ -146,3 +158,33 @@ jobs:
           name: vcpkg-cache
           # VCPKG_INSTALLATION_ROOT is C:\vcpkg
           path: C:\vcpkg\installed\
+
+  dvc_cache:
+    name: Cache DVC baseline images
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup data version control (DVC)
+        uses: iterative/setup-dvc@v2
+
+      - name: Pull baseline image data from dvc remote
+        env:
+          DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
+        run: |
+          dvc remote modify origin url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/gmt.dvc --local
+          dvc pull --remote origin --no-run-cache --verbose
+
+      - name: Upload DVC cache as artifacts to GitHub
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: dvc-cache
+          include-hidden-files: true
+          path: .dvc/cache/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,11 +82,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Pull baseline image data from dvc remote
+        id: dvc-pull
+        continue-on-error: true
         run: |
           dvc remote modify origin url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/gmt.dvc --local
-          dvc pull --no-run-cache
+          dvc pull --remote origin --no-run-cache
         env:
           DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
+
+      - name: Download DVC cache from GitHub Artifacts and restore baseline image data
+        if: steps.dvc-pull.outcome == 'failure'
+        run: |
+          gh run download -n dvc-cache -D .dvc/cache/
+          dvc checkout --force
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Configure GMT
         run: |

--- a/.github/workflows/dvc-diff.yml
+++ b/.github/workflows/dvc-diff.yml
@@ -33,6 +33,24 @@ jobs:
     - name: Setup data version control (DVC)
       uses: iterative/setup-dvc@v2
 
+    - name: Pull baseline image data from dvc remote
+      id: dvc-pull
+      continue-on-error: true
+      env:
+        DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
+      run: |
+        dvc remote modify origin url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/gmt.dvc --local
+        dvc pull --remote origin --no-run-cache
+        dvc pull --remote origin --no-run-cache
+
+    - name: Download DVC cache from GitHub Artifacts and restore baseline image data
+      if: steps.dvc-pull.outcome == 'failure'
+      run: |
+        gh run download -n dvc-cache -D .dvc/cache/
+        dvc checkout --force
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Setup continuous machine learning (CML)
       uses: iterative/setup-cml@v3
 
@@ -78,10 +96,6 @@ jobs:
         # Fetch the master branch
         git fetch origin master
 
-        # Pull image data from cloud storage
-        dvc remote modify origin url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/gmt.dvc --local
-        dvc pull --remote origin
-        dvc pull --remote origin
         dvc diff --md master HEAD >> report.md
 
         # Get just the filename of the added and modified image from the report
@@ -93,10 +107,14 @@ jobs:
         mkdir -p newbaseline/doc/examples && cp -r doc/examples/images newbaseline/doc/examples/
         mkdir -p newbaseline/doc/scripts && cp -r doc/scripts/images newbaseline/doc/scripts/
         rm -r test/baseline/**/*.ps doc/examples/images/*.ps doc/scripts/images/*.ps
-        # Pull images in the master branch from cloud storage
+        # Restore images for the master branch, using the DVC remote when available.
         git checkout master
-        dvc pull --remote origin
-        dvc pull --remote origin
+        if ! dvc pull --remote origin --no-run-cache; then
+          dvc checkout --force
+        fi
+        if ! dvc pull --remote origin --no-run-cache; then
+          dvc checkout --force
+        fi
 
         # Append each image to the markdown report
         echo -e "## Image diff(s)\n" >> report.md

--- a/.github/workflows/release-baseline-images.yml
+++ b/.github/workflows/release-baseline-images.yml
@@ -26,12 +26,21 @@ jobs:
       uses: iterative/setup-dvc@v2
 
     - name: Pull baseline image data from dvc remote
+      id: dvc-pull
+      continue-on-error: true
       run: |
         dvc remote modify origin url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/gmt.dvc --local
-        dvc pull
-        ls -lhR test/baseline/
+        dvc pull --remote origin --no-run-cache
       env:
         DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
+
+    - name: Download DVC cache from GitHub Artifacts and restore baseline image data
+      if: steps.dvc-pull.outcome == 'failure'
+      run: |
+        gh run download -n dvc-cache -D .dvc/cache/
+        dvc checkout --force
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Create the baseline image asset in zip format
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,11 +122,21 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Pull baseline image data from dvc remote
+        id: dvc-pull
+        continue-on-error: true
         run: |
           dvc remote modify origin url https://${DAGSHUB_TOKEN}@dagshub.com/GenericMappingTools/gmt.dvc --local
-          dvc pull --no-run-cache
+          dvc pull --remote origin --no-run-cache
         env:
           DAGSHUB_TOKEN: ${{ secrets.DAGSHUB_TOKEN }}
+
+      - name: Download DVC cache from GitHub Artifacts and restore baseline image data
+        if: steps.dvc-pull.outcome == 'failure'
+        run: |
+          gh run download -n dvc-cache -D .dvc/cache/
+          dvc checkout --force
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Install GMT
         run: |


### PR DESCRIPTION
As mentioned previously and also discussed in https://github.com/GenericMappingTools/pygmt/issues/4147, `dvc pull` started to require authentication recently, so PRs from external contributors or maintainers who are not added to DagsHub, will see failures because `dvc` fails to pull images.

The solution is to let the CI cache the DVC images, and then use the cached version if `dvc pull` fails. This workaround has been used in the pygmt project and works well. So it should also work in GMT.