### PR TITLE
CI: Use setup-msvc-dev action instead of hardcoding the VS install path on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           - name: macOS
             os: macos-15-intel
           - name: Windows
-            os: windows-latest
+            os: windows-2025
           - name: Linux (without optional dependencies)
             os: ubuntu-latest
             EXCLUDE_OPTIONAL : true
@@ -111,7 +111,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           setlocal enabledelayedexpansion
           set "INSTALLDIR=%INSTALLDIR:\=/%"
           set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           - name: macOS
             os: macos-15-intel
           - name: Windows
-            os: windows-2025
+            os: windows-latest
           - name: Linux (without optional dependencies)
             os: ubuntu-latest
             EXCLUDE_OPTIONAL : true
@@ -105,13 +105,18 @@ jobs:
           cmake --build .
         if: runner.os != 'Windows'
 
+      - name: Setup MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: TheMrMilchmann/setup-msvc-dev@v4.1.0
+        with:
+          arch: x64
+
       - name: Compile and Install GMT (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
           mkdir build
           cd build
-          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           setlocal enabledelayedexpansion
           set "INSTALLDIR=%INSTALLDIR:\=/%"
           set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -142,7 +142,7 @@ jobs:
 
   vcpkg_cache:
     name: Cache vcpkg libraries
-    runs-on: windows-2025
+    runs-on: windows-latest
     if: github.event_name != 'push'
 
     steps:

--- a/.github/workflows/ci-caches.yml
+++ b/.github/workflows/ci-caches.yml
@@ -142,7 +142,7 @@ jobs:
 
   vcpkg_cache:
     name: Cache vcpkg libraries
-    runs-on: windows-latest
+    runs-on: windows-2025
     if: github.event_name != 'push'
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
           - name: macOS
             os: macos-latest
           - name: Windows
-            os: windows-2025
+            os: windows-latest
 
     steps:
       - name: Checkout
@@ -115,12 +115,17 @@ jobs:
           cmake --build .
         if: runner.os != 'Windows'
 
+      - name: Setup MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: TheMrMilchmann/setup-msvc-dev@v4.1.0
+        with:
+          arch: x64
+
       - name: Compile GMT (Windows)
         shell: cmd
         run: |
           mkdir build
           cd build
-          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
         if: runner.os == 'Windows'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
           - name: macOS
             os: macos-latest
           - name: Windows
-            os: windows-latest
+            os: windows-2025
 
     steps:
       - name: Checkout
@@ -120,7 +120,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
         if: runner.os == 'Windows'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           - name: macOS
             os: macos-15-intel # macos-14 use M1 chips, which causes many failures
           - name: Windows
-            os: windows-2025
+            os: windows-latest
 
     steps:
       - name: Checkout
@@ -112,12 +112,17 @@ jobs:
           cmake --build .
         if: runner.os != 'Windows'
 
+      - name: Setup MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: TheMrMilchmann/setup-msvc-dev@v4.1.0
+        with:
+          arch: x64
+
       - name: Compile GMT (Windows)
         shell: cmd
         run: |
           mkdir build
           cd build
-          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
         if: runner.os == 'Windows'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           - name: macOS
             os: macos-15-intel # macos-14 use M1 chips, which causes many failures
           - name: Windows
-            os: windows-latest
+            os: windows-2025
 
     steps:
       - name: Checkout
@@ -117,7 +117,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
         if: runner.os == 'Windows'


### PR DESCRIPTION
The Windows CI started to fail recently because the `windows-latest` runner image has migrated from the `windows-2022` to `windows-2025` (xref: https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/), which ships VS 2026, rather than 2022.

This PR use the `setup-msvc-dev` action to automatically find the MSVC path and configure it, so that the Windows CI won't break suddenly due to runner image migrations.

References:

- https://github.com/actions/runner-images
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#visual-studio-enterprise-2022
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md#visual-studio-enterprise-2026