### PR TITLE
Add bitflag to allow resetting GMT->init.runtime_bindir

### DIFF
--- a/src/gmt_api.c
+++ b/src/gmt_api.c
@@ -8471,6 +8471,11 @@ void * GMT_Create_Session (const char *session, unsigned int pad, unsigned int m
 	}
 	GMT_Report (API, GMT_MSG_DEBUG, "GMT_Create_Session initialized GMT structure\n");
 
+	if (API->external && (mode & GMT_SESSION_BIN2LIBDIR)) {	/* Reset bindir to libdir. This is to be used from externals only */
+		free(API->GMT->init.runtime_bindir);				/* where the bindir was set to the bin of launcher. In Julia it's julia/bin */
+		API->GMT->init.runtime_bindir = strdup(API->GMT->init.runtime_libdir);	/* but the libdir is correctly set to the GMT shared lib dir */
+	}
+
 	if (mode & GMT_SESSION_LOGERRORS) {	/* Want to redirect errors to a log file */
 		char file[PATH_MAX] = {""};
 		FILE *fp = NULL;

--- a/src/gmt_enum_dict.h
+++ b/src/gmt_enum_dict.h
@@ -28,7 +28,7 @@ struct GMT_API_DICT {
 	int value;
 };
 
-#define GMT_N_API_ENUMS 263
+#define GMT_N_API_ENUMS 264
 
 static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_ADD_DEFAULT", 6},
@@ -232,6 +232,7 @@ static struct GMT_API_DICT gmt_api_enums[GMT_N_API_ENUMS] = {
 	{"GMT_RGB", 0},
 	{"GMT_ROW", 2},
 	{"GMT_SEG", 1},
+	{"GMT_SESSION_BIN2LIBDIR", 128},
 	{"GMT_SESSION_COLMAJOR", 4},
 	{"GMT_SESSION_EXTERNAL", 2},
 	{"GMT_SESSION_LOGERRORS", 8},

--- a/src/gmt_resources.h
+++ b/src/gmt_resources.h
@@ -61,7 +61,8 @@ enum GMT_enum_session {
 	GMT_SESSION_LOGERRORS = 8,	/* External API uses column-major formats (e.g., MATLAB, FORTRAN). [Row-major format] */
 	GMT_SESSION_RUNMODE   = 16,	/* If set enable GMT's modern runmode. [Classic] */
 	GMT_SESSION_NOHISTORY = 32,	/* Do not use gmt.history at all [Let modules decide] */
-	GMT_SESSION_NOGDALCLOSE = 64	/* Do not call GDALDestroyDriverManager when using GDAL functions */
+	GMT_SESSION_NOGDALCLOSE = 64,	/* Do not call GDALDestroyDriverManager when using GDAL functions */
+	GMT_SESSION_BIN2LIBDIR  = 128	/* Reset bindir to libdir. This is to be used from externals only where bindir is set to callers bindir */
 };
 
 /*! Logging settings */


### PR DESCRIPTION
The issue is that when called from externals `GMT->init.runtime_bindir` is set to the binary of the external caller. For example from Julia `GMT->init.runtime_bindir` is set to `.../Julia/bin` and this is not good for example to find the Ghostscript location on Windows.

This PR adds a new `GMT_SESSION_BIN2LIBDIR`  bit flag that can be used at the time of `GMT_Create_Session()` call and will set `GMT->init.runtime_bindir` equal to `GMT->init.runtime_libdir`. This latter does not seem to be affected by the guessing machinery in `gmt_begin` and holds the right address on Windows. Unix systems may still be affected by the issue this PR tries to address. In all cases, this should be a harmless change when the `GMT_SESSION_BIN2LIBDIR` bit flag is not used.

