### PR TITLE
legend: Clarify the behavior of -M option

### DIFF
--- a/doc/rst/source/legend.rst
+++ b/doc/rst/source/legend.rst
@@ -118,9 +118,13 @@ Optional Arguments
     - **e**: Explicitly given information from input file(s) given on the command line (or via
       standard input).
 
-    Default is **he**, meaning we will first place any hidden auto-generated legend items (if any)
-    and then we append the explicitly given information (if present).  **Note**: For classic
-    mode an input file must be given or else we will attempt read from standard input.
+    If **-M** is not given, we will use the input file if provided, otherwise we will
+    use the auto-generated legend information if it exists.
+
+    If **-M** is given without any directives, the default is **he**, meaning we will first
+    place any hidden auto-generated legend items (if any) and then we append the explicitly
+    given information (if present). **Note**: For classic mode an input file must be given
+    or else we will attempt read from standard input.
 
 .. |Add_-R| replace:: |Add_-R_links|
 .. include:: explain_-R.rst_


### PR DESCRIPTION
As shown by the test script https://github.com/GenericMappingTools/gmt/blob/master/test/pslegend/mixlegend.sh.

<img width="2090" height="3121" alt="mixlegend" src="https://github.com/user-attachments/assets/8bdc343e-e6e9-45b1-ab1c-27ef25f9ad68" />

When `-M` is not used, the default behavior is use the input file and ignore any hidden file. The current docstring is misleading:

> Default is **he**, meaning we will first place any hidden auto-generated legend items (if any) and then we append the explicitly given information (if present).

This PR fixes it.