### PR TITLE
Preserve selected data server in movie frames

### DIFF
--- a/src/movie.c
+++ b/src/movie.c
@@ -1746,8 +1746,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_PREFLIGHT].fp)) {	/* Read the background script and copy to preflight script with some exceptions */
 				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert gmt figure after this line (or as first line) in case a background plot will be made */
-					fprintf (fp, "gmt begin\n");	/* To ensure there are no args here since we are using gmt figure instead */
 					if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+					fprintf (fp, "gmt begin\n");	/* To ensure there are no args here since we are using gmt figure instead */
 					gmt_set_comment (fp, Ctrl->In.mode, "\tSet fixed background output ps name");
 					fprintf (fp, "\tgmt figure movie_background ps\n");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
@@ -1923,8 +1923,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 			fprintf (fp, "%s %s\n", load[Ctrl->In.mode], init_file);	/* Include the initialization parameters */
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->S[MOVIE_POSTFLIGHT].fp)) {	/* Read the foreground script and copy to postflight script with some exceptions */
 				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert gmt figure after this line */
-					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 					if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 					gmt_set_comment (fp, Ctrl->In.mode, "\tSet fixed foreground output ps name");
 					fprintf (fp, "\tgmt figure movie_foreground ps\n");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
@@ -2084,8 +2084,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		else {	/* Read the title script */
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->E.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
 				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
-					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 					if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 					gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 					fprintf (fp, "\tgmt set PS_MEDIA %g%cx%g%c\n", Ctrl->C.dim[GMT_X], Ctrl->C.unit, Ctrl->C.dim[GMT_Y], Ctrl->C.unit);
 					fprintf (fp, "\tgmt set DIR_DATA \"%s\"\n", datadir);
@@ -2414,8 +2414,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 				}
 				while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->E.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
 					if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
-						fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 						if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+						fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 						gmt_set_comment (fp, Ctrl->In.mode, "\tSet output name and plot conversion parameters");
 						fprintf (fp, "\tgmt figure %s %s", Ctrl->N.prefix, Ctrl->M.format);
 						fprintf (fp, " %s", extra);
@@ -2440,8 +2440,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 		else {	/* Process main script */
 			while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->In.fp)) {	/* Read the mainscript and copy to loop script, with some exceptions */
 				if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
-					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 					if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+					fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 					gmt_set_comment (fp, Ctrl->In.mode, "\tSet output name and plot conversion parameters");
 					fprintf (fp, "\tgmt figure %s %s", Ctrl->N.prefix, Ctrl->M.format);
 					fprintf (fp, " %s", extra);
@@ -2604,8 +2604,8 @@ EXTERN_MSC int GMT_movie (void *V_API, int mode, void *args) {
 	fprintf (fp, "cd %s\n", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"));		/* cd to the temp directory */
 	while (gmt_fgets (GMT, line, PATH_MAX, Ctrl->In.fp)) {	/* Read the main script and copy to loop script, with some exceptions */
 		if (gmt_is_gmtmodule (line, "begin")) {	/* Need to insert a gmt figure call after this line */
-			fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 			if (has_conf && !strstr (line, "-C")) fprintf (fp, cpconf[Ctrl->In.mode], conf_file);
+			fprintf (fp, "gmt begin\n");	/* Ensure there are no args here since we are using gmt figure instead */
 			gmt_set_comment (fp, Ctrl->In.mode, "\tSet output PNG name and plot conversion parameters");
 			fprintf (fp, "\tgmt figure ../%s %s", gmt_place_var (Ctrl->In.mode, "MOVIE_NAME"), frame_products);
 			fprintf (fp, " E%s,%s", gmt_place_var (Ctrl->In.mode, "MOVIE_DPU"), extra);

--- a/test/movie/trajectory2.sh
+++ b/test/movie/trajectory2.sh
@@ -21,7 +21,7 @@ cat << 'EOF' > pre.sh
 gmt math -T0/14/24+n -o0 T = times.txt
 # Make background static plot with entire dashed line and knots in black
 gmt begin
-	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Ar${MOVIE_DPU} trajectory.txt --GMT_INTERPOLANT=linear > points.txt
+	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Ar${MOVIE_DPU}c trajectory.txt --GMT_INTERPOLANT=linear > points.txt
 	gmt plot trajectory.txt -W0.25p,- -B0 -X0 -Y0
 	gmt plot -Sc9p -Gblack trajectory.txt
 gmt end

--- a/test/movie/trajectory3.sh
+++ b/test/movie/trajectory3.sh
@@ -22,7 +22,7 @@ gmt math -T0/14/24+n -o0 T = times.txt
 # Make background static plot with entire dashed line and knots in black
 # and also discretize the line to points at required resolution
 gmt begin
-	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Ar${MOVIE_DPU} trajectory.txt --GMT_INTERPOLANT=linear > points.txt
+	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Ar${MOVIE_DPU}c trajectory.txt --GMT_INTERPOLANT=linear > points.txt
 	gmt makecpt -Chot -T-5/5 -H > heat.cpt
 	gmt plot trajectory.txt -W0.25p,- -B0 -X0 -Y0
 	gmt plot -Sc9p -Gblack trajectory.txt

--- a/test/movie/trajectory5.sh
+++ b/test/movie/trajectory5.sh
@@ -23,7 +23,7 @@ gmt math -T0/14/24+n -o0 T = times.txt
 # Make background static plot with entire dashed line and knots in black
 # and also discretize the line to points at required resolution
 gmt begin
-	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Ar${MOVIE_DPU}+z trajectory.txt --GMT_INTERPOLANT=linear > points.txt
+	gmt events -R0/9.6/-2.7/2.7 -Jx0.5i -Ar${MOVIE_DPU}c+z trajectory.txt --GMT_INTERPOLANT=linear > points.txt
 	gmt makecpt -Chot -T0/1 -H > heat.cpt
 	gmt plot trajectory.txt -W0.25p,- -B0 -X0 -Y0
 	gmt plot -Sc9p -Gblack trajectory.txt


### PR DESCRIPTION
**Done with Claude Sonnet 5**

Fix #8209.

When running gmt movie, the selected GMT_DATA_SERVER was not consistently preserved inside the frame sessions. As a result, gmt --show-dataserver could report a different server in the movie script than the one configured in the parent session.

This PR ensures that the active data server setting is propagated correctly to movie frame sessions.

**Fix**: swapped the order at all 6 locations where scripts are generated (preflight, postflight, intro title-frame loop x2, main script x2), so `cp -f gmt.conf .` now runs before `gmt begin`.
### Test

The issue can be reproduced with:

```
gmt set GMT_DATA_SERVER oceania
gmt --show-dataserver
cat << 'EOF' > main.sh
gmt begin
	gmt --show-dataserver
	gmt basemap -R-114/-103/35/40 -JM10c -Baf
gmt end
EOF
gmt movie main.sh -Chd -Nanim02 -T1 -Zs -Ml,png
```
Expected result: the same data server name should be printed twice (once in the terminal and once from inside the movie script). For example:
```
http://oceania.generic-mapping-tools.org
http://oceania.generic-mapping-tools.org
```
