### PR TITLE
Fix subplot -F modifier bugs (+g, +w, +c, +f)

### DIFF
--- a/src/subplot.c
+++ b/src/subplot.c
@@ -504,10 +504,13 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 					char *q = NULL;
 					double f = 0.0;
 					if ((q = strstr (opt->arg, "+f")) != NULL) {	/* Gave optional fractions on how to partition width and height on a per row/col basis */
-						char *ytxt = strchr (&q[2], '/');	/* Find the slash */
+						char *ytxt = NULL, *nxt = strchr (&q[2], '+');	/* Find start of any subsequent modifier so we can bound the +f value */
+						if (nxt) nxt[0] = '\0';	/* Temporarily hide later modifiers so they cannot be swept into the fraction lists below */
+						ytxt = strchr (&q[2], '/');	/* Find the slash */
 						if (!ytxt) {
 							GMT_Report (API, GMT_MSG_ERROR, "Option -Ff...+f missing slash between width and height fractions.\n");
 							n_errors++;
+							if (nxt) nxt[0] = '+';	/* Restore before bailing */
 							break;
 						}
 						k = GMT_Get_Values (API, &ytxt[1], Ctrl->F.h, Ctrl->N.dim[GMT_Y]);
@@ -533,6 +536,7 @@ static int parse (struct GMT_CTRL *GMT, struct SUBPLOT_CTRL *Ctrl, struct GMT_OP
 						for (j = 0; j < Ctrl->N.dim[GMT_X]; j++) Ctrl->F.w[j] /= f;
 						for (j = 0, f = 0.0; j < Ctrl->N.dim[GMT_Y]; j++) f += Ctrl->F.h[j];
 						for (j = 0; j < Ctrl->N.dim[GMT_Y]; j++) Ctrl->F.h[j] /= f;
+						if (nxt) nxt[0] = '+';	/* Restore any later modifiers */
 						q[0] = '+';	/* Restore the fraction settings for now */
 					}
 					else {	/* Equal rows and cols */
@@ -1487,6 +1491,10 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 			if (GMT_Open_VirtualFile (API, GMT_IS_DATASET, GMT_IS_LINE, GMT_IN|GMT_IS_REFERENCE, L, vfile) != GMT_NOERROR) {
 				Return (API->error);
 			}
+			/* This call must never paint a canvas background - it only strokes the divider lines on top of
+			 * whatever was already drawn (e.g. the +g fill from the earlier plot call above). Make sure no
+			 * stale/leaked canvas-paint request survives from that earlier internal plot call. */
+			GMT->current.map.frame.paint[GMT_Z] = false;
 			sprintf (command, "-R0/%g/0/%g -Jx1i -W%s %s --GMT_HISTORY=readonly", Ctrl->F.dim[GMT_X] + GMT->current.setting.map_origin[GMT_X], Ctrl->F.dim[GMT_Y] + GMT->current.setting.map_origin[GMT_Y], Ctrl->F.Lpen, vfile);
 			GMT_Report (API, GMT_MSG_DEBUG, "Subplot command for plot: %s\n", command);
 			if (GMT_Call_Module (API, "plot", GMT_MODULE_CMD, command) != GMT_OK)	/* Plot the canvas with heading */

--- a/src/subplot.c
+++ b/src/subplot.c
@@ -1482,6 +1482,9 @@ EXTERN_MSC int GMT_subplot (void *V_API, int mode, void *args) {
 		if (fabs (Ctrl->F.clearance[GMT_X]) > 0.0 || fabs (Ctrl->F.clearance[GMT_Y]) > 0.0) {	/* Must reset origin */
 			width  -= 2.0 * Ctrl->F.clearance[GMT_X];
 			height -= 2.0 * Ctrl->F.clearance[GMT_Y];
+			/* Same reasoning as for the divider-line call below: this call only resets the origin (-T, no -B)
+			 * and must never repaint the canvas, so make sure no stale canvas-paint request survives here. */
+			GMT->current.map.frame.paint[GMT_Z] = false;
 			sprintf (command, "-R0/%g/0/%g -Jx1i -T -X%c%gi -Y%c%gi --GMT_HISTORY=readonly", width, height, 'r', Ctrl->F.clearance[GMT_X], 'r', Ctrl->F.clearance[GMT_Y]);
 			GMT_Report (API, GMT_MSG_DEBUG, "Subplot command for plot: %s\n", command);
 			if (GMT_Call_Module (API, "plot", GMT_MODULE_CMD, command) != GMT_OK)	/* Plot the canvas with heading */


### PR DESCRIPTION
**Fixed done with Claude Sonnet 5.**

Fixes several issues in gmt subplot begin -F where combining fill, pen, clearance, and layout-fraction modifiers produced incorrect warnings or an incomplete/incorrect canvas fill. 

Closes #8744.

Test with: 

```
#!/usr/bin/env bash

# -----------------------------------------------------------------------
# BUG 1 — "+g behaves strange with +w"

gmt begin bug1_w_and_g png
  gmt subplot begin 2x2 -Ff6c+w1p,-+gyellow -R0/10/0/10
    gmt basemap -c
  gmt subplot end
gmt end

# -----------------------------------------------------------------------
# BUG 2 — "+f must be at the end of -F"

gmt begin bug2_f_ordering png
  gmt subplot begin 2x2 -Ff6c+f3,1/1,2+w1p -R0/10/0/10
    gmt basemap -c
  gmt subplot end
gmt end

# -----------------------------------------------------------------------
# BUG 3 — "+g doesn't have the same effect with and without +c"

gmt begin bug3_g_with_clearance png
  gmt subplot begin 2x2 -Ff6c+gyellow+c1c+f3,1/1,2 -R0/10/0/10
    gmt basemap -c
  gmt subplot end
gmt end
```

## BUG 1 — "+g behaves strange with +w"

EXPECTED: solid yellow background behind all 4 panels, no visible dividing lines (pen color is "-").
BEFORE THE FIX: the internal `plot` call used to draw the dividing lines painted an opaque white rectangle over the whole canvas first, hiding the yellow fill completely.

<img width="50%" alt="bug1_w_and_g" src="https://github.com/user-attachments/assets/67f70ac1-be10-4515-b95f-e2f07b2bb7f8" />

## BUG 2 — "+f must be at the end of -F"
EXPECTED: no warning, correct 3:1 / 1:2 asymmetric layout, divider lines drawn with a 1pt pen.
BEFORE THE FIX: GMT printed "2+w1 not a valid number and may not be decoded properly" and the layout fractions came out wrong, because the +f value-parser did not know where its own argument ended and  swallowed the following +w1p into the height-fraction list.

<img width="50%" alt="bug2_f_ordering" src="https://github.com/user-attachments/assets/9ff64b6f-637f-4c30-ab6e-5c36c2ef2acd" />

## BUG 3 — "+g doesn't have the same effect with and without +c"

EXPECTED: yellow background fill visible everywhere, including the 1cm clearance gaps between/around panels.
BEFORE THE FIX: the internal `plot` call used to reset the origin after applying the clearance also painted an opaque white rectangle over the canvas first, hiding the yellow fill - same root cause as Bug 1, but triggered by +c instead of +w.

<img width="50%" alt="bug3_g_with_clearance" src="https://github.com/user-attachments/assets/9a708100-ba54-482a-8df2-a816b0773e15" />
