### PR TITLE
Add default reference point for map inset (-D)

### DIFF
--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -53,8 +53,8 @@ Required Arguments (begin mode)
 
     .. include:: explain_refpoint.rst_
 
-    If *refpoint* is omitted, the map inset is placed by default in the upper-left corner of the map
-    (using **jTL**).
+    If *refpoint* is omitted, the map inset is placed by default in the upper-right corner of the map
+    (using **jTR**).
 
     Alternatively, Give *west/east/south/north* of geographic rectangle bounded by parallels
     and meridians; append **+r** if the coordinates instead are the lower left and

--- a/doc/rst/source/inset.rst
+++ b/doc/rst/source/inset.rst
@@ -48,10 +48,13 @@ Required Arguments (begin mode)
 
 .. _-D:
 
-**-D**\ *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*]] \| **-D**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
+**-D**\ *xmin/xmax/ymin/ymax*\ [**+r**][**+u**\ *unit*]] \| **-D**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ [*refpoint*]\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]]
     Define the map inset rectangle on the map.  Specify the rectangle in one of three ways:
 
     .. include:: explain_refpoint.rst_
+
+    If *refpoint* is omitted, the map inset is placed by default in the upper-left corner of the map
+    (using **jTL**).
 
     Alternatively, Give *west/east/south/north* of geographic rectangle bounded by parallels
     and meridians; append **+r** if the coordinates instead are the lower left and

--- a/doc/rst/source/psbasemap.rst
+++ b/doc/rst/source/psbasemap.rst
@@ -41,7 +41,7 @@ Synopsis
 
 .. _-D:
 
