### PR TITLE
doc: Fix macOS test failure in GMT_App_M_1c.sh (locale-dependent sort)

### DIFF
--- a/doc/scripts/GMT_App_M_1a.sh
+++ b/doc/scripts/GMT_App_M_1a.sh
@@ -30,7 +30,7 @@ plot () {
 GMT_SHAREDIR=$(gmt --show-sharedir)
 
 # Here we list all cpt, except cyclic, categorical, cmocean, SCM, srtm
-sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | egrep -vi "cyclic|categorical|cmocean|SCM|srtm" | awk '{print $1}' | sort > tt.lis
+sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | egrep -vi "cyclic|categorical|cmocean|SCM|srtm" | awk '{print $1}' | LC_ALL=C sort > tt.lis
 
 n=$(cat tt.lis | wc -l)
 # dy is line spacing and y0 is total box height

--- a/doc/scripts/GMT_App_M_1b.sh
+++ b/doc/scripts/GMT_App_M_1b.sh
@@ -30,7 +30,7 @@ plot () {
 GMT_SHAREDIR=$(gmt --show-sharedir)
 
 # Here we list all the non-categorical/non-cyclic cpts from the SCM:
-sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | egrep SCM | egrep -v "categorical|cyclic" | awk '{print $1}' | sort > tt.lis
+sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | egrep SCM | egrep -v "categorical|cyclic" | awk '{print $1}' | LC_ALL=C sort > tt.lis
 
 n=$(cat tt.lis | wc -l)
 # dy is line spacing and y0 is total box height

--- a/doc/scripts/GMT_App_M_1c.sh
+++ b/doc/scripts/GMT_App_M_1c.sh
@@ -30,7 +30,7 @@ plot () {
 GMT_SHAREDIR=$(gmt --show-sharedir)
 
 # Here we list all the cyclic cpts:
-sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | egrep cyclic | awk '{print $1}' | sort > tt.lis
+sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | egrep cyclic | awk '{print $1}' | LC_ALL=C sort > tt.lis
 
 n=$(cat tt.lis | wc -l)
 # dy is line spacing and y0 is total box height

--- a/doc/scripts/GMT_App_M_1d.sh
+++ b/doc/scripts/GMT_App_M_1d.sh
@@ -30,7 +30,7 @@ plot () {
 GMT_SHAREDIR=$(gmt --show-sharedir)
 
 # Here we list all the cmocean cpts:
-sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | egrep cmocean | awk '{print $1}' | sort > tt.lis
+sed -e 's/"//g' "${GMT_SOURCE_DIR}"/src/gmt_cpt_masters.h | egrep cmocean | awk '{print $1}' | LC_ALL=C sort > tt.lis
 
 n=$(cat tt.lis | wc -l)
 # dy is line spacing and y0 is total box height


### PR DESCRIPTION
Claude Opus suggests this edit to fix the macOS-only test failure in `GMT_App_M_1c.sh` (and the same latent bug in 1a/1b/1d).

**Cause**: the colorbar order comes from a locale-dependent `sort` over a mixed-case CPT name list, and the baseline image was made under a different collation than the macOS runner uses — so the colorbars land in the wrong slots and the image comparison fails (RMS 0.0852). Pinning `LC_ALL=C` on the `sort` fixes it.

I don't have a macOS machine, so I could only reproduce the failure on Linux by forcing the same locale mismatch; I'm relying on this PR's CI run to confirm it actually fixes macOS.

**Assisted-by: Claude Opus 5**