### PR TITLE
Fix psrose canvas fill (-B+g) being drawn max_radius times too small

### DIFF
--- a/src/psrose.c
+++ b/src/psrose.c
@@ -826,12 +826,13 @@ EXTERN_MSC int GMT_psrose (void *V_API, int mode, void *args) {
 	if (GMT->current.map.frame.draw && !GMT->current.map.frame.no_frame && gmt_M_is_zero (GMT->current.map.frame.axis[GMT_Y].item[GMT_ANNOT_UPPER].interval) && gmt_M_is_zero (GMT->current.map.frame.axis[GMT_Y].item[GMT_GRID_UPPER].interval)) do_labels = false;
 
 	if (do_fill) {	/* Until psrose uses a polar projection we must bypass the basemap fill and do it ourself here */
-		double dim = 2.0 * Ctrl->S.scale;
+		/* Note: Ctrl->S.scale may have been divided by max_radius above, so use the plot diameter set before that */
+		double dim = diameter, radius = 0.5 * diameter;
 		GMT->current.map.frame.paint[GMT_Z] = true;	/* Restore original setting */
 		if (half_only) {	/* Clip the bottom half of the circle */
 			double xc[4], yc[4];
-			xc[0] = xc[3] = -Ctrl->S.scale;	xc[1] = xc[2] = Ctrl->S.scale;
-			yc[0] = yc[1] = 0.0;	yc[2] = yc[3] = Ctrl->S.scale;
+			xc[0] = xc[3] = -radius;	xc[1] = xc[2] = radius;
+			yc[0] = yc[1] = 0.0;	yc[2] = yc[3] = radius;
 			PSL_beginclipping (PSL, xc, yc, 4, GMT->session.no_rgb, 3);
 		}
 		gmt_setfill (GMT, &GMT->current.map.frame.fill[GMT_Z], 0);


### PR DESCRIPTION
**Diagnosed and patched with Claude Code (Claude Opus 5).**

## Bug

The` do_fill` block sized the canvas-fill circle as `2 * Ctrl->S.scale`, but a few lines earlier `Ctrl->S.scale` was divided by `max_radius`, so it is no longer the plot radius in inches but inches per data unit. With `-B+g<fill>` and any `-R0/<rmax>/...` where `rmax != 1` the fill circle came out `max_radius` times too small and was hidden behind the rose.

Use the local variable diameter, which is set before that division and is what the frame-drawing block at the end of the module already uses. The half-circle clip rectangle in the same block had the same defect and is fixed too.

**Tested with this script**

```
gmt begin psrose_fill png
	gmt rose @fractures_06.txt -: -R0/20000/0/360 -JX5c -A20 -Gred -B+glightblue
gmt end
```
Without the fix the lightblue background is not visible at all.

<img width="40%" alt="psrose_fill" src="https://github.com/user-attachments/assets/7f5a6ca3-c518-4ac3-81ae-9aaf5a348d28" />
