### PR TITLE
Fix font color transparency (`red@50` in `-F+f`) being silently ignored

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7023,13 +7023,7 @@ unsigned int gmt_setfont (struct GMT_CTRL *GMT, struct GMT_FONT *F) {
 		outline = 2;	/* Indicates outline font is needed for filling but will not be stroked */
 	}
 	else {	/* Regular, solid text fill is set via stroke color */
-		if (F->fill.rgb[3] > 0.0) {
-			/* Honor transparency embedded in the font color (e.g. red@50), which
-			 * PSL_setcolor does not apply on its own (unlike PSL_setfill/PSL_setline). */
-			PSL_command (GMT->PSL, "%.12g %.12g /%s PSL_transp\n",
-			             1.0 - F->fill.rgb[3], 1.0 - F->fill.rgb[3], GMT->current.setting.ps_transpmode);
-		}
-		PSL_setcolor (GMT->PSL, F->fill.rgb, PSL_IS_FONT);
+	PSL_setcolor (GMT->PSL, F->fill.rgb, PSL_IS_FONT);
 		outline = 0;	/* Indicates we will fill text using "show" which takes current color (i.e., stroke color) */
 	}
 	return (outline);

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7023,6 +7023,12 @@ unsigned int gmt_setfont (struct GMT_CTRL *GMT, struct GMT_FONT *F) {
 		outline = 2;	/* Indicates outline font is needed for filling but will not be stroked */
 	}
 	else {	/* Regular, solid text fill is set via stroke color */
+		if (F->fill.rgb[3] > 0.0) {
+			/* Honor transparency embedded in the font color (e.g. red@50), which
+			 * PSL_setcolor does not apply on its own (unlike PSL_setfill/PSL_setline). */
+			PSL_command (GMT->PSL, "%.12g %.12g /%s PSL_transp\n",
+			             1.0 - F->fill.rgb[3], 1.0 - F->fill.rgb[3], GMT->current.setting.ps_transpmode);
+		}
 		PSL_setcolor (GMT->PSL, F->fill.rgb, PSL_IS_FONT);
 		outline = 0;	/* Indicates we will fill text using "show" which takes current color (i.e., stroke color) */
 	}

--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -7023,7 +7023,7 @@ unsigned int gmt_setfont (struct GMT_CTRL *GMT, struct GMT_FONT *F) {
 		outline = 2;	/* Indicates outline font is needed for filling but will not be stroked */
 	}
 	else {	/* Regular, solid text fill is set via stroke color */
-	PSL_setcolor (GMT->PSL, F->fill.rgb, PSL_IS_FONT);
+		PSL_setcolor (GMT->PSL, F->fill.rgb, PSL_IS_FONT);
 		outline = 0;	/* Indicates we will fill text using "show" which takes current color (i.e., stroke color) */
 	}
 	return (outline);

--- a/src/postscriptlight.c
+++ b/src/postscriptlight.c
@@ -5216,10 +5216,12 @@ int PSL_setcolor (struct PSL_CTRL *PSL, double rgb[], int mode) {
 	 * rgb[0] = -1: ignore. Do not change pen color. Leave untouched.
 	 * rgb[0] >= 0: rgb is the color with R G B in 0-1 range.
 	 */
+	int is_font = 0;
 	if (!rgb) return (PSL_NO_ERROR);	/* NULL args to be ignored */
 	if (mode == PSL_IS_FONT) {	/* Internally update font color but set stroke color */
 		PSL_rgb_copy (PSL->current.rgb[mode], rgb);
 		mode = PSL_IS_STROKE;
+		is_font = 1;	/* Remember this color paints text, which is filled, not stroked */
 	}
 	if (PSL_eq (rgb[0], -2.0) || PSL_eq (rgb[0], -1.0)) return (PSL_NO_ERROR);	/* Settings to be ignored */
 	if (PSL_same_rgb (rgb, PSL->current.rgb[mode])) return (PSL_NO_ERROR);	/* Same color as already set */
@@ -5227,9 +5229,18 @@ int PSL_setcolor (struct PSL_CTRL *PSL, double rgb[], int mode) {
 	/* Guard: When setting stroke or fill with transparency, preserve the other channel's transparency */
 	if (!PSL_eq (rgb[3], 0.0) && (mode == PSL_IS_STROKE || mode == PSL_IS_FILL)) {
 		double transp[2], rgb_copy[4];
-		/* Preserve current transparencies and update only the relevant channel */
-		transp[PSL_FILL_TRANSP] = (mode == PSL_IS_FILL) ? rgb[3] : PSL->current.rgb[PSL_IS_FILL][3];
-		transp[PSL_PEN_TRANSP]  = (mode == PSL_IS_STROKE) ? rgb[3] : PSL->current.rgb[PSL_IS_STROKE][3];
+		/* Preserve current transparencies and update only the relevant channel.
+		 * Text glyphs are painted as filled shapes even though their color is
+		 * tracked in the stroke slot, so font transparency must land on the
+		 * FILL channel, not the PEN channel, or it has no visible effect. */
+		if (is_font) {
+			transp[PSL_FILL_TRANSP] = rgb[3];
+			transp[PSL_PEN_TRANSP]  = PSL->current.rgb[PSL_IS_STROKE][3];
+		}
+		else {
+			transp[PSL_FILL_TRANSP] = (mode == PSL_IS_FILL) ? rgb[3] : PSL->current.rgb[PSL_IS_FILL][3];
+			transp[PSL_PEN_TRANSP]  = (mode == PSL_IS_STROKE) ? rgb[3] : PSL->current.rgb[PSL_IS_STROKE][3];
+		}
 		/* Set transparency explicitly for both channels */
 		PSL_command (PSL, "%.12g %.12g /%s PSL_transp\n", 1.0 - transp[PSL_FILL_TRANSP], 1.0 - transp[PSL_PEN_TRANSP], PSL->current.transparency_mode);
 		/* Make a copy with transparency zeroed out for psl_putcolor to avoid double-setting */


### PR DESCRIPTION
**Done with Claude Sonnet 5**
**Cause:** in `PSL_setcolor()`, font colors are internally treated as `PSL_IS_STROKE`, so embedded `@<transparency>` was applied to `PEN_TRANSP` instead of `FILL_TRANSP` — but text is painted as a filled shape, so it had no visible effect.
**Fix:** track that the color came from `PSL_IS_FONT` and route its transparency to `FILL_TRANSP`.

<img width="80%" height="597" alt="map" src="https://github.com/user-attachments/assets/ad8778c9-c55a-4ab6-b350-a8be931fecff" />

Without this fix, the "GMT" in the center has no transparency.

**Full script:**
```shellscript
gmt begin map png
    gmt coast -Rg -JH10c -Baf -Glightgreen -Slightblue
    echo GMT | gmt text -F+cMC+f40p,red@50      # Now works
    echo GMT | gmt text -F+cML+f40p,red -t50    # Works
    echo 180 40 | gmt plot -Sc1c -Gblack@50     # Works
gmt end
```

Fixes #9125