### PR TITLE
WIP. Github actions: Fix Windows Install GMT step in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,9 @@ jobs:
           mkdir build
           cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+          set INSTALLDIR=%INSTALLDIR:\=/%
+          set COASTLINEDIR=%COASTLINEDIR:\=/%
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%INSTALLDIR%
           cmake --build .
         if: runner.os == 'Windows'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Check a few simple commands
-        run: bash ci/simple-gmt-tests.sh
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          export PATH="$INSTALLDIR/bin:$PATH"
+          bash ci/simple-gmt-tests.sh
 
       - name: Check a few simple commands (Windows)
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,12 +115,22 @@ jobs:
           cmake --build .
         if: runner.os == 'Windows'
 
-      - name: Install GMT
+      - name: Install GMT (Linux/macOS)
+        if: runner.os != 'Windows'
         run: |
           cd build
           cmake --build . --target install
           # Add GMT PATH to bin
           echo "${INSTALLDIR}/bin" >> $GITHUB_PATH
+
+      - name: Install GMT (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          cd build
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cmake --build . --target install
+          echo %INSTALLDIR%\bin >> %GITHUB_PATH%
 
       - name: Download cached GMT remote data from GitHub Artifacts
         run: gh run download -n gmt-cache -D ~/.gmt/static/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,12 +112,13 @@ jobs:
           mkdir build
           cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          setlocal enabledelayedexpansion
+          set "INSTALLDIR=%INSTALLDIR:\=/%"
           set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%WINVCPKGROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
           cmake --build . --target install
-          setlocal enabledelayedexpansion
-          set "WININSTALLDIR=%INSTALLDIR:/=\%"
+          set "WININSTALLDIR=!INSTALLDIR:/=\!"
           echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
           endlocal
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,17 +105,21 @@ jobs:
           cmake --build .
         if: runner.os != 'Windows'
 
-      - name: Compile GMT (Windows)
+      - name: Compile and Install GMT (Windows)
+        if: runner.os == 'Windows'
         shell: cmd
         run: |
           mkdir build
           cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          set INSTALLDIR=%INSTALLDIR:\=/%
-          set COASTLINEDIR=%COASTLINEDIR:\=/%
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%INSTALLDIR%
+          set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%WINVCPKGROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
-        if: runner.os == 'Windows'
+          cmake --build . --target install
+          setlocal enabledelayedexpansion
+          set "WININSTALLDIR=%INSTALLDIR:/=\%"
+          echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
+          endlocal
 
       - name: Install GMT (Linux/macOS)
         if: runner.os != 'Windows'
@@ -124,18 +128,6 @@ jobs:
           cmake --build . --target install
           # Add GMT PATH to bin
           echo "${INSTALLDIR}/bin" >> $GITHUB_PATH
-
-      - name: Install GMT (Windows)
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          cd build
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake --build . --target install
-          setlocal enabledelayedexpansion
-          set "WININSTALLDIR=%INSTALLDIR:/=\%"
-          echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
-          endlocal
 
       - name: Download cached GMT remote data from GitHub Artifacts
         run: gh run download -n gmt-cache -D ~/.gmt/static/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,8 @@ jobs:
           cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake --build . --target install
-          echo %INSTALLDIR%\bin >> %GITHUB_PATH%
+          set "WININSTALLDIR=%INSTALLDIR:/=\%"
+          echo %WININSTALLDIR%\bin >> %GITHUB_PATH%
 
       - name: Download cached GMT remote data from GitHub Artifacts
         run: gh run download -n gmt-cache -D ~/.gmt/static/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,8 +132,10 @@ jobs:
           cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake --build . --target install
+          setlocal enabledelayedexpansion
           set "WININSTALLDIR=%INSTALLDIR:/=\%"
-          echo %WININSTALLDIR%\bin >> %GITHUB_PATH%
+          echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
+          endlocal
 
       - name: Download cached GMT remote data from GitHub Artifacts
         run: gh run download -n gmt-cache -D ~/.gmt/static/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Check a few simple commands
-        if: runner.os == 'Windows'
         shell: bash
         run: |
           export PATH="$INSTALLDIR/bin:$PATH"


### PR DESCRIPTION
**Done by Claude Sonnet 5.**

This fixes  "Install GMT" step on Windows (https://github.com/GenericMappingTools/gmt/actions/runs/29061283206/job/86263495049).

**Cause**: It was failing on Windows because it used bash without the Visual Studio environment variables.

**Fix:** 
The step has been split into two:
- Linux/macOS: uses bash as before
- Windows: uses cmd with vcvars64.bat configured
