### PR TITLE
CI: Don't leave required checks pending on documentation-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,19 +8,7 @@ on:
     branches:
       - master
       - 6.[0-9]+
-    paths:
-      - 'ci/**'
-      - 'cmake/**'
-      - 'src/**'
-      - '**/CMakeLists.txt'
-      - '.github/workflows/build.yml'
   pull_request:
-    paths:
-      - 'ci/**'
-      - 'cmake/**'
-      - 'src/**'
-      - 'CMakeLists.txt'
-      - '.github/workflows/build.yml'
   workflow_dispatch:
 
 defaults:
@@ -33,8 +21,30 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      # paths-filter needs a checkout for push events; on PRs it uses the API
+      - uses: actions/checkout@v6.0.2
+
+      - uses: dorny/paths-filter@v4.0.3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'ci/**'
+              - 'cmake/**'
+              - 'src/**'
+              - '**/CMakeLists.txt'
+              - '.github/workflows/build.yml'
+
   build:
     name: ${{ matrix.name }}
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
 
     env:

--- a/.github/workflows/code-validator.yml
+++ b/.github/workflows/code-validator.yml
@@ -14,24 +14,35 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+'
-    paths:
-      - 'src/**'
-      - 'cmake/**'
-      - '**/*.sh'
-      - '.github/workflows/code-validator.yml'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'cmake/**'
-      - '**/*.sh'
-      - '.github/workflows/code-validator.yml'
   workflow_dispatch:
 
 name: Code Validator
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      # paths-filter needs a checkout for push events; on PRs it uses the API
+      - uses: actions/checkout@v6.0.2
+
+      - uses: dorny/paths-filter@v4.0.3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'cmake/**'
+              - '**/*.sh'
+              - '.github/workflows/code-validator.yml'
+
   code-validator:
     name: Code Validator
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,19 +10,7 @@ on:
     branches:
       - master
       - 6.[0-9]+
-    paths:
-      - 'ci/**'
-      - 'cmake/**'
-      - 'src/**'
-      - '**/CMakeLists.txt'
-      - '.github/workflows/docker.yml'
   pull_request:
-    paths:
-      - 'ci/**'
-      - 'cmake/**'
-      - 'src/**'
-      - '**/CMakeLists.txt'
-      - '.github/workflows/docker.yml'
   workflow_dispatch:
 
 defaults:
@@ -38,8 +26,30 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      # paths-filter needs a checkout for push events; on PRs it uses the API
+      - uses: actions/checkout@v6.0.2
+
+      - uses: dorny/paths-filter@v4.0.3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'ci/**'
+              - 'cmake/**'
+              - 'src/**'
+              - '**/CMakeLists.txt'
+              - '.github/workflows/docker.yml'
+
   docker:
     name: ${{ matrix.image }}
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,9 @@ jobs:
   changes:
     name: Detect relevant changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read  # required by dorny/paths-filter on pull_request events
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,11 +9,6 @@ on:
     branches:
       - master
       - 6.[0-9]+
-    paths:
-      - 'ci/**'
-      - 'doc/**'
-      - '**/CMakeLists.txt'
-      - '.github/workflows/docs.yml'
   release:
     types:
       - published
@@ -29,8 +24,29 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      # paths-filter needs a checkout for push events; on PRs it uses the API
+      - uses: actions/checkout@v6.0.2
+
+      - uses: dorny/paths-filter@v4.0.3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'ci/**'
+              - 'doc/**'
+              - '**/CMakeLists.txt'
+              - '.github/workflows/docs.yml'
+
   docs:
     name: ${{ matrix.name }}
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true' || github.event_name != 'push'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - master
       - 6.[0-9]+
+    paths:
+      - 'ci/**'
+      - 'doc/**'
+      - '**/CMakeLists.txt'
+      - '.github/workflows/docs.yml'
   release:
     types:
       - published
@@ -24,29 +29,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-  changes:
-    name: Detect relevant changes
-    runs-on: ubuntu-latest
-    outputs:
-      relevant: ${{ steps.filter.outputs.relevant }}
-    steps:
-      # paths-filter needs a checkout for push events; on PRs it uses the API
-      - uses: actions/checkout@v6.0.2
-
-      - uses: dorny/paths-filter@v4.0.3
-        id: filter
-        with:
-          filters: |
-            relevant:
-              - 'ci/**'
-              - 'doc/**'
-              - '**/CMakeLists.txt'
-              - '.github/workflows/docs.yml'
-
   docs:
     name: ${{ matrix.name }}
-    needs: changes
-    if: needs.changes.outputs.relevant == 'true' || github.event_name != 'push'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,19 +8,7 @@ on:
     branches:
       - master
       - 6.[0-9]+
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'doc/examples/**'
-      - 'doc/scripts/**'
-      - '.github/workflows/tests.yml'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'doc/examples/**'
-      - 'doc/scripts/**'
-      - '.github/workflows/tests.yml'
   workflow_dispatch:
 
 defaults:
@@ -33,8 +21,30 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      # paths-filter needs a checkout for push events; on PRs it uses the API
+      - uses: actions/checkout@v6.0.2
+
+      - uses: dorny/paths-filter@v4.0.3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'test/**'
+              - 'doc/examples/**'
+              - 'doc/scripts/**'
+              - '.github/workflows/tests.yml'
+
   test:
     name: ${{ matrix.name }}
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
 
     env:


### PR DESCRIPTION
Documentation-only PRs leave the required checks (`Linux`, `macOS`, `Windows`, `Linux (without optional dependencies)`, `Code Validator`) stuck at "Expected — Waiting for status to be reported", which blocks the merge: with `paths:` on the trigger the workflow never runs, so no status is ever reported for those names. The filtering now happens in a small `changes` job and the real job is skipped via `if:` instead, which does report a status and satisfies branch protection.

Assisted-by: Claude Sonnet 5 (implementation) and Claude Opus 5 (review)