### PR TITLE
Just avoiding two compiler warnings

### DIFF
--- a/src/gmt_remote.c
+++ b/src/gmt_remote.c
@@ -731,7 +731,7 @@ CURL * gmtremote_setup_curl (struct GMTAPI_CTRL *API, char *url, char *local_fil
 		return NULL;
 	}
 	if (time_out) {	/* Set a timeout limit */
-		if (curl_easy_setopt (Curl, CURLOPT_TIMEOUT, time_out)) {
+		if (curl_easy_setopt (Curl, CURLOPT_TIMEOUT, (long)time_out)) {
 			GMT_Report (API, GMT_MSG_ERROR, "Failed to set curl option to time out after %d seconds\n", time_out);
 			return NULL;
 		}

--- a/src/grdview.c
+++ b/src/grdview.c
@@ -313,7 +313,7 @@ GMT_LOCAL void grdview_paint_gouraud_tile(struct GMT_CTRL *GMT, struct PSL_CTRL 
 
 	/* Get color for each of 4 vertices */
 	for (k = 0; k < 4; k++) {
-		int index = gmt_get_rgb_from_z(GMT, P, Z_vert[k], &rgb_vert[k*3]);
+		gmt_get_rgb_from_z(GMT, P, Z_vert[k], &rgb_vert[k*3]);
 		if (k == 0)
 			PH = gmt_get_C_hidden(P);
 


### PR DESCRIPTION
**Description of proposed changes**

Changed two source files to avoid compiler warnings.
- gmt_remote.c: removed unused variable.
- grdview.c: cast input argument to curl_easy_setopt as long, as is required.

No bug fixes, no new functionalities.
 
**Reminders**

- [x] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
