### PR TITLE
Fix spurious warning with subplot -B+a modifiers

### DIFF
--- a/src/subplot.c
+++ b/src/subplot.c
@@ -297,7 +297,7 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 
 	unsigned int n_errors = 0, error, k, j, n = 0, pos, side;
 	bool B_args = false, noB = false;
-	char *c = NULL, add[2] = {0, 0}, string[GMT_LEN128] = {""}, p[GMT_LEN128] = {""};
+	char *c = NULL, *s = NULL, add[2] = {0, 0}, string[GMT_LEN128] = {""}, p[GMT_LEN128] = {""};
 	struct GMT_OPTION *opt = NULL, *Bframe = NULL, *Bx = NULL, *By = NULL, *Bxy = NULL;
 	struct GMT_PEN pen;	/* Only used to make sure any pen is given with correct syntax */
 	struct GMT_FILL fill;	/* Only used to make sure any fill is given with correct syntax */
@@ -703,9 +703,16 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 				}
 			}
 			if (Bx) {	/* Did get separate x-axis annotation settings */
-				if ((c = gmt_first_modifier (GMT, Bx->arg, "lpsu"))) {	/* Gave valid axes modifiers for custom labels */
+				s = Bx->arg;
+				/* +a (annotation angle/parallel/normal) is a valid modifier but must not be treated as the
+				 * cut point below since it has to survive verbatim in Ctrl->S[GMT_X].b; skip past any +a
+				 * we encounter and keep looking for a genuine label/prefix/unit modifier to truncate at.
+				 * Note: if +a appears *after* a genuine l/p/s/u modifier it will still be chopped off below;
+				 * that combination is not currently supported. */
+				while ((c = gmt_first_modifier (GMT, s, "alpsu")) && c[1] == 'a') s = c + 2;
+				if (c) {	/* Gave valid axes modifiers for custom labels */
 					pos = error = 0;
-					while (gmt_getmodopt (GMT, 'B', c, "lpsu", &pos, p, &error) && error == 0) {
+					while (gmt_getmodopt (GMT, 'B', c, "alpsu", &pos, p, &error) && error == 0) {
 						switch (p[0]) {
 							case 'l':	/* Regular x-axis label */
 								Ctrl->S[GMT_X].label[GMT_PRIMARY] = strdup (&p[1]);	break;
@@ -715,6 +722,8 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 								Ctrl->S[GMT_X].label[GMT_SECONDARY] = strdup (&p[1]);	break;
 							case 'u':	/* Annotation units */
 								Ctrl->S[GMT_X].unit[GMT_PRIMARY] = strdup (&p[1]);	break;
+							case 'a':	/* Annotation angle/parallel/normal - passed through verbatim via subplot_prep_annot_args */
+								break;
 							default:	/* These are caught in gmt_getmodopt so break is just for Coverity */
 								break;
 						}
@@ -728,9 +737,12 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 			else if (Bxy)	/* Did common x and y-axes annotation settings */
 				Ctrl->S[GMT_X].b = strdup (Bxy->arg);
 			if (By) {	/* Did get y-axis annotation settings */
-				if ((c = gmt_first_modifier (GMT, By->arg, "lpsu"))) {	/* Gave valid axes modifiers for custom labels */
+				s = By->arg;
+				/* See comment in the Bx block above: skip past +a so it is preserved verbatim. */
+				while ((c = gmt_first_modifier (GMT, s, "alpsu")) && c[1] == 'a') s = c + 2;
+				if (c) {	/* Gave valid axes modifiers for custom labels */
 					pos = 0;
-					while (gmt_getmodopt (GMT, 'B', c, "lpsu", &pos, p, &error) && error == 0) {
+					while (gmt_getmodopt (GMT, 'B', c, "alpsu", &pos, p, &error) && error == 0) {
 						switch (p[0]) {
 							case 'l':	/* Regular y-axis label */
 								Ctrl->S[GMT_Y].label[GMT_PRIMARY] = strdup (&p[1]);	break;
@@ -740,6 +752,8 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 								Ctrl->S[GMT_Y].label[GMT_SECONDARY] = strdup (&p[1]);	break;
 							case 'u':	/* Annotation units */
 								Ctrl->S[GMT_Y].unit[GMT_PRIMARY] = strdup (&p[1]);	break;
+							case 'a':	/* Annotation angle/parallel/normal - passed through verbatim via subplot_prep_annot_args */
+								break;
 							default:	/* These are caught in gmt_getmodopt so break is just for Coverity */
 								break;
 						}


### PR DESCRIPTION
**Done with Claude Sonnet 5.**

The figure continues to be created correctly, and no warning messages appear in the terminal now.

Closes #8639 

Test with:

```
gmt begin panels png
  gmt subplot begin 1x1 -Fs5c -M5p -R0/80/0/80 -Bxaf+a30 -Byaf+ap
    gmt subplot set
    gmt basemap
  gmt subplot end
gmt end
```

<img width="30%" alt="panels" src="https://github.com/user-attachments/assets/6afb4a78-9bc4-4a7b-93d1-02345fea1036" />