### PR TITLE
Fix segfault in plot/psxyz when -a references an unknown aspatial field or -C is missing

### DIFF
--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -7720,6 +7720,7 @@ int gmt_parse_segment_header (struct GMT_CTRL *GMT, char *header, struct GMT_PAL
 					}
 					break;
 				case GMT_IS_Z:
+					if (!P) break;	/* No CPT given via -C so we cannot look up a fill for this z-value */
 					if (P->categorical & GMT_CPT_CATEGORICAL_KEY)
 						gmt_get_fill_from_key (GMT, P, txt, fill);
 					else

--- a/src/gmt_io.c
+++ b/src/gmt_io.c
@@ -768,14 +768,20 @@ GMT_LOCAL bool gmtio_ogr_data_parser (struct GMT_CTRL *GMT, char *record) {
 }
 
 /*! Simplify aspatial data grabbing when -a is used */
-GMT_LOCAL void gmtio_align_ogr_values (struct GMT_CTRL *GMT) {
+GMT_LOCAL bool gmtio_align_ogr_values (struct GMT_CTRL *GMT) {
 	unsigned int k;
 	int id;
-	if (!GMT->common.a.active) return;	/* Nothing selected with -a */
+	if (!GMT->common.a.active) return true;	/* Nothing selected with -a */
 	for (k = 0; k < GMT->common.a.n_aspatial; k++) {	/* Process the requested columns */
 		id = gmt_get_ogr_id (GMT->current.io.OGR, GMT->common.a.name[k]);	/* See what order in the OGR struct this -a column appear */
+		if (id == GMT_NOTSET) {	/* No aspatial field by that name - bail before it is used as an array index */
+			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Option -a: No such named aspatial item: %s\n", GMT->common.a.name[k]);
+			GMT->current.io.ogr = GMT_OGR_FALSE;
+			return false;
+		}
 		GMT->common.a.ogr[k] = id;
 	}
+	return true;
 }
 
 GMT_LOCAL void gmtio_ogr_check_if_geographic (struct GMT_CTRL *GMT) {
@@ -830,7 +836,7 @@ GMT_LOCAL bool gmtio_ogr_header_parser (struct GMT_CTRL *GMT, char *record) {
 	if (record[0] != '#') return (false);			/* Not a comment record so no point looking any further */
 	if (GMT->current.io.ogr == GMT_OGR_TRUE && !strncmp (record, "# FEATURE_DATA", 14)) {	/* It IS an OGR file and we found end of OGR header section and start of feature data */
 		GMT->current.io.ogr_parser = &gmtio_ogr_data_parser;	/* From now on only parse for feature tags */
-		gmtio_align_ogr_values (GMT);	/* Simplify copy from aspatial values to input columns as per -a option */
+		if (!gmtio_align_ogr_values (GMT)) return (false);	/* Simplify copy from aspatial values to input columns as per -a option */
 		gmtio_ogr_check_if_geographic (GMT);	/* Check if we should set -fg */
 		return (true);
 	}
@@ -3805,6 +3811,7 @@ GMT_LOCAL void *gmtio_ascii_input (struct GMT_CTRL *GMT, FILE *fp, uint64_t *n, 
 
 		if (GMT->common.a.active && GMT->current.io.ogr == GMT_OGR_FALSE) {	/* Cannot give -a and not be reading an OGR/GMT file */
 			GMT_Report (GMT->parent, GMT_MSG_ERROR, "Aspatial associations set with -a but input file is not in OGR/GMT format!\n");
+			*status = gmtio_reached_EOF (GMT);
 			return NULL;
 		}
 

--- a/src/psxy.c
+++ b/src/psxy.c
@@ -825,7 +825,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, ztype, n_files = 0;
+	unsigned int n_errors = 0, ztype, n_files = 0, k;
 	int j;
 	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
@@ -1160,6 +1160,9 @@ static int parse (struct GMT_CTRL *GMT, struct PSXY_CTRL *Ctrl, struct GMT_OPTIO
 	if (Ctrl->T.active && n_files) GMT_Report (API, GMT_MSG_WARNING, "Option -T ignores all input files\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && Ctrl->Z.set_transp != 1 && !Ctrl->C.active, "Option -Z: No CPT given via -C\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && (Ctrl->C.file == NULL || Ctrl->C.file[0] == '\0'), "Option -C: No CPT given\n");
+	for (k = 0; k < GMT->common.a.n_aspatial; k++)
+		n_errors += gmt_M_check_condition (GMT, GMT->common.a.col[k] == GMT_IS_Z && !Ctrl->C.active,
+			"Option -a...=Z: Must supply a CPT via -C to look up the fill color\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && gmt_parse_symbol_option (GMT, Ctrl->S.arg, S, 0, true), "Option -S: Parsing failure\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->E.active && (S->symbol == PSL_VECTOR || S->symbol == GMT_SYMBOL_GEOVECTOR || S->symbol == PSL_MARC \
 		|| S->symbol == PSL_ELLIPSE || S->symbol == GMT_SYMBOL_FRONT || S->symbol == GMT_SYMBOL_QUOTED_LINE || S->symbol == GMT_SYMBOL_DECORATED_LINE || S->symbol == PSL_ROTRECT),

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -418,7 +418,7 @@ static int parse (struct GMT_CTRL *GMT, struct PSXYZ_CTRL *Ctrl, struct GMT_OPTI
 	 * returned when registering these sources/destinations with the API.
 	 */
 
-	unsigned int n_errors = 0, ztype;
+	unsigned int n_errors = 0, ztype, k;
 	int n;
 	char txt_a[GMT_LEN256] = {""}, txt_b[GMT_LEN256] = {""}, txt_c[GMT_LEN256] = {""}, *c = NULL;
 	struct GMT_OPTION *opt = NULL;
@@ -611,6 +611,9 @@ static int parse (struct GMT_CTRL *GMT, struct PSXYZ_CTRL *Ctrl, struct GMT_OPTI
 
 	n_errors += gmt_M_check_condition (GMT, Ctrl->Z.active && Ctrl->Z.set_transp != 1 && !Ctrl->C.active, "Option -Z: No CPT given via -C\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->C.active && (Ctrl->C.file == NULL || Ctrl->C.file[0] == '\0'), "Option -C: No CPT given\n");
+	for (k = 0; k < GMT->common.a.n_aspatial; k++)
+		n_errors += gmt_M_check_condition (GMT, GMT->common.a.col[k] == GMT_IS_Z && !Ctrl->C.active,
+			"Option -a...=Z: Must supply a CPT via -C to look up the fill color\n");
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.R.active[RSET], "Must specify -R option\n");
 	n_errors += gmt_M_check_condition (GMT, !GMT->common.J.active, "Must specify a map projection with the -J option\n");
 	n_errors += gmt_M_check_condition (GMT, Ctrl->S.active && gmt_parse_symbol_option (GMT, Ctrl->S.arg, S, 1, true), "Option -S: Parsing failure\n");


### PR DESCRIPTION
Issue: `plot` crashes with a segfault when `-a` references an aspatial field name that doesn't exist in the shapefile, or when `-aZ=<field>` is used without `-C`. With this fix, now fail with a clear error message instead:

```
$ gmt plot ne_110m_admin_0_countries.shp -W1p -G+z -aZ=POP -pdf map -L -Ctest.cpt
plot [ERROR]: Option -a: No such named aspatial item: POP
plot [ERROR]: Aspatial associations set with -a but input file is not in OGR/GMT format!

$ gmt plot ne_110m_admin_0_countries.shp -W1p -G+z -aZ=POP_EST -pdf map -L
plot [ERROR]: Option -a...=Z: Must supply a CPT via -C to look up the fill color
```

@seisman are those messages ok?


Fixes #9153 

**Done with Sonnet 5**