### PR TITLE
Fix unfilled vector head in auto-legend when fill comes from +g<fill>

### DIFF
--- a/src/psxy.c
+++ b/src/psxy.c
@@ -1509,7 +1509,7 @@ EXTERN_MSC int GMT_psxy (void *V_API, int mode, void *args) {
 		geovector = (S.symbol == GMT_SYMBOL_GEOVECTOR);
 		if ((S.v.status & PSL_VEC_FILL) == 0 && !S.v.parsed_v4) Ctrl->G.active = false;	/* Want no fill so override -G */
 		if (S.v.status & PSL_VEC_FILL2) {	/* Gave +g<fill> to set head fill; odd, but overrides -G (and sets -G true) */
-			current_fill = S.v.fill;	/* Override any -G<fill> with specified head fill */
+			current_fill = Ctrl->G.fill = S.v.fill;	/* Override any -G<fill> with specified head fill, and let auto-legend see it too */
 			if (S.v.status & PSL_VEC_FILL) Ctrl->G.active = true;
 		}
 		else if (S.v.status & PSL_VEC_FILL) {

--- a/src/psxyz.c
+++ b/src/psxyz.c
@@ -1047,7 +1047,7 @@ EXTERN_MSC int GMT_psxyz (void *V_API, int mode, void *args) {
 	if (S.symbol == PSL_VECTOR || S.symbol == GMT_SYMBOL_GEOVECTOR || S.symbol == PSL_MARC ) {	/* One of the vector symbols */
 		geovector = (S.symbol == GMT_SYMBOL_GEOVECTOR);
 		if (S.v.status & PSL_VEC_FILL2) {	/* Gave +g<fill> to set head fill; odd, but overrides -G (and sets -G true) */
-			current_fill = S.v.fill;	/* Override any -G<fill> with specified head fill */
+			current_fill = Ctrl->G.fill = S.v.fill;	/* Override any -G<fill> with specified head fill, and let auto-legend see it too */
 			if (S.v.status & PSL_VEC_FILL) Ctrl->G.active = true;
 		}
 		else if (S.v.status & PSL_VEC_FILL) {


### PR DESCRIPTION
When a vector symbol's head fill is set via the symbol's own `+g<fill>` modifier, the sample vector shown in the auto-legend (`-l`) is drawn unfilled. This PR fixes this in `psxy.c` and `psxyz.c`.

**Tested with:**
```
echo "0.5 0.5 45 1.5" | gmt plot -JX5c -R0/1/0/1 -B -lVector -SV0.3c+e+gred -png vector_heads
echo "0.5 0.5 0 45 1.5" | gmt plot3d -JX5c -JZ3c -R0/1/0/1/0/1 -B -p135/30 -lVector3D -SV0.3c+e+gred -png vector_heads_3D
```
Fixes #9167

*Implemented with Claude Sonnet 5 (Claude Code).*