### PR TITLE
CI: Use pcre2-devel instead of pcre-devel in dockers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,7 +83,7 @@ jobs:
             dnf install -y \
                 cmake ninja-build \
                 libcurl-devel netcdf-devel gdal-devel gdal \
-                fftw3-devel pcre-devel lapack-devel openblas-devel glib2-devel \
+                fftw3-devel pcre2-devel lapack-devel openblas-devel glib2-devel \
                 ghostscript openssl gh
           fi
 


### PR DESCRIPTION
pcre2-devel is not available in Fedora:rawhide. That's why the docker CI fails.

This PR updates `prec-devel` to `prec2-devel`, according to https://www.pcre.org/.

> There are two major versions of the PCRE library. The current version, PCRE2, [released in 2015,](https://lists.exim.org/lurker/message/20150105.162835.0666407a.en.html) is now at version 10.47.

> The older, but still widely deployed PCRE library, originally released in 1997, is at version 8.45. This version of PCRE is now at end of life, and is no longer being actively maintained. Version 8.45 is expected to be the final release of the older PCRE library, and new projects should use PCRE2 instead. However, it's still found in various legacy systems and some platforms, including certain services that continue to use the original PCRE for compatibility reasons.