### PR TITLE
batch: Recognize the +W modifier in -T (case-sensitive lookup bug)

### DIFF
--- a/src/batch.c
+++ b/src/batch.c
@@ -340,9 +340,9 @@ static int parse (struct GMT_CTRL *GMT, struct BATCH_CTRL *Ctrl, struct GMT_OPTI
 
 			case 'T':	/* Number of jobs or the name of file with job information (note: file may not exist yet) */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
-				if ((c = gmt_first_modifier (GMT, opt->arg, "psw"))) {	/* Process any modifiers */
+				if ((c = gmt_first_modifier (GMT, opt->arg, "pswW"))) {	/* Process any modifiers */
 					pos = 0;	/* Reset to start of new word */
-					while (gmt_getmodopt (GMT, 'T', c, "psw", &pos, p, &n_errors) && n_errors == 0) {
+					while (gmt_getmodopt (GMT, 'T', c, "pswW", &pos, p, &n_errors) && n_errors == 0) {
 						switch (p[0]) {
 							case 'p':	/* Set a fixed precision in job naming ###### */
 								n_errors += gmt_get_required_uint (GMT, opt->arg, opt->option, 'p', &Ctrl->T.precision);


### PR DESCRIPTION
**Description of proposed changes**

[batch`'s `-T](https://docs.generic-mapping-tools.org/dev/batch.html#t) option documents `+W` as a modifier but this doesn't work. I got this error `ERROR: No jobs specified! - exiting.`

Fix: add `W` to both separator strings (`"psw"` → `"pswW"`) so it's recognized on par with the other modifiers, matching the documented behavior.

**Tested with:**
```
printf '1\tAlphaWord\tBetaWord\n' > timefile.txt

cat << 'EOF' > main.sh
gmt begin
	echo "WORD0=${BATCH_WORD0}"
	echo "WORD1=${BATCH_WORD1}"
gmt end
EOF

gmt batch main.sh -Ttimefile.txt+W -Nbugtest -V -Z

```

Without this fix: `ERROR: No jobs specified! - exiting`.
With this fix: `WORD0=AlphaWord / WORD1=BetaWord
`

**Assisted-by: Claude Sonnet 5 (extra effort)**