### PR TITLE
psconvert: fix spurious -N warning

### DIFF
--- a/src/psconvert.c
+++ b/src/psconvert.c
@@ -1764,8 +1764,9 @@ EXTERN_MSC int GMT_psconvert(void *V_API, int mode, void *args) {
 		GMT_Report (API, GMT_MSG_WARNING, "The -TE option does not support the -!\n");
 	}
 	if (Ctrl->N.BB_paint || Ctrl->N.outline) {
+		if (Ctrl->O.active)
+			GMT_Report(API, GMT_MSG_WARNING, "The -N+g or -N+p options do not support the -!\n");
 		Ctrl->O.active = false;
-		GMT_Report (API, GMT_MSG_WARNING, "The -N+g or -N+p options do not support the -!\n");
 	}
 
 	if (Ctrl->T.device == GS_DEV_SVG && (gsVersion.major > 9 || (gsVersion.major == 9 && gsVersion.minor >= 16))) {


### PR DESCRIPTION
Check that the warning is printed only if -N+g|p was used. The -! option is the one that controls if the ps file is modified _insitu_ or duplicated.

Fix #8868