### PR TITLE
grdimage: Fix uninitialized inc[] read with variable transparency

### DIFF
--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1454,6 +1454,11 @@ EXTERN_MSC int GMT_grdimage(void *V_API, int mode, void *args) {
 	unsigned int grid_registration = GMT_GRID_NODE_REG, try, row, col, mixed = 0, pad_mode = 0;
 	uint64_t node, k, kk, dim[GMT_DIM_SIZE] = {0, 0, 3, 0};
 	int error = 0, ret_val = GMT_NOERROR, ftype = GMT_NOTSET, ftype2 = GMT_NOTSET;
+	/* Dimensions and increments of the projected grid/image.  These must be declared (and initialized) here at
+	 * function scope: the variable-transparency shortcut below does "goto tr_image", which jumps into the middle
+	 * of the projection block and would skip the initializers of any variables declared inside it. */
+	int nx_proj = 0, ny_proj = 0;
+	double inc[2] = {0.0, 0.0};
 
 	char *img_ProjectionRefPROJ4 = NULL, *way[2] = {"via GDAL", "directly"}, cmd[GMT_LEN256] = {""}, data_grd[GMT_VF_LEN] = {""}, *e = NULL;
 	unsigned char *bitimage_8 = NULL, *bitimage_24 = NULL, *rgb_used = NULL;
@@ -1960,9 +1965,6 @@ EXTERN_MSC int GMT_grdimage(void *V_API, int mode, void *args) {
 		goto tr_image;
 	}
 	if (need_to_project) {	/* Need to resample the grid or image [and intensity grid] using the specified map projection */
-		int nx_proj = 0, ny_proj = 0;
-		double inc[2] = {0.0, 0.0};
-
 		if (got_z_grid && P && P->categorical && (GMT->common.n.interpolant != BCR_NEARNEIGHBOR || GMT->common.n.antialias)) {
 			GMT_Report(API, GMT_MSG_WARNING, "Your CPT is categorical. Enabling -nn+a to avoid interpolation across categories.\n");
 			GMT->common.n.interpolant = BCR_NEARNEIGHBOR;

--- a/src/grdimage.c
+++ b/src/grdimage.c
@@ -1454,9 +1454,7 @@ EXTERN_MSC int GMT_grdimage(void *V_API, int mode, void *args) {
 	unsigned int grid_registration = GMT_GRID_NODE_REG, try, row, col, mixed = 0, pad_mode = 0;
 	uint64_t node, k, kk, dim[GMT_DIM_SIZE] = {0, 0, 3, 0};
 	int error = 0, ret_val = GMT_NOERROR, ftype = GMT_NOTSET, ftype2 = GMT_NOTSET;
-	/* Dimensions and increments of the projected grid/image.  These must be declared (and initialized) here at
-	 * function scope: the variable-transparency shortcut below does "goto tr_image", which jumps into the middle
-	 * of the projection block and would skip the initializers of any variables declared inside it. */
+	/* Projected dimensions/increments; declared here since "goto tr_image" below would skip their initializers */
 	int nx_proj = 0, ny_proj = 0;
 	double inc[2] = {0.0, 0.0};
 


### PR DESCRIPTION
`test/grdimage/image_vartrans.sh` has been failing intermittently, on roughly half the runs. I have seen this myself running the same script on different occasions: sometimes panels 3 and 4 come out fine, and sometimes they are blank.

According to Claude the cause is an uninitialized variable. For images with a variable alpha channel, `GMT_grdimage` does `goto tr_image`, which jumps into the `if (need_to_project)` block past the declaration of `double inc[2] = {0.0, 0.0}`, so the initializer never runs. `gmt_project_init()` then branches on that leftover stack value and, when it happens to look positive, projects the image to 1x1 pixels — a blank panel, with no warning. Hence the coin-flip behavior.

This PR adds the fix proposed by **Claude Opus 5**.