-**-D**\ *xmin/xmax/ymin/ymax*\ [**+r**][**+s**\ *file*][**+t**][**+u**\ *unit*]\  \| **-D**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]][**+s**\ *file*][**+t**]
+**-D**\ *xmin/xmax/ymin/ymax*\ [**+r**][**+s**\ *file*][**+t**][**+u**\ *unit*]\  \| **-D**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ [*refpoint*]\ **+w**\ *width*\ [/*height*][**+j**\ *justify*][**+o**\ *dx*\ [/*dy*]][**+s**\ *file*][**+t**]
     Draw a simple map inset box on the map.  Requires |-F|.  Specify the box in one of three ways:
     (a) Give *west/east/south/north* of geographic rectangle bounded by parallels
     and meridians; append **r** if the coordinates instead are the lower left and
@@ -51,7 +51,8 @@ Synopsis
     (1) Use **-Dg** for map (user) coordinates, (2) use **-Dj** or **-DJ** for setting *refpoint* via
     a 2-char justification code that refers to the (invisible) map domain rectangle,
     (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
-    (inches, cm, etc.).
+    (inches, cm, etc.). If *refpoint* is omitted, the map inset is placed by default in the
+    upper-left corner of the map (using **jTL**).
     Append **+w**\ *width*\ [/*height*] of bounding rectangle or box in plot coordinates (inches, cm, etc.).
     By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`pstext`).

--- a/doc/rst/source/psbasemap.rst
+++ b/doc/rst/source/psbasemap.rst
@@ -52,7 +52,7 @@ Synopsis
     a 2-char justification code that refers to the (invisible) map domain rectangle,
     (3) use **-Dn** for normalized (0-1) coordinates, or (4) use **-Dx** for plot coordinates
     (inches, cm, etc.). If *refpoint* is omitted, the map inset is placed by default in the
-    upper-left corner of the map (using **jTL**).
+    upper-right corner of the map (using **jTR**).
     Append **+w**\ *width*\ [/*height*] of bounding rectangle or box in plot coordinates (inches, cm, etc.).
     By default, the anchor point on the scale is assumed to be the bottom left corner (BL), but this
     can be changed by appending **+j** followed by a 2-char justification code *justify* (see :doc:`pstext`).

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8905,7 +8905,7 @@ void gmt_mapinset_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 1);
 	GMT_Usage (API, 3, "Append +w<width>[<u>]/<height>[<u>] of bounding rectangle (<u> is a unit from %s).", GMT_DIM_UNITS_DISPLAY);
 	gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 2);
-	GMT_Usage (API, -2, "If <refpoint> is omitted, the inset defaults to the top-left corner inside the map frame (using jTL).");
+	GMT_Usage (API, -2, "If <refpoint> is omitted, the inset defaults to the top-right corner inside the map frame (using jTR).");
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) {
 		GMT_Usage (API, 2, "Append +s<file> to save inset lower left corner and dimensions to <file>.");
 		GMT_Usage (API, 2, "Append +t to translate plot origin to the lower left corner of the inset.");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8905,6 +8905,7 @@ void gmt_mapinset_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 1);
 	GMT_Usage (API, 3, "Append +w<width>[<u>]/<height>[<u>] of bounding rectangle (<u> is a unit from %s).", GMT_DIM_UNITS_DISPLAY);
 	gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 2);
+	GMT_Usage (API, -2, "If <refpoint> is omitted, the inset defaults to the top-left corner inside the map frame (using jTL).");
 	if (GMT->current.setting.run_mode == GMT_CLASSIC) {
 		GMT_Usage (API, 2, "Append +s<file> to save inset lower left corner and dimensions to <file>.");
 		GMT_Usage (API, 2, "Append +t to translate plot origin to the lower left corner of the inset.");

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13955,7 +13955,7 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 	 * 1) -D<xmin/xmax/ymin/ymax>[+r][+s<file>][+u<unit>]
 	 * 2) -Dg|j|J|n|x[<refpoint>]+w<width>[<u>][/<height>[<u>]][+j<justify>][+o<dx>[/<dy>]][+s<file>]
 	 *    Note: the [+s<file>] is only valid in classic mode (via psbasemap)
-	 *    If <refpoint> (and its g|j|J|n|x code) is entirely omitted, we default to jTL (Top-Left inside)
+	 *    If <refpoint> (and its g|j|J|n|x code) is entirely omitted, we default to jTR (Top-Right inside)
 	 *
 	 * For backwards compatibility we also check the deprecated form of (1):
 	 *    [<unit>]<xmin/xmax/ymin/ymax>
@@ -13977,12 +13977,12 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 
 	/* Determine if we got an reference point or a region */
 
-	/* Inject default reference point (jTL) if omitted by user --- */
+	/* Inject default reference point (jTR) if omitted by user --- */
 	char refpoint_str[GMT_LEN256];
 	char *parse_text = text;
-	/* If the user omitted the reference point (e.g., -D+w5c), inject a default one (jTL = Top-Left inside) */
+	/* If the user omitted the reference point (e.g., -D+w5c), inject a default one (jTR = Top-Right inside) */
 	if (text[0] == '+' || text[0] == '\0') {
-		snprintf (refpoint_str, GMT_LEN256-1, "jTL%s", text);
+		snprintf (refpoint_str, GMT_LEN256-1, "jTR%s", text);
 		parse_text = refpoint_str;
 	}
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -13953,8 +13953,9 @@ bool gmt_x_is_outside (struct GMT_CTRL *GMT, double *x, double left, double righ
 int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_MAP_INSET *B) {
 	/* Parse the map inset option, which comes in two flavors:
 	 * 1) -D<xmin/xmax/ymin/ymax>[+r][+s<file>][+u<unit>]
-	 * 2) -Dg|j|J|n|x<refpoint>+w<width>[<u>][/<height>[<u>]][+j<justify>][+o<dx>[/<dy>]][+s<file>]
+	 * 2) -Dg|j|J|n|x[<refpoint>]+w<width>[<u>][/<height>[<u>]][+j<justify>][+o<dx>[/<dy>]][+s<file>]
 	 *    Note: the [+s<file>] is only valid in classic mode (via psbasemap)
+	 *    If <refpoint> (and its g|j|J|n|x code) is entirely omitted, we default to jTL (Top-Left inside)
 	 *
 	 * For backwards compatibility we also check the deprecated form of (1):
 	 *    [<unit>]<xmin/xmax/ymin/ymax>
@@ -13976,12 +13977,21 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 
 	/* Determine if we got an reference point or a region */
 
-	if (strchr (GMT_REFPOINT_CODES, text[0])) {	/* Did the reference point thing. */
+	/* Inject default reference point (jTL) if omitted by user --- */
+	char refpoint_str[GMT_LEN256];
+	char *parse_text = text;
+	/* If the user omitted the reference point (e.g., -D+w5c), inject a default one (jTL = Top-Left inside) */
+	if (text[0] == '+' || text[0] == '\0') {
+		snprintf (refpoint_str, GMT_LEN256-1, "jTL%s", text);
+		parse_text = refpoint_str;
+	}
+
+	if (strchr (GMT_REFPOINT_CODES, parse_text[0])) {	/* Did the reference point thing. */
 		/* Syntax is -Dg|j|J|n|x<refpoint>+w<width>[/<height>][+j<justify>][+o<dx>[/<dy>]][+s<file>], with +s<file> only in classic mode */
 		unsigned int last;
 		char *q[2] = {NULL, NULL};
 		size_t len;
-		if ((B->refpoint = gmt_get_refpoint (GMT, text, option)) == NULL) {
+		if ((B->refpoint = gmt_get_refpoint (GMT, parse_text, option)) == NULL) {
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Map inset reference point was not accepted\n", option);
 			gmt_refpoint_syntax (GMT, "D", NULL, GMT_ANCHOR_INSET, 1);
 			return (1);	/* Failed basic parsing */


### PR DESCRIPTION
Assisted-by: **Claude Sonnet 4.6**

This PR makes the <refpoint> argument optional for the map inset option (`-D`).

When omitted, GMT now defaults to `jTL` (top-left corner inside the map frame) instead of raising a parsing error.

Test with:

```
gmt begin ex44 png
	gmt coast -R110E/170E/44S/9S -JM15c -Gbrown -Baf
    gmt inset begin -D+w4c -F+gwhite+p1p+c0.1c+s -Vi
		gmt coast -Rg -JG120/30S/? -Gbrown -Bg
	gmt inset end
gmt end
```
<img width="1938" height="1257" alt="ex44" src="https://github.com/user-attachments/assets/3ba626b3-6e8a-4ebd-9d54-6d48fd17b5c6" />

Please let me know if you’d prefer a different default setting. In PyGMT the Bottom Left corner is used. 

