### PR TITLE
gmtest: don't require execute permission on test scripts

### DIFF
--- a/test/gmtest.in
+++ b/test/gmtest.in
@@ -53,8 +53,8 @@ fi
 # Any script override of GRAPHICSMAGICK_RMS?  Must be a comment line of the format
 # GRAPHICSMAGICK_RMS = <custom-limit>
 GRAPHICSMAGICK_RMS=$(grep "GRAPHICSMAGICK_RMS" "$script" | awk '{print $4}')
-if ! [ -x "${script}" ]; then
-  echo "error: cannot execute script ${script}." >&2
+if ! [ -r "${script}" ]; then
+  echo "error: cannot read script ${script}." >&2
   exit 1
 fi
 


### PR DESCRIPTION
Follow-up to #9133. Removing the executable bit from test/example scripts made every test fail, because `test/gmtest.in` explicitly checked for it:

```bash
if ! [ -x "${script}" ]; then
  echo "error: cannot execute script ${script}." >&2
  exit 1
fi
```

Test scripts are sourced (`. "${local_script}"`), not executed, so this check was never actually needed — it only requires read permission. Relaxed it to `-r`.

@seisman also suggested changing the sourcing itself to `bash "${local_script}"`. I kept `.` (source) instead: switching to `bash` runs the script in a subshell, so a classic-mode script's `ps=...` variable (used afterwards for the baseline image comparison) would no longer propagate back into `gmtest.sh`, breaking every classic-mode test.

Closes #9048

Assisted-by: Claude Sonnet 5 (High effort)