### PR TITLE
Add default reference point for map rose ( -Td and -Tm)

### DIFF
--- a/doc/rst/source/explain_-T_rose.rst_
+++ b/doc/rst/source/explain_-T_rose.rst_
@@ -1,4 +1,4 @@
-**-Td**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ [**+f**\|\ **F**\ [*level*]]\ [**+j**\ *justify*]\ 
+**-Td**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ [*refpoint*]\ [**+f**\|\ **F**\ [*level*]]\ [**+j**\ *justify*]\ 
 [**+l**\ [*w,e,s,n*]][**+o**\ *dx*\ [/*dy*]]\ [**+w**\ *width*]
 
     Draw a map directional rose on the map at the location defined by the reference (*refpoint*) and anchor point
@@ -6,6 +6,9 @@
     of four coordinate systems:
 
     .. include:: explain_refpoint.rst_
+
+    If *refpoint* is omitted, the directional rose is placed by default in the upper-right corner of the map
+    (using **+jTR**).
 
     The following optional modifiers can be appended to |-T|\ **d**, with additional explanation and
     examples provided in the :ref:`Placing-dir-map-roses` cookbook section. Optionally, use |-F| to place a panel
@@ -29,7 +32,7 @@
 
     For further information, see the Map Embellishment section on :ref:`Directional Roses <Placing-dir-map-roses>`.
 
-**-Tm**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ [**+d**\ *dec*\ [/\ *dlabel*]]]\ [**+i**\ *pen*]\ 
+**-Tm**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ [*refpoint*]\ [**+d**\ *dec*\ [/\ *dlabel*]]]\ [**+i**\ *pen*]\ 
 [**+j**\ *justify*][**+l**\ [*w,e,s,n*]][**+p**\ *pen*]\ [**+t**\ *ints*][**+o**\ *dx*\ [/*dy*]]\ [**+w**\ *width*]
 
     Draw a map magnetic rose on the map at the location defined by the reference (*refpoint*) and anchor point
@@ -37,6 +40,9 @@
     of four coordinate systems:
 
     .. include:: explain_refpoint.rst_
+
+    If *refpoint* is omitted, the directional rose is placed by default in the upper-right corner of the map
+    (using **+jTR**).
 
     The following optional modifiers can be appended to |-T|\ **m**, with additional explanation and
     examples provided in the :ref:`Placing-mag-map-roses` cookbook section. Optionally, use |-F| to place a panel

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -4973,8 +4973,17 @@ GMT_LOCAL int gmtsupport_getrose_old (struct GMT_CTRL *GMT, char option, char *t
 		snprintf (string, GMT_LEN256, "x%s/%s", txt_a, txt_b);
 	else	/* Set up ancher in geographical coordinates */
 		snprintf (string, GMT_LEN256, "g%s/%s", txt_a, txt_b);
-	if ((ms->refpoint = gmt_get_refpoint (GMT, string, option)) == NULL) {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Map rose reference point was not accepted\n", option);
+	char default_ref[GMT_LEN256];
+	/* If no reference point is provided (it starts with '+' or is empty), use jTR by default */
+	if (text[1] == '+' || text[1] == '\0') {
+		snprintf(default_ref, GMT_LEN256, "jTR%s", &text[1]);
+		ms->refpoint = gmt_get_refpoint(GMT, default_ref, option);
+	} else {
+		ms->refpoint = gmt_get_refpoint(GMT, &text[1], option);
+	}
+
+	if (ms->refpoint == NULL) {
+		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: Map rose reference point was not accepted\n", option);
 		gmt_refpoint_syntax (GMT, "Td|m", NULL, GMT_ANCHOR_MAPROSE, 3);
 		return (1);	/* Failed basic parsing */
 	}
@@ -14280,19 +14289,37 @@ int gmt_getrose (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_R
 	char txt_a[GMT_LEN256] = {""}, string[GMT_LEN256] = {""};
 	struct GMT_MAP_PANEL *save_panel = ms->panel;	/* In case it was set and we wipe it below with gmt_M_memset */
 
-	/* SYNTAX is -Td|m[g|j|n|x]<refpoint>[+w<width>][+f|F[<kind>]][+i<pen>][+j<justify>][+l<w,e,s,n>][+m[<dec>[/<dlabel>]]][+o<dx>[/<dy>]][+p<pen>][+t<ints>]
+	/* SYNTAX is -Td|m[g|j|n|x][<refpoint>][+w<width>][+f|F[<kind>]][+i<pen>][+j<justify>][+l<w,e,s,n>][+m[<dec>[/<dlabel>]]][+o<dx>[/<dy>]][+p<pen>][+t<ints>]
 	 * 1)  +f: fancy direction rose, <kind> = 1,2,3 which is the level of directions [1]. Use +F to flip W/E/S/N so readable from south
 	 * 2)  Tm: magnetic rose.  Optionally, append +d<dec>[/<dlabel>], where <dec> is magnetic declination and dlabel its label [no declination info].
 	 * If  -Tm, optionally set annotation interval with +t
 	 */
 
 	if (!text || text[0] == '\0') {
-		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c: No argument given\n", option);
+		GMT_Report (GMT->parent, GMT_MSG_ERROR,  "Option -%c: No argument given\n ", option);
 		return GMT_PARSE_ERROR;
 	}
 	gmt_M_memset (ms, 1, struct GMT_MAP_ROSE);
 	ms->panel = save_panel;	/* In case it is not NULL */
-	if (!strstr (text, "+w") && (strchr ("gjn", text[1]) == NULL || strchr ("fm", text[1]))) return gmtsupport_getrose_old (GMT, option, text, ms);	/* Most likely old-style args */
+
+	/* Inject default reference point (jTR) if omitted by user --- */
+	char refpoint_str[GMT_LEN256];
+	char *parse_text = text;
+	/* If the user omitted the reference point (e.g., -Td or -Tm), inject a default one (jTR = Top-Right inside) */
+	if (text[0] == 'd' || text[0] == 'm') {
+		if (text[1] == '+' || text[1] == '\0') {
+			snprintf(refpoint_str, GMT_LEN256, "%cjTR%s", text[0], &text[1]);
+			parse_text = refpoint_str;
+		}
+	}
+	/* Determine if we should fallback to the old-style parser.*/
+	if (parse_text[0] != 'd' && !strstr(parse_text, "+w")) {
+		char c = parse_text[1];
+		/* Old syntax starts with f, m, x, or numeric coordinates */
+		if (c == 'f' || c == 'm' || c == 'x' || isdigit((unsigned char)c) || c == '-' || c == '.') {
+			return gmtsupport_getrose_old(GMT, option, parse_text, ms);
+		}
+	}
 
 	/* Assign default values */
 	ms->type = GMT_ROSE_DIR_PLAIN;
@@ -14308,7 +14335,7 @@ int gmt_getrose (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_R
 			return (-1);
 			break;
 	}
-	if ((ms->refpoint = gmt_get_refpoint (GMT, &text[1], option)) == NULL) {
+	if ((ms->refpoint = gmt_get_refpoint (GMT,  &parse_text[1], option)) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Map rose reference point was not accepted\n", option);
 		gmt_refpoint_syntax (GMT, "Td|m", NULL, GMT_ANCHOR_MAPROSE, 3);
 		return (1);	/* Failed basic parsing */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14308,7 +14308,7 @@ int gmt_getrose (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_R
 	/* If the user omitted the reference point (e.g., -Td or -Tm), inject a default one (jTR = Top-Right inside) */
 	if (text[0] == 'd' || text[0] == 'm') {
 		if (text[1] == '+' || text[1] == '\0') {
-			snprintf(refpoint_str, GMT_LEN256, "%cjTR%s", text[0], &text[1]);
+			snprintf(refpoint_str, GMT_LEN256-1, "%cjTR%s", text[0], &text[1]);
 			parse_text = refpoint_str;
 		}
 	}

--- a/src/psbasemap.c
+++ b/src/psbasemap.c
@@ -126,7 +126,9 @@ static int usage (struct GMTAPI_CTRL *API, int level) {
 	gmt_mapscale_syntax (API->GMT, 'L', "Draw a map scale at specified reference point.");
 	GMT_Option (API, "O,P");
 	gmt_maprose_syntax (API->GMT, 'd', "Draw a north-pointing directional map rose at specified reference point.");
+	GMT_Usage (API, -2, "If <refpoint> is omitted, it defaults to the top-right corner inside the map frame.");
 	gmt_maprose_syntax (API->GMT, 'm', "Draw a north-pointing magnetic map rose at specified reference point.");
+	GMT_Usage (API, -2, "If <refpoint> is omitted, it defaults to the top-right corner inside the map frame.");
 	GMT_Option (API, "U,V,X,c,f,p,t,.");
 
 	return (GMT_MODULE_USAGE);


### PR DESCRIPTION
This PR makes the <refpoint> argument optional for the map rose options (`-Td` and `-Tm`).

When omitted, GMT now defaults to **jTR** (top-right corner inside the map frame) instead of raising a parsing error.

This behavior can be tested with:

`gmt basemap -R-50/-40/-20/-18 -JM10c -Bf -Td+f -png test
`
<img width="1203" height="271" alt="test" src="https://github.com/user-attachments/assets/5a02a2e8-1116-4d1f-b636-3a833d1b3632" />


Feedback on the default position is welcome.