### PR TITLE
inset: Fix gmt inset end not removing its own tagged history/settings files

### DIFF
--- a/src/inset.c
+++ b/src/inset.c
@@ -420,11 +420,11 @@ EXTERN_MSC int GMT_inset (void *V_API, int mode, void *args) {
 
 		/* Remove the inset history file */
 		gmt_hierarchy_tag (API, GMT_HISTORY_FILE, GMT_OUT, tag);
-		sprintf (ffile, "%s/%s.%s", API->gwf_dir, GMT_HISTORY_FILE, tag);
+		sprintf (ffile, "%s/%s%s", API->gwf_dir, GMT_HISTORY_FILE, tag);
 		gmt_remove_file (GMT, ffile);
 		/* Remove the gmt settings file */
 		gmt_hierarchy_tag (API, GMT_SETTINGS_FILE, GMT_OUT, tag);
-		sprintf (ffile, "%s/%s.%s", API->gwf_dir, GMT_HISTORY_FILE, tag);
+		sprintf (ffile, "%s/%s%s", API->gwf_dir, GMT_SETTINGS_FILE, tag);
 		gmt_remove_file (GMT, ffile);
 		/* Restore the old frame B setting to what it was before inset begin was called, if any */
 		if ((fp = fopen (file, "r"))) {	/* There is a gmt.frame.<fig> file */


### PR DESCRIPTION
## Summary

`gmt inset end` is supposed to delete two temporary files (`gmt.history.inset`, `gmt.conf.inset`) it created when the inset began, so that a later inset in the same figure does not inherit state from a previous, already-closed one. 

## Reproduction

```bash
gmt begin inset_leak png
	gmt basemap -JM7c -R-70/-60/-56/-50 -Baf
	gmt inset begin -DjTR+w2.2c+o-0.08c
		gmt set MAP_FRAME_PEN thick,red
		gmt basemap -Rg -JG-67/-54/? -B0
	gmt inset end
	gmt inset begin -DjBL+w3.5c
		gmt basemap -B0
	gmt inset end
gmt end show
```

<img width="2039" height="1016" alt="BUG_Inset_State_Leak" src="https://github.com/user-attachments/assets/7494b6f0-ce91-4d54-bce8-7513831fa159" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
