### PR TITLE
Fix the baseline image for the psxy/elbowvec.sh

### DIFF
--- a/test/baseline/psxy.dvc
+++ b/test/baseline/psxy.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 510204715a512de392ee93ea016a172f.dir
+- md5: b994ae4d948b528c374c69d709a1ebc3.dir
   nfiles: 145
   path: psxy
   hash: md5
-  size: 9459764
+  size: 9459753


### PR DESCRIPTION
Patches #8967.

The baseline image added in PR #8967 is generally correct, but the plotting origin is shifted. It's likely because the baseline image was not created by running `ctest`.