### PR TITLE
plot: Fix the bug that -M+r modifier doesn't set the pen thickness

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1046,9 +1046,11 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 								Ctrl->M.do_draw = true;
 								break;
 							case 'r':
-								if (p[1] && gmt_getpen (GMT, &p[1], &Ctrl->M.xpen)) {
-									gmt_pen_syntax (GMT, 'M', NULL, "Option -M: The +r modifier sets pen attributes for the legend rgb exchange", NULL, 0);
-									n_errors++;
+								if (p[1]) {
+									if (gmt_getpen (GMT, &p[1], &Ctrl->M.xpen)) {
+										gmt_pen_syntax (GMT, 'M', NULL, "Option -M: The +r modifier sets pen attributes for the legend rgb exchange", NULL, 0);
+										n_errors++;
+									}
 								}
 								else /* Guesswork */
 									Ctrl->M.xpen.width = 2.5;	/* Default pen width in points */


### PR DESCRIPTION
The `plot`'s `-M` documenation says (https://docs.generic-mapping-tools.org/6.6/plot.html#m):

> +r - Specify a pen to simply draw a line instead of a filled box in the legend, but replace the color information with that from the fill settings (i.e., only the pen width is used as specified, the color is not used).

Based on the documentation, the `+r` modifier should control the pen thickness of legend entries, but it doesn't work as expected. In the following script, `+r5p` set the pen thickness to `5p`, but `5p` is silently ignored.
```bash
#!/usr/bin/env bash
# Demonstrate filling of area between two sinusoidal curves with a section of NaNs
gmt begin GMT_fill_curves
	gmt math -T0/720/5 -N3/0 T -C1 COSD -C2 3 MUL SIND 4 DIV -C1,2 1 T 200 250 INRANGE SUB 0 NAN MUL = both_NaN.txt
	gmt plot -Mc+gblue+r5p+l"Short @~l@~ exceeds long" -Bxa90g90+u@. -Byafg -BWStr -JX15c/3c -R0/720/-1.25/2.5 both_NaN.txt -Gred -l"Long @~l@~ exceeds short"
gmt end show
```

This PR fixes the bug.