### PR TITLE
barb: Fix plotting the wind components u and v

### DIFF
--- a/src/windbarbs/psbarb.c
+++ b/src/windbarbs/psbarb.c
@@ -541,7 +541,7 @@ EXTERN_MSC int GMT_psbarb (void *V_API, int mode, void *args) {
 				Ctrl->Q.B.pen.width = (float)(current_pen.width * GMT->session.u2u[GMT_PT][GMT_INCH]);
 
 			if (Ctrl->Q.B.status & PSL_VEC_COMPONENTS)	/* Read dx, dy in user units */
-				d = d_atan2d (in[ex2+2*S.read_size], in[ex1+2*S.read_size]);
+				d = d_atan2d (-in[ex2+2*S.read_size], -in[ex1+2*S.read_size]);
 			else
 				d = in[ex1+2*S.read_size];	/* Got direction */
 			if (!gmt_M_is_geographic (GMT, GMT_IN))	/* Cartesian azimuth; change to direction */


### PR DESCRIPTION
**Description of proposed changes**

It seems like plotting the wind components `u` and `v` are mixed up in `barb`.

_Related to_: https://github.com/GenericMappingTools/gmt/issues/8985#issuecomment-4271149579
_Fix based on_: https://github.com/GenericMappingTools/gmt/issues/8985#issuecomment-4321455430

Fixes #8985


**Reminders**

- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
