### PR TITLE
DOC: Clarify the default label position for vertical/horizontal scales

### DIFF
--- a/doc/rst/source/explain_-L_scale.rst_
+++ b/doc/rst/source/explain_-L_scale.rst_
@@ -18,7 +18,7 @@
     - **+w**\ *length* to set scale *length* in km, or append :ref:`unit <tbl-distunits>` from
       **e**\|\ **f**\|\ **k**\|\ **M**\|\ **n**\|\ **u**.
     - **+a**\ *align* to change the label alignment (choose among **l**\ (eft), **r**\ (ight), **t**\ (op), and
-      **b**\ (ottom)) [default is **t**\ (op)].
+      **b**\ (ottom)) [default is **t**\ (op) for horizontal scale and **r**\ (ight) for vertical scale].
     - **+c**\ [[*slon*/]\ *slat*] to control where on a geographic map the scale applies. Map scale is calculated for
       latitude *slat* (optionally supply longitude *slon* for oblique projections [default is central meridian]). If
       **+c** is not given we default to the location of the *refpoint*. If **+c** is given with no arguments then we


### PR DESCRIPTION
When plotting scales, the default label position depends on the scale orientation. The old docs say "default is top". It's correct only for horizontal scales. For vertical scales, the default position is right, as shown by commands below.

```
gmt basemap -R0/10/0/10 -JX10c -Baf -LjMC+w2 -pdf map
gmt basemap -R0/10/0/10 -JX10c -Baf -LjMC+w2+v -pdf map
```