### PR TITLE
CI: Deduplicate links in the Check Links report

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -58,6 +58,54 @@ jobs:
           **/*.rst_
           **/*.md
 
+    - name: Remove duplicate links from the report
+      if: steps.lychee.outputs.exit_code != 0
+      shell: python3 {0}
+      run: |
+        import re
+        from pathlib import Path
+
+        report = Path("/tmp/lychee-out.md")
+        lines = report.read_text().splitlines()
+
+        # Each bullet line reports one link, e.g. "* [404] <https://example.com> (at ...)".
+        # The same link is often referenced from many files, so lychee lists it once
+        # per file. Keep only the first occurrence of each link.
+        bullet_re = re.compile(r"^\* (?:\[[^\]]+\] )?<?([^\s>]+)>?")
+
+        seen = set()
+        deduped = []
+        for line in lines:
+            if line.startswith("* "):
+                match = bullet_re.match(line)
+                if match:
+                    link = match.group(1)
+                    if link in seen:
+                        continue
+                    seen.add(link)
+            deduped.append(line)
+
+        # Drop "### ... in <file>" subsections left with no links after deduplication.
+        filtered = []
+        i = 0
+        while i < len(deduped):
+            line = deduped[i]
+            if line.startswith("### "):
+                j = i + 1
+                has_link = False
+                while j < len(deduped) and not deduped[j].startswith("##"):
+                    if deduped[j].startswith("* "):
+                        has_link = True
+                        break
+                    j += 1
+                if not has_link:
+                    i = j
+                    continue
+            filtered.append(line)
+            i += 1
+
+        report.write_text("\n".join(filtered) + "\n")
+
     - name: Get current date
       id: date
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -60,51 +60,18 @@ jobs:
 
     - name: Remove duplicate links from the report
       if: steps.lychee.outputs.exit_code != 0
-      shell: python3 {0}
       run: |
-        import re
-        from pathlib import Path
-
-        report = Path("/tmp/lychee-out.md")
-        lines = report.read_text().splitlines()
-
-        # Each bullet line reports one link, e.g. "* [404] <https://example.com> (at ...)".
-        # The same link is often referenced from many files, so lychee lists it once
-        # per file. Keep only the first occurrence of each link.
-        bullet_re = re.compile(r"^\* (?:\[[^\]]+\] )?<?([^\s>]+)>?")
-
-        seen = set()
-        deduped = []
-        for line in lines:
-            if line.startswith("* "):
-                match = bullet_re.match(line)
-                if match:
-                    link = match.group(1)
-                    if link in seen:
-                        continue
-                    seen.add(link)
-            deduped.append(line)
-
-        # Drop "### ... in <file>" subsections left with no links after deduplication.
-        filtered = []
-        i = 0
-        while i < len(deduped):
-            line = deduped[i]
-            if line.startswith("### "):
-                j = i + 1
-                has_link = False
-                while j < len(deduped) and not deduped[j].startswith("##"):
-                    if deduped[j].startswith("* "):
-                        has_link = True
-                        break
-                    j += 1
-                if not has_link:
-                    i = j
-                    continue
-            filtered.append(line)
-            i += 1
-
-        report.write_text("\n".join(filtered) + "\n")
+        # The same link is often referenced from many files, so lychee lists it
+        # once per file. Keep the "Summary" table, then list each broken/timed-out
+        # link only once, stripping the "(at file:line)" part so duplicates collapse.
+        {
+          awk '/^## /{exit} {print}' /tmp/lychee-out.md
+          echo
+          echo "## Broken/timed-out links"
+          echo
+          grep '^\* \[' /tmp/lychee-out.md | sed -E 's/ \(at [^)]*\)//' | sort -u
+        } > /tmp/lychee-dedup.md
+        mv /tmp/lychee-dedup.md /tmp/lychee-out.md
 
     - name: Get current date
       id: date


### PR DESCRIPTION
The same broken link often gets listed once per file that references
it, so a single dead link can flood the weekly "Link Checker Report"
issue with repeated entries.

Added a post-processing step that keeps only the first occurrence of
each link in the report and drops the per-file subsections that end
up empty after deduplication.

Assisted-by: Claude Sonnet 5 (High effort)