### PR TITLE
Fix division by zero (NaN) in gmt_extend_region when +r/+e increment is 0

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -18677,10 +18677,12 @@ void gmt_extend_region (struct GMT_CTRL *GMT, double wesn[], unsigned int mode, 
 	}
 	else {	/* Make region be in multiples of increments, possibly with adjustment */
 		double adjust = (mode == GMT_REGION_ROUND_EXTEND) ? GMT_REGION_INCFACTOR : 0.0;
-		wesn[XLO] = floor ((wesn[XLO] - adjust * inc[XLO]) / inc[XLO]) * inc[XLO];
-		wesn[YLO] = floor ((wesn[YLO] - adjust * inc[YLO]) / inc[YLO]) * inc[YLO];
-		wesn[XHI] = ceil  ((wesn[XHI] + adjust * inc[XHI]) / inc[XHI]) * inc[XHI];
-		wesn[YHI] = ceil  ((wesn[YHI] + adjust * inc[YHI]) / inc[YHI]) * inc[YHI];
+		/* A zero increment on either axis means "leave that axis alone" - skip rounding
+		 * for that axis instead of dividing by zero (which produced NaN, see issue #6434) */
+		if (inc[XLO] > 0.0) wesn[XLO] = floor ((wesn[XLO] - adjust * inc[XLO]) / inc[XLO]) * inc[XLO];
+		if (inc[YLO] > 0.0) wesn[YLO] = floor ((wesn[YLO] - adjust * inc[YLO]) / inc[YLO]) * inc[YLO];
+		if (inc[XHI] > 0.0) wesn[XHI] = ceil  ((wesn[XHI] + adjust * inc[XHI]) / inc[XHI]) * inc[XHI];
+		if (inc[YHI] > 0.0) wesn[YHI] = ceil  ((wesn[YHI] + adjust * inc[YHI]) / inc[YHI]) * inc[YHI];
 	}
 }
 


### PR DESCRIPTION
**Done with Claude Sonnet 5**

## Problem

`-Rcode+r<inc>` and `-Rcode+e<inc>` allow specifying 0 for one axis to mean "don't adjust that axis" (e.g. +e1/0 to only round/extend in x). However, `gmt_extend_region()` divided by `inc[...]` unconditionally when rounding to multiples of the increment, so a 0 increment produced a division by zero → `-nan `propagated into the resulting region `(wesn[YLO]/wesn[YHI])`.

## Fix

In `gmt_extend_region()`, skip the floor/ceil rounding for any axis whose increment is 0, leaving that axis's bound untouched instead of dividing by zero.

## Tested with

```
gmt begin test_6434 png
	gmt coast -Bf -W -RIT+r0/2 -Vi
	gmt coast -Bf -W -RIT+e2/0 -Vi -Xw
	gmt coast -Bf -W -RIT+e0/0/0/2 -Vi -Xw
gmt end
```

The figure is now generated correctly, and the region is reported correctly in the terminal:
```
coast [INFORMATION]: Region implied by DCW polygons is 6.6149/18.5135/34/48
coast [INFORMATION]: Region implied by DCW polygons is 6/20/35.4922/47.0952
coast [INFORMATION]: Region implied by DCW polygons is 6.6149/18.5135/35.4922/48
```


Closes #6434