### PR TITLE
Add default position for map scales when refpoint is omitted

### DIFF
--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -1,4 +1,4 @@
-**-L**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ *refpoint*\ **+w**\ *length*\ [**e**\|\ **f**\|\ **k**\|\
+**-L**\ [**g**\|\ **j**\|\ **J**\|\ **n**\|\ **x**]\ [*refpoint*]\ **+w**\ *length*\ [**e**\|\ **f**\|\ **k**\|\
 **M**\|\ **n**\|\ **u**]\ [**+a**\ *align*]\ [**+c**\ [[*slon*/]\ *slat*]]\ [**+f**]\ [**+j**\ *justify*]\ [**+l**\
 [*label*]\ ]\ [**+o**\ *dx*\ [/*dy*]]\ [**+u**][**+v**]
 
@@ -7,6 +7,9 @@
     coordinate systems:
 
     .. include:: explain_refpoint.rst_
+
+    If *refpoint* is omitted, the map scale is placed by default in the lower-right corner of the map
+    (using **+jBR+o0.5c**), nudged slightly inward so it does not sit flush against the map frame.
 
     The following modifiers can be appended to |-L| (**+w** is required), with additional explanation and
     examples provided in the :ref:`placing-map-scales` cookbook section. For Cartesian projection, the modifier

--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -9,7 +9,7 @@
     .. include:: explain_refpoint.rst_
 
     If *refpoint* is omitted, the map scale is placed by default in the lower-left corner of the map
-    (using **+jBL+o0.5c**), nudged slightly inward so it does not sit flush against the map frame.
+    (using **+jBL+o0.2c/0.4c**), nudged slightly inward so it does not sit flush against the map frame.
 
     The following modifiers can be appended to |-L| (**+w** is required), with additional explanation and
     examples provided in the :ref:`placing-map-scales` cookbook section. For Cartesian projection, the modifier

--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -8,8 +8,8 @@
 
     .. include:: explain_refpoint.rst_
 
-    If *refpoint* is omitted, the map scale is placed by default in the lower-right corner of the map
-    (using **+jBR+o0.5c**), nudged slightly inward so it does not sit flush against the map frame.
+    If *refpoint* is omitted, the map scale is placed by default in the lower-left corner of the map
+    (using **+jBL+o0.5c**), nudged slightly inward so it does not sit flush against the map frame.
 
     The following modifiers can be appended to |-L| (**+w** is required), with additional explanation and
     examples provided in the :ref:`placing-map-scales` cookbook section. For Cartesian projection, the modifier

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8925,7 +8925,7 @@ void gmt_mapscale_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	GMT_Usage (API, 1, "\n-%c%s", option, GMT_SCALE);
 	GMT_Usage (API, -2, "%s", string);
 	gmt_refpoint_syntax (GMT, "L", NULL, GMT_ANCHOR_MAPSCALE, 3);
-	GMT_Usage (API, -2, "If <refpoint> is omitted, the scale defaults to the bottom-right corner inside the map frame, nudged 0.5 cm inward (using +jBR+o0.5c).");
+	GMT_Usage (API, -2, "If <refpoint> is omitted, the scale defaults to the bottom-left corner inside the map frame, nudged 0.5 cm inward (using +jBL+o0.5c).");
 	GMT_Usage (API, -2, "Set required scale via +w<length>, and (for geographic projection) append a unit from %s [km]. Other scale modifiers are optional:",
 		GMT_LEN_UNITS2_DISPLAY);
 	GMT_Usage (API, 3, "+a Append label alignment (choose among l(eft), r(ight), t(op), and b(ottom)) [t].");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8925,7 +8925,7 @@ void gmt_mapscale_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	GMT_Usage (API, 1, "\n-%c%s", option, GMT_SCALE);
 	GMT_Usage (API, -2, "%s", string);
 	gmt_refpoint_syntax (GMT, "L", NULL, GMT_ANCHOR_MAPSCALE, 3);
-	GMT_Usage (API, -2, "If <refpoint> is omitted, the scale defaults to the bottom-left corner inside the map frame, nudged 0.5 cm inward (using +jBL+o0.5c).");
+	GMT_Usage (API, -2, "If <refpoint> is omitted, the scale defaults to the bottom-left corner inside the map frame, nudged slightly inward (using +jBL+o0.2/0.4c).");
 	GMT_Usage (API, -2, "Set required scale via +w<length>, and (for geographic projection) append a unit from %s [km]. Other scale modifiers are optional:",
 		GMT_LEN_UNITS2_DISPLAY);
 	GMT_Usage (API, 3, "+a Append label alignment (choose among l(eft), r(ight), t(op), and b(ottom)) [t].");

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8925,6 +8925,7 @@ void gmt_mapscale_syntax (struct GMT_CTRL *GMT, char option, char *string) {
 	GMT_Usage (API, 1, "\n-%c%s", option, GMT_SCALE);
 	GMT_Usage (API, -2, "%s", string);
 	gmt_refpoint_syntax (GMT, "L", NULL, GMT_ANCHOR_MAPSCALE, 3);
+	GMT_Usage (API, -2, "If <refpoint> is omitted, the scale defaults to the bottom-right corner inside the map frame, nudged 0.5 cm inward (using +jBR+o0.5c).");
 	GMT_Usage (API, -2, "Set required scale via +w<length>, and (for geographic projection) append a unit from %s [km]. Other scale modifiers are optional:",
 		GMT_LEN_UNITS2_DISPLAY);
 	GMT_Usage (API, 3, "+a Append label alignment (choose among l(eft), r(ight), t(op), and b(ottom)) [t].");

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14129,7 +14129,7 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_SCALE *ms) {
 	/* This function parses the -L map scale syntax:
 	 *   -L[g|j|J|n|x][<refpoint>]+c[/<slon>]/<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+j<just>][+l<label>][+u]
-	 * If <refpoint> (and its g|j|J|n|x code) is entirely omitted, we default to jBR (Bottom-Right inside)
+	 * If <refpoint> (and its g|j|J|n|x code) is entirely omitted, we default to jBL (Bottom-Left inside)
 	 * If the required +w is not present we call the backwards compatible parsert for the previous map scale syntax.
 	 * An optional background panel is handled by a separate option (typically -F). */
 
@@ -14150,18 +14150,18 @@ int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	ms->measure = 'k';	/* Default distance unit is km */
 	ms->alignment = (vertical) ? 'r' : 't';	/* Default label placement is on top for map scale and right for vertical scale */
 
-	/* Inject default reference point (jBR) if omitted by user --- */
+	/* Inject default reference point (jBL) if omitted by user --- */
 	char refpoint_str[GMT_LEN256];
 	char *parse_text = text;
-	/* If the user omitted the reference point (e.g., -L+w100k), inject a default one (jBR = Bottom-Right inside),
+	/* If the user omitted the reference point (e.g., -L+w100k), inject a default one (jBL = Bottom-Left inside),
 	 * plus a small 0.5 cm inward offset (+o) so the scale does not sit flush against the map frame.
 	 * If the user already gave their own +o modifier, leave it untouched. */
 	if (text[0] == '+') {
 		char dummy[GMT_LEN256] = {""};
 		if (gmt_get_modifier (text, 'o', dummy))	/* User already specified +o<dx>/<dy>; do not override */
-			snprintf (refpoint_str, GMT_LEN256-1, "jBR%s", text);
+			snprintf (refpoint_str, GMT_LEN256-1, "jBL%s", text);
 		else
-			snprintf (refpoint_str, GMT_LEN256-1, "jBR+o0.5c/0.5c%s", text);
+			snprintf (refpoint_str, GMT_LEN256-1, "jBL+o0.5c/0.5c%s", text);
 		parse_text = refpoint_str;
 	}
 

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14128,7 +14128,8 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 
 int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_SCALE *ms) {
 	/* This function parses the -L map scale syntax:
-	 *   -L[g|j|J|n|x]<refpoint>+c[/<slon>]/<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+j<just>][+l<label>][+u]
+	 *   -L[g|j|J|n|x][<refpoint>]+c[/<slon>]/<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+j<just>][+l<label>][+u]
+	 * If <refpoint> (and its g|j|J|n|x code) is entirely omitted, we default to jBR (Bottom-Right inside)
 	 * If the required +w is not present we call the backwards compatible parsert for the previous map scale syntax.
 	 * An optional background panel is handled by a separate option (typically -F). */
 
@@ -14149,7 +14150,22 @@ int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	ms->measure = 'k';	/* Default distance unit is km */
 	ms->alignment = (vertical) ? 'r' : 't';	/* Default label placement is on top for map scale and right for vertical scale */
 
-	if ((ms->refpoint = gmt_get_refpoint (GMT, text, option)) == NULL) {
+	/* Inject default reference point (jBR) if omitted by user --- */
+	char refpoint_str[GMT_LEN256];
+	char *parse_text = text;
+	/* If the user omitted the reference point (e.g., -L+w100k), inject a default one (jBR = Bottom-Right inside),
+	 * plus a small 0.5 cm inward offset (+o) so the scale does not sit flush against the map frame.
+	 * If the user already gave their own +o modifier, leave it untouched. */
+	if (text[0] == '+') {
+		char dummy[GMT_LEN256] = {""};
+		if (gmt_get_modifier (text, 'o', dummy))	/* User already specified +o<dx>/<dy>; do not override */
+			snprintf (refpoint_str, GMT_LEN256-1, "jBR%s", text);
+		else
+			snprintf (refpoint_str, GMT_LEN256-1, "jBR+o0.5c/0.5c%s", text);
+		parse_text = refpoint_str;
+	}
+
+	if ((ms->refpoint = gmt_get_refpoint (GMT, parse_text, option)) == NULL) {
 		GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -%c:  Scale reference point was not accepted\n", option);
 		gmt_refpoint_syntax (GMT, "L", NULL, GMT_ANCHOR_MAPSCALE, 3);
 		return (1);	/* Failed basic parsing */

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -14129,7 +14129,7 @@ int gmt_getinset (struct GMT_CTRL *GMT, char option, char *in_text, struct GMT_M
 int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_SCALE *ms) {
 	/* This function parses the -L map scale syntax:
 	 *   -L[g|j|J|n|x][<refpoint>]+c[/<slon>]/<slat>+w<length>[e|f|M|n|k|u][+a<align>][+f][+j<just>][+l<label>][+u]
-	 * If <refpoint> (and its g|j|J|n|x code) is entirely omitted, we default to jBL (Bottom-Left inside)
+	 * If <refpoint> (and its g|j|J|n|x code) is entirely omitted, we default to jBL+o0.2c/0.4c (Bottom-Left plus a small nudge)
 	 * If the required +w is not present we call the backwards compatible parsert for the previous map scale syntax.
 	 * An optional background panel is handled by a separate option (typically -F). */
 
@@ -14150,18 +14150,18 @@ int gmt_getscale (struct GMT_CTRL *GMT, char option, char *text, struct GMT_MAP_
 	ms->measure = 'k';	/* Default distance unit is km */
 	ms->alignment = (vertical) ? 'r' : 't';	/* Default label placement is on top for map scale and right for vertical scale */
 
-	/* Inject default reference point (jBL) if omitted by user --- */
+	/* Inject default reference point (jBL+o0.2c/0.4c) if omitted by user --- */
 	char refpoint_str[GMT_LEN256];
 	char *parse_text = text;
-	/* If the user omitted the reference point (e.g., -L+w100k), inject a default one (jBL = Bottom-Left inside),
-	 * plus a small 0.5 cm inward offset (+o) so the scale does not sit flush against the map frame.
+	/* If the user omitted the reference point (e.g., -L+w100k), inject a default one (jBL = Bottom-Left inside), plus a small inward
+	 * offset of 0.2 cm horizontally and 0.4 cm vertically (+o0.2c/0.4c) so the scale does not sit flush against the map frame.
 	 * If the user already gave their own +o modifier, leave it untouched. */
 	if (text[0] == '+') {
 		char dummy[GMT_LEN256] = {""};
 		if (gmt_get_modifier (text, 'o', dummy))	/* User already specified +o<dx>/<dy>; do not override */
 			snprintf (refpoint_str, GMT_LEN256-1, "jBL%s", text);
 		else
-			snprintf (refpoint_str, GMT_LEN256-1, "jBL+o0.5c/0.5c%s", text);
+			snprintf (refpoint_str, GMT_LEN256-1, "jBL+o0.2c/0.4c%s", text);
 		parse_text = refpoint_str;
 	}
 


### PR DESCRIPTION
**Assisted by Claude Sonnet 4.6** 

This PR adds a default placement for map scales when refpoint is omitted. The scale is automatically placed in the lower-right corner of the map (**+jBR+o0.5c**), slightly offset from the frame.

Testing
`gmt basemap -R0/10/0/1 -JM10c -Baf -L+f+w150k -png test`

<img width="1275" height="187" alt="test" src="https://github.com/user-attachments/assets/b2601c77-6ab4-4886-befc-064d824a5eb2" />

Let me know if you prefer another position.