### PR TITLE
Switch tests to cached files instead of third-party URLs

### DIFF
--- a/doc/rst/source/grdinfo.rst
+++ b/doc/rst/source/grdinfo.rst
@@ -200,7 +200,7 @@ Get the grid spacing in earth_relief_10m::
 
 To learn about the extreme values and coordinates in the 3-D data cube S362ANI_kmps.nc?vs::
 
-    gmt grdinfo -M S362ANI_kmps.nc?vs
+    gmt grdinfo -M @S362ANI_kmps.nc?vs
 
 **Note**: if you do a subset of a remote tiled file, e.g., earth_relief_01m, you must add |-G|
 so that any missing tiles are first downloaded::

--- a/doc/rst/source/grdinterpolate.rst
+++ b/doc/rst/source/grdinterpolate.rst
@@ -236,7 +236,7 @@ To extract a vertical slice of the 3-D grid S362ANI_kmps.nc with seismic velocit
 through the Hawaii hotspot, selecting cube vs (Isotropic Shear Velocity) and letting the
 distances be longitude degrees along the parallel, try::
 
-    gmt grdinterpolate S362ANI_kmps.nc?vs -E180/20/220/20+i1d+g+p -T25/500/25 -Gslice.nc
+    gmt grdinterpolate @S362ANI_kmps.nc?vs -E180/20/220/20+i1d+g+p -T25/500/25 -Gslice.nc
 
 See Also
 --------

--- a/test/filter1d/mfilter.sh
+++ b/test/filter1d/mfilter.sh
@@ -2,9 +2,7 @@
 # Get and filter the Keeling curve with monthly averages
 ps=mfilter.ps
 gmt set MAP_ANNOT_ORTHO "" FORMAT_TIME_PRIMARY_MAP Abbreviated FORMAT_DATE_MAP o
-#URL=https://scrippsco2.ucsd.edu/assets/data/atmospheric/stations/in_situ_co2/weekly/weekly_in_situ_co2_mlo.csv
-URL=https://keelinglabsites.ucsd.edu/websitedataco2/weekly_in_situ_co2_mlo.csv
-gmt filter1d $URL -T1o+t -Fg30 --TIME_UNIT=d -f0T --IO_HEADER_MARKER=\" > monthly.txt
+gmt filter1d @weekly_in_situ_co2_mlo.csv -T1o+t -Fg30 --TIME_UNIT=d -f0T --IO_HEADER_MARKER=\" > monthly.txt
 gmt psxy -R1958T/2018T/300/430 -JX6iT/4i -Bxa10Yf5y -Byaf+u" ppm" -BWSne -W0.25p monthly.txt -P -K -Xc > $ps
-gmt psxy -R2012T/2013T/380/410 -J -Bsxa1Y -Bpxa1Og1o -Byaf+u" ppm" -BWSne+t"Keeling CO@-2@- curve" $URL -Sc0.2c -Gred -O -K -Y4.75i --IO_HEADER_MARKER=\" >> $ps
+gmt psxy -R2012T/2013T/380/410 -J -Bsxa1Y -Bpxa1Og1o -Byaf+u" ppm" -BWSne+t"Keeling CO@-2@- curve" @weekly_in_situ_co2_mlo.csv -Sc0.2c -Gred -O -K -Y4.75i --IO_HEADER_MARKER=\" >> $ps
 gmt psxy -R -J -Sx0.2i -Gblue monthly.txt -O >> $ps

--- a/test/grdinterpolate/slices.sh
+++ b/test/grdinterpolate/slices.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 # Test grdinterpolate slicing along equator through a 3-D grid
-# Getting the file directly from IRIS
 #
 # GRAPHICSMAGICK_RMS = 0.0072
 
 gmt begin slices ps
 	gmt set PROJ_ELLIPSOID sphere
-	curl -s http://ds.iris.edu/spudservice/data/17996723 -o S362ANI_kmps.nc
-	gmt grdinterpolate S362ANI_kmps.nc?vs -E0/0/180/0+i0.5d+g+p -T30/2890/10 -Gvs.nc
+	gmt grdinterpolate @S362ANI_kmps.nc?vs -E0/0/180/0+i0.5d+g+p -T30/2890/10 -Gvs.nc
 	gmt makecpt -Cseis -T4.25/7.35
 	gmt subplot begin 3x1 -Fs12c/7c -Bafg -R0/180/0/2900  -A
 		gmt grdimage vs.nc -JP?+fp+kx -c  -BWESn

--- a/test/grdinterpolate/slices_file.sh
+++ b/test/grdinterpolate/slices_file.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 # Test grdinterpolate slicing along equator through a 3-D grid
-# Getting the file directly from IRIS.
 # This script tests ability to supply our own profile file
 
 gmt begin slices_file ps
 	gmt set PROJ_ELLIPSOID sphere
-	curl -s http://ds.iris.edu/spudservice/data/17996723 -o S362ANI_kmps.nc
 	gmt math -T0/180/0.5 0 = line.txt
-	gmt grdinterpolate S362ANI_kmps.nc?vs -Eline.txt -T30/2890/10 -Gvs.nc
+	gmt grdinterpolate @S362ANI_kmps.nc?vs -Eline.txt -T30/2890/10 -Gvs.nc
 	gmt makecpt -Cseis -T4.25/7.35
 	gmt subplot begin 3x1 -Fs12c/7c -Bafg -R0/180/0/2900  -A
 		gmt grdimage vs.nc -JP?+fp+kx -c  -BWESn

--- a/test/psxy/urlquakes.sh
+++ b/test/psxy/urlquakes.sh
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
-# Test reading directly from URL
-# Note: The URL tends to change every few years...
 ps=urlquakes.ps
-
-SITE="https://earthquake.usgs.gov/fdsnws/event/1/query.csv"
-TIME="starttime=2016-01-01%2000:00:00&endtime=2016-02-01%2000:00:00"
-MAG="minmagnitude=4.5"
-ORDER="orderby=magnitude"
-URL="${SITE}?${TIME}&${MAG}&${ORDER}"
 
 gmt makecpt -Cred,green,blue -T0,70,300,10000 > q.cpt
 gmt pscoast -Rg -JN180/7i -Gbisque -Sazure1 -Baf -B+t"Earthquakes for January 2016 with M @~\263@~ 4.5" -Xc -K -P > $ps
-gmt psxy -R -J -O -K $URL -hi1 -Sci -Cq.cpt -i2,1,3,4+s0.01 >> $ps
+gmt psxy -R -J -O -K @urlquakes.csv -hi1 -Sci -Cq.cpt -i2,1,3,4+s0.01 >> $ps
 gmt psxy -R -J -O @ridge.txt -W0.5p >> $ps


### PR DESCRIPTION
Depends on GenericMappingTools/gmtserver-admin#298 being merged and synced first.

Fixes #9186

Drafted with **Claude Opus 5**.