### PR TITLE
Fix pssac drawing a wrong short line (#5954)

### DIFF
--- a/src/gmt_plot.c
+++ b/src/gmt_plot.c
@@ -6155,6 +6155,11 @@ GMT_LOCAL void gmtplot_get_outside_point_extension (struct GMT_CTRL *GMT, double
 		L = 0.0;
 	else	/* Safe to get width (but still truncate to width of map) */
 		L = MIN (fabs (W / tan_angle), GMT->current.map.half_width);	/* L is positive */
+	/* For lines that cross the border at a shallow (near-tangent) angle, L can blow up far beyond
+	 * the segment that defines the crossing direction, producing a visible stray line segment
+	 * (https://github.com/GenericMappingTools/gmt/issues/5954). The extension should never need
+	 * to reach further than the segment itself, so cap it at that segment's length. */
+	L = MIN (L, hypot (dx, dy));
 	/* Compute the coordinates of the point at a distance L away from clip point in the direction of angle */
 	*x_off = x_on - L * cosd (angle);
 	*y_off = y_on - L * sind (angle);

--- a/src/seis/pssac.c
+++ b/src/seis/pssac.c
@@ -674,6 +674,8 @@ EXTERN_MSC int GMT_pssac (void *V_API, int mode, void *args) {	/* High-level fun
 	}
 	GMT_Report (API, GMT_MSG_INFORMATION, "Collecting %ld SAC files to plot.\n", n_files);
 
+	gmt_map_clip_on (GMT, GMT->session.no_rgb, 3);	/* Clip to map so border-crossing traces don't leak stray pen segments outside the frame */
+
 	for (n = 0; n < (int)n_files; n++) {  /* Loop over all SAC files */
  		GMT_Report (API, GMT_MSG_INFORMATION, "Plotting SAC file %d: %s\n", n, L[n].file);
 
@@ -936,6 +938,8 @@ EXTERN_MSC int GMT_pssac (void *V_API, int mode, void *args) {	/* High-level fun
 	gmt_M_free(GMT, x);		gmt_M_free(GMT, y);		/* They might not have been released above due to 'continues' */
 	gmt_M_free (GMT, L);
 	gmt_M_free (GMT, Ctrl->In.file);
+
+	gmt_map_clip_off (GMT);
 
 	if (Ctrl->D.active) PSL_setorigin (PSL, -Ctrl->D.dx, -Ctrl->D.dy, 0.0, PSL_FWD);	/* Reset shift */
 


### PR DESCRIPTION
**Done with Claude (Sonnet 5, high reasoning effort).**

## Summary
Fixes #5954, where `pssac`/`sac` occasionally draws a short, disconnected
stray line segment near a trace peak.

Two bugs combined to produce this:
- `pssac.c` never wrapped its line/fill drawing in `gmt_map_clip_on`/   `gmt_map_clip_off`, unlike other line-plotting modules (`psxy`, `pswiggle`, ...), so traces briefly exceeding the plotted y-range were   never clipped to the frame.
- The shared `gmt_plot_line` pen-width border-extension helper (`gmtplot_get_outside_point_extension` in `gmt_plot.c`) computes an extension length via `W / tan(angle)`. When a line crosses the border at a near-tangent angle — which happens whenever a smooth waveform peak just barely pokes above/below the plotted range, as in the reporter's SAC trace — this blows up to a length far beyond the segment that defines the crossing direction, producing a visible stray line. This is a generic bug (reproduced identically via plain `psxy` on the same sample values), not specific to SAC data.

## Fix
- `gmt_plot.c`: cap the extension length to the length of the segment that defines the crossing direction (`L = MIN(L, hypot(dx, dy))`).
- `seis/pssac.c`: add the missing `gmt_map_clip_on`/`gmt_map_clip_off` around the per-trace plotting loop.


Checked visually with:

<img width="70%" height="827" alt="plot_test_5954" src="https://github.com/user-attachments/assets/ea5dc656-5157-4e42-95e2-e50d7116bf61" />

```
gmt begin plot_test_5954 png
    gmt plot test.txt -JX10c/5c -W1p -R-8.22653e-14/3.935039/9.907071e-08/0.43307
gmt end
```

<img width="70%" height="131" alt="sac_test_5954_fixed" src="https://github.com/user-attachments/assets/aa75854d-7327-45f7-abf8-933a79f5157e" />


```
gmt begin sac_test_5954 png
    gmt sac -JX10c/1.1c -R-2.23517e-07/20/-4.80721e-06/4.30574e-06 bug.sac
gmt end
```

The files are in #5954.
