### PR TITLE
CI: Touch gmt_data_server.txt and gmt_hash_server.txt so they're not outdated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,9 @@ jobs:
           echo "${INSTALLDIR}/bin" >> $GITHUB_PATH
 
       - name: Download cached GMT remote data from GitHub Artifacts
-        run: gh run download -n gmt-cache -D ~/.gmt/static/
+        run: |
+          gh run download -n gmt-cache -D ~/.gmt/static/
+          touch ~/.gmt/static/gmt_data_server.txt ~/.gmt/static/gmt_hash_server.txt
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,7 +115,9 @@ jobs:
           echo "${INSTALLDIR}/bin" >> $GITHUB_PATH
 
       - name: Download cached GMT remote data from GitHub Artifacts
-        run: gh run download -n gmt-cache -D ~/.gmt/static/
+        run: |
+          gh run download -n gmt-cache -D ~/.gmt/static/
+          touch ~/.gmt/static/gmt_data_server.txt ~/.gmt/static/gmt_hash_server.txt
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,7 +161,9 @@ jobs:
           echo "${INSTALLDIR}/bin" >> $GITHUB_PATH
 
       - name: Download cached GMT remote data from GitHub Artifacts
-        run: gh run download -n gmt-cache -D ~/.gmt/static/
+        run: |
+          gh run download -n gmt-cache -D ~/.gmt/static/
+          touch ~/.gmt/static/gmt_data_server.txt ~/.gmt/static/gmt_hash_server.txt
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
As I understand it, GMT tries to refresh remote files if `gmt_data_server.txt` or `gmt_hash_server.txt` are 24-hours old.

The files stored in cache are refreshed weekly, so GMT thinks they're outdated. This PR fixes the issue by changing the modifications times of the two files, which has been working well in PyGMT.