### PR TITLE
Fix test/psxy/bezier_demo_quadratic.sh

### DIFF
--- a/test/baseline/psxy.dvc
+++ b/test/baseline/psxy.dvc
@@ -1,6 +1,5 @@
 outs:
-- md5: 7b323ca3e95771d2e957825b6200bff0.dir
+- md5: fd04135cb8226c86f8f109e5dca463fe.dir
   nfiles: 147
   path: psxy
   hash: md5
-  size: 9545412

--- a/test/psxy/bezier_demo_quadratic.sh
+++ b/test/psxy/bezier_demo_quadratic.sh
@@ -2,7 +2,7 @@
 #
 # Test Q (quadratic Bezier) command in custom symbol macro language.
 # Uses share/custom/leaf.def (closed leaf shape from two Q curves)
-# and @qbezier_test.def (open parabolic arc).
+# and qbezier_test.def (open parabolic arc).
 
 ps=bezier_demo_quadratic.ps
 
@@ -15,9 +15,18 @@ for lon in -4 -2 0 2 4; do
 	echo "$lon -2" | gmt psxy -R -J -Skleaf/2.5c -Gdarkgreen  -W1p,black       -O -K >> $ps
 done
 
+cat > qbezier_test.def << EOF
+# Test quadratic Bezier Q command
+# Draws a simple parabolic arc from (-0.5,0) to (0.5,0) curving up to (0,0.5)
+# M = moveto start, Q = quadratic bezier, S = stroke
+-0.5  0.0  M
+ 0.0  0.5  0.5  0.0  Q
+S
+EOF
+
 # Parabolic arc symbol (open path, just stroked)
 for lon in -3 -1 1 3; do
-	echo "$lon  3.2" | gmt psxy -R -J -Sk@qbezier_test/1.5c -W1.5p,red -O -K >> $ps
+	echo "$lon  3.2" | gmt psxy -R -J -Skqbezier_test/1.5c -W1.5p,red -O -K >> $ps
 done
 
 # Labels
@@ -29,3 +38,4 @@ gmt pstext -R -J -F+f9p+jCM -O >> $ps << EOF
 0 0.7 2.0c leaves
 0 -1.3 2.5c leaves
 EOF
+rm qbezier_test.def

--- a/test/psxy/qbezier_test.def
+++ b/test/psxy/qbezier_test.def
@@ -1,0 +1,6 @@
+# Test quadratic Bezier Q command
+# Draws a simple parabolic arc from (-0.5,0) to (0.5,0) curving up to (0,0.5)
+# M = moveto start, Q = quadratic bezier, S = stroke
+-0.5  0.0  M
+ 0.0  0.5  0.5  0.0  Q
+S


### PR DESCRIPTION
The test `test/psxy/bezier_demo_quadratic.sh` is failing because,

1. `qbezier_test.def` is added to the GMT server, but our tests are using the static server.
2. The baseline image is incorrect that, some texts and arcs are missing.

This PR fixes the issue by generating the `qbezier_test.def` file on the fly and also updates the baseline image.