### PR TITLE
psevents: Allow -R to be determined automatically from input data

### DIFF
--- a/src/psevents.c
+++ b/src/psevents.c
@@ -31,7 +31,7 @@
 #define THIS_MODULE_LIB		"core"
 #define THIS_MODULE_PURPOSE	"Plot event symbols, lines, polygons and labels for one moment in time"
 #define THIS_MODULE_KEYS	"<D{,CC(,>?}"
-#define THIS_MODULE_NEEDS	"JR"
+#define THIS_MODULE_NEEDS	"Jd"
 #define THIS_MODULE_OPTIONS	"-:>BJKOPRUVXYabdefhilpqtw"
 
 enum Psevent {	/* Misc. named array indices */


### PR DESCRIPTION
**Tested with:**
`printf "1 1 3\n0 0 3\n" | gmt events -T3 -Gred -Sc0.1c -JX3c -Ba -Ra -png lixo`

Previously this failed with `Must specify -R` option since `-Ra` had no way to determine the region for `psevents`; now it correctly infers `-R` from the input data.

**Assisted-by: Claude Sonnet 5 (Medium effort)**