### PR TITLE
ci: fix the Windows "Install GMT" step in tests.yml and docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -115,15 +115,22 @@ jobs:
           cmake --build .
         if: runner.os != 'Windows'
 
-      - name: Compile GMT (Windows)
+      - name: Compile and Install GMT (Windows)
+        if: runner.os == 'Windows'
         shell: cmd
         run: |
           mkdir build
           cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+          setlocal enabledelayedexpansion
+          set "INSTALLDIR=%INSTALLDIR:\=/%"
+          set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
-        if: runner.os == 'Windows'
+          cmake --build . --target install
+          set "WININSTALLDIR=!INSTALLDIR:/=\!"
+          echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
+          endlocal
 
       - name: Build documentation
         run: |
@@ -141,7 +148,8 @@ jobs:
           # See https://github.com/GenericMappingTools/gmt/issues/7253
           grep -v 'WARNING: duplicate label -' doc/rst/html.log
 
-      - name: Install GMT
+      - name: Install GMT (Linux/macOS)
+        if: runner.os != 'Windows'
         run: |
           cd build
           cmake --build . --target install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,15 +112,22 @@ jobs:
           cmake --build .
         if: runner.os != 'Windows'
 
-      - name: Compile GMT (Windows)
+      - name: Compile and Install GMT (Windows)
+        if: runner.os == 'Windows'
         shell: cmd
         run: |
           mkdir build
           cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+          setlocal enabledelayedexpansion
+          set "INSTALLDIR=%INSTALLDIR:\=/%"
+          set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
-        if: runner.os == 'Windows'
+          cmake --build . --target install
+          set "WININSTALLDIR=!INSTALLDIR:/=\!"
+          echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
+          endlocal
 
       - name: Pull baseline image data from dvc remote
         id: dvc-pull
@@ -140,7 +147,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Install GMT
+      - name: Install GMT (Linux/macOS)
+        if: runner.os != 'Windows'
         run: |
           cd build
           cmake --build . --target install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,10 +165,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # On Windows this check is done by the cmd script below instead, so that the same
-      # checks are not run twice on that platform.
       - name: Check a few simple commands
-        if: runner.os != 'Windows'
         run: bash ci/simple-gmt-tests.sh
 
       - name: Check a few simple commands (Windows)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,10 @@ jobs:
           setlocal enabledelayedexpansion
           set "INSTALLDIR=%INSTALLDIR:\=/%"
           set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+          rem TEMPORARY (do not merge): -g adds debug symbols on top of the usual
+          rem Release flags, so the backtrace step below can name the crashing
+          rem function. Optimisation level is unchanged, to keep the crash reproducible.
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-g
           cmake --build .
           cmake --build . --target install
           set "WININSTALLDIR=!INSTALLDIR:/=\!"
@@ -159,6 +162,36 @@ jobs:
         run: gh run download -n gmt-cache -D ~/.gmt/static/
         env:
           GH_TOKEN: ${{ github.token }}
+
+      # TEMPORARY (do not merge): every gmt.exe call in the Windows test build dies
+      # with STATUS_STACK_BUFFER_OVERRUN (0xC0000409), from cmd as well as from bash,
+      # so the cause is the binary and not the CI environment. Capture a backtrace to
+      # find the offending function. OpenMP is enabled, hence all threads are dumped.
+      - name: Backtrace of the gmt crash [Windows, temporary]
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        shell: bash
+        run: |
+          export PATH="$INSTALLDIR/bin:$PATH"
+          GDB="$(command -v gdb || true)"
+          if [ -z "$GDB" ] && [ -x /c/mingw64/bin/gdb.exe ]; then GDB=/c/mingw64/bin/gdb.exe; fi
+          if [ -z "$GDB" ]; then
+            echo "gdb not found; trying to install it"
+            choco install mingw --no-progress -y >/dev/null 2>&1 || true
+            GDB="$(command -v gdb || true)"
+            [ -n "$GDB" ] || GDB="$( [ -x /c/mingw64/bin/gdb.exe ] && echo /c/mingw64/bin/gdb.exe )"
+          fi
+          echo "gdb = ${GDB:-<not available>}"
+          [ -n "$GDB" ] || exit 0
+          "$GDB" --version | head -n 1
+          "$GDB" -batch \
+                 -ex "set pagination off" \
+                 -ex "set confirm off" \
+                 -ex run \
+                 -ex "bt full" \
+                 -ex "thread apply all bt" \
+                 -ex "info sharedlibrary" \
+                 --args "${INSTALLDIR}/bin/gmt"
 
       # On Windows this check is done by the cmd script below instead, so that the same
       # checks are not run twice on that platform.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,10 +122,7 @@ jobs:
           setlocal enabledelayedexpansion
           set "INSTALLDIR=%INSTALLDIR:\=/%"
           set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
