### PR TITLE
Fix double filtering in psevents when using -q option

### DIFF
--- a/src/gmt_common.h
+++ b/src/gmt_common.h
@@ -251,7 +251,7 @@ struct GMT_COMMON {
 		char string[2][GMT_LEN64];
 		unsigned int col;	/* When +c<col> sets a specific data column */
 		unsigned int mode;	/* 1 for in row-range check, 2 for in time check, 3 for out-row check, 4 for out-time check */
-		uint64_t *rec;		/* POinter to the relevant record counter (dataset, table, segment) */
+		uint64_t *rec;		/* Pointer to the relevant record counter (dataset, table, segment) */
 	} q;
 	struct s {	/* -s[r] */
 		bool active;

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -913,8 +913,8 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 	bool do_coda, finite_duration, has_text, out_segment = false, have_previous_point = false;
 
 	/* Save state for -q option to prevent double filtering in internal calls. Fixes #8460. */
-	bool q_active_in_save, q_active_out_save;
-	unsigned int q_mode_save; 
+	bool q_active_in_save, q_active_out_save = false;
+	unsigned int q_mode_save = 0; 
 
 	int error;
 
@@ -1478,12 +1478,13 @@ Do_txt:			if (Ctrl->E.active[PSEVENTS_TEXT] && has_text) {	/* Also plot trailing
 			Return (GMT_RUNTIME_ERROR);
 		}
 	}
-	if (fp_symbols || fp_labels)	/* Recover settings provided by user (if -b -g -h -i were used at all) */
+	if (fp_symbols || fp_labels) {	/* Recover settings provided by user (if -b -g -h -i were used at all) */
 		gmt_reenable_bghio_opts (GMT);
 		/* Restore original -q state before re-enabling other I/O options (Fixes #8460). */
 		GMT->common.q.mode = q_mode_save;
 		GMT->common.q.active[GMT_IN] = q_active_in_save;
 		GMT->common.q.active[GMT_OUT] = q_active_out_save;
+	}
 
 	/* Finalize plot and we are done */
 

--- a/src/psevents.c
+++ b/src/psevents.c
@@ -912,6 +912,10 @@ EXTERN_MSC int GMT_psevents (void *V_API, int mode, void *args) {
 
 	bool do_coda, finite_duration, has_text, out_segment = false, have_previous_point = false;
 
+	/* Save state for -q option to prevent double filtering in internal calls. Fixes #8460. */
+	bool q_active_in_save, q_active_out_save;
+	unsigned int q_mode_save; 
+
 	int error;
 
 	enum gmt_col_enum time_type, end_type;
@@ -1390,6 +1394,14 @@ Do_txt:			if (Ctrl->E.active[PSEVENTS_TEXT] && has_text) {	/* Also plot trailing
 		if (fp_symbols) fclose (fp_symbols);	/* Close the file so symbol output is flushed */
 		if (fp_labels)  fclose (fp_labels);		/* Close the file so label output is flushed */
 		gmt_disable_bghio_opts (GMT);	/* Do not want any -b -g -h -i -o to affect the reading from temp files in psxy or pstext below */
+		/* Save current -q state and disable it temporarily. This prevents the internal psxy/pstext calls
+		 * from applying the -q filter a second time to the already filtered temporary files (Fixes #8460). */		
+		q_mode_save = GMT->common.q.mode;
+		q_active_in_save = GMT->common.q.active[GMT_IN];
+		q_active_out_save = GMT->common.q.active[GMT_OUT];
+		GMT->common.q.mode = 0;               /* Disable row/time range checks */
+		GMT->common.q.active[GMT_IN] = false; /* Disable input filtering */
+		GMT->common.q.active[GMT_OUT] = false;/* Disable output filtering */
 	}
 
 	if (gmt_map_setup (GMT, GMT->common.R.wesn)) {	/* Set up map projection */
@@ -1468,6 +1480,10 @@ Do_txt:			if (Ctrl->E.active[PSEVENTS_TEXT] && has_text) {	/* Also plot trailing
 	}
 	if (fp_symbols || fp_labels)	/* Recover settings provided by user (if -b -g -h -i were used at all) */
 		gmt_reenable_bghio_opts (GMT);
+		/* Restore original -q state before re-enabling other I/O options (Fixes #8460). */
+		GMT->common.q.mode = q_mode_save;
+		GMT->common.q.active[GMT_IN] = q_active_in_save;
+		GMT->common.q.active[GMT_OUT] = q_active_out_save;
 
 	/* Finalize plot and we are done */
 


### PR DESCRIPTION
**Assisted by Qwen 3.7 Plus**

### Bug:
psevents applies the -q filter, and writes the selected data to temporary files. Afterwards, it calls internal modules to plot the symbols/labels from these temporary files. Because the -q option remained active, the internal modules applied the exact same filter a second time on the already-filtered temporary files.

### Solution:
Implemented a local patch to temporarily suspend the -q option before calling the internal modules, and restore it immediately after.

### Alternative solution:
I also considered modifying the global `gmt_disable_bghio_opts()` and `gmt_reenable_bghio_opts()` functions in `gmt_io.c` to include `-q`. However, this will affect dozens of other modules, and I'm not sure if the -q option should also be disabled for them. But maybe it should. 

Test with:

I use -`qi0:30: `to plot a data point every 30. 

```
gmt math -T0/360/1 T SIND = sin_curve.txt
cat << 'EOF' > main.sh
gmt begin
	gmt basemap -R0/360/-1.2/1.6 -JX22c/11.5c -X1c -Y1c -Bxa30g30f -By
	gmt events sin_curve.txt -i0,1,0 -T${MOVIE_FRAME} -Sc0.2c -Gblack -qi0:30:
gmt end
EOF
gmt movie main.sh -Chd -Tsin_curve.txt -Ntest -Ml,png -Zs

```
<img width="1920" height="1080" alt="test" src="https://github.com/user-attachments/assets/0c00e696-2db9-485f-b0ea-b93c6db89d09" />


Closes #8460.