### PR TITLE
CMake: Normalize installation path on Windows to avoid mixing slashes and backslashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,15 +118,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          setlocal enabledelayedexpansion
-          set "INSTALLDIR=%INSTALLDIR:\=/%"
-          set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
           cmake --build . --target install
-          set "WININSTALLDIR=!INSTALLDIR:/=\!"
-          echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
-          endlocal
+          echo %INSTALLDIR%\bin>> %GITHUB_PATH%
 
       - name: Install GMT (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           arch: x64
 
-      - name: Compile and Install GMT (Windows)
+      - name: Compile GMT (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
@@ -120,11 +120,8 @@ jobs:
           cd build
           cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
-          cmake --build . --target install
-          echo %INSTALLDIR%\bin>> %GITHUB_PATH%
 
-      - name: Install GMT (Linux/macOS)
-        if: runner.os != 'Windows'
+      - name: Install GMT
         run: |
           cd build
           cmake --build . --target install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,9 +137,7 @@ jobs:
 
       - name: Check a few simple commands
         shell: bash
-        run: |
-          export PATH="$INSTALLDIR/bin:$PATH"
-          bash ci/simple-gmt-tests.sh
+        run: bash ci/simple-gmt-tests.sh
 
       - name: Check a few simple commands (Windows)
         shell: cmd

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           arch: x64
 
-      - name: Compile and Install GMT (Windows)
+      - name: Compile (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
@@ -130,8 +130,6 @@ jobs:
           cd build
           cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
-          cmake --build . --target install
-          echo %INSTALLDIR%\bin>> %GITHUB_PATH%
 
       - name: Build documentation
         run: |
@@ -149,8 +147,7 @@ jobs:
           # See https://github.com/GenericMappingTools/gmt/issues/7253
           grep -v 'WARNING: duplicate label -' doc/rst/html.log
 
-      - name: Install GMT (Linux/macOS)
-        if: runner.os != 'Windows'
+      - name: Install GMT
         run: |
           cd build
           cmake --build . --target install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -128,15 +128,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          setlocal enabledelayedexpansion
-          set "INSTALLDIR=%INSTALLDIR:\=/%"
-          set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
           cmake --build . --target install
-          set "WININSTALLDIR=!INSTALLDIR:/=\!"
-          echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
-          endlocal
+          echo %INSTALLDIR%\bin>> %GITHUB_PATH%
 
       - name: Build documentation
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           arch: x64
 
-      - name: Compile (Windows)
+      - name: Compile GMT (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Install GMT 
+      - name: Install GMT
         run: |
           cd build
           cmake --build . --target install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           arch: x64
 
-      - name: Compile and Install GMT (Windows)
+      - name: Compile GMT (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
@@ -126,8 +126,6 @@ jobs:
           cd build
           cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
-          cmake --build . --target install
-          echo %INSTALLDIR%\bin>> %GITHUB_PATH%
 
       - name: Pull baseline image data from dvc remote
         id: dvc-pull
@@ -147,8 +145,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Install GMT (Linux/macOS)
-        if: runner.os != 'Windows'
+      - name: Install GMT 
         run: |
           cd build
           cmake --build . --target install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,15 +124,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          setlocal enabledelayedexpansion
-          set "INSTALLDIR=%INSTALLDIR:\=/%"
-          set "WINVCPKGROOT=%VCPKG_INSTALLATION_ROOT:/=\%"
-          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=!WINVCPKGROOT!\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+          cmake -G Ninja .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
           cmake --build .
           cmake --build . --target install
-          set "WININSTALLDIR=!INSTALLDIR:/=\!"
-          echo !WININSTALLDIR!\bin>> %GITHUB_PATH%
-          endlocal
+          echo %INSTALLDIR%\bin>> %GITHUB_PATH%
 
       - name: Pull baseline image data from dvc remote
         id: dvc-pull

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -51,6 +51,11 @@ endif (EXISTS "${CMAKE_BINARY_DIR}/cmake/ConfigUserAdvanced.cmake")
 # Do any needed processing of the configuration variables #
 ###########################################################
 
+# Normalize the installation prefix on Windows (avoid mixing slashed and backslashed).
+if (WIN32)
+	file (TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}" CMAKE_INSTALL_PREFIX)
+endif (WIN32)
+
 # Set default build type to 'Release'
 if (NOT CMAKE_BUILD_TYPE)
 	set (CMAKE_BUILD_TYPE Release)

--- a/cmake/modules/ConfigCMake.cmake
+++ b/cmake/modules/ConfigCMake.cmake
@@ -51,7 +51,7 @@ endif (EXISTS "${CMAKE_BINARY_DIR}/cmake/ConfigUserAdvanced.cmake")
 # Do any needed processing of the configuration variables #
 ###########################################################
 
-# Normalize the installation prefix on Windows (avoid mixing slashed and backslashed).
+# Normalize the installation prefix on Windows (avoid mixing slashes and backslashes).
 if (WIN32)
 	file (TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}" CMAKE_INSTALL_PREFIX)
 endif (WIN32)


### PR DESCRIPTION
Previously, we had issues building GMT on Windows with errors like:
```
CMake Error at cmake_install.cmake:5 (set):
  Syntax error in cmake code at

    D:/a/gmt/gmt/build/cmake_install.cmake:5

  when parsing string

    D:\a\gmt\gmt/gmt-install-dir

  Invalid character escape '\a'.
```
The real cause is that Windows uses backslashes (`D:\a\gmt\gmt`) while CI (and CMake) uses slashes.

PR https://github.com/GenericMappingTools/gmt/pull/9097 fixed the issue by applying a workaround to convert backslashes to slashes. It works for CI, but users who build GMT locally (via WSL or similar) may still have the same issue.

This PR fixes the root issue by normalizing paths on Windows using CMake's `TO_CMAKE_PATH` directive (xref: https://cmake.org/cmake/help/latest/command/file.html#to-cmake-path). With the fix, the CI workflows can be simplified.

Helped with Claude Opus 5.