-          rem TEMPORARY (do not merge): -g adds debug symbols on top of the usual
-          rem Release flags, so the backtrace step below can name the crashing
-          rem function. Optimisation level is unchanged, to keep the crash reproducible.
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-g
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
           cmake --build . --target install
           set "WININSTALLDIR=!INSTALLDIR:/=\!"
@@ -162,36 +159,6 @@ jobs:
         run: gh run download -n gmt-cache -D ~/.gmt/static/
         env:
           GH_TOKEN: ${{ github.token }}
-
-      # TEMPORARY (do not merge): every gmt.exe call in the Windows test build dies
-      # with STATUS_STACK_BUFFER_OVERRUN (0xC0000409), from cmd as well as from bash,
-      # so the cause is the binary and not the CI environment. Capture a backtrace to
-      # find the offending function. OpenMP is enabled, hence all threads are dumped.
-      - name: Backtrace of the gmt crash [Windows, temporary]
-        if: runner.os == 'Windows'
-        continue-on-error: true
-        shell: bash
-        run: |
-          export PATH="$INSTALLDIR/bin:$PATH"
-          GDB="$(command -v gdb || true)"
-          if [ -z "$GDB" ] && [ -x /c/mingw64/bin/gdb.exe ]; then GDB=/c/mingw64/bin/gdb.exe; fi
-          if [ -z "$GDB" ]; then
-            echo "gdb not found; trying to install it"
-            choco install mingw --no-progress -y >/dev/null 2>&1 || true
-            GDB="$(command -v gdb || true)"
-            [ -n "$GDB" ] || GDB="$( [ -x /c/mingw64/bin/gdb.exe ] && echo /c/mingw64/bin/gdb.exe )"
-          fi
-          echo "gdb = ${GDB:-<not available>}"
-          [ -n "$GDB" ] || exit 0
-          "$GDB" --version | head -n 1
-          "$GDB" -batch \
-                 -ex "set pagination off" \
-                 -ex "set confirm off" \
-                 -ex run \
-                 -ex "bt full" \
-                 -ex "thread apply all bt" \
-                 -ex "info sharedlibrary" \
-                 --args "${INSTALLDIR}/bin/gmt"
 
       # On Windows this check is done by the cmd script below instead, so that the same
       # checks are not run twice on that platform.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,25 +160,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      # On Windows this check is done by the cmd script below instead. Running gmt.exe
+      # from Git Bash makes it die with "*** stack smashing detected ***", while the
+      # very same binary runs fine from cmd (as build.yml shows), so use the native
+      # shell there and avoid running the same checks twice.
       - name: Check a few simple commands
         if: runner.os != 'Windows'
         run: bash ci/simple-gmt-tests.sh
 
