### PR TITLE
Change default GMT data server to remotedata.generic-mapping-tools.org

### DIFF
--- a/cmake/ConfigDefault.cmake
+++ b/cmake/ConfigDefault.cmake
@@ -140,7 +140,7 @@ endif (NOT DEFINED GMT_RELEASE_PREFIX)
 
 # Default location of remote data server
 if (NOT DEFINED GMT_DATA_SERVER)
-	set (GMT_DATA_SERVER "oceania")
+	set (GMT_DATA_SERVER "remotedata.generic-mapping-tools.org")
 endif (NOT DEFINED GMT_DATA_SERVER)
 
 # Default name of ghostscript executable

--- a/cmake/ConfigUserAdvancedTemplate.cmake
+++ b/cmake/ConfigUserAdvancedTemplate.cmake
@@ -208,7 +208,7 @@ set (GMT_ENABLE_OPENMP TRUE)
 #set (DO_SUPPLEMENT_TESTS ON)
 
 # Uncomment the following line if you need to override the default data server
-# for tests. When DO_TESTS is ON, the default "oceania" server is changed to
+# for tests. When DO_TESTS is ON, the default "remotedata.generic-mapping-tools.org" server is changed to
 # "static" automatically unless you set GMT_DATA_SERVER explicitly.
 # set (GMT_DATA_SERVER "static")
 

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -233,10 +233,10 @@ endif (DO_EXAMPLES OR DO_TESTS AND NOT SUPPORT_EXEC_IN_BINARY_DIR)
 
 # Tests should use the static data server by default unless the user explicitly set
 # GMT_DATA_SERVER to something else.
-if (DO_TESTS AND GMT_DATA_SERVER STREQUAL "oceania")
+if (DO_TESTS AND GMT_DATA_SERVER STREQUAL "remotedata.generic-mapping-tools.org")
 	message (STATUS "Setting GMT_DATA_SERVER to 'static' for tests")
 	set (GMT_DATA_SERVER "static")
-endif (DO_TESTS AND GMT_DATA_SERVER STREQUAL "oceania")
+endif (DO_TESTS AND GMT_DATA_SERVER STREQUAL "remotedata.generic-mapping-tools.org")
 
 # Some tests are known to fail, and can be excluded from the test by adding
 # the comment "# GMT_KNOWN_FAILURE".

--- a/doc/rst/source/devdocs/debug.rst
+++ b/doc/rst/source/devdocs/debug.rst
@@ -237,7 +237,7 @@ Getting started
       REPO_DIR="<path to the local GMT repository>"
       GMT_LIBRARY_PATH="${REPO_DIR}/vbuild/gmt6/lib"
       GMT_SHARE_PATH="${REPO_DIR}/vbuild/gmt6/share"
-      GMT_DATA_SERVER=https://oceania.generic-mapping-tools.org
+      GMT_DATA_SERVER=remotedata.generic-mapping-tools.org
 
 Building GMT
 ~~~~~~~~~~~~

--- a/doc/rst/source/gmt.conf.rst
+++ b/doc/rst/source/gmt.conf.rst
@@ -365,7 +365,7 @@ GMT Miscellaneous Parameters
         likewise for 6: obsolete syntax from early GMT 5 will be considered errors.
 
     **GMT_DATA_SERVER**
-        Name (or URL) of a GMT data server [default is **oceania**]. Please set
+        Name (or URL) of a GMT data server [default is **remotedata.generic-mapping-tools.org**]. Please set
         to the data server closest to your location for faster data download. See
         `Data Server Mirrors <https://www.generic-mapping-tools.org/mirrors/#data-server-mirrors>`_
         for a list of the currently available mirrors.

--- a/test/gmt_remote/dataserver_alias.sh
+++ b/test/gmt_remote/dataserver_alias.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Regression test for GMT_DATA_SERVER alias redirect resolution.
 #
-# Background: Alias server names (e.g., china, australia) expand to Hover DNS
-# URL-forwards that redirect to the real mirror but strip the file path.
+# Background: Alias server names (e.g., remotedata, china, australia) expand to
+# Hover DNS URL-forwards that redirect to the real mirror but strip the file path.
 # Before the fix, GMT constructed download URLs using the alias base (e.g.,
 # http://china.generic-mapping-tools.org/server/earth/earth_relief/file.grd),
 # which Hover would redirect to the mirror root — discarding the file path and
@@ -20,10 +20,10 @@
 # Remove any cached copy to force a real download from the server
 rm -f "${HOME}/.gmt/server/earth/earth_relief/earth_relief_01d_p.grd"
 
-# Force the canonical GMT data server hostname so the alias expansion and
-# redirect resolver code in gmt_dataserver_url() is always exercised,
-# regardless of the build-time GMT_DATA_SERVER default.
-export GMT_DATA_SERVER=remotedata.generic-mapping-tools.org
+# Use the short alias form to exercise alias expansion and the redirect resolver.
+# GMT expands "remotedata" to "remotedata.generic-mapping-tools.org", follows the
+# Hover redirect to discover the real mirror URL, then builds file paths against it.
+export GMT_DATA_SERVER=remotedata
 
 # Download (or use cached) global 1 arc-degree relief grid and get its range
 gmt grdinfo @earth_relief_01d_p.grd -I- > got.txt 2>err.txt

