### PR TITLE
Fix issues with Aki-Richards convention

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -7515,7 +7515,10 @@ bool gmt_getpen (struct GMT_CTRL *GMT, char *buffer, struct GMT_PEN *P) {
 
 	/* Processes pen specifications given as [width[,<color>[,<style>[t<unit>]]][@<transparency>] */
 
-	if (gmt_M_is_dnan (P->width)) {	/* Worry in case no width is given */
+	if (gmt_M_is_dnan (P->width) || P->width < 0.0) {	/* Worry in case no width is given.  Some callers (e.g., psmeca)
+		                                                   use a negative width as a sentinel for "not yet set"; treat
+		                                                   that the same as NaN so a color- or style-only pen string
+		                                                   (e.g., "red") is not mistaken for an explicit (bogus) width. */
 		strcpy (def_width, "0");	/* To avoid any parsing errors */
 		set_NaN = true;	/* Flag this specific case */
 	}

--- a/src/seis/meca.h
+++ b/src/seis/meca.h
@@ -62,6 +62,7 @@ enum Seis_scaletype {
 struct SEIS_OFFSET_LINE { 
 	bool active;
 	bool convert_geo;	/* True if coupe -D+c, i.e., given geographical coordinates as alternate location */
+	bool pen_set;		/* True if +p<pen> was given (even if <pen> only had a color and/or style) */
 	unsigned int mode;	/* 0-3 as above */
 	unsigned int symbol;	/* Default to PSL_CIRCLE */
 	unsigned int fill_mode;	/* Default to SEIS_EVENT_FILL */

--- a/src/seis/pscoupe.c
+++ b/src/seis/pscoupe.c
@@ -1438,8 +1438,12 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 					meca.NP1.dip    = in[4];
 					meca.NP1.rake   = in[5];
 					meca.magms      = in[6];
-					moment.mant     = meca.magms;
-					moment.exponent = 0;
+					if (Ctrl->S.linear)	/* Aki & Richards only gives us the magnitude; derive M0 for +l [#6840] */
+						moment = meca_computed_moment (meca.magms);
+					else {
+						moment.mant     = meca.magms;
+						moment.exponent = 0;
+					}
 					meca_define_second_plane (meca.NP1, &meca.NP2);
 					pscoupe_rot_meca (meca, Ctrl->A.PREF, &mecar);
 				}
@@ -1449,8 +1453,12 @@ EXTERN_MSC int GMT_pscoupe (void *V_API, int mode, void *args) {
 					meca.NP2.str = in[5];
 					fault        = in[6];
 					meca.magms   = in[7];
-					moment.exponent = 0;
-					moment.mant = meca.magms;
+					if (Ctrl->S.linear)	/* Principal planes format only gives us the magnitude; derive M0 for +l [#6840] */
+						moment = meca_computed_moment (meca.magms);
+					else {
+						moment.exponent = 0;
+						moment.mant = meca.magms;
+					}
 					meca.NP2.dip = meca_computed_dip2 (meca.NP1.str, meca.NP1.dip, meca.NP2.str);
 					if (meca.NP2.dip == 1000.0) {
 						not_defined = true;

--- a/src/seis/psmeca.c
+++ b/src/seis/psmeca.c
@@ -78,6 +78,7 @@ struct PSMECA_CTRL {
 	} I;
 	struct PSMECA_L {	/* -L<pen> */
 		bool active;
+		bool pen_set;	/* True if a pen (even just color/style) was given */
 		struct GMT_PEN pen;
 	} L;
 	struct PSMECA_N {	/* -N */
@@ -88,6 +89,7 @@ struct PSMECA_CTRL {
 	} S;
 	struct PSMECA_T {	/* -T[<plane>][+p<pen>] */
 		bool active;
+		bool pen_set;	/* True if a pen (even just color/style) was given */
 		unsigned int n_plane;
 		struct GMT_PEN pen;
 	} T;
@@ -110,6 +112,7 @@ struct PSMECA_CTRL {
 	} G2;
 	struct PSMECA_P2 {	/* -Fp[<pen>] */
 		bool active;
+		bool pen_set;	/* True if a pen (even just color/style) was given */
 		struct GMT_PEN pen;
 	} P2;
 	struct PSMECA_R2 {	/* -Fr[<fill>] */
@@ -118,6 +121,7 @@ struct PSMECA_CTRL {
 	} R2;
 	struct PSMECA_T2 {	/* -Ft[<pen>] */
 		bool active;
+		bool pen_set;	/* True if a pen (even just color/style) was given */
 		struct GMT_PEN pen;
 	} T2;
 	struct PSMECA_O2 {	/* -Fo */
@@ -125,6 +129,7 @@ struct PSMECA_CTRL {
 	} O2;
 	struct PSMECA_Z2 {	/* -Fz[<pen>] */
 		bool active;
+		bool pen_set;	/* True if a pen (even just color/style) was given */
 		struct GMT_PEN pen;
 	} Z2;
 };
@@ -352,9 +357,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 						break;
 					case 'p':	/* Draw outline of P axis symbol [set outline attributes] */
 						n_errors += gmt_M_repeated_module_option (API, Ctrl->P2.active);
-						if (opt->arg[1] && gmt_getpen (GMT, &opt->arg[1], &Ctrl->P2.pen)) {
-							gmt_pen_syntax (GMT, ' ', "Fp", " ", NULL, 0);
-							n_errors++;
+						if (opt->arg[1]) {
+							Ctrl->P2.pen_set = true;
+							if (gmt_getpen (GMT, &opt->arg[1], &Ctrl->P2.pen)) {
+								gmt_pen_syntax (GMT, ' ', "Fp", " ", NULL, 0);
+								n_errors++;
+							}
 						}
 						break;
 					case 'r':	/* draw box around text */
@@ -366,9 +374,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 						break;
 					case 't':	/* Draw outline of T axis symbol [set outline attributes] */
 						n_errors += gmt_M_repeated_module_option (API, Ctrl->T2.active);
-						if (opt->arg[1] && gmt_getpen (GMT, &opt->arg[1], &Ctrl->T2.pen)) {
-							gmt_pen_syntax (GMT, ' ', "Ft", " ", NULL, 0);
-							n_errors++;
+						if (opt->arg[1]) {
+							Ctrl->T2.pen_set = true;
+							if (gmt_getpen (GMT, &opt->arg[1], &Ctrl->T2.pen)) {
+								gmt_pen_syntax (GMT, ' ', "Ft", " ", NULL, 0);
+								n_errors++;
+							}
 						}
 						break;
 					case 'o':	/* use psvelomeca format (without depth in 3rd column) */
@@ -376,9 +387,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 						break;
 					case 'z':	/* overlay zerotrace moment tensor */
 						n_errors += gmt_M_repeated_module_option (API, Ctrl->Z2.active);
-						if (opt->arg[1] && gmt_getpen (GMT, &opt->arg[1], &Ctrl->Z2.pen)) { /* Set pen attributes */
-							gmt_pen_syntax (GMT, ' ', "Fz", " ", NULL, 0);
-							n_errors++;
+						if (opt->arg[1]) {
+							Ctrl->Z2.pen_set = true;
+							if (gmt_getpen (GMT, &opt->arg[1], &Ctrl->Z2.pen)) { /* Set pen attributes */
+								gmt_pen_syntax (GMT, ' ', "Fz", " ", NULL, 0);
+								n_errors++;
+							}
 						}
 						break;
 				}
@@ -406,9 +420,12 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 				break;
 			case 'L':	/* Draw outline [set outline attributes] */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->L.active);
-				if (opt->arg[0] && gmt_getpen (GMT, opt->arg, &Ctrl->L.pen)) {
-					gmt_pen_syntax (GMT, 'L', NULL, " ", NULL, 0);
-					n_errors++;
+				if (opt->arg[0]) {
+					Ctrl->L.pen_set = true;
+					if (gmt_getpen (GMT, opt->arg, &Ctrl->L.pen)) {
+						gmt_pen_syntax (GMT, 'L', NULL, " ", NULL, 0);
+						n_errors++;
+					}
 				}
 				break;
 			case 'M':	/* Same size for any magnitude [Deprecated 8/14/2021 6.3.0 - use -S+m instead] */
@@ -519,13 +536,19 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 			case 'T':
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
 				if (opt->arg[0] == '\0') continue;	/* Default plane and pen implied; move on */
-				if ((p = strstr (opt->arg, "+p")) && gmt_getpen (GMT, &p[2], &Ctrl->T.pen)) {	/* Modern modifier for pen but failed parsing the pen */
-					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
-					n_errors++;
+				if ((p = strstr (opt->arg, "+p"))) {	/* Modern modifier for pen */
+					Ctrl->T.pen_set = true;
+					if (gmt_getpen (GMT, &p[2], &Ctrl->T.pen)) {	/* Failed parsing the pen */
+						gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
+						n_errors++;
+					}
 				}
-				else if ((p = strchr (opt->arg, '/')) && gmt_getpen (GMT, &p[1], &Ctrl->T.pen)) {
-					gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
-					n_errors++;
+				else if ((p = strchr (opt->arg, '/'))) {
+					Ctrl->T.pen_set = true;
+					if (gmt_getpen (GMT, &p[1], &Ctrl->T.pen)) {
+						gmt_pen_syntax (GMT, 'T', NULL, " ", NULL, 0);
+						n_errors++;
+					}
 				}
 				if (strchr ("012", opt->arg[0])) Ctrl->T.n_plane = opt->arg[0] - '0';
 				break;
@@ -561,14 +584,27 @@ static int parse (struct GMT_CTRL *GMT, struct PSMECA_CTRL *Ctrl, struct GMT_OPT
 	//n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && Ctrl->S.scale <= 0.0, "Option -S: must specify scale\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && Ctrl->O2.active, "Option -Z cannot be combined with -Fo\n");
 
-	/* Set to default pen where needed */
+	/* Set to default pen where needed.  If the option was never given a pen at all
+	 * (e.g., plain -T with no plane/pen, or -L with no argument) we fully inherit
+	 * -W's pen.  But if a pen was given, even if it only set the color and/or style
+	 * (e.g., -T0/red or -A+pred), we must not discard that; we only need to supply
+	 * a width, since none was given [see #6840]. */
+#define SEIS_PEN_UNSET(pen) (gmt_M_is_dnan ((pen).width) || (pen).width < 0.0)
 
-	if (Ctrl->A.pen.width  < 0.0) Ctrl->A.pen  = Ctrl->W.pen;
-	if (Ctrl->L.pen.width  < 0.0) Ctrl->L.pen  = Ctrl->W.pen;
-	if (Ctrl->T.pen.width  < 0.0) Ctrl->T.pen  = Ctrl->W.pen;
-	if (Ctrl->T2.pen.width < 0.0) Ctrl->T2.pen = Ctrl->W.pen;
-	if (Ctrl->P2.pen.width < 0.0) Ctrl->P2.pen = Ctrl->W.pen;
-	if (Ctrl->Z2.pen.width < 0.0) Ctrl->Z2.pen = Ctrl->W.pen;
+	if (Ctrl->A.pen_set)  { if (SEIS_PEN_UNSET (Ctrl->A.pen))  Ctrl->A.pen.width  = Ctrl->W.pen.width; }
+	else if (SEIS_PEN_UNSET (Ctrl->A.pen))  Ctrl->A.pen  = Ctrl->W.pen;
+	if (Ctrl->L.pen_set)  { if (SEIS_PEN_UNSET (Ctrl->L.pen))  Ctrl->L.pen.width  = Ctrl->W.pen.width; }
+	else if (SEIS_PEN_UNSET (Ctrl->L.pen))  Ctrl->L.pen  = Ctrl->W.pen;
+	if (Ctrl->T.pen_set)  { if (SEIS_PEN_UNSET (Ctrl->T.pen))  Ctrl->T.pen.width  = Ctrl->W.pen.width; }
+	else if (SEIS_PEN_UNSET (Ctrl->T.pen))  Ctrl->T.pen  = Ctrl->W.pen;
+	if (Ctrl->T2.pen_set) { if (SEIS_PEN_UNSET (Ctrl->T2.pen)) Ctrl->T2.pen.width = Ctrl->W.pen.width; }
+	else if (SEIS_PEN_UNSET (Ctrl->T2.pen)) Ctrl->T2.pen = Ctrl->W.pen;
+	if (Ctrl->P2.pen_set) { if (SEIS_PEN_UNSET (Ctrl->P2.pen)) Ctrl->P2.pen.width = Ctrl->W.pen.width; }
+	else if (SEIS_PEN_UNSET (Ctrl->P2.pen)) Ctrl->P2.pen = Ctrl->W.pen;
+	if (Ctrl->Z2.pen_set) { if (SEIS_PEN_UNSET (Ctrl->Z2.pen)) Ctrl->Z2.pen.width = Ctrl->W.pen.width; }
+	else if (SEIS_PEN_UNSET (Ctrl->Z2.pen)) Ctrl->Z2.pen = Ctrl->W.pen;
+
+#undef SEIS_PEN_UNSET
 
 	/* Default -Fe<fill> and -Fg<fill> to -E<fill> and -G<fill> */
 
@@ -858,6 +894,8 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 					if (gmt_M_is_zero (meca.NP1.rake)) meca.NP1.rake = 0.00001;	/* Fixing the issue http://gmt.soest.hawaii.edu/issues/894 */
 					meca.magms = in[5+new_fmt];
 					meca.moment.exponent = 0;
+					if (Ctrl->S.linear)	/* Aki & Richards only gives us the magnitude; derive M0 for +l [#6840] */
+						meca.moment = meca_computed_moment (meca.magms);
 					meca_define_second_plane (meca.NP1, &meca.NP2);
 				}
 				else if (Ctrl->S.readmode == SEIS_READ_PLANES) {
@@ -871,6 +909,8 @@ EXTERN_MSC int GMT_psmeca (void *V_API, int mode, void *args) {
 					fault = in[5+new_fmt];
 					meca.magms = in[6+new_fmt];
 					meca.moment.exponent = 0;
+					if (Ctrl->S.linear)	/* Principal planes format only gives us the magnitude; derive M0 for +l [#6840] */
+						meca.moment = meca_computed_moment (meca.magms);
 					meca.NP2.dip = meca_computed_dip2(meca.NP1.str, meca.NP1.dip, meca.NP2.str);
 					if (meca.NP2.dip == 1000.0) {
 						not_defined = true;

--- a/src/seis/utilmeca.c
+++ b/src/seis/utilmeca.c
@@ -418,6 +418,24 @@ double meca_computed_mw (struct SEIS_MOMENT moment, double ms) {
 	return (mw);
 }
 
+/**********************************************************************/
+struct SEIS_MOMENT meca_computed_moment (double mw) {
+	/* Compute the scalar seismic moment M0 (as mantissa * 10^exponent, with the
+	 * mantissa normalized to [1,10)) from a given Mw magnitude.  This is simply
+	 * the inverse of meca_computed_mw and is needed for formats such as Aki &
+	 * Richards (-Sa) or principal planes (-Sp) that only carry a magnitude, yet
+	 * still wish to support the -S...+l modifier that scales symbol size by the
+	 * seismic moment instead of the magnitude [see issue #6840]. */
+
+	struct SEIS_MOMENT moment;
+	double log10_M0 = 1.5 * mw + 16.1;	/* Kanamori (1977): Mw = (2/3)(log10(M0) - 16.1) */
+
+	moment.exponent = (int)floor (log10_M0);
+	moment.mant = pow (10.0, log10_M0 - moment.exponent);
+
+	return (moment);
+}
+
 /*********************************************************************/
 static double utilmeca_computed_strike1 (struct SEIS_NODAL_PLANE NP1) {
 	/*
@@ -1059,6 +1077,7 @@ unsigned int meca_line_parse (struct GMT_CTRL *GMT, struct SEIS_OFFSET_LINE *L, 
 						L->mode |= SEIS_CART_OFFSET_FIX;
 					break;
 				case 'p':	/* Line and symbol pen */
+					L->pen_set = true;
 					if (p[1] == '\0' || gmt_getpen (GMT, &p[1], &L->pen)) {
 						gmt_pen_syntax (GMT, option, NULL, " ", NULL, 0);
 						n_errors++;

--- a/src/seis/utilmeca.h
+++ b/src/seis/utilmeca.h
@@ -29,6 +29,7 @@ void meca_get_trans (struct GMT_CTRL *GMT, double slon, double slat, double *t11
 double meca_ps_mechanism (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double x0, double y0, st_me meca, double size, struct GMT_FILL *F, struct GMT_FILL *E, int outline);
 double meca_ps_plan (struct GMT_CTRL *GMT, struct PSL_CTRL *PSL, double x0, double y0, st_me meca, double size, int num_of_plane);
 double meca_computed_mw(struct SEIS_MOMENT moment, double ms);
+struct SEIS_MOMENT meca_computed_moment(double mw);
 double meca_computed_dip2(double str1, double dip1, double str2);
 double meca_computed_rake2(double str1, double dip1, double str2, double dip2, double fault);
 void meca_define_second_plane(struct SEIS_NODAL_PLANE NP, struct SEIS_NODAL_PLANE *NP2);


### PR DESCRIPTION
**Done with Claude 5.0**

This PR fixes the issues reported in #6840 for the Aki-Richards convention.

I use the following input data:

```text
112 32 25  30  90   0  4.5  112 33 Strike-slip
115 34 15  30  60  90  5    115 32 Reverse
118 32 45  30  60 -90  5.4  118 34 Normal
```

The fix was tested using the following scripts:

## Issue: -S+l may not work as expected
> The script doesn't plot any beachballs with `+l`.

```
gmt begin 6840 png
    gmt basemap -R110/120/30/35 -JM10c -Baf -B+t"Don't plot any beachball"
    gmt meca meca.dat -Sa1c+l -T0
gmt end
```
Output with this fix:
<img width="40%" alt="6840" src="https://github.com/user-attachments/assets/0855fdf0-7a45-408f-a53d-763cac4b3750" />


## Issue: Sometimes the nodal plane lines are not drawn correctly:

```
gmt begin beachball5_T0 png
    gmt basemap -R110/120/30/35 -JM10c -Baf -B+t"Nodal planes lines not drawn (T0)"
    gmt meca meca.dat -Sa1c -T0
gmt end
```
Output with this fix:
 
<img width="40%" height="911" alt="beachball5_T0" src="https://github.com/user-attachments/assets/980a42fb-b6ba-42ad-87a5-b60820cd864b" />

## Issue: -T0/red doesn't work

```
gmt begin beachball5_T0red png
    gmt basemap -R110/120/30/35 -JM10c -Baf -B+t"-T0/red doesn't work but"
    gmt meca meca.dat -Sa1c -T0/red
gmt end
```
Output with this fix:
<img width="40%" height="911" alt="beachball5_T0red" src="https://github.com/user-attachments/assets/b328065f-47b6-49c4-bc75-bbd01e6c0576" />

## Issue: -Lblue doesn't work

```
gmt begin beachball5_Lblue png
    gmt basemap -R110/120/30/35 -JM10c -Baf -B+t"-Lblue doesn't work"
    gmt meca meca.dat -Sa1c -Lblue
gmt end
```
Output with this fix:

<img width="40%" height="911" alt="beachball5_Lblue" src="https://github.com/user-attachments/assets/bd436dca-5950-424b-a10e-b467c9442b5c" />

## Issue: -A+pred also doesn't work,

Output with this fix:

```
gmt begin beachball5_A+p png
    gmt basemap -R110/120/30/35 -JM10c -Baf -B+t"-A+pred also doesn't work"
    gmt meca meca.dat -Sa1c -A+pred
gmt end
```
Output with this fix:

<img width="40%" height="911" alt="beachball5_A+p" src="https://github.com/user-attachments/assets/59bcb8d8-6717-46a7-8f5f-1597e513b9c7" />

Fix #6840