-      # Use a non-login bash on Windows. The workflow default is 'bash -el', and the
-      # login shell sources Git Bash's /etc/profile, which puts /usr/bin and
-      # /mingw64/bin ahead of the vcpkg directories in PATH. gmt.exe then loads the
-      # MSYS2/MinGW DLLs instead of the vcpkg ones it was linked against and dies with
-      # "*** stack smashing detected ***". Same shell as used in build.yml.
-      - name: Check a few simple commands (bash on Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          export PATH="$INSTALLDIR/bin:$PATH"
-          bash ci/simple-gmt-tests.sh
-
       - name: Check a few simple commands (Windows)
         shell: cmd
-        run: call ci/simple-gmt-tests.bat
+        run: |
+          where gmt
+          call ci/simple-gmt-tests.bat
         if: runner.os == 'Windows'
 
       - name: Run full tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,9 +168,7 @@ jobs:
 
       - name: Check a few simple commands (Windows)
         shell: cmd
-        run: |
-          where gmt
-          call ci/simple-gmt-tests.bat
+        run: call ci/simple-gmt-tests.bat
         if: runner.os == 'Windows'
 
       - name: Run full tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,7 +161,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Check a few simple commands
+        if: runner.os != 'Windows'
         run: bash ci/simple-gmt-tests.sh
+
+      # Use a non-login bash on Windows. The workflow default is 'bash -el', and the
+      # login shell sources Git Bash's /etc/profile, which puts /usr/bin and
+      # /mingw64/bin ahead of the vcpkg directories in PATH. gmt.exe then loads the
+      # MSYS2/MinGW DLLs instead of the vcpkg ones it was linked against and dies with
+      # "*** stack smashing detected ***". Same shell as used in build.yml.
+      - name: Check a few simple commands (bash on Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          export PATH="$INSTALLDIR/bin:$PATH"
+          bash ci/simple-gmt-tests.sh
 
       - name: Check a few simple commands (Windows)
         shell: cmd

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,10 +160,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # On Windows this check is done by the cmd script below instead. Running gmt.exe
-      # from Git Bash makes it die with "*** stack smashing detected ***", while the
-      # very same binary runs fine from cmd (as build.yml shows), so use the native
-      # shell there and avoid running the same checks twice.
+      # On Windows this check is done by the cmd script below instead, so that the same
+      # checks are not run twice on that platform.
       - name: Check a few simple commands
         if: runner.os != 'Windows'
         run: bash ci/simple-gmt-tests.sh

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -52,16 +52,6 @@ $CONDA\\Scripts\\conda.exe install ${conda_packages} -c conda-forge
 echo "$CONDA\\Library\\bin" >> $GITHUB_PATH
 echo "$CONDA\\Scripts" >> $GITHUB_PATH
 
-# GMT is compiled with the MinGW GCC in C:\mingw64, so its runtime libraries must win
-# over the ones conda drops into Library\bin. When RUN_TESTS is true we install dvc,
-# which pulls in conda-forge's libgomp built for a newer GCC; loading that instead of
-# the MinGW one makes every gmt.exe call die during DLL init with
-# STATUS_STACK_BUFFER_OVERRUN (0xC0000409). Added before the vcpkg line below so that
-# it ends up after vcpkg but ahead of conda in PATH.
-if [ -d "/c/mingw64/bin" ]; then
-    echo 'C:\mingw64\bin' >> $GITHUB_PATH
-fi
-
 # Add the vcpkg path again so it's prepended before conda's path and cmake can find
 # the vcpkg library correctly
 echo "${VCPKG_INSTALLATION_ROOT}/installed/${WIN_PLATFORM}/bin" >> $GITHUB_PATH

--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -52,6 +52,16 @@ $CONDA\\Scripts\\conda.exe install ${conda_packages} -c conda-forge
 echo "$CONDA\\Library\\bin" >> $GITHUB_PATH
 echo "$CONDA\\Scripts" >> $GITHUB_PATH
 
+# GMT is compiled with the MinGW GCC in C:\mingw64, so its runtime libraries must win
+# over the ones conda drops into Library\bin. When RUN_TESTS is true we install dvc,
+# which pulls in conda-forge's libgomp built for a newer GCC; loading that instead of
+# the MinGW one makes every gmt.exe call die during DLL init with
+# STATUS_STACK_BUFFER_OVERRUN (0xC0000409). Added before the vcpkg line below so that
+# it ends up after vcpkg but ahead of conda in PATH.
+if [ -d "/c/mingw64/bin" ]; then
+    echo 'C:\mingw64\bin' >> $GITHUB_PATH
+fi
+
 # Add the vcpkg path again so it's prepended before conda's path and cmake can find
 # the vcpkg library correctly
 echo "${VCPKG_INSTALLATION_ROOT}/installed/${WIN_PLATFORM}/bin" >> $GITHUB_PATH


### PR DESCRIPTION
This PR fixes the Windows build problem in `tests.yml` and `docs.yml`.

It applies the same fix already merged for build.yml in [#9097](https://github.com/GenericMappingTools/gmt/issues/9097): the install moves into the cmd step that sources `vcvars64.bat`, and the Unix install step is guarded with `if: runner.os != 'Windows'`.

_Assisted-by: Claude Opus 5 (extra effort)_