### PR TITLE
Keep the pixel registration of grids written through GDAL (#8633)

### DIFF
--- a/src/gmt_customio.c
+++ b/src/gmt_customio.c
@@ -1446,9 +1446,11 @@ int gmt_srf_write_grd_info (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header
 	/* coverity[buffer_size] */		/* For Coverity analysis. Do not remove this comment */
 	gmt_strncpy (h.id, "DSBB", 4U);
 	h.n_columns = (short int)header->n_columns;	 h.n_rows = (short int)header->n_rows;
-	if (header->registration == GMT_GRID_PIXEL_REG) {
+	if (header->registration == GMT_GRID_PIXEL_REG) {	/* Surfer headers only hold node coordinates */
 		h.wesn[XLO] = header->wesn[XLO] + header->inc[GMT_X]/2.0;	 h.wesn[XHI] = header->wesn[XHI] - header->inc[GMT_X]/2.0;
 		h.wesn[YLO] = header->wesn[YLO] + header->inc[GMT_Y]/2.0;	 h.wesn[YHI] = header->wesn[YHI] - header->inc[GMT_Y]/2.0;
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Surfer grids are always gridline-registered.  Your pixel-registered grid will be converted.\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Surfer grid region in file %s written as %g/%g/%g/%g\n", HH->name, h.wesn[XLO], h.wesn[XHI], h.wesn[YLO], h.wesn[YHI]);
 	}
 	else
 		gmt_M_memcpy (h.wesn, header->wesn, 4, double);
@@ -1674,9 +1676,11 @@ int gmt_srf_write_grd (struct GMT_CTRL *GMT, struct GMT_GRID_HEADER *header, gmt
 	/* coverity[buffer_size] */		/* For Coverity analysis. Do not remove this comment */
 	gmt_strncpy (h.id, "DSBB", 4U);
 	h.n_columns = (short int)header->n_columns;	 h.n_rows = (short int)header->n_rows;
-	if (header->registration == GMT_GRID_PIXEL_REG) {
+	if (header->registration == GMT_GRID_PIXEL_REG) {	/* Surfer headers only hold node coordinates */
 		h.wesn[XLO] = header->wesn[XLO] + header->inc[GMT_X]/2;	 h.wesn[XHI] = header->wesn[XHI] - header->inc[GMT_X]/2;
 		h.wesn[YLO] = header->wesn[YLO] + header->inc[GMT_Y]/2;	 h.wesn[YHI] = header->wesn[YHI] - header->inc[GMT_Y]/2;
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Surfer grids are always gridline-registered.  Your pixel-registered grid will be converted.\n");
+		GMT_Report (GMT->parent, GMT_MSG_WARNING, "Surfer grid region in file %s written as %g/%g/%g/%g\n", HH->name, h.wesn[XLO], h.wesn[XHI], h.wesn[YLO], h.wesn[YHI]);
 	}
 	else
 		gmt_M_memcpy (h.wesn, header->wesn, 4, double);

--- a/src/gmt_gdalread.c
+++ b/src/gmt_gdalread.c
@@ -53,6 +53,20 @@ GMT_LOCAL GDALDatasetH gmtgdalread_gdal_open (struct GMT_CTRL *GMT, char *gdal_f
 	return (GDALOpen (path, GA_ReadOnly));
 }
 
+GMT_LOCAL int gmtgdalread_gmt_registration (GDALDatasetH hDataset) {
+	/* Grids saved by gmt_gdalwrite carry a GMT_REGISTRATION metadata item that states, without ambiguity,
+	   which registration the grid had.  We need it because GDAL only records AREA_OR_POINT in the file when
+	   it is "Point" ("Area" is the implicit default and is dropped, in particular for rasters that carry no
+	   referencing at all), so a pixel registered grid written to, say, a Cartesian GeoTIFF would otherwise
+	   come back as gridline registered.  Returns 1 (pixel), 0 (gridline) or GMT_NOTSET if the file has no
+	   such item, in which case the caller sticks to its own guess. */
+	const char *item = GDALGetMetadataItem (hDataset, "GMT_REGISTRATION", NULL);
+	if (item == NULL) return (GMT_NOTSET);
+	if (!strcmp (item, "pixel"))    return (1);
+	if (!strcmp (item, "gridline")) return (0);
+	return (GMT_NOTSET);
+}
+
 GMT_LOCAL int gmtgdalread_decode_columns (struct GMT_CTRL *GMT, char *txt, int *whichBands) {
 	unsigned int n = 0, i, start, stop, pos = 0;
 	char p[GMT_LEN256];
@@ -321,6 +335,7 @@ GMT_LOCAL int gmtgdalread_populate_metadata (struct GMT_CTRL *GMT, struct GMT_GD
 	const char  *pszProjection = NULL;
 	int     i, j;
 	int     status, bSuccess;	/* success or failure */
+	int     reg_from_gmt;		/* Registration as declared by GMT when it wrote the file, or GMT_NOTSET */
 	int     nBand, raster_count;
 	int     bGotMin, bGotMax;	/* To know if driver transmitted Min/Max */
 	bool    got_noDataValue = false, pixel_reg = false, compute_minmax = false;
@@ -685,6 +700,9 @@ GMT_LOCAL int gmtgdalread_populate_metadata (struct GMT_CTRL *GMT, struct GMT_GD
 			!strcmp(GDALGetMetadataItem(hDataset, "GDALMD_AREA_OR_POINT", NULL), "Area"))
 			pixel_reg = true;
 
+		if ((reg_from_gmt = gmtgdalread_gmt_registration (hDataset)) != GMT_NOTSET)
+			pixel_reg = (reg_from_gmt == 1);	/* File was written by GMT and it told us the registration */
+
 		Ctrl->hdr[6] = pixel_reg;
 		Ctrl->hdr[7] = adfGeoTransform[1];
 		Ctrl->hdr[8] = fabs(adfGeoTransform[5]);
@@ -751,6 +769,7 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 	int nBufXSize[2] = {0,0}, nBufYSize, buffy, startRow = 0, endRow;
 	int nRowsPerBlock, nBlocks, nYOff, row_i, row_e;
 	int k, pad_w[2] = {0,0}, pad_e[2] = {0,0}, pad_s = 0, pad_n = 0;    /* Different pads for when sub-regioning near the edges */
+	int reg_from_gmt;	/* Registration as declared by GMT when it wrote the file, or GMT_NOTSET */
 	int	incStep = 1;	/* 1 for real only arrays and 2 for complex arrays (index step increment) */
 	int error = 0, gdal_code = 0, first_layer;
 	int piece, n_pieces = 1;	/* Normally 1, but will be 2 if the desired image subset is split across a periodic boundary */
@@ -1193,6 +1212,9 @@ int gmt_gdalread (struct GMT_CTRL *GMT, char *gdal_filename, struct GMT_GDALREAD
 				else if (!pixel_reg && GDALGetMetadataItem(hDataset, "GDALMD_AREA_OR_POINT", NULL) &&
 					!strcmp(GDALGetMetadataItem(hDataset, "GDALMD_AREA_OR_POINT", NULL), "Area"))
 					pixel_reg = true;
+
+				if ((reg_from_gmt = gmtgdalread_gmt_registration (hDataset)) != GMT_NOTSET)
+					pixel_reg = (reg_from_gmt == 1);	/* File was written by GMT and it told us the registration */
 			}
 
 			i_x_nXYSize = i * ((size_t)nBufXSize[piece] + pad_w[piece] + pad_e[piece]) * ((size_t)nBufYSize + pad_s + pad_n);

--- a/src/gmt_gdalwrite.c
+++ b/src/gmt_gdalwrite.c
@@ -47,6 +47,17 @@ static char *gdal_drv[N_GDAL_EXTENSIONS] = {"GTiff", "GIF", "PNG", "JPEG", "BMP"
  *----------------------------------------------------------|
  */
 
+GMT_LOCAL bool gmtgdalwrite_is_picture_driver (const char *format) {
+	/* True for the drivers that only make pictures.  They cannot record a georeferencing-related tag in the
+	 * file itself, so asking GDAL to store one there just litters the place with .aux.xml sidecars. */
+	static const char *picture[] = {"PNG", "JPEG", "JPG", "GIF", "BMP", "WEBP", NULL};
+	unsigned int k;
+	if (format == NULL) return (false);
+	for (k = 0; picture[k]; k++)
+		if (!strcasecmp (format, picture[k])) return (true);
+	return (false);
+}
+
 int gmt_export_image(struct GMT_CTRL *GMT, char *fname, struct GMT_IMAGE *I) {
 	/* Take the image stored in the I structure and write to file by calling gmt_gdalwrite()
 	   The image format is inferred from the image name (in *fname) file extension,
@@ -514,14 +525,19 @@ int gmt_gdalwrite(struct GMT_CTRL *GMT, char *fname, struct GMT_GDALWRITE_CTRL *
 		 * supported everywhere, when n_cols < tile_width || n_rows < tile_height */
 		if (n_cols > 3 * GDAL_TILE_SIZE && n_rows > 3 * GDAL_TILE_SIZE)
 			papszOptions = CSLAddString(papszOptions, "TILED=YES");
+	}
 
-		if (is_geog || projWKT) {
-			/* Be respectful to data type registration */
-			if (registration == 0)
-				GDALSetMetadataItem(hDstDS, "AREA_OR_POINT", "Point", NULL);
-			else
-				GDALSetMetadataItem(hDstDS, "AREA_OR_POINT", "Area", NULL);
-		}
+	/* Be respectful to the registration of the data we are saving: without a tag in the file a pixel registered grid
+	 * comes back gridline registered, with its region shrunk by half a cell.  Note this used to be done for GTiff
+	 * only, and then only when the grid was georeferenced and the user had passed no +c<options>, which is why plain
+	 * Cartesian grids lost their registration.  We skip the picture-only drivers, which have nowhere to put this and
+	 * would only gain a .aux.xml sidecar for it. */
+	if (!gmtgdalwrite_is_picture_driver (pszFormat)) {
+		GDALSetMetadataItem(hDstDS, "AREA_OR_POINT", (registration == 0) ? "Point" : "Area", NULL);
+		/* AREA_OR_POINT alone is not enough: GDAL never records it when it is "Area", that being the implicit
+		 * default, and the GeoTIFF driver writes no keys at all for a raster with no referencing.  So state the
+		 * registration in a GMT item as well - that is what gmt_gdalread reads back. */
+		GDALSetMetadataItem(hDstDS, "GMT_REGISTRATION", (registration == 0) ? "gridline" : "pixel", NULL);
 	}
 	if (prhs->co_options)
 		free (prhs->co_options);		/* Was allocated with an strdup() in gmt_gdal_write_grd() */

--- a/src/grdsample.c
+++ b/src/grdsample.c
@@ -160,6 +160,7 @@ static int parse (struct GMT_CTRL *GMT, struct GRDSAMPLE_CTRL *Ctrl, struct GMT_
 				}
 				else
 					n_errors += gmt_default_option_error (GMT, opt);
+				break;
 			case 'T':	/* Convert from pixel file <-> gridfile */
 				n_errors += gmt_M_repeated_module_option (API, Ctrl->T.active);
 				if (GMT->common.R.active[FSET]) GMT->common.R.active[GSET] = false;	/* Override any implicit -r via -Rgridfile */

--- a/test/gdal/gdal_registration.sh
+++ b/test/gdal/gdal_registration.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Test that the node registration of a grid survives a round-trip through a GDAL format.
+#
+# GDAL only records the AREA_OR_POINT tag in the file when it is "Point", since "Area" is the
+# implicit default, and it writes no GeoTIFF keys at all for a raster that carries no referencing.
+# Because of that a pixel registered Cartesian grid used to come back gridline registered, with a
+# half-cell shifted region.  See issues #8633 (grdsample) and #8988 (grdmath).
+
+cat << EOF > answer.txt
+pixel.tif 0 10 0 10 1
+gridline.tif 0 10 0 10 0
+lonlat.tif -180 180 -90 90 1
+math.tif 0 1 0 1 1
+pixel.asc 0 10 0 10 1
+EOF
+
+# Cartesian gridline grid to start from
+gmt grdmath -R0/10/0/10 -I1 X Y MUL = gridline.nc
+
+gmt grdsample gridline.nc -r -Gpixel.tif=gd:GTiff		# -r must give a pixel registered GeoTIFF
+gmt grdconvert gridline.nc -Ggridline.tif=gd:GTiff		# and a gridline grid must stay gridline
+gmt grdmath -R-180/180/-90/90 -I2 -rp -fg X = lonlat.tif=gd:GTiff	# Referenced grids worked before
+gmt grdmath -R0/1/0/1 -I0.1 -rp X = "math.tif=gd:GTiff+cCOMPRESS=LZW"	# Also with +c<options>
+gmt grdsample gridline.nc -r -Gpixel.asc=gd:AAIGrid		# Not only the GeoTIFF driver
+
+for file in pixel.tif gridline.tif lonlat.tif math.tif pixel.asc; do
+	gmt grdinfo ${file} -C | awk '{printf "%s %s %s %s %s %s\n", $1, $2, $3, $4, $5, $12}'
+done > result.txt
+
+diff -q --strip-trailing-cr answer.txt result.txt


### PR DESCRIPTION
Let grdsample and grdmath save pixel registered grids.

Fixes #8633 (grdsample) and #8988 (grdmath): a pixel registered grid saved with =gd came back gridline registered, its region pulled in by half a cell, so in practice only gridline registered grids could be written that way.

A new test `gdal_registration.sh` tests this issue.

Assisted by: GPT Terra and revised/corrected by Claude Opus 5.0