### PR TITLE
Fix NaN region when -Ra determines a degenerate (zero-range) region from data

### DIFF
--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15101,9 +15101,7 @@ GMT_LOCAL int gmtinit_get_region_from_data(struct GMTAPI_CTRL *API, int family, 
 			if (GMT_Destroy_Data (API, &Out) != GMT_OK)
 				return (API->error);
 			geo = gmt_M_is_geographic (API->GMT, GMT_IN);
-			/* Safety valve if w == e or s == n (e.g., a single data point, or points that only vary in
-			 * one dimension) - must be done before gmt_round_wesn, which otherwise takes log10 of a
-			 * zero range and turns wesn into NaNs. */
+			/* Safety valve if w == e or s == n */
 			if (doubleAlmostEqualZero (wesn[XLO], wesn[XHI])) {
 				if (gmt_M_is_zero (wesn[XLO]))	/* No info to do anything other than this */
 					wesn[XLO] = -1.0, wesn[XHI] = +1.0;

--- a/src/gmt_init.c
+++ b/src/gmt_init.c
@@ -15101,8 +15101,9 @@ GMT_LOCAL int gmtinit_get_region_from_data(struct GMTAPI_CTRL *API, int family, 
 			if (GMT_Destroy_Data (API, &Out) != GMT_OK)
 				return (API->error);
 			geo = gmt_M_is_geographic (API->GMT, GMT_IN);
-			if (!exact) gmt_round_wesn (wesn, geo);	/* Use data range to round to nearest reasonable multiples */
-			/* Safety valve if w == e or s == n */
+			/* Safety valve if w == e or s == n (e.g., a single data point, or points that only vary in
+			 * one dimension) - must be done before gmt_round_wesn, which otherwise takes log10 of a
+			 * zero range and turns wesn into NaNs. */
 			if (doubleAlmostEqualZero (wesn[XLO], wesn[XHI])) {
 				if (gmt_M_is_zero (wesn[XLO]))	/* No info to do anything other than this */
 					wesn[XLO] = -1.0, wesn[XHI] = +1.0;
@@ -15115,6 +15116,7 @@ GMT_LOCAL int gmtinit_get_region_from_data(struct GMTAPI_CTRL *API, int family, 
 				else
 					wesn[YLO] *= 0.9, wesn[YHI] *= 1.1;	/* +/- 10% of values */
 			}
+			if (!exact) gmt_round_wesn (wesn, geo);	/* Use data range to round to nearest reasonable multiples */
 			break;
 		default:
 			GMT_Report (API, GMT_MSG_DEBUG, "gmtinit_get_region_from_data: Family %d not supported", family);


### PR DESCRIPTION
**Description of proposed changes**

Move the existing `w==e/s==n safety valve` fixing a `NaN` region when `-Ra` determines the region from a single data point (or points that only vary in one dimension).

**Tested with:**

`echo "0 0" | gmt plot  -Gred -Sc0.1c -JX3c -Ba -Ra -png lixo`



**Assisted-by: Claude Sonnet 5 (Medium effort)**