### PR TITLE
Allow map inset dimensions as percentages

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8903,7 +8903,8 @@ void gmt_mapinset_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	GMT_Usage (API, 3, "%s Give <xmin>/<xmax>/<ymin>/<ymax>[+u<unit>] of bounding rectangle in projected coordinates [meters].", GMT_LINE_BULLET);
 	GMT_Usage (API, 3, "%s Set reference point and dimensions of the inset:", GMT_LINE_BULLET);
 	gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 1);
-	GMT_Usage (API, 3, "Append +w<width>[<u>]/<height>[<u>] of bounding rectangle (<u> is a unit from %s).", GMT_DIM_UNITS_DISPLAY);
+	GMT_Usage (API, 3, "Append +w<width>[<u>][%%][/<height>[<u>][%%]] of bounding rectangle (<u> is a unit from %s). "
+		"Append %% instead of a unit to set that dimension as a percentage of the map width or height, respectively.", GMT_DIM_UNITS_DISPLAY);
 	gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 2);
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) {
 		GMT_Usage (API, 2, "Append +s<file> to save inset lower left corner and dimensions to <file>.");

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7045,6 +7045,12 @@ void gmt_draw_map_inset (struct GMT_CTRL *GMT, struct GMT_MAP_INSET *B, bool cli
 				return;
 		}
 		if (B->refpoint) {	/* Got a geographic center point and width/height for a rectangular box */
+			if (B->fraction[GMT_X] || B->fraction[GMT_Y]) {	/* One or both dimensions were given as %% of the map width/height */
+				if (B->fraction[GMT_X]) B->dim[GMT_X] = B->scl[GMT_X] * GMT->current.proj.rect[XHI];
+				if (B->fraction[GMT_Y]) B->dim[GMT_Y] = B->scl[GMT_Y] * GMT->current.proj.rect[YHI];
+				else if (B->dim[GMT_Y] == 0.0) B->dim[GMT_Y] = B->dim[GMT_X];	/* Square inset from single % width */
+				GMT_Report (GMT->parent, GMT_MSG_DEBUG, "Map inset dimensions resolved from percentages to %g/%g inches\n", B->dim[GMT_X], B->dim[GMT_Y]);
+			}
 			gmt_M_memcpy (dim, B->dim, 2, double);		/* Duplicate the width/height of rectangle */
 			if (B->unit) {	/* Gave dimensioned box */
 				for (k = 0; k < 2; k++) {

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13999,18 +13999,36 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 			else {	/* Gave some arguments */
 				n = sscanf (string, "%[^/]/%s", txt_a, txt_b);
 				/* First deal with inset dimensions and horizontal vs vertical */
-				/* Handle either <unit><width>/<height> or <width>/<height> */
+				/* Handle either <unit><width>/<height>, <width>/<height>, or <width>%[/<height>%] */
 				q[GMT_X] = txt_a;	q[GMT_Y] = txt_b;
 				last = (n == 1) ? GMT_X : GMT_Y;
 				for (k = GMT_X; k <= last; k++) {
 					len = strlen (q[k]) - 1;
-					if (strchr (GMT_LEN_UNITS2, q[k][len])) {	/* Got dimensions in these units */
-						B->unit = q[k][len];
-						q[k][len] = 0;
+					if (q[k][len] == '%') {	/* Gave this dimension as a percentage of the map width/height */
+						q[k][len] = 0;	/* Chop off the % sign */
+						B->fraction[k] = true;
+						B->scl[k] = atof (q[k]) * 0.01;	/* Convert to fraction */
+						B->dim[k] = 0.0;	/* Resolved later in gmt_draw_map_inset once the map dimensions are known */
 					}
-					B->dim[k] = (B->unit) ? atof (q[k]) : gmt_M_to_inch (GMT, q[k]);
+					else {
+						if (strchr (GMT_LEN_UNITS2, q[k][len])) {	/* Got dimensions in these units */
+							B->unit = q[k][len];
+							q[k][len] = 0;
+						}
+						B->dim[k] = (B->unit) ? atof (q[k]) : gmt_M_to_inch (GMT, q[k]);
+					}
 				}
-				if (last == GMT_X) B->dim[GMT_Y] = B->dim[GMT_X];
+				if (last == GMT_X) {	/* Only got <width> so let height match width */
+					if (B->fraction[GMT_X]) {
+						B->fraction[GMT_Y] = false;
+						B->dim[GMT_Y] = 0.0;	/* Will be copied from X after X is resolved */
+					}
+					else {
+						B->dim[GMT_Y] = B->dim[GMT_X];
+						B->fraction[GMT_Y] = B->fraction[GMT_X];
+						B->scl[GMT_Y] = B->scl[GMT_X];
+					}
+				}
 			}
 		}
 		/* Optional modifiers +j, +o, +s */

--- a/src/gmt_symbol.h
+++ b/src/gmt_symbol.h
@@ -159,7 +159,9 @@ struct GMT_MAP_INSET {
 	struct GMT_REFPOINT *refpoint;
 	double wesn[4];		/* Geographic or projected boundaries */
 	double off[2];		/* Offset from reference point */
-	double dim[2];		/* Width & height of box */
+	double dim[2];		/* Width & height of box, in inches once resolved */
+	bool fraction[2];	/* True if the corresponding dim[] was given as %% of map width/height and still needs resolving */
+	double scl[2];		/* Fraction (0-1) of map width/height to use for dim[] when fraction[] is true */
 	char *file;			/* Used to write inset location and dimensions [+s] */
 	struct GMT_MAP_PANEL *panel;	/* Everything about optional back panel */
 };


### PR DESCRIPTION
This PR adds support for specifying map inset dimensions as percentages of the figure size. For example, using -DjTR+w24% sets the inset width to 24% of the map width. When a single percentage is given, the inset is drawn as a square. Both dimensions can also be specified independently, as in -DjTR+w24%/30%, or mixed with absolute units, like -DjTR+w4c/30%. The change is fully backward compatible with existing scripts.

Example:
```
gmt begin ex44 png
	gmt coast -R110E/170E/44S/9S -JM15c -Gbrown -Baf
    gmt inset begin -DjTR+w24% -F+gwhite+p1p+c0.1c+s -Vi
		gmt coast -Rg -JG120/30S/? -Gbrown -Bg
	gmt inset end
gmt end

```
<img width="1938" height="1257" alt="ex44" src="https://github.com/user-attachments/assets/dd5a45e6-9eae-4e52-af6c-d278cc821197" />


As a future enhancement, it would be possible to add modifiers such as `+dw`, `+dh`, `+du`, and `+dl` (similar to those used in `-J`) to let the user choose which map dimension a single percentage refers to (width, height, maximum, or minimum).