--- a/test/gmt_remote/dataserver_alias.sh
+++ b/test/gmt_remote/dataserver_alias.sh
@@ -17,6 +17,9 @@
 # also exercises the redirect resolver; a broken resolver would return an HTML
 # body that GMT cannot parse as a netCDF grid, causing the test to fail.
 
+# Remove any cached copy to force a real download from the server
+rm -f "${HOME}/.gmt/server/earth/earth_relief/earth_relief_15m_g.grd"
+
 # Force an alias server name so the alias expansion and redirect resolver code
 # in gmt_dataserver_url() is always exercised, regardless of the build-time
 # GMT_DATA_SERVER default.  oceania is a stable direct server (no DNS forward).

--- a/test/gmt_remote/dataserver_alias.sh
+++ b/test/gmt_remote/dataserver_alias.sh
@@ -18,15 +18,15 @@
 # body that GMT cannot parse as a netCDF grid, causing the test to fail.
 
 # Remove any cached copy to force a real download from the server
-rm -f "${HOME}/.gmt/server/earth/earth_relief/earth_relief_15m_g.grd"
+rm -f "${HOME}/.gmt/server/earth/earth_relief/earth_relief_01d_p.grd"
 
 # Force an alias server name so the alias expansion and redirect resolver code
 # in gmt_dataserver_url() is always exercised, regardless of the build-time
 # GMT_DATA_SERVER default.  oceania is a stable direct server (no DNS forward).
 export GMT_DATA_SERVER=oceania
 
-# Download (or use cached) global 15 arc-minute relief grid and get its range
-gmt grdinfo @earth_relief_15m_g.grd -I- > got.txt 2>err.txt
+# Download (or use cached) global 1 arc-degree relief grid and get its range
+gmt grdinfo @earth_relief_01d_p.grd -I- > got.txt 2>err.txt
 
 # A valid global grid must report exactly this region
 echo "-R-180/180/-90/90" > expected.txt

--- a/test/gmt_remote/dataserver_alias.sh
+++ b/test/gmt_remote/dataserver_alias.sh
@@ -17,16 +17,13 @@
 # also exercises the redirect resolver; a broken resolver would return an HTML
 # body that GMT cannot parse as a netCDF grid, causing the test to fail.
 
-# Remove any cached copy to force a real download from the server
-rm -f "${HOME}/.gmt/server/earth/earth_relief/earth_relief_01d_p.grd"
-
 # Force an alias server name so the alias expansion and redirect resolver code
 # in gmt_dataserver_url() is always exercised, regardless of the build-time
 # GMT_DATA_SERVER default.  oceania is a stable direct server (no DNS forward).
 export GMT_DATA_SERVER=oceania
 
-# Download (or use cached) global 1 arc-degree relief grid and get its range
-gmt grdinfo @earth_relief_01d_p.grd -I- > got.txt 2>err.txt
+# Download (or use cached) global 15 arc-minute relief grid and get its range
+gmt grdinfo @earth_relief_15m_g.grd -I- > got.txt 2>err.txt
 
 # A valid global grid must report exactly this region
 echo "-R-180/180/-90/90" > expected.txt

--- a/test/gmt_remote/dataserver_alias.sh
+++ b/test/gmt_remote/dataserver_alias.sh
@@ -20,10 +20,10 @@
 # Remove any cached copy to force a real download from the server
 rm -f "${HOME}/.gmt/server/earth/earth_relief/earth_relief_01d_p.grd"
 
-# Force an alias server name so the alias expansion and redirect resolver code
-# in gmt_dataserver_url() is always exercised, regardless of the build-time
-# GMT_DATA_SERVER default.  oceania is a stable direct server (no DNS forward).
-export GMT_DATA_SERVER=oceania
+# Force the canonical GMT data server hostname so the alias expansion and
+# redirect resolver code in gmt_dataserver_url() is always exercised,
+# regardless of the build-time GMT_DATA_SERVER default.
+export GMT_DATA_SERVER=remotedata.generic-mapping-tools.org
 
 # Download (or use cached) global 1 arc-degree relief grid and get its range
 gmt grdinfo @earth_relief_01d_p.grd -I- > got.txt 2>err.txt


### PR DESCRIPTION
Changes the compiled-in default GMT_DATA_SERVER from oceania to remotedata.generic-mapping-tools.org.

remotedata.generic-mapping-tools.org is a Hover DNS URL-forward that currently redirects to the oceania mirror. Because it is a managed DNS entry, the GMT team can redirect it to any mirror at any time without requiring a new GMT release. This gives us operational flexibility to migrate the data server function to earthscope resources or to address other future needs that may arise. 

This change depends on the redirect resolver introduced in #9068. At session start, GMT follows the redirect once to discover the real mirror base URL (http://oceania.generic-mapping-tools.org), then constructs all file download paths against that resolved URL.


cmake/ConfigDefault.cmake: set default GMT_DATA_SERVER to remotedata.generic-mapping-tools.org
cmake/modules/ConfigCMake.cmake: update CI auto-switch condition from oceania to remotedata.generic-mapping-tools.org so tests still use static
cmake/ConfigUserAdvancedTemplate.cmake, doc/rst/source/gmt.conf.rst, doc/rst/source/devdocs/debug.rst: update references to new default
test/gmt_remote/dataserver_alias.sh: update test to exercise the new default server hostname
Testing
Verified locally with a clean build (no ConfigUser.cmake, no gmt.conf, no GMT_DATA_SERVER environment variable). GMT resolves the redirect and successfully downloads earth_relief_01d_p.grd via the oceania mirror.