### PR TITLE
gmtwhich/gmtget: Report a failed download through the exit status

### DIFF
--- a/src/gmtget.c
+++ b/src/gmtget.c
@@ -184,7 +184,9 @@ EXTERN_MSC void gmt_free_list (struct GMT_CTRL *GMT, char **list, uint64_t n);
 
 EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 	int error = GMT_NOERROR;
-	char *datasets = NULL, *c = NULL, file[PATH_MAX] = {""};
+	unsigned int first = 0;
+	bool missing = false;
+	char *datasets = NULL, *c = NULL, file[PATH_MAX] = {""}, path[PATH_MAX] = {""};
 
 	struct GMTGET_CTRL *Ctrl = NULL;
 	struct GMT_CTRL *GMT = NULL, *GMT_cpy = NULL;
@@ -280,13 +282,16 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 				else {
 					if (API->remote_info[k].tile_size > 0.0) {	/* Must obtain all tiles */
 						char **list = gmt_get_dataset_tiles (API, world, k, &n_tiles, NULL);
-						for (t = 0; t < n_tiles; t++)
-							gmt_download_file_if_not_found (GMT, list[t], GMT_AUTO_DIR);
+						for (t = 0; t < n_tiles; t++) {
+							first = gmt_download_file_if_not_found (GMT, list[t], GMT_AUTO_DIR);
+							if (gmt_getdatapath (GMT, &list[t][first], path, R_OK) == NULL) missing = true;
+						}
 						gmt_free_list (GMT, list, n_tiles);
 					}
 					else {
 						sprintf (file, "@%s", API->remote_info[k].file);
-						gmt_download_file_if_not_found (GMT, file, GMT_AUTO_DIR);
+						first = gmt_download_file_if_not_found (GMT, file, GMT_AUTO_DIR);
+						if (gmt_getdatapath (GMT, &file[first], path, R_OK) == NULL) missing = true;
 					}
 				}
 			}
@@ -314,11 +319,12 @@ EXTERN_MSC int GMT_gmtget (void *V_API, int mode, void *args) {
 			fgets (line, GMT_LEN256, fp);	/* Skip first record with record count */
 			while (fscanf (fp, "%s %*s %*s", line) == 1) {
 				sprintf (file, "@%s", line);
-				gmt_download_file_if_not_found (GMT, file, GMT_AUTO_DIR);
+				first = gmt_download_file_if_not_found (GMT, file, GMT_AUTO_DIR);
+				if (gmt_getdatapath (GMT, &file[first], path, R_OK) == NULL) missing = true;
 			}
 			fclose (fp);
 		}
-		Return (GMT_NOERROR);
+		Return (missing ? GMT_FILE_NOT_FOUND : GMT_NOERROR);
 	}
 
 	/* Read the supplied default file or the users defaults to override system settings */

--- a/src/gmtwhich.c
+++ b/src/gmtwhich.c
@@ -197,7 +197,7 @@ GMT_LOCAL int gmtwhich_list_tiles (struct GMTAPI_CTRL *API, char *list, unsigned
 #define Return(code) {Free_Ctrl (GMT, Ctrl); gmt_end_module (GMT, GMT_cpy); bailout (code);}
 
 EXTERN_MSC int GMT_gmtwhich (void *V_API, int mode, void *args) {
-	bool list;
+	bool list, missing = false;
 	int error = 0, fmode, k_data;
 	unsigned int first = 0;	/* Real start of filename */
 
@@ -294,6 +294,7 @@ EXTERN_MSC int GMT_gmtwhich (void *V_API, int mode, void *args) {
 				GMT_Put_Record (API, GMT_WRITE_DATA, Out);
 			}
 			GMT_Report (API, GMT_MSG_ERROR, "File %s not found!\n", &file[first]);
+			if (Ctrl->G.active) missing = true;	/* Asked to fetch it and still don't have it */
 		}
 	}
 
@@ -302,5 +303,6 @@ EXTERN_MSC int GMT_gmtwhich (void *V_API, int mode, void *args) {
 		Return (API->error);
 	}
 
-	Return (GMT_NOERROR);
+	/* -C's purpose is to report Y/N as text without erroring, so it always keeps exiting 0 */
+	Return ((missing && !Ctrl->C.active) ? GMT_FILE_NOT_FOUND : GMT_NOERROR);
 }


### PR DESCRIPTION
Proposes an answer to #9195: `gmt which -G` and `gmt get -D` now return `GMT_FILE_NOT_FOUND` (16) when a requested download didn't produce the file, instead of always exiting 0 — both already detected the miss for their error messages, just discarded it. Scoped to `-G`/`-D` only (plain `gmt which <local file>` is untouched), `-C` keeps exiting 0 since its job is reporting Y/N as text, and tiled dataset listings aren't covered. These are judgment calls, not answers from the issue thread — happy to adjust.

**Tested with:**
```
$ gmt which -Ga @earth_relief_01d_g @nonexistent.nc --GMT_AUTO_DOWNLOAD=off; echo "exit = $?"
...
/home/x/.gmt/static/server/earth/earth_relief/earth_relief_01d_g.grd
exit = 16

$ gmt get -Ddata=earth_mask -I1d --GMT_AUTO_DOWNLOAD=off; echo "exit = $?"
...
exit = 16
```

Fixes #9195

Assisted-by: Claude Sonnet 5
