### PR TITLE
Fix dropped fractional digit in latitude annotations for FORMAT_GEO_MAP with 3 decimals

### DIFF
--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16204,9 +16204,7 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 			zero_fix = true;
 		}
 		if (hemi_pre[0]) strcpy (label, hemi_pre);
-		/* For latitudes, the leading degree field must be shrunk from 3 to 2 digits (max latitude is 90, not 360).
-		 * Only touch that leading field: a blind gmt_strrep for "%3.3d" would also corrupt a fractional-seconds/minutes/degrees
-		 * field of exactly 3 decimals (n_sec_decimals == 3), which happens to share the same "%3.3d" text. */
+		/* Only shrink the leading degree field, not any other "%3.3d" occurring later in the format */
 		use_format = strdup (GMT->current.plot.format[level][type]);
 		if ((lonlat & 1) && !strncmp (use_format, "%3.3d", 5U))
 			gmt_M_memcpy (use_format, "%2.2d", 5U, char);

--- a/src/gmt_support.c
+++ b/src/gmt_support.c
@@ -16204,7 +16204,12 @@ void gmtlib_get_annot_label (struct GMT_CTRL *GMT, double val, char *label, bool
 			zero_fix = true;
 		}
 		if (hemi_pre[0]) strcpy (label, hemi_pre);
-        use_format = (lonlat & 1 ? gmt_strrep (GMT->current.plot.format[level][type], "%3.3d", "%2.2d") :strdup (GMT->current.plot.format[level][type]));
+		/* For latitudes, the leading degree field must be shrunk from 3 to 2 digits (max latitude is 90, not 360).
+		 * Only touch that leading field: a blind gmt_strrep for "%3.3d" would also corrupt a fractional-seconds/minutes/degrees
+		 * field of exactly 3 decimals (n_sec_decimals == 3), which happens to share the same "%3.3d" text. */
+		use_format = strdup (GMT->current.plot.format[level][type]);
+		if ((lonlat & 1) && !strncmp (use_format, "%3.3d", 5U))
+			gmt_M_memcpy (use_format, "%2.2d", 5U, char);
 
 		switch (2*level+type) {
 			case 0:


### PR DESCRIPTION
## Summary

Fixes #9154.

`gmtlib_get_annot_label()` (in [gmt_support.c](src/gmt_support.c)) shrinks the leading degree field of the plot format string from 3 digits to 2 for latitudes (max 90°, vs 360° for longitudes) by doing a text substitution: replace every `"%3.3d"` in the format string with `"%2.2d"`.

The bug: when `FORMAT_GEO_MAP` requests exactly **3** fractional digits (e.g. `ddd.xxxF`), the fractional-part printf format built for that case is *also* literally `"%3.3d"` — same text, unrelated purpose. The blind, whole-string `gmt_strrep()` call corrupted that fractional format too, shrinking it from 3 digits to 2. This silently dropped the leading zero of any fraction that happened to be `0**` (e.g. `.024` became `.24`), while leaving the value visually plausible (`9.020` → `9.20` → rendered as if only two decimals had been requested).

This only manifests for latitudes with exactly 3 fractional digits — `ddd.xxF` (2 digits) and `ddd.xxxxF` (4 digits) don't produce the literal string `"%3.3d"` anywhere else in the format, so they were unaffected. That matches the issue report exactly (3rd panel wrong, 4th panel correct).

## Fix

Only replace the leading degree field — which is always at position 0 of the format string — instead of replacing every occurrence of `"%3.3d"` anywhere in the string.

## Test plan

- [x] Reproduced the bug with the PyGMT snippet from the issue, translated to plain GMT (`FORMAT_GEO_MAP=ddd.xxxF`, `-Ba0.0001`) — before the fix, y-axis annotations read `9.24°N, 9.23°N, 9.21°N, ...` (2 digits, leading zero dropped); after the fix they correctly read `9.024°N, 9.023°N, 9.021°N, ...` (3 digits).
- [x] Confirmed `ddd.xxF` / `ddd.xxxxF` (2 and 4 decimals) were unaffected before and after.
- [x] Built with `ninja gmt` (warnings-only, pre-existing and unrelated to this file).
- [x] Ran the `doc/scripts` ctest suite's `-B_geo` tests; `GMT_-B_geo_2` fails identically on `master` and on this branch (pre-existing, unrelated font-rendering baseline diff), `GMT_-B_geo_1` passes on both.

Assisted-by: Claude Sonnet 5 (medium effort)