### PR TITLE
DOC: Improve the description of the -p option

### DIFF
--- a/doc/rst/source/explain_perspective_full.rst_
+++ b/doc/rst/source/explain_perspective_full.rst_
@@ -19,13 +19,14 @@ supported:
 - */zlevel* to indicate the z-level at which all 2D material, like the plot frame, is plotted (only valid when **-p**
   is used in consort with **-Jz** or **-JZ**) [Default is at the bottom of the z-axis].
 
-For frames used for animation, we fix the center of your data domain. Specify another center using one of the following
-modifiers:
+By default, the view rotates about the plotting origin. Whether you set a full perspective view
+(*azim*\ /*elev*\ [/*zlevel*]) or just a plain rotation about the z-axis (*azim* only), you can rotate about a
+different point instead, given in either data or plot coordinates, with one of the following modifiers:
 
-- **+w** - Project *lon0*/*lat0* (and *z0* if applicable) to the center of the page size.
-- **+v** - Specify the coordinates of the projected 2-D view point as *x0*/*y0*.
+- **+w**\ *lon0*/*lat0*\ [/*z0*] - Rotate about the fixed data coordinates *lon0*/*lat0* (and *z0* if applicable)
+  instead of the plotting origin.
+- **+v**\ *x0*/*y0* - Rotate about the fixed plot coordinates *x0*/*y0* instead of the plotting origin.
 
 When **-p** is used without any further arguments, the values from the last use of **-p** in a previous GMT command
 will be used (in modern mode this also supplies the previous **-Jz** or **-JZ** if doing a 3-D region). Alternatively,
-you can perform a simple rotation about the z-axis by just giving the rotation angle. Optionally, use **+v** or **+w**
-to select another axis location than the plot origin.
+you can perform a simple rotation about the z-axis by just giving the rotation angle, without *elev* or *zlevel*.

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8374,8 +8374,8 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 					"Alternatively, give the rotation angle only for a plain rotation about the z-axis. "
 					"By default, the view rotates about the plot origin; use modifiers +w or +v to rotate "
 					"about a different point instead:");
-				GMT_Usage (API, 3, "+w Rotate about the fixed data coordinates <lon0>/<lat0>[/<z0>].");
-				GMT_Usage (API, 3, "+v Rotate about the fixed plot coordinates <x0>/<y0>.");
+				GMT_Usage (API, 3, "+w Rotate about the fixed data coordinates [region center].");
+				GMT_Usage (API, 3, "+v Rotate about the fixed plot coordinates [panel center].");
 			}
 			break;
 

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -8371,10 +8371,11 @@ void gmtlib_explain_options (struct GMT_CTRL *GMT, char *options) {
 					"<azimuth>/<elevation> of the viewpoint [180/90], and "
 					"when used with -Jz|Z, optionally add /<zlevel> for basemap level [bottom of z-axis]. "
 					"Prepend x or y to plot against the \"wall\" x = level or y = level [z]. "
-					"For a plain rotation about the z-axis, give rotation angle only "
-					"and optionally use modifiers +w or +v to select location of axis:");
-				GMT_Usage (API, 3, "+w Specify a fixed coordinate point [region center].");
-				GMT_Usage (API, 3, "+v Set a fixed projected point [panel center].");
+					"Alternatively, give the rotation angle only for a plain rotation about the z-axis. "
+					"By default, the view rotates about the plot origin; use modifiers +w or +v to rotate "
+					"about a different point instead:");
+				GMT_Usage (API, 3, "+w Rotate about the fixed data coordinates <lon0>/<lat0>[/<z0>].");
+				GMT_Usage (API, 3, "+v Rotate about the fixed plot coordinates <x0>/<y0>.");
 			}
 			break;
 


### PR DESCRIPTION
When wrapping the `-p` option in PyGMT, I feel the `-p` documentation is confusing and misleading. This PR improves it.

See https://github.com/GenericMappingTools/pygmt/issues/4176#issuecomment-5387216212 for a related test to understand the behavior.