### PR TITLE
plot: Fix the description of the -M option

### DIFF
--- a/doc/rst/source/plot.rst
+++ b/doc/rst/source/plot.rst
@@ -252,7 +252,7 @@ Optional Arguments
 
 .. _-M:
 
-**-M**\ [**c**\|\ **s**][**+l**\ *seclabel*][**+g**\ *fill*][**p**\ *pen*][**+r**\ *pen*][**+y**\ [*level*]]
+**-M**\ [**c**\|\ **s**][**+l**\ *seclabel*][**+g**\ *fill*][**+p**\ *pen*][**+r**\ *pen*][**+y**\ [*level*]]
     Fill the middle area between two curves :math:`y_0(x)` and :math:`y_1(x)`, expected to be
     given via one or more pairs of separate tables, each pair of tables having the same
     number of segments (which can vary from pair to pair). Thus, the order of the even
@@ -269,8 +269,7 @@ Optional Arguments
       :math:`y_1(x)`. For the opposite case, append another *fill* here.
     - **+l** - For the primary curve :math:`y_0(x)`, a legend label can be set via option
       |SYN_OPT-l|. For a secondary label use this modifier to append the label.
-    - **+p** - Specify a separate pen for drawing curve :math:`y_1(x)` [Default is same pen
-      as :math:`y_0(x)`]. See |-W| for specifying the pen for curve :math:`y_0(x)`.
+    - **+p** - Specify a separate pen for drawing curve :math:`y_1(x)`. See |-W| for specifying the pen for curve :math:`y_0(x)`.
     - **+r** - Specify a pen to simply draw a line instead of a filled box in the legend, but
       replace the color information with that from the fill settings (i.e., only the *pen*
       width is used as specified, the color is not used).


### PR DESCRIPTION
In `plot -M`, when `+p` modifier is not set, it defaults to not drawing the curve, but the docs say
> Specify a separate pen for drawing curve :math:`y_1(x)` [Default is same pen as :math:`y_0(x)`]. See |-W| for specifying the pen for curve :math:`y_0(x)`.

The behavior can be confirmed by the following script:
```
#!/usr/bin/env bash
# Demonstrate filling of area between two sinusoidal curves with a section of NaNs
gmt begin GMT_fill_curves
	gmt math -T0/720/5 -N3/0 T -C1 COSD -C2 3 MUL SIND 4 DIV -C1,2 1 T 200 250 INRANGE SUB 0 NAN MUL = both_NaN.txt
	gmt plot -Mc+gblue+r+l"Short @~l@~ exceeds long" -Bxa90g90+u@. -Byafg -BWStr -JX15c/3c -R0/720/-1.25/2.5 both_NaN.txt -Gred -l"Long @~l@~ exceeds short" -W1p,red
gmt end show
```