### PR TITLE
CI: Retry graphicsmagick choco install on Windows

### DIFF
--- a/ci/install-dependencies-windows.sh
+++ b/ci/install-dependencies-windows.sh
@@ -37,8 +37,12 @@ fi
 if [ "$RUN_TESTS" = "true" ]; then
     conda_packages+=" dvc"
 
-    # Install graphicsmagick via choco
-    choco install graphicsmagick --version 1.3.42 --no-progress
+    # Install graphicsmagick via choco (retry: SourceForge download occasionally times out)
+    for i in 1 2 3; do
+        choco install graphicsmagick --version 1.3.42 --no-progress && break
+        [ "$i" -lt 3 ] || { echo "choco install graphicsmagick failed after $i attempts" >&2; exit 1; }
+        sleep 15
+    done
     echo 'C:\Program Files\GraphicsMagick-1.3.42-Q8\' >> $GITHUB_PATH
 fi
 


### PR DESCRIPTION
This PR wraps the `choco install` call in a retry loop (3 attempts, 15s apart) so a transient SourceForge timeout doesn't fail the whole run.

**Assisted by Claude Sonnet 5**