### PR TITLE
ci: Remove stale `gcov` input from codecov-action step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,5 +206,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: false
-          gcov: true
         if: always()


### PR DESCRIPTION
`gcov: true` has been ignored since codecov-action v4.0.0 moved to the Codecov CLI, where gcov runs by default — it only produces an "Unexpected input(s)" warning on every OS. Coverage collection is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 5, reviewed with Opus 5)