### PR TITLE
Allow -L+f map scales for Cartesian projections

### DIFF
--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -9,8 +9,8 @@
     .. include:: explain_refpoint.rst_
 
     The following modifiers can be appended to |-L| (**+w** is required), with additional explanation and
-    examples provided in the :ref:`placing-map-scales` cookbook section. For Cartesian projection, the modifiers
-    **+c** and **+f** are not allowed and no units should be appended in **+w**.
+    examples provided in the :ref:`placing-map-scales` cookbook section. For Cartesian projection, the modifier
+    **+c** is not allowed and no units should be appended in **+w**.
 
     - **+w**\ *length* to set scale *length* in km, or append :ref:`unit <tbl-distunits>` from
       **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7213,7 +7213,7 @@ int gmt_draw_map_scale (struct GMT_CTRL *GMT, struct GMT_MAP_SCALE *ms) {
 	x_left  = ms->refpoint->x - 0.5 * bar_width;	/* x-coordinate of leftmost  scalebar point */
 	x_right = ms->refpoint->x + 0.5 * bar_width;	/* x-coordinate of rightmost scalebar point */
 
-	if (ms->fancy && gmt_M_is_geographic (GMT, GMT_IN)) {	/* Fancy scale */
+	if (ms->fancy) {	/* Fancy (checkerboard) scale, now allowed for both geographic and Cartesian projections */
 		unsigned int i, justify, form;
 		unsigned int n_f_ticks[10] = {5, 4, 6, 4, 5, 6, 7, 4, 3, 5};
 		unsigned int n_a_ticks[10] = {1, 2, 3, 2, 1, 3, 1, 2, 1, 1};

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14202,14 +14202,8 @@ int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 		error++;
 	}
 	/* Optional modifiers +a, +f, +j, +l, +o, +u, +v */
-	if (gmt_get_modifier (ms->refpoint->args, 'f', NULL)) {	/* Do fancy label */
-		if (gmt_M_is_cartesian (GMT, GMT_IN)) {	/* Not allowed' */
-			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  No fancy map scale modifier allowed for Cartesian projections\n", option);
-			error++;
-		}
-		else
-			ms->fancy = true;
-	}
+	if (gmt_get_modifier (ms->refpoint->args, 'f', NULL))	/* Do fancy (checkerboard) scale bar; now allowed for both geographic and Cartesian projections */
+		ms->fancy = true;
 	if (gmt_get_modifier (ms->refpoint->args, 'v', NULL)) {	/* Ask for vertical Cartesian scale */
 		if (gmt_M_is_geographic (GMT, GMT_IN)) {	/* Not allowed' */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  No vertical scale modifier allowed for geographic projections\n", option);


### PR DESCRIPTION
This PR addresses issue #8999.

Made with help of Claude Sonnet 4.6 free version. 

Tested with:
`gmt basemap -R0/1000/0/1000 -JX10/2c -Baf  -LjLB+w200m+o0.5c+f -png test`

<img width="1315" height="299" alt="test" src="https://github.com/user-attachments/assets/8d26fca3-d683-4a45-937a-b23043ce9fb8" />
