### PR TITLE
grdview: Fix the bug when -N is set but level is not specified

### DIFF
--- a/src/grdview.c
+++ b/src/grdview.c
@@ -991,8 +991,8 @@ EXTERN_MSC int GMT_grdview(void *V_API, int mode, void *args) {
 	if (GMT->common.R.wesn[ZLO] == 0.0 && GMT->common.R.wesn[ZHI] == 0.0) {
 		GMT->common.R.wesn[ZLO] = Topo->header->z_min;
 		GMT->common.R.wesn[ZHI] = Topo->header->z_max;
-		if (Ctrl->N.active && Ctrl->N.level < GMT->common.R.wesn[ZLO]) GMT->common.R.wesn[ZLO] = Ctrl->N.level;
-		if (Ctrl->N.active && Ctrl->N.level > GMT->common.R.wesn[ZHI]) GMT->common.R.wesn[ZHI] = Ctrl->N.level;
+		if (Ctrl->N.active && !Ctrl->N.implicit && Ctrl->N.level < GMT->common.R.wesn[ZLO]) GMT->common.R.wesn[ZLO] = Ctrl->N.level;
+		if (Ctrl->N.active && !Ctrl->N.implicit && Ctrl->N.level > GMT->common.R.wesn[ZHI]) GMT->common.R.wesn[ZHI] = Ctrl->N.level;
 	}
 
 	if (gmt_map_setup (GMT, GMT->common.R.wesn)) Return (GMT_PROJECTION_ERROR);


### PR DESCRIPTION
According to the documentation (https://docs.generic-mapping-tools.org/dev/grdview#n), when `-N` is set but `-R` isn't, the default level should be the minimum value in the grid.

> -N[level][+gfill]
> Draws a plane at this z-level. If the optional color is provided via the +g modifier, and the projection is not oblique, the frontal facade between the plane and the data perimeter is colored. See -Wf for setting the pen used for the outline. If no level is set then we default to the minimum value in the reliefgrid. However, if [-R](https://docs.generic-mapping-tools.org/dev/grdview#r) was used to set zmin/zmax then we use that value if it is less than the grid minimum value.

However, the default level is set to 0 due to a bug. This can be verified by the following test:
```
gmt begin map
    gmt grdview @static_earth_relief.nc -Jz0.005 -Wf0.5p,blue,dashed -p225/30 -Baf -Bzaf -N
    gmt grdview @static_earth_relief.nc -Jz0.005 -Wf0.5p,blue,dashed -p225/30 -Baf -Bzaf -N -R-55/-47/-24/-10/0/1000 -Xw+1c
    gmt grdview @static_earth_relief.nc -Jz0.005 -Wf0.5p,blue,dashed -p225/30 -Baf -Bzaf -N190 -Xw+1c
gmt end show
```
| Actual output | Expected output |
|---|---|
|<img width="6243" height="1273" alt="map" src="https://github.com/user-attachments/assets/8fea238f-3cfb-4703-b622-f92b6853c5c7" />|<img width="6243" height="1273" alt="map" src="https://github.com/user-attachments/assets/a031dce8-ad7b-4e30-92ca-0008eb99c322" />|

When `-R` is not specified, GMT first determines the z-range based on the grid min/max values, then checks if `Ctrl->N.level` is set and updates zmin to `Ctrl->N.level` if zmin<level, as shown below:
https://github.com/GenericMappingTools/gmt/blob/d52a1e5825b73c3ad6948efce1ac8eeff01c2c93/src/grdview.c#L990-L996

However, when `-N` is set without any level, `Ctrl->N.implicit` is `true` and `Ctrl->N.level` is not set until https://github.com/GenericMappingTools/gmt/blob/d52a1e5825b73c3ad6948efce1ac8eeff01c2c93/src/grdview.c#L1320
so, `Ctrl->N.level` still has the initial value (0.0), and then zmin is updated to `0.0` in this case.

This PR fixes